### PR TITLE
[release/6.0] Always build App.Ref and the targeting packs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -141,11 +141,6 @@
     <RuntimeInstallerBaseName>aspnetcore-runtime</RuntimeInstallerBaseName>
     <TargetingPackInstallerBaseName>aspnetcore-targeting-pack</TargetingPackInstallerBaseName>
 
-    <!-- This is used to produce targeting pack installers/packages once per major.minor, or when we need to service it (e.g. 6.0.2) -->
-    <IsTargetingPackBuilding
-        Condition=" '$(IsTargetingPackBuilding)' == '' AND '$(AspNetCorePatchVersion)' != '2' ">false</IsTargetingPackBuilding>
-    <IsTargetingPackBuilding Condition=" '$(IsTargetingPackBuilding)' == '' ">true</IsTargetingPackBuilding>
-
     <!--
       Archives and installers using this prefix are intended for internal use only.
       For example, this .zip is used to handoff bits to partner teams who then incorporate our shared frameworks
@@ -247,5 +242,4 @@
   <Import Project="eng\targets\Npm.Common.props"  Condition="'$(MSBuildProjectExtension)' == '.npmproj'" />
   <Import Project="eng\targets\Java.Common.props"  Condition="'$(MSBuildProjectExtension)' == '.javaproj'" />
   <Import Project="eng\targets\Helix.props" Condition="'$(IsTestProject)' == 'true'" />
-
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -49,7 +49,6 @@
     <SharedFxProductName>$(Product) $(SharedFxVersion) Shared Framework</SharedFxProductName>
 
     <TargetingPackVersion>$(SharedFxVersion)</TargetingPackVersion>
-    <TargetingPackVersion Condition=" ! $(IsTargetingPackBuilding) ">$(TargetingPackVersionPrefix)</TargetingPackVersion>
 
     <PackageVersion Condition=" '$(NoSemVer20)' == 'true' ">$(SiteExtensionVersion)</PackageVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,8 +28,6 @@
       It's also used in root Directory.Build.targets to determine the version of the last-built targeting pack.
     -->
     <TargetingPackVersionPrefix>$(VersionPrefix)</TargetingPackVersionPrefix>
-    <!-- Targeting packs do not produce patch versions in servicing builds. No API changes are allowed in patches. -->
-    <TargetingPackVersionPrefix Condition="'$(IsTargetingPackBuilding)' != 'true'">$(AspNetCoreMajorMinorVersion).2</TargetingPackVersionPrefix>
     <ExperimentalVersionPrefix>0.3.$(AspNetCorePatchVersion)</ExperimentalVersionPrefix>
     <!-- ANCM versioning is intentionally 10 + AspNetCoreMajorVersion because earlier versions of ANCM shipped as 8.x. -->
     <AspNetCoreModuleVersionMajor>$([MSBuild]::Add(10, $(AspNetCoreMajorVersion)))</AspNetCoreModuleVersionMajor>

--- a/eng/targets/ResolveReferences.targets
+++ b/eng/targets/ResolveReferences.targets
@@ -234,8 +234,7 @@
   -->
   <ItemGroup Condition=" '$(MSBuildProjectName)' != 'Microsoft.AspNetCore.App.Runtime' AND
       '$(MSBuildProjectName)' != 'RepoTasks' AND
-      ($(_CompileTfmUsingReferenceAssemblies) OR
-       ('$(IsTargetingPackBuilding)' != 'false' AND '$(MSBuildProjectName)' == 'Microsoft.AspNetCore.App.Ref')) ">
+      ($(_CompileTfmUsingReferenceAssemblies) OR '$(MSBuildProjectName)' == 'Microsoft.AspNetCore.App.Ref') ">
     <PackageReference Include="Microsoft.Internal.Runtime.AspNetCore.Transport"
         Version="$(MicrosoftInternalRuntimeAspNetCoreTransportVersion)"
         IsImplicitlyDefined="true"
@@ -258,8 +257,7 @@
           '$(IsImplementationProject)' == 'true' AND
           '$(MSBuildProjectName)' != 'Ignitor' AND
           '$(MSBuildProjectName)' != 'Microsoft.AspNetCore.App.Runtime' AND
-          ($(_CompileTfmUsingReferenceAssemblies) OR
-           ('$(IsTargetingPackBuilding)' != 'false' AND '$(MSBuildProjectName)' == 'Microsoft.AspNetCore.App.Ref')) ">
+          ($(_CompileTfmUsingReferenceAssemblies) OR '$(MSBuildProjectName)' == 'Microsoft.AspNetCore.App.Ref') ">
     <ItemGroup>
       <ResolvedCompileFileDefinitions Remove="@(ResolvedCompileFileDefinitions)"
           Condition=" '%(NuGetPackageId)' != 'Microsoft.Internal.Runtime.AspNetCore.Transport' AND

--- a/src/Framework/App.Ref.Internal/src/Microsoft.AspNetCore.App.Ref.Internal.csproj
+++ b/src/Framework/App.Ref.Internal/src/Microsoft.AspNetCore.App.Ref.Internal.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <IsShippingPackage>false</IsShippingPackage>
     <IsPackable>true</IsPackable>
-    <IsPackable Condition="'$(IsTargetingPackBuilding)' == 'false'">false</IsPackable>
     <PackageId>$(TargetingPackName).Internal</PackageId>
     <VersionPrefix>$(TargetingPackVersionPrefix)</VersionPrefix>
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <IsPackable Condition="'$(IsTargetingPackBuilding)' == 'false'">false</IsPackable>
     <PackageId>$(TargetingPackName)</PackageId>
     <VersionPrefix>$(TargetingPackVersionPrefix)</VersionPrefix>
 
@@ -92,8 +91,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- If this project won't produce a package, don't bother building anything. -->
-    <BuildDependsOn Condition="'$(IsTargetingPackBuilding)' != 'false'">
+    <BuildDependsOn>
       $(BuildDependsOn);
       _ResolveTargetingPackContent;
       GeneratePackageOverrides;
@@ -102,9 +100,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       _InstallTargetingPackIntoLocalDotNet;
       _CreateTargetingPackArchive;
     </BuildDependsOn>
-
-    <!-- No-op when in source build -->
-    <BuildDependsOn Condition="'$(IsTargetingPackBuilding)' == 'false'"/>
   </PropertyGroup>
 
   <!-- Override the default MSBuild targets so that nothing is returned from the project since it represents a collection of assemblies. -->

--- a/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
+++ b/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
@@ -56,10 +56,6 @@
       <_Parameter2>$(TargetingPackLayoutRoot)</_Parameter2>
     </AssemblyAttribute>
     <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
-      <_Parameter1>IsTargetingPackBuilding</_Parameter1>
-      <_Parameter2>$(IsTargetingPackBuilding)</_Parameter2>
-    </AssemblyAttribute>
-    <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
       <_Parameter1>VerifyAncmBinary</_Parameter1>
       <_Parameter2>$(VerifyAncmBinary)</_Parameter2>
     </AssemblyAttribute>
@@ -71,16 +67,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
-        Condition=" $(IsTargetingPackBuilding) ">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-    </ProjectReference>
-    <ProjectReference Include="..\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
-        Condition=" !$(IsTargetingPackBuilding) ">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-    </ProjectReference>
+    <ProjectReference Include="$(RepoRoot)\src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
+      Private="false"
+      ReferenceOutputAssembly="false"
+      SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
 
   <Target Name="GenerateTestData" BeforeTargets="GetAssemblyAttributes" DependsOnTargets="InitializeSourceControlInformation">

--- a/src/Framework/test/TargetingPackTests.cs
+++ b/src/Framework/test/TargetingPackTests.cs
@@ -23,7 +23,6 @@ namespace Microsoft.AspNetCore
         private readonly string _targetingPackTfm;
         private readonly string _targetingPackRoot;
         private readonly ITestOutputHelper _output;
-        private readonly bool _isTargetingPackBuilding;
 
         public TargetingPackTests(ITestOutputHelper output)
         {
@@ -38,17 +37,11 @@ namespace Microsoft.AspNetCore
                 "packs",
                 "Microsoft.AspNetCore.App.Ref",
                 TestData.GetTestDataValue("TargetingPackVersion"));
-            _isTargetingPackBuilding = bool.Parse(TestData.GetTestDataValue("IsTargetingPackBuilding"));
         }
 
         [Fact]
         public void TargetingPackContainsListedAssemblies()
         {
-            if (!_isTargetingPackBuilding)
-            {
-                return;
-            }
-
             var actualAssemblies = Directory.GetFiles(Path.Combine(_targetingPackRoot, "ref", _targetingPackTfm), "*.dll")
                 .Select(Path.GetFileNameWithoutExtension)
                 .ToHashSet();
@@ -74,11 +67,6 @@ namespace Microsoft.AspNetCore
         [Fact]
         public void RefAssembliesHaveExpectedAssemblyVersions()
         {
-            if (!_isTargetingPackBuilding)
-            {
-                return;
-            }
-
             IEnumerable<string> dlls = Directory.GetFiles(Path.Combine(_targetingPackRoot, "ref", _targetingPackTfm), "*.dll", SearchOption.AllDirectories);
             Assert.NotEmpty(dlls);
 
@@ -99,11 +87,6 @@ namespace Microsoft.AspNetCore
         [Fact]
         public void RefAssemblyReferencesHaveExpectedAssemblyVersions()
         {
-            if (!_isTargetingPackBuilding)
-            {
-                return;
-            }
-
             IEnumerable<string> dlls = Directory.GetFiles(Path.Combine(_targetingPackRoot, "ref", _targetingPackTfm), "*.dll", SearchOption.AllDirectories);
             Assert.NotEmpty(dlls);
 
@@ -126,11 +109,6 @@ namespace Microsoft.AspNetCore
         [Fact]
         public void PackageOverridesContainsCorrectEntries()
         {
-            if (!_isTargetingPackBuilding)
-            {
-                return;
-            }
-
             var packageOverridePath = Path.Combine(_targetingPackRoot, "data", "PackageOverrides.txt");
 
             AssertEx.FileExists(packageOverridePath);
@@ -190,11 +168,6 @@ namespace Microsoft.AspNetCore
         [Fact]
         public void AssembliesAreReferenceAssemblies()
         {
-            if (!_isTargetingPackBuilding)
-            {
-                return;
-            }
-
             IEnumerable<string> dlls = Directory.GetFiles(Path.Combine(_targetingPackRoot, "ref"), "*.dll", SearchOption.AllDirectories);
             Assert.NotEmpty(dlls);
 
@@ -222,11 +195,6 @@ namespace Microsoft.AspNetCore
         [Fact]
         public void PlatformManifestListsAllFiles()
         {
-            if (!_isTargetingPackBuilding)
-            {
-                return;
-            }
-
             var platformManifestPath = Path.Combine(_targetingPackRoot, "data", "PlatformManifest.txt");
             var expectedAssemblies = TestData.GetSharedFxDependencies()
                 .Split(';', StringSplitOptions.RemoveEmptyEntries)
@@ -292,11 +260,6 @@ namespace Microsoft.AspNetCore
         [Fact]
         public void FrameworkListListsContainsCorrectEntries()
         {
-            if (!_isTargetingPackBuilding)
-            {
-                return;
-            }
-
             var frameworkListPath = Path.Combine(_targetingPackRoot, "data", "FrameworkList.xml");
             var expectedAssemblies = TestData.GetTargetingPackDependencies()
                 .Split(';', StringSplitOptions.RemoveEmptyEntries)
@@ -364,7 +327,7 @@ namespace Microsoft.AspNetCore
         [Fact]
         public void FrameworkListListsContainsCorrectPaths()
         {
-            if (!_isTargetingPackBuilding || string.IsNullOrEmpty(Environment.GetEnvironmentVariable("helix")))
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("helix")))
             {
                 return;
             }
@@ -406,7 +369,7 @@ namespace Microsoft.AspNetCore
         [Fact]
         public void FrameworkListListsContainsAnalyzerLanguage()
         {
-            if (!_isTargetingPackBuilding || string.IsNullOrEmpty(Environment.GetEnvironmentVariable("helix")))
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("helix")))
             {
                 return;
             }

--- a/src/Installers/Debian/Directory.Build.targets
+++ b/src/Installers/Debian/Directory.Build.targets
@@ -28,7 +28,7 @@
   <Target Name="Pack" />
 
   <Target Name="DebBuild" DependsOnTargets="$(DebBuildDependsOn)"
-      Condition="!( '$(IsTargetingPackBuilding)' == 'false' AND '$(MSBuildProjectName)' == 'Debian.TargetingPack' )">
+      Condition=" '$(MSBuildProjectName)' != 'Debian.TargetingPack' ">
     <!-- Generate debian_config.json. We can't simply use WriteLinesToFile because of https://github.com/Microsoft/msbuild/issues/1622. Use our custom GenerateFileFromTemplate task instead -->
     <PropertyGroup>
       <DebianConfigProperties>

--- a/src/Installers/Debian/Directory.Build.targets
+++ b/src/Installers/Debian/Directory.Build.targets
@@ -27,8 +27,7 @@
   <Target Name="Build" DependsOnTargets="DebBuild" />
   <Target Name="Pack" />
 
-  <Target Name="DebBuild" DependsOnTargets="$(DebBuildDependsOn)"
-      Condition=" '$(MSBuildProjectName)' != 'Debian.TargetingPack' ">
+  <Target Name="DebBuild" DependsOnTargets="$(DebBuildDependsOn)">
     <!-- Generate debian_config.json. We can't simply use WriteLinesToFile because of https://github.com/Microsoft/msbuild/issues/1622. Use our custom GenerateFileFromTemplate task instead -->
     <PropertyGroup>
       <DebianConfigProperties>

--- a/src/Installers/Debian/TargetingPack/Debian.TargetingPack.debproj
+++ b/src/Installers/Debian/TargetingPack/Debian.TargetingPack.debproj
@@ -44,9 +44,6 @@
     <!-- Deb installers are versioned as M.N.P~PreReleaseVersionLabel-Build following the core-setup convention -->
     <DebPackageVersion Condition="'$(VersionSuffix)' != ''">$(DebPackageVersion)~$(VersionSuffix)</DebPackageVersion>
     <PackageRevision>1</PackageRevision>
-
-    <!-- Suppresses building this project completely during servicing builds. -->
-    <DebBuildDependsOn Condition="'$(IsTargetingPackBuilding)' == 'false'" />
   </PropertyGroup>
 
 </Project>

--- a/src/Installers/Rpm/Directory.Build.targets
+++ b/src/Installers/Rpm/Directory.Build.targets
@@ -37,7 +37,7 @@
   <Target Name="Pack" />
 
   <Target Name="RpmBuild" DependsOnTargets="$(RpmBuildDependsOn)"
-      Condition="!( '$(IsTargetingPackBuilding)' == 'false' AND '$(MSBuildProjectName)' == 'Rpm.TargetingPack' )">
+      Condition=" '$(MSBuildProjectName)' != 'Rpm.TargetingPack' ">
     <!-- Create layout: Create changelog -->
     <PropertyGroup>
       <ChangeLogProps>DATE=$([System.DateTime]::UtcNow.ToString(ddd MMM dd yyyy))</ChangeLogProps>

--- a/src/Installers/Rpm/Directory.Build.targets
+++ b/src/Installers/Rpm/Directory.Build.targets
@@ -36,8 +36,7 @@
   <Target Name="Build" DependsOnTargets="RpmBuild" />
   <Target Name="Pack" />
 
-  <Target Name="RpmBuild" DependsOnTargets="$(RpmBuildDependsOn)"
-      Condition=" '$(MSBuildProjectName)' != 'Rpm.TargetingPack' ">
+  <Target Name="RpmBuild" DependsOnTargets="$(RpmBuildDependsOn)">
     <!-- Create layout: Create changelog -->
     <PropertyGroup>
       <ChangeLogProps>DATE=$([System.DateTime]::UtcNow.ToString(ddd MMM dd yyyy))</ChangeLogProps>

--- a/src/Installers/Rpm/TargetingPack/Rpm.TargetingPack.rpmproj
+++ b/src/Installers/Rpm/TargetingPack/Rpm.TargetingPack.rpmproj
@@ -39,8 +39,5 @@
     <!-- Set package revision to '1' for RTM releases, but include the build number in pre-releases -->
     <PackageRevision Condition=" '$(VersionSuffix)' == '' ">1</PackageRevision>
     <PackageRevision Condition=" '$(VersionSuffix)' != '' ">0.1.$(VersionSuffix.Replace('-', '_'))</PackageRevision>
-
-    <!-- Suppresses building this project completely during servicing builds. -->
-    <RpmBuildDependsOn Condition="'$(IsTargetingPackBuilding)' == 'false'" />
   </PropertyGroup>
 </Project>

--- a/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
+++ b/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
@@ -10,7 +10,6 @@
     <OutputType>Package</OutputType>
     <Cabinet>targeting_pack_$(Platform).cab</Cabinet>
     <IsShipping>true</IsShipping>
-    <SkipCopyToArtifactsDirectory Condition="'$(IsTargetingPackBuilding)' == 'false'">true</SkipCopyToArtifactsDirectory>
     <ProjectGuid>0AC34F1B-8056-4FFB-A398-E6BB7D67B48D</ProjectGuid>
     <HarvestDirectoryAutoGenerateGuids>true</HarvestDirectoryAutoGenerateGuids>
     <HarvestDirectorySuppressSpecificWarnings>5150;5151</HarvestDirectorySuppressSpecificWarnings>
@@ -79,13 +78,9 @@
     <ProductName>Microsoft ASP.NET Core $(PackageBrandingVersion) Targeting Pack ($(Platform))</ProductName>
     <PackageFileName>$(OutputName)$(TargetExt)</PackageFileName>
     <DefineConstants>$(DefineConstants);ProductName=$(ProductName)</DefineConstants>
-
-    <!-- Suppresses building this project completely during servicing builds. -->
-    <BuildDependsOn Condition="'$(IsTargetingPackBuilding)' == 'false'" />
   </PropertyGroup>
 
-   <Target Name="CreateTargetingPackNugetPackage" AfterTargets="CopyToArtifactsDirectory;Build"
-      Condition="'$(IsTargetingPackBuilding)' != 'false'">
+   <Target Name="CreateTargetingPackNugetPackage" AfterTargets="CopyToArtifactsDirectory;Build">
     <PropertyGroup>
       <MsiFullPath>$(InstallersOutputPath)$(PackageFileName)</MsiFullPath>
     </PropertyGroup>

--- a/src/Security/Authentication/test/CertificateTests.cs
+++ b/src/Security/Authentication/test/CertificateTests.cs
@@ -330,7 +330,7 @@ namespace Microsoft.AspNetCore.Authentication.Certificate.Test
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
-        [Fact]
+    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/39669")]
         public async Task VerifyValidClientCertWithTrustedChainAuthenticates()
         {
             using var host = await CreateHost(
@@ -347,7 +347,7 @@ namespace Microsoft.AspNetCore.Authentication.Certificate.Test
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
-        [Fact]
+    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/39669")]
         public async Task VerifyValidClientCertWithAdditionalCertificatesAuthenticates()
         {
             using var host = await CreateHost(

--- a/src/Security/Authentication/test/CertificateTests.cs
+++ b/src/Security/Authentication/test/CertificateTests.cs
@@ -330,7 +330,7 @@ namespace Microsoft.AspNetCore.Authentication.Certificate.Test
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
-    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/39669")]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/39669")]
         public async Task VerifyValidClientCertWithTrustedChainAuthenticates()
         {
             using var host = await CreateHost(
@@ -347,7 +347,7 @@ namespace Microsoft.AspNetCore.Authentication.Certificate.Test
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
-    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/39669")]
+        [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/39669")]
         public async Task VerifyValidClientCertWithAdditionalCertificatesAuthenticates()
         {
             using var host = await CreateHost(

--- a/src/SignalR/clients/ts/FunctionalTests/EchoConnectionHandler.cs
+++ b/src/SignalR/clients/ts/FunctionalTests/EchoConnectionHandler.cs
@@ -4,21 +4,11 @@
 using System.Buffers;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
-using Microsoft.AspNetCore.Http.Connections;
 
 namespace FunctionalTests
 {
     public class EchoConnectionHandler : ConnectionHandler
     {
-        public override async Task OnConnectedAsync(ConnectionContext connection)
-        {
-            var context = connection.GetHttpContext();
-            // The 'withCredentials' tests wont send a cookie for cross-site requests
-            if (!context.WebSockets.IsWebSocketRequest && !context.Request.Cookies.ContainsKey("testCookie"))
-            {
-                return;
-            }
-
             while (true)
             {
                 var result = await connection.Transport.Input.ReadAsync();

--- a/src/SignalR/clients/ts/FunctionalTests/EchoConnectionHandler.cs
+++ b/src/SignalR/clients/ts/FunctionalTests/EchoConnectionHandler.cs
@@ -9,6 +9,8 @@ namespace FunctionalTests
 {
     public class EchoConnectionHandler : ConnectionHandler
     {
+        public override async Task OnConnectedAsync(ConnectionContext connection)
+        {
             while (true)
             {
                 var result = await connection.Transport.Input.ReadAsync();

--- a/src/SignalR/clients/ts/FunctionalTests/ts/ConnectionTests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/ConnectionTests.ts
@@ -185,6 +185,8 @@ describe("connection", () => {
 
                         await connection.start(TransferFormat.Text);
 
+                        await connection.stop();
+
                         await closePromise;
                     });
                 }

--- a/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
@@ -40,16 +40,17 @@ function getConnectionBuilder(transportType?: HttpTransportType, url?: string, o
 describe("hubConnection", () => {
     eachTransportAndProtocolAndHttpClient((transportType, protocol, httpClient) => {
         describe("using " + protocol.name + " over " + HttpTransportType[transportType] + " transport", () => {
-            it("can invoke server method and receive result", async (done) => {
+            it("can invoke server method and receive result", async () => {
                 const message = "你好，世界！";
 
                 const hubConnection = getConnectionBuilder(transportType, undefined, { httpClient })
                     .withHubProtocol(protocol)
                     .build();
 
+                const closePromise = new PromiseSource();
                 hubConnection.onclose((error) => {
                     expect(error).toBeUndefined();
-                    done();
+                    closePromise.resolve();
                 });
 
                 await hubConnection.start();
@@ -57,20 +58,21 @@ describe("hubConnection", () => {
                 expect(result).toBe(message);
 
                 await hubConnection.stop();
-                done();
+                await closePromise;
             });
 
             if (shouldRunHttpsTests) {
-                it("using https, can invoke server method and receive result", async (done) => {
+                it("using https, can invoke server method and receive result", async () => {
                     const message = "你好，世界！";
 
                     const hubConnection = getConnectionBuilder(transportType, TESTHUBENDPOINT_HTTPS_URL, { httpClient })
                         .withHubProtocol(protocol)
                         .build();
 
+                    const closePromise = new PromiseSource();
                     hubConnection.onclose((error) => {
                         expect(error).toBeUndefined();
-                        done();
+                        closePromise.resolve();
                     });
 
                     await hubConnection.start();
@@ -78,30 +80,31 @@ describe("hubConnection", () => {
                     expect(result).toBe(message);
 
                     await hubConnection.stop();
-                    done();
+                    await closePromise;
                 });
             }
 
-            it("can invoke server method non-blocking and not receive result", async (done) => {
+            it("can invoke server method non-blocking and not receive result", async () => {
                 const message = "你好，世界！";
 
                 const hubConnection = getConnectionBuilder(transportType, undefined, { httpClient })
                     .withHubProtocol(protocol)
                     .build();
 
+                const closePromise = new PromiseSource();
                 hubConnection.onclose((error) => {
                     expect(error).toBe(undefined);
-                    done();
+                    closePromise.resolve();
                 });
 
                 await hubConnection.start();
                 await hubConnection.send("Echo", message);
 
                 await hubConnection.stop();
-                done();
+                await closePromise;
             });
 
-            it("can invoke server method structural object and receive structural result", async (done) => {
+            it("can invoke server method structural object and receive structural result", async () => {
                 const hubConnection = getConnectionBuilder(transportType, undefined, { httpClient })
                     .withHubProtocol(protocol)
                     .build();
@@ -112,23 +115,26 @@ describe("hubConnection", () => {
                     await hubConnection.stop();
                 });
 
+                const closePromise = new PromiseSource();
                 hubConnection.onclose((error) => {
                     expect(error).toBe(undefined);
-                    done();
+                    closePromise.resolve();
                 });
 
                 await hubConnection.start();
                 await hubConnection.send("SendCustomObject", { Name: "test", Value: 42 });
+                await closePromise;
             });
 
-            it("can stream server method and receive result", async (done) => {
+            it("can stream server method and receive result", async () => {
                 const hubConnection = getConnectionBuilder(transportType, undefined, { httpClient })
                     .withHubProtocol(protocol)
                     .build();
 
+                const closePromise = new PromiseSource();
                 hubConnection.onclose((error) => {
                     expect(error).toBe(undefined);
-                    done();
+                    closePromise.resolve();
                 });
 
                 const received: string[] = [];
@@ -146,16 +152,18 @@ describe("hubConnection", () => {
                         received.push(item);
                     },
                 });
+                await closePromise;
             });
 
-            it("can stream server method and cancel stream", async (done) => {
+            it("can stream server method and cancel stream", async () => {
                 const hubConnection = getConnectionBuilder(transportType, undefined, { httpClient })
                     .withHubProtocol(protocol)
                     .build();
 
+                const closePromise = new PromiseSource();
                 hubConnection.onclose((error) => {
                     expect(error).toBe(undefined);
-                    done();
+                    closePromise.resolve();
                 });
 
                 hubConnection.on("StreamCanceled", async () => {
@@ -175,9 +183,10 @@ describe("hubConnection", () => {
                 });
 
                 subscription.dispose();
+                await closePromise;
             });
 
-            it("rethrows an exception from the server when invoking", async (done) => {
+            it("rethrows an exception from the server when invoking", async () => {
                 const errorMessage = "An unexpected error occurred invoking 'ThrowException' on the server. InvalidOperationException: An error occurred.";
                 const hubConnection = getConnectionBuilder(transportType, undefined, { httpClient })
                     .withHubProtocol(protocol)
@@ -193,10 +202,9 @@ describe("hubConnection", () => {
                 }
 
                 await hubConnection.stop();
-                done();
             });
 
-            it("throws an exception when invoking streaming method with invoke", async (done) => {
+            it("throws an exception when invoking streaming method with invoke", async () => {
                 const hubConnection = getConnectionBuilder(transportType, undefined, { httpClient })
                     .withHubProtocol(protocol)
                     .build();
@@ -212,10 +220,9 @@ describe("hubConnection", () => {
                 }
 
                 await hubConnection.stop();
-                done();
             });
 
-            it("throws an exception when receiving a streaming result for method called with invoke", async (done) => {
+            it("throws an exception when receiving a streaming result for method called with invoke", async () => {
                 const hubConnection = getConnectionBuilder(transportType, undefined, { httpClient })
                     .withHubProtocol(protocol)
                     .build();
@@ -231,15 +238,15 @@ describe("hubConnection", () => {
                 }
 
                 await hubConnection.stop();
-                done();
             });
 
-            it("rethrows an exception from the server when streaming", async (done) => {
+            it("rethrows an exception from the server when streaming", async () => {
                 const errorMessage = "An unexpected error occurred invoking 'StreamThrowException' on the server. InvalidOperationException: An error occurred.";
                 const hubConnection = getConnectionBuilder(transportType, undefined, { httpClient })
                     .withHubProtocol(protocol)
                     .build();
 
+                const closePromise = new PromiseSource();
                 await hubConnection.start();
                 hubConnection.stream("StreamThrowException", "An error occurred.").subscribe({
                     async complete() {
@@ -249,20 +256,22 @@ describe("hubConnection", () => {
                     async error(err) {
                         expect(err.message).toEqual(errorMessage);
                         await hubConnection.stop();
-                        done();
+                        closePromise.resolve();
                     },
                     async next() {
                         await hubConnection.stop();
                         fail();
                     },
                 });
+                await closePromise;
             });
 
-            it("throws an exception when invoking hub method with stream", async (done) => {
+            it("throws an exception when invoking hub method with stream", async () => {
                 const hubConnection = getConnectionBuilder(transportType, undefined, { httpClient })
                     .withHubProtocol(protocol)
                     .build();
 
+                const closePromise = new PromiseSource();
                 await hubConnection.start();
                 hubConnection.stream("Echo", "42").subscribe({
                     async complete() {
@@ -272,16 +281,18 @@ describe("hubConnection", () => {
                     async error(err) {
                         expect(err.message).toEqual("The client attempted to invoke the non-streaming 'Echo' method with a streaming invocation.");
                         await hubConnection.stop();
-                        done();
+                        closePromise.resolve();
                     },
                     async next() {
                         await hubConnection.stop();
                         fail();
                     },
                 });
+
+                await closePromise;
             });
 
-            it("can receive server calls", async (done) => {
+            it("can receive server calls", async () => {
                 const hubConnection = getConnectionBuilder(transportType, undefined, { httpClient })
                     .withHubProtocol(protocol)
                     .build();
@@ -305,10 +316,9 @@ describe("hubConnection", () => {
                 expect(receiveMsg).toBe(message);
 
                 await hubConnection.stop();
-                done();
             });
 
-            it("can receive server calls without rebinding handler when restarted", async (done) => {
+            it("can receive server calls without rebinding handler when restarted", async () => {
                 const hubConnection = getConnectionBuilder(transportType, undefined, { httpClient })
                     .withHubProtocol(protocol)
                     .build();
@@ -323,6 +333,7 @@ describe("hubConnection", () => {
                 let closeCount = 0;
                 let invocationCount = 0;
 
+                const closePromise = new PromiseSource();
                 hubConnection.onclose(async (e) => {
                     expect(e).toBeUndefined();
                     closeCount += 1;
@@ -333,7 +344,7 @@ describe("hubConnection", () => {
                         await hubConnection.stop();
                     } else {
                         expect(invocationCount).toBe(2);
-                        done();
+                        closePromise.resolve();
                     }
                 });
 
@@ -345,37 +356,41 @@ describe("hubConnection", () => {
                 await hubConnection.start();
                 await hubConnection.invoke("InvokeWithString", message);
                 await hubConnection.stop();
+                await closePromise;
             });
 
-            it("closed with error or start fails if hub cannot be created", async (done) => {
+            it("closed with error or start fails if hub cannot be created", async () => {
                 const hubConnection = getConnectionBuilder(transportType, ENDPOINT_BASE_URL + "/uncreatable", { httpClient })
                     .withHubProtocol(protocol)
                     .build();
 
                 const expectedErrorMessage = "Server returned an error on close: Connection closed with an error. InvalidOperationException: Unable to resolve service for type 'System.Object' while attempting to activate 'FunctionalTests.UncreatableHub'.";
 
+                const closePromise = new PromiseSource();
                 // Either start will fail or onclose will be called. Never both.
                 hubConnection.onclose((error) => {
                     expect(error!.message).toEqual(expectedErrorMessage);
-                    done();
+                    closePromise.resolve();
                 });
 
                 try {
                     await hubConnection.start();
                 } catch (error) {
                     expect(error!.message).toEqual(expectedErrorMessage);
-                    done();
+                    closePromise.resolve();
                 }
+                await closePromise;
             });
 
-            it("can handle different types", async (done) => {
+            it("can handle different types", async () => {
                 const hubConnection = getConnectionBuilder(transportType, undefined, { httpClient })
                     .withHubProtocol(protocol)
                     .build();
 
+                const closePromise = new PromiseSource();
                 hubConnection.onclose((error) => {
                     expect(error).toBe(undefined);
-                    done();
+                    closePromise.resolve();
                 });
 
                 const complexObject = {
@@ -395,16 +410,18 @@ describe("hubConnection", () => {
                 expect(value).toEqual(complexObject);
 
                 await hubConnection.stop();
+                await closePromise;
             });
 
-            it("can receive different types", async (done) => {
+            it("can receive different types", async () => {
                 const hubConnection = getConnectionBuilder(transportType, undefined, { httpClient })
                     .withHubProtocol(protocol)
                     .build();
 
+                const closePromise = new PromiseSource();
                 hubConnection.onclose((error) => {
                     expect(error).toBe(undefined);
-                    done();
+                    closePromise.resolve();
                 });
 
                 const complexObject = {
@@ -424,9 +441,10 @@ describe("hubConnection", () => {
                 expect(value).toEqual(complexObject);
 
                 await hubConnection.stop();
+                await closePromise;
             });
 
-            it("can be restarted", async (done) => {
+            it("can be restarted", async () => {
                 const message = "你好，世界！";
 
                 const hubConnection = getConnectionBuilder(transportType, undefined, { httpClient })
@@ -434,6 +452,7 @@ describe("hubConnection", () => {
                     .build();
 
                 let closeCount = 0;
+                const closePromise = new PromiseSource();
                 hubConnection.onclose(async (error) => {
                     expect(error).toBe(undefined);
 
@@ -445,7 +464,7 @@ describe("hubConnection", () => {
                         expect(value).toBe(message);
                         await hubConnection.stop();
                     } else {
-                        done();
+                        closePromise.resolve();
                     }
                 });
 
@@ -454,9 +473,10 @@ describe("hubConnection", () => {
                 expect(result).toBe(message);
 
                 await hubConnection.stop();
+                await closePromise;
             });
 
-            it("can stream from client to server with rxjs", async (done) => {
+            it("can stream from client to server with rxjs", async () => {
                 const hubConnection = getConnectionBuilder(transportType, undefined, { httpClient })
                     .withHubProtocol(protocol)
                     .build();
@@ -470,10 +490,9 @@ describe("hubConnection", () => {
                 subject.complete();
                 expect(await resultPromise).toBe("Hello world!");
                 await hubConnection.stop();
-                done();
             });
 
-            it("can stream from client to server and close with error with rxjs", async (done) => {
+            it("can stream from client to server and close with error with rxjs", async () => {
                 const hubConnection = getConnectionBuilder(transportType, undefined, { httpClient })
                     .withHubProtocol(protocol)
                     .build();
@@ -493,7 +512,6 @@ describe("hubConnection", () => {
                 } finally {
                     await hubConnection.stop();
                 }
-                done();
             });
         });
     });
@@ -501,7 +519,7 @@ describe("hubConnection", () => {
     eachTransport((transportType) => {
         describe("over " + HttpTransportType[transportType] + " transport", () => {
 
-            it("can connect to hub with authorization", async (done) => {
+            it("can connect to hub with authorization", async () => {
                 const message = "你好，世界！";
 
                 try {
@@ -511,9 +529,10 @@ describe("hubConnection", () => {
                         accessTokenFactory: () => jwtToken,
                     }).build();
 
+                    const closePromise = new PromiseSource();
                     hubConnection.onclose((error) => {
                         expect(error).toBe(undefined);
-                        done();
+                        closePromise.resolve();
                     });
                     await hubConnection.start();
                     const response = await hubConnection.invoke("Echo", message);
@@ -522,14 +541,13 @@ describe("hubConnection", () => {
 
                     await hubConnection.stop();
 
-                    done();
+                    await closePromise;
                 } catch (err) {
                     fail(err);
-                    done();
                 }
             });
 
-            it("can connect to hub with authorization using async token factory", async (done) => {
+            it("can connect to hub with authorization using async token factory", async () => {
                 const message = "你好，世界！";
 
                 try {
@@ -537,9 +555,10 @@ describe("hubConnection", () => {
                         accessTokenFactory: () => getJwtToken(ENDPOINT_BASE_URL + "/generateJwtToken"),
                     }).build();
 
+                    const closePromise = new PromiseSource();
                     hubConnection.onclose((error) => {
                         expect(error).toBe(undefined);
-                        done();
+                        closePromise.resolve();
                     });
                     await hubConnection.start();
                     const response = await hubConnection.invoke("Echo", message);
@@ -548,20 +567,18 @@ describe("hubConnection", () => {
 
                     await hubConnection.stop();
 
-                    done();
+                    await closePromise;
                 } catch (err) {
                     fail(err);
-                    done();
                 }
             });
 
-            it("can get error from unauthorized hub connection", async (done) => {
+            it("can get error from unauthorized hub connection", async () => {
                 try {
                     const hubConnection = getConnectionBuilder(transportType, ENDPOINT_BASE_URL + "/authorizedhub").build();
 
                     hubConnection.onclose((error) => {
                         expect(error).toBe(undefined);
-                        done();
                     });
 
                     await hubConnection.start();
@@ -569,17 +586,17 @@ describe("hubConnection", () => {
                     fail("shouldn't reach here");
                 } catch (err) {
                     expect(err).toEqual(new Error("Failed to complete negotiation with the server: Error: Unauthorized: Status code '401'"));
-                    done();
                 }
             });
 
             if (transportType !== HttpTransportType.LongPolling) {
-                it("terminates if no messages received within timeout interval", async (done) => {
+                it("terminates if no messages received within timeout interval", async () => {
                     const hubConnection = getConnectionBuilder(transportType).build();
 
+                    const closePromise = new PromiseSource();
                     hubConnection.onclose((error) => {
                         expect(error).toEqual(new Error("Server timeout elapsed without receiving a message from the server."));
-                        done();
+                        closePromise.resolve();
                     });
 
                     await hubConnection.start();
@@ -589,30 +606,31 @@ describe("hubConnection", () => {
 
                     // invoke a method with a response to reset the timeout using the new value
                     await hubConnection.invoke("Echo", "");
+                    await closePromise;
                 });
             }
 
-            it("preserves cookies between requests", async (done) => {
-                const hubConnection = getConnectionBuilder(transportType, HTTPORHTTPS_TESTHUBENDPOINT_URL).build();
-                await hubConnection.start();
-                const cookieValue = await hubConnection.invoke<string>("GetCookie", "testCookie");
-                const cookieValue2 = await hubConnection.invoke<string>("GetCookie", "testCookie2");
-                expect(cookieValue).toEqual("testValue");
-                expect(cookieValue2).toEqual("testValue2");
-                await hubConnection.stop();
-                done();
-            });
+            if (shouldRunHttpsTests) {
+                it("preserves cookies between requests", async () => {
+                    const hubConnection = getConnectionBuilder(transportType, HTTPORHTTPS_TESTHUBENDPOINT_URL).build();
+                    await hubConnection.start();
+                    const cookieValue = await hubConnection.invoke<string>("GetCookie", "testCookie");
+                    const cookieValue2 = await hubConnection.invoke<string>("GetCookie", "testCookie2");
+                    expect(cookieValue).toEqual("testValue");
+                    expect(cookieValue2).toEqual("testValue2");
+                    await hubConnection.stop();
+                });
+            }
 
-            it("expired cookies are not preserved", async (done) => {
+            it("expired cookies are not preserved", async () => {
                 const hubConnection = getConnectionBuilder(transportType, HTTPORHTTPS_TESTHUBENDPOINT_URL).build();
                 await hubConnection.start();
                 const cookieValue = await hubConnection.invoke<string>("GetCookie", "expiredCookie");
                 expect(cookieValue).toBeNull();
                 await hubConnection.stop();
-                done();
             });
 
-            it("can reconnect", async (done) => {
+            it("can reconnect", async () => {
                 try {
                     const reconnectingPromise = new PromiseSource();
                     const reconnectedPromise = new PromiseSource<string | undefined>();
@@ -645,16 +663,13 @@ describe("hubConnection", () => {
                     expect(response).toEqual("test");
 
                     await hubConnection.stop();
-
-                    done();
                 } catch (err) {
                     fail(err);
-                    done();
                 }
             });
         });
 
-        it("can change url in reconnecting state", async (done) => {
+        it("can change url in reconnecting state", async () => {
             try {
                 const reconnectingPromise = new PromiseSource();
                 const hubConnection = getConnectionBuilder(transportType)
@@ -676,16 +691,13 @@ describe("hubConnection", () => {
                 expect(hubConnection.baseUrl).toBe("http://example123.com");
 
                 await hubConnection.stop();
-
-                done();
             } catch (err) {
                 fail(err);
-                done();
             }
         });
     });
 
-    it("can reconnect after negotiate redirect", async (done) => {
+    it("can reconnect after negotiate redirect", async () => {
         try {
             const reconnectingPromise = new PromiseSource();
             const reconnectedPromise = new PromiseSource<string | undefined>();
@@ -723,15 +735,12 @@ describe("hubConnection", () => {
             expect(postReconnectRedirects).toBeGreaterThan(preReconnectRedirects);
 
             await hubConnection.stop();
-
-            done();
         } catch (err) {
             fail(err);
-            done();
         }
     });
 
-    it("can reconnect after skipping negotiation", async (done) => {
+    it("can reconnect after skipping negotiation", async () => {
         try {
             const reconnectingPromise = new PromiseSource();
             const reconnectedPromise = new PromiseSource<string | undefined>();
@@ -766,15 +775,12 @@ describe("hubConnection", () => {
             expect(response).toEqual("test");
 
             await hubConnection.stop();
-
-            done();
         } catch (err) {
             fail(err);
-            done();
         }
     });
 
-    it("connection id matches server side connection id", async (done) => {
+    it("connection id matches server side connection id", async () => {
         try {
             const reconnectingPromise = new PromiseSource();
             const reconnectedPromise = new PromiseSource<string | undefined>();
@@ -813,15 +819,12 @@ describe("hubConnection", () => {
 
             await hubConnection.stop();
             expect(hubConnection.connectionId).toBeNull();
-
-            done();
         } catch (err) {
             fail(err);
-            done();
         }
     });
 
-    it("connection id is alwys null is negotiation is skipped", async (done) => {
+    it("connection id is alwys null is negotiation is skipped", async () => {
         try {
             const hubConnection = getConnectionBuilder(
                     HttpTransportType.WebSockets,
@@ -839,16 +842,13 @@ describe("hubConnection", () => {
             await hubConnection.stop();
 
             expect(hubConnection.connectionId).toBeNull();
-
-            done();
         } catch (err) {
             fail(err);
-            done();
         }
     });
 
     if (typeof EventSource !== "undefined") {
-        it("allows Server-Sent Events when negotiating for JSON protocol", async (done) => {
+        it("allows Server-Sent Events when negotiating for JSON protocol", async () => {
             const hubConnection = getConnectionBuilder(undefined, TESTHUB_NOWEBSOCKETS_ENDPOINT_URL)
                 .withHubProtocol(new JsonHubProtocol())
                 .build();
@@ -860,14 +860,13 @@ describe("hubConnection", () => {
                 expect(await hubConnection.invoke("GetActiveTransportName")).toEqual("ServerSentEvents");
 
                 await hubConnection.stop();
-                done();
             } catch (e) {
                 fail(e);
             }
         });
     }
 
-    it("skips Server-Sent Events when negotiating for MessagePack protocol", async (done) => {
+    it("skips Server-Sent Events when negotiating for MessagePack protocol", async () => {
         const hubConnection = getConnectionBuilder(undefined, TESTHUB_NOWEBSOCKETS_ENDPOINT_URL)
             .withHubProtocol(new MessagePackHubProtocol())
             .build();
@@ -879,16 +878,14 @@ describe("hubConnection", () => {
             expect(await hubConnection.invoke("GetActiveTransportName")).toEqual("LongPolling");
 
             await hubConnection.stop();
-            done();
         } catch (e) {
             fail(e);
         }
     });
 
-    it("transport falls back from WebSockets to SSE or LongPolling", async (done) => {
+    it("transport falls back from WebSockets to SSE or LongPolling", async () => {
         // Skip test on Node as there will always be a WebSockets implementation on Node
         if (typeof window === "undefined") {
-            done();
             return;
         }
 
@@ -914,11 +911,10 @@ describe("hubConnection", () => {
             fail(e);
         } finally {
             (window as any).WebSocket = oldWebSocket;
-            done();
         }
     });
 
-    it("over LongPolling it sends DELETE request and waits for poll to terminate", async (done) => {
+    it("over LongPolling it sends DELETE request and waits for poll to terminate", async () => {
         // Create an HTTP client to capture the poll
         const defaultClient = new DefaultHttpClient(TestLogger.instance);
 
@@ -966,14 +962,12 @@ describe("hubConnection", () => {
         } catch (e) {
             fail(e);
         } finally {
-            done();
         }
     });
 
-    it("populates the Content-Type header when sending XMLHttpRequest", async (done) => {
+    it("populates the Content-Type header when sending XMLHttpRequest", async () => {
         // Skip test on Node as this header isn't set (it was added for React-Native)
         if (typeof window === "undefined") {
-            done();
             return;
         }
         const hubConnection = getConnectionBuilder(HttpTransportType.LongPolling, TESTHUB_NOWEBSOCKETS_ENDPOINT_URL)
@@ -989,14 +983,13 @@ describe("hubConnection", () => {
             expect(await hubConnection.invoke("GetContentTypeHeader")).toEqual("text/plain;charset=UTF-8");
 
             await hubConnection.stop();
-            done();
         } catch (e) {
             fail(e);
         }
     });
 
     eachTransport((t) => {
-        it("sets the user agent header", async (done) => {
+        it("sets the user agent header", async () => {
             const hubConnection = getConnectionBuilder(t, TESTHUBENDPOINT_URL)
                 .withHubProtocol(new JsonHubProtocol())
                 .build();
@@ -1015,13 +1008,12 @@ describe("hubConnection", () => {
                 }
 
                 await hubConnection.stop();
-                done();
             } catch (e) {
                 fail(e);
             }
         });
 
-        it("overwrites library headers with user headers", async (done) => {
+        it("overwrites library headers with user headers", async () => {
             const [name] = getUserAgentHeader();
             const headers = { [name]: "Custom Agent", "X-HEADER": "VALUE" };
             const hubConnection = getConnectionBuilder(t, TESTHUBENDPOINT_URL, { headers })
@@ -1043,7 +1035,6 @@ describe("hubConnection", () => {
                 }
 
                 await hubConnection.stop();
-                done();
             } catch (e) {
                 fail(e);
             }

--- a/src/SignalR/clients/ts/signalr/src/Utils.ts
+++ b/src/SignalR/clients/ts/signalr/src/Utils.ts
@@ -288,7 +288,7 @@ export function getErrorString(e: any): string {
 }
 
 /** @private */
-export function getGlobalThis() {
+export function getGlobalThis(): unknown {
     // globalThis is semi-new and not available in Node until v12
     if (typeof globalThis !== "undefined") {
         return globalThis;

--- a/src/SiteExtensions/LoggingBranch/LB.csproj
+++ b/src/SiteExtensions/LoggingBranch/LB.csproj
@@ -25,15 +25,9 @@
     <HostingStartupRuntimeStoreTargets Include="$(DefaultNetCoreTargetFramework)" Runtime="$(TargetRuntimeIdentifier)" />
 
     <ProjectReference Include="..\..\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
-        Condition=" $(IsTargetingPackBuilding) ">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
-        Condition=" !$(IsTargetingPackBuilding) ">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-    </ProjectReference>
+      Private="false"
+      ReferenceOutputAssembly="false"
+      SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
 
   <!-- Cannot assume this project and Microsoft.AspNetCore.AzureAppServices.HostingStartup have the same package version. -->


### PR DESCRIPTION
# [release/6.0] Always build App.Ref and the targeting packs

- remove `$(IsTargetingPackBuilding)` entirely
- 6.0.x version of #39568

## Description

Remove `$(IsTargetingPackBuilding)` settings and remove all use of the property. For example, it's not necessary to reference Microsoft.AspNetCore.App.Runtime.csproj when Microsoft.AspNetCore.App.Ref.csproj won't build; references to Microsoft.AspNetCore.App.Ref.csproj are all we need.

In detail:
- where `Condition`s were positive (`$(IsTargetingPackBuilding)` or `$(IsTargetingPackBuilding)' == 'true'`), remove the `Condition` or its relevant portion
- otherwise, (`! $(IsTargetingPackBuilding)` or `$(IsTargetingPackBuilding)' != 'true'`), remove the affected block or the relevant portion of the `Condition`

nit: simplify any leftover `Condition`s if possible

Fixes #39471

## Customer Impact

Without this change, we're unable to create source-build tarballs except with significant hacks.

We also realized skipping builds of the &hellip;Ref packages and targeting pack installers would be uncommon given their new analyzer and code generator content in 6.0.x. Decided always building these assets simplified everything in the relevant repos.

In this repo, not releasing the targeting packs was a major exception. We build and pack everything else for every release and have since 3.1.0.

## Regression?

- [ ] Yes
- [x] No

The main difference from 5.0.x in this release is the analyzer and code generator assemblies in our targeting packs. This content makes it easier to justify building the targeting packs for every release.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

This PR removes some complexity from our build and should simplify our release process.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

This PR does not change individual packages. It just ensures Microsoft.AspNetCore.App.Ref.nupkg and our targeting pack installers are always created.

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props