### PR TITLE
Fix typo in localization file

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/zh-CN/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/zh-CN/strings.json
@@ -4,7 +4,7 @@
     "name": "ASP.NET Core Web API",
     "description": "用于创建包含 RESTful HTTP 服务示例控制器的 ASP.NET Core 应用程序的项目模板。此模板还可以用于 ASP.NET Core MVC 视图和控制器。",
     "parameter.DisableOpenAPI.name": "启用 OpenAPI 支持(_O)",
-    "parameter.DisableOpenAPI.description": "启用 OpenAI (Swagger)支持",
+    "parameter.DisableOpenAPI.description": "启用 OpenAPI (Swagger)支持",
     "parameter.UseMinimalAPIs.name": "使用控制器(取消选中以使用最小 API)",
     "parameter.UseMinimalAPIs.description": "是否使用最小 API 而不是控制器。"
   }


### PR DESCRIPTION
## Description

Fixes a typo in the localization file for templates that manifested in the VS UI.

Closes https://github.com/dotnet/aspnetcore/issues/39529.

## Customer Impact

This PR fixes a low-stakes typo that might be confusing to some users interacting with the OpenAPI flag for VS users using simplified Chinese translations.

## Regression?

- [X] Yes
- [ ] No

This typo was introduced in a template change in 6.0.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

This change is a "cosmetic" change to the translation files and doesn't affect any behavior.

## Verification

- [X] Manual (required)
- [ ] Automated