### PR TITLE
Declare readonly members for mutable structs

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
@@ -243,11 +243,11 @@ internal sealed partial class HttpRequestHeaders : HttpHeaders
                 : default;
         }
 
-        public KeyValuePair<string, StringValues> Current => _current;
+        public readonly KeyValuePair<string, StringValues> Current => _current;
 
-        object IEnumerator.Current => _current;
+        readonly object IEnumerator.Current => _current;
 
-        public void Dispose()
+        public readonly void Dispose()
         {
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseHeaders.cs
@@ -161,13 +161,13 @@ internal sealed partial class HttpResponseHeaders : HttpHeaders
                 : default;
         }
 
-        public KeyValuePair<string, StringValues> Current => _current;
+        public readonly KeyValuePair<string, StringValues> Current => _current;
 
-        internal KnownHeaderType CurrentKnownType => _currentKnownType;
+        internal readonly KnownHeaderType CurrentKnownType => _currentKnownType;
 
-        object IEnumerator.Current => _current;
+        readonly object IEnumerator.Current => _current;
 
-        public void Dispose()
+        public readonly void Dispose()
         {
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseTrailers.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpResponseTrailers.cs
@@ -69,13 +69,13 @@ internal partial class HttpResponseTrailers : HttpHeaders
                 : default;
         }
 
-        public KeyValuePair<string, StringValues> Current => _current;
+        public readonly KeyValuePair<string, StringValues> Current => _current;
 
-        internal KnownHeaderType CurrentKnownType => _currentKnownType;
+        internal readonly KnownHeaderType CurrentKnownType => _currentKnownType;
 
-        object IEnumerator.Current => _current;
+        readonly object IEnumerator.Current => _current;
 
-        public void Dispose()
+        public readonly void Dispose()
         {
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/FlowControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/FlowControl/FlowControl.cs
@@ -15,8 +15,8 @@ internal struct FlowControl
         IsAborted = false;
     }
 
-    public int Available { get; private set; }
-    public bool IsAborted { get; private set; }
+    public int Available { readonly get; private set; }
+    public bool IsAborted { readonly get; private set; }
 
     public void Advance(int bytes)
     {

--- a/src/Servers/Kestrel/shared/PooledStreamStack.cs
+++ b/src/Servers/Kestrel/shared/PooledStreamStack.cs
@@ -27,7 +27,7 @@ internal struct PooledStreamStack<TValue> where TValue : class, IPooledStream
         _size = 0;
     }
 
-    public int Count => _size;
+    public readonly int Count => _size;
 
     public bool TryPop([NotNullWhen(true)] out TValue? result)
     {

--- a/src/Shared/Buffers/BufferSegmentStack.cs
+++ b/src/Shared/Buffers/BufferSegmentStack.cs
@@ -18,7 +18,7 @@ internal struct BufferSegmentStack
         _size = 0;
     }
 
-    public int Count => _size;
+    public readonly int Count => _size;
 
     public bool TryPop([NotNullWhen(true)] out BufferSegment? result)
     {

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -970,7 +970,7 @@ internal abstract class CertificateManager
     {
     }
 
-    internal struct CheckCertificateStateResult
+    internal readonly struct CheckCertificateStateResult
     {
         public bool Success { get; }
         public string? FailureMessage { get; }

--- a/src/Shared/ServerInfrastructure/BufferWriter.cs
+++ b/src/Shared/ServerInfrastructure/BufferWriter.cs
@@ -49,12 +49,12 @@ internal ref struct BufferWriter<T> where T : IBufferWriter<byte>
     /// <summary>
     /// Gets the result of the last call to <see cref="IBufferWriter{T}.GetSpan(int)"/>.
     /// </summary>
-    public Span<byte> Span => _span;
+    public readonly Span<byte> Span => _span;
 
     /// <summary>
     /// Gets the total number of bytes written with this writer.
     /// </summary>
-    public long BytesCommitted => _bytesCommitted;
+    public readonly long BytesCommitted => _bytesCommitted;
 
     /// <summary>
     /// Calls <see cref="IBufferWriter{T}.Advance(int)"/> on the underlying writer


### PR DESCRIPTION
On Kestrel solution, apply https://docs.microsoft.com/en-us/dotnet/csharp/write-safe-efficient-code#declare-readonly-members-for-mutable-structs