### PR TITLE
Unconditionally enable `DebBuild` and `RpmBuild`

### DIFF
--- a/src/Installers/Debian/Directory.Build.targets
+++ b/src/Installers/Debian/Directory.Build.targets
@@ -27,8 +27,7 @@
   <Target Name="Build" DependsOnTargets="DebBuild" />
   <Target Name="Pack" />
 
-  <Target Name="DebBuild" DependsOnTargets="$(DebBuildDependsOn)"
-      Condition=" '$(MSBuildProjectName)' != 'Debian.TargetingPack' ">
+  <Target Name="DebBuild" DependsOnTargets="$(DebBuildDependsOn)">
     <!-- Generate debian_config.json. We can't simply use WriteLinesToFile because of https://github.com/Microsoft/msbuild/issues/1622. Use our custom GenerateFileFromTemplate task instead -->
     <PropertyGroup>
       <DebianConfigProperties>

--- a/src/Installers/Rpm/Directory.Build.targets
+++ b/src/Installers/Rpm/Directory.Build.targets
@@ -36,8 +36,7 @@
   <Target Name="Build" DependsOnTargets="RpmBuild" />
   <Target Name="Pack" />
 
-  <Target Name="RpmBuild" DependsOnTargets="$(RpmBuildDependsOn)"
-      Condition=" '$(MSBuildProjectName)' != 'Rpm.TargetingPack' ">
+  <Target Name="RpmBuild" DependsOnTargets="$(RpmBuildDependsOn)">
     <!-- Create layout: Create changelog -->
     <PropertyGroup>
       <ChangeLogProps>DATE=$([System.DateTime]::UtcNow.ToString(ddd MMM dd yyyy))</ChangeLogProps>


### PR DESCRIPTION
- address a build issue mentioned in dotnet/aspnetcore-internal#3988
- I accidentally disabled these targets for targeting packs in 08968dd0d6ab