### PR TITLE
Fix logger variable name in ViewComponentResultExecutor

### DIFF
--- a/src/Mvc/Mvc.ViewFeatures/src/ViewComponentResultExecutor.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/ViewComponentResultExecutor.cs
@@ -183,7 +183,7 @@ public partial class ViewComponentResultExecutor : IActionResultExecutor<ViewCom
         }
         else
         {
-            Log.ViewComponentResultExecuting(_logger, result.ViewComponentType);
+            Log.ViewComponentResultExecuting(logger, result.ViewComponentType);
             return viewComponentHelper.InvokeAsync(result.ViewComponentType, result.Arguments);
         }
     }


### PR DESCRIPTION
Fix logger variable name in ViewComponentResultExecutor

Fixes issue with #38658
