### PR TITLE
Add dark mode for developer exception page

### DIFF
--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/Views/ErrorPage.css
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/Views/ErrorPage.css
@@ -202,3 +202,70 @@ a {
     border: 0;
     margin: 0;
 }
+
+@media (prefers-color-scheme: dark) {
+    body {
+        color: #dcdcdc;
+        background-color: #222;
+    }
+
+    h1 {
+        color: #9dacb8;
+    }
+
+    h3 {
+        color: #c7c7c7;
+    }
+
+    #header {
+        border-top-color: #444;
+        border-bottom-color: #444;
+    }
+
+    #header .selected {
+        color: #222;
+    }
+
+    #stackpage .details {
+        color: #000;
+    }
+
+    #stackpage .stackerror {
+        border-bottom-color: #444;
+    }
+
+    #stackpage .source ol li {
+        background-color: #1c1c1c;
+    }
+
+    #stackpage .frame .source .highlight {
+        border-left-color: #C53731;
+    }
+
+    #stackpage .frame .source .highlight li span {
+        color: #C53731;
+    }
+
+    #stackpage .source ol.collapsible li span {
+        color: #9B9B9B;
+    }
+
+    #routingpage .subheader {
+        border-bottom-color: #444;
+    }
+
+    .page th, .page td {
+        border-right-color: #444;
+        border-bottom-color: #444;
+    }
+
+    .rawExceptionBlock {
+        border-top-color: #444;
+        border-bottom-color: #444;
+    }
+
+    .expandCollapseButton {
+        background-color: #444;
+        color: inherit;
+    }
+}


### PR DESCRIPTION
This pull request provides **dark mode** for the exception page provided by the developer exception middleware. Apparently, there is now a Google Chrome extension that provides this on the client-side, and [@blowdart suggested on Twitter](https://twitter.com/blowdart/status/1484354667538620418) to simply provide the necessary style adjustments directly.

So here it is. I didn’t follow the colors that the extension uses (I didn’t even *try* the extension to be honest and I also didn’t find public source code for it) but tried to come up with my own sensible colors for a dark mode scheme. Some colors are loosely based on the VS color scheme.

Here are two screenshots that show off the colors:

![“Stack” view of the developer exception page](https://user-images.githubusercontent.com/132240/150554181-54691ea0-3953-40a6-810c-cb78f4931ad1.png)
![“Routing” view of the developer exception page](https://user-images.githubusercontent.com/132240/150554190-68303457-9e07-4749-b292-843eae9503eb.png)

In the implementation, I just provided a media section for now that overrides all relevant colors (some are untouched because they fit). I didn’t bother investing into CSS variables here, a solution that often makes color schemes a bit nicer to handle, since I didn’t know what your target browser requirements are. Switching to variables there would either mean having to provide fallbacks (which would increase the size of the style sheet), or introducing *some* kind of breaking change for the browser support (though support for [variables is pretty good](https://caniuse.com/css-variables) nowadays).

Anyway, if you prefer to have it in a different style, e.g. using/introducing CSS variables, or mixing the color overrides into the normal styles above, let me know and I’m happy to adjust the style declarations.