### PR TITLE
Move some targets into a Directory.Build.targets file

### DIFF
--- a/src/Servers/IIS/IIS/test/Directory.Build.props
+++ b/src/Servers/IIS/IIS/test/Directory.Build.props
@@ -2,13 +2,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
-    <!-- Tests do not work on Helix or when bin/ directory is not in project directory due to undeclared dependency on test content. -->
-    <BaseOutputPath />
-    <OutputPath />
-
     <!-- IIS tests are Windows-only -->
     <IsWindowsOnlyTest>true</IsWindowsOnlyTest>
     <TestDependsOnIIS>true</TestDependsOnIIS>
   </PropertyGroup>
-
 </Project>

--- a/src/Servers/IIS/IIS/test/Directory.Build.props
+++ b/src/Servers/IIS/IIS/test/Directory.Build.props
@@ -2,8 +2,13 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
+    <!-- Tests do not work on Helix or when bin/ directory is not in project directory due to undeclared dependency on test content. -->
+    <BaseOutputPath />
+    <OutputPath />
+
     <!-- IIS tests are Windows-only -->
     <IsWindowsOnlyTest>true</IsWindowsOnlyTest>
     <TestDependsOnIIS>true</TestDependsOnIIS>
   </PropertyGroup>
+
 </Project>

--- a/src/Servers/IIS/IIS/test/testassets/Directory.Build.targets
+++ b/src/Servers/IIS/IIS/test/testassets/Directory.Build.targets
@@ -1,0 +1,48 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.targets))\Directory.Build.targets" />
+
+  <PropertyGroup>
+    <!-- Work around until we get a new WebSdk -->
+    <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
+
+    <HasTestAssetProfile Condition="'$(TestAssetProfile)' != ''">true</HasTestAssetProfile>
+    <TestAssetOutputName>$(MSBuildProjectName)</TestAssetOutputName>
+  </PropertyGroup>
+
+  <Target Name="PreventProjectReferencesFromBuilding" BeforeTargets="BeforeResolveReferences" Condition="'@(TestAssetPublishProfile->Count())' != '0'">
+    <PropertyGroup>
+      <BuildProjectReferences Condition="'$(HasTestAssetProfile)' == 'true'">false</BuildProjectReferences>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="PrepareForTestAssetPublish" BeforeTargets="PrepareForPublish" Condition="'@(TestAssetPublishProfile->Count())' != '0'">
+    <PropertyGroup Condition="'$(HasTestAssetProfile)' == 'true'">
+      <PublishDir>$(PublishDir)\$(TestAssetOutputName)-$(TestAssetProfile)\</PublishDir>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(HasTestAssetProfile)' != 'true'">
+      <IsPublishable>false</IsPublishable>
+      <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="PublishTestsAsset" DependsOnTargets="Publish" Returns="@(PublishedTestAsset)">
+    <ConvertToAbsolutePath Paths="$(PublishDir)">
+      <Output TaskParameter="AbsolutePaths" PropertyName="PublishAbsoluteDir" />
+    </ConvertToAbsolutePath>
+
+    <ItemGroup>
+      <PublishedTestAsset Include="$(TestAssetOutputName)-$(TestAssetProfile)" Path="$(PublishAbsoluteDir)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="PublishTestsAssets" Condition="'$(TestAssetProfile)' == '' AND '@(TestAssetPublishProfile->Count())' != '0'" Returns="@(PublishedTestAsset)">
+    <!-- Platform;PlatformTarget removal is to fix builds inside VS. -->
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="PublishTestsAsset"
+             RemoveProperties="Platform;PlatformTarget"
+             Properties="PublishDir=$(PublishDir);TestAssetProfile=%(TestAssetPublishProfile.Identity);ReferenceTestTasks=false;%(TestAssetPublishProfile.Properties)">
+      <Output TaskParameter="TargetOutputs" ItemName="PublishedTestAsset" />
+    </MSBuild>
+  </Target>
+</Project>

--- a/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <Import Project="..\..\..\..\build\testsite.props" />
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <AssemblyName>InProcessWebSite</AssemblyName>
-    <TestAssetOutputName>InProcessNewShimWebSite</TestAssetOutputName>
     <DefineConstants>FORWARDCOMPAT</DefineConstants>
     <CompileUsingReferenceAssemblies>false</CompileUsingReferenceAssemblies>
     <ImplicitUsings>disable</ImplicitUsings>
@@ -61,5 +59,4 @@
     </PackageReference>
     <Reference Include="xunit.assert" />
   </ItemGroup>
-
 </Project>

--- a/src/Servers/IIS/build/testsite.props
+++ b/src/Servers/IIS/build/testsite.props
@@ -1,15 +1,10 @@
 <Project>
-
   <PropertyGroup>
     <RuntimeIdentifiers>$(RuntimeIdentifiers);win-x64;win-x86</RuntimeIdentifiers>
     <Platforms>x64;x86</Platforms>
     <IISExpressAppHostConfig>$(MSBuildThisFileDirectory)applicationhost.config</IISExpressAppHostConfig>
     <IISAppHostConfig>$(MSBuildThisFileDirectory)applicationhost.iis.config</IISAppHostConfig>
     <PreserveCompilationContext>false</PreserveCompilationContext>
-    <!-- Work around until we get a new WebSdk -->
-    <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
-    <HasTestAssetProfile Condition="'$(TestAssetProfile)' != ''">true</HasTestAssetProfile>
-    <TestAssetOutputName Condition="'$(TestAssetOutputName)' == ''">$(MSBuildProjectName)</TestAssetOutputName>
   </PropertyGroup>
 
   <Import Project="assets.props" />
@@ -80,42 +75,5 @@
           BeforeTargets="Publish"
           DependsOnTargets="GeneratePublishDependencyFile;CopyFilesToPublishDirectory;PrepareInjectionApp">
     <Exec Command="$(InjectDepsApp) &quot;$(PublishDepsFilePath)&quot; $(RuntimeIdentifier) " />
-  </Target>
-
-  <Target Name="PreventProjectReferencesFromBuilding" BeforeTargets="BeforeResolveReferences" Condition="'@(TestAssetPublishProfile->Count())' != '0'">
-    <PropertyGroup>
-      <BuildProjectReferences Condition="'$(HasTestAssetProfile)' == 'true'">false</BuildProjectReferences>
-    </PropertyGroup>
-  </Target>
-
-  <Target Name="PrepareForTestAssetPublish" BeforeTargets="PrepareForPublish" Condition="'@(TestAssetPublishProfile->Count())' != '0'">
-    <PropertyGroup Condition="'$(HasTestAssetProfile)' == 'true'">
-      <PublishDir>$(PublishDir)\$(TestAssetOutputName)-$(TestAssetProfile)\</PublishDir>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(HasTestAssetProfile)' != 'true'">
-      <IsPublishable>false</IsPublishable>
-      <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>
-    </PropertyGroup>
-  </Target>
-
-  <Target Name="PublishTestsAsset" DependsOnTargets="Publish" Returns="@(PublishedTestAsset)">
-    <ConvertToAbsolutePath Paths="$(PublishDir)">
-      <Output TaskParameter="AbsolutePaths" PropertyName="PublishAbsoluteDir" />
-    </ConvertToAbsolutePath>
-
-    <ItemGroup>
-      <PublishedTestAsset Include="$(TestAssetOutputName)-$(TestAssetProfile)" Path="$(PublishAbsoluteDir)" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="PublishTestsAssets" Condition="'$(TestAssetProfile)' == '' AND '@(TestAssetPublishProfile->Count())' != '0'" Returns="@(PublishedTestAsset)">
-    <!-- Platform;PlatformTarget removal is to fix builds inside VS. -->
-    <MSBuild Projects="$(MSBuildProjectFullPath)"
-             Targets="PublishTestsAsset"
-             RemoveProperties="Platform;PlatformTarget"
-             Properties="PublishDir=$(PublishDir);TestAssetProfile=%(TestAssetPublishProfile.Identity);ReferenceTestTasks=false;%(TestAssetPublishProfile.Properties)">
-      <Output TaskParameter="TargetOutputs" ItemName="PublishedTestAsset" />
-    </MSBuild>
   </Target>
 </Project>

--- a/src/Servers/IIS/build/testsite.props
+++ b/src/Servers/IIS/build/testsite.props
@@ -45,7 +45,7 @@
 
   <Target Name="PrepareInjectionApp" Condition="'$(InProcessTestSite)' == 'true'">
     <PropertyGroup>
-      <InjectDepsAssembly>$(ArtifactsBinDir)TestTasks\$(Configuration)\$(TargetFramework)\TestTasks</InjectDepsAssembly>
+      <InjectDepsAssembly>$(MSBuildThisFileDirectory)..\IIS\test\testassets\TestTasks\bin\$(Configuration)\$(TargetFramework)\TestTasks</InjectDepsAssembly>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' != '.NETFramework' ">

--- a/src/Servers/IIS/build/testsite.props
+++ b/src/Servers/IIS/build/testsite.props
@@ -31,9 +31,9 @@
     <IISArguments>-h "$(IISAppHostConfig)"</IISArguments>
 
     <AncmInProcessRHPath>aspnetcorev2_inprocess.dll</AncmInProcessRHPath>
-    <!-- TODO: use LocalDotNetRoot instead to find dotnet.exe (see reporoot/Directory.Build.props). Requires a fix to https://github.com/dotnet/aspnetcore/issues/7196 -->
-    <DotNetPath>$(RepoRoot).dotnet\dotnet.exe</DotNetPath>
-    <DotNetPath Condition="'$(NativePlatform)' != 'x64'">$(RepoRoot).dotnet\$(NativePlatform)\dotnet.exe</DotNetPath>
+
+    <DotNetPath>$(DotNetRoot)dotnet.exe</DotNetPath>
+    <DotNetPath Condition="'$(NativePlatform)' != 'x64'">$(DotNetRoot)$(NativePlatform)\dotnet.exe</DotNetPath>
   </PropertyGroup>
 
   <Target Name="CopyLaunchSettings" AfterTargets="CoreBuild">
@@ -50,7 +50,7 @@
 
   <Target Name="PrepareInjectionApp" Condition="'$(InProcessTestSite)' == 'true'">
     <PropertyGroup>
-      <InjectDepsAssembly>$(MSBuildThisFileDirectory)..\IIS\test\testassets\TestTasks\bin\$(Configuration)\$(TargetFramework)\TestTasks</InjectDepsAssembly>
+      <InjectDepsAssembly>$(ArtifactsBinDir)TestTasks\$(Configuration)\$(TargetFramework)\TestTasks</InjectDepsAssembly>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' != '.NETFramework' ">
@@ -110,10 +110,7 @@
   </Target>
 
   <Target Name="PublishTestsAssets" Condition="'$(TestAssetProfile)' == '' AND '@(TestAssetPublishProfile->Count())' != '0'" Returns="@(PublishedTestAsset)">
-
-    <!--
-      _InsidePublishTestsAssets is to avoid invoking this target recursively
-      Platform;PlatformTarget removal is fix builds inside VS -->
+    <!-- Platform;PlatformTarget removal is to fix builds inside VS. -->
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishTestsAsset"
              RemoveProperties="Platform;PlatformTarget"

--- a/src/Servers/testassets/Directory.Build.props
+++ b/src/Servers/testassets/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
-    <!-- Tests do not work on Helix or when bin/ directory is not in project directory due to undeclared dependency on test content. -->
+    <!-- Local testing does not work when bin/ directory is not in project directory due to deployer expectations. -->
     <BaseOutputPath />
     <OutputPath />
   </PropertyGroup>


### PR DESCRIPTION
- not used outside IIS testassets/ folder

nits:
- remove / update outdated comments
- use `$(DotNetRoot)` property