### PR TITLE
Fixed typo in "systemd"

### DIFF
--- a/src/Servers/Kestrel/Core/src/Systemd/KestrelServerOptionsSystemdExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Systemd/KestrelServerOptionsSystemdExtensions.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 namespace Microsoft.AspNetCore.Hosting;
 
 /// <summary>
-/// Extensions for integrating with System MD
+/// Extensions for integrating with systemd
 /// </summary>
 public static class KestrelServerOptionsSystemdExtensions
 {


### PR DESCRIPTION
# Fixed typo in "systemd"

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Changed a documentation summary on an extension class

## Description

The class integrates kestrel projects into systemd, the linux service manager. Maybe System MD is a thing, but probably not what's meant here.
