### PR TITLE
Fix: The next event handler is not called if the previous event handler removes itself

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/HubConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnection.ts
@@ -674,8 +674,9 @@ export class HubConnection {
     private _invokeClientMethod(invocationMessage: InvocationMessage) {
         const methods = this._methods[invocationMessage.target.toLowerCase()];
         if (methods) {
+            const methodsCopy = methods.slice();
             try {
-                methods.forEach((m) => m.apply(this, invocationMessage.arguments));
+                methodsCopy.forEach((m) => m.apply(this, invocationMessage.arguments));
             } catch (e) {
                 this._logger.log(LogLevel.Error, `A callback for the method ${invocationMessage.target.toLowerCase()} threw error '${e}'.`);
             }

--- a/src/SignalR/clients/ts/signalr/tests/HubConnection.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HubConnection.test.ts
@@ -947,6 +947,16 @@ describe("HubConnection", () => {
 
                     expect(numInvocations1).toBe(1);
                     expect(numInvocations2).toBe(1);
+
+                    connection.receive({
+                        arguments: [],
+                        nonblocking: true,
+                        target: eventToTrack,
+                        type: MessageType.Invocation,
+                    });
+
+                    expect(numInvocations1).toBe(1);
+                    expect(numInvocations2).toBe(2);
                 }
                 finally {
                     await hubConnection.stop();


### PR DESCRIPTION
# Fixes "the next event handler is not called if the previous event handler removes itself" issue within SignalR TypeScript Client

As suggested in the issue description (#39512) the cause of the bug is in a collection that is modified during an iteration over it.

## Description

To fix the above described, a copy of the collection was created locally (within the _invokeClientMethod). This copy is used for iterating over callbacks.

Unit test for this specific case was added.

Fixes #39512 
