### PR TITLE
Use SHA256.HashData(Stream) one-shot

### DIFF
--- a/src/Mvc/Mvc.Razor/src/Infrastructure/DefaultFileVersionProvider.cs
+++ b/src/Mvc/Mvc.Razor/src/Infrastructure/DefaultFileVersionProvider.cs
@@ -97,13 +97,10 @@ internal class DefaultFileVersionProvider : IFileVersionProvider
 
     private static string GetHashForFile(IFileInfo fileInfo)
     {
-        using (var sha256 = SHA256.Create())
+        using (var readStream = fileInfo.CreateReadStream())
         {
-            using (var readStream = fileInfo.CreateReadStream())
-            {
-                var hash = sha256.ComputeHash(readStream);
-                return WebEncoders.Base64UrlEncode(hash);
-            }
+            var hash = SHA256.HashData(readStream);
+            return WebEncoders.Base64UrlEncode(hash);
         }
     }
 }


### PR DESCRIPTION
# Use SHA256.HashData(Stream) one-shot

Use the new one-shot SHA-256 implementation for streams.

## Description

Use the new one-shot SHA-256 implementation for streams to hash files introduced by dotnet/runtime#63757.
