### PR TITLE
Allow pdb delta to be optionally included in a hot reload payload 

### DIFF
--- a/src/Components/Web.JS/src/Boot.WebAssembly.ts
+++ b/src/Components/Web.JS/src/Boot.WebAssembly.ts
@@ -42,8 +42,8 @@ async function boot(options?: Partial<WebAssemblyStartOptions>): Promise<void> {
     }
   });
 
-  Blazor._internal.applyHotReload = (id: string, metadataDelta: string, ilDeta: string) => {
-    DotNet.invokeMethod('Microsoft.AspNetCore.Components.WebAssembly', 'ApplyHotReloadDelta', id, metadataDelta, ilDeta);
+  Blazor._internal.applyHotReload = (id: string, metadataDelta: string, ilDelta: string, pdbDelta: string | undefined) => {
+    DotNet.invokeMethod('Microsoft.AspNetCore.Components.WebAssembly', 'ApplyHotReloadDelta', id, metadataDelta, ilDelta, pdbDelta);
   };
 
   Blazor._internal.getApplyUpdateCapabilities = () => DotNet.invokeMethod('Microsoft.AspNetCore.Components.WebAssembly', 'GetApplyUpdateCapabilities');

--- a/src/Components/Web.JS/src/GlobalExports.ts
+++ b/src/Components/Web.JS/src/GlobalExports.ts
@@ -60,7 +60,7 @@ interface IBlazor {
     attachWebRendererInterop?: typeof attachWebRendererInterop,
 
     // APIs invoked by hot reload
-    applyHotReload?: (id: string, metadataDelta: string, ilDelta: string) => void,
+    applyHotReload?: (id: string, metadataDelta: string, ilDelta: string, pdbDelta: string | undefined) => void,
     getApplyUpdateCapabilities?: () => string,
   }
 }

--- a/src/Components/WebAssembly/WebAssembly/src/HotReload/HotReloadAgent.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/HotReload/HotReloadAgent.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Extensions.HotReload
                 {
                     if (TryGetModuleId(assembly) is Guid moduleId && moduleId == item.ModuleId)
                     {
-                        MetadataUpdater.ApplyUpdate(assembly, item.MetadataDelta, item.ILDelta, ReadOnlySpan<byte>.Empty);
+                        MetadataUpdater.ApplyUpdate(assembly, item.MetadataDelta, item.ILDelta, item.PdbBytes ?? ReadOnlySpan<byte>.Empty);
                     }
                 }
 

--- a/src/Components/WebAssembly/WebAssembly/src/HotReload/UpdateDelta.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/HotReload/UpdateDelta.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Extensions.HotReload
 
         public byte[] ILDelta { get; set; } = default!;
 
+        public byte[]? PdbBytes { get; set; }
+
         public int[]? UpdatedTypes { get; set; }
     }
 }

--- a/src/Components/WebAssembly/WebAssembly/src/HotReload/WebAssemblyHotReload.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/HotReload/WebAssemblyHotReload.cs
@@ -42,13 +42,14 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.HotReload
         /// For framework use only.
         /// </summary>
         [JSInvokable(nameof(ApplyHotReloadDelta))]
-        public static void ApplyHotReloadDelta(string moduleIdString, byte[] metadataDelta, byte[] ilDeta)
+        public static void ApplyHotReloadDelta(string moduleIdString, byte[] metadataDelta, byte[] ilDelta, byte[] pdbBytes)
         {
             var moduleId = Guid.Parse(moduleIdString);
 
             _updateDeltas[0].ModuleId = moduleId;
             _updateDeltas[0].MetadataDelta = metadataDelta;
-            _updateDeltas[0].ILDelta = ilDeta;
+            _updateDeltas[0].ILDelta = ilDelta;
+            _updateDeltas[0].PdbBytes = pdbBytes;
 
             _hotReloadAgent!.ApplyDeltas(_updateDeltas);
         }

--- a/src/Components/WebAssembly/WebAssembly/src/PublicAPI.Unshipped.txt
+++ b/src/Components/WebAssembly/WebAssembly/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+*REMOVED*static Microsoft.AspNetCore.Components.WebAssembly.HotReload.WebAssemblyHotReload.ApplyHotReloadDelta(string! moduleIdString, byte[]! metadataDelta, byte[]! ilDeta) -> void
+static Microsoft.AspNetCore.Components.WebAssembly.HotReload.WebAssemblyHotReload.ApplyHotReloadDelta(string! moduleIdString, byte[]! metadataDelta, byte[]! ilDelta, byte[]! pdbBytes) -> void


### PR DESCRIPTION
* Allow pdb delta to be optionally included in a hot reload payload

Fixes https://github.com/dotnet/aspnetcore/issues/39036

Ports https://github.com/dotnet/aspnetcore/pull/39540 to release/6.0

Adds features to Blazor WASM's runtime to allow hot reload to be performed while being debugged. 

## Description

In Blazor WASM, VS sends hot-reload updates via a WebSocket connection. Blazor's runtime exposes JavaScript interop APIs to accept these deltas and call the .NET APIs. VS 17.2 has done the work to send the deltas over the WebSocket connection, this PR adds the runtime plumbing to accept it. 

Fixes https://github.com/dotnet/aspnetcore/issues/39036

## Customer Impact

Hot reload for Blazor WebAssembly under the debugger.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

## Verification

- [x] Manual (required)
- [ ] Automated (we do not have any automated tests for this).

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
