### PR TITLE
Use IndexOfAny(char, char) with Span

### DIFF
--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -16,7 +16,6 @@ namespace Microsoft.AspNetCore.Components.Routing;
 /// </summary>
 public partial class Router : IComponent, IHandleAfterRender, IDisposable
 {
-    static readonly char[] _queryOrHashStartChar = new[] { '?', '#' };
     // Dictionary is intentionally used instead of ReadOnlyDictionary to reduce Blazor size
     static readonly IReadOnlyDictionary<string, object> _emptyParametersDictionary
         = new Dictionary<string, object>();
@@ -146,9 +145,9 @@ public partial class Router : IComponent, IHandleAfterRender, IDisposable
         }
     }
 
-    private static string StringUntilAny(string str, char[] chars)
+    private static string TrimQueryOrHash(string str)
     {
-        var firstIndex = str.IndexOfAny(chars);
+        var firstIndex = str.AsSpan().IndexOfAny('?', '#');
         return firstIndex < 0
             ? str
             : str.Substring(0, firstIndex);
@@ -189,7 +188,7 @@ public partial class Router : IComponent, IHandleAfterRender, IDisposable
         RefreshRouteTable();
 
         var locationPath = NavigationManager.ToBaseRelativePath(_locationAbsolute);
-        locationPath = StringUntilAny(locationPath, _queryOrHashStartChar);
+        locationPath = TrimQueryOrHash(locationPath);
         var context = new RouteContext(locationPath);
         Routes.Route(context);
 

--- a/src/Http/Routing/src/Patterns/RoutePatternParser.cs
+++ b/src/Http/Routing/src/Patterns/RoutePatternParser.cs
@@ -18,11 +18,11 @@ internal static class RoutePatternParser
 
     internal static readonly char[] InvalidParameterNameChars = new char[]
     {
-            Separator,
-            OpenBrace,
-            CloseBrace,
-            QuestionMark,
-            Asterisk
+        Separator,
+        OpenBrace,
+        CloseBrace,
+        QuestionMark,
+        Asterisk
     };
 
     public static RoutePattern Parse(string pattern)

--- a/src/Http/Routing/src/RouteCollection.cs
+++ b/src/Http/Routing/src/RouteCollection.cs
@@ -16,7 +16,6 @@ namespace Microsoft.AspNetCore.Routing;
 /// </summary>
 public class RouteCollection : IRouteCollection
 {
-    private static readonly char[] UrlQueryDelimiters = new char[] { '?', '#' };
     private readonly List<IRouter> _routes = new List<IRouter>();
     private readonly List<IRouter> _unnamedRoutes = new List<IRouter>();
     private readonly Dictionary<string, INamedRouter> _namedRoutes =
@@ -157,7 +156,7 @@ public class RouteCollection : IRouteCollection
 
         if (!string.IsNullOrEmpty(url) && (_options.LowercaseUrls || _options.AppendTrailingSlash))
         {
-            var indexOfSeparator = url.IndexOfAny(UrlQueryDelimiters);
+            var indexOfSeparator = url.AsSpan().IndexOfAny('?', '#');
             var urlWithoutQueryString = url;
             var queryString = string.Empty;
 

--- a/src/Mvc/Mvc.Razor/src/Infrastructure/DefaultFileVersionProvider.cs
+++ b/src/Mvc/Mvc.Razor/src/Infrastructure/DefaultFileVersionProvider.cs
@@ -17,7 +17,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Infrastructure;
 internal class DefaultFileVersionProvider : IFileVersionProvider
 {
     private const string VersionKey = "v";
-    private static readonly char[] QueryStringAndFragmentTokens = new[] { '?', '#' };
 
     public DefaultFileVersionProvider(
         IWebHostEnvironment hostingEnvironment,
@@ -50,7 +49,7 @@ internal class DefaultFileVersionProvider : IFileVersionProvider
 
         var resolvedPath = path;
 
-        var queryStringOrFragmentStartIndex = path.IndexOfAny(QueryStringAndFragmentTokens);
+        var queryStringOrFragmentStartIndex = path.AsSpan().IndexOfAny('?', '#');
         if (queryStringOrFragmentStartIndex != -1)
         {
             resolvedPath = path.Substring(0, queryStringOrFragmentStartIndex);


### PR DESCRIPTION
# Use ROS<char>.IndexOfAny(char, char)

Use `IndexOfAny(char, char)` with `ReadOnlySpan<char>`.

## Description

Use `AsSpan().IndexOfAny(char, char)` rather than pre-allocate a static array for use with `IndexOfAny(params char[])` on a string.

I spotted the array in [`DefaultFileVersionProvider`](https://github.com/dotnet/aspnetcore/blob/244ed8af2dd9d2907796c3d7957fd19400a2338b/src/Mvc/Mvc.Razor/src/Infrastructure/DefaultFileVersionProvider.cs#L20) while working on #39738 so thought I'd see if there were any that could be removed in lieu of overloads that just took the characters without an array. This PR updates all the ones I found that were in projects with TFMs that supported it, except for the usages in [`RoutePatternFactory`](https://github.com/dotnet/aspnetcore/blob/main/src/Http/Routing/src/Patterns/RoutePatternFactory.cs#L620) that use an array of 5 characters in multiple places.

I wrote a quick microbenchmark comparing the two approaches with .NET 6, and using the span version does appear to give a performance improvement.

### Benchmarks

#### Results

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1466 (21H1/May2021Update)
Intel Core i9-9980HK CPU 2.40GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK=7.0.100-alpha.1.22068.17
  [Host]     : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT
  DefaultJob : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT


```
|                    Method |     Mean |     Error |    StdDev | Ratio | RatioSD | Allocated |
|-------------------------- |---------:|----------:|----------:|------:|--------:|----------:|
|         IndexOfAny_String | 8.037 ns | 0.1816 ns | 0.2018 ns |  1.00 |    0.00 |         - |
|     IndexOfAny_Span_Array | 6.101 ns | 0.1178 ns | 0.1044 ns |  0.76 |    0.02 |         - |
| IndexOfAny_Span_Two_Chars | 5.013 ns | 0.0341 ns | 0.0302 ns |  0.62 |    0.01 |         - |

#### Code

<details>

```csharp
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Running;

BenchmarkRunner.Run<IndexOfAnyBenchmarks>();

[MemoryDiagnoser]
public class IndexOfAnyBenchmarks
{
    private const string AUrlWithAPathAndQueryString = "http://www.example.com/path/to/file.html?query=string";
    private static readonly char[] QueryStringAndFragmentTokens = new[] { '?', '#' };

    [Benchmark(Baseline = true)]
    public int IndexOfAny_String()
    {
        return AUrlWithAPathAndQueryString.IndexOfAny(QueryStringAndFragmentTokens);
    }

    [Benchmark]
    public int IndexOfAny_Span_Array()
    {
        return AUrlWithAPathAndQueryString.AsSpan().IndexOfAny(QueryStringAndFragmentTokens);
    }

    [Benchmark]
    public int IndexOfAny_Span_Two_Chars()
    {
        return AUrlWithAPathAndQueryString.AsSpan().IndexOfAny('?', '#');
    }
}
```

```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net6.0</TargetFramework>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>disable</Nullable>
  </PropertyGroup>
  <ItemGroup>
    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
  </ItemGroup>
</Project>
```

</details>
