### PR TITLE
Fix: HttpMethodMatcherPolicy.ApplyAsync ArgumentNullException

### DIFF
--- a/src/Http/Routing/src/Matching/HttpMethodMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/HttpMethodMatcherPolicy.cs
@@ -102,7 +102,7 @@ public sealed class HttpMethodMatcherPolicy : MatcherPolicy, IEndpointComparerPo
         // We want to return a 405 iff we eliminated ALL of the currently valid endpoints due to HTTP method
         // mismatch.
         bool? needs405Endpoint = null;
-        HashSet<string> methods = new HashSet<string>();
+        HashSet<string>? methods = null;
 
         for (var i = 0; i < candidates.Count; i++)
         {
@@ -397,9 +397,9 @@ public sealed class HttpMethodMatcherPolicy : MatcherPolicy, IEndpointComparerPo
         }
     }
 
-    private static Endpoint CreateRejectionEndpoint(IEnumerable<string> httpMethods)
+    private static Endpoint CreateRejectionEndpoint(IEnumerable<string>? httpMethods)
     {
-        var allow = string.Join(", ", httpMethods);
+        var allow = httpMethods is null ? string.Empty : string.Join(", ", httpMethods);
         return new Endpoint(
             (context) =>
             {

--- a/src/Http/Routing/src/Matching/HttpMethodMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/HttpMethodMatcherPolicy.cs
@@ -102,7 +102,7 @@ public sealed class HttpMethodMatcherPolicy : MatcherPolicy, IEndpointComparerPo
         // We want to return a 405 iff we eliminated ALL of the currently valid endpoints due to HTTP method
         // mismatch.
         bool? needs405Endpoint = null;
-        HashSet<string>? methods = null;
+        HashSet<string> methods = new HashSet<string>();
 
         for (var i = 0; i < candidates.Count; i++)
         {
@@ -143,7 +143,6 @@ public sealed class HttpMethodMatcherPolicy : MatcherPolicy, IEndpointComparerPo
                 var candidateMethod = metadata.HttpMethods[j];
                 if (!HttpMethods.Equals(httpMethod, candidateMethod))
                 {
-                    methods = methods ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                     methods.Add(candidateMethod);
                     continue;
                 }
@@ -162,7 +161,7 @@ public sealed class HttpMethodMatcherPolicy : MatcherPolicy, IEndpointComparerPo
         if (needs405Endpoint == true)
         {
             // We saw some endpoints coming in, and we eliminated them all.
-            httpContext.SetEndpoint(CreateRejectionEndpoint(methods!.OrderBy(m => m, StringComparer.OrdinalIgnoreCase)));
+            httpContext.SetEndpoint(CreateRejectionEndpoint(methods.OrderBy(m => m, StringComparer.OrdinalIgnoreCase)));
             httpContext.Request.RouteValues = null!;
         }
 

--- a/src/Http/Routing/src/Matching/HttpMethodMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/HttpMethodMatcherPolicy.cs
@@ -143,6 +143,7 @@ public sealed class HttpMethodMatcherPolicy : MatcherPolicy, IEndpointComparerPo
                 var candidateMethod = metadata.HttpMethods[j];
                 if (!HttpMethods.Equals(httpMethod, candidateMethod))
                 {
+                    methods = methods ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                     methods.Add(candidateMethod);
                     continue;
                 }
@@ -161,7 +162,7 @@ public sealed class HttpMethodMatcherPolicy : MatcherPolicy, IEndpointComparerPo
         if (needs405Endpoint == true)
         {
             // We saw some endpoints coming in, and we eliminated them all.
-            httpContext.SetEndpoint(CreateRejectionEndpoint(methods.OrderBy(m => m, StringComparer.OrdinalIgnoreCase)));
+            httpContext.SetEndpoint(CreateRejectionEndpoint(methods?.OrderBy(m => m, StringComparer.OrdinalIgnoreCase)));
             httpContext.Request.RouteValues = null!;
         }
 

--- a/src/Http/Routing/test/UnitTests/Matching/HttpMethodMatcherPolicyTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/HttpMethodMatcherPolicyTest.cs
@@ -158,7 +158,7 @@ public class HttpMethodMatcherPolicyTest
     {
         var policy = (IEndpointSelectorPolicy)CreatePolicy();
 
-        RouteEndpoint[] endpoints = new RouteEndpoint[candidateNum];
+        var endpoints = new RouteEndpoint[candidateNum];
         for (int i = 0; i < candidateNum; i++)
         {
             endpoints[i] = CreateEndpoint("/", new HttpMethodMetadata(new[] { "DEL" }));

--- a/src/Http/Routing/test/UnitTests/Matching/HttpMethodMatcherPolicyTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/HttpMethodMatcherPolicyTest.cs
@@ -151,6 +151,28 @@ public class HttpMethodMatcherPolicyTest
         Assert.False(result);
     }
 
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task IEndpointSelectorPolicy_ApplyAsync_ProcessesInvalidCandidate(int candidateNum)
+    {
+        var policy = (IEndpointSelectorPolicy)CreatePolicy();
+
+        RouteEndpoint[] endpoints = new RouteEndpoint[candidateNum];
+        for (int i = 0; i < candidateNum; i++)
+        {
+            endpoints[i] = CreateEndpoint("/", new HttpMethodMetadata(new[] { "DEL" }));
+        }
+
+        var candidates = new CandidateSet(endpoints, new RouteValueDictionary[endpoints.Length], Enumerable.Repeat<int>(-1, candidateNum).ToArray());
+        var httpContext = new DefaultHttpContext();
+
+        await policy.ApplyAsync(httpContext, candidates);
+
+        Assert.Equal(httpContext.GetEndpoint().Metadata, EndpointMetadataCollection.Empty);
+        Assert.True(string.Equals(httpContext.GetEndpoint().DisplayName, Http405EndpointDisplayName, StringComparison.OrdinalIgnoreCase));
+    }
+
     [Fact]
     public void GetEdges_GroupsByHttpMethod()
     {


### PR DESCRIPTION
# Fix of a possible ArgumentNullException
Applied an approach used in the method 'GetEdges' with inlined collection initialization instead of deferred approach.

## Description
The 'ArgumentNullException' is thrown by execution of the 'OrderBy' Linq method over uninitialized collection (local variable 'methods'). This situation is possibile under following conditions:

* all candidates passed to the 'ApplyAsync' method are invalid (line 123)
* **and** endpoints of the candidates **either** don't contain metadata **or** 'HttpMethod' collection within them is empty (line 113)

As a solution I suggest to initialize the 'methods' collection in place of defining it.

Alternatives might be:
* checking the 'methods' collection against null before executing the 'OrderBy' extension method
* refusing from ordering the colection

Unit test to cover the above case was added.

Fixes #39398 
