### PR TITLE
Update Bug Report Duplicate Issue Search Link

### DIFF
--- a/.github/ISSUE_TEMPLATE/10_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/10_bug_report.yml
@@ -13,7 +13,7 @@ body:
 - type: checkboxes
   attributes:
     label: Is there an existing issue for this?
-    description: Please search to see if an issue already exists for the bug you encountered (https://github.com/dotnet/aspnetcore/issues).
+    description: Please search to see if an issue already exists for the bug you encountered ([https://github.com/dotnet/aspnetcore/issues](https://github.com/dotnet/aspnetcore/issues?q=is%3Aissue)).
     options:
     - label: I have searched the existing issues
       required: true

--- a/.github/ISSUE_TEMPLATE/10_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/10_bug_report.yml
@@ -13,7 +13,7 @@ body:
 - type: checkboxes
   attributes:
     label: Is there an existing issue for this?
-    description: Please search to see if an issue already exists for the bug you encountered ([https://github.com/dotnet/aspnetcore/issues](https://github.com/dotnet/aspnetcore/issues?q=is%3Aissue)).
+    description: Please search to see if an issue already exists for the bug you encountered ([aspnetcore/issues](https://github.com/dotnet/aspnetcore/issues?q=is%3Aissue)).
     options:
     - label: I have searched the existing issues
       required: true

--- a/.github/ISSUE_TEMPLATE/10_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/10_bug_report.yml
@@ -13,7 +13,7 @@ body:
 - type: checkboxes
   attributes:
     label: Is there an existing issue for this?
-    description: Please search to see if an issue already exists for the bug you encountered ([aspnetcore/issues](https://github.com/dotnet/aspnetcore/issues?q=is%3Aissue)).
+    description: Please search to see if an issue already exists for the bug you encountered ([aspnetcore/issues](https://github.com/dotnet/aspnetcore/issues?q=is%3Aissue)). More information on our issue management policies is available [here](https://aka.ms/aspnet/issue-policies).
     options:
     - label: I have searched the existing issues
       required: true


### PR DESCRIPTION
Currently it goes to https://github.com/dotnet/aspnetcore/issues which only searches for `open` issues. This updated link removes the `is:open` filter to ensure the user duplicate issue search includes all issues.

Prevent something like: https://github.com/dotnet/aspnetcore/issues/39787
