### PR TITLE
[7.0-preview1] Update precedence of templates for 7.0

### DIFF
--- a/docs/UpdatingMajorVersionAndTFM.md
+++ b/docs/UpdatingMajorVersionAndTFM.md
@@ -44,6 +44,10 @@ Once dotnet/runtime has updated their TFM, we update ours in the dependency upda
   2. Create a PR like [this one](https://github.com/dotnet/aspnetcore/pull/36932) updating the current release branch in `aspnetcore` to reference the new release branch you just created in dotnet/spa-templates.
   3. Create a PR like [this one](https://github.com/dotnet/spa-templates/pull/21) updating the branding & TFM in the `main` branch of dotnet/spa-templates.
     * Do not merge this until the PR from the previous step is merged.
+* Update template precedence
+  1. Create & merge a PR like [this one](https://github.com/dotnet/spa-templates/pull/39) in dotnet/spa-templates updating `precedence` and `identity` elements in all template.json files.
+  2. Create a PR like [this one](https://github.com/dotnet/aspnetcore/pull/39783) in dotnet/aspnetcore that updates the spa-templates submodule, and updates the `precedence`, `identity`, and (if it exists) `thirdPartyNotices` elements in all template.json files.
+  3. Make sure the new aka.ms link you're referencing in `thirdPartyNotices` exists.
 
 ### Validation
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/.template.config/template.json
@@ -9,10 +9,10 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating a Blazor server app that runs server-side inside an ASP.NET Core app and handles user interactions over a SignalR connection. This template can be used for web apps with rich dynamic user interfaces (UIs).",
   "groupIdentity": "Microsoft.Web.Blazor.Server",
-  "precedence": "8000",
-  "identity": "Microsoft.Web.Blazor.Server.CSharp.6.0",
+  "precedence": "9000",
+  "identity": "Microsoft.Web.Blazor.Server.CSharp.7.0",
   "shortName": "blazorserver",
-  "thirdPartyNotices": "https://aka.ms/aspnetcore/6.0-third-party-notices",
+  "thirdPartyNotices": "https://aka.ms/aspnetcore/7.0-third-party-notices",
   "tags": {
     "language": "C#",
     "type": "project"

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -11,7 +11,7 @@
   "defaultName": "BlazorApp",
   "description": "A project template for creating a Blazor app that runs on WebAssembly and is optionally hosted by an ASP.NET Core app. This template can be used for web apps with rich dynamic user interfaces (UIs).",
   "groupIdentity": "Microsoft.Web.Blazor.Wasm",
-  "precedence": "8000",
+  "precedence": "9000",
   "guids": [
     "4C26868E-5E7C-458D-82E3-040509D0C71F",
     "5990939C-7E7B-4CFA-86FF-44CA5756498A",
@@ -20,8 +20,8 @@
     "09732173-2cef-46b7-83db-1334bcb079d3", // Tenant ID
     "53bc9b9d-9d6a-45d4-8429-2a2761773502" // Client ID
   ],
-  "identity": "Microsoft.Web.Blazor.Wasm.CSharp.6.0",
-  "thirdPartyNotices": "https://aka.ms/aspnetcore/6.0-third-party-notices",
+  "identity": "Microsoft.Web.Blazor.Wasm.CSharp.7.0",
+  "thirdPartyNotices": "https://aka.ms/aspnetcore/7.0-third-party-notices",
   "preferNameDirectory": true,
   "primaryOutputs": [
     {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
@@ -9,8 +9,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "An empty project template for creating an ASP.NET Core application. This template does not have any content in it.",
   "groupIdentity": "Microsoft.Web.Empty",
-  "precedence": "8000",
-  "identity": "Microsoft.Web.Empty.CSharp.6.0",
+  "precedence": "9000",
+  "identity": "Microsoft.Web.Empty.CSharp.7.0",
   "shortName": "web",
   "tags": {
     "language": "C#",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/template.json
@@ -8,8 +8,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "An empty project template for creating an ASP.NET Core application. This template does not have any content in it.",
   "groupIdentity": "Microsoft.Web.Empty",
-  "precedence": "8000",
-  "identity": "Microsoft.Web.Empty.FSharp.6.0",
+  "precedence": "9000",
+  "identity": "Microsoft.Web.Empty.FSharp.7.0",
   "shortName": "web",
   "tags": {
     "language": "F#",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/template.json
@@ -9,8 +9,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating a gRPC ASP.NET Core service.",
   "groupIdentity": "Microsoft.Web.Grpc",
-  "precedence": "8000",
-  "identity": "Microsoft.Grpc.Service.CSharp.6.0",
+  "precedence": "9000",
+  "identity": "Microsoft.Grpc.Service.CSharp.7.0",
   "shortName": "grpc",
   "tags": {
     "language": "C#",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/template.json
@@ -10,8 +10,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a Razor class library that targets .NET Standard",
   "groupIdentity": "Microsoft.Web.Razor",
-  "precedence": "8000",
-  "identity": "Microsoft.Web.Razor.Library.CSharp.6.0",
+  "precedence": "9000",
+  "identity": "Microsoft.Web.Razor.Library.CSharp.7.0",
   "shortName": "razorclasslib",
   "tags": {
     "language": "C#",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
@@ -10,13 +10,13 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating an ASP.NET Core application with example ASP.NET Core Razor Pages content",
   "groupIdentity": "Microsoft.Web.RazorPages",
-  "precedence": "8000",
-  "identity": "Microsoft.Web.RazorPages.CSharp.6.0",
+  "precedence": "9000",
+  "identity": "Microsoft.Web.RazorPages.CSharp.7.0",
   "shortName": [
     "webapp",
     "razor"
   ],
-  "thirdPartyNotices": "https://aka.ms/aspnetcore/6.0-third-party-notices",
+  "thirdPartyNotices": "https://aka.ms/aspnetcore/7.0-third-party-notices",
   "tags": {
     "language": "C#",
     "type": "project"

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
@@ -9,10 +9,10 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating an ASP.NET Core application with example ASP.NET Core MVC Views and Controllers. This template can also be used for RESTful HTTP services.",
   "groupIdentity": "Microsoft.Web.Mvc",
-  "precedence": "8000",
-  "identity": "Microsoft.Web.Mvc.CSharp.6.0",
+  "precedence": "9000",
+  "identity": "Microsoft.Web.Mvc.CSharp.7.0",
   "shortName": "mvc",
-  "thirdPartyNotices": "https://aka.ms/aspnetcore/6.0-third-party-notices",
+  "thirdPartyNotices": "https://aka.ms/aspnetcore/7.0-third-party-notices",
   "tags": {
     "language": "C#",
     "type": "project"

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
@@ -9,10 +9,10 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating an ASP.NET Core application with example ASP.NET Core MVC Views and Controllers. This template can also be used for RESTful HTTP services.",
   "groupIdentity": "Microsoft.Web.Mvc",
-  "precedence": "8000",
-  "identity": "Microsoft.Web.Mvc.FSharp.6.0",
+  "precedence": "9000",
+  "identity": "Microsoft.Web.Mvc.FSharp.7.0",
   "shortName": "mvc",
-  "thirdPartyNotices": "https://aka.ms/aspnetcore/6.0-third-party-notices",
+  "thirdPartyNotices": "https://aka.ms/aspnetcore/7.0-third-party-notices",
   "tags": {
     "language": "F#",
     "type": "project"

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
@@ -9,8 +9,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers.",
   "groupIdentity": "Microsoft.Web.WebApi",
-  "precedence": "8000",
-  "identity": "Microsoft.Web.WebApi.CSharp.6.0",
+  "precedence": "9000",
+  "identity": "Microsoft.Web.WebApi.CSharp.7.0",
   "shortName": "webapi",
   "tags": {
     "language": "C#",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
@@ -8,8 +8,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers.",
   "groupIdentity": "Microsoft.Web.WebApi",
-  "precedence": "8000",
-  "identity": "Microsoft.Web.WebApi.FSharp.6.0",
+  "precedence": "9000",
+  "identity": "Microsoft.Web.WebApi.FSharp.7.0",
   "shortName": "webapi",
   "tags": {
     "language": "F#",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/.template.config/template.json
@@ -10,8 +10,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "An empty project template for creating a worker service.",
   "groupIdentity": "Microsoft.Worker.Empty",
-  "precedence": "8000",
-  "identity": "Microsoft.Worker.Empty.CSharp.6.0",
+  "precedence": "9000",
+  "identity": "Microsoft.Worker.Empty.CSharp.7.0",
   "shortName": "worker",
   "tags": {
     "language": "C#",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-FSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-FSharp/.template.config/template.json
@@ -10,8 +10,8 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "An empty project template for creating a worker service.",
   "groupIdentity": "Microsoft.Worker.Empty",
-  "precedence": "8000",
-  "identity": "Microsoft.Worker.Empty.FSharp.6.0",
+  "precedence": "9000",
+  "identity": "Microsoft.Worker.Empty.FSharp.7.0",
   "shortName": "worker",
   "tags": {
     "language": "F#",


### PR DESCRIPTION
Contingent on validation of https://github.com/dotnet/aspnetcore/pull/39783 in the SDK

# Update precedence of templates for 7.0

## Description

Updates 7.0 template precedence so that the SDK doesn't confuse them with 6.0 templates

## Customer Impact

Without this, customers can't use the 7.0 SDK to create 6.0 web apps (i.e. `dotnet new web -f net6.0` doesn't work): https://github.com/dotnet/aspnetcore/issues/39731

## Regression?

- [x] Yes (from 6.0)
- [ ] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [x] Medium
- [ ] Low

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props
