### PR TITLE
Added support for arrays of types with TryParse, StringValues and string[] for query strings and headers

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -349,8 +349,10 @@ public static partial class RequestDelegateFactory
             factoryContext.TrackedParameters.Add(parameter.Name, RequestDelegateFactoryConstants.RouteOrQueryStringParameter);
             return BindParameterFromRouteValueOrQueryString(parameter, parameter.Name, factoryContext);
         }
-        else if ((parameter.ParameterType.IsArray && factoryContext.DisableInferredFromBody) &&
-                 (parameter.ParameterType == typeof(string[]) || ParameterBindingMethodCache.HasTryParseMethod(parameter.ParameterType.GetElementType()!)))
+        else if (factoryContext.DisableInferredFromBody &&
+                 (parameter.ParameterType.IsArray && ParameterBindingMethodCache.HasTryParseMethod(parameter.ParameterType.GetElementType()!)) ||
+                 parameter.ParameterType == typeof(string[]) ||
+                 parameter.ParameterType == typeof(StringValues))
         {
             // We only infer parameter types if you have an array of TryParsables/string[]/StringValues, and DisableInferredFromBody is true
 
@@ -901,7 +903,7 @@ public static partial class RequestDelegateFactory
         var parameterNameConstant = Expression.Constant(parameter.Name);
         var sourceConstant = Expression.Constant(source);
 
-        if (parameter.ParameterType == typeof(string) || parameter.ParameterType == typeof(string[]))
+        if (parameter.ParameterType == typeof(string) || parameter.ParameterType == typeof(string[]) || parameter.ParameterType == typeof(StringValues))
         {
             return BindParameterFromExpression(parameter, valueExpression, factoryContext, source);
         }

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -428,7 +428,7 @@ public static partial class RequestDelegateFactory
         // }
 
         var localVariables = new ParameterExpression[factoryContext.ExtraLocals.Count + 1];
-        var blockExpressions = new Expression[factoryContext.ParamCheckExpressions.Count + 1];
+        var checkParamAndCallMethod = new Expression[factoryContext.ParamCheckExpressions.Count + 1];
 
         for (var i = 0; i < factoryContext.ExtraLocals.Count; i++)
         {
@@ -437,7 +437,7 @@ public static partial class RequestDelegateFactory
 
         for (var i = 0; i < factoryContext.ParamCheckExpressions.Count; i++)
         {
-            blockExpressions[i] = factoryContext.ParamCheckExpressions[i];
+            checkParamAndCallMethod[i] = factoryContext.ParamCheckExpressions[i];
         }
 
         localVariables[factoryContext.ExtraLocals.Count] = WasParamCheckFailureExpr;
@@ -452,9 +452,9 @@ public static partial class RequestDelegateFactory
             set400StatusAndReturnCompletedTask,
             AddResponseWritingToMethodCall(methodCall, methodInfo.ReturnType));
 
-        blockExpressions[factoryContext.ParamCheckExpressions.Count] = checkWasParamCheckFailure;
+        checkParamAndCallMethod[factoryContext.ParamCheckExpressions.Count] = checkWasParamCheckFailure;
 
-        return Expression.Block(localVariables, blockExpressions);
+        return Expression.Block(localVariables, checkParamAndCallMethod);
     }
 
     private static Expression AddResponseWritingToMethodCall(Expression methodCall, Type returnType)

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -197,12 +197,6 @@ public static partial class RequestDelegateFactory
             args[i] = CreateArgument(parameters[i], factoryContext);
         }
 
-        if (factoryContext.HasInferredBody && factoryContext.HasInferredQueryArray)
-        {
-            var errorMessage = BuildErrorMessageForQueryAndJsonBodyParameters(factoryContext);
-            throw new InvalidOperationException(errorMessage);
-        }
-
         if (factoryContext.HasInferredBody && factoryContext.DisableInferredFromBody)
         {
             var errorMessage = BuildErrorMessageForInferredBodyParameter(factoryContext);
@@ -355,8 +349,6 @@ public static partial class RequestDelegateFactory
                  parameter.ParameterType == typeof(StringValues)))
         {
             // We only infer parameter types if you have an array of TryParsables/string[]/StringValues, and DisableInferredFromBody is true
-
-            factoryContext.HasInferredQueryArray = true;
 
             factoryContext.TrackedParameters.Add(parameter.Name, RequestDelegateFactoryConstants.QueryStringParameter);
             return BindParameterFromProperty(parameter, QueryExpr, parameter.Name, factoryContext, "query string");
@@ -1560,7 +1552,6 @@ public static partial class RequestDelegateFactory
         public Dictionary<string, string> TrackedParameters { get; } = new();
         public bool HasMultipleBodyParameters { get; set; }
         public bool HasInferredBody { get; set; }
-        public bool HasInferredQueryArray { get; set; }
 
         public List<object> Metadata { get; } = new();
 
@@ -1791,20 +1782,6 @@ public static partial class RequestDelegateFactory
     {
         var errorMessage = new StringBuilder();
         errorMessage.AppendLine("An action cannot use both form and JSON body parameters.");
-        errorMessage.AppendLine("Below is the list of parameters that we found: ");
-        errorMessage.AppendLine();
-        errorMessage.AppendLine(FormattableString.Invariant($"{"Parameter",-20}| {"Source",-30}"));
-        errorMessage.AppendLine("---------------------------------------------------------------------------------");
-
-        FormatTrackedParameters(factoryContext, errorMessage);
-
-        return errorMessage.ToString();
-    }
-
-    private static string BuildErrorMessageForQueryAndJsonBodyParameters(FactoryContext factoryContext)
-    {
-        var errorMessage = new StringBuilder();
-        errorMessage.AppendLine("An action cannot use both inferred query and JSON body parameters. This is ambiguous");
         errorMessage.AppendLine("Below is the list of parameters that we found: ");
         errorMessage.AppendLine();
         errorMessage.AppendLine(FormattableString.Invariant($"{"Parameter",-20}| {"Source",-30}"));

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -197,15 +197,15 @@ public static partial class RequestDelegateFactory
             args[i] = CreateArgument(parameters[i], factoryContext);
         }
 
-        if (factoryContext.HasInferredBody && factoryContext.DisableInferredFromBody)
-        {
-            var errorMessage = BuildErrorMessageForInferredBodyParameter(factoryContext);
-            throw new InvalidOperationException(errorMessage);
-        }
-
         if (factoryContext.HasInferredBody && factoryContext.HasInferredQueryArray)
         {
             var errorMessage = BuildErrorMessageForQueryAndJsonBodyParameters(factoryContext);
+            throw new InvalidOperationException(errorMessage);
+        }
+
+        if (factoryContext.HasInferredBody && factoryContext.DisableInferredFromBody)
+        {
+            var errorMessage = BuildErrorMessageForInferredBodyParameter(factoryContext);
             throw new InvalidOperationException(errorMessage);
         }
 
@@ -349,10 +349,10 @@ public static partial class RequestDelegateFactory
             factoryContext.TrackedParameters.Add(parameter.Name, RequestDelegateFactoryConstants.RouteOrQueryStringParameter);
             return BindParameterFromRouteValueOrQueryString(parameter, parameter.Name, factoryContext);
         }
-        else if (factoryContext.DisableInferredFromBody &&
+        else if (factoryContext.DisableInferredFromBody && (
                  (parameter.ParameterType.IsArray && ParameterBindingMethodCache.HasTryParseMethod(parameter.ParameterType.GetElementType()!)) ||
                  parameter.ParameterType == typeof(string[]) ||
-                 parameter.ParameterType == typeof(StringValues))
+                 parameter.ParameterType == typeof(StringValues)))
         {
             // We only infer parameter types if you have an array of TryParsables/string[]/StringValues, and DisableInferredFromBody is true
 

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -1061,7 +1061,7 @@ public static partial class RequestDelegateFactory
 
         var fullParamCheckBlock = (parameter.ParameterType.IsArray, isOptional) switch
         {
-            // (isArray: false, optional: true)
+            // (isArray: true, optional: true)
             (true, true) =>
 
             Expression.Block(
@@ -1074,7 +1074,7 @@ public static partial class RequestDelegateFactory
                 )
             ),
 
-            // (isArray: false, optional: false)
+            // (isArray: true, optional: false)
             (true, false) =>
 
             Expression.Block(

--- a/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
+++ b/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
@@ -144,7 +144,7 @@ public class ParameterBindingMethodCacheTests
     [MemberData(nameof(TryParseStringParameterInfoData))]
     public void HasTryParseStringMethod_ReturnsTrueWhenMethodExists(ParameterInfo parameterInfo)
     {
-        Assert.True(new ParameterBindingMethodCache().HasTryParseMethod(parameterInfo));
+        Assert.True(new ParameterBindingMethodCache().HasTryParseMethod(parameterInfo.ParameterType));
     }
 
     [Fact]

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -496,6 +496,7 @@ public class RequestDelegateFactoryTests : LoggedTest
                     new object[] { (Action<HttpContext, MyTryParseRecord[]>)Store, new[] { "https://example.org" },new[] { new MyTryParseRecord(new Uri("https://example.org")) } },
                     new object?[] { (Action<HttpContext, int?[]>)Store, null, null },
                     new object?[] { (Action<HttpContext, int[]>)Store, new string[] {}, Array.Empty<int>() },
+                    new object?[] { (Action<HttpContext, int?[]>)Store, new string?[] { "1", "2", null, "4" }, new int?[] { 1,2, null, 4 } },
                     new object?[] { (Action<HttpContext, int?[]>)Store, new string[] { "1", "2", "", "4" }, new int?[] { 1,2, null, 4 } },
                 };
         }

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -730,7 +730,8 @@ public class RequestDelegateFactoryTests : LoggedTest
         var factoryResult = RequestDelegateFactory.Create((HttpContext context, int[] a) =>
         {
             context.Items["tryParsable"] = a;
-        });
+        }, new() { DisableInferBodyFromParameters = true });
+
         var requestDelegate = factoryResult.RequestDelegate;
 
         await requestDelegate(httpContext);

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -719,6 +719,26 @@ public class RequestDelegateFactoryTests : LoggedTest
     }
 
     [Fact]
+    public async Task RequestDelegateHandlesArraysFromQueryString()
+    {
+        var httpContext = CreateHttpContext();
+        httpContext.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+        {
+            ["a"] = new(new[] { "1", "2", "3" })
+        });
+
+        var factoryResult = RequestDelegateFactory.Create((HttpContext context, int[] a) =>
+        {
+            context.Items["tryParsable"] = a;
+        });
+        var requestDelegate = factoryResult.RequestDelegate;
+
+        await requestDelegate(httpContext);
+
+        Assert.Equal(new[] { 1, 2, 3 }, (int[])httpContext.Items["tryParsable"]!);
+    }
+
+    [Fact]
     public async Task RequestDelegatePopulatesUnattributedTryParsableParametersFromRouteValueBeforeQueryString()
     {
         var httpContext = CreateHttpContext();

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -498,6 +498,7 @@ public class RequestDelegateFactoryTests : LoggedTest
                     new object?[] { (Action<HttpContext, int[]>)Store, new string[] {}, Array.Empty<int>() },
                     new object?[] { (Action<HttpContext, int?[]>)Store, new string?[] { "1", "2", null, "4" }, new int?[] { 1,2, null, 4 } },
                     new object?[] { (Action<HttpContext, int?[]>)Store, new string[] { "1", "2", "", "4" }, new int?[] { 1,2, null, 4 } },
+                    new object[] { (Action<HttpContext, MyTryParseRecord?[]?>)Store, new[] { "" }, new MyTryParseRecord?[] { null } },
                 };
         }
     }

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -1166,9 +1166,9 @@ public class RequestDelegateFactoryTests : LoggedTest
     {
         var invoked = false;
 
-        static void StoreNullableIntArray(HttpContext httpContext, int?[] values)
+        void StoreNullableIntArray(HttpContext httpContext, int?[] values)
         {
-            httpContext.Items["values"] = values;
+            invoked = true;
         }
 
         var httpContext = CreateHttpContext();

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -771,6 +771,28 @@ public class RequestDelegateFactoryTests : LoggedTest
     }
 
     [Fact]
+    public async Task RequestDelegateHandlesStringValuesFromQueryString()
+    {
+        var httpContext = CreateHttpContext();
+        httpContext.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+        {
+            ["a"] = new(new[] { "1", "2", "3" })
+        });
+
+        var factoryResult = RequestDelegateFactory.Create((HttpContext context, StringValues a) =>
+        {
+            context.Items["tryParsable"] = a.ToArray();
+        },
+        new() { DisableInferBodyFromParameters = true });
+
+        var requestDelegate = factoryResult.RequestDelegate;
+
+        await requestDelegate(httpContext);
+
+        Assert.Equal(new[] { "1", "2", "3" }, (string[])httpContext.Items["tryParsable"]!);
+    }
+
+    [Fact]
     public async Task RequestDelegateHandlesArraysFromQueryStringParesFailureWithOptionalArray()
     {
         var httpContext = CreateHttpContext();

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -297,10 +297,10 @@ internal class EndpointMetadataApiDescriptionProvider : IApiDescriptionProvider
         {
             return (BindingSource.FormFile, parameter.Name ?? string.Empty, false, parameter.ParameterType);
         }
-        else if (disableInferredBody &&
+        else if (disableInferredBody && (
                  (parameter.ParameterType.IsArray && ParameterBindingMethodCache.HasTryParseMethod(parameter.ParameterType.GetElementType()!)) ||
                  parameter.ParameterType == typeof(string[]) ||
-                 parameter.ParameterType == typeof(StringValues))
+                 parameter.ParameterType == typeof(StringValues)))
         {
             return (BindingSource.Query, parameter.Name ?? string.Empty, false, parameter.ParameterType);
         }

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Internal;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Mvc.ApiExplorer;
 
@@ -296,7 +297,10 @@ internal class EndpointMetadataApiDescriptionProvider : IApiDescriptionProvider
         {
             return (BindingSource.FormFile, parameter.Name ?? string.Empty, false, parameter.ParameterType);
         }
-        else if (disableInferredBody && parameter.ParameterType.IsArray && ParameterBindingMethodCache.HasTryParseMethod(parameter.ParameterType.GetElementType()!))
+        else if (disableInferredBody &&
+                 (parameter.ParameterType.IsArray && ParameterBindingMethodCache.HasTryParseMethod(parameter.ParameterType.GetElementType()!)) ||
+                 parameter.ParameterType == typeof(string[]) ||
+                 parameter.ParameterType == typeof(StringValues))
         {
             return (BindingSource.Query, parameter.Name ?? string.Empty, false, parameter.ParameterType);
         }

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -347,6 +347,24 @@ public class EndpointMetadataApiDescriptionProviderTest
         AssertQueryParameter<TryParseStringRecordStruct[]>(GetApiDescription((TryParseStringRecordStruct[] foo) => { }, "/"));
     }
 
+    [Theory]
+    [InlineData("Put")]
+    [InlineData("Post")]
+    public void BodyIsInferredForArraysInsteadOfQuerySomeHttpMethods(string httpMethod)
+    {
+        static void AssertBody<T>(ApiDescription apiDescription)
+        {
+            var param = Assert.Single(apiDescription.ParameterDescriptions);
+            Assert.Equal(typeof(T), param.Type);
+            Assert.Equal(typeof(T), param.ModelMetadata.ModelType);
+            Assert.Equal(BindingSource.Body, param.Source);
+        }
+
+        AssertBody<int[]>(GetApiDescription((int[] foo) => { }, "/", httpMethods: new[] { httpMethod }));
+        AssertBody<string[]>(GetApiDescription((string[] foo) => { }, "/", httpMethods: new[] { httpMethod }));
+        AssertBody<TryParseStringRecordStruct[]>(GetApiDescription((TryParseStringRecordStruct[] foo) => { }, "/", httpMethods: new[] { httpMethod }));
+    }
+
     [Fact]
     public void AddsFromHeaderParameterAsHeader()
     {
@@ -1169,8 +1187,8 @@ public class EndpointMetadataApiDescriptionProviderTest
     private static TestEndpointRouteBuilder CreateBuilder() =>
         new TestEndpointRouteBuilder(new ApplicationBuilder(new TestServiceProvider()));
 
-    private static ApiDescription GetApiDescription(Delegate action, string pattern = null, string displayName = null) =>
-        Assert.Single(GetApiDescriptions(action, pattern, displayName: displayName));
+    private static ApiDescription GetApiDescription(Delegate action, string pattern = null, string displayName = null, IEnumerable<string> httpMethods = null) =>
+        Assert.Single(GetApiDescriptions(action, pattern, displayName: displayName, httpMethods: httpMethods));
 
     private static void TestAction()
     {

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Mvc.ApiExplorer;
 
@@ -329,16 +330,21 @@ public class EndpointMetadataApiDescriptionProviderTest
     [Fact]
     public void AddsFromQueryParameterAsQuery()
     {
-        static void AssertQueryParameter(ApiDescription apiDescription)
+        static void AssertQueryParameter<T>(ApiDescription apiDescription)
         {
             var param = Assert.Single(apiDescription.ParameterDescriptions);
-            Assert.Equal(typeof(int), param.Type);
-            Assert.Equal(typeof(int), param.ModelMetadata.ModelType);
+            Assert.Equal(typeof(T), param.Type);
+            Assert.Equal(typeof(T), param.ModelMetadata.ModelType);
             Assert.Equal(BindingSource.Query, param.Source);
         }
 
-        AssertQueryParameter(GetApiDescription((int foo) => { }, "/"));
-        AssertQueryParameter(GetApiDescription(([FromQuery] int foo) => { }));
+        AssertQueryParameter<int>(GetApiDescription((int foo) => { }, "/"));
+        AssertQueryParameter<int>(GetApiDescription(([FromQuery] int foo) => { }));
+        AssertQueryParameter<TryParseStringRecordStruct>(GetApiDescription(([FromQuery] TryParseStringRecordStruct foo) => { }));
+        AssertQueryParameter<int[]>(GetApiDescription((int[] foo) => { }, "/"));
+        AssertQueryParameter<string[]>(GetApiDescription((string[] foo) => { }, "/"));
+        AssertQueryParameter<StringValues>(GetApiDescription((StringValues foo) => { }, "/"));
+        AssertQueryParameter<TryParseStringRecordStruct[]>(GetApiDescription((TryParseStringRecordStruct[] foo) => { }, "/"));
     }
 
     [Fact]

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -43,9 +43,9 @@ internal sealed class ParameterBindingMethodCache
         _enumTryParseMethod = GetEnumTryParseMethod(preferNonGenericEnumParseOverload);
     }
 
-    public bool HasTryParseMethod(ParameterInfo parameter)
+    public bool HasTryParseMethod(Type type)
     {
-        var nonNullableParameterType = Nullable.GetUnderlyingType(parameter.ParameterType) ?? parameter.ParameterType;
+        var nonNullableParameterType = Nullable.GetUnderlyingType(type) ?? type;
         return FindTryParseMethod(nonNullableParameterType) is not null;
     }
 


### PR DESCRIPTION
- Added inferred query support for methods where the body inference is disabled.
- Added a tests.

Fixes #32516 
Fixes #36726