### PR TITLE
[Blazor] Fix null reference exception caused by ambiguous routes

### DIFF
--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -159,8 +159,8 @@ public partial class Router : IComponent, IHandleAfterRender, IDisposable
 
         if (!routeKey.Equals(_routeTableLastBuiltForRouteKey))
         {
-            _routeTableLastBuiltForRouteKey = routeKey;
             Routes = RouteTableFactory.Create(routeKey);
+            _routeTableLastBuiltForRouteKey = routeKey;
         }
     }
 


### PR DESCRIPTION
When two Blazor routes are ambiguous the generated exception is obfuscated by following attempts to access the route table. 

The reason this happens is that we update the route key before we compute a new table, and when the table fails, the next time we try the key, we return null.

The solution is to wait to set the key until we've successfully computed the route table to avoid hiding exceptions in that case.