### PR TITLE
Use non-generic TaskCompletionSource

### DIFF
--- a/src/Components/Components/src/Rendering/RendererSynchronizationContext.cs
+++ b/src/Components/Components/src/Rendering/RendererSynchronizationContext.cs
@@ -147,7 +147,7 @@ internal class RendererSynchronizationContext : SynchronizationContext
     public override void Send(SendOrPostCallback d, object state)
     {
         Task antecedent;
-        var completion = new TaskCompletionSource<object>();
+        var completion = new TaskCompletionSource();
 
         lock (_state.Lock)
         {
@@ -176,7 +176,7 @@ internal class RendererSynchronizationContext : SynchronizationContext
     // if necessary.
     private void ExecuteSynchronouslyIfPossible(SendOrPostCallback d, object state)
     {
-        TaskCompletionSource<object> completion;
+        TaskCompletionSource completion;
         lock (_state.Lock)
         {
             if (!_state.Task.IsCompleted)
@@ -187,7 +187,7 @@ internal class RendererSynchronizationContext : SynchronizationContext
 
             // We can execute this synchronously because nothing is currently running
             // or queued.
-            completion = new TaskCompletionSource<object>();
+            completion = new TaskCompletionSource();
             _state.Task = completion.Task;
         }
 
@@ -221,7 +221,7 @@ internal class RendererSynchronizationContext : SynchronizationContext
     }
 
     private void ExecuteSynchronously(
-        TaskCompletionSource<object> completion,
+        TaskCompletionSource completion,
         SendOrPostCallback d,
         object state)
     {
@@ -238,7 +238,7 @@ internal class RendererSynchronizationContext : SynchronizationContext
             _state.IsBusy = false;
             SetSynchronizationContext(original);
 
-            completion?.SetResult(null);
+            completion?.SetResult();
         }
     }
 

--- a/src/Components/Components/test/ComponentBaseTest.cs
+++ b/src/Components/Components/test/ComponentBaseTest.cs
@@ -234,7 +234,7 @@ public class ComponentBaseTest
         // Arrange
         var renderer = new TestRenderer();
         var component = new TestComponent() { Counter = 1 };
-        var initTask = new TaskCompletionSource<object>();
+        var initTask = new TaskCompletionSource();
         component.OnInitAsyncLogic = _ => initTask.Task;
 
         // Act
@@ -307,7 +307,7 @@ public class ComponentBaseTest
         var component = new TestComponent() { Counter = 1 };
 
         var onAfterRenderCompleted = false;
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
         component.OnAfterRenderAsyncLogic = async (c, firstRender) =>
         {
             Assert.True(firstRender);
@@ -321,7 +321,7 @@ public class ComponentBaseTest
         var renderTask = renderer.RenderRootComponentAsync(componentId);
 
         // Assert
-        tcs.SetResult(null);
+        tcs.SetResult();
         await renderTask;
         Assert.True(onAfterRenderCompleted);
 
@@ -330,7 +330,7 @@ public class ComponentBaseTest
 
         // Act: Render again!
         onAfterRenderCompleted = false;
-        tcs = new TaskCompletionSource<object>();
+        tcs = new TaskCompletionSource();
         component.OnAfterRenderAsyncLogic = async (c, firstRender) =>
         {
             Assert.False(firstRender);
@@ -342,7 +342,7 @@ public class ComponentBaseTest
         renderTask = renderer.RenderRootComponentAsync(componentId);
 
         // Assert
-        tcs.SetResult(null);
+        tcs.SetResult();
         await renderTask;
         Assert.True(onAfterRenderCompleted);
         Assert.Equal(2, renderer.Batches.Count);
@@ -378,7 +378,7 @@ public class ComponentBaseTest
         // Arrange
         var renderer = new TestRenderer();
         var component = new TestComponent() { Counter = 1 };
-        var onParametersSetTask = new TaskCompletionSource<object>();
+        var onParametersSetTask = new TaskCompletionSource();
         component.OnParametersSetAsyncLogic = _ => onParametersSetTask.Task;
 
         // Act

--- a/src/Components/Components/test/RendererTest.cs
+++ b/src/Components/Components/test/RendererTest.cs
@@ -176,7 +176,7 @@ public class RendererTest
     {
         // Arrange
         var renderer = new TestRenderer();
-        var tcs = new TaskCompletionSource<int>();
+        var tcs = new TaskCompletionSource();
         var component = new AsyncComponent(tcs.Task, 5); // Triggers n renders, the first one creating <p>n</p> and the n-1 renders asynchronously update the value.
 
         // Act
@@ -185,7 +185,7 @@ public class RendererTest
 
         // Assert
         Assert.False(renderTask.IsCompleted);
-        tcs.SetResult(0);
+        tcs.SetResult();
         await renderTask;
         Assert.Equal(5, renderer.Batches.Count);
 
@@ -825,7 +825,7 @@ public class RendererTest
         EventArgs receivedArgs = null;
 
         var state = 0;
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
 
         var component = new EventComponent
         {
@@ -854,7 +854,7 @@ public class RendererTest
         Assert.Equal(1, state);
         Assert.Same(eventArgs, receivedArgs);
 
-        tcs.SetResult(null);
+        tcs.SetResult();
         await task;
 
         Assert.Equal(2, state);
@@ -868,7 +868,7 @@ public class RendererTest
         DerivedEventArgs receivedArgs = null;
 
         var state = 0;
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
 
         var component = new EventComponent
         {
@@ -897,7 +897,7 @@ public class RendererTest
         Assert.Equal(1, state);
         Assert.Same(eventArgs, receivedArgs);
 
-        tcs.SetResult(null);
+        tcs.SetResult();
         await task;
 
         Assert.Equal(2, state);
@@ -911,7 +911,7 @@ public class RendererTest
         object receivedArgs = null;
 
         var state = 0;
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
 
         var component = new EventComponent
         {
@@ -940,7 +940,7 @@ public class RendererTest
         Assert.Equal(1, state);
         Assert.NotNull(receivedArgs);
 
-        tcs.SetResult(null);
+        tcs.SetResult();
         await task;
 
         Assert.Equal(2, state);
@@ -952,7 +952,7 @@ public class RendererTest
         EventArgs receivedArgs = null;
 
         var state = 0;
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
 
         // Arrange: Render parent component
         var renderer = new TestRenderer();
@@ -994,7 +994,7 @@ public class RendererTest
         Assert.Equal(1, state);
         Assert.Same(eventArgs, receivedArgs);
 
-        tcs.SetResult(null);
+        tcs.SetResult();
         await task;
 
         Assert.Equal(2, state);
@@ -1630,7 +1630,7 @@ public class RendererTest
     public async Task DispatchEventAsync_Delegate_AsynchronousCompletion()
     {
         // Arrange
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
 
         var renderer = new TestRenderer();
         var parentComponent = new OuterEventComponent();
@@ -1657,7 +1657,7 @@ public class RendererTest
 
         // Assert
         Assert.Equal(TaskStatus.WaitingForActivation, task.Status);
-        tcs.SetResult(null);
+        tcs.SetResult();
         await task; // Does not throw
     }
 
@@ -1665,7 +1665,7 @@ public class RendererTest
     public async Task DispatchEventAsync_EventCallback_AsynchronousCompletion()
     {
         // Arrange
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
 
         var renderer = new TestRenderer();
         var parentComponent = new OuterEventComponent();
@@ -1692,7 +1692,7 @@ public class RendererTest
 
         // Assert
         Assert.Equal(TaskStatus.WaitingForActivation, task.Status);
-        tcs.SetResult(null);
+        tcs.SetResult();
         await task; // Does not throw
     }
 
@@ -1700,7 +1700,7 @@ public class RendererTest
     public async Task DispatchEventAsync_EventCallbackOfT_AsynchronousCompletion()
     {
         // Arrange
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
 
         DerivedEventArgs arg = null;
 
@@ -1731,7 +1731,7 @@ public class RendererTest
         // Assert
         Assert.NotNull(arg);
         Assert.Equal(TaskStatus.WaitingForActivation, task.Status);
-        tcs.SetResult(null);
+        tcs.SetResult();
         await task; // Does not throw
     }
 
@@ -1739,7 +1739,7 @@ public class RendererTest
     public async Task DispatchEventAsync_Delegate_AsynchronousCancellation()
     {
         // Arrange
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
 
         var renderer = new TestRenderer();
         var parentComponent = new OuterEventComponent();
@@ -1767,7 +1767,7 @@ public class RendererTest
 
         // Assert
         Assert.Equal(TaskStatus.WaitingForActivation, task.Status);
-        tcs.SetResult(null);
+        tcs.SetResult();
 
         await task; // Does not throw
         Assert.Empty(renderer.HandledExceptions);
@@ -1777,7 +1777,7 @@ public class RendererTest
     public async Task DispatchEventAsync_EventCallback_AsynchronousCancellation()
     {
         // Arrange
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
 
         var renderer = new TestRenderer();
         var parentComponent = new OuterEventComponent();
@@ -1805,7 +1805,7 @@ public class RendererTest
 
         // Assert
         Assert.Equal(TaskStatus.WaitingForActivation, task.Status);
-        tcs.SetResult(null);
+        tcs.SetResult();
 
         await task; // Does not throw
         Assert.Empty(renderer.HandledExceptions);
@@ -1815,7 +1815,7 @@ public class RendererTest
     public async Task DispatchEventAsync_EventCallbackOfT_AsynchronousCancellation()
     {
         // Arrange
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
 
         DerivedEventArgs arg = null;
 
@@ -1847,7 +1847,7 @@ public class RendererTest
         // Assert
         Assert.NotNull(arg);
         Assert.Equal(TaskStatus.WaitingForActivation, task.Status);
-        tcs.SetResult(null);
+        tcs.SetResult();
 
         await task; // Does not throw
         Assert.Empty(renderer.HandledExceptions);
@@ -1857,7 +1857,7 @@ public class RendererTest
     public async Task DispatchEventAsync_Delegate_AsynchronousException()
     {
         // Arrange
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
 
         var renderer = new TestRenderer();
         var parentComponent = new OuterEventComponent();
@@ -1885,7 +1885,7 @@ public class RendererTest
 
         // Assert
         Assert.Equal(TaskStatus.WaitingForActivation, task.Status);
-        tcs.SetResult(null);
+        tcs.SetResult();
 
         await Assert.ThrowsAsync<InvalidTimeZoneException>(() => task);
     }
@@ -1894,7 +1894,7 @@ public class RendererTest
     public async Task DispatchEventAsync_EventCallback_AsynchronousException()
     {
         // Arrange
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
 
         var renderer = new TestRenderer();
         var parentComponent = new OuterEventComponent();
@@ -1922,7 +1922,7 @@ public class RendererTest
 
         // Assert
         Assert.Equal(TaskStatus.WaitingForActivation, task.Status);
-        tcs.SetResult(null);
+        tcs.SetResult();
 
         await Assert.ThrowsAsync<InvalidTimeZoneException>(() => task);
     }
@@ -1931,7 +1931,7 @@ public class RendererTest
     public async Task DispatchEventAsync_EventCallbackOfT_AsynchronousException()
     {
         // Arrange
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
 
         DerivedEventArgs arg = null;
 
@@ -1963,7 +1963,7 @@ public class RendererTest
         // Assert
         Assert.NotNull(arg);
         Assert.Equal(TaskStatus.WaitingForActivation, task.Status);
-        tcs.SetResult(null);
+        tcs.SetResult();
 
         await Assert.ThrowsAsync<InvalidTimeZoneException>(() => task);
     }
@@ -3115,8 +3115,8 @@ public class RendererTest
     {
         // Arrange
         var @event = new ManualResetEventSlim();
-        var tcs = new TaskCompletionSource<object>();
-        var afterRenderTcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
+        var afterRenderTcs = new TaskCompletionSource();
         var onAfterRenderCallCountLog = new List<int>();
         var component = new AsyncAfterRenderComponent(afterRenderTcs.Task)
         {
@@ -3130,8 +3130,8 @@ public class RendererTest
 
         // Act
         component.TriggerRender();
-        tcs.SetResult(null);
-        afterRenderTcs.SetResult(null);
+        tcs.SetResult();
+        afterRenderTcs.SetResult();
 
         // We need to wait here because the completions from SetResult will be scheduled.
         @event.Wait(Timeout);
@@ -3145,7 +3145,7 @@ public class RendererTest
     {
         // Arrange
         var @event = new ManualResetEventSlim();
-        var afterRenderTcs = new TaskCompletionSource<object>();
+        var afterRenderTcs = new TaskCompletionSource();
         var onAfterRenderCallCountLog = new List<int>();
         var component = new AsyncAfterRenderComponent(afterRenderTcs.Task)
         {
@@ -3159,7 +3159,7 @@ public class RendererTest
 
         // Act
         component.TriggerRender();
-        afterRenderTcs.SetResult(null);
+        afterRenderTcs.SetResult();
 
         // We need to wait here because the completions from SetResult will be scheduled.
         @event.Wait(Timeout);
@@ -3290,14 +3290,14 @@ public class RendererTest
             .AttributeEventHandlerId;
 
         // Act/Assert 1: Event can be fired for the first time
-        var render1TCS = new TaskCompletionSource<object>();
+        var render1TCS = new TaskCompletionSource();
         renderer.NextUpdateDisplayReturnTask = render1TCS.Task;
         await renderer.DispatchEventAsync(eventHandlerId, new EventArgs());
         Assert.Equal(1, numEventsFired);
 
         // Act/Assert 2: *Same* event handler ID can be reused prior to completion of
         // preceding UI update
-        var render2TCS = new TaskCompletionSource<object>();
+        var render2TCS = new TaskCompletionSource();
         renderer.NextUpdateDisplayReturnTask = render2TCS.Task;
         await renderer.DispatchEventAsync(eventHandlerId, new EventArgs());
         Assert.Equal(2, numEventsFired);
@@ -3311,7 +3311,7 @@ public class RendererTest
         // For that case, we are going to queue a continuation on render1TCS.Task, include a 1s delay and await the resulting
         // task to offer the best chance that we get to see the error in all cases.
         var awaitableTask = render1TCS.Task.ContinueWith(_ => Task.Delay(1000)).Unwrap();
-        render1TCS.SetResult(null);
+        render1TCS.SetResult();
         await awaitableTask;
         var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
         {
@@ -3426,7 +3426,7 @@ public class RendererTest
         // Arrange
         var renderer = new TestRenderer { ShouldHandleExceptions = true };
         var component = new NestedAsyncComponent();
-        var tcs = new TaskCompletionSource<int>();
+        var tcs = new TaskCompletionSource();
         var exception = new InvalidTimeZoneException();
 
         // Act/Assert
@@ -3455,7 +3455,7 @@ public class RendererTest
         }));
 
         Assert.False(renderTask.IsCompleted);
-        tcs.SetResult(0);
+        tcs.SetResult();
         await renderTask;
         Assert.Same(exception, Assert.Single(renderer.HandledExceptions).GetBaseException());
     }
@@ -3483,7 +3483,7 @@ public class RendererTest
         var componentId = renderer.AssignRootComponentId(component);
         await renderer.RenderRootComponentAsync(componentId); // Not throwing on first render
 
-        var asyncExceptionTcs = new TaskCompletionSource<object>();
+        var asyncExceptionTcs = new TaskCompletionSource();
         taskToAwait = asyncExceptionTcs.Task;
         await renderer.Dispatcher.InvokeAsync(component.TriggerRender);
 
@@ -3508,7 +3508,7 @@ public class RendererTest
         var component = new NestedAsyncComponent();
         var exception1 = new InvalidTimeZoneException();
         var exception2 = new UriFormatException();
-        var tcs = new TaskCompletionSource<int>();
+        var tcs = new TaskCompletionSource();
 
         // Act/Assert
         var componentId = renderer.AssignRootComponentId(component);
@@ -3551,7 +3551,7 @@ public class RendererTest
         }));
 
         Assert.False(renderTask.IsCompleted);
-        tcs.SetResult(0);
+        tcs.SetResult();
 
         await renderTask;
         Assert.Equal(2, renderer.HandledExceptions.Count);
@@ -3621,7 +3621,7 @@ public class RendererTest
         var component = new NestedAsyncComponent();
         var exception = new InvalidTimeZoneException();
 
-        var taskCompletionSource = new TaskCompletionSource<int>();
+        var taskCompletionSource = new TaskCompletionSource();
 
         // Act/Assert
         var componentId = renderer.AssignRootComponentId(component);
@@ -3647,7 +3647,7 @@ public class RendererTest
                             Event = NestedAsyncComponent.EventType.OnAfterRenderAsyncSync,
                             EventAction = () =>
                             {
-                                taskCompletionSource.TrySetResult(0);
+                                taskCompletionSource.TrySetResult();
                                 return Task.FromResult((1, NestedAsyncComponent.EventType.OnAfterRenderAsyncSync));
                             },
                         }
@@ -3675,7 +3675,7 @@ public class RendererTest
         var component = new NestedAsyncComponent();
         var exception = new InvalidTimeZoneException();
 
-        var taskCompletionSource = new TaskCompletionSource<int>();
+        var taskCompletionSource = new TaskCompletionSource();
 
         // Act/Assert
         var componentId = renderer.AssignRootComponentId(component);
@@ -3703,7 +3703,7 @@ public class RendererTest
                             EventAction = async () =>
                             {
                                 await Task.Yield();
-                                taskCompletionSource.TrySetResult(0);
+                                taskCompletionSource.TrySetResult();
                                 return (1, NestedAsyncComponent.EventType.OnAfterRenderAsyncAsync);
                             },
                         }
@@ -3874,7 +3874,7 @@ public class RendererTest
         // Arrange
         var renderer = new TestRenderer { ShouldHandleExceptions = true };
         var component = new NestedAsyncComponent();
-        var taskCompletionSource = new TaskCompletionSource<int>();
+        var taskCompletionSource = new TaskCompletionSource();
         var cancellationTokenSource = new CancellationTokenSource();
         cancellationTokenSource.Cancel();
 
@@ -3891,7 +3891,7 @@ public class RendererTest
                             Event = NestedAsyncComponent.EventType.OnAfterRenderAsyncSync,
                             EventAction = () =>
                             {
-                                taskCompletionSource.TrySetResult(0);
+                                taskCompletionSource.TrySetResult();
                                 cancellationTokenSource.Token.ThrowIfCancellationRequested();
                                 return default;
                             },
@@ -4137,7 +4137,7 @@ public class RendererTest
         // Arrange: Render a component with an event handler
         // We want the renderer to think none of the "UpdateDisplay" calls ever complete, because we
         // want to keep reusing the same eventHandlerId and not let it get disposed
-        var renderCompletedTcs = new TaskCompletionSource<object>();
+        var renderCompletedTcs = new TaskCompletionSource();
         var renderer = new TestRenderer { NextRenderResultTask = renderCompletedTcs.Task };
         var component = new BoundPropertyComponent { BoundString = "old property value" };
         var componentId = renderer.AssignRootComponentId(component);
@@ -5569,7 +5569,7 @@ public class RendererTest
 
             // Return a task that never completes to show that access is forbidden
             // after the synchronous return, not just after the returned task completes
-            return new TaskCompletionSource<object>().Task;
+            return new TaskCompletionSource().Task;
         }
     }
 

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -239,7 +239,7 @@ public class CircuitHostTest
     {
         // Arrange
         var handler = new Mock<CircuitHandler>(MockBehavior.Strict);
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
         var reportedErrors = new List<UnhandledExceptionEventArgs>();
 
         handler

--- a/src/Components/Server/test/Circuits/CircuitRegistryTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitRegistryTest.cs
@@ -230,7 +230,7 @@ public class CircuitRegistryTest
 
         var registry = new TestCircuitRegistry(circuitIdFactory);
         registry.BeforeDisconnect = new ManualResetEventSlim();
-        var tcs = new TaskCompletionSource<int>();
+        var tcs = new TaskCompletionSource();
 
         var circuitHost = TestCircuitHost.Create(circuitIdFactory.CreateCircuitId());
         registry.Register(circuitHost);
@@ -241,7 +241,7 @@ public class CircuitRegistryTest
         var disconnect = Task.Run(() =>
         {
             var task = registry.DisconnectAsync(circuitHost, circuitHost.Client.ConnectionId);
-            tcs.SetResult(0);
+            tcs.SetResult();
             return task;
         });
         var connect = Task.Run(async () =>
@@ -303,11 +303,11 @@ public class CircuitRegistryTest
             DisconnectedCircuitRetentionPeriod = TimeSpan.FromSeconds(3),
         };
         var registry = new TestCircuitRegistry(circuitIdFactory, circuitOptions);
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
 
         registry.OnAfterEntryEvicted = () =>
         {
-            tcs.TrySetResult(new object());
+            tcs.TrySetResult();
         };
         var circuitHost = TestCircuitHost.Create();
 
@@ -330,11 +330,11 @@ public class CircuitRegistryTest
             DisconnectedCircuitRetentionPeriod = TimeSpan.FromSeconds(8),
         };
         var registry = new TestCircuitRegistry(circuitIdFactory, circuitOptions);
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
 
         registry.OnAfterEntryEvicted = () =>
         {
-            tcs.TrySetResult(new object());
+            tcs.TrySetResult();
         };
         var circuitHost = TestCircuitHost.Create(circuitIdFactory.CreateCircuitId());
 

--- a/src/Components/Server/test/Circuits/RemoteRendererTest.cs
+++ b/src/Components/Server/test/Circuits/RemoteRendererTest.cs
@@ -124,9 +124,9 @@ public class RemoteRendererTest
         var serviceProvider = CreateServiceProvider();
         var renderIds = new List<long>();
 
-        var firstBatchTCS = new TaskCompletionSource<object>();
-        var secondBatchTCS = new TaskCompletionSource<object>();
-        var thirdBatchTCS = new TaskCompletionSource<object>();
+        var firstBatchTCS = new TaskCompletionSource();
+        var secondBatchTCS = new TaskCompletionSource();
+        var thirdBatchTCS = new TaskCompletionSource();
 
         var initialClient = new Mock<IClientProxy>();
         initialClient.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
@@ -151,7 +151,7 @@ public class RemoteRendererTest
         _ = renderer.OnRenderCompletedAsync(2, null);
 
         @event.Reset();
-        firstBatchTCS.SetResult(null);
+        firstBatchTCS.SetResult();
 
         // Waiting is required here because the continuations of SetResult will not execute synchronously.
         @event.Wait(Timeout);
@@ -169,8 +169,8 @@ public class RemoteRendererTest
             _ = renderer.OnRenderCompletedAsync(id, null);
         }
 
-        secondBatchTCS.SetResult(null);
-        thirdBatchTCS.SetResult(null);
+        secondBatchTCS.SetResult();
+        thirdBatchTCS.SetResult();
 
         // Assert
         Assert.Equal(new long[] { 2, 3, 4 }, renderIds);
@@ -184,8 +184,8 @@ public class RemoteRendererTest
     {
         // Arrange
         var serviceProvider = CreateServiceProvider();
-        var firstBatchTCS = new TaskCompletionSource<object>();
-        var secondBatchTCS = new TaskCompletionSource<object>();
+        var firstBatchTCS = new TaskCompletionSource();
+        var secondBatchTCS = new TaskCompletionSource();
         var offlineClient = new CircuitClientProxy(new Mock<IClientProxy>(MockBehavior.Strict).Object, "offline-client");
         offlineClient.SetDisconnected();
         var renderer = GetRemoteRenderer(serviceProvider, offlineClient);
@@ -233,8 +233,8 @@ public class RemoteRendererTest
         // Receive the ack for the second batch
         _ = renderer.OnRenderCompletedAsync(3, null);
 
-        firstBatchTCS.SetResult(null);
-        secondBatchTCS.SetResult(null);
+        firstBatchTCS.SetResult();
+        secondBatchTCS.SetResult();
         // Repeat the ack for the third batch
         _ = renderer.OnRenderCompletedAsync(3, null);
 
@@ -247,8 +247,8 @@ public class RemoteRendererTest
     {
         // Arrange
         var serviceProvider = CreateServiceProvider();
-        var firstBatchTCS = new TaskCompletionSource<object>();
-        var secondBatchTCS = new TaskCompletionSource<object>();
+        var firstBatchTCS = new TaskCompletionSource();
+        var secondBatchTCS = new TaskCompletionSource();
         var offlineClient = new CircuitClientProxy(new Mock<IClientProxy>(MockBehavior.Strict).Object, "offline-client");
         offlineClient.SetDisconnected();
         var renderer = GetRemoteRenderer(serviceProvider, offlineClient);
@@ -296,8 +296,8 @@ public class RemoteRendererTest
         // Receive the ack for the second batch
         _ = renderer.OnRenderCompletedAsync(2, null);
 
-        firstBatchTCS.SetResult(null);
-        secondBatchTCS.SetResult(null);
+        firstBatchTCS.SetResult();
+        secondBatchTCS.SetResult();
         // Repeat the ack for the third batch
         _ = renderer.OnRenderCompletedAsync(3, null);
 
@@ -310,8 +310,8 @@ public class RemoteRendererTest
     {
         // Arrange
         var serviceProvider = CreateServiceProvider();
-        var firstBatchTCS = new TaskCompletionSource<object>();
-        var secondBatchTCS = new TaskCompletionSource<object>();
+        var firstBatchTCS = new TaskCompletionSource();
+        var secondBatchTCS = new TaskCompletionSource();
         var renderIds = new List<long>();
 
         var onlineClient = new Mock<IClientProxy>();
@@ -354,8 +354,8 @@ public class RemoteRendererTest
 
         // Pretend that we missed the ack for the initial batch
         _ = renderer.OnRenderCompletedAsync(3, null);
-        firstBatchTCS.SetResult(null);
-        secondBatchTCS.SetResult(null);
+        firstBatchTCS.SetResult();
+        secondBatchTCS.SetResult();
 
         // Assert
         Assert.Empty(exceptions);
@@ -367,8 +367,8 @@ public class RemoteRendererTest
     {
         // Arrange
         var serviceProvider = CreateServiceProvider();
-        var firstBatchTCS = new TaskCompletionSource<object>();
-        var secondBatchTCS = new TaskCompletionSource<object>();
+        var firstBatchTCS = new TaskCompletionSource();
+        var secondBatchTCS = new TaskCompletionSource();
         var renderIds = new List<long>();
 
         var onlineClient = new Mock<IClientProxy>();
@@ -410,8 +410,8 @@ public class RemoteRendererTest
         };
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => renderer.OnRenderCompletedAsync(4, null));
-        firstBatchTCS.SetResult(null);
-        secondBatchTCS.SetResult(null);
+        firstBatchTCS.SetResult();
+        secondBatchTCS.SetResult();
 
         // Assert
         Assert.Equal(

--- a/src/Components/Server/test/Circuits/RevalidatingServerAuthenticationStateProviderTest.cs
+++ b/src/Components/Server/test/Circuits/RevalidatingServerAuthenticationStateProviderTest.cs
@@ -183,7 +183,7 @@ public class RevalidatingServerAuthenticationStateProviderTest
     {
         // Arrange
         var validationTcs = new TaskCompletionSource<bool>();
-        var incrementExecuted = new TaskCompletionSource<bool>();
+        var incrementExecuted = new TaskCompletionSource();
         var authenticationStateChangedCount = 0;
         using var provider = new TestRevalidatingServerAuthenticationStateProvider(
             TimeSpan.FromMilliseconds(50));
@@ -192,7 +192,7 @@ public class RevalidatingServerAuthenticationStateProviderTest
         provider.AuthenticationStateChanged += _ =>
         {
             authenticationStateChangedCount++;
-            incrementExecuted.TrySetResult(true);
+            incrementExecuted.TrySetResult();
         };
 
         // Be waiting for the first ValidateAuthenticationStateAsync to complete
@@ -225,8 +225,8 @@ public class RevalidatingServerAuthenticationStateProviderTest
     class TestRevalidatingServerAuthenticationStateProvider : RevalidatingServerAuthenticationStateProvider
     {
         private readonly TimeSpan _revalidationInterval;
-        private TaskCompletionSource<object> _nextValidateAuthenticationStateAsyncCallSource
-            = new TaskCompletionSource<object>();
+        private TaskCompletionSource _nextValidateAuthenticationStateAsyncCallSource
+            = new TaskCompletionSource();
 
         public TestRevalidatingServerAuthenticationStateProvider(TimeSpan revalidationInterval)
             : base(NullLoggerFactory.Instance)
@@ -249,8 +249,8 @@ public class RevalidatingServerAuthenticationStateProviderTest
             RevalidationCallLog.Add((authenticationState, cancellationToken));
             var result = NextValidationResult;
             var prevCts = _nextValidateAuthenticationStateAsyncCallSource;
-            _nextValidateAuthenticationStateAsyncCallSource = new TaskCompletionSource<object>();
-            prevCts.SetResult(true);
+            _nextValidateAuthenticationStateAsyncCallSource = new TaskCompletionSource();
+            prevCts.SetResult();
             return result;
         }
     }

--- a/src/Components/WebView/Samples/PhotinoPlatform/src/PhotinoSynchronizationContext.cs
+++ b/src/Components/WebView/Samples/PhotinoPlatform/src/PhotinoSynchronizationContext.cs
@@ -171,7 +171,7 @@ internal class PhotinoSynchronizationContext : SynchronizationContext
     public override void Send(SendOrPostCallback d, object state)
     {
         Task antecedent;
-        var completion = new TaskCompletionSource<object>();
+        var completion = new TaskCompletionSource();
 
         lock (_state.Lock)
         {
@@ -200,7 +200,7 @@ internal class PhotinoSynchronizationContext : SynchronizationContext
     // if necessary.
     private void ExecuteSynchronouslyIfPossible(SendOrPostCallback d, object state)
     {
-        TaskCompletionSource<object> completion;
+        TaskCompletionSource completion;
         lock (_state.Lock)
         {
             if (!_state.Task.IsCompleted)
@@ -211,7 +211,7 @@ internal class PhotinoSynchronizationContext : SynchronizationContext
 
             // We can execute this synchronously because nothing is currently running
             // or queued.
-            completion = new TaskCompletionSource<object>();
+            completion = new TaskCompletionSource();
             _state.Task = completion.Task;
         }
 
@@ -245,7 +245,7 @@ internal class PhotinoSynchronizationContext : SynchronizationContext
     }
 
     private void ExecuteSynchronously(
-        TaskCompletionSource<object> completion,
+        TaskCompletionSource completion,
         SendOrPostCallback d,
         object state)
     {
@@ -265,7 +265,7 @@ internal class PhotinoSynchronizationContext : SynchronizationContext
                     _state.IsBusy = false;
                     SetSynchronizationContext(original);
 
-                    completion?.SetResult(null);
+                    completion?.SetResult();
                 }
             }});
     }

--- a/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/CircuitGracefulTerminationTests.cs
@@ -23,7 +23,7 @@ public class CircuitGracefulTerminationTests : ServerTestBase<BasicTestAppServer
     {
     }
 
-    public TaskCompletionSource<object> GracefulDisconnectCompletionSource { get; private set; }
+    public TaskCompletionSource GracefulDisconnectCompletionSource { get; private set; }
     public TestSink Sink { get; private set; }
     public List<(Extensions.Logging.LogLevel level, string eventIdName)> Messages { get; private set; }
 
@@ -42,7 +42,7 @@ public class CircuitGracefulTerminationTests : ServerTestBase<BasicTestAppServer
         Browser.MountTestComponent<GracefulTermination>();
         Browser.Equal("Graceful Termination", () => Browser.Exists(By.TagName("h1")).Text);
 
-        GracefulDisconnectCompletionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        GracefulDisconnectCompletionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         Sink = _serverFixture.Host.Services.GetRequiredService<TestSink>();
         Messages = new List<(Extensions.Logging.LogLevel level, string eventIdName)>();
         Sink.MessageLogged += Log;
@@ -129,7 +129,7 @@ public class CircuitGracefulTerminationTests : ServerTestBase<BasicTestAppServer
     {
         if ((Extensions.Logging.LogLevel.Debug, "CircuitTerminatedGracefully") == (wc.LogLevel, wc.EventId.Name))
         {
-            GracefulDisconnectCompletionSource.TrySetResult(null);
+            GracefulDisconnectCompletionSource.TrySetResult();
         }
         Messages.Add((wc.LogLevel, wc.EventId.Name));
     }

--- a/src/Components/test/testassets/BasicTestApp/AsyncEventHandlerComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/AsyncEventHandlerComponent.razor
@@ -8,13 +8,13 @@
 
 @code
 {
-    TaskCompletionSource<object> _tcs;
+    TaskCompletionSource _tcs;
     string state = "Stopped";
     Task Tick(MouseEventArgs e)
     {
         if (_tcs == null)
         {
-            _tcs = new TaskCompletionSource<object>();
+            _tcs = new TaskCompletionSource();
 
             state = "Started";
             return _tcs.Task.ContinueWith((task) =>
@@ -29,6 +29,6 @@
 
     void Tock(MouseEventArgs e)
     {
-        _tcs.TrySetResult(null);
+        _tcs.TrySetResult();
     }
 }

--- a/src/DataProtection/DataProtection/test/HostingTests.cs
+++ b/src/DataProtection/DataProtection/test/HostingTests.cs
@@ -19,11 +19,11 @@ public class HostingTests
     [Fact]
     public async Task WebhostLoadsKeyRingBeforeServerStarts()
     {
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
         var mockKeyRing = new Mock<IKeyRingProvider>();
         mockKeyRing.Setup(m => m.GetCurrentKeyRing())
             .Returns(Mock.Of<IKeyRing>())
-            .Callback(() => tcs.TrySetResult(null));
+            .Callback(() => tcs.TrySetResult());
 
         var builder = new WebHostBuilder()
             .UseStartup<TestStartup>()
@@ -46,11 +46,11 @@ public class HostingTests
     [Fact]
     public async Task GenericHostLoadsKeyRingBeforeServerStarts()
     {
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
         var mockKeyRing = new Mock<IKeyRingProvider>();
         mockKeyRing.Setup(m => m.GetCurrentKeyRing())
             .Returns(Mock.Of<IKeyRing>())
-            .Callback(() => tcs.TrySetResult(null));
+            .Callback(() => tcs.TrySetResult());
 
         var builder = new HostBuilder()
             .ConfigureServices(s =>

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -950,10 +950,10 @@ public class WebApplicationTests
 
         Assert.Contains("*", options.AllowedHosts);
 
-        var changed = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var changed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         monitor.OnChange(newOptions =>
         {
-            changed.TrySetResult(0);
+            changed.TrySetResult();
         });
 
         config["AllowedHosts"] = "NewHost";

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebHostTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebHostTests.cs
@@ -40,10 +40,10 @@ public class WebHostTests
 
         Assert.Contains("*", options.AllowedHosts);
 
-        var changed = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var changed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         monitor.OnChange(newOptions =>
         {
-            changed.SetResult(0);
+            changed.SetResult();
         });
 
         config["AllowedHosts"] = "NewHost";

--- a/src/Grpc/test/InteropTests/Helpers/ClientProcess.cs
+++ b/src/Grpc/test/InteropTests/Helpers/ClientProcess.cs
@@ -15,7 +15,7 @@ public class ClientProcess : IDisposable
 {
     private readonly Process _process;
     private readonly ProcessEx _processEx;
-    private readonly TaskCompletionSource<object> _startTcs;
+    private readonly TaskCompletionSource _startTcs;
     private readonly StringBuilder _output;
     private readonly object _outputLock = new object();
 
@@ -38,7 +38,7 @@ public class ClientProcess : IDisposable
 
         _processEx = new ProcessEx(output, _process, timeout: Timeout.InfiniteTimeSpan);
 
-        _startTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _startTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 
     public Task WaitForReadyAsync() => _startTcs.Task;
@@ -61,7 +61,7 @@ public class ClientProcess : IDisposable
         {
             if (data.Contains("Application started."))
             {
-                _startTcs.TrySetResult(null);
+                _startTcs.TrySetResult();
             }
 
             lock (_outputLock)

--- a/src/Grpc/test/InteropTests/Helpers/WebsiteProcess.cs
+++ b/src/Grpc/test/InteropTests/Helpers/WebsiteProcess.cs
@@ -16,7 +16,7 @@ public class WebsiteProcess : IDisposable
 {
     private readonly Process _process;
     private readonly ProcessEx _processEx;
-    private readonly TaskCompletionSource<object> _startTcs;
+    private readonly TaskCompletionSource _startTcs;
     private static readonly Regex NowListeningRegex = new Regex(@"^\s*Now listening on: .*:(?<port>\d*)$");
     private readonly StringBuilder _output;
     private readonly object _outputLock = new object();
@@ -43,7 +43,7 @@ public class WebsiteProcess : IDisposable
 
         _processEx = new ProcessEx(output, _process, Timeout.InfiniteTimeSpan);
 
-        _startTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _startTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 
     public string GetOutput()
@@ -77,7 +77,7 @@ public class WebsiteProcess : IDisposable
 
             if (data.Contains("Application started. Press Ctrl+C to shut down."))
             {
-                _startTcs.TrySetResult(null);
+                _startTcs.TrySetResult();
             }
 
             lock (_outputLock)

--- a/src/Hosting/TestHost/test/RequestLifetimeTests.cs
+++ b/src/Hosting/TestHost/test/RequestLifetimeTests.cs
@@ -15,10 +15,10 @@ public class RequestLifetimeTests
     [Fact]
     public async Task LifetimeFeature_Abort_TriggersRequestAbortedToken()
     {
-        var requestAborted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestAborted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using var host = await CreateHost(async httpContext =>
         {
-            httpContext.RequestAborted.Register(() => requestAborted.SetResult(0));
+            httpContext.RequestAborted.Register(() => requestAborted.SetResult());
             httpContext.Abort();
 
             await requestAborted.Task.DefaultTimeout();
@@ -33,7 +33,7 @@ public class RequestLifetimeTests
     [Fact]
     public async Task LifetimeFeature_AbortBeforeHeadersSent_ClientThrows()
     {
-        var abortReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var abortReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using var host = await CreateHost(async httpContext =>
         {
             httpContext.Abort();
@@ -43,14 +43,14 @@ public class RequestLifetimeTests
         var client = host.GetTestServer().CreateClient();
         var ex = await Assert.ThrowsAsync<Exception>(() => client.GetAsync("/", HttpCompletionOption.ResponseHeadersRead));
         Assert.Equal("The application aborted the request.", ex.Message);
-        abortReceived.SetResult(0);
+        abortReceived.SetResult();
     }
 
     [Fact]
     public async Task LifetimeFeature_AbortAfterHeadersSent_ClientBodyThrows()
     {
-        var responseReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var abortReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var responseReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var abortReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using var host = await CreateHost(async httpContext =>
         {
             await httpContext.Response.Body.FlushAsync();
@@ -61,19 +61,19 @@ public class RequestLifetimeTests
 
         var client = host.GetTestServer().CreateClient();
         var response = await client.GetAsync("/", HttpCompletionOption.ResponseHeadersRead);
-        responseReceived.SetResult(0);
+        responseReceived.SetResult();
         response.EnsureSuccessStatusCode();
         var ex = await Assert.ThrowsAsync<HttpRequestException>(() => response.Content.ReadAsByteArrayAsync());
         var rex = ex.GetBaseException();
         Assert.Equal("The application aborted the request.", rex.Message);
-        abortReceived.SetResult(0);
+        abortReceived.SetResult();
     }
 
     [Fact]
     public async Task LifetimeFeature_AbortAfterSomeDataSent_ClientBodyThrows()
     {
-        var responseReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var abortReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var responseReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var abortReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using var host = await CreateHost(async httpContext =>
         {
             await httpContext.Response.WriteAsync("Hello World");
@@ -84,12 +84,12 @@ public class RequestLifetimeTests
 
         var client = host.GetTestServer().CreateClient();
         using var response = await client.GetAsync("/", HttpCompletionOption.ResponseHeadersRead);
-        responseReceived.SetResult(0);
+        responseReceived.SetResult();
         response.EnsureSuccessStatusCode();
         var ex = await Assert.ThrowsAsync<HttpRequestException>(() => response.Content.ReadAsByteArrayAsync());
         var rex = ex.GetBaseException();
         Assert.Equal("The application aborted the request.", rex.Message);
-        abortReceived.SetResult(0);
+        abortReceived.SetResult();
     }
 
     // TODO: Abort after CompleteAsync - No-op, the request is already complete.

--- a/src/Hosting/TestHost/test/TestClientTests.cs
+++ b/src/Hosting/TestHost/test/TestClientTests.cs
@@ -321,7 +321,7 @@ public class TestClientTests
     public async Task ClientStreaming_ResponseCompletesWithoutReadingRequest()
     {
         // Arrange
-        var requestStreamTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestStreamTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var responseEndingSyncPoint = new SyncPoint();
 
         RequestDelegate appDelegate = async ctx =>
@@ -362,7 +362,7 @@ public class TestClientTests
             try
             {
                 await requestStream.WriteAsync(Encoding.UTF8.GetBytes(new string('!', 1024 * 1024 * 50))).AsTask().DefaultTimeout();
-                requestStreamTcs.SetResult(null);
+                requestStreamTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -383,7 +383,7 @@ public class TestClientTests
     public async Task ClientStreaming_ResponseCompletesWithPendingRead_ThrowError()
     {
         // Arrange
-        var requestStreamTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestStreamTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         RequestDelegate appDelegate = async ctx =>
         {
@@ -424,14 +424,14 @@ public class TestClientTests
         Assert.Equal("An error occurred when completing the request. Request delegate may have finished while there is a pending read of the request body.", ex.InnerException.Message);
 
         // Unblock request
-        requestStreamTcs.TrySetResult(null);
+        requestStreamTcs.TrySetResult();
     }
 
     [Fact]
     public async Task ClientStreaming_ResponseCompletesWithoutResponseBodyWrite()
     {
         // Arrange
-        var requestStreamTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestStreamTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         RequestDelegate appDelegate = ctx =>
         {
@@ -471,7 +471,7 @@ public class TestClientTests
         await Assert.ThrowsAnyAsync<Exception>(() => requestStream.WriteAsync(buffer).AsTask());
 
         // Unblock request
-        requestStreamTcs.TrySetResult(null);
+        requestStreamTcs.TrySetResult();
     }
 
     [Fact]
@@ -804,7 +804,7 @@ public class TestClientTests
     public async Task ClientDisposalAbortsRequest()
     {
         // Arrange
-        var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         RequestDelegate appDelegate = async ctx =>
         {
             // Write Headers
@@ -837,13 +837,13 @@ public class TestClientTests
     [Fact]
     public async Task ClientCancellationAbortsRequest()
     {
-        var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var builder = new WebHostBuilder().Configure(app => app.Run(async ctx =>
         {
             try
             {
                 await Task.Delay(TimeSpan.FromSeconds(30), ctx.RequestAborted);
-                tcs.SetResult(0);
+                tcs.SetResult();
             }
             catch (Exception e)
             {

--- a/src/Hosting/TestHost/test/TestServerTests.cs
+++ b/src/Hosting/TestHost/test/TestServerTests.cs
@@ -665,7 +665,7 @@ public class TestServerTests
                               {
                                   app.Run(context =>
                                   {
-                                      TaskCompletionSource<int> tcs = new TaskCompletionSource<int>();
+                                      TaskCompletionSource tcs = new TaskCompletionSource();
                                       tcs.SetCanceled();
                                       return tcs.Task;
                                   });

--- a/src/Http/Http.Extensions/test/HttpResponseJsonExtensionsTests.cs
+++ b/src/Http/Http.Extensions/test/HttpResponseJsonExtensionsTests.cs
@@ -484,8 +484,8 @@ public class HttpResponseJsonExtensionsTests
 
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
-            var tcs = new TaskCompletionSource<int>();
-            cancellationToken.Register(s => ((TaskCompletionSource<int>)s!).SetCanceled(), tcs);
+            var tcs = new TaskCompletionSource();
+            cancellationToken.Register(s => ((TaskCompletionSource)s!).SetCanceled(), tcs);
             return new ValueTask(tcs.Task);
         }
     }

--- a/src/Http/Http.Extensions/test/TestStream.cs
+++ b/src/Http/Http.Extensions/test/TestStream.cs
@@ -45,8 +45,8 @@ public class TestStream : Stream
 
     public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
     {
-        var tcs = new TaskCompletionSource<int>();
-        cancellationToken.Register(s => ((TaskCompletionSource<int>)s).SetCanceled(), tcs);
+        var tcs = new TaskCompletionSource();
+        cancellationToken.Register(s => ((TaskCompletionSource)s).SetCanceled(), tcs);
         return new ValueTask(tcs.Task);
     }
 }

--- a/src/Http/Http/test/HttpContextAccessorTests.cs
+++ b/src/Http/Http/test/HttpContextAccessorTests.cs
@@ -35,16 +35,16 @@ public class HttpContextAccessorTests
         var context = new DefaultHttpContext();
         accessor.HttpContext = context;
 
-        var checkAsyncFlowTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var waitForNullTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var afterNullCheckTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var checkAsyncFlowTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var waitForNullTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var afterNullCheckTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         ThreadPool.QueueUserWorkItem(async _ =>
         {
             // The HttpContext flows with the execution context
             Assert.Same(context, accessor.HttpContext);
 
-            checkAsyncFlowTcs.SetResult(null);
+            checkAsyncFlowTcs.SetResult();
 
             await waitForNullTcs.Task;
 
@@ -52,7 +52,7 @@ public class HttpContextAccessorTests
             {
                 Assert.Null(accessor.HttpContext);
 
-                afterNullCheckTcs.SetResult(null);
+                afterNullCheckTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -65,7 +65,7 @@ public class HttpContextAccessorTests
         // Null out the accessor
         accessor.HttpContext = null;
 
-        waitForNullTcs.SetResult(null);
+        waitForNullTcs.SetResult();
 
         Assert.Null(accessor.HttpContext);
 
@@ -80,16 +80,16 @@ public class HttpContextAccessorTests
         var context = new DefaultHttpContext();
         accessor.HttpContext = context;
 
-        var checkAsyncFlowTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var waitForNullTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var afterNullCheckTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var checkAsyncFlowTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var waitForNullTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var afterNullCheckTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         ThreadPool.QueueUserWorkItem(async _ =>
         {
             // The HttpContext flows with the execution context
             Assert.Same(context, accessor.HttpContext);
 
-            checkAsyncFlowTcs.SetResult(null);
+            checkAsyncFlowTcs.SetResult();
 
             await waitForNullTcs.Task;
 
@@ -97,7 +97,7 @@ public class HttpContextAccessorTests
             {
                 Assert.Null(accessor.HttpContext);
 
-                afterNullCheckTcs.SetResult(null);
+                afterNullCheckTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -111,7 +111,7 @@ public class HttpContextAccessorTests
         var context2 = new DefaultHttpContext();
         accessor.HttpContext = context2;
 
-        waitForNullTcs.SetResult(null);
+        waitForNullTcs.SetResult();
 
         Assert.Same(context2, accessor.HttpContext);
 
@@ -126,7 +126,7 @@ public class HttpContextAccessorTests
         var context = new DefaultHttpContext();
         accessor.HttpContext = context;
 
-        var checkAsyncFlowTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var checkAsyncFlowTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         accessor.HttpContext = null;
 
@@ -136,7 +136,7 @@ public class HttpContextAccessorTests
             {
                 // The HttpContext flows with the execution context
                 Assert.Null(accessor.HttpContext);
-                checkAsyncFlowTcs.SetResult(null);
+                checkAsyncFlowTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -155,7 +155,7 @@ public class HttpContextAccessorTests
         var context = new DefaultHttpContext();
         accessor.HttpContext = context;
 
-        var checkAsyncFlowTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var checkAsyncFlowTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         ThreadPool.UnsafeQueueUserWorkItem(_ =>
         {
@@ -163,7 +163,7 @@ public class HttpContextAccessorTests
             {
                 // The HttpContext flows with the execution context
                 Assert.Null(accessor.HttpContext);
-                checkAsyncFlowTcs.SetResult(null);
+                checkAsyncFlowTcs.SetResult();
             }
             catch (Exception ex)
             {

--- a/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetDispatcherTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetDispatcherTest.cs
@@ -936,7 +936,7 @@ public class DotNetDispatcherTest
 
     public class TestJSRuntime : JSInProcessRuntime
     {
-        private TaskCompletionSource<object> _nextInvocationTcs = new TaskCompletionSource<object>();
+        private TaskCompletionSource _nextInvocationTcs = new TaskCompletionSource();
         public Task NextInvocationTask => _nextInvocationTcs.Task;
         public long LastInvocationAsyncHandle { get; private set; }
         public string LastInvocationIdentifier { get; private set; }
@@ -950,8 +950,8 @@ public class DotNetDispatcherTest
             LastInvocationAsyncHandle = asyncHandle;
             LastInvocationIdentifier = identifier;
             LastInvocationArgsJson = argsJson;
-            _nextInvocationTcs.SetResult(null);
-            _nextInvocationTcs = new TaskCompletionSource<object>();
+            _nextInvocationTcs.SetResult();
+            _nextInvocationTcs = new TaskCompletionSource();
         }
 
         protected override string InvokeJS(string identifier, string argsJson, JSCallResultType resultType, long targetInstanceId)
@@ -959,8 +959,8 @@ public class DotNetDispatcherTest
             LastInvocationAsyncHandle = default;
             LastInvocationIdentifier = identifier;
             LastInvocationArgsJson = argsJson;
-            _nextInvocationTcs.SetResult(null);
-            _nextInvocationTcs = new TaskCompletionSource<object>();
+            _nextInvocationTcs.SetResult();
+            _nextInvocationTcs = new TaskCompletionSource();
             return null;
         }
 
@@ -968,8 +968,8 @@ public class DotNetDispatcherTest
         {
             LastCompletionCallId = invocationInfo.CallId;
             LastCompletionResult = invocationResult;
-            _nextInvocationTcs.SetResult(null);
-            _nextInvocationTcs = new TaskCompletionSource<object>();
+            _nextInvocationTcs.SetResult();
+            _nextInvocationTcs = new TaskCompletionSource();
         }
     }
 }

--- a/src/Middleware/ConcurrencyLimiter/test/MiddlewareTests.cs
+++ b/src/Middleware/ConcurrencyLimiter/test/MiddlewareTests.cs
@@ -125,7 +125,7 @@ public class MiddlewareTests
     [Fact]
     public async Task ExceptionThrownDuringOnRejected()
     {
-        TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>();
+        TaskCompletionSource tcs = new TaskCompletionSource();
 
         var concurrent = 0;
         var testQueue = new TestQueue(
@@ -167,7 +167,7 @@ public class MiddlewareTests
         Assert.Equal(0, testQueue.QueuedRequests);
 
         // the first request is unblocked, and the queue continues functioning as expected
-        tcs.SetResult(true);
+        tcs.SetResult();
         Assert.True(firstRequest.IsCompletedSuccessfully);
         Assert.Equal(0, concurrent);
         Assert.Equal(0, testQueue.QueuedRequests);

--- a/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
@@ -754,8 +754,8 @@ public class HttpLoggingMiddlewareTests : LoggedTest
         var options = CreateOptionsAccessor();
         options.CurrentValue.LoggingFields = HttpLoggingFields.Response;
 
-        var writtenHeaders = new TaskCompletionSource<object>();
-        var letBodyFinish = new TaskCompletionSource<object>();
+        var writtenHeaders = new TaskCompletionSource();
+        var letBodyFinish = new TaskCompletionSource();
 
         var middleware = new HttpLoggingMiddleware(
             async c =>
@@ -764,7 +764,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
                 c.Response.Headers[HeaderNames.TransferEncoding] = "test";
                 c.Response.ContentType = "text/plain";
                 await c.Response.WriteAsync("test");
-                writtenHeaders.SetResult(null);
+                writtenHeaders.SetResult();
                 await letBodyFinish.Task;
             },
             options,
@@ -780,7 +780,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
         Assert.Contains(TestSink.Writes, w => w.Message.Contains("Transfer-Encoding: test"));
         Assert.DoesNotContain(TestSink.Writes, w => w.Message.Contains("Body: test"));
 
-        letBodyFinish.SetResult(null);
+        letBodyFinish.SetResult();
 
         await middlewareTask;
 
@@ -793,8 +793,8 @@ public class HttpLoggingMiddlewareTests : LoggedTest
         var options = CreateOptionsAccessor();
         options.CurrentValue.LoggingFields = HttpLoggingFields.Response;
 
-        var writtenHeaders = new TaskCompletionSource<object>();
-        var letBodyFinish = new TaskCompletionSource<object>();
+        var writtenHeaders = new TaskCompletionSource();
+        var letBodyFinish = new TaskCompletionSource();
 
         var middleware = new HttpLoggingMiddleware(
             async c =>
@@ -803,7 +803,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
                 c.Response.Headers[HeaderNames.TransferEncoding] = "test";
                 c.Response.ContentType = "text/plain";
                 await c.Response.StartAsync();
-                writtenHeaders.SetResult(null);
+                writtenHeaders.SetResult();
                 await letBodyFinish.Task;
             },
             options,
@@ -819,7 +819,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
         Assert.Contains(TestSink.Writes, w => w.Message.Contains("Transfer-Encoding: test"));
         Assert.DoesNotContain(TestSink.Writes, w => w.Message.Contains("Body: test"));
 
-        letBodyFinish.SetResult(null);
+        letBodyFinish.SetResult();
 
         await middlewareTask;
     }

--- a/src/Middleware/ResponseCompression/test/ResponseCompressionMiddlewareTest.cs
+++ b/src/Middleware/ResponseCompression/test/ResponseCompressionMiddlewareTest.cs
@@ -619,7 +619,7 @@ public class ResponseCompressionMiddlewareTest
     [MemberData(nameof(SupportedEncodingsWithBodyLength))]
     public async Task FlushHeaders_SendsHeaders_Compresses(string encoding, int expectedBodyLength)
     {
-        var responseReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var responseReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         using var host = new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>
@@ -654,7 +654,7 @@ public class ResponseCompressionMiddlewareTest
         request.Headers.AcceptEncoding.ParseAdd(encoding);
 
         var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
-        responseReceived.SetResult(0);
+        responseReceived.SetResult();
 
         await response.Content.LoadIntoBufferAsync();
 
@@ -665,7 +665,7 @@ public class ResponseCompressionMiddlewareTest
     [MemberData(nameof(SupportedEncodingsWithBodyLength))]
     public async Task FlushAsyncHeaders_SendsHeaders_Compresses(string encoding, int expectedBodyLength)
     {
-        var responseReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var responseReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         using var host = new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>
@@ -699,7 +699,7 @@ public class ResponseCompressionMiddlewareTest
         request.Headers.AcceptEncoding.ParseAdd(encoding);
 
         var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
-        responseReceived.SetResult(0);
+        responseReceived.SetResult();
 
         await response.Content.LoadIntoBufferAsync();
 
@@ -710,7 +710,7 @@ public class ResponseCompressionMiddlewareTest
     [MemberData(nameof(SupportedEncodings))]
     public async Task FlushBody_CompressesAndFlushes(string encoding)
     {
-        var responseReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var responseReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         using var host = new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>
@@ -759,7 +759,7 @@ public class ResponseCompressionMiddlewareTest
         var read = await body.ReadAsync(new byte[100], 0, 100);
         Assert.True(read > 0);
 
-        responseReceived.SetResult(0);
+        responseReceived.SetResult();
 
         read = await body.ReadAsync(new byte[100], 0, 100);
         Assert.True(read > 0);
@@ -769,7 +769,7 @@ public class ResponseCompressionMiddlewareTest
     [MemberData(nameof(SupportedEncodings))]
     public async Task FlushAsyncBody_CompressesAndFlushes(string encoding)
     {
-        var responseReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var responseReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         using var host = new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>
@@ -812,7 +812,7 @@ public class ResponseCompressionMiddlewareTest
         var read = await body.ReadAsync(new byte[100], 0, 100);
         Assert.True(read > 0);
 
-        responseReceived.SetResult(0);
+        responseReceived.SetResult();
 
         read = await body.ReadAsync(new byte[100], 0, 100);
         Assert.True(read > 0);
@@ -824,11 +824,11 @@ public class ResponseCompressionMiddlewareTest
     {
         var responseReceived = new[]
         {
-                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
-                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
-                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
-                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
-                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
             };
 
         using var host = new HostBuilder()
@@ -884,7 +884,7 @@ public class ResponseCompressionMiddlewareTest
             var read = await body.ReadAsync(new byte[100], 0, 100);
             Assert.True(read > 0);
 
-            signal.SetResult(0);
+            signal.SetResult();
         }
     }
 
@@ -894,11 +894,11 @@ public class ResponseCompressionMiddlewareTest
     {
         var responseReceived = new[]
         {
-                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
-                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
-                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
-                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
-                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
             };
 
         using var host = new HostBuilder()
@@ -948,7 +948,7 @@ public class ResponseCompressionMiddlewareTest
             var read = await body.ReadAsync(new byte[100], 0, 100);
             Assert.True(read > 0);
 
-            signal.SetResult(0);
+            signal.SetResult();
         }
     }
 
@@ -958,11 +958,11 @@ public class ResponseCompressionMiddlewareTest
     {
         var responseReceived = new[]
         {
-                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
-                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
-                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
-                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
-                new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
+                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously),
             };
 
         using var host = new HostBuilder()
@@ -1015,7 +1015,7 @@ public class ResponseCompressionMiddlewareTest
             Assert.Equal(1, read);
             Assert.Equal('a', (char)data[0]);
 
-            signal.SetResult(0);
+            signal.SetResult();
         }
     }
 
@@ -1173,7 +1173,7 @@ public class ResponseCompressionMiddlewareTest
     [MemberData(nameof(SupportedEncodings))]
     public async Task Dispose_SyncWriteOrFlushNotCalled(string encoding)
     {
-        var responseReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var responseReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         using var host = new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>
@@ -1221,7 +1221,7 @@ public class ResponseCompressionMiddlewareTest
         var read = await body.ReadAsync(new byte[100], 0, 100);
         Assert.True(read > 0);
 
-        responseReceived.SetResult(0);
+        responseReceived.SetResult();
 
         read = await body.ReadAsync(new byte[100], 0, 100);
         Assert.True(read > 0);

--- a/src/Middleware/StaticFiles/test/FunctionalTests/StaticFileMiddlewareTests.cs
+++ b/src/Middleware/StaticFiles/test/FunctionalTests/StaticFileMiddlewareTests.cs
@@ -235,9 +235,9 @@ public class StaticFileMiddlewareTests : LoggedTest
     private async Task ClientDisconnect_NoWriteExceptionThrown(ServerType serverType)
     {
         var interval = TimeSpan.FromSeconds(15);
-        var requestReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var requestCancelled = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var responseComplete = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var responseComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         Exception exception = null;
         using var host = new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>
@@ -251,7 +251,7 @@ public class StaticFileMiddlewareTests : LoggedTest
                     {
                         try
                         {
-                            requestReceived.SetResult(0);
+                            requestReceived.SetResult();
                             await requestCancelled.Task.TimeoutAfter(interval);
                             Assert.True(context.RequestAborted.WaitHandle.WaitOne(interval), "not aborted");
                             await next(context);
@@ -260,7 +260,7 @@ public class StaticFileMiddlewareTests : LoggedTest
                         {
                             exception = ex;
                         }
-                        responseComplete.SetResult(0);
+                        responseComplete.SetResult();
                     });
                     app.UseStaticFiles();
                 })
@@ -284,7 +284,7 @@ public class StaticFileMiddlewareTests : LoggedTest
 
         socket.LingerState = new LingerOption(true, 0);
         socket.Dispose();
-        requestCancelled.SetResult(0);
+        requestCancelled.SetResult();
 
         await responseComplete.Task.TimeoutAfter(interval);
         Assert.Null(exception);

--- a/src/Middleware/WebSockets/test/UnitTests/BufferStream.cs
+++ b/src/Middleware/WebSockets/test/UnitTests/BufferStream.cs
@@ -19,14 +19,14 @@ public class BufferStream : Stream
     private ArraySegment<byte> _topBuffer;
     private readonly SemaphoreSlim _readLock;
     private readonly SemaphoreSlim _writeLock;
-    private TaskCompletionSource<object> _readWaitingForData;
+    private TaskCompletionSource _readWaitingForData;
 
     internal BufferStream()
     {
         _readLock = new SemaphoreSlim(1, 1);
         _writeLock = new SemaphoreSlim(1, 1);
         _bufferedData = new ConcurrentQueue<byte[]>();
-        _readWaitingForData = new TaskCompletionSource<object>();
+        _readWaitingForData = new TaskCompletionSource();
     }
 
     public override bool CanRead
@@ -87,7 +87,7 @@ public class BufferStream : Stream
     {
         if (cancellationToken.IsCancellationRequested)
         {
-            TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
+            TaskCompletionSource tcs = new TaskCompletionSource();
             tcs.TrySetCanceled();
             return tcs.Task;
         }
@@ -260,7 +260,7 @@ public class BufferStream : Stream
         VerifyBuffer(buffer, offset, count, allowEmpty: true);
         if (cancellationToken.IsCancellationRequested)
         {
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource();
             tcs.TrySetCanceled();
             return tcs.Task;
         }
@@ -285,17 +285,17 @@ public class BufferStream : Stream
     private void SignalDataAvailable()
     {
         // Dispatch, as TrySetResult will synchronously execute the waiters callback and block our Write.
-        Task.Factory.StartNew(() => _readWaitingForData.TrySetResult(null));
+        Task.Factory.StartNew(() => _readWaitingForData.TrySetResult());
     }
 
     private Task WaitForDataAsync()
     {
-        _readWaitingForData = new TaskCompletionSource<object>();
+        _readWaitingForData = new TaskCompletionSource();
 
         if (!_bufferedData.IsEmpty || _disposed)
         {
             // Race, data could have arrived before we created the TCS.
-            _readWaitingForData.TrySetResult(null);
+            _readWaitingForData.TrySetResult();
         }
 
         return _readWaitingForData.Task;
@@ -330,7 +330,7 @@ public class BufferStream : Stream
         {
             // Throw for further writes, but not reads.  Allow reads to drain the buffered data and then return 0 for further reads.
             _disposed = true;
-            _readWaitingForData.TrySetResult(null);
+            _readWaitingForData.TrySetResult();
         }
 
         base.Dispose(disposing);

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/test/PageLoaderMatcherPolicyTest.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/test/PageLoaderMatcherPolicyTest.cs
@@ -64,7 +64,7 @@ public class PageLoaderMatcherPolicyTest
         var compiled = new CompiledPageActionDescriptor();
         compiled.Endpoint = CreateEndpoint(new PageActionDescriptor());
 
-        var tcs = new TaskCompletionSource<int>();
+        var tcs = new TaskCompletionSource();
         var candidateSet = CreateCandidateSet(compiled);
 
         var loadTask = Task.Run(async () =>
@@ -77,7 +77,7 @@ public class PageLoaderMatcherPolicyTest
 
         // Act
         var applyTask = policy.ApplyAsync(new DefaultHttpContext(), candidateSet);
-        tcs.SetResult(0);
+        tcs.SetResult();
         await applyTask;
 
         // Assert

--- a/src/Mvc/Mvc.TagHelpers/test/CacheTagHelperTest.cs
+++ b/src/Mvc/Mvc.TagHelpers/test/CacheTagHelperTest.cs
@@ -540,9 +540,9 @@ public class CacheTagHelperTest
         // Arrange
         var id = "unique-id";
         var childContent = "some-content";
-        var event1 = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var event2 = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var event3 = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var event1 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var event2 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var event3 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var calls = 0;
         var cache = new MemoryCache(new MemoryCacheOptions());
 
@@ -555,7 +555,7 @@ public class CacheTagHelperTest
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 calls++;
-                event2.SetResult(0);
+                event2.SetResult();
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 tagHelperContent.SetHtmlContent(childContent);
@@ -593,7 +593,7 @@ public class CacheTagHelperTest
         {
             await event1.Task.TimeoutAfter(TimeSpan.FromSeconds(5));
             await cacheTagHelper1.ProcessAsync(tagHelperContext1, tagHelperOutput1);
-            event3.SetResult(0);
+            event3.SetResult();
         });
 
         var task2 = Task.Run(async () =>
@@ -602,7 +602,7 @@ public class CacheTagHelperTest
             await cacheTagHelper2.ProcessAsync(tagHelperContext1, tagHelperOutput2);
         });
 
-        event1.SetResult(0);
+        event1.SetResult();
         await Task.WhenAll(task1, task2);
 
         // Assert
@@ -625,9 +625,9 @@ public class CacheTagHelperTest
         // Arrange
         var id = "unique-id";
         var childContent = "some-content";
-        var event1 = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var event2 = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var event3 = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var event1 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var event2 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var event3 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var calls = 0;
         var cache = new MemoryCache(new MemoryCacheOptions());
 
@@ -640,7 +640,7 @@ public class CacheTagHelperTest
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 calls++;
-                event2.SetResult(0);
+                event2.SetResult();
 
                 throw new Exception();
             });
@@ -676,7 +676,7 @@ public class CacheTagHelperTest
         {
             await event1.Task.TimeoutAfter(TimeSpan.FromSeconds(5));
             await Assert.ThrowsAsync<Exception>(() => cacheTagHelper1.ProcessAsync(tagHelperContext1, tagHelperOutput1));
-            event3.SetResult(0);
+            event3.SetResult();
         });
 
         var task2 = Task.Run(async () =>
@@ -685,7 +685,7 @@ public class CacheTagHelperTest
             await cacheTagHelper2.ProcessAsync(tagHelperContext2, tagHelperOutput2);
         });
 
-        event1.SetResult(0);
+        event1.SetResult();
         await Task.WhenAll(task1, task2);
 
         // Assert

--- a/src/Mvc/Mvc.TagHelpers/test/DistributedCacheTagHelperTest.cs
+++ b/src/Mvc/Mvc.TagHelpers/test/DistributedCacheTagHelperTest.cs
@@ -533,9 +533,9 @@ public class DistributedCacheTagHelperTest
     {
         // Arrange
         var childContent = "some-content";
-        var event1 = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var event2 = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var event3 = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var event1 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var event2 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var event3 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var calls = 0;
         var formatter = GetFormatter();
         var storage = GetStorage();
@@ -554,7 +554,7 @@ public class DistributedCacheTagHelperTest
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 calls++;
-                event2.SetResult(0);
+                event2.SetResult();
 
                 var tagHelperContent = new DefaultTagHelperContent();
                 tagHelperContent.SetHtmlContent(childContent);
@@ -596,7 +596,7 @@ public class DistributedCacheTagHelperTest
         {
             await event1.Task.TimeoutAfter(TimeSpan.FromSeconds(5));
             await cacheTagHelper1.ProcessAsync(tagHelperContext1, tagHelperOutput1);
-            event3.SetResult(0);
+            event3.SetResult();
         });
 
         var task2 = Task.Run(async () =>
@@ -605,7 +605,7 @@ public class DistributedCacheTagHelperTest
             await cacheTagHelper2.ProcessAsync(tagHelperContext1, tagHelperOutput2);
         });
 
-        event1.SetResult(0);
+        event1.SetResult();
         await Task.WhenAll(task1, task2);
 
         // Assert
@@ -627,9 +627,9 @@ public class DistributedCacheTagHelperTest
     {
         // Arrange
         var childContent = "some-content";
-        var event1 = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var event2 = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var event3 = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var event1 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var event2 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var event3 = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var calls = 0;
         var formatter = GetFormatter();
         var storage = GetStorage();
@@ -648,7 +648,7 @@ public class DistributedCacheTagHelperTest
             getChildContentAsync: (useCachedResult, encoder) =>
             {
                 calls++;
-                event2.SetResult(0);
+                event2.SetResult();
 
                 throw new Exception();
             });
@@ -688,7 +688,7 @@ public class DistributedCacheTagHelperTest
         {
             await event1.Task.TimeoutAfter(TimeSpan.FromSeconds(5));
             await Assert.ThrowsAsync<Exception>(() => cacheTagHelper1.ProcessAsync(tagHelperContext1, tagHelperOutput1));
-            event3.SetResult(0);
+            event3.SetResult();
         });
 
         var task2 = Task.Run(async () =>
@@ -697,7 +697,7 @@ public class DistributedCacheTagHelperTest
             await cacheTagHelper2.ProcessAsync(tagHelperContext2, tagHelperOutput2);
         });
 
-        event1.SetResult(0);
+        event1.SetResult();
         await Task.WhenAll(task1, task2);
 
         // Assert

--- a/src/Servers/HttpSys/test/FunctionalTests/AuthenticationTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/AuthenticationTests.cs
@@ -167,7 +167,7 @@ public class AuthenticationTests
     [ConditionalFact]
     public async Task AuthTypes_AccessUserInOnCompleted_Success()
     {
-        var completed = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         string userName = null;
         var authTypes = AuthenticationSchemes.Negotiate | AuthenticationSchemes.NTLM;
         using (var server = Utilities.CreateDynamicHost(authTypes, DenyAnoymous, out var address, httpContext =>
@@ -178,8 +178,8 @@ public class AuthenticationTests
             httpContext.Response.OnCompleted(() =>
             {
                 userName = httpContext.User.Identity.Name;
-                completed.SetResult(0);
-                return Task.FromResult(0);
+                completed.SetResult();
+                return Task.CompletedTask;
             });
             return Task.FromResult(0);
         }))

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/ResponseBodyTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/ResponseBodyTests.cs
@@ -240,8 +240,8 @@ public class ResponseBodyTests
 
             var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
 
-            var disconnectCts = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-            context.DisconnectToken.Register(() => disconnectCts.SetResult(0));
+            var disconnectCts = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            context.DisconnectToken.Register(() => disconnectCts.SetResult());
 
             // Make sure the client is aborted
             cts.Cancel();
@@ -276,8 +276,8 @@ public class ResponseBodyTests
 
             var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
 
-            var disconnectCts = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-            context.DisconnectToken.Register(() => disconnectCts.SetResult(0));
+            var disconnectCts = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            context.DisconnectToken.Register(() => disconnectCts.SetResult());
 
             // First write sends headers
             cts.Cancel();
@@ -312,8 +312,8 @@ public class ResponseBodyTests
             server.Options.AllowSynchronousIO = true;
             var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
 
-            var disconnectCts = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-            context.DisconnectToken.Register(() => disconnectCts.SetResult(0));
+            var disconnectCts = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            context.DisconnectToken.Register(() => disconnectCts.SetResult());
 
             cts.Cancel();
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
@@ -339,8 +339,8 @@ public class ResponseBodyTests
 
             var context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
 
-            var disconnectCts = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-            context.DisconnectToken.Register(() => disconnectCts.SetResult(0));
+            var disconnectCts = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            context.DisconnectToken.Register(() => disconnectCts.SetResult());
 
             cts.Cancel();
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
@@ -369,8 +369,8 @@ public class ResponseBodyTests
 
                 context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
 
-                var disconnectCts = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-                context.DisconnectToken.Register(() => disconnectCts.SetResult(0));
+                var disconnectCts = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                context.DisconnectToken.Register(() => disconnectCts.SetResult());
 
                 // First write sends headers
                 context.AllowSynchronousIO = true;
@@ -409,8 +409,8 @@ public class ResponseBodyTests
 
                 context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
 
-                var disconnectCts = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-                context.DisconnectToken.Register(() => disconnectCts.SetResult(0));
+                var disconnectCts = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                context.DisconnectToken.Register(() => disconnectCts.SetResult());
 
                 // First write sends headers
                 await context.Response.Body.WriteAsync(new byte[10], 0, 10);
@@ -448,8 +448,8 @@ public class ResponseBodyTests
 
                 context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
 
-                var disconnectCts = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-                context.DisconnectToken.Register(() => disconnectCts.SetResult(0));
+                var disconnectCts = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                context.DisconnectToken.Register(() => disconnectCts.SetResult());
 
                 // First write sends headers
                 context.Response.Body.Write(new byte[10], 0, 10);
@@ -482,8 +482,8 @@ public class ResponseBodyTests
 
                 context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
 
-                var disconnectCts = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-                context.DisconnectToken.Register(() => disconnectCts.SetResult(0));
+                var disconnectCts = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                context.DisconnectToken.Register(() => disconnectCts.SetResult());
 
                 // First write sends headers
                 await context.Response.Body.WriteAsync(new byte[10], 0, 10);

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/ServerTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/ServerTests.cs
@@ -22,7 +22,7 @@ public class ServerTests
     public async Task Server_TokenRegisteredAfterClientDisconnects_CallCanceled()
     {
         var interval = TimeSpan.FromSeconds(1);
-        var canceled = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var canceled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         string address;
         using (var server = Utilities.CreateHttpServer(out address))
@@ -38,7 +38,7 @@ public class ServerTests
 
                 var ct = context.DisconnectToken;
                 Assert.True(ct.CanBeCanceled, "CanBeCanceled");
-                ct.Register(() => canceled.SetResult(0));
+                ct.Register(() => canceled.SetResult());
                 await canceled.Task.TimeoutAfter(interval);
                 Assert.True(ct.IsCancellationRequested, "IsCancellationRequested");
 
@@ -51,7 +51,7 @@ public class ServerTests
     public async Task Server_TokenRegisteredAfterResponseSent_Success()
     {
         var interval = TimeSpan.FromSeconds(1);
-        var canceled = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var canceled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         string address;
         using (var server = Utilities.CreateHttpServer(out address))
@@ -69,7 +69,7 @@ public class ServerTests
 
                 var ct = context.DisconnectToken;
                 Assert.False(ct.CanBeCanceled, "CanBeCanceled");
-                ct.Register(() => canceled.SetResult(0));
+                ct.Register(() => canceled.SetResult());
                 Assert.False(ct.IsCancellationRequested, "IsCancellationRequested");
 
                 Assert.False(canceled.Task.IsCompleted, "canceled");
@@ -81,7 +81,7 @@ public class ServerTests
     public async Task Server_ConnectionCloseHeader_CancellationTokenFires()
     {
         var interval = TimeSpan.FromSeconds(1);
-        var canceled = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var canceled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         string address;
         using (var server = Utilities.CreateHttpServer(out address))
@@ -92,7 +92,7 @@ public class ServerTests
             var ct = context.DisconnectToken;
             Assert.True(ct.CanBeCanceled, "CanBeCanceled");
             Assert.False(ct.IsCancellationRequested, "IsCancellationRequested");
-            ct.Register(() => canceled.SetResult(0));
+            ct.Register(() => canceled.SetResult());
 
             context.Response.Headers["Connection"] = "close";
 

--- a/src/Servers/HttpSys/test/FunctionalTests/ResponseBodyTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ResponseBodyTests.cs
@@ -23,10 +23,10 @@ public class ResponseBodyTests
     {
         using (Utilities.CreateHttpServer(out var address, async httpContext =>
         {
-            var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var startingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             httpContext.Response.OnStarting(() =>
             {
-                startingTcs.SetResult(0);
+                startingTcs.SetResult();
                 return Task.CompletedTask;
             });
             await httpContext.Response.StartAsync();
@@ -49,13 +49,13 @@ public class ResponseBodyTests
     [ConditionalFact]
     public async Task ResponseBody_CompleteAsync_TriggersOnStartingAndLocksHeaders()
     {
-        var responseReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var responseReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using (Utilities.CreateHttpServer(out var address, async httpContext =>
         {
-            var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var startingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             httpContext.Response.OnStarting(() =>
             {
-                startingTcs.SetResult(0);
+                startingTcs.SetResult();
                 return Task.CompletedTask;
             });
             await httpContext.Response.CompleteAsync();
@@ -69,14 +69,14 @@ public class ResponseBodyTests
             Assert.Equal(200, (int)response.StatusCode);
             Assert.Equal(new Version(1, 1), response.Version);
             Assert.Equal(0, response.Content.Headers.ContentLength);
-            responseReceived.SetResult(0);
+            responseReceived.SetResult();
         }
     }
 
     [ConditionalFact]
     public async Task ResponseBody_CompleteAsync_FlushesThePipe()
     {
-        var responseReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var responseReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using (Utilities.CreateHttpServer(out var address, async httpContext =>
         {
             var writer = httpContext.Response.BodyWriter;
@@ -90,7 +90,7 @@ public class ResponseBodyTests
             Assert.Equal(200, (int)response.StatusCode);
             Assert.Equal(new Version(1, 1), response.Version);
             Assert.True(0 < (await response.Content.ReadAsByteArrayAsync()).Length);
-            responseReceived.SetResult(0);
+            responseReceived.SetResult();
         }
     }
 

--- a/src/Servers/HttpSys/test/FunctionalTests/ResponseSendFileTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ResponseSendFileTests.cs
@@ -366,7 +366,7 @@ public class ResponseSendFileTests
     [ConditionalFact]
     public async Task ResponseSendFileWriteExceptions_FirstCallWithCanceledCancellationToken_CancelsAndAborts()
     {
-        var testComplete = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var testComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using (Utilities.CreateHttpServer(out var address, httpContext =>
         {
             try
@@ -376,7 +376,7 @@ public class ResponseSendFileTests
                 // First write sends headers
                 var writeTask = httpContext.Response.SendFileAsync(AbsoluteFilePath, 0, null, cts.Token);
                 Assert.True(writeTask.IsCanceled);
-                testComplete.SetResult(0);
+                testComplete.SetResult();
             }
             catch (Exception ex)
             {
@@ -394,7 +394,7 @@ public class ResponseSendFileTests
     [ConditionalFact]
     public async Task ResponseSendFile_FirstSendWithCanceledCancellationToken_CancelsAndAborts()
     {
-        var testComplete = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var testComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using (Utilities.CreateHttpServer(out var address, httpContext =>
         {
             try
@@ -404,7 +404,7 @@ public class ResponseSendFileTests
                 // First write sends headers
                 var writeTask = httpContext.Response.SendFileAsync(AbsoluteFilePath, 0, null, cts.Token);
                 Assert.True(writeTask.IsCanceled);
-                testComplete.SetResult(0);
+                testComplete.SetResult();
             }
             catch (Exception ex)
             {
@@ -422,7 +422,7 @@ public class ResponseSendFileTests
     [ConditionalFact]
     public async Task ResponseSendFileExceptions_SecondSendWithCanceledCancellationToken_CancelsAndAborts()
     {
-        var testComplete = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var testComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using (Utilities.CreateHttpServer(out var address, async httpContext =>
         {
             try
@@ -433,7 +433,7 @@ public class ResponseSendFileTests
                 cts.Cancel();
                 var writeTask = httpContext.Response.SendFileAsync(AbsoluteFilePath, 0, null, cts.Token);
                 Assert.True(writeTask.IsCanceled);
-                testComplete.SetResult(0);
+                testComplete.SetResult();
             }
             catch (Exception ex)
             {
@@ -449,7 +449,7 @@ public class ResponseSendFileTests
     [ConditionalFact]
     public async Task ResponseSendFile_SecondSendWithCanceledCancellationToken_CancelsAndAborts()
     {
-        var testComplete = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var testComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using (Utilities.CreateHttpServer(out var address, async httpContext =>
         {
             try
@@ -460,7 +460,7 @@ public class ResponseSendFileTests
                 cts.Cancel();
                 var writeTask = httpContext.Response.SendFileAsync(AbsoluteFilePath, 0, null, cts.Token);
                 Assert.True(writeTask.IsCanceled);
-                testComplete.SetResult(0);
+                testComplete.SetResult();
             }
             catch (Exception ex)
             {
@@ -476,14 +476,14 @@ public class ResponseSendFileTests
     [ConditionalFact]
     public async Task ResponseSendFileExceptions_ClientDisconnectsBeforeFirstSend_SendThrows()
     {
-        var requestReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var requestCancelled = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var cancellationReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var testComplete = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var testComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using (Utilities.CreateHttpServer(out var address, async httpContext =>
         {
-            httpContext.RequestAborted.Register(() => cancellationReceived.SetResult(0));
-            requestReceived.SetResult(0);
+            httpContext.RequestAborted.Register(() => cancellationReceived.SetResult());
+            requestReceived.SetResult();
             await requestCancelled.Task;
 
             try
@@ -504,7 +504,7 @@ public class ResponseSendFileTests
                 await Assert.ThrowsAsync<ObjectDisposedException>(() =>
                     httpContext.Response.SendFileAsync(AbsoluteFilePath, 0, null, cts.Token));
 
-                testComplete.SetResult(0);
+                testComplete.SetResult();
             }
             catch (Exception ex)
             {
@@ -519,7 +519,7 @@ public class ResponseSendFileTests
             // First write sends headers
             cts.Cancel();
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
-            requestCancelled.SetResult(0);
+            requestCancelled.SetResult();
 
             await testComplete.Task.DefaultTimeout();
             await cancellationReceived.Task.DefaultTimeout();
@@ -529,14 +529,14 @@ public class ResponseSendFileTests
     [ConditionalFact]
     public async Task ResponseSendFile_ClientDisconnectsBeforeFirstSend_SendCompletesSilently()
     {
-        var requestReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var requestCancelled = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var cancellationReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var testComplete = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var testComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using (Utilities.CreateHttpServer(out var address, async httpContext =>
         {
-            httpContext.RequestAborted.Register(() => cancellationReceived.SetResult(0));
-            requestReceived.SetResult(0);
+            httpContext.RequestAborted.Register(() => cancellationReceived.SetResult());
+            requestReceived.SetResult();
             await requestCancelled.Task;
 
             try
@@ -547,7 +547,7 @@ public class ResponseSendFileTests
                     await httpContext.Response.SendFileAsync(AbsoluteFilePath, 0, null);
                 }
 
-                testComplete.SetResult(0);
+                testComplete.SetResult();
             }
             catch (Exception ex)
             {
@@ -562,7 +562,7 @@ public class ResponseSendFileTests
             // First write sends headers
             cts.Cancel();
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
-            requestCancelled.SetResult(0);
+            requestCancelled.SetResult();
 
             await testComplete.Task.DefaultTimeout();
             await cancellationReceived.Task.DefaultTimeout();
@@ -572,20 +572,20 @@ public class ResponseSendFileTests
     [ConditionalFact]
     public async Task ResponseSendFileExceptions_ClientDisconnectsBeforeSecondSend_SendThrows()
     {
-        var firstSendComplete = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var clientDisconnected = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var cancellationReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var testComplete = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstSendComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var clientDisconnected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var testComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using (Utilities.CreateHttpServer(out var address, async httpContext =>
         {
             // Note Response.SendFileAsync uses RequestAborted by default. This can cause the response to be disposed
             // before it throws an IOException, but there's a race depending on when the disconnect is noticed.
             // Passing our own token to skip that.
             using var cts = new CancellationTokenSource();
-            httpContext.RequestAborted.Register(() => cancellationReceived.SetResult(0));
+            httpContext.RequestAborted.Register(() => cancellationReceived.SetResult());
             // First write sends headers
             await httpContext.Response.SendFileAsync(AbsoluteFilePath, 0, null, cts.Token);
-            firstSendComplete.SetResult(0);
+            firstSendComplete.SetResult();
             await clientDisconnected.Task;
 
             try
@@ -599,7 +599,7 @@ public class ResponseSendFileTests
                     }
                 });
 
-                testComplete.SetResult(0);
+                testComplete.SetResult();
             }
             catch (Exception ex)
             {
@@ -619,7 +619,7 @@ public class ResponseSendFileTests
                 // Abort
                 response.Dispose();
             }
-            clientDisconnected.SetResult(0);
+            clientDisconnected.SetResult();
             await testComplete.Task.DefaultTimeout();
             await cancellationReceived.Task.DefaultTimeout();
         }
@@ -628,16 +628,16 @@ public class ResponseSendFileTests
     [ConditionalFact]
     public async Task ResponseSendFile_ClientDisconnectsBeforeSecondSend_SendCompletesSilently()
     {
-        var firstSendComplete = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var clientDisconnected = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var cancellationReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var testComplete = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstSendComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var clientDisconnected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var testComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using (Utilities.CreateHttpServer(out var address, async httpContext =>
         {
-            httpContext.RequestAborted.Register(() => cancellationReceived.SetResult(0));
+            httpContext.RequestAborted.Register(() => cancellationReceived.SetResult());
             // First write sends headers
             await httpContext.Response.SendFileAsync(AbsoluteFilePath, 0, null);
-            firstSendComplete.SetResult(0);
+            firstSendComplete.SetResult();
             await clientDisconnected.Task;
 
             try
@@ -648,7 +648,7 @@ public class ResponseSendFileTests
                     await httpContext.Response.SendFileAsync(AbsoluteFilePath, 0, null, CancellationToken.None);
                 }
 
-                testComplete.SetResult(0);
+                testComplete.SetResult();
             }
             catch (Exception ex)
             {
@@ -668,7 +668,7 @@ public class ResponseSendFileTests
                 // Abort
                 response.Dispose();
             }
-            clientDisconnected.SetResult(0);
+            clientDisconnected.SetResult();
             await testComplete.Task.DefaultTimeout();
             await cancellationReceived.Task.DefaultTimeout();
         }

--- a/src/Servers/HttpSys/test/FunctionalTests/ResponseTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ResponseTests.cs
@@ -126,24 +126,24 @@ public class ResponseTests
     [ConditionalFact]
     public async Task Response_Empty_CallsOnStartingAndOnCompleted()
     {
-        var onStartingCalled = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var onCompletedCalled = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var onStartingCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var onCompletedCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         using (Utilities.CreateHttpServer(out var address, httpContext =>
         {
             httpContext.Response.OnStarting(state =>
             {
                 Assert.Same(state, httpContext);
-                onStartingCalled.SetResult(0);
-                return Task.FromResult(0);
+                onStartingCalled.SetResult();
+                return Task.CompletedTask;
             }, httpContext);
             httpContext.Response.OnCompleted(state =>
             {
                 Assert.Same(state, httpContext);
-                onCompletedCalled.SetResult(0);
-                return Task.FromResult(0);
+                onCompletedCalled.SetResult();
+                return Task.CompletedTask;
             }, httpContext);
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }))
         {
             var response = await SendRequestAsync(address);
@@ -157,22 +157,22 @@ public class ResponseTests
     [ConditionalFact]
     public async Task Response_OnStartingThrows_StillCallsOnCompleted()
     {
-        var onStartingCalled = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var onCompletedCalled = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var onStartingCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var onCompletedCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using (Utilities.CreateHttpServer(out var address, httpContext =>
         {
             httpContext.Response.OnStarting(state =>
             {
-                onStartingCalled.SetResult(0);
+                onStartingCalled.SetResult();
                 throw new Exception("Failed OnStarting");
             }, httpContext);
             httpContext.Response.OnCompleted(state =>
             {
                 Assert.Same(state, httpContext);
-                onCompletedCalled.SetResult(0);
-                return Task.FromResult(0);
+                onCompletedCalled.SetResult();
+                return Task.CompletedTask;
             }, httpContext);
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }))
         {
             var response = await SendRequestAsync(address);
@@ -186,23 +186,23 @@ public class ResponseTests
     [ConditionalFact]
     public async Task Response_OnStartingThrowsAfterWrite_WriteThrowsAndStillCallsOnCompleted()
     {
-        var onStartingCalled = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var onCompletedCalled = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var onStartingCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var onCompletedCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using (Utilities.CreateHttpServer(out var address, httpContext =>
         {
             httpContext.Response.OnStarting(state =>
             {
-                onStartingCalled.SetResult(0);
+                onStartingCalled.SetResult();
                 throw new InvalidTimeZoneException("Failed OnStarting");
             }, httpContext);
             httpContext.Response.OnCompleted(state =>
             {
                 Assert.Same(state, httpContext);
-                onCompletedCalled.SetResult(0);
-                return Task.FromResult(0);
+                onCompletedCalled.SetResult();
+                return Task.CompletedTask;
             }, httpContext);
             Assert.Throws<InvalidTimeZoneException>(() => httpContext.Response.Body.Write(new byte[10], 0, 10));
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }))
         {
             var response = await SendRequestAsync(address);

--- a/src/Servers/HttpSys/test/FunctionalTests/ResponseTrailersTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ResponseTrailersTests.cs
@@ -118,7 +118,7 @@ public class ResponseTrailersTests
     public async Task ResponseTrailers_WithContentLengthBody_TrailersNotSent()
     {
         var body = "Hello World";
-        var responseFinished = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var responseFinished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using (Utilities.CreateDynamicHttpsServer(out var address, async httpContext =>
         {
             httpContext.Response.ContentLength = body.Length;
@@ -126,7 +126,7 @@ public class ResponseTrailersTests
             try
             {
                 Assert.Throws<InvalidOperationException>(() => httpContext.Response.AppendTrailer("TrailerName", "Trailer Value"));
-                responseFinished.SetResult(0);
+                responseFinished.SetResult();
             }
             catch (Exception ex)
             {
@@ -224,7 +224,7 @@ public class ResponseTrailersTests
     [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Requires HTTP/2 Trailers support.")]
     public async Task ResponseTrailers_CompleteAsyncNoBody_TrailersSent()
     {
-        var trailersReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var trailersReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using (Utilities.CreateDynamicHttpsServer(out var address, async httpContext =>
         {
             httpContext.Response.AppendTrailer("trailername", "TrailerValue");
@@ -237,7 +237,7 @@ public class ResponseTrailersTests
             Assert.Equal(HttpVersion.Version20, response.Version);
             Assert.NotEmpty(response.TrailingHeaders);
             Assert.Equal("TrailerValue", response.TrailingHeaders.GetValues("TrailerName").Single());
-            trailersReceived.SetResult(0);
+            trailersReceived.SetResult();
         }
     }
 
@@ -245,7 +245,7 @@ public class ResponseTrailersTests
     [MinimumOSVersion(OperatingSystems.Windows, "10.0.19529", SkipReason = "Requires HTTP/2 Trailers support.")]
     public async Task ResponseTrailers_CompleteAsyncWithBody_TrailersSent()
     {
-        var trailersReceived = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var trailersReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using (Utilities.CreateDynamicHttpsServer(out var address, async httpContext =>
         {
             await httpContext.Response.WriteAsync("Hello World");
@@ -260,7 +260,7 @@ public class ResponseTrailersTests
             Assert.Equal("Hello World", await response.Content.ReadAsStringAsync());
             Assert.NotEmpty(response.TrailingHeaders);
             Assert.Equal("Trailer Value", response.TrailingHeaders.GetValues("TrailerName").Single());
-            trailersReceived.SetResult(0);
+            trailersReceived.SetResult();
         }
     }
 

--- a/src/Servers/IIS/IIS/test/IIS.Tests/Utilities/TestServer.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/Utilities/TestServer.cs
@@ -40,7 +40,7 @@ public class TestServer : IDisposable
 
     private static readonly int PortRetryCount = 10;
 
-    private readonly TaskCompletionSource<object> _startedTaskCompletionSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _startedTaskCompletionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
     private readonly Action<IApplicationBuilder> _appBuilder;
     private readonly ILoggerFactory _loggerFactory;
@@ -155,7 +155,7 @@ public class TestServer : IDisposable
 
         lifetime.ApplicationStopping.Register(() => doneEvent.Set());
         _host.Start();
-        _startedTaskCompletionSource.SetResult(null);
+        _startedTaskCompletionSource.SetResult();
         doneEvent.Wait();
         _host.Dispose();
         return 0;

--- a/src/Servers/IIS/IIS/test/testassets/IIS.Common.TestLib/TestConnections.cs
+++ b/src/Servers/IIS/IIS/test/testassets/IIS.Common.TestLib/TestConnections.cs
@@ -207,7 +207,7 @@ public class TestConnection : IDisposable
 
     public Task WaitForConnectionClose()
     {
-        var tcs = new TaskCompletionSource<object>();
+        var tcs = new TaskCompletionSource();
         var eventArgs = new SocketAsyncEventArgs();
         eventArgs.SetBuffer(new byte[128], 0, 128);
         eventArgs.Completed += ReceiveAsyncCompleted;
@@ -223,10 +223,10 @@ public class TestConnection : IDisposable
 
     private void ReceiveAsyncCompleted(object sender, SocketAsyncEventArgs e)
     {
-        var tcs = (TaskCompletionSource<object>)e.UserToken;
+        var tcs = (TaskCompletionSource)e.UserToken;
         if (e.BytesTransferred == 0)
         {
-            tcs.SetResult(null);
+            tcs.SetResult();
         }
         else
         {

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -1387,7 +1387,7 @@ public partial class Startup
         await _resetDuringRequestBodyResetsCts.Task;
     }
 
-    private TaskCompletionSource _onCompletedHttpContext = new TaskCompletionSource();
+    private TaskCompletionSource<object> _onCompletedHttpContext = new TaskCompletionSource<object>();
     public async Task OnCompletedHttpContext(HttpContext context)
     {
         // This shouldn't block the response or the server from shutting down.

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -1422,7 +1422,7 @@ public partial class Startup
                 _onCompletedHttpContext.TrySetResult(ex);
             }
 
-            _onCompletedHttpContext.TrySetResult();
+            _onCompletedHttpContext.TrySetResult(null);
         });
 
         await context.Response.WriteAsync("SlowOnCompleted");

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -1205,7 +1205,7 @@ public partial class Startup
         return httpContext.Response.WriteAsync("Hello World");
     }
 
-    private TaskCompletionSource<object> _resetBeforeResponseResetsCts = new TaskCompletionSource<object>();
+    private TaskCompletionSource _resetBeforeResponseResetsCts = new TaskCompletionSource();
     public Task Reset_BeforeResponse_Resets(HttpContext httpContext)
     {
         try
@@ -1214,7 +1214,7 @@ public partial class Startup
             var feature = httpContext.Features.Get<IHttpResetFeature>();
             Assert.NotNull(feature);
             feature.Reset(1111); // Custom
-            _resetBeforeResponseResetsCts.SetResult(0);
+            _resetBeforeResponseResetsCts.SetResult();
         }
         catch (Exception ex)
         {
@@ -1228,7 +1228,7 @@ public partial class Startup
         await _resetBeforeResponseResetsCts.Task;
     }
 
-    private TaskCompletionSource<object> _resetBeforeResponseZeroResetsCts = new TaskCompletionSource<object>();
+    private TaskCompletionSource _resetBeforeResponseZeroResetsCts = new TaskCompletionSource();
     public Task Reset_BeforeResponse_Zero_Resets(HttpContext httpContext)
     {
         try
@@ -1237,7 +1237,7 @@ public partial class Startup
             var feature = httpContext.Features.Get<IHttpResetFeature>();
             Assert.NotNull(feature);
             feature.Reset(0); // Zero should be an allowed errorCode
-            _resetBeforeResponseZeroResetsCts.SetResult(0);
+            _resetBeforeResponseZeroResetsCts.SetResult();
         }
         catch (Exception ex)
         {
@@ -1251,7 +1251,7 @@ public partial class Startup
         await _resetBeforeResponseZeroResetsCts.Task;
     }
 
-    private TaskCompletionSource<object> _resetAfterResponseHeadersResetsCts = new TaskCompletionSource<object>();
+    private TaskCompletionSource _resetAfterResponseHeadersResetsCts = new TaskCompletionSource();
 
     public async Task Reset_AfterResponseHeaders_Resets(HttpContext httpContext)
     {
@@ -1262,7 +1262,7 @@ public partial class Startup
             Assert.NotNull(feature);
             await httpContext.Response.Body.FlushAsync();
             feature.Reset(1111); // Custom
-            _resetAfterResponseHeadersResetsCts.SetResult(0);
+            _resetAfterResponseHeadersResetsCts.SetResult();
         }
         catch (Exception ex)
         {
@@ -1274,7 +1274,7 @@ public partial class Startup
         await _resetAfterResponseHeadersResetsCts.Task;
     }
 
-    private TaskCompletionSource<object> _resetDuringResponseBodyResetsCts = new TaskCompletionSource<object>();
+    private TaskCompletionSource _resetDuringResponseBodyResetsCts = new TaskCompletionSource();
 
     public async Task Reset_DuringResponseBody_Resets(HttpContext httpContext)
     {
@@ -1286,7 +1286,7 @@ public partial class Startup
             await httpContext.Response.WriteAsync("Hello World");
             await httpContext.Response.Body.FlushAsync();
             feature.Reset(1111); // Custom
-            _resetDuringResponseBodyResetsCts.SetResult(0);
+            _resetDuringResponseBodyResetsCts.SetResult();
         }
         catch (Exception ex)
         {
@@ -1299,7 +1299,7 @@ public partial class Startup
         await _resetDuringResponseBodyResetsCts.Task;
     }
 
-    private TaskCompletionSource<object> _resetBeforeRequestBodyResetsCts = new TaskCompletionSource<object>();
+    private TaskCompletionSource _resetBeforeRequestBodyResetsCts = new TaskCompletionSource();
 
     public async Task Reset_BeforeRequestBody_Resets(HttpContext httpContext)
     {
@@ -1314,7 +1314,7 @@ public partial class Startup
 
             await Assert.ThrowsAsync<IOException>(() => readTask);
 
-            _resetBeforeRequestBodyResetsCts.SetResult(0);
+            _resetBeforeRequestBodyResetsCts.SetResult();
         }
         catch (Exception ex)
         {
@@ -1327,7 +1327,7 @@ public partial class Startup
         await _resetBeforeRequestBodyResetsCts.Task;
     }
 
-    private TaskCompletionSource<object> _resetDuringRequestBodyResetsCts = new TaskCompletionSource<object>();
+    private TaskCompletionSource _resetDuringRequestBodyResetsCts = new TaskCompletionSource();
 
     public async Task Reset_DuringRequestBody_Resets(HttpContext httpContext)
     {
@@ -1348,7 +1348,7 @@ public partial class Startup
             feature.Reset(1111);
             await Assert.ThrowsAsync<IOException>(() => readTask);
 
-            _resetDuringRequestBodyResetsCts.SetResult(0);
+            _resetDuringRequestBodyResetsCts.SetResult();
         }
         catch (Exception ex)
         {
@@ -1387,7 +1387,7 @@ public partial class Startup
         await _resetDuringRequestBodyResetsCts.Task;
     }
 
-    private TaskCompletionSource<object> _onCompletedHttpContext = new TaskCompletionSource<object>();
+    private TaskCompletionSource _onCompletedHttpContext = new TaskCompletionSource();
     public async Task OnCompletedHttpContext(HttpContext context)
     {
         // This shouldn't block the response or the server from shutting down.
@@ -1422,7 +1422,7 @@ public partial class Startup
                 _onCompletedHttpContext.TrySetResult(ex);
             }
 
-            _onCompletedHttpContext.TrySetResult(null);
+            _onCompletedHttpContext.TrySetResult();
         });
 
         await context.Response.WriteAsync("SlowOnCompleted");
@@ -1433,7 +1433,7 @@ public partial class Startup
         await _onCompletedHttpContext.Task;
     }
 
-    private TaskCompletionSource<object> _responseTrailers_CompleteAsyncNoBody_TrailersSent = new TaskCompletionSource<object>();
+    private TaskCompletionSource _responseTrailers_CompleteAsyncNoBody_TrailersSent = new TaskCompletionSource();
     public async Task ResponseTrailers_CompleteAsyncNoBody_TrailersSent(HttpContext httpContext)
     {
         httpContext.Response.AppendTrailer("trailername", "TrailerValue");
@@ -1443,11 +1443,11 @@ public partial class Startup
 
     public Task ResponseTrailers_CompleteAsyncNoBody_TrailersSent_Completed(HttpContext httpContext)
     {
-        _responseTrailers_CompleteAsyncNoBody_TrailersSent.TrySetResult(null);
+        _responseTrailers_CompleteAsyncNoBody_TrailersSent.TrySetResult();
         return Task.CompletedTask;
     }
 
-    private TaskCompletionSource<object> _responseTrailers_CompleteAsyncWithBody_TrailersSent = new TaskCompletionSource<object>();
+    private TaskCompletionSource _responseTrailers_CompleteAsyncWithBody_TrailersSent = new TaskCompletionSource();
     public async Task ResponseTrailers_CompleteAsyncWithBody_TrailersSent(HttpContext httpContext)
     {
         await httpContext.Response.WriteAsync("Hello World");
@@ -1458,7 +1458,7 @@ public partial class Startup
 
     public Task ResponseTrailers_CompleteAsyncWithBody_TrailersSent_Completed(HttpContext httpContext)
     {
-        _responseTrailers_CompleteAsyncWithBody_TrailersSent.TrySetResult(null);
+        _responseTrailers_CompleteAsyncWithBody_TrailersSent.TrySetResult();
         return Task.CompletedTask;
     }
 

--- a/src/Servers/IIS/IISIntegration/test/Tests/IISMiddlewareTests.cs
+++ b/src/Servers/IIS/IISIntegration/test/Tests/IISMiddlewareTests.cs
@@ -101,8 +101,8 @@ public class IISMiddlewareTests
     [InlineData("/pathBase", "/pathBase/iisintegration", "Shutdown")]
     public async Task MiddlewareShutsdownGivenANCMShutdown(string pathBase, string requestPath, string shutdownEvent)
     {
-        var requestExecuted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var applicationStoppingFired = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestExecuted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var applicationStoppingFired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using var host = new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>
             {
@@ -114,12 +114,12 @@ public class IISMiddlewareTests
                     .Configure(app =>
                     {
                         var appLifetime = app.ApplicationServices.GetRequiredService<IHostApplicationLifetime>();
-                        appLifetime.ApplicationStopping.Register(() => applicationStoppingFired.SetResult(0));
+                        appLifetime.ApplicationStopping.Register(() => applicationStoppingFired.SetResult());
 
                         app.Run(context =>
                         {
-                            requestExecuted.SetResult(0);
-                            return Task.FromResult(0);
+                            requestExecuted.SetResult();
+                            return Task.CompletedTask;
                         });
                     })
                     .UseTestServer();
@@ -160,8 +160,8 @@ public class IISMiddlewareTests
     [MemberData(nameof(InvalidShutdownMethods))]
     public async Task MiddlewareIgnoresShutdownGivenWrongMethod(HttpMethod method)
     {
-        var requestExecuted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var applicationStoppingFired = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestExecuted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var applicationStoppingFired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using var host = new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>
             {
@@ -173,12 +173,12 @@ public class IISMiddlewareTests
                     .Configure(app =>
                     {
                         var appLifetime = app.ApplicationServices.GetRequiredService<IHostApplicationLifetime>();
-                        appLifetime.ApplicationStopping.Register(() => applicationStoppingFired.SetResult(0));
+                        appLifetime.ApplicationStopping.Register(() => applicationStoppingFired.SetResult());
 
                         app.Run(context =>
                         {
-                            requestExecuted.SetResult(0);
-                            return Task.FromResult(0);
+                            requestExecuted.SetResult();
+                            return Task.CompletedTask;
                         });
                     })
                     .UseTestServer();
@@ -205,8 +205,8 @@ public class IISMiddlewareTests
     [InlineData("/path/iisintegration")]
     public async Task MiddlewareIgnoresShutdownGivenWrongPath(string path)
     {
-        var requestExecuted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var applicationStoppingFired = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestExecuted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var applicationStoppingFired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using var host = new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>
             {
@@ -218,12 +218,12 @@ public class IISMiddlewareTests
                     .Configure(app =>
                     {
                         var appLifetime = app.ApplicationServices.GetRequiredService<IHostApplicationLifetime>();
-                        appLifetime.ApplicationStopping.Register(() => applicationStoppingFired.SetResult(0));
+                        appLifetime.ApplicationStopping.Register(() => applicationStoppingFired.SetResult());
 
                         app.Run(context =>
                         {
-                            requestExecuted.SetResult(0);
-                            return Task.FromResult(0);
+                            requestExecuted.SetResult();
+                            return Task.CompletedTask;
                         });
                     })
                     .UseTestServer();
@@ -250,8 +250,8 @@ public class IISMiddlewareTests
     [InlineData(null)]
     public async Task MiddlewareIgnoresShutdownGivenWrongEvent(string shutdownEvent)
     {
-        var requestExecuted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var applicationStoppingFired = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestExecuted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var applicationStoppingFired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using var host = new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>
             {
@@ -263,12 +263,12 @@ public class IISMiddlewareTests
                     .Configure(app =>
                     {
                         var appLifetime = app.ApplicationServices.GetRequiredService<IHostApplicationLifetime>();
-                        appLifetime.ApplicationStopping.Register(() => applicationStoppingFired.SetResult(0));
+                        appLifetime.ApplicationStopping.Register(() => applicationStoppingFired.SetResult());
 
                         app.Run(context =>
                         {
-                            requestExecuted.SetResult(0);
-                            return Task.FromResult(0);
+                            requestExecuted.SetResult();
+                            return Task.CompletedTask;
                         });
                     })
                     .UseTestServer();

--- a/src/Servers/Kestrel/stress/Program.cs
+++ b/src/Servers/Kestrel/stress/Program.cs
@@ -652,8 +652,8 @@ public class Program
         {
             await stream.WriteAsync(new byte[] { 1, 2, 3 });
 
-            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            using (_cancellationToken.Register(() => tcs.SetResult(true)))
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using (_cancellationToken.Register(() => tcs.SetResult()))
             {
                 await tcs.Task.ConfigureAwait(false);
             }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -3111,7 +3111,7 @@ public class Http2ConnectionTests : Http2TestBase
     [Fact]
     public async Task RST_STREAM_IncompleteRequest_AdditionalDataFrames_ConnectionAborted()
     {
-        var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var headers = new[]
         {
@@ -3126,7 +3126,7 @@ public class Http2ConnectionTests : Http2TestBase
         await SendDataAsync(1, new byte[2], endStream: false);
         await SendRstStreamAsync(1);
         await SendDataAsync(1, new byte[10], endStream: false);
-        tcs.TrySetResult(0);
+        tcs.TrySetResult();
 
         await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(ignoreNonGoAwayFrames: false, expectedLastStreamId: 1,
             Http2ErrorCode.STREAM_CLOSED, CoreStrings.FormatHttp2ErrorStreamAborted(Http2FrameType.DATA, 1));
@@ -3135,7 +3135,7 @@ public class Http2ConnectionTests : Http2TestBase
     [Fact]
     public async Task RST_STREAM_IncompleteRequest_AdditionalTrailerFrames_ConnectionAborted()
     {
-        var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var headers = new[]
         {
@@ -3150,7 +3150,7 @@ public class Http2ConnectionTests : Http2TestBase
         await SendDataAsync(1, new byte[2], endStream: false);
         await SendRstStreamAsync(1);
         await SendHeadersAsync(1, Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM, _requestTrailers);
-        tcs.TrySetResult(0);
+        tcs.TrySetResult();
 
         await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(ignoreNonGoAwayFrames: false, expectedLastStreamId: 1,
             Http2ErrorCode.STREAM_CLOSED, CoreStrings.FormatHttp2ErrorStreamAborted(Http2FrameType.HEADERS, 1));
@@ -3159,7 +3159,7 @@ public class Http2ConnectionTests : Http2TestBase
     [Fact]
     public async Task RST_STREAM_IncompleteRequest_AdditionalResetFrame_IgnoreAdditionalReset()
     {
-        var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var headers = new[]
         {
@@ -3173,7 +3173,7 @@ public class Http2ConnectionTests : Http2TestBase
         await SendDataAsync(1, new byte[1], endStream: false);
         await SendRstStreamAsync(1);
         await SendRstStreamAsync(1);
-        tcs.TrySetResult(0);
+        tcs.TrySetResult();
 
         await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
     }
@@ -3181,7 +3181,7 @@ public class Http2ConnectionTests : Http2TestBase
     [Fact]
     public async Task RST_STREAM_IncompleteRequest_AdditionalWindowUpdateFrame_ConnectionAborted()
     {
-        var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var headers = new[]
         {
@@ -3195,7 +3195,7 @@ public class Http2ConnectionTests : Http2TestBase
         await SendDataAsync(1, new byte[1], endStream: false);
         await SendRstStreamAsync(1);
         await SendWindowUpdateAsync(1, 1024);
-        tcs.TrySetResult(0);
+        tcs.TrySetResult();
 
         await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(ignoreNonGoAwayFrames: false, expectedLastStreamId: 1,
             Http2ErrorCode.STREAM_CLOSED, CoreStrings.FormatHttp2ErrorStreamAborted(Http2FrameType.WINDOW_UPDATE, 1));
@@ -4983,7 +4983,7 @@ public class Http2ConnectionTests : Http2TestBase
     [Fact]
     public async Task RefusedStream_Post_2xLimitRefused()
     {
-        var requestBlock = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestBlock = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         CreateConnection();
 
@@ -5046,7 +5046,7 @@ public class Http2ConnectionTests : Http2TestBase
         await WaitForStreamErrorAsync(3, Http2ErrorCode.REFUSED_STREAM, "HTTP/2 stream ID 3 error (REFUSED_STREAM): A new stream was refused because this connection has reached its stream limit.");
         await WaitForStreamErrorAsync(5, Http2ErrorCode.REFUSED_STREAM, "HTTP/2 stream ID 5 error (REFUSED_STREAM): A new stream was refused because this connection has reached its stream limit.");
         await WaitForStreamErrorAsync(7, Http2ErrorCode.REFUSED_STREAM, "HTTP/2 stream ID 7 error (REFUSED_STREAM): A new stream was refused because this connection has reached its stream limit.");
-        requestBlock.SetResult(0);
+        requestBlock.SetResult();
         await StopConnectionAsync(expectedLastStreamId: 7, ignoreNonGoAwayFrames: true);
     }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2KeepAliveTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2KeepAliveTests.cs
@@ -277,7 +277,7 @@ public class Http2KeepAliveTests : Http2TestBase
         // Reduce connection window size so that one stream can fill it
         _serviceContext.ServerOptions.Limits.Http2.InitialConnectionWindowSize = 65535;
 
-        var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         await InitializeConnectionAsync(async c =>
         {
             // Don't consume any request data
@@ -313,7 +313,7 @@ public class Http2KeepAliveTests : Http2TestBase
         TriggerTick(now + TimeSpan.FromSeconds(1.1 * 2));
 
         // Continue request delegate on server
-        tcs.SetResult(null);
+        tcs.SetResult();
 
         await ExpectAsync(Http2FrameType.HEADERS,
             withLength: 36,
@@ -332,7 +332,7 @@ public class Http2KeepAliveTests : Http2TestBase
         // Reduce connection window size so that one stream can fill it
         _serviceContext.ServerOptions.Limits.Http2.InitialConnectionWindowSize = 65535;
 
-        var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         await InitializeConnectionAsync(async c =>
         {
             // Don't consume any request data
@@ -372,7 +372,7 @@ public class Http2KeepAliveTests : Http2TestBase
         TriggerTick(now + TimeSpan.FromSeconds(1.1 * 3));
 
         // Continue request delegate on server
-        tcs.SetResult(null);
+        tcs.SetResult();
 
         await ExpectAsync(Http2FrameType.HEADERS,
             withLength: 36,

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -1129,9 +1129,9 @@ public class Http3StreamTests : Http3TestBase
     [Fact]
     public async Task CompleteAsync_BeforeBodyStarted_SendsHeadersWithEndStream()
     {
-        var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var appTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var clientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var headers = new[]
         {
                 new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
@@ -1143,7 +1143,7 @@ public class Http3StreamTests : Http3TestBase
         {
             try
             {
-                context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                context.Response.OnStarting(() => { startingTcs.SetResult(); return Task.CompletedTask; });
                 await context.Response.CompleteAsync().DefaultTimeout();
 
                 Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
@@ -1152,7 +1152,7 @@ public class Http3StreamTests : Http3TestBase
 
                 // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
                 await clientTcs.Task.DefaultTimeout();
-                appTcs.SetResult(0);
+                appTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -1164,7 +1164,7 @@ public class Http3StreamTests : Http3TestBase
 
         var decodedHeaders = await requestStream.ExpectHeadersAsync();
 
-        clientTcs.SetResult(0);
+        clientTcs.SetResult();
         await appTcs.Task;
 
         Assert.Equal(3, decodedHeaders.Count);
@@ -1178,9 +1178,9 @@ public class Http3StreamTests : Http3TestBase
     [Fact]
     public async Task CompleteAsync_BeforeBodyStarted_WithTrailers_SendsHeadersAndTrailersWithEndStream()
     {
-        var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var appTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var clientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var headers = new[]
         {
                 new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
@@ -1191,7 +1191,7 @@ public class Http3StreamTests : Http3TestBase
         {
             try
             {
-                context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                context.Response.OnStarting(() => { startingTcs.SetResult(); return Task.CompletedTask; });
                 context.Response.AppendTrailer("CustomName", "Custom Value");
 
                 await context.Response.CompleteAsync().DefaultTimeout();
@@ -1203,7 +1203,7 @@ public class Http3StreamTests : Http3TestBase
 
                 // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
                 await clientTcs.Task.DefaultTimeout();
-                appTcs.SetResult(0);
+                appTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -1216,7 +1216,7 @@ public class Http3StreamTests : Http3TestBase
         var decodedHeaders = await requestStream.ExpectHeadersAsync();
         var decodedTrailers = await requestStream.ExpectHeadersAsync();
 
-        clientTcs.SetResult(0);
+        clientTcs.SetResult();
         await appTcs.Task;
 
         await requestStream.ExpectReceiveEndOfStream();
@@ -1233,8 +1233,8 @@ public class Http3StreamTests : Http3TestBase
     [Fact]
     public async Task CompleteAsync_BeforeBodyStarted_WithTrailers_TruncatedContentLength_ThrowsAnd500()
     {
-        var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var appTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var headers = new[]
         {
                 new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
@@ -1245,7 +1245,7 @@ public class Http3StreamTests : Http3TestBase
         {
             try
             {
-                context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                context.Response.OnStarting(() => { startingTcs.SetResult(); return Task.CompletedTask; });
 
                 context.Response.ContentLength = 25;
                 context.Response.AppendTrailer("CustomName", "Custom Value");
@@ -1257,7 +1257,7 @@ public class Http3StreamTests : Http3TestBase
                 Assert.False(context.Response.Headers.IsReadOnly);
                 Assert.False(context.Features.Get<IHttpResponseTrailersFeature>().Trailers.IsReadOnly);
 
-                appTcs.SetResult(0);
+                appTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -1282,9 +1282,9 @@ public class Http3StreamTests : Http3TestBase
     [Fact]
     public async Task CompleteAsync_AfterBodyStarted_SendsBodyWithEndStream()
     {
-        var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var appTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var clientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var headers = new[]
         {
                 new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
@@ -1295,7 +1295,7 @@ public class Http3StreamTests : Http3TestBase
         {
             try
             {
-                context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                context.Response.OnStarting(() => { startingTcs.SetResult(); return Task.CompletedTask; });
 
                 await context.Response.WriteAsync("Hello World");
                 Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
@@ -1308,7 +1308,7 @@ public class Http3StreamTests : Http3TestBase
 
                 // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
                 await clientTcs.Task.DefaultTimeout();
-                appTcs.SetResult(0);
+                appTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -1328,7 +1328,7 @@ public class Http3StreamTests : Http3TestBase
 
         Assert.Equal("Hello World", Encoding.UTF8.GetString(data.Span));
 
-        clientTcs.SetResult(0);
+        clientTcs.SetResult();
         await appTcs.Task;
 
         await requestStream.ExpectReceiveEndOfStream();
@@ -1337,9 +1337,9 @@ public class Http3StreamTests : Http3TestBase
     [Fact]
     public async Task CompleteAsync_WriteAfterComplete_Throws()
     {
-        var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var appTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var clientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var headers = new[]
         {
                 new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
@@ -1350,7 +1350,7 @@ public class Http3StreamTests : Http3TestBase
         {
             try
             {
-                context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                context.Response.OnStarting(() => { startingTcs.SetResult(); return Task.CompletedTask; });
                 await context.Response.CompleteAsync().DefaultTimeout();
 
                 Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
@@ -1362,7 +1362,7 @@ public class Http3StreamTests : Http3TestBase
 
                 // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
                 await clientTcs.Task.DefaultTimeout();
-                appTcs.SetResult(0);
+                appTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -1379,7 +1379,7 @@ public class Http3StreamTests : Http3TestBase
         Assert.Equal("200", decodedHeaders[HeaderNames.Status]);
         Assert.Equal("0", decodedHeaders[HeaderNames.ContentLength]);
 
-        clientTcs.SetResult(0);
+        clientTcs.SetResult();
         await appTcs.Task;
 
         await requestStream.ExpectReceiveEndOfStream();
@@ -1388,9 +1388,9 @@ public class Http3StreamTests : Http3TestBase
     [Fact]
     public async Task CompleteAsync_WriteAgainAfterComplete_Throws()
     {
-        var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var appTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var clientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var headers = new[]
         {
                 new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
@@ -1401,7 +1401,7 @@ public class Http3StreamTests : Http3TestBase
         {
             try
             {
-                context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                context.Response.OnStarting(() => { startingTcs.SetResult(); return Task.CompletedTask; });
 
                 await context.Response.WriteAsync("Hello World").DefaultTimeout();
                 Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
@@ -1416,7 +1416,7 @@ public class Http3StreamTests : Http3TestBase
 
                 // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
                 await clientTcs.Task.DefaultTimeout();
-                appTcs.SetResult(0);
+                appTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -1435,7 +1435,7 @@ public class Http3StreamTests : Http3TestBase
         var data = await requestStream.ExpectDataAsync();
         Assert.Equal("Hello World", Encoding.UTF8.GetString(data.Span));
 
-        clientTcs.SetResult(0);
+        clientTcs.SetResult();
         await appTcs.Task;
 
         await requestStream.ExpectReceiveEndOfStream();
@@ -1485,9 +1485,9 @@ public class Http3StreamTests : Http3TestBase
     [Fact]
     public async Task CompleteAsync_AfterPipeWrite_WithTrailers_SendsBodyAndTrailersWithEndStream()
     {
-        var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var appTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var clientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var headers = new[]
         {
                 new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
@@ -1498,7 +1498,7 @@ public class Http3StreamTests : Http3TestBase
         {
             try
             {
-                context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                context.Response.OnStarting(() => { startingTcs.SetResult(); return Task.CompletedTask; });
 
                 var buffer = context.Response.BodyWriter.GetMemory();
                 var length = Encoding.UTF8.GetBytes("Hello World", buffer.Span);
@@ -1517,7 +1517,7 @@ public class Http3StreamTests : Http3TestBase
 
                 // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
                 await clientTcs.Task.DefaultTimeout();
-                appTcs.SetResult(0);
+                appTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -1538,7 +1538,7 @@ public class Http3StreamTests : Http3TestBase
         var decodedTrailers = await requestStream.ExpectHeadersAsync();
         Assert.Equal("Custom Value", decodedTrailers["CustomName"]);
 
-        clientTcs.SetResult(0);
+        clientTcs.SetResult();
         await appTcs.Task;
 
         await requestStream.ExpectReceiveEndOfStream();
@@ -1547,9 +1547,9 @@ public class Http3StreamTests : Http3TestBase
     [Fact]
     public async Task CompleteAsync_AfterBodyStarted_WithTrailers_SendsBodyAndTrailersWithEndStream()
     {
-        var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var appTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var clientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var headers = new[]
         {
                 new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
@@ -1560,7 +1560,7 @@ public class Http3StreamTests : Http3TestBase
         {
             try
             {
-                context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                context.Response.OnStarting(() => { startingTcs.SetResult(); return Task.CompletedTask; });
 
                 await context.Response.WriteAsync("Hello World");
                 Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
@@ -1574,7 +1574,7 @@ public class Http3StreamTests : Http3TestBase
 
                 // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
                 await clientTcs.Task.DefaultTimeout();
-                appTcs.SetResult(0);
+                appTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -1595,7 +1595,7 @@ public class Http3StreamTests : Http3TestBase
         var decodedTrailers = await requestStream.ExpectHeadersAsync();
         Assert.Equal("Custom Value", decodedTrailers["CustomName"]);
 
-        clientTcs.SetResult(0);
+        clientTcs.SetResult();
         await appTcs.Task;
 
         await requestStream.ExpectReceiveEndOfStream();
@@ -1604,9 +1604,9 @@ public class Http3StreamTests : Http3TestBase
     [Fact]
     public async Task CompleteAsync_AfterBodyStarted_WithTrailers_TruncatedContentLength_ThrowsAndReset()
     {
-        var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var appTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var clientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var headers = new[]
         {
                 new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
@@ -1617,7 +1617,7 @@ public class Http3StreamTests : Http3TestBase
         {
             try
             {
-                context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                context.Response.OnStarting(() => { startingTcs.SetResult(); return Task.CompletedTask; });
 
                 context.Response.ContentLength = 25;
                 await context.Response.WriteAsync("Hello World");
@@ -1633,7 +1633,7 @@ public class Http3StreamTests : Http3TestBase
 
                 // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
                 await clientTcs.Task.DefaultTimeout();
-                appTcs.SetResult(0);
+                appTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -1652,7 +1652,7 @@ public class Http3StreamTests : Http3TestBase
         var data = await requestStream.ExpectDataAsync();
         Assert.Equal("Hello World", Encoding.UTF8.GetString(data.Span));
 
-        clientTcs.SetResult(0);
+        clientTcs.SetResult();
 
         await requestStream.WaitForStreamErrorAsync(Http3ErrorCode.InternalError,
             expectedErrorMessage: CoreStrings.FormatTooFewBytesWritten(11, 25));
@@ -1663,9 +1663,9 @@ public class Http3StreamTests : Http3TestBase
     [Fact]
     public async Task PipeWriterComplete_AfterBodyStarted_WithTrailers_TruncatedContentLength_ThrowsAndReset()
     {
-        var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var appTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var clientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var headers = new[]
         {
                 new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
@@ -1677,7 +1677,7 @@ public class Http3StreamTests : Http3TestBase
         {
             try
             {
-                context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                context.Response.OnStarting(() => { startingTcs.SetResult(); return Task.CompletedTask; });
 
                 context.Response.ContentLength = 25;
                 await context.Response.WriteAsync("Hello World");
@@ -1693,7 +1693,7 @@ public class Http3StreamTests : Http3TestBase
 
                 // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
                 await clientTcs.Task.DefaultTimeout();
-                appTcs.SetResult(0);
+                appTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -1712,7 +1712,7 @@ public class Http3StreamTests : Http3TestBase
         var data = await requestStream.ExpectDataAsync();
         Assert.Equal("Hello World", Encoding.UTF8.GetString(data.Span));
 
-        clientTcs.SetResult(0);
+        clientTcs.SetResult();
 
         await requestStream.WaitForStreamErrorAsync(Http3ErrorCode.InternalError,
             expectedErrorMessage: CoreStrings.FormatTooFewBytesWritten(11, 25));
@@ -1723,9 +1723,9 @@ public class Http3StreamTests : Http3TestBase
     [Fact]
     public async Task AbortAfterCompleteAsync_GETWithResponseBodyAndTrailers_ResetsAfterResponse()
     {
-        var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var appTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var clientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var headers = new[]
         {
                 new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
@@ -1736,7 +1736,7 @@ public class Http3StreamTests : Http3TestBase
         {
             try
             {
-                context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                context.Response.OnStarting(() => { startingTcs.SetResult(); return Task.CompletedTask; });
 
                 await context.Response.WriteAsync("Hello World");
                 Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
@@ -1754,7 +1754,7 @@ public class Http3StreamTests : Http3TestBase
 
                 // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
                 await clientTcs.Task.DefaultTimeout();
-                appTcs.SetResult(0);
+                appTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -1777,16 +1777,16 @@ public class Http3StreamTests : Http3TestBase
 
         await requestStream.WaitForStreamErrorAsync(Http3ErrorCode.InternalError, expectedErrorMessage: null);
 
-        clientTcs.SetResult(0);
+        clientTcs.SetResult();
         await appTcs.Task;
     }
 
     [Fact]
     public async Task AbortAfterCompleteAsync_POSTWithResponseBodyAndTrailers_RequestBodyThrows()
     {
-        var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var appTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var clientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var headers = new[]
         {
                 new KeyValuePair<string, string>(HeaderNames.Method, "POST"),
@@ -1799,7 +1799,7 @@ public class Http3StreamTests : Http3TestBase
             {
                 var requestBodyTask = context.Request.BodyReader.ReadAsync();
 
-                context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                context.Response.OnStarting(() => { startingTcs.SetResult(); return Task.CompletedTask; });
 
                 await context.Response.WriteAsync("Hello World");
                 Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
@@ -1820,7 +1820,7 @@ public class Http3StreamTests : Http3TestBase
 
                 // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
                 await clientTcs.Task.DefaultTimeout();
-                appTcs.SetResult(0);
+                appTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -1843,16 +1843,16 @@ public class Http3StreamTests : Http3TestBase
 
         await requestStream.WaitForStreamErrorAsync(Http3ErrorCode.InternalError, expectedErrorMessage: null);
 
-        clientTcs.SetResult(0);
+        clientTcs.SetResult();
         await appTcs.Task;
     }
 
     [Fact]
     public async Task ResetAfterCompleteAsync_GETWithResponseBodyAndTrailers_ResetsAfterResponse()
     {
-        var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var appTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var clientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var headers = new[]
         {
                 new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
@@ -1863,7 +1863,7 @@ public class Http3StreamTests : Http3TestBase
         {
             try
             {
-                context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                context.Response.OnStarting(() => { startingTcs.SetResult(); return Task.CompletedTask; });
 
                 await context.Response.WriteAsync("Hello World");
                 Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
@@ -1883,7 +1883,7 @@ public class Http3StreamTests : Http3TestBase
 
                 // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
                 await clientTcs.Task.DefaultTimeout();
-                appTcs.SetResult(0);
+                appTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -1908,16 +1908,16 @@ public class Http3StreamTests : Http3TestBase
             Http3ErrorCode.NoError,
             expectedErrorMessage: "The HTTP/3 stream was reset by the application with error code H3_NO_ERROR.");
 
-        clientTcs.SetResult(0);
+        clientTcs.SetResult();
         await appTcs.Task;
     }
 
     [Fact]
     public async Task ResetAfterCompleteAsync_POSTWithResponseBodyAndTrailers_RequestBodyThrows()
     {
-        var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var appTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var clientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var headers = new[]
         {
                 new KeyValuePair<string, string>(HeaderNames.Method, "POST"),
@@ -1930,7 +1930,7 @@ public class Http3StreamTests : Http3TestBase
             {
                 var requestBodyTask = context.Request.BodyReader.ReadAsync();
 
-                context.Response.OnStarting(() => { startingTcs.SetResult(0); return Task.CompletedTask; });
+                context.Response.OnStarting(() => { startingTcs.SetResult(); return Task.CompletedTask; });
 
                 await context.Response.WriteAsync("Hello World");
                 Assert.True(startingTcs.Task.IsCompletedSuccessfully); // OnStarting got called.
@@ -1953,7 +1953,7 @@ public class Http3StreamTests : Http3TestBase
 
                 // Make sure the client gets our results from CompleteAsync instead of from the request delegate exiting.
                 await clientTcs.Task.DefaultTimeout();
-                appTcs.SetResult(0);
+                appTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -1978,7 +1978,7 @@ public class Http3StreamTests : Http3TestBase
             Http3ErrorCode.NoError,
             expectedErrorMessage: "The HTTP/3 stream was reset by the application with error code H3_NO_ERROR.");
 
-        clientTcs.SetResult(0);
+        clientTcs.SetResult();
         await appTcs.Task;
     }
 
@@ -2762,9 +2762,9 @@ public class Http3StreamTests : Http3TestBase
     [Fact]
     public async Task PostRequest_ServerReadsPartialAndFinishes_SendsBodyWithEndStream()
     {
-        var startingTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var appTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var clientTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var appTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var clientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var requestStream = await Http3Api.InitializeConnectionAndStreamsAsync(async context =>
         {
@@ -2780,7 +2780,7 @@ public class Http3StreamTests : Http3TestBase
 
                 await context.Response.Body.WriteAsync(buffer.AsMemory(0, 100));
                 await clientTcs.Task.DefaultTimeout();
-                appTcs.SetResult(0);
+                appTcs.SetResult();
             }
             catch (Exception ex)
             {
@@ -2810,7 +2810,7 @@ public class Http3StreamTests : Http3TestBase
 
         Assert.Equal(sourceData.AsMemory(0, 100).ToArray(), data.ToArray());
 
-        clientTcs.SetResult(0);
+        clientTcs.SetResult();
         await appTcs.Task;
 
         await requestStream.ExpectReceiveEndOfStream();

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -532,7 +532,7 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
     [InlineData(StatusCodes.Status304NotModified)]
     public async Task AttemptingToWriteFailsForNonBodyResponse(int statusCode)
     {
-        var responseWriteTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var responseWriteTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         await using (var server = new TestServer(async httpContext =>
         {
@@ -548,7 +548,7 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
                 throw;
             }
 
-            responseWriteTcs.TrySetResult("This should not be reached.");
+            responseWriteTcs.TrySetResult();
         }, new TestServiceContext(LoggerFactory)))
         {
             using (var connection = server.CreateConnection())
@@ -574,7 +574,7 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
     [Fact]
     public async Task AttemptingToWriteFailsFor205Response()
     {
-        var responseWriteTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var responseWriteTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         await using (var server = new TestServer(async httpContext =>
         {
@@ -590,7 +590,7 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
                 throw;
             }
 
-            responseWriteTcs.TrySetResult("This should not be reached.");
+            responseWriteTcs.TrySetResult();
         }, new TestServiceContext(LoggerFactory)))
         {
             using (var connection = server.CreateConnection())

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/UpgradeTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/UpgradeTests.cs
@@ -22,7 +22,7 @@ public class UpgradeTests : LoggedTest
     [Fact]
     public async Task ResponseThrowsAfterUpgrade()
     {
-        var upgrade = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var upgrade = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         await using (var server = new TestServer(async context =>
         {
             var feature = context.Features.Get<IHttpUpgradeFeature>();
@@ -38,7 +38,7 @@ public class UpgradeTests : LoggedTest
                 await writer.DisposeAsync();
             }
 
-            upgrade.TrySetResult(true);
+            upgrade.TrySetResult();
         }, new TestServiceContext(LoggerFactory)))
         {
             using (var connection = server.CreateConnection())
@@ -62,7 +62,7 @@ public class UpgradeTests : LoggedTest
         const string send = "Custom protocol send";
         const string recv = "Custom protocol recv";
 
-        var upgrade = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var upgrade = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         await using (var server = new TestServer(async context =>
         {
             try
@@ -84,7 +84,7 @@ public class UpgradeTests : LoggedTest
                     await writer.DisposeAsync();
                 }
 
-                upgrade.TrySetResult(true);
+                upgrade.TrySetResult();
             }
             catch (Exception ex)
             {
@@ -264,7 +264,7 @@ public class UpgradeTests : LoggedTest
     [Fact]
     public async Task ThrowsWhenUpgradingNonUpgradableRequest()
     {
-        var upgradeTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var upgradeTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         await using (var server = new TestServer(async context =>
         {
             var feature = context.Features.Get<IHttpUpgradeFeature>();
@@ -279,7 +279,7 @@ public class UpgradeTests : LoggedTest
             }
             finally
             {
-                upgradeTcs.TrySetResult(false);
+                upgradeTcs.TrySetResult();
             }
         }, new TestServiceContext(LoggerFactory)))
         {
@@ -385,7 +385,7 @@ public class UpgradeTests : LoggedTest
     [Fact]
     public async Task DoesNotThrowGivenCanceledReadResult()
     {
-        var appCompletedTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var appCompletedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         await using var server = new TestServer(async context =>
         {
@@ -404,7 +404,7 @@ public class UpgradeTests : LoggedTest
                 // Use ReadAsync() instead of CopyToAsync() for this test since IsCanceled is only checked in
                 // HttpRequestStream.ReadAsync() and not HttpRequestStream.CopyToAsync()
                 Assert.Equal(0, await duplexStream.ReadAsync(new byte[1]));
-                appCompletedTcs.SetResult(null);
+                appCompletedTcs.SetResult();
             }
             catch (Exception ex)
             {

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecCommands.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/H2SpecCommands.cs
@@ -239,12 +239,12 @@ public static class H2SpecCommands
                     logger.LogError(args.Data);
                 }
             };
-            var exitedTcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var exitedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             process.EnableRaisingEvents = true; // Enables Exited
             process.Exited += (_, args) =>
             {
                 logger.LogDebug("H2spec has exited.");
-                exitedTcs.TrySetResult(0);
+                exitedTcs.TrySetResult();
             };
 
             Assert.True(process.Start());

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -632,13 +632,13 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
 
             // Allow a maximum of one caller to use code at one time
             var callerTracker = new SemaphoreSlim(1, 1);
-            var waitTcs = new TaskCompletionSource<bool>();
+            var waitTcs = new TaskCompletionSource();
 
             // This tests thread safety of sending multiple pieces of data to a connection at once
             var executeTask1 = DispatcherExecuteAsync(dispatcher, connection, callerTracker, waitTcs.Task);
             var executeTask2 = DispatcherExecuteAsync(dispatcher, connection, callerTracker, waitTcs.Task);
 
-            waitTcs.SetResult(true);
+            waitTcs.SetResult();
 
             await Task.WhenAll(executeTask1, executeTask2);
         }
@@ -2563,12 +2563,12 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
 
             connection.Abort();
 
-            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            connection.ConnectionClosed.Register(() => tcs.SetResult(null));
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            connection.ConnectionClosed.Register(() => tcs.SetResult());
             await tcs.Task.DefaultTimeout();
 
-            tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-            lifetimeFeature.RequestAborted.Register(() => tcs.SetResult(null));
+            tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            lifetimeFeature.RequestAborted.Register(() => tcs.SetResult());
             await tcs.Task.DefaultTimeout();
         }
     }

--- a/src/SignalR/common/testassets/Tests.Utils/TestClient.cs
+++ b/src/SignalR/common/testassets/Tests.Utils/TestClient.cs
@@ -31,7 +31,7 @@ internal
     private readonly CancellationTokenSource _cts;
 
     public DefaultConnectionContext Connection { get; }
-    public Task Connected => ((TaskCompletionSource<bool>)Connection.Items["ConnectedTask"]).Task;
+    public Task Connected => ((TaskCompletionSource)Connection.Items["ConnectedTask"]).Task;
     public HandshakeResponseMessage HandshakeResponseMessage { get; private set; }
 
     public TransferFormat SupportedFormats { get; set; } = TransferFormat.Text | TransferFormat.Binary;
@@ -57,7 +57,7 @@ internal
         }
 
         Connection.User = new ClaimsPrincipal(new ClaimsIdentity(claims));
-        Connection.Items["ConnectedTask"] = new TaskCompletionSource<bool>();
+        Connection.Items["ConnectedTask"] = new TaskCompletionSource();
 
         _protocol = protocol ?? new NewtonsoftJsonHubProtocol();
         _invocationBinder = invocationBinder ?? new DefaultInvocationBinder();

--- a/src/SignalR/perf/Microbenchmarks/HubConnectionReceiveBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/HubConnectionReceiveBenchmark.cs
@@ -29,7 +29,7 @@ public class HubConnectionReceiveBenchmark
     private int _currentInterationMessageCount;
     private TaskCompletionSource<ReadResult> _tcs;
     private TaskCompletionSource<ReadResult> _nextReadTcs;
-    private TaskCompletionSource<bool> _waitTcs;
+    private TaskCompletionSource _waitTcs;
 
     [GlobalSetup]
     public void GlobalSetup()
@@ -100,7 +100,7 @@ public class HubConnectionReceiveBenchmark
             if (_currentInterationMessageCount == MessageCount)
             {
                 _currentInterationMessageCount = 0;
-                _waitTcs.SetResult(true);
+                _waitTcs.SetResult();
             }
             else if (_currentInterationMessageCount > MessageCount)
             {
@@ -141,7 +141,7 @@ public class HubConnectionReceiveBenchmark
         _nextReadTcs = new TaskCompletionSource<ReadResult>();
         _pipe.AddReadResult(new ValueTask<ReadResult>(_nextReadTcs.Task));
 
-        _waitTcs = new TaskCompletionSource<bool>();
+        _waitTcs = new TaskCompletionSource();
     }
 
     [Benchmark]

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -327,8 +327,8 @@ public class MethodHub : TestHub
 
     public async Task BlockingMethod()
     {
-        var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-        Context.ConnectionAborted.Register(state => ((TaskCompletionSource<object>)state).SetResult(null), tcs);
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Context.ConnectionAborted.Register(state => ((TaskCompletionSource)state).SetResult(), tcs);
 
         await tcs.Task;
     }
@@ -348,8 +348,8 @@ public abstract class TestHub : Hub
 {
     public override Task OnConnectedAsync()
     {
-        var tcs = (TaskCompletionSource<bool>)Context.Items["ConnectedTask"];
-        tcs?.TrySetResult(true);
+        var tcs = (TaskCompletionSource)Context.Items["ConnectedTask"];
+        tcs?.TrySetResult();
         return base.OnConnectedAsync();
     }
 }
@@ -358,8 +358,8 @@ public class DynamicTestHub : DynamicHub
 {
     public override Task OnConnectedAsync()
     {
-        var tcs = (TaskCompletionSource<bool>)Context.Items["ConnectedTask"];
-        tcs?.TrySetResult(true);
+        var tcs = (TaskCompletionSource)Context.Items["ConnectedTask"];
+        tcs?.TrySetResult();
         return base.OnConnectedAsync();
     }
 
@@ -438,8 +438,8 @@ public class HubT : Hub<Test>
 {
     public override Task OnConnectedAsync()
     {
-        var tcs = (TaskCompletionSource<bool>)Context.Items["ConnectedTask"];
-        tcs?.TrySetResult(true);
+        var tcs = (TaskCompletionSource)Context.Items["ConnectedTask"];
+        tcs?.TrySetResult();
         return base.OnConnectedAsync();
     }
 
@@ -1228,8 +1228,8 @@ public class CallerServiceHub : Hub
     public override Task OnConnectedAsync()
     {
         _service.SetCaller(Clients.Caller);
-        var tcs = (TaskCompletionSource<bool>)Context.Items["ConnectedTask"];
-        tcs?.TrySetResult(true);
+        var tcs = (TaskCompletionSource)Context.Items["ConnectedTask"];
+        tcs?.TrySetResult();
         return base.OnConnectedAsync();
     }
 }

--- a/src/Tools/Shared/TestHelpers/TestConsole.cs
+++ b/src/Tools/Shared/TestHelpers/TestConsole.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.Tools.Internal;
 public class TestConsole : IConsole
 {
     private event ConsoleCancelEventHandler _cancelKeyPress = default!;
-    private readonly TaskCompletionSource<bool> _cancelKeySubscribed = new TaskCompletionSource<bool>();
+    private readonly TaskCompletionSource _cancelKeySubscribed = new TaskCompletionSource();
     private readonly TestOutputWriter _testWriter;
 
     public TestConsole(ITestOutputHelper output)
@@ -29,7 +29,7 @@ public class TestConsole : IConsole
         add
         {
             _cancelKeyPress += value;
-            _cancelKeySubscribed.TrySetResult(true);
+            _cancelKeySubscribed.TrySetResult();
         }
         remove => _cancelKeyPress -= value;
     }


### PR DESCRIPTION
# Use non-generic TaskCompletionSource

Use the non-generic `TaskCompletionSource` where appropriate.

## Description

Inspired by dotnet/runtime#64423, I had a look to see if there were any usages of `TaskCompletionSource<T>` that could just use the non generic variant instead. Searching for `bool`, `int` and `object` I found quite a few, mostly in tests, which were just being used to signal completion of arbitrary operation where the `T` value wasn't used.

This PR changes all such usages that wouldn't require use of conditional compilation to handle TFMs that don't have support for `TaskCompletionSource`.

I've left this as a draft for now because it touches a lot of files so it doesn't create a notification deluge. If this change isn't welcome (or is too big), I can just close it (or amend it).
