### PR TITLE
[release/6.0] Make UseUrls() override default hosting config

### DIFF
--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -22,6 +22,7 @@ namespace Microsoft.AspNetCore.Builder
         private readonly BootstrapHostBuilder _bootstrapHostBuilder;
         private readonly WebApplicationServiceCollection _services = new();
         private readonly List<KeyValuePair<string, string>> _hostConfigurationValues;
+        private readonly ConfigurationManager _hostConfigurationManager = new();
 
         private WebApplication? _builtApplication;
 
@@ -76,6 +77,8 @@ namespace Microsoft.AspNetCore.Builder
             });
 
             Configuration = new();
+            // This is chained as the first configuration source in Configuration so host config can be added later without overriding app config.
+            Configuration.AddConfiguration(_hostConfigurationManager, shouldDisposeConfiguration: true);
 
             // Collect the hosted services separately since we want those to run after the user's hosted services
             _services.TrackHostedServices = true;
@@ -194,6 +197,9 @@ namespace Microsoft.AspNetCore.Builder
                 // to the new one. This allows code that has references to the service collection to still function.
                 _services.InnerCollection = services;
 
+                // Keep any configuration sources added before the TrackingChainedConfigurationSource (namely host configuration from _hostConfigurationValues)
+                // from overriding config values set via Configuration by inserting them at beginning using _hostConfigurationValues.
+                var beforeChainedConfig = true;
                 var hostBuilderProviders = ((IConfigurationRoot)context.Configuration).Providers;
 
                 if (!hostBuilderProviders.Contains(chainedConfigSource.BuiltProvider))
@@ -201,15 +207,22 @@ namespace Microsoft.AspNetCore.Builder
                     // Something removed the _hostBuilder's TrackingChainedConfigurationSource pointing back to the ConfigurationManager.
                     // This is likely a test using WebApplicationFactory. Replicate the effect by clearing the ConfingurationManager sources.
                     ((IConfigurationBuilder)Configuration).Sources.Clear();
+                    beforeChainedConfig = false;
                 }
 
-                // Make builder.Configuration match the final configuration. To do that, we add the additional
-                // providers in the inner _hostBuilders's Configuration to the ConfigurationManager.
+                // Make the ConfigurationManager match the final _hostBuilder's configuration. To do that, we add the additional providers
+                // to the inner _hostBuilders's configuration to the ConfigurationManager. We wrap the existing provider in a
+                // configuration source to avoid rebuilding or reloading the already added configuration sources.
                 foreach (var provider in hostBuilderProviders)
                 {
-                    if (!ReferenceEquals(provider, chainedConfigSource.BuiltProvider))
+                    if (ReferenceEquals(provider, chainedConfigSource.BuiltProvider))
                     {
-                        ((IConfigurationBuilder)Configuration).Add(new ConfigurationProviderSource(provider));
+                        beforeChainedConfig = false;
+                    }
+                    else
+                    {
+                        IConfigurationBuilder configBuilder = beforeChainedConfig ? _hostConfigurationManager : Configuration;
+                        configBuilder.Add(new ConfigurationProviderSource(provider));
                     }
                 }
             });

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -130,6 +130,33 @@ namespace Microsoft.AspNetCore.Tests
         }
 
         [Fact]
+        public async Task WebApplicationWebHostUseUrls_OverridesDefaultHostingConfiguration()
+        {
+            var builder = new WebApplicationBuilder(new(), bootstrapBuilder =>
+            {
+                bootstrapBuilder.ConfigureHostConfiguration(configBuilder =>
+                {
+                    configBuilder.AddInMemoryCollection(new Dictionary<string, string>
+                    {
+                        [WebHostDefaults.ServerUrlsKey] = "http://localhost:5000",
+                    });
+                });
+            });
+
+            builder.WebHost.UseUrls("http://localhost:5001");
+
+            var urls = new List<string>();
+            var server = new MockAddressesServer(urls);
+            builder.Services.AddSingleton<IServer>(server);
+            await using var app = builder.Build();
+
+            await app.StartAsync();
+
+            var url = Assert.Single(urls);
+            Assert.Equal("http://localhost:5001", url);
+        }
+
+        [Fact]
         public async Task WebApplicationUrls_ThrowsInvalidOperationExceptionIfThereIsNoIServerAddressesFeature()
         {
             var builder = WebApplication.CreateBuilder();


### PR DESCRIPTION
## Description

Prior to this change, default config (typically loaded from `DOTNET_`/`ASPNET_` environment variables and command line arguments) could override the application-level configuration. This would prevent `GenericWebHostService` from seeing the latest configuration set by `UseUrls()` of `DOTNET_URLS`, `ASPNET_URLS` or `--urls` was set.

Fixes #38185

## Customer Impact

This is a big gotcha to customers using `WebApplicationBuilder` (which is used in all the ASP.NET Core 6 templates) who expect the following to work:

```C#
var builder = WebApplication.CreateBuilder(args);
builder.WebHost.UseUrls("http://*:8080");
var app = builder.Build();
app.Run();
```

A comment on the issue suggesting we patch this has gotten 5 thumbs ups not counting mine.

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

This is a small well tested change which only affects the loading of default config sources and those added via a HostFactoryResolver to host configuration.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
