### PR TITLE
Do not upgrade warnings to errors in VS

### DIFF
--- a/eng/tools/GenerateFiles/Directory.Build.props.in
+++ b/eng/tools/GenerateFiles/Directory.Build.props.in
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <DefaultNetCoreTargetFramework>${DefaultNetCoreTargetFramework}</DefaultNetCoreTargetFramework>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors Condition="'$(BuildingInsideVisualStudio)' != 'true'">true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Now that we have enabled a bunch of code analysis, we've discovered it adds friction to the dev process. This change aims to reduce the friction by preventing warnings to be upgraded to errors in VS. This way you can continue developing, while possible issues are still surfaced. E.g. from a recent error:

![image](https://user-images.githubusercontent.com/174281/151622882-d64f986a-bfa3-4f5c-bc43-d28bc61d3d9e.png)
