### PR TITLE
Consistently serialize child members returned from route handlers

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -1452,12 +1452,12 @@ public static partial class RequestDelegateFactory
 
         static async Task ExecuteAwaited(Task<T> task, HttpContext httpContext)
         {
-            await httpContext.Response.WriteAsJsonAsync(await task);
+            await httpContext.Response.WriteAsJsonAsync<object?>(await task);
         }
 
         if (task.IsCompletedSuccessfully)
         {
-            return httpContext.Response.WriteAsJsonAsync(task.GetAwaiter().GetResult());
+            return httpContext.Response.WriteAsJsonAsync<object?>(task.GetAwaiter().GetResult());
         }
 
         return ExecuteAwaited(task, httpContext);
@@ -1506,12 +1506,12 @@ public static partial class RequestDelegateFactory
     {
         static async Task ExecuteAwaited(ValueTask<T> task, HttpContext httpContext)
         {
-            await httpContext.Response.WriteAsJsonAsync(await task);
+            await httpContext.Response.WriteAsJsonAsync<object?>(await task);
         }
 
         if (task.IsCompletedSuccessfully)
         {
-            return httpContext.Response.WriteAsJsonAsync(task.GetAwaiter().GetResult());
+            return httpContext.Response.WriteAsJsonAsync<object?>(task.GetAwaiter().GetResult());
         }
 
         return ExecuteAwaited(task, httpContext);


### PR DESCRIPTION
The comments show the response bodies produced by the following route handlers before and after the PR.

```C#
var app = WebApplication.Create(args);

// Before: { "p": "p" }
// After: { "c": "c", "p": "p" }
app.MapGet("/task", () => Task.FromResult<Parent>(new Child()));
app.MapGet("/valuetask", ValueTask<Parent> () => new(new Child()));

// Before: { "c": "c", "p": "p" }
// After: { "c": "c", "p": "p" }
app.MapGet("/", Parent () => new Child());

// Before: { "c": "c", "p": "p" }
// After: { "c": "c", "p": "p" }
app.MapGet("/taskobj", () => Task.FromResult<object>(new Child()));
app.MapGet("/valuetaskobj", ValueTask<object> () => new(new Child()));

app.Run();

record Parent(string P = "p");
record Child(string C = "c") : Parent;
```

This shows an inconsistency in how returned objects are serialized in async methods that return a `Task<Parent>` or `ValueTask<Parent>` vs non-async methods that return `Parent` when the runtime type is a child type.

The non-async route handler has the right behavior because it results in a call to `WriteAsJsonAsync<object>(...)` instead of `WriteAsJsonAsync<Parent>(...)` which is what gets called in the async case. See https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-polymorphism

Fixes #39856
