### PR TITLE
Remove static char arrays

### DIFF
--- a/src/Components/Components/src/Routing/RouteContext.cs
+++ b/src/Components/Components/src/Routing/RouteContext.cs
@@ -8,13 +8,11 @@ namespace Microsoft.AspNetCore.Components.Routing;
 
 internal class RouteContext
 {
-    private static readonly char[] Separator = new[] { '/' };
-
     public RouteContext(string path)
     {
         // This is a simplification. We are assuming there are no paths like /a//b/. A proper routing
         // implementation would be more sophisticated.
-        Segments = path.Trim('/').Split(Separator, StringSplitOptions.RemoveEmptyEntries);
+        Segments = path.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
         // Individual segments are URL-decoded in order to support arbitrary characters, assuming UTF-8 encoding.
         for (int i = 0; i < Segments.Length; i++)
         {

--- a/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureApiResources.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureApiResources.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 
 internal class ConfigureApiResources : IConfigureOptions<ApiAuthorizationOptions>
 {
-    private static readonly char[] ScopesSeparator = new char[] { ' ' };
+    private const char ScopesSeparator = ' ';
 
     private readonly IConfiguration _configuration;
     private readonly ILogger<ConfigureApiResources> _logger;

--- a/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureClientScopes.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureClientScopes.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer.Configuration;
 
 internal class ConfigureClientScopes : IPostConfigureOptions<ApiAuthorizationOptions>
 {
-    private static readonly char[] DefaultClientListSeparator = new char[] { ' ' };
+    private const char DefaultClientListSeparator = ' ';
     private readonly ILogger<ConfigureClientScopes> _logger;
 
     public ConfigureClientScopes(ILogger<ConfigureClientScopes> logger)

--- a/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureIdentityResources.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/Configuration/ConfigureIdentityResources.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer;
@@ -10,13 +9,11 @@ namespace Microsoft.AspNetCore.ApiAuthorization.IdentityServer;
 internal class ConfigureIdentityResources : IConfigureOptions<ApiAuthorizationOptions>
 {
     private readonly IConfiguration _configuration;
-    private readonly ILogger<ConfigureIdentityResources> _logger;
-    private static readonly char[] ScopesSeparator = new char[] { ' ' };
+    private const char ScopesSeparator = ' ';
 
-    public ConfigureIdentityResources(IConfiguration configuration, ILogger<ConfigureIdentityResources> logger)
+    public ConfigureIdentityResources(IConfiguration configuration)
     {
         _configuration = configuration;
-        _logger = logger;
     }
 
     public void Configure(ApiAuthorizationOptions options)

--- a/src/Identity/ApiAuthorization.IdentityServer/src/IdentityServerBuilderConfigurationExtensions.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/IdentityServerBuilderConfigurationExtensions.cs
@@ -154,9 +154,8 @@ public static class IdentityServerBuilderConfigurationExtensions
         builder.Services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IConfigureOptions<ApiAuthorizationOptions>, ConfigureIdentityResources>(sp =>
             {
-                var logger = sp.GetRequiredService<ILogger<ConfigureIdentityResources>>();
                 var effectiveConfig = configuration ?? sp.GetRequiredService<IConfiguration>().GetSection("IdentityServer:Identity");
-                return new ConfigureIdentityResources(effectiveConfig, logger);
+                return new ConfigureIdentityResources(effectiveConfig);
             }));
 
         // We take over the setup for the identity resources as Identity Server registers the enumerable as a singleton

--- a/src/Mvc/Mvc.Core/src/ModelBinding/PrefixContainer.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/PrefixContainer.cs
@@ -112,7 +112,7 @@ public class PrefixContainer
     {
         string key;
         string fullName;
-        var delimiterPosition = entry.IndexOfAny(Delimiters, 0);
+        var delimiterPosition = entry.AsSpan().IndexOfAny('[', '.');
 
         if (delimiterPosition == 0 && entry[0] == '[')
         {


### PR DESCRIPTION
# Remove static char arrays

Remove static `char` arrays in lieu of just a `char` (or two).

## Description

Remove static `char` arrays where newer method overloads can instead use a single or pair of characters.

Also removes an unused `ILogger<T>` from `ConfigureIdentityResources`.

Contributes to #39771.
