### PR TITLE
Use ConfigureAwait(false) on ConnectionMultiplexerFactory

### DIFF
--- a/src/Caching/StackExchangeRedis/src/.editorconfig
+++ b/src/Caching/StackExchangeRedis/src/.editorconfig
@@ -1,0 +1,4 @@
+[*.{cs,vb}]
+
+# CA2007: Consider calling ConfigureAwait on the awaited task
+dotnet_diagnostic.CA2007.severity = warning

--- a/src/Caching/StackExchangeRedis/src/.editorconfig
+++ b/src/Caching/StackExchangeRedis/src/.editorconfig
@@ -1,4 +1,0 @@
-[*.{cs,vb}]
-
-# CA2007: Consider calling ConfigureAwait on the awaited task
-dotnet_diagnostic.CA2007.severity = warning

--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -261,7 +261,7 @@ public class RedisCache : IDistributedCache, IDisposable
                 }
                 else
                 {
-                    _connection = await _options.ConnectionMultiplexerFactory();
+                    _connection = await _options.ConnectionMultiplexerFactory().ConfigureAwait(false);
                 }
 
                 PrepareConnection();


### PR DESCRIPTION
# Use ConfigureAwait(false) on ConnectionMultiplexerFactory

Every await in `RedisCache` has `ConfigureAwait(false)`, should it also be there on `ConnectionMultiplexerFactory`?


