### PR TITLE
Improve App build reliability and performance

### DIFF
--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -44,7 +44,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
     <!-- Platform manifest data -->
     <FrameworkListFileName>FrameworkList.xml</FrameworkListFileName>
-    <FrameworkListOutputPath>$(ArtifactsObjDir)$(FrameworkListFileName)</FrameworkListOutputPath>
+    <FrameworkListOutputPath>$(BaseIntermediateOutputPath)$(FrameworkListFileName)</FrameworkListOutputPath>
 
     <!-- Runtime transport path i.e. location of runtime ref/ assemblies that are not in Microsoft.NETCore.App.Ref. -->
     <RuntimeTransportReferenceDirectory>$(PkgMicrosoft_Internal_Runtime_AspNetCore_Transport)\ref\$(TargetFramework)\</RuntimeTransportReferenceDirectory>
@@ -52,7 +52,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <!-- Package overrides and platform manifest metadata. -->
     <PackageOverridesFileName>PackageOverrides.txt</PackageOverridesFileName>
     <!-- PackageOverrides.txt is written in GeneratePackageOverrides target unless servicing. -->
-    <ReferencePackageOverridesPath Condition="'$(IsServicingBuild)' != 'true'">$(ArtifactsObjDir)$(PackageOverridesFileName)</ReferencePackageOverridesPath>
+    <ReferencePackageOverridesPath Condition="'$(IsServicingBuild)' != 'true'">$(BaseIntermediateOutputPath)$(PackageOverridesFileName)</ReferencePackageOverridesPath>
     <ReferencePackageOverridesPath Condition="'$(IsServicingBuild)' == 'true'">$(RepoRoot)eng\$(PackageOverridesFileName)</ReferencePackageOverridesPath>
     <!-- PlatformManifest.txt is written in App.Runtime's GenerateSharedFxDepsFile target but not used here when servicing. -->
     <ReferencePlatformManifestPath Condition="'$(IsServicingBuild)' != 'true'">$(PlatformManifestOutputPath)</ReferencePlatformManifestPath>
@@ -94,13 +94,23 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   <PropertyGroup>
     <BuildDependsOn>
       $(BuildDependsOn);
-      _ResolveTargetingPackContent;
+      _ResolveInitialTargetingPackContent;
       GeneratePackageOverrides;
-      IncludeFrameworkListFile;
+      GenerateFrameworkListFile;
+      _ResolveTargetingPackContent;
       _BatchCopyToLayoutTargetDir;
       _InstallTargetingPackIntoLocalDotNet;
       _CreateTargetingPackArchive;
     </BuildDependsOn>
+    <ResolveTargetingPackContentDependsOn>
+      _ResolveInitialTargetingPackContent;
+      _ResolveTargetingPackContent;
+    </ResolveTargetingPackContentDependsOn>
+    <!-- If Build won't run in the GenerateNuspec context, need to update _PackageFiles. -->
+    <GenerateNuspecDependsOn Condition=" '$(NoBuild)' == 'true' AND '$(GeneratePackageOnBuild)' != 'true' ">
+      $(GenerateNuspecDependsOn);
+      $(ResolveTargetingPackContentDependsOn)
+    </GenerateNuspecDependsOn>
   </PropertyGroup>
 
   <!-- Override the default MSBuild targets so that nothing is returned from the project since it represents a collection of assemblies. -->
@@ -114,9 +124,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   <Target Name="CopyFilesToOutputDirectory" />
 
   <!-- This target finds the reference assemblies. -->
-  <Target Name="_ResolveTargetingPackContent"
+  <Target Name="_ResolveInitialTargetingPackContent"
           Returns="@(AspNetCoreReferenceAssemblyPath)"
-          BeforeTargets="_GetPackageFiles"
           DependsOnTargets="ResolveReferences;FindReferenceAssembliesForReferences">
     <ItemGroup>
       <!-- Exclude a dependency that we don't want to expose. -->
@@ -158,23 +167,31 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           Include="@(AspNetCoreReferenceAssemblyPath->WithMetadataValue('ExternallyResolved', 'true')->'%(RootDir)%(Directory)%(Filename).xml')"
           Condition="Exists('%(RootDir)%(Directory)%(Filename).xml')" />
 
-      <RefPackContent Include="$(PkgMicrosoft_Internal_Runtime_AspNetCore_Transport)\$(AnalyzersPackagePath)**\*.*" PackagePath="$(AnalyzersPackagePath)" />
-      <RefPackContent Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.App.Analyzers\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.App.Analyzers.dll" PackagePath="$(AnalyzersPackagePath)dotnet/cs/" />
-      <RefPackContent Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Components.Analyzers\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.Components.Analyzers.dll" PackagePath="$(AnalyzersPackagePath)dotnet/cs/" />
-      <RefPackContent Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.App.CodeFixes\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.App.CodeFixes.dll" PackagePath="$(AnalyzersPackagePath)dotnet/cs/" />
+      <_InitialRefPackContent Include="$(PkgMicrosoft_Internal_Runtime_AspNetCore_Transport)\$(AnalyzersPackagePath)**\*.*" PackagePath="$(AnalyzersPackagePath)" />
+      <_InitialRefPackContent Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.App.Analyzers\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.App.Analyzers.dll" PackagePath="$(AnalyzersPackagePath)dotnet/cs/" />
+      <_InitialRefPackContent Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Components.Analyzers\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.Components.Analyzers.dll" PackagePath="$(AnalyzersPackagePath)dotnet/cs/" />
+      <_InitialRefPackContent Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.App.CodeFixes\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.App.CodeFixes.dll" PackagePath="$(AnalyzersPackagePath)dotnet/cs/" />
 
-      <RefPackContent Include="@(AspNetCoreReferenceAssemblyPath)" PackagePath="$(RefAssemblyPackagePath)" />
-      <RefPackContent Include="@(AspNetCoreReferenceDocXml)" PackagePath="$(RefAssemblyPackagePath)" />
-      <RefPackContent Include="$(ReferencePackageOverridesPath)" PackagePath="$(ManifestsPackagePath)" />
-      <RefPackContent Include="$(ReferencePlatformManifestPath)" PackagePath="$(ManifestsPackagePath)" />
+      <_InitialRefPackContent Include="@(AspNetCoreReferenceAssemblyPath)" PackagePath="$(RefAssemblyPackagePath)" />
+      <_InitialRefPackContent Include="@(AspNetCoreReferenceDocXml)" PackagePath="$(RefAssemblyPackagePath)" />
+      <_InitialRefPackContent Include="$(ReferencePlatformManifestPath)" PackagePath="$(ManifestsPackagePath)" />
     </ItemGroup>
   </Target>
 
-  <Target Name="GeneratePackageOverrides"
-          Condition=" '$(IsServicingBuild)' != 'true' "
-          DependsOnTargets="_ResolveTargetingPackContent"
-          Inputs="@(RefPackContent)"
-          Outputs="$(ReferencePackageOverridesPath)">
+  <Target Name="_ResolveTargetingPackContent">
+    <ItemGroup>
+      <RefPackContent Include="@(_InitialRefPackContent)" />
+      <RefPackContent Include="$(ReferencePackageOverridesPath)" PackagePath="$(ManifestsPackagePath)" />
+      <RefPackContent Include="$(FrameworkListOutputPath)" PackagePath="$(ManifestsPackagePath)" />
+      <_PackageFiles Include="@(RefPackContent)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ResolveTargetingPackContent"
+      DependsOnTargets="$(ResolveTargetingPackContentDependsOn)"
+      Returns="@(AspNetCoreReferenceAssemblyPath)" />
+
+  <Target Name="GeneratePackageOverrides" Condition=" '$(IsServicingBuild)' != 'true' ">
     <ItemGroup>
       <!-- Use package version for non-Runtime references. -->
       <_AspNetCoreAppPackageOverrides Include="@(AspNetCoreReferenceAssemblyPath->'%(NuGetPackageId)|%(NuGetPackageVersion)')"
@@ -196,25 +213,40 @@ This package is an internal implementation of the .NET Core SDK and is not meant
         Overwrite="true" />
   </Target>
 
-  <!-- Written to take advantage of target batching in MSBuild. -->
+  <!--
+    Cannot use RemoveDir task because _BatchCopyToLayoutTargetDir may only copy a subset of the files to the
+    layout directory. Instead, remove any files that shouldn't exist.
+  -->
+  <Target Name="_CleanLayout" BeforeTargets="_BatchCopyToLayoutTargetDir">
+    <ItemGroup>
+      <_ExtraLayoutFiles Include="$(LayoutTargetDir)**\*.*"
+          Exclude="@(RefPackContent->'$(LayoutTargetDir)%(PackagePath)%(RecursiveDir)%(FileName)%(Extension)')" />
+    </ItemGroup>
+    <Delete Files="@(_ExtraLayoutFiles)" />
+  </Target>
+
   <Target Name="_BatchCopyToLayoutTargetDir"
-          DependsOnTargets="_ResolveTargetingPackContent"
           Inputs="@(RefPackContent)"
           Outputs="@(RefPackContent->'$(LayoutTargetDir)%(PackagePath)%(RecursiveDir)%(FileName)%(Extension)')">
-    <RemoveDir Directories="$(TargetingPackLayoutRoot)" />
     <Copy SourceFiles="@(RefPackContent)"
           DestinationFiles="@(RefPackContent->'$(LayoutTargetDir)%(PackagePath)%(RecursiveDir)%(FileName)%(Extension)')"
           UseHardlinksIfPossible="true" />
     <Message Importance="High" Text="$(MSBuildProjectName) -> $(LayoutTargetDir)" />
   </Target>
 
+  <Target Name="_CleanLocalDotNet" BeforeTargets="_InstallTargetingPackIntoLocalDotNet">
+    <ItemGroup>
+      <_ExtraDotNetFiles Include="$(LocalInstallationOutputPath)**\*.*"
+          Exclude="@(RefPackContent->'$(LocalInstallationOutputPath)%(PackagePath)%(RecursiveDir)%(FileName)%(Extension)')" />
+    </ItemGroup>
+    <Delete Files="@(_ExtraDotNetFiles)" />
+  </Target>
+
   <!-- Workaround https://github.com/dotnet/sdk/issues/2910 by copying targeting pack into local installation. -->
   <Target Name="_InstallTargetingPackIntoLocalDotNet"
-          DependsOnTargets="_ResolveTargetingPackContent"
           Condition="'$(DotNetBuildFromSource)' != 'true'"
           Inputs="@(RefPackContent)"
           Outputs="@(RefPackContent->'$(LocalInstallationOutputPath)%(PackagePath)%(RecursiveDir)%(FileName)%(Extension)')">
-    <RemoveDir Directories="$(LocalInstallationOutputPath)" />
     <Copy SourceFiles="@(RefPackContent)"
           DestinationFiles="@(RefPackContent->'$(LocalInstallationOutputPath)%(PackagePath)%(RecursiveDir)%(FileName)%(Extension)')"
           UseHardlinksIfPossible="true" />
@@ -223,8 +255,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
   <Target Name="_CreateTargetingPackArchive"
           Inputs="@(RefPackContent)"
-          Outputs="$(ZipArchiveOutputPath);$(TarArchiveOutputPath)"
-          Condition=" '$(IsPackable)' == 'true' ">
+          Outputs="$(ZipArchiveOutputPath);$(TarArchiveOutputPath)">
     <PropertyGroup>
       <_TarCommand>tar</_TarCommand>
       <_TarCommand Condition="Exists('$(RepoRoot).tools\tar.exe')">"$(RepoRoot).tools\tar.exe"</_TarCommand>
@@ -248,19 +279,10 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <Message Importance="High" Text="$(MSBuildProjectName) -> $(TarArchiveOutputPath)" />
   </Target>
 
-  <Target Name="IncludeFrameworkListFile"
-          DependsOnTargets="_ResolveTargetingPackContent"
-          BeforeTargets="_GetPackageFiles"
-          Inputs="@(RefPackContent)"
-          Outputs="$(FrameworkListOutputPath)">
+  <Target Name="GenerateFrameworkListFile">
     <RepoTasks.CreateFrameworkListFile
-      Files="@(RefPackContent)"
+      Files="@(_InitialRefPackContent)"
       TargetFile="$(FrameworkListOutputPath)"
       RootAttributes="@(FrameworkListRootAttributes)" />
-
-    <ItemGroup>
-      <RefPackContent Include="$(FrameworkListOutputPath)" PackagePath="$(ManifestsPackagePath)" />
-      <_PackageFiles Include="@(RefPackContent)" />
-    </ItemGroup>
   </Target>
 </Project>

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -166,8 +166,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <RedistLayoutTargetDir>$(RedistSharedFrameworkLayoutRoot)$(SharedRuntimeSubPath)</RedistLayoutTargetDir>
     <LocalInstallationOutputPath>$(LocalDotNetRoot)$(SharedRuntimeSubPath)</LocalInstallationOutputPath>
 
-    <FrameworkListFileName>RuntimeList.xml</FrameworkListFileName>
-    <FrameworkListOutputPath>$(ArtifactsObjDir)$(FrameworkListFileName)</FrameworkListOutputPath>
+    <RuntimeListFileName>RuntimeList.xml</RuntimeListFileName>
+    <RuntimeListOutputPath>$(BaseIntermediateOutputPath)$(RuntimeListFileName)</RuntimeListOutputPath>
 
     <InternalArchiveOutputFileName>$(InternalInstallerBaseName)-$(PackageVersion)-$(TargetRuntimeIdentifier)$(ArchiveExtension)</InternalArchiveOutputFileName>
     <InternalArchiveOutputPath>$(InstallersOutputPath)$(InternalArchiveOutputFileName)</InternalArchiveOutputPath>
@@ -185,10 +185,14 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     </ResolveReferencesDependsOn>
     <CoreBuildDependsOn>
       $(CoreBuildDependsOn);
+      Crossgen;
       GenerateSharedFxDepsFile;
       GenerateSharedFxVersionsFiles;
-      Crossgen;
-      IncludeFrameworkListFile;
+      _ResolveNativePackContent;
+      _IncludeVersionFile;
+      _ResolveInitialSharedFrameworkContent;
+      _GenerateRuntimeListFile;
+      _ResolveRuntimePackContent;
       _ResolveSharedFrameworkContent;
       _InstallFrameworkIntoLocalDotNet;
       _DownloadAndExtractDotNetRuntime;
@@ -197,6 +201,15 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       _CreateInternalSharedFxArchive;
       _CreateRedistSharedFxArchive;
     </CoreBuildDependsOn>
+    <!-- If Build won't run in the GenerateNuspec context, need to update Content, None and _PackageFiles. -->
+    <GenerateNuspecDependsOn Condition=" '$(NoBuild)' == 'true' AND '$(GeneratePackageOnBuild)' != 'true' ">
+      _ResolveNativePackContent;
+      _IncludeVersionFile;
+      $(GenerateNuspecDependsOn);
+      _ResolveInitialSharedFrameworkContent;
+      _ResolveRuntimePackContent;
+      _ResolveSharedFrameworkContent;
+    </GenerateNuspecDependsOn>
     <CrossGenDependsOn>
       ResolveReferences;
     </CrossGenDependsOn>
@@ -204,6 +217,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       $(CrossGenDependsOn);
       _BatchCrossGenAssemblies;
     </CrossGenDependsOn>
+    <!-- _GetBuildOutputFilesWithTfm executes in a separate context from Build, GenerateNuspec, and so on. -->
     <TargetsForTfmSpecificBuildOutput>
       $(TargetsForTfmSpecificBuildOutput);
       _ResolveRuntimePackBuildOutput
@@ -245,11 +259,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     </ItemGroup>
   </Target>
 
-  <Target Name="GenerateSharedFxDepsFile"
-          DependsOnTargets="ResolveReferences;CrossGen"
-          Inputs="@(ReferenceCopyLocalPaths);$(_RepoTaskAssembly);$(ProjectAssetsFile);$(MSBuildAllProjects)"
-          Outputs="$(ProjectDepsFilePath)">
-
+  <Target Name="GenerateSharedFxDepsFile" DependsOnTargets="ResolveReferences">
     <ItemGroup>
       <_RuntimeReference Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Extension)' != '.pdb' AND '%(ReferenceCopyLocalPaths.Extension)' != '.r2rmap'" />
     </ItemGroup>
@@ -292,7 +302,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   </Target>
 
   <!-- This target resolves files into the BuiltProjectOutputGroupOutput which NuGet uses to generate the package files. -->
-  <Target Name="_ResolveRuntimePackBuildOutput" DependsOnTargets="ResolveReferences;Crossgen">
+  <Target Name="_ResolveRuntimePackBuildOutput" DependsOnTargets="ResolveReferences">
     <ItemGroup>
       <BuildOutputFiles Include="$(ProjectDepsFilePath)" />
       <BuildOutputFiles Include="@(ReferenceCopyLocalPaths)" Condition=" '%(ReferenceCopyLocalPaths.IsNativeImage)' != 'true' " />
@@ -307,15 +317,13 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       </OutputFileNames>
       <DistinctOutputFileNames Include="@(OutputFileNames->Distinct())"></DistinctOutputFileNames>
 
-      <!--BuiltProjectOutputGroupOuput is the item actually used by Nuget -->
+      <!--BuiltProjectOutputGroupOutput is the item actually used by Nuget -->
       <BuiltProjectOutputGroupOutput Include="%(DistinctOutputFileNames.ItemPath)" />
       <NuGetPackInput Include="@(BuiltProjectOutputGroupOutput)" />
     </ItemGroup>
   </Target>
 
-  <Target Name="_ResolveNativePackContent"
-          BeforeTargets="_GetPackageFiles;GenerateNuspec"
-          DependsOnTargets="ResolveReferences">
+  <Target Name="_ResolveNativePackContent" DependsOnTargets="ResolveReferences">
     <ItemGroup>
       <!-- Native files are included in _PackageFile instead because they belong in a separate package folder. -->
       <Content Include="@(ReferenceCopyLocalPaths)" PackagePath="$(NativeAssetsPackagePath)"
@@ -323,9 +331,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     </ItemGroup>
   </Target>
 
-  <Target Name="_ResolveRuntimePackContent"
-          BeforeTargets="_GetPackageFiles"
-          DependsOnTargets="GenerateSharedFxDepsFile">
+  <Target Name="_ResolveRuntimePackContent">
     <ItemGroup>
       <RuntimePackContent Include="$(PlatformManifestOutputPath)" PackagePath="$(ManifestsPackagePath)" />
     </ItemGroup>
@@ -473,48 +479,87 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       OverwriteReadOnlyFiles="true" />
   </Target>
 
-  <Target Name="_ResolveSharedFrameworkContent" DependsOnTargets="ResolveReferences;Crossgen">
+  <Target Name="_ResolveInitialSharedFrameworkContent" DependsOnTargets="ResolveReferences">
     <ItemGroup>
-      <SharedFxContent Include="$(DotVersionFileIntermediateOutputPath)" />
-      <SharedFxContent Include="$(ProjectDepsFilePath)" />
-      <SharedFxContent Include="$(ProjectRuntimeConfigFilePath)" />
-      <SharedFxContent Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' != '.pdb'" />
-      <SharedFxContent Include="$(RepoRoot)THIRD-PARTY-NOTICES.txt" />
+      <_InitialSharedFxContent Include="$(DotVersionFileIntermediateOutputPath)" />
+      <_InitialSharedFxContent Include="$(ProjectDepsFilePath)" />
+      <_InitialSharedFxContent Include="$(ProjectRuntimeConfigFilePath)" />
+      <_InitialSharedFxContent Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' != '.pdb'" />
+      <_InitialSharedFxContent Include="$(RepoRoot)THIRD-PARTY-NOTICES.txt" />
+    </ItemGroup>
+    <ItemGroup>
+      <_InitialSharedFxContent Condition="'%(_InitialSharedFxContent.Extension)' == '.dll'">
+        <PackagePath Condition="'%(_InitialSharedFxContent.IsNativeImage)' == 'true'">$(NativeAssetsPackagePath)</PackagePath>
+        <PackagePath Condition="'%(_InitialSharedFxContent.IsNativeImage)' != 'true'">$(ManagedAssetsPackagePath)</PackagePath>
+      </_InitialSharedFxContent>
     </ItemGroup>
   </Target>
 
-  <!-- Written to take advantage of target batching in MSBuild. -->
+  <Target Name="_ResolveSharedFrameworkContent">
+    <ItemGroup>
+      <SharedFxContent Include="@(_InitialSharedFxContent)" />
+
+      <!-- We only need RuntimeList.xml in the .nupkg, so we intentionally do not include it in the archives -->
+      <_PackageFiles Include="$(RuntimeListOutputPath)" PackagePath="$(ManifestsPackagePath)" />
+      <_PackageFiles Include="@(RuntimePackContent)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Cannot use RemoveDir task because _BatchCopyToSharedFrameworkLayout may only copy a subset of the files to the
+    layout directory. Instead, remove any files that shouldn't exist.
+  -->
+  <Target Name="_CleanLayout" BeforeTargets="_BatchCopyToSharedFrameworkLayout">
+    <ItemGroup>
+      <_ExtraLayoutFiles Include="$(SharedFxLayoutTargetDir)**\*.*"
+          Exclude="@(RefPackContent->'$(SharedFxLayoutTargetDir)%(FileName)%(Extension)')" />
+    </ItemGroup>
+    <Delete Files="@(_ExtraLayoutFiles)" />
+  </Target>
+
   <Target Name="_BatchCopyToSharedFrameworkLayout"
-          DependsOnTargets="_ResolveSharedFrameworkContent"
           Inputs="@(SharedFxContent)"
           Outputs="@(SharedFxContent->'$(SharedFxLayoutTargetDir)%(FileName)%(Extension)')">
-    <RemoveDir Directories="$(SharedFrameworkLayoutRoot)" />
     <Copy SourceFiles="@(SharedFxContent)"
           DestinationFiles="@(SharedFxContent->'$(SharedFxLayoutTargetDir)%(FileName)%(Extension)')"
           UseHardlinksIfPossible="true" />
     <Message Importance="High" Text="$(MSbuildProjectFile) -> $(SharedFxLayoutTargetDir)" />
   </Target>
 
-  <!-- Written to take advantage of target batching in MSBuild. -->
+  <Target Name="_CleanRedist" BeforeTargets="_BatchCopyToRedistLayout">
+    <ItemGroup>
+      <_ExtraRedistFiles Include="$(RedistLayoutTargetDir)**\*.*"
+          Exclude="@(RefPackContent->'$(RedistLayoutTargetDir)%(FileName)%(Extension)')" />
+    </ItemGroup>
+    <Delete Files="@(_ExtraRedistFiles)" />
+  </Target>
+
   <Target Name="_BatchCopyToRedistLayout"
-          DependsOnTargets="_ResolveSharedFrameworkContent"
           Inputs="@(SharedFxContent)"
           Outputs="@(SharedFxContent->'$(RedistLayoutTargetDir)%(FileName)%(Extension)')">
-    <RemoveDir Directories="$(RedistLayoutTargetDir)" />
     <Copy SourceFiles="@(SharedFxContent)"
           DestinationFiles="@(SharedFxContent->'$(RedistLayoutTargetDir)%(FileName)%(Extension)')"
           UseHardlinksIfPossible="true" />
     <Message Importance="High" Text="$(MSbuildProjectFile) -> $(RedistLayoutTargetDir)" />
   </Target>
 
-  <!-- Required to workaround https://github.com/dotnet/core-setup/issues/4809. This copies the shared framework into the $reporoot/.dotnet folder so tests can run against the shared framework. -->
-  <!-- This workaround is not needed in source build -->
+  <Target Name="_CleanLocalDotNet" BeforeTargets="_InstallFrameworkIntoLocalDotNet">
+    <ItemGroup>
+      <_ExtraDotNetFiles Include="$(LocalInstallationOutputPath)**\*.*"
+          Exclude="@(RefPackContent->'$(LocalInstallationOutputPath)%(FileName)%(Extension)')" />
+    </ItemGroup>
+    <Delete Files="@(_ExtraDotNetFiles)" />
+  </Target>
+
+  <!--
+    Required to workaround https://github.com/dotnet/core-setup/issues/4809. This copies the shared framework
+    into the $reporoot/.dotnet folder so tests can run against the shared framework. This workaround is not
+    needed in source build.
+  -->
   <Target Name="_InstallFrameworkIntoLocalDotNet"
-          DependsOnTargets="_ResolveSharedFrameworkContent"
           Condition="'$(DotNetBuildFromSource)' != 'true'"
           Inputs="@(SharedFxContent)"
           Outputs="@(SharedFxContent->'$(LocalInstallationOutputPath)%(FileName)%(Extension)')">
-    <RemoveDir Directories="$(LocalInstallationOutputPath)" />
     <Copy SourceFiles="@(SharedFxContent)"
           DestinationFiles="@(SharedFxContent->'$(LocalInstallationOutputPath)%(FileName)%(Extension)')"
           UseHardlinksIfPossible="true" />
@@ -522,7 +567,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   </Target>
 
   <Target Name="_CreateInternalSharedFxArchive"
-          DependsOnTargets="_BatchCopyToSharedFrameworkLayout"
           Inputs="@(SharedFxContent)"
           Outputs="$(InternalArchiveOutputPath)">
     <ZipDirectory
@@ -539,7 +583,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
   <!-- Redist tarball including the dotnet-runtime is not needed in source build -->
   <Target Name="_CreateRedistSharedFxArchive"
-          DependsOnTargets="_DownloadAndExtractDotNetRuntime;_BatchCopyToRedistLayout"
           Condition="'$(DotNetBuildFromSource)' != 'true'"
           Inputs="@(SharedFxContent)"
           Outputs="$(RedistArchiveOutputPath)">
@@ -555,34 +598,16 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       Condition="'$(ArchiveExtension)' == '.tar.gz'" />
   </Target>
 
-  <Target Name="IncludeFrameworkListFile"
-          DependsOnTargets="_ResolveSharedFrameworkContent"
-          BeforeTargets="_GetPackageFiles">
-    <ItemGroup>
-      <SharedFxContent Condition="'%(SharedFxContent.Extension)' == '.dll'">
-        <PackagePath Condition="'%(SharedFxContent.IsNativeImage)' == 'true'">$(NativeAssetsPackagePath)</PackagePath>
-        <PackagePath Condition="'%(SharedFxContent.IsNativeImage)' != 'true'">$(ManagedAssetsPackagePath)</PackagePath>
-      </SharedFxContent>
-    </ItemGroup>
-
+  <Target Name="_GenerateRuntimeListFile">
     <RepoTasks.CreateFrameworkListFile
-      Files="@(SharedFxContent)"
-      TargetFile="$(FrameworkListOutputPath)"
+      Files="@(_InitialSharedFxContent)"
+      TargetFile="$(RuntimeListOutputPath)"
       RootAttributes="@(FrameworkListRootAttributes)" />
-
-    <ItemGroup>
-      <!-- We only need RuntimeList.xml in the .nupkg, so we intentionally do not include it in the archives -->
-      <_PackageFiles Include="$(FrameworkListOutputPath)" PackagePath="$(ManifestsPackagePath)" />
-      <_PackageFiles Include="@(RuntimePackContent)" />
-    </ItemGroup>
   </Target>
 
-  <Target Name="IncludeVersionFile"
-          DependsOnTargets="GenerateSharedFxVersionsFiles"
-          BeforeTargets="_GetPackageFiles">
+  <Target Name="_IncludeVersionFile">
     <ItemGroup>
       <None Include="$(VersionTxtFileIntermediateOutputPath)" Pack="true" PackagePath="." />
     </ItemGroup>
   </Target>
-
 </Project>

--- a/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
+++ b/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
@@ -76,7 +76,7 @@
   <Target Name="GenerateTestData" BeforeTargets="GetAssemblyAttributes" DependsOnTargets="InitializeSourceControlInformation">
     <!-- Use the ref pack logic to compute the list of expected targeting pack content -->
     <MSBuild Projects="$(RepoRoot)src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
-        Targets="_ResolveTargetingPackContent">
+        Targets="ResolveTargetingPackContent">
       <Output TaskParameter="TargetOutputs" ItemName="_TargetingPackDependencies" />
     </MSBuild>
 


### PR DESCRIPTION
- clean layouts safely
    - `<RemoveDir/>` and batching can cause incomplete layouts
- set `@(SharedFxContent)`, `@(RefPackContent)` et cetera just once
- avoid `BeforeTargets` or `DependsUponTargets`, especially dependency loops
- run each target once and only generate new files within the Build target

nits:
- don't bother batching `GenerateXYZ` targets
- remove useless check of `$(IsPackable)` in App.Ref
- move unshared files into individual obj/ folders
    - obj/ exists for both App.Ref and App.Runtime; less confusing to use them
- rename `$(FrameworkListOutputPath)` to `$(RuntimeListOutputPath)` in App.Runtime to avoid another confusion
- remove useless "Written to take advantage of target batching in MSBuild." comments
- correct a spelling mistake or two