### PR TITLE
Add missing ConfigureAwait(false) to PolicyHttpMessageHandler

### DIFF
--- a/src/HttpClientFactory/Polly/src/.editorconfig
+++ b/src/HttpClientFactory/Polly/src/.editorconfig
@@ -1,0 +1,4 @@
+[*.{cs,vb}]
+
+# CA2007: Consider calling ConfigureAwait on the awaited task
+dotnet_diagnostic.CA2007.severity = warning

--- a/src/HttpClientFactory/Polly/src/.editorconfig
+++ b/src/HttpClientFactory/Polly/src/.editorconfig
@@ -1,4 +1,0 @@
-[*.{cs,vb}]
-
-# CA2007: Consider calling ConfigureAwait on the awaited task
-dotnet_diagnostic.CA2007.severity = warning

--- a/src/HttpClientFactory/Polly/src/PolicyHttpMessageHandler.cs
+++ b/src/HttpClientFactory/Polly/src/PolicyHttpMessageHandler.cs
@@ -167,7 +167,7 @@ public class PolicyHttpMessageHandler : DelegatingHandler
             disposable.Dispose();
         }
 
-        var result = await base.SendAsync(request, cancellationToken);
+        var result = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
         request.Properties[PriorResponseKey] = result;
 


### PR DESCRIPTION
# Add missing ConfigureAwait(false)

Add missing `ConfigureAwait(false)` on task await.

## Description

Add missing `ConfigureAwait(false)` on task await in `PolicyHttpMessageHandler`.

Looks like this got overlooked in #36162 when `async` was added to the method.
