### PR TITLE
Refactor : Small refactorings

### DIFF
--- a/src/DataProtection/DataProtection/src/Internal/ContainerUtils.cs
+++ b/src/DataProtection/DataProtection/src/Internal/ContainerUtils.cs
@@ -46,7 +46,7 @@ internal static class ContainerUtils
         // Expected file format: http://man7.org/linux/man-pages/man5/fstab.5.html
         foreach (var line in fstab)
         {
-            if (line == null || line.Length == 0 || line[0] == '#')
+            if (string.IsNullOrEmpty(line) || line[0] == '#')
             {
                 // skip empty and commented-out lines
                 continue;

--- a/src/Hosting/Hosting/src/Internal/StartupLoader.cs
+++ b/src/Hosting/Hosting/src/Internal/StartupLoader.cs
@@ -290,7 +290,7 @@ internal class StartupLoader
 
     internal static bool HasConfigureServicesIServiceProviderDelegate([DynamicallyAccessedMembers(StartupLinkerOptions.Accessibility)] Type startupType, string environmentName)
     {
-        return null != FindMethod(startupType, "Configure{0}Services", environmentName, typeof(IServiceProvider), required: false);
+        return FindMethod(startupType, "Configure{0}Services", environmentName, typeof(IServiceProvider), required: false) != null;
     }
 
     internal static ConfigureServicesBuilder FindConfigureServicesDelegate([DynamicallyAccessedMembers(StartupLinkerOptions.Accessibility)] Type startupType, string environmentName)

--- a/src/Shared/runtime/Http2/Hpack/IntegerEncoder.cs
+++ b/src/Shared/runtime/Http2/Hpack/IntegerEncoder.cs
@@ -44,7 +44,7 @@ namespace System.Net.Http.HPack
             {
                 destination[0] |= (byte)((1 << numBits) - 1);
 
-                if (1 == destination.Length)
+                if (destination.Length == 1)
                 {
                     bytesWritten = 0;
                     return false;


### PR DESCRIPTION
1. use `string.IsNullOrEmpty` instead of raw.
2. Constant should be on the right-hand side while comparing.