### PR TITLE
Fix typo in 'knownMehods'

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
@@ -202,8 +202,8 @@ internal static partial class HttpUtilities
             {
                 var value = BinaryPrimitives.ReadUInt64LittleEndian(span);
                 var index = GetKnownMethodIndex(value);
-                var knownMehods = _knownMethods;
-                if ((uint)index < (uint)knownMehods.Length)
+                var knownMethods = _knownMethods;
+                if ((uint)index < (uint)knownMethods.Length)
                 {
                     var knownMethod = _knownMethods[index];
 


### PR DESCRIPTION
Fix typo in 'knownMehods'
Should be 'knownMethods'
