### PR TITLE
Reduce build steps in our pipelines

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -680,14 +680,10 @@ stages:
         agentOs: Windows
         timeoutInMinutes: 240
         steps:
-        # Build the shared framework
-        - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64
-                  /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
-          displayName: Build shared fx
-        - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildNative
+        - script: ./eng/build.cmd -ci -nobl -test -pack -arch x64 -all
                   -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
-          displayName: Run build.cmd helix target
+          displayName: Build and run Helix tests
           env:
             HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
             SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -24,19 +24,15 @@ variables:
 jobs:
 - template: jobs/default-build.yml
   parameters:
-    jobName: Helix_matrix_x64
-    jobDisplayName: 'Tests: Helix full matrix x64'
+    jobName: Helix_matrix
+    jobDisplayName: 'Tests: Helix full matrix'
     agentOs: Windows
     timeoutInMinutes: 480
     steps:
-    # Build the shared framework
-    - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64
-              /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
-      displayName: Build shared fx
-    - script: .\eng\build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildNative
+    - script: ./eng/build.cmd -ci -nobl -test -pack -arch x64 -all
               -projects eng\helix\helix.proj /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
-      displayName: Run build.cmd helix target
+      displayName: Build and run Helix tests
       env:
         HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
         SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -49,18 +49,15 @@ jobs:
 - template: jobs/default-build.yml
   parameters:
     jobName: Helix_quarantined_x64
-    jobDisplayName: 'Tests: Helix'
+    jobDisplayName: 'Tests: Helix x64'
     agentOs: Windows
     timeoutInMinutes: 120
     steps:
-    # Build the shared framework
-    - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64
-              /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
-      displayName: Build shared fx
-    - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildJava -noBuildNative
+    # Don't build Java projects because tests there cannot be quarantined and nothing else depends on them.
+    - script: ./eng/build.cmd -ci -nobl -test -pack -arch x64 -all -noBuildJava
               -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:RunQuarantinedTests=true /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
-      displayName: Run build.cmd helix target
+      displayName: Build and run quarantined Helix tests
       continueOnError: true
       env:
         HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
@@ -79,10 +76,10 @@ jobs:
     isAzDOTestingJob: true
     enablePublishTestResults: false
     steps:
-    - powershell: "& ./eng/build.ps1 -CI -nobl -all -pack -NoBuildJava"
-      displayName: Build
-    - script: ./eng/build.cmd -ci -nobl -test -NoRestore -NoBuild -NoBuilddeps "/p:RunQuarantinedTests=true /p:SkipHelixReadyTests=true"
-      displayName: Run Quarantined Tests
+    # Don't build Java projects because tests there cannot be quarantined and nothing else depends on them.
+    - script: ./eng/build.cmd -ci -nobl -test -pack -arch x64 -all -noBuildJava
+        /p:RunQuarantinedTests=true /p:SkipHelixReadyTests=true
+      displayName: Build and run Quarantined Tests
       continueOnError: true
     - task: PublishTestResults@2
       displayName: Publish Quarantined Test Results
@@ -112,10 +109,10 @@ jobs:
     isAzDOTestingJob: true
     enablePublishTestResults: false
     steps:
-    - bash: ./eng/build.sh --all --pack --ci --nobl --no-build-java
-      displayName: Build
-    - bash: ./eng/build.sh --no-build --ci --nobl --test -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
-      displayName: Run Quarantined Tests
+    # Don't build Java projects because tests there cannot be quarantined and nothing else depends on them.
+    - bash: ./eng/build.sh --ci --nobl --test --pack -arch x64 --all --no-build-java
+        -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
+      displayName: Build and run Quarantined Tests
       continueOnError: true
     - task: PublishTestResults@2
       displayName: Publish Quarantined Test Results
@@ -146,10 +143,10 @@ jobs:
     enablePublishTestResults: false
     useHostedUbuntu: false
     steps:
-    - bash: ./eng/build.sh --all --pack --ci --nobl --no-build-java
-      displayName: Build
-    - bash: ./eng/build.sh --no-build --ci --nobl --test -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
-      displayName: Run Quarantined Tests
+    # Don't build Java projects because tests there cannot be quarantined and nothing else depends on them.
+    - bash: ./eng/build.sh --ci --nobl --test --pack -arch x64 --all --no-build-java
+        -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
+      displayName: Build and run Quarantined Tests
       continueOnError: true
     - task: PublishTestResults@2
       displayName: Publish Quarantined Test Results

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -19,19 +19,16 @@ variables:
 jobs:
 - template: jobs/default-build.yml
   parameters:
-    jobName: Helix_quarantined_x64
+    jobName: Helix_quarantined
     jobDisplayName: 'Tests: Helix'
     agentOs: Windows
     timeoutInMinutes: 480
     steps:
-    # Build the shared framework
-    - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64
-              /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
-      displayName: Build shared fx
-    - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildJava -noBuildNative
+    # Don't build Java projects because tests there cannot be quarantined and nothing else depends on them.
+    - script: ./eng/build.cmd -ci -nobl -test -pack -arch x64 -all -noBuildJava
               -projects eng\helix\helix.proj /p:RunQuarantinedTests=true /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
-      displayName: Run build.cmd helix target
+      displayName: Build and run quarantined Helix tests
       continueOnError: true
       env:
         HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,5 +1,5 @@
 <Project>
-  <Import Project="Common.props" />
+  <Import Project="Common.props" Condition=" '$(ImportedCommonProps)' != 'true' " />
 
   <!-- These projects are always excluded, even when -projects is specified on command line. -->
   <ItemGroup>
@@ -144,7 +144,6 @@
         -->
         <DotNetProjects Include="
                           $(RepoRoot)src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj;
-                          $(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj;
                           $(RepoRoot)src\Framework\App.Ref.Internal\src\Microsoft.AspNetCore.App.Ref.Internal.csproj;
                           $(RepoRoot)src\Framework\test\Microsoft.AspNetCore.App.UnitTests.csproj;
                           $(RepoRoot)src\Caching\**\*.*proj;

--- a/eng/Common.props
+++ b/eng/Common.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <ImportedCommonProps>true</ImportedCommonProps>
     <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('Windows'))">win</TargetOsName>
     <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('OSX'))">osx</TargetOsName>
     <TargetOsName Condition=" '$(TargetOsName)' == '' AND $([MSBuild]::IsOSPlatform('Linux'))">linux</TargetOsName>

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test" TreatAsLocalProperty="ProjectToBuild">
-
   <PropertyGroup>
     <!--
       When invoking helix.proj for the whole repo with build.cmd, ProjectToBuild will be set to the path to this project.
@@ -8,9 +7,21 @@
     <ProjectToBuild Condition="'$(ProjectToBuild)' == '$(MSBuildProjectFullPath)'"/>
   </PropertyGroup>
 
+  <Import Project="$(RepoRoot)artifacts\bin\GenerateFiles\Directory.Build.props" />
   <Import Project="..\targets\Helix.Common.props" />
   <Import Project="..\Build.props" />
   <Import Project="..\Versions.props" />
+
+  <!--
+    Ensure shared framework and targeting pack packages are available for correlation payload but not when
+    requirement is suppressed (the default RunHelix.ps1 case).
+  -->
+  <ItemGroup Condition=" !$(IsFrameworkBuilding) AND '$(DoNotRequireSharedFxHelix)' != 'true' ">
+    <ProjectReference Include="$(RepoRoot)\src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
+      Private="false"
+      ReferenceOutputAssembly="false"
+      SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
 
   <!-- Microsoft.DotNet.Helix.Sdk.MultiQueue.targets splits $(HelixTargetQueues) into @(HelixTargetQueue) items. -->
   <ItemGroup Condition=" '$(HelixTargetQueues)' == '' ">
@@ -44,23 +55,28 @@
     </AdditionalDotNetPackage>
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(ContinuousIntegrationBuild)' == 'true' ">
-    <HelixType>ci</HelixType>
-    <!-- Creator is not valid for internal queues -->
-    <Creator Condition="'$(_UseHelixOpenQueues)' == 'true'">aspnetcore</Creator>
-    <HelixBuild>$(BUILD_BUILDNUMBER).$(SYSTEM_JOBATTEMPT)</HelixBuild>
-    <WaitForWorkItemCompletion>true</WaitForWorkItemCompletion>
-    <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
-    <EnableXUnitReporter>true</EnableXUnitReporter>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(ContinuousIntegrationBuild)' != 'true' ">
-    <HelixType>dev</HelixType>
-    <!-- Creator is not valid for internal queues -->
-    <Creator Condition="'$(_UseHelixOpenQueues)' == 'true'">$(USERNAME)</Creator>
-    <Creator Condition="'$(USERNAME)' == '' AND '$(_UseHelixOpenQueues)' == 'true'">$(USER)</Creator>
-    <HelixBuild>$([System.DateTime]::Now.ToString('yyyyMMddHHmm'))</HelixBuild>
-  </PropertyGroup>
+  <Choose>
+    <When Condition=" '$(ContinuousIntegrationBuild)' == 'true' ">
+      <PropertyGroup>
+        <HelixType>ci</HelixType>
+        <!-- Creator is not valid for internal queues -->
+        <Creator Condition="'$(_UseHelixOpenQueues)' == 'true'">aspnetcore</Creator>
+        <HelixBuild>$(BUILD_BUILDNUMBER).$(SYSTEM_JOBATTEMPT)</HelixBuild>
+        <WaitForWorkItemCompletion>true</WaitForWorkItemCompletion>
+        <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
+        <EnableXUnitReporter>true</EnableXUnitReporter>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <HelixType>dev</HelixType>
+        <!-- Creator is not valid for internal queues -->
+        <Creator Condition="'$(_UseHelixOpenQueues)' == 'true'">$(USERNAME)</Creator>
+        <Creator Condition="'$(USERNAME)' == '' AND '$(_UseHelixOpenQueues)' == 'true'">$(USER)</Creator>
+        <HelixBuild>$([System.DateTime]::Now.ToString('yyyyMMddHHmm'))</HelixBuild>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 
   <!-- Items with the type "HelixProperties" will become arbitrary JSON associated with the job -->
   <!-- NOTE: These are global to the whole Job, so don't include project-specific content here. -->
@@ -79,7 +95,7 @@
     <HelixCorrelationPayload Include="$(HelixTestConfigurationFilePath)" AsArchive="false" />
   </ItemGroup>
 
-  <Target Name="IncludeAspNetRuntime" BeforeTargets="Gather"
+  <Target Name="IncludeAspNetRuntime"
     Condition="'$(DoNotRequireSharedFxHelix)' != 'true' OR
     EXISTS('$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\Microsoft.AspNetCore.App.Runtime.$(TargetRuntimeIdentifier).$(SharedFxVersion).nupkg')">
     <MSBuild Projects="$(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
@@ -119,12 +135,15 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="Gather" BeforeTargets="Build">
+  <Target Name="_Gather">
     <MSBuild Projects="@(ProjectToBuild)"
-              Targets="CreateHelixPayload"
-              SkipNonexistentTargets="true">
+             Targets="CreateHelixPayload"
+             SkipNonexistentTargets="true">
       <Output TaskParameter="TargetOutputs" ItemName="HelixWorkItem" />
     </MSBuild>
   </Target>
 
+  <Target Name="Gather"
+      BeforeTargets="Build"
+      DependsOnTargets="ResolveProjectReferences;_Gather;IncludeAspNetRuntime" />
 </Project>

--- a/eng/scripts/RunHelix.ps1
+++ b/eng/scripts/RunHelix.ps1
@@ -56,6 +56,6 @@ Write-Host -ForegroundColor Yellow "And if packing for a different platform, add
 
 $HelixQueues = $HelixQueues -replace ";", "%3B"
 dotnet msbuild $Project /t:Helix /p:TargetArchitecture="$TargetArchitecture" `
-    /p:HelixTargetQueues=$HelixQueues /p:RunQuarantinedTests=$RunQuarantinedTests `
+    /p:HelixTargetQueues=$HelixQueues /p:RunQuarantinedTests=$RunQuarantinedTests /p:IsHelixJob=true `
     /p:_UseHelixOpenQueues=true /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log `
     /p:DoNotRequireSharedFxHelix=true @MSBuildArguments

--- a/eng/tools/GenerateFiles/Directory.Build.props.in
+++ b/eng/tools/GenerateFiles/Directory.Build.props.in
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <DefaultNetCoreTargetFramework>${DefaultNetCoreTargetFramework}</DefaultNetCoreTargetFramework>
+    <IsFrameworkBuilding>${IsFrameworkBuilding}</IsFrameworkBuilding>
     <TreatWarningsAsErrors Condition="'$(BuildingInsideVisualStudio)' != 'true'">true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/eng/tools/GenerateFiles/GenerateFiles.csproj
+++ b/eng/tools/GenerateFiles/GenerateFiles.csproj
@@ -1,4 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(RepoRoot)eng/Build.props" />
+
   <PropertyGroup>
     <!-- Use fixed version instead of $(DefaultNetCoreTargetFramework) to avoid needing workarounds set up here. -->
     <TargetFramework>net5.0</TargetFramework>
@@ -12,9 +14,23 @@
   <!-- Update artifacts/bin/GenerateFiles/Directory.Build.* files. -->
   <Target Name="GenerateDirectoryBuildFiles">
     <PropertyGroup>
+      <!--
+        Are we going to build Framework projects unconditionally? The listed projects are App.Runtime or have
+        unconditional references to App.Runtime. Other projects reference App.Runtime but mostly use this (often
+        together w/ checks on what helix.proj will do) in their conditions to minimize reference duplication.
+        Installers and Site Extension projects are a special case because they build separately and can make
+        assumptions about what was built in earlier steps.
+      -->
+      <_IsFrameworkBuilding>false</_IsFrameworkBuilding>
+      <_IsFrameworkBuilding Condition=" '@(ProjectToBuild)' != '' AND
+        (@(ProjectToBuild -> AnyHaveMetadataValue('Identity', '$(RepoRoot)src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj')) OR
+         @(ProjectToBuild -> AnyHaveMetadataValue('Identity', '$(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj')) OR
+         @(ProjectToBuild -> AnyHaveMetadataValue('Identity', '$(RepoRoot)src\Grpc\InteropTests\*.csproj'))) ">true</_IsFrameworkBuilding>
+
       <_TemplateProperties>
         AspNetCorePatchVersion=$(AspNetCorePatchVersion);
         DefaultNetCoreTargetFramework=$(DefaultNetCoreTargetFramework);
+        IsFrameworkBuilding=$(_IsFrameworkBuilding);
         MicrosoftAspNetCoreAppRefVersion=$(TargetingPackVersion);
         MicrosoftAspNetCoreAppRuntimeVersion=$(SharedFxVersion);
         MicrosoftNETCoreAppRefVersion=$(MicrosoftNETCoreAppRefVersion);

--- a/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -25,9 +25,11 @@
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" PrivateAssets="All" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" IsImplicitlyDefined="true" AllowExplicitReference="true" />
   </ItemGroup>
 
-  <!--  We include this here to ensure that the shared framework is built before we leverage it when running
-  the dev server. -->
-  <ItemGroup>
+  <!--
+    Do not enforce build order in most cases but make sure builds of this project are done together with
+    App.Runtime. Need latest App.Runtime due to blazor-devserver.runtimeconfig.json setup below.
+  -->
+  <ItemGroup Condition=" !$(IsFrameworkBuilding) AND ('$(IsHelixJob)' != 'true' OR '$(DoNotRequireSharedFxHelix)' == 'true') ">
     <ProjectReference Include="$(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
       Private="false"
       ReferenceOutputAssembly="false"

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -57,6 +57,12 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <!-- PlatformManifest.txt is written in App.Runtime's GenerateSharedFxDepsFile target but not used here when servicing. -->
     <ReferencePlatformManifestPath Condition="'$(IsServicingBuild)' != 'true'">$(PlatformManifestOutputPath)</ReferencePlatformManifestPath>
     <ReferencePlatformManifestPath Condition="'$(IsServicingBuild)' == 'true'">$(RepoRoot)eng\PlatformManifest.txt</ReferencePlatformManifestPath>
+
+    <!--
+      Package is needed when publishing for Helix tests. Set GeneratePackageOnBuild here, though sometimes
+      unnecessary, to avoid distinct references to this project.
+    -->
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -113,6 +113,12 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
     <NativePlatform>$(TargetArchitecture)</NativePlatform>
     <NativePlatform Condition=" '$(NativePlatform)' == 'x86' ">Win32</NativePlatform>
+
+    <!--
+      Package is needed when publishing for Helix tests. Set GeneratePackageOnBuild here, though sometimes
+      unnecessary, to avoid distinct references to this project.
+    -->
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
+++ b/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <RootNamespace>Microsoft.AspNetCore</RootNamespace>
@@ -66,7 +65,11 @@
     <Reference Include="NuGet.Versioning" />
   </ItemGroup>
 
-  <ItemGroup>
+  <!--
+    Do not enforce build order in most cases but make sure builds of this project are done together with
+    App.Runtime. Need latest App.Runtime when testing.
+  -->
+  <ItemGroup Condition=" !$(IsFrameworkBuilding) AND ('$(IsHelixJob)' != 'true' OR '$(DoNotRequireSharedFxHelix)' == 'true') ">
     <ProjectReference Include="$(RepoRoot)\src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
       Private="false"
       ReferenceOutputAssembly="false"
@@ -124,5 +127,4 @@
       </AssemblyAttribute>
     </ItemGroup>
   </Target>
-
 </Project>

--- a/src/Installers/Debian/Runtime/Debian.Runtime.debproj
+++ b/src/Installers/Debian/Runtime/Debian.Runtime.debproj
@@ -23,7 +23,11 @@
     </DebianConfigProperties>
   </PropertyGroup>
 
-  <ItemGroup>
+  <!--
+    In a CI build, a prior build step included the App.Runtime project.
+    All local builds need this because $(IsFrameworkBuilding) does not guarantee build order.
+  -->
+  <ItemGroup Condition=" '$(ContinuousIntegrationBuild)' != 'true' ">
     <ProjectReference Include="..\..\..\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
       Private="false"
       ReferenceOutputAssembly="false"

--- a/src/Installers/Debian/TargetingPack/Debian.TargetingPack.debproj
+++ b/src/Installers/Debian/TargetingPack/Debian.TargetingPack.debproj
@@ -27,7 +27,11 @@
 
   </PropertyGroup>
 
-  <ItemGroup>
+  <!--
+    In a CI build, a prior build step included the App.Ref project.
+    All local builds need this because $(IsFrameworkBuilding) does not guarantee build order.
+  -->
+  <ItemGroup Condition=" '$(ContinuousIntegrationBuild)' != 'true' ">
     <ProjectReference Include="..\..\..\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
       Private="false"
       ReferenceOutputAssembly="false"

--- a/src/Installers/Rpm/Rpm.Runtime.Common.targets
+++ b/src/Installers/Rpm/Rpm.Runtime.Common.targets
@@ -19,12 +19,18 @@
     <MicrosoftNETCoreAppRuntimeMajorMinorVersion>$(MicrosoftNETCoreAppRuntimeVersion.Split('.')[0]).$(MicrosoftNETCoreAppRuntimeVersion.Split('.')[1])</MicrosoftNETCoreAppRuntimeMajorMinorVersion>
   </PropertyGroup>
 
-  <ItemGroup>
+  <!--
+    In a CI build, a prior build step included the App.Runtime project.
+    All local builds need this because $(IsFrameworkBuilding) does not guarantee build order.
+  -->
+  <ItemGroup Condition=" '$(ContinuousIntegrationBuild)' != 'true' ">
     <ProjectReference Include="$(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
       Private="false"
       ReferenceOutputAssembly="false"
       SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
 
+  <ItemGroup>
     <InstallerOwnedDirectory Include="$(RpmPackageInstallRoot)shared/Microsoft.AspNetCore.App" />
     <RpmDependency Include="dotnet-runtime-$(MicrosoftNETCoreAppRuntimeMajorMinorVersion)" Version="$(MicrosoftNETCoreAppRuntimeVersion.Split('-')[0])" />
   </ItemGroup>

--- a/src/Installers/Rpm/TargetingPack/Rpm.TargetingPack.rpmproj
+++ b/src/Installers/Rpm/TargetingPack/Rpm.TargetingPack.rpmproj
@@ -16,12 +16,18 @@
     <MicrosoftNETCoreAppRefMajorMinorVersion>$(MicrosoftNETCoreAppRefVersion.Split('.')[0]).$(MicrosoftNETCoreAppRefVersion.Split('.')[1])</MicrosoftNETCoreAppRefMajorMinorVersion>
   </PropertyGroup>
 
-  <ItemGroup>
+  <!--
+    In a CI build, a prior build step included the App.Ref project.
+    All local builds need this because $(IsFrameworkBuilding) does not guarantee build order.
+  -->
+  <ItemGroup Condition=" '$(ContinuousIntegrationBuild)' != 'true' ">
     <ProjectReference Include="..\..\..\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
       Private="false"
       ReferenceOutputAssembly="false"
       SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
 
+  <ItemGroup>
     <InstallerOwnedDirectory Include="$(RpmPackageInstallRoot)packs/$(TargetingPackName)/" />
     <RpmDependency Include="dotnet-targeting-pack-$(MicrosoftNETCoreAppRefMajorMinorVersion)" Version="$(MicrosoftNETCoreAppRefVersion.Split('-')[0])" />
   </ItemGroup>

--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplates.Tests.csproj
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplates.Tests.csproj
@@ -49,10 +49,6 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.Playwright" Condition="'$(IsPlaywrightAvailable)' == 'true'" />
     <Reference Include="Microsoft.Playwright" ExcludeAssets="build" Condition="'$(IsPlaywrightAvailable)' != 'true'" />
-    <ProjectReference Include="$(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
-      Private="false"
-      ReferenceOutputAssembly="false"
-      SkipGetTargetFrameworkProperties="true" />
 
     <ProjectReference Include="$(RepoRoot)src\Hosting\Server.IntegrationTesting\src\Microsoft.AspNetCore.Server.IntegrationTesting.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Shared\BrowserTesting\src\Microsoft.AspNetCore.BrowserTesting.csproj" />
@@ -61,6 +57,17 @@
       ReferenceOutputAssembly="false"
       SkipGetTargetFrameworkProperties="true" />
     <ProjectReference Include="../Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj"
+      Private="false"
+      ReferenceOutputAssembly="false"
+      SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+
+  <!--
+    Do not enforce build order in most cases but make sure builds of this project are done together with
+    App.Runtime. Need latest App.Runtime when testing.
+  -->
+  <ItemGroup Condition=" !$(IsFrameworkBuilding) AND ('$(IsHelixJob)' != 'true' OR '$(DoNotRequireSharedFxHelix)' == 'true') ">
+    <ProjectReference Include="$(RepoRoot)\src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
       Private="false"
       ReferenceOutputAssembly="false"
       SkipGetTargetFrameworkProperties="true" />
@@ -75,6 +82,4 @@
     </ItemGroup>
     <Copy SourceFiles="@(_PublishFiles)" DestinationFolder="$(PublishDir)\.playwright\%(_PublishFiles.RecursiveDir)\" />
   </Target>
-
-
 </Project>

--- a/src/ProjectTemplates/README.md
+++ b/src/ProjectTemplates/README.md
@@ -30,22 +30,29 @@ To build the ProjectTemplates, use one of:
 
 1. Run `eng\build.cmd -all -pack -configuration Release` in the repository root to build and pack all of the repo, including template projects.
 1. Run `src\ProjectTemplates\build.cmd -pack -configuration Release` to produce NuGet packages only for the template projects.
+    - This will also build and pack the shared framework.
 
 **Note** use `eng/build.sh` or `src/ProjectTemplates/build.sh` on non-Windows platforms.
 
 ### Test
 
-To run the ProjectTemplate tests:
+To run ProjectTemplate tests, first ensure the ASP.NET localhost development certificate is installed and trusted.
+Otherwise, you'll get a test error "Certificate error: Navigation blocked".
 
-1. Because the templates build against the version of `Microsoft.AspNetCore.App` that was built during the previous step, it is NOT advised that you install templates created on your local machine via `dotnet new -i [nupkgPath]`. Instead, use the `Run-[Template]-Locally.ps1` scripts in the script folder. These scripts do `dotnet new -i` with your packages, but also apply a series of fixes and tweaks to the created template which keep the fact that you don't have a production `Microsoft.AspNetCore.App` from interfering.
-1. The ASP.NET localhost development certificate must also be installed and trusted or else you'll get a test error "Certificate error: Navigation blocked".
-1. Run `eng\build.cmd -test -NoRestore -NoBuild -NoBuilddeps -configuration Release "/p:RunTemplateTests=true"` to run template tests.
+Then, use one of:
+
+1. Run `src\ProjectTemplates\build.cmd -test -NoRestore -NoBuild -NoBuilddeps -configuration Release` (or equivalent src\ProjectTemplates\build.sh` command) to run all template tests.
+1. To test specific templates, use the `Run-[Template]-Locally.ps1` scripts in the script folder.
+    - These scripts do `dotnet new -i` with your packages, but also apply a series of fixes and tweaks to the created template which keep the fact that you don't have a production `Microsoft.AspNetCore.App` from interfering.
+1. Run templates manually with `custom-hive` and `disable-sdk-templates` to install to a custom location and turn off the built-in templates e.g.
+    - `dotnet new -i Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0.6.0.0-dev.nupkg --debug:custom-hive C:\TemplateHive\`
+    - `dotnet new angular --auth Individual --debug:disable-sdk-templates --debug:custom-hive C:\TemplateHive\`
 
 **Note** ProjectTemplates tests require Visual Studio unless a full build (CI) is performed.
 
-Alternatively, you can run with `custom-hive` and `disable-sdk-templates` to install to a custom location and turn off the built in templates
-- `dotnet new -i Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0.6.0.0-dev.nupkg --debug:custom-hive C:\TemplateHive\`
-- `dotnet new angular --auth Individual --debug:disable-sdk-templates --debug:custom-hive C:\TemplateHive\`
+**Note** Because the templates build against the version of `Microsoft.AspNetCore.App` that was built during the
+previous step, it is NOT advised that you install templates created on your local machine using just
+`dotnet new -i [nupkgPath]`.
 
 ## More Information
 

--- a/src/ProjectTemplates/test/ProjectTemplates.Tests.csproj
+++ b/src/ProjectTemplates/test/ProjectTemplates.Tests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <!-- Shared testing infrastructure for running E2E tests using selenium -->
   <Import Condition="'$(SkipTestBuild)' != 'true'" Project="$(SharedSourceRoot)E2ETesting\E2ETesting.props" />
 
@@ -47,10 +46,6 @@
   <ItemGroup>
     <Reference Include="AngleSharp" />
     <Reference Include="System.Net.Http" />
-    <ProjectReference Include="$(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
-      Private="false"
-      ReferenceOutputAssembly="false"
-      SkipGetTargetFrameworkProperties="true" />
 
     <ProjectReference Include="$(RepoRoot)src\Hosting\Server.IntegrationTesting\src\Microsoft.AspNetCore.Server.IntegrationTesting.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Shared\BrowserTesting\src\Microsoft.AspNetCore.BrowserTesting.csproj" />
@@ -71,6 +66,17 @@
       ReferenceOutputAssembly="false"
       SkipGetTargetFrameworkProperties="true" />
     <ProjectReference Include="$(RepoRoot)src\submodules\spa-templates\src\Microsoft.DotNet.Web.Spa.ProjectTemplates.csproj"
+      Private="false"
+      ReferenceOutputAssembly="false"
+      SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+
+  <!--
+    Do not enforce build order in most cases but make sure builds of this project are done together with
+    App.Runtime. Need latest App.Runtime when testing.
+  -->
+  <ItemGroup Condition=" !$(IsFrameworkBuilding) AND ('$(IsHelixJob)' != 'true' OR '$(DoNotRequireSharedFxHelix)' == 'true') ">
+    <ProjectReference Include="$(RepoRoot)\src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
       Private="false"
       ReferenceOutputAssembly="false"
       SkipGetTargetFrameworkProperties="true" />

--- a/src/SiteExtensions/LoggingBranch/LB.csproj
+++ b/src/SiteExtensions/LoggingBranch/LB.csproj
@@ -23,7 +23,13 @@
 
   <ItemGroup>
     <HostingStartupRuntimeStoreTargets Include="$(DefaultNetCoreTargetFramework)" Runtime="$(TargetRuntimeIdentifier)" />
+  </ItemGroup>
 
+  <!--
+    In a CI build, a prior build step included the App.Ref and App.Runtime projects.
+    All local builds need this because $(IsFrameworkBuilding) does not guarantee build order.
+  -->
+  <ItemGroup Condition=" '$(ContinuousIntegrationBuild)' != 'true' ">
     <ProjectReference Include="..\..\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
       Private="false"
       ReferenceOutputAssembly="false"

--- a/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
+++ b/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
@@ -33,14 +33,20 @@
       ReferenceOutputAssembly="false"
       SkipGetTargetFrameworkProperties="true" />
 
-    <!-- Make sure redist folder is built and ready -->
+    <NativeProjectReference Include="$(RepoRoot)src\Servers\IIS\AspNetCoreModuleV2\AspNetCore\AspNetCore.vcxproj" Platform="$(TargetArchitecture)" />
+    <NativeProjectReference Include="$(RepoRoot)src\Servers\IIS\AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj" HandlerPath="2.0.0" Platform="$(TargetArchitecture)" />
+  </ItemGroup>
+
+  <!--
+    Make sure redist folder (DotNetUnpackFolder aka RedistSharedFrameworkLayoutRoot) is built and ready.
+    In a CI build, a prior build step included the App.Runtime project.
+    All local builds need this because $(IsFrameworkBuilding) does not guarantee build order.
+  -->
+  <ItemGroup Condition=" '$(ContinuousIntegrationBuild)' != 'true' ">
     <ProjectReference Include="..\..\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
       Private="false"
       ReferenceOutputAssembly="false"
       SkipGetTargetFrameworkProperties="true" />
-
-    <NativeProjectReference Include="$(RepoRoot)src\Servers\IIS\AspNetCoreModuleV2\AspNetCore\AspNetCore.vcxproj" Platform="$(TargetArchitecture)" />
-    <NativeProjectReference Include="$(RepoRoot)src\Servers\IIS\AspNetCoreModuleV2\OutOfProcessRequestHandler\OutOfProcessRequestHandler.vcxproj" HandlerPath="2.0.0" Platform="$(TargetArchitecture)" />
   </ItemGroup>
 
   <Target Name="ResolveReferenceItemsForPackage" DependsOnTargets="ResolveReferences" BeforeTargets="_GetPackageFiles">


### PR DESCRIPTION
- `msbuild` now enforces the ordering as needed for tests
  - see below
- do not build Java projects in any quarantined tests
- ensure App.Runtime and App.Ref packages are built before creating Helix correlation payload
- reduce the number of App.Ref / App.Runtime references in most builds
  - add new `$(IsFrameworkBuilding)` property; base value on `@(ProjectToBuild)` items
  - add `$(ImportedCommonProps)` to avoid `<Import/>` repetition in GenerateFiles.csproj
- always pack App.Ref and App.Runtime for consistency though required only in some cases
  - avoid need to reference both projects when packages are needed
- `Publish` test projects before creating SharedFx.Layout.zip; tests may build App.Ref and App.Runtime

nits:
- be explicit and use `-arch x64` in affected build steps
- add a few more comments about targeting pack to Versions.props
- modernize documentation in the project template README
  - account for project builds creating the shared Fx
- ignore shared Fx .nupkg that may be out-of-date
- remove `$(HelixTestConfigurationFilePath)` and related `@(HelixCorrelationPayload)` setting
  - Helix SDK does these
