### PR TITLE
MVC: Save an allocation in PageRequestDelegateFactory & ControllerRequestDelegateFactory

### DIFF
--- a/src/Mvc/Mvc.Core/src/ControllerContext.cs
+++ b/src/Mvc/Mvc.Core/src/ControllerContext.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Core;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
 
 namespace Microsoft.AspNetCore.Mvc;
 
@@ -37,6 +39,20 @@ public class ControllerContext : ActionContext
                 typeof(ControllerActionDescriptor)),
                 nameof(context));
         }
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="ControllerContext"/>.
+    /// </summary>
+    /// <param name="httpContext">The <see cref="HttpContext"/> for the current request.</param>
+    /// <param name="routeData">The <see cref="RouteData"/> for the current request.</param>
+    /// <param name="actionDescriptor">The <see cref="ControllerActionDescriptor"/> for the selected action.</param>
+    internal ControllerContext(
+        HttpContext httpContext,
+        RouteData routeData,
+        ControllerActionDescriptor actionDescriptor)
+        : base(httpContext, routeData, actionDescriptor)
+    {
     }
 
     /// <summary>

--- a/src/Mvc/Mvc.Core/src/Routing/ControllerRequestDelegateFactory.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/ControllerRequestDelegateFactory.cs
@@ -56,7 +56,7 @@ internal class ControllerRequestDelegateFactory : IRequestDelegateFactory
     public RequestDelegate? CreateRequestDelegate(ActionDescriptor actionDescriptor, RouteValueDictionary? dataTokens)
     {
         // Fallback to action invoker extensibility so that invokers can override any default behaviors
-        if (_enableActionInvokers || actionDescriptor is not ControllerActionDescriptor)
+        if (_enableActionInvokers || actionDescriptor is not ControllerActionDescriptor controller)
         {
             return null;
         }
@@ -75,9 +75,7 @@ internal class ControllerRequestDelegateFactory : IRequestDelegateFactory
                 routeData.PushState(router: null, context.Request.RouteValues, dataTokens);
             }
 
-            var actionContext = new ActionContext(context, routeData, actionDescriptor);
-
-            var controllerContext = new ControllerContext(actionContext)
+            var controllerContext = new ControllerContext(context, routeData, controller)
             {
                 // PERF: These are rarely going to be changed, so let's go copy-on-write.
                 ValueProviderFactories = new CopyOnWriteList<IValueProviderFactory>(_valueProviderFactories)

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageRequestDelegateFactory.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageRequestDelegateFactory.cs
@@ -91,17 +91,13 @@ internal sealed class PageRequestDelegateFactory : IRequestDelegateFactory
                 routeData.PushState(router: null, context.Request.RouteValues, dataTokens);
             }
 
-            var actionContext = new ActionContext(context, routeData, page);
+            var pageContext = new PageContext(context, routeData, page);
 
-            var (cacheEntry, filters) = _cache.GetCachedResult(actionContext);
+            var (cacheEntry, filters) = _cache.GetCachedResult(pageContext);
 
-            var pageContext = new PageContext(actionContext)
-            {
-                ActionDescriptor = cacheEntry.ActionDescriptor,
-                ValueProviderFactories = new CopyOnWriteList<IValueProviderFactory>(_valueProviderFactories),
-                ViewData = cacheEntry.ViewDataFactory(_modelMetadataProvider, actionContext.ModelState),
-                ViewStartFactories = cacheEntry.ViewStartFactories.ToList(),
-            };
+            pageContext.ValueProviderFactories = new CopyOnWriteList<IValueProviderFactory>(_valueProviderFactories);
+            pageContext.ViewData = cacheEntry.ViewDataFactory(_modelMetadataProvider, pageContext.ModelState);
+            pageContext.ViewStartFactories = cacheEntry.ViewStartFactories.ToList();
 
             var pageInvoker = new PageActionInvoker(
                 _selector,

--- a/src/Mvc/Mvc.RazorPages/src/PageContext.cs
+++ b/src/Mvc/Mvc.RazorPages/src/PageContext.cs
@@ -48,7 +48,7 @@ public class PageContext : ActionContext
         HttpContext httpContext,
         RouteData routeData,
         CompiledPageActionDescriptor actionDescriptor)
-        : base(httpContext, routeData, actionDescriptor, new ModelStateDictionary())
+        : base(httpContext, routeData, actionDescriptor)
     {
         _actionDescriptor = actionDescriptor;
     }

--- a/src/Mvc/Mvc.RazorPages/src/PageContext.cs
+++ b/src/Mvc/Mvc.RazorPages/src/PageContext.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
 
 namespace Microsoft.AspNetCore.Mvc.RazorPages;
 
@@ -34,6 +36,21 @@ public class PageContext : ActionContext
     public PageContext(ActionContext actionContext)
         : base(actionContext)
     {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="PageContext"/>.
+    /// </summary>
+    /// <param name="httpContext">The <see cref="HttpContext"/> for the current request.</param>
+    /// <param name="routeData">The <see cref="RouteData"/> for the current request.</param>
+    /// <param name="actionDescriptor">The <see cref="CompiledPageActionDescriptor"/> for the selected action.</param>
+    internal PageContext(
+        HttpContext httpContext,
+        RouteData routeData,
+        CompiledPageActionDescriptor actionDescriptor)
+        : base(httpContext, routeData, actionDescriptor, new ModelStateDictionary())
+    {
+        _actionDescriptor = actionDescriptor;
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

It looks like we can save an `ActionContext` allocation and a few cycles spent setting fields inside the lambda created by `PageRequestDelegateFactory` & `ControllerRequestDelegateFactory` by adding an extra ctor on `PageContext` & `ControllerContext`.

Figured I would run it up the flagpole and see what folks thought about it.