### PR TITLE
Fire an event when allowing a bad request 

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -612,6 +612,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                         // replace it with the value from the request line.
                         if (_context.ServiceContext.ServerOptions.EnableInsecureAbsoluteFormHostOverride)
                         {
+                            ReportAllowedBadRequest(KestrelBadHttpRequestException.GetException(RequestRejectionReason.InvalidHostHeader, hostText));
+
                             hostText = _absoluteRequestTarget.Authority + ":" + _absoluteRequestTarget.Port.ToString(CultureInfo.InvariantCulture);
                             HttpRequestHeaders.HeaderHost = hostText;
                         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -1344,6 +1344,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         public void ReportAllowedBadRequest(BadHttpRequestException ex)
         {
             Log.ConnectionBadRequest(ConnectionId, ex);
+            // Set this so DiagnosticSource listeners can observe the exception via the IBadRequestExceptionFeature.
+            // Make sure to unset before exiting the method so the request doesn't actually get rejected.
+            // This means the exception will not be visible to normal middleware.
             _requestRejectedException = ex;
 
             const string badRequestEventName = "Microsoft.AspNetCore.Server.Kestrel.BadRequest";

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -1340,6 +1340,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             _keepAlive = false;
         }
 
+        // Normally this would have been rejected, but the developer opted into allowing the bad behavior.
+        public void ReportAllowedBadRequest(BadHttpRequestException ex)
+        {
+            Log.ConnectionBadRequest(ConnectionId, ex);
+            _requestRejectedException = ex;
+
+            const string badRequestEventName = "Microsoft.AspNetCore.Server.Kestrel.BadRequest";
+            if (ServiceContext.DiagnosticSource?.IsEnabled(badRequestEventName) == true)
+            {
+                ServiceContext.DiagnosticSource.Write(badRequestEventName, this);
+            }
+
+            _requestRejectedException = null;
+        }
+
         public void ReportApplicationError(Exception? ex)
         {
             // ReportApplicationError can be called with a null exception from MessageBody


### PR DESCRIPTION
# Fire an event when allowing a bad request 

This adds diagnostics for a prior fix so partners can determine when the client issues have been addressed.

## Description

https://github.com/dotnet/aspnetcore/pull/39334 from Feb allowed a partner to opt into accepting a specific kind of bad request. They're working to address the issues with the remote client and aren't sure how long that will take. They've requested new event so they can add in their own logging to monitor the client's progress, detect if anyone else is encountering the issue, and decide if we need a long term fix added to 7.0.

Fixes #39756

## Customer Impact

The customer is unable to tell if the prior mitigation is still required without disabling it and potentially breaking live customers.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

[Justify the selection above]

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A