### PR TITLE
Also build `npm` projects in parallel

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -50,8 +50,12 @@
     <!-- Project selection can be overridden on the command line by passing in -projects. -->
     <When Condition="'$(ProjectToBuild)' != ''">
       <ItemGroup>
-        <ProjectToBuild Include="$(ProjectToBuild)" Exclude="@(ProjectToExclude);$(RepoRoot)**\bin\**\*;$(RepoRoot)**\obj\**\*">
-          <RestoreInParallel Condition="'%(Extension)' == '.npmproj'">false</RestoreInParallel>
+        <ProjectToBuild Include="$(ProjectToBuild)"
+            Exclude="@(ProjectToExclude);$(RepoRoot)**\bin\**\*;$(RepoRoot)**\obj\**\*">
+          <BuildInParallel Condition=" '%(Extension)' == '.npmproj' ">false</BuildInParallel>
+          <RestoreInParallel Condition=" '%(Extension)' == '.npmproj' ">false</RestoreInParallel>
+          <!-- Also do not build in parallel w/in npm projects. -->
+          <AdditionalProperties Condition=" '%(Extension)' == '.npmproj' ">BuildInParallel=false</AdditionalProperties>
         </ProjectToBuild>
       </ItemGroup>
     </When>
@@ -115,9 +119,10 @@
         <NodeJsProjects Include="
                           $(RepoRoot)src\Components\Web.JS\Microsoft.AspNetCore.Components.Web.JS.npmproj;
                           $(RepoRoot)src\SignalR\**\*.npmproj;
-                          $(RepoRoot)src\Middleware\**\*.npmproj;
                           $(RepoRoot)src\JSInterop\**\*.npmproj;
                           "
+                        AdditionalProperties="BuildInParallel=false"
+                        BuildInParallel="false"
                         RestoreInParallel="false"
                         Exclude="@(ProjectToExclude)" />
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -219,6 +219,7 @@ if ($BuildManaged -or ($All -and (-not $NoBuildManaged))) {
         if ($node) {
             $nodeHome = Split-Path -Parent (Split-Path -Parent $node.Path)
             Write-Host -f Magenta "Building of C# project is enabled and has dependencies on NodeJS projects. Building of NodeJS projects is enabled since node is detected in $nodeHome."
+            $BuildNodeJS = $true
         }
         else {
             Write-Host -f Magenta "Building of NodeJS projects is disabled since node is not detected on Path and no BuildNodeJs or NoBuildNodeJs setting is set explicitly."

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -255,6 +255,7 @@ if [ "$build_managed" = true ] || ([ "$build_all" = true ] && [ "$build_managed"
     if [ -z "$build_nodejs" ]; then
         if [ -x "$(command -v node)" ]; then
             __warn "Building of C# project is enabled and has dependencies on NodeJS projects. Building of NodeJS projects is enabled since node is detected on PATH."
+            build_nodejs=true
         else
             __warn "Building of NodeJS projects is disabled since node is not detected on Path and no BuildNodeJs or NoBuildNodeJs setting is set explicitly."
             build_nodejs=false


### PR DESCRIPTION
- extend `%(RestoreInParallel)` choice to `%(BuildInParallel)`

nits:
- use `<ItemDefinitionGroup />`
- remove reference to non-existent .npmproj files