### PR TITLE
Build targeting pack archives less

### DIFF
--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -254,6 +254,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   </Target>
 
   <Target Name="_CreateTargetingPackArchive"
+          Condition=" '$(IsPackable)' == 'true' "
           Inputs="@(RefPackContent)"
           Outputs="$(ZipArchiveOutputPath);$(TarArchiveOutputPath)">
     <PropertyGroup>


### PR DESCRIPTION
- revert small part of aa8d62341d27
- `Condition` was _not_ "useless"