### PR TITLE
Don't compare SequencePosition instances

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
@@ -213,9 +213,11 @@ internal sealed class Http1ContentLengthMessageBody : Http1MessageBody
         // The current body is read, though there might be more bytes to read on the stream with pipelining
         if (_readCompleted)
         {
-            if (!_finalAdvanceCalled && consumed.Equals(_readResult.Buffer.End))
+            var buffer = _readResult.Buffer.Slice(consumed, _readResult.Buffer.End);
+
+            if (!_finalAdvanceCalled && buffer.IsEmpty)
             {
-                // Don't reference the old buffer as it will be released by the pipe afer calling AdvancedTo
+                // Don't reference the old buffer as it will be released by the pipe after calling AdvancedTo
                 _readResult = new ReadResult(new ReadOnlySequence<byte>(), isCanceled: false, isCompleted: true);
 
                 _context.Input.AdvanceTo(consumed);
@@ -225,7 +227,7 @@ internal sealed class Http1ContentLengthMessageBody : Http1MessageBody
             else
             {
                 // If the old stored _readResult was canceled, it's already been observed. Do not store a canceled read result permanently.
-                _readResult = new ReadResult(_readResult.Buffer.Slice(consumed, _readResult.Buffer.End), isCanceled: false, isCompleted: true);
+                _readResult = new ReadResult(buffer, isCanceled: false, isCompleted: true);
             }
 
             return;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1ContentLengthMessageBody.cs
@@ -217,7 +217,7 @@ internal sealed class Http1ContentLengthMessageBody : Http1MessageBody
 
             if (!_finalAdvanceCalled && buffer.IsEmpty)
             {
-                // Don't reference the old buffer as it will be released by the pipe after calling AdvancedTo
+                // Don't reference the old buffer as it will be released by the pipe after calling AdvanceTo
                 _readResult = new ReadResult(new ReadOnlySequence<byte>(), isCanceled: false, isCompleted: true);
 
                 _context.Input.AdvanceTo(consumed);


### PR DESCRIPTION
We can't compare `SequencePosition` instances. The problem is that consumed could theoretically point to the very end of a `ReadOnlySequenceSegment<byte>` and `_readResult.Buffer.End` might point to the very beginning of the next `ReadOnlySequenceSegment<byte>`. All the bytes would be consumed in this case, but the `SequencePosition` instances wouldn't be equal.

Existing test added in a previous PR this is fixing: https://github.com/dotnet/aspnetcore/blob/047e331ecc057dbf27187965261a3fc3c56978cf/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTests.cs#L1087