### PR TITLE
SimpleTypeModelBinder.CheckModel: add API doc

### DIFF
--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/SimpleTypeModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/SimpleTypeModelBinder.cs
@@ -115,7 +115,11 @@ public class SimpleTypeModelBinder : IModelBinder
         }
     }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// If the <paramref name="model" /> is <see langword="null" />, verifies that it is allowed to be <see langword="null" />,
+    /// otherwise notifies the <see cref="P:ModelBindingContext.ModelState" /> about the invalid <paramref name="valueProviderResult" />.
+    /// Sets the <see href="P:ModelBindingContext.Result" /> to the <paramref name="model" /> if successful.
+    /// </summary>
     protected virtual void CheckModel(
         ModelBindingContext bindingContext,
         ValueProviderResult valueProviderResult,


### PR DESCRIPTION
# [SimpleTypeModelBinder.CheckModel](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.modelbinding.binders.simpletypemodelbinder.checkmodel#microsoft-aspnetcore-mvc-modelbinding-binders-simpletypemodelbinder-checkmodel(microsoft-aspnetcore-mvc-modelbinding-modelbindingcontext-microsoft-aspnetcore-mvc-modelbinding-valueproviderresult-system-object)): add API doc

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description
There is no documentation to inherit from, so specific documentation must be provided.

Having this interface documented would allow me to do the following trick:
```csharp
protected override
void CheckModel (ModelBindingContext ctx, ValueProviderResult r, object? m)
 { if (m is string v) ctx .Result = ModelBindingResult .Success (v .Trim ()); }
```