### PR TITLE
Support Custom Classes for ValidationMessage (with E2E)

### DIFF
--- a/src/Components/Web/src/Forms/ValidationMessage.cs
+++ b/src/Components/Web/src/Forms/ValidationMessage.cs
@@ -71,8 +71,8 @@ public class ValidationMessage<TValue> : ComponentBase, IDisposable
         foreach (var message in CurrentEditContext.GetValidationMessages(_fieldIdentifier))
         {
             builder.OpenElement(0, "div");
-            builder.AddMultipleAttributes(1, AdditionalAttributes);
             builder.AddAttribute(2, "class", "validation-message");
+            builder.AddMultipleAttributes(1, AdditionalAttributes);
             builder.AddContent(3, message);
             builder.CloseElement();
         }

--- a/src/Components/Web/src/Forms/ValidationMessage.cs
+++ b/src/Components/Web/src/Forms/ValidationMessage.cs
@@ -71,8 +71,8 @@ public class ValidationMessage<TValue> : ComponentBase, IDisposable
         foreach (var message in CurrentEditContext.GetValidationMessages(_fieldIdentifier))
         {
             builder.OpenElement(0, "div");
-            builder.AddAttribute(2, "class", "validation-message");
-            builder.AddMultipleAttributes(1, AdditionalAttributes);
+            builder.AddAttribute(1, "class", "validation-message");
+            builder.AddMultipleAttributes(2, AdditionalAttributes);
             builder.AddContent(3, message);
             builder.CloseElement();
         }

--- a/src/Components/Web/src/Forms/ValidationSummary.cs
+++ b/src/Components/Web/src/Forms/ValidationSummary.cs
@@ -73,8 +73,8 @@ public class ValidationSummary : ComponentBase, IDisposable
                 first = false;
 
                 builder.OpenElement(0, "ul");
-                builder.AddMultipleAttributes(1, AdditionalAttributes);
-                builder.AddAttribute(2, "class", "validation-errors");
+                builder.AddAttribute(1, "class", "validation-errors");
+                builder.AddMultipleAttributes(2, AdditionalAttributes);
             }
 
             builder.OpenElement(3, "li");

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -100,6 +100,9 @@ public class FormsTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
         var appElement = MountTypicalValidationComponent();
         var nameInput = appElement.FindElement(By.ClassName("name")).FindElement(By.TagName("input"));
         var messagesAccessor = CreateValidationMessagesAccessor(appElement);
+        var summaryMessagesAccessor = CreateValidationMessagesAccessor(
+            appElement.FindElement(By.ClassName("all-errors")),
+            ".validation-errors > .validation-message"); // Shows that the default class name for ValidationSummary is validation-errors
 
         // InputText emits unmatched attributes
         Browser.Equal("Enter your name", () => nameInput.GetAttribute("placeholder"));
@@ -115,6 +118,7 @@ public class FormsTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
         Browser.Equal("modified invalid", () => nameInput.GetAttribute("class"));
         EnsureAttributeValue(nameInput, "aria-invalid", "true");
         Browser.Equal(new[] { "That name is too long" }, messagesAccessor);
+        Browser.True(() => summaryMessagesAccessor().Contains("That name is too long"));
 
         // Can become valid
         nameInput.Clear();
@@ -122,6 +126,7 @@ public class FormsTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
         Browser.Equal("modified valid", () => nameInput.GetAttribute("class"));
         EnsureAttributeNotRendered(nameInput, "aria-invalid");
         Browser.Empty(messagesAccessor);
+        Browser.False(() => summaryMessagesAccessor().Contains("That name is too long"));
     }
 
     [Fact]
@@ -502,7 +507,7 @@ public class FormsTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
         var appElement = MountTypicalValidationComponent();
         var emailContainer = appElement.FindElement(By.ClassName("email"));
         var emailInput = emailContainer.FindElement(By.TagName("input"));
-        var emailMessagesAccessor = CreateValidationMessagesAccessor(emailContainer);
+        var emailMessagesAccessor = CreateValidationMessagesAccessor(emailContainer, ".special-email-css-class-override");
         var submitButton = appElement.FindElement(By.CssSelector("button[type=submit]"));
 
         // Doesn't show messages for other fields
@@ -532,7 +537,7 @@ public class FormsTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
         var confirmEmailContainer = appElement.FindElement(By.ClassName("confirm-email"));
         var confirmInput = confirmEmailContainer.FindElement(By.TagName("input"));
         var confirmEmailValidationMessage = CreateValidationMessagesAccessor(confirmEmailContainer);
-        CreateValidationMessagesAccessor(emailContainer);
+        CreateValidationMessagesAccessor(emailContainer, "special-email-css-class-override");
         var submitButton = appElement.FindElement(By.CssSelector("button[type=submit]"));
 
         // Updates on edit
@@ -769,9 +774,46 @@ public class FormsTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
             => appElement.FindElement(By.ClassName("airlines")).FindElements(By.TagName("input"));
     }
 
-    private Func<string[]> CreateValidationMessagesAccessor(IWebElement appElement)
+    [Fact]
+    public void CanHaveModelLevelValidationErrors()
     {
-        return () => appElement.FindElements(By.ClassName("validation-message"))
+        var appElement = Browser.MountTestComponent<ModelLevelValidationComponent>();
+        var isCatCheckbox = appElement.FindElement(By.ClassName("cattiness")).FindElement(By.TagName("input"));
+        var ageInput = appElement.FindElement(By.ClassName("age")).FindElement(By.TagName("input"));
+        var submitButton = appElement.FindElement(By.CssSelector("button[type=submit]"));
+        var modelMessagesAccessor = CreateValidationMessagesAccessor(
+            appElement.FindElement(By.ClassName("model-errors")),
+            "ul.model-summary-custom-class > .validation-message"); // This shows we can override the ul's CSS class
+        var allMessagesAccessor = CreateValidationMessagesAccessor(
+            appElement.FindElement(By.ClassName("all-errors")));
+
+        // Cause a property-level validation error
+        ageInput.Clear();
+        ageInput.SendKeys("-1");
+        submitButton.Click();
+        Browser.Collection(allMessagesAccessor, x => Assert.Equal("Under-zeros should not be filling out forms", x));
+        Browser.Empty(modelMessagesAccessor);
+
+        // Cause a model-level validation error
+        ageInput.Clear();
+        ageInput.SendKeys("10");
+        submitButton.Click();
+        Browser.Collection(allMessagesAccessor, x => Assert.Equal("Sorry, you're not old enough as a non-cat", x));
+        Browser.Collection(modelMessagesAccessor, x => Assert.Equal("Sorry, you're not old enough as a non-cat", x));
+
+        // Become valid
+        isCatCheckbox.Click();
+        submitButton.Click();
+        Browser.Empty(allMessagesAccessor);
+        Browser.Empty(modelMessagesAccessor);
+
+        Func<string[]> logEntries = () => appElement.FindElements(By.ClassName("submission-log-entry")).Select(x => x.Text).ToArray();
+        Browser.Collection(logEntries, x => Assert.Equal("OnValidSubmit", x));
+    }
+
+    private Func<string[]> CreateValidationMessagesAccessor(IWebElement appElement, string messageSelector = ".validation-message")
+    {
+        return () => appElement.FindElements(By.CssSelector(messageSelector))
             .Select(x => x.Text)
             .OrderBy(x => x)
             .ToArray();

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -537,7 +537,6 @@ public class FormsTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
         var confirmEmailContainer = appElement.FindElement(By.ClassName("confirm-email"));
         var confirmInput = confirmEmailContainer.FindElement(By.TagName("input"));
         var confirmEmailValidationMessage = CreateValidationMessagesAccessor(confirmEmailContainer);
-        CreateValidationMessagesAccessor(emailContainer, "special-email-css-class-override");
         var submitButton = appElement.FindElement(By.CssSelector("button[type=submit]"));
 
         // Updates on edit

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/ModelLevelValidationComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/ModelLevelValidationComponent.razor
@@ -1,0 +1,60 @@
+﻿@using System.ComponentModel.DataAnnotations
+@using Microsoft.AspNetCore.Components.Forms
+
+<EditForm Model="@person" OnValidSubmit="@HandleValidSubmit">
+    <DataAnnotationsValidator />
+
+    <h2>We only accept cats over 3 years of age, or non-cats over 18 years of age.</h2>
+
+    <p class="cattiness">
+        <label>
+            <InputCheckbox @bind-Value="person.IsACat" /> I am a cat
+        </label>
+    </p>
+
+    <p class="age">
+        Age (years): <InputNumber @bind-Value="person.AgeInYears" placeholder="Enter your age" />
+    </p>
+
+    <button type="submit">Submit</button>
+
+    <p class="model-errors">
+        <ValidationSummary Model="person" class="model-summary-custom-class" />
+    </p>
+
+    <p class="all-errors">
+        <ValidationSummary />
+    </p>
+</EditForm>
+
+<ul>@foreach (var entry in submissionLog) { <li class="submission-log-entry">@entry</li> }</ul>
+
+@code {
+    Person person = new Person();
+
+    class Person : IValidatableObject
+    {
+        [Required]
+        public bool IsACat { get; set; }
+
+        [Range(0, int.MaxValue, ErrorMessage = "Under-zeros should not be filling out forms")]
+        public int AgeInYears { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            var minAge = IsACat ? 3 : 18;
+            if (AgeInYears < minAge)
+            {
+                // Supply a model-level error (i.e., not attached to a specific property)
+                yield return new ValidationResult($"Sorry, you're not old enough as a {( IsACat ? "cat" : "non-cat" )}");
+            }
+        }
+    }
+
+    List<string> submissionLog = new List<string>(); // So we can assert about the callbacks
+
+    void HandleValidSubmit()
+    {
+        submissionLog.Add("OnValidSubmit");
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/TypicalValidationComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/TypicalValidationComponent.razor
@@ -12,7 +12,7 @@
     </p>
     <p class="email">
         Email: <InputText @bind-Value="person.Email" />
-        <ValidationMessage For="@(() => person.Email)" />
+        <ValidationMessage For="@(() => person.Email)" class="special-email-css-class-override" />
     </p>
     <p class="confirm-email">
         Email: <InputText @bind-Value="person.ConfirmEmail" />
@@ -141,11 +141,9 @@
 
     <button type="submit">Submit</button>
 
-    <p class="model-errors">
-        <ValidationSummary Model="person" />
+    <p class="all-errors">
+        <ValidationSummary />
     </p>
-
-    <ValidationSummary />
 </EditForm>
 
 <ul>@foreach (var entry in submissionLog) { <li class="submission-log-entry">@entry</li> }</ul>

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -38,6 +38,7 @@
         <option value="BasicTestApp.FormsTest.NotifyPropertyChangedValidationComponent">INotifyPropertyChanged validation</option>
         <option value="BasicTestApp.FormsTest.SimpleValidationComponent">Simple validation</option>
         <option value="BasicTestApp.FormsTest.SimpleValidationComponentUsingExperimentalValidator">Simple validation using experimental validator</option>
+        <option value="BasicTestApp.FormsTest.ModelLevelValidationComponent">Model-level validation</option>
         <option value="BasicTestApp.FormsTest.TypicalValidationComponent">Typical validation</option>
         <option value="BasicTestApp.FormsTest.TypicalValidationComponentUsingExperimentalValidator">Typical validation using experimental validator</option>
         <option value="BasicTestApp.FormsTest.ValidationComponentDI">Validation with Dependency Injection</option>


### PR DESCRIPTION
This is a continuation of https://github.com/dotnet/aspnetcore/pull/38639, also adding E2E tests. It preserves the original commits by @eluchsinger

I noticed that we don't have any reasonable coverage for `ValidationSummary`, and yet it has a whole category of behavior for model-level validation errors. That is, errors associated with the model object itself rather than any individual property on it. So I've added a new scenario for that.
