### PR TITLE
[blazor][debugger] Fixing vs-js-debugger: redirect ws to http is not supported anymore

### DIFF
--- a/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
+++ b/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
@@ -168,6 +168,7 @@ internal static class DebugProxyLauncher
                 if (match.Success)
                 {
                     capturedUrl = match.Groups["url"].Value;
+                    capturedUrl = capturedUrl.Replace("http://", "ws://");
                 }
             }
         }

--- a/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
+++ b/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
@@ -169,6 +169,7 @@ internal static class DebugProxyLauncher
                 {
                     capturedUrl = match.Groups["url"].Value;
                     capturedUrl = capturedUrl.Replace("http://", "ws://");
+                    capturedUrl = capturedUrl.Replace("https://", "wss://");
                 }
             }
         }


### PR DESCRIPTION
After microsoft/vscode-js-debug update the ws package to use version "8.4.2" as you can see here:
https://github.com/microsoft/vscode-js-debug/blob/2dfdba1f6f6e4f264d2beb90c80fa7cc4d4396dc/package.json#L78

This new check was added in ws library:
https://github.com/websockets/ws/blob/35d45c2a4fead953654ae7bcf029cdf6d2590121/lib/websocket.js#L682

So as we were trying to redirect `ws://localhost:[PORTNUMBER]/_framework/debug/ws-proxy?browser={browserInspectUri}` to `http://localhost:[BROWSERDEBUGPROXYPORT]/{browserInspectUri}` we were getting this new error:
`The URL's protocol must be one of "ws:", "wss:", or "ws+unix:"`

Then the browser was being launched correctly but it never loads the Blazor App Page.

With this fix it works in the current version of the vscode-js-debug and also in the nightly build.


Fixes: https://github.com/microsoft/vscode-js-debug/issues/1190
Related: https://github.com/dotnet/aspnetcore/issues/38413
Fixes: https://github.com/dotnet/aspnetcore/issues/39976