### PR TITLE
Use `-noBuild` in second build steps of test jobs

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -684,6 +684,7 @@ stages:
         - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
           displayName: Build shared fx
+        # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
         - script: ./eng/build.cmd -ci -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -test
                   -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -228,7 +228,6 @@ stages:
                 -noBuildRepoTasks
                 -noBuildNative
                 -noBuild
-                -noRestore
                 -sign
                 /p:DotNetSignType=$(_SignType)
                 $(_BuildArgs)
@@ -685,7 +684,7 @@ stages:
         - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
           displayName: Build shared fx
-        - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildNative
+        - script: ./eng/build.cmd -ci -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -test
                   -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
           displayName: Run build.cmd helix target

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -33,7 +33,7 @@ jobs:
     - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
-    - script: .\eng\build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildNative
+    - script: .\eng\build.cmd -ci -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -test
               -projects eng\helix\helix.proj /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -33,6 +33,7 @@ jobs:
     - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
+    # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
     - script: .\eng\build.cmd -ci -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -test
               -projects eng\helix\helix.proj /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -57,6 +57,7 @@ jobs:
     - script: ./eng/build.cmd -ci -nobl -all -noBuildJava -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
+    # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
     - script: ./eng/build.cmd -ci -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -noBuildJava -test
               -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:RunQuarantinedTests=true /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -54,10 +54,10 @@ jobs:
     timeoutInMinutes: 120
     steps:
     # Build the shared framework
-    - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64
+    - script: ./eng/build.cmd -ci -nobl -all -noBuildJava -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
-    - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildJava -noBuildNative
+    - script: ./eng/build.cmd -ci -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -noBuildJava -test
               -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:RunQuarantinedTests=true /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target
@@ -79,9 +79,10 @@ jobs:
     isAzDOTestingJob: true
     enablePublishTestResults: false
     steps:
-    - powershell: "& ./eng/build.ps1 -CI -nobl -all -pack -NoBuildJava"
+    - script: ./eng/build.cmd -ci -nobl -all -noBuildJava -pack
       displayName: Build
-    - script: ./eng/build.cmd -ci -nobl -test -NoRestore -NoBuild -NoBuilddeps "/p:RunQuarantinedTests=true /p:SkipHelixReadyTests=true"
+    - script: ./eng/build.cmd -ci -nobl -all -noBuildRepoTasks -noBuildNative -NoBuild -noBuildJava -test
+              /p:RunQuarantinedTests=true /p:SkipHelixReadyTests=true
       displayName: Run Quarantined Tests
       continueOnError: true
     - task: PublishTestResults@2
@@ -112,9 +113,10 @@ jobs:
     isAzDOTestingJob: true
     enablePublishTestResults: false
     steps:
-    - bash: ./eng/build.sh --all --pack --ci --nobl --no-build-java
+    - bash: ./eng/build.sh --ci --nobl --all --no-build-java --pack
       displayName: Build
-    - bash: ./eng/build.sh --no-build --ci --nobl --test -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
+    - bash: ./eng/build.sh --ci --nobl --all --no-build-repo-tasks --no-build --no-build-java --test
+            -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
       displayName: Run Quarantined Tests
       continueOnError: true
     - task: PublishTestResults@2
@@ -146,9 +148,10 @@ jobs:
     enablePublishTestResults: false
     useHostedUbuntu: false
     steps:
-    - bash: ./eng/build.sh --all --pack --ci --nobl --no-build-java
+    - bash: ./eng/build.sh --ci --nobl --all --no-build-java --pack
       displayName: Build
-    - bash: ./eng/build.sh --no-build --ci --nobl --test -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
+    - bash: ./eng/build.sh --ci --nobl --all --no-build-repo-tasks --no-build --no-build-java --test
+            -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
       displayName: Run Quarantined Tests
       continueOnError: true
     - task: PublishTestResults@2

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -28,6 +28,7 @@ jobs:
     - script: ./eng/build.cmd -ci -nobl -all -noBuildJava -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
+    # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
     - script: ./eng/build.cmd -ci -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -noBuildJava -test
               -projects eng\helix\helix.proj /p:RunQuarantinedTests=true /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -25,10 +25,10 @@ jobs:
     timeoutInMinutes: 480
     steps:
     # Build the shared framework
-    - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64
+    - script: ./eng/build.cmd -ci -nobl -all -noBuildJava -pack -arch x64
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Build shared fx
-    - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildJava -noBuildNative
+    - script: ./eng/build.cmd -ci -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -noBuildJava -test
               -projects eng\helix\helix.proj /p:RunQuarantinedTests=true /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target

--- a/eng/scripts/RunHelix.ps1
+++ b/eng/scripts/RunHelix.ps1
@@ -52,7 +52,8 @@ $env:BUILD_REPOSITORY_NAME="aspnetcore"
 $env:SYSTEM_TEAMPROJECT="aspnetcore"
 
 Write-Host -ForegroundColor Yellow "If running tests that need the shared Fx, run './build -pack -all' before this."
-Write-Host -ForegroundColor Yellow "And if packing for a different platform, add '/p:CrossgenOutput=false'."
+Write-Host -ForegroundColor Yellow "If everything is up-to-date, add '/p:NoBuild=true' to this command."
+Write-Host -ForegroundColor Yellow "Or, if only the test project is out-of-date, add '/p:BuildProjectReferences=false'."
 
 $HelixQueues = $HelixQueues -replace ";", "%3B"
 dotnet msbuild $Project /t:Helix /p:TargetArchitecture="$TargetArchitecture" `

--- a/eng/targets/FunctionalTestWithAssets.props
+++ b/eng/targets/FunctionalTestWithAssets.props
@@ -14,7 +14,6 @@
       <RelativeFolder>%(Filename)</RelativeFolder>
       <!-- Whether to _only_ publish the test asset into the test project's folders. -->
       <SkipBuild>false</SkipBuild>
-      <AdditionalProperties Condition=" '%(SkipBuild)' == 'true' ">NoBuild=true</AdditionalProperties>
     </TestAssetProjectReference>
   </ItemDefinitionGroup>
 </Project>

--- a/eng/targets/FunctionalTestWithAssets.targets
+++ b/eng/targets/FunctionalTestWithAssets.targets
@@ -7,12 +7,25 @@
   <Target Name="PublishTestAssets"
       BeforeTargets="Publish;RunTests;VSTest"
       Condition=" '@(TestAssetProjectReference->Count())' != 0 ">
-    <!-- Build and Publish test assets into folders relative to test project. -->
     <ItemGroup>
       <_ProjectsToPublish Include="@(TestAssetProjectReference)" />
+
+      <!-- Always Publish test assets relative to test project's output. -->
       <_ProjectsToPublish AdditionalProperties="%(_ProjectsToPublish.AdditionalProperties);
-          OutputPath=$(OutputPath)%(RelativeFolder);
           PublishDir=$(PublishDir)%(RelativeFolder)" />
+
+      <!-- Do not build when publishing if SkipBuild requested. -->
+      <_ProjectsToPublish Condition=" '%(SkipBuild)' == 'true' "
+          AdditionalProperties="%(_ProjectsToPublish.AdditionalProperties);NoBuild=true" />
+
+      <!--
+        Otherwise, both Build and Publish test assets into folders relative to test project's output. Reset
+        NoBuild because these projects aren't referenced anywhere else.
+      -->
+      <_ProjectsToPublish Condition=" '%(SkipBuild)' != 'true' "
+          AdditionalProperties="%(_ProjectsToPublish.AdditionalProperties);
+            NoBuild=false;
+            OutputPath=$(OutputPath)%(RelativeFolder)" />
     </ItemGroup>
 
     <!--

--- a/src/Mvc/samples/MvcSandbox/MvcSandbox.csproj
+++ b/src/Mvc/samples/MvcSandbox/MvcSandbox.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
@@ -14,4 +13,12 @@
     <Reference Include="Microsoft.Extensions.Logging.Debug" />
   </ItemGroup>
 
+  <!-- Work around https://github.com/dotnet/sdk/issues/23777. Reset ContentWithTargetPath items if not building. -->
+  <Target Name="RemoveCshtmlFiles" BeforeTargets="GetCopyToPublishDirectoryItems" Condition=" '$(NoBuild)' == true ">
+    <ItemGroup>
+      <ContentWithTargetPath>
+        <CopyToPublishDirectory Condition=" '%(Extension)' == '.cshtml' ">None</CopyToPublishDirectory>
+      </ContentWithTargetPath>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Mvc/test/Mvc.FunctionalTests/Microsoft.AspNetCore.Mvc.FunctionalTests.csproj
+++ b/src/Mvc/test/Mvc.FunctionalTests/Microsoft.AspNetCore.Mvc.FunctionalTests.csproj
@@ -19,7 +19,8 @@
     <ProjectReference Include="..\..\shared\Mvc.Core.TestCommon\Microsoft.AspNetCore.Mvc.Core.TestCommon.csproj" />
     <ProjectReference Include="..\WebSites\*\*.csproj"
         Exclude="..\WebSites\ControllersFromServicesClassLibrary\ControllersFromServicesClassLibrary.csproj;
-          ..\WebSites\RazorBuildWebSite.*\RazorBuildWebSite.*.csproj" />
+          ..\WebSites\RazorBuildWebSite.*\RazorBuildWebSite.*.csproj;
+          ..\WebSites\RazorPagesClassLibrary\RazorPagesClassLibrary.csproj" />
 
     <Reference Include="AngleSharp" />
     <Reference Include="System.Net.Http" />

--- a/src/Mvc/test/WebSites/Directory.Build.props
+++ b/src/Mvc/test/WebSites/Directory.Build.props
@@ -7,6 +7,6 @@
     -->
     <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
-  <!-- Skip the parent folder to prevent getting test package references. -->
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\..\, Directory.Build.props))\Directory.Build.props" />
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 </Project>

--- a/src/Mvc/test/WebSites/Directory.Build.targets
+++ b/src/Mvc/test/WebSites/Directory.Build.targets
@@ -1,0 +1,14 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.targets))\Directory.Build.targets" />
+
+  <!-- Work around https://github.com/dotnet/sdk/issues/23777. Reset ContentWithTargetPath items if not building. -->
+  <Target Name="RemoveCshtmlFiles"
+      BeforeTargets="GetCopyToPublishDirectoryItems"
+      Condition=" '$(RazorCompileOnPublish)' != false AND '$(NoBuild)' == true ">
+    <ItemGroup>
+      <ContentWithTargetPath>
+        <CopyToPublishDirectory Condition=" '%(Extension)' == '.cshtml' ">None</CopyToPublishDirectory>
+      </ContentWithTargetPath>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
@@ -217,7 +217,6 @@ public class StartupTests : IISFunctionalTestBase
         // We need the right dotnet on the path in IIS
         deploymentParameters.EnvironmentVariables["PATH"] = Path.GetDirectoryName(DotNetCommands.GetDotNetExecutable(deploymentParameters.RuntimeArchitecture));
 
-        // ReferenceTestTasks is workaround for https://github.com/dotnet/sdk/issues/2482
         var deploymentResult = await DeployAsync(deploymentParameters);
 
         Assert.True(File.Exists(Path.Combine(deploymentResult.ContentRoot, "InProcessWebSite.exe")));

--- a/src/Servers/IIS/IIS/test/FunctionalTest.props
+++ b/src/Servers/IIS/IIS/test/FunctionalTest.props
@@ -1,25 +1,24 @@
 <Project>
-
   <ItemGroup>
     <Content Include="..\Common.FunctionalTests\Infrastructure\*.config" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <Target Name="BuildAssets" AfterTargets="Build" Condition="'$(ExcludeFromBuild)' != 'true'">
-    <MSBuild Projects="@(ProjectReference)" Targets="PublishTestsAssets" SkipNonexistentTargets="true" BuildInParallel="True">
+  <Target Name="CopyAssets" BeforeTargets="Publish" Condition=" '$(ExcludeFromBuild)' != true ">
+    <MSBuild Projects="@(ProjectReference)"
+        Targets="PublishTestsAssets"
+        SkipNonexistentTargets="true"
+        BuildInParallel="True">
       <Output TaskParameter="TargetOutputs" ItemName="PublishedTestAsset" />
     </MSBuild>
-  </Target>
 
-  <Target Name="CopyAssets" AfterTargets="Publish" Condition="'@(PublishedTestAsset->Count())' != '0'">
-
-    <ItemGroup>
+    <ItemGroup Condition=" @(PublishedTestAsset->Count()) != 0 ">
      <_FilesToCopy Include="%(PublishedTestAsset.Path)\**\*">
         <DestinationDir>$(PublishDir)\%(PublishedTestAsset.Identity)\</DestinationDir>
       </_FilesToCopy>
     </ItemGroup>
 
-    <Copy SourceFiles="@(_FilesToCopy)" DestinationFiles="@(_FilesToCopy->'%(DestinationDir)%(RecursiveDir)%(FileName)%(Extension)')" />
-
+    <Copy SourceFiles="@(_FilesToCopy)"
+        Condition=" @(PublishedTestAsset->Count()) != 0 "
+        DestinationFiles="@(_FilesToCopy->'%(DestinationDir)%(RecursiveDir)%(FileName)%(Extension)')" />
   </Target>
-
 </Project>

--- a/src/Servers/IIS/IIS/test/testassets/Directory.Build.targets
+++ b/src/Servers/IIS/IIS/test/testassets/Directory.Build.targets
@@ -41,7 +41,7 @@
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishTestsAsset"
              RemoveProperties="Platform;PlatformTarget"
-             Properties="PublishDir=$(PublishDir);TestAssetProfile=%(TestAssetPublishProfile.Identity);ReferenceTestTasks=false;%(TestAssetPublishProfile.Properties)">
+             Properties="PublishDir=$(PublishDir);TestAssetProfile=%(TestAssetPublishProfile.Identity);%(TestAssetPublishProfile.Properties)">
       <Output TaskParameter="TargetOutputs" ItemName="PublishedTestAsset" />
     </MSBuild>
   </Target>

--- a/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
@@ -11,7 +11,11 @@
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <TestAssetPublishProfile Include="Portable" Properties="TargetFramework=$(DefaultNetCoreTargetFramework)" />
-    <TestAssetPublishProfile Condition="'$(TargetArchitecture)' != 'arm'" Include="Standalone-x64" Properties="RuntimeIdentifier=win-x64;" />
+
+    <!-- ReferenceTestTasks is workaround for https://github.com/dotnet/sdk/issues/2482 -->
+    <TestAssetPublishProfile Include="Standalone-x64"
+        Condition=" '$(TargetArchitecture)' != 'arm' "
+        Properties="RuntimeIdentifier=win-x64;ReferenceTestTasks=false" />
   </ItemGroup>
 
   <ItemGroup>
@@ -59,4 +63,13 @@
     </PackageReference>
     <Reference Include="xunit.assert" />
   </ItemGroup>
+
+  <!-- Repeat Build target for win-x64 to allow later Publish w/ NoBuild=true. -->
+  <Target Name="BuildX64"
+      BeforeTargets="Build"
+      Condition=" '$(RuntimeIdentifier)' != 'win-x64' AND '$(TargetArchitecture)' != 'arm' ">
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+        Properties="RuntimeIdentifier=win-x64;ReferenceTestTasks=false"
+        Targets="Build" />
+  </Target>
 </Project>

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/InProcessWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/InProcessWebSite.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
   <Import Project="..\..\..\..\build\testsite.props" />
 
   <PropertyGroup>
@@ -9,7 +8,11 @@
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <TestAssetPublishProfile Include="Portable" Properties="TargetFramework=$(DefaultNetCoreTargetFramework)" />
-    <TestAssetPublishProfile Condition="'$(TargetArchitecture)' != 'arm'" Include="Standalone-x64" Properties="RuntimeIdentifier=win-x64;" />
+
+    <!-- ReferenceTestTasks is workaround for https://github.com/dotnet/sdk/issues/2482 -->
+    <TestAssetPublishProfile Include="Standalone-x64"
+        Condition=" '$(TargetArchitecture)' != 'arm' "
+        Properties="RuntimeIdentifier=win-x64;ReferenceTestTasks=false" />
   </ItemGroup>
 
   <ItemGroup>
@@ -32,4 +35,12 @@
     <Reference Include="xunit.assert" />
   </ItemGroup>
 
+  <!-- Repeat Build target for win-x64 to allow later Publish w/ NoBuild=true. -->
+  <Target Name="BuildX64"
+      BeforeTargets="Build"
+      Condition=" '$(RuntimeIdentifier)' != 'win-x64' AND '$(TargetArchitecture)' != 'arm' ">
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+        Properties="RuntimeIdentifier=win-x64;ReferenceTestTasks=false"
+        Targets="Build" />
+  </Target>
 </Project>


### PR DESCRIPTION
- building again in Publish target adds nothing in most cases
- use `-noBuildRepoTasks` more consistently
  - again, building the repo tasks wastefully repeated work done in previous build step
- use `-noBuildJava` more consistently in quarantined pipelines
  - Java tests aren't worth testing _or building_ in these pipelines because they cannot be quarantined
- remove `-noRestore` and `-noBuildDeps` when `-noBuild` specified; redundant
- work around https://github.com/dotnet/aspnetcore/issues/43835
  - do not publish .cshtml files of most test asset projects when `$(NoBuild)` is set
- update FunctionalTestWithAssets.targets to help Publish succeed when `$(NoBuild)` is set
  - fixes build jobs in quarantined-pr pipeline where `--no-build` was already specified
- for IIS test assets, perform all builds needed for their profiles within Build target
  - move `ReferenceTestTasks=false` and comments about it to where property matters
  - merge separate targets in FunctionalTest.props to make items available during (now separate) Publish

nits:
- touch up RunHelix.ps1 console output
- reorder command line arguments for consistency in changed parts of the YAML files
- move `NoBuild=true` setting out of FunctionalTestWithAssets.props
- use `BeforeTargets` in FunctionalTest.props to improve determinism