### PR TITLE
Avoid request body rate timeout in flaky test

### DIFF
--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -1493,7 +1493,21 @@ public class Http3RequestTests : LoggedTest
             readAsyncTask.SetResult(readTask);
 
             await readTask;
-        }, protocol: protocol);
+        },
+        protocol: protocol,
+        configureKestrel: kestrel =>
+        {
+            // Disable the min rate limit to ensure a shutdown timeout aborts an ongoing read and not the rate limit.
+            // This could also be fixed by sending more data from the client.
+            kestrel.Limits.MinRequestBodyDataRate = null;
+
+            // This would normally be done automatically for us if the "configureKestrel" callback we're in was left null.
+            kestrel.Listen(IPAddress.Loopback, 0, listenOptions =>
+            {
+                listenOptions.Protocols = protocol;
+                listenOptions.UseHttps();
+            });
+        });
 
         using (var host = builder.Build())
         using (var client = HttpHelpers.CreateClient())


### PR DESCRIPTION
GET_GracefulServerShutdown_AbortRequestsAfterHostTimeout is testing the behavior of shutdown timeouts, not rate timeouts.

> [6.098s] [Microsoft.AspNetCore.Server.Kestrel.BadRequests] [Debug] Connection id "0HMF7DR9L1H02", Request id "null": the request timed out because it was not sent by the client at a minimum of 240 bytes/second.

> [7.351s] [Microsoft.AspNetCore.Server.Kestrel] [Warning] As of "02/03/2022 23:42:38 +00:00", the heartbeat has been running for "00:00:01.2496930" which is longer than "00:00:01". This could be caused by thread pool starvation.

Even though the Http3ReuestsTests sets the ShutdownTimeout to 1 second instead of the 5 second default, it looks like timer didn't fire fast enough due to likely threadpool starvation. If the threadpool starvation is bad enough, even this won't help, but this should give more time for the threadpool to work the queue of work items.

Addresses #39985
