### PR TITLE
Log IIS BadHttpRequestExceptions at debug level

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.IO.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.IO.cs
@@ -135,6 +135,12 @@ internal partial class IISHttpContext
             AbortIO(clientDisconnect: true);
             error = ex;
         }
+        catch (Http.BadHttpRequestException ex)
+        {
+            // Similar to a ConnectionResetException, this shouldn't be logged as an "Unexpected exception."
+            // This should be logged by whatever catches it. Likely IISHttpContextOfT.ProcessRequestsAsync().
+            error = ex;
+        }
         catch (Exception ex)
         {
             error = ex;

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.Log.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.Log.cs
@@ -20,7 +20,7 @@ internal abstract partial class IISHttpContext
             LoggerMessage.Define<string, string?>(LogLevel.Error, new EventId(3, "UnexpectedError"), @"Unexpected exception in ""{ClassName}.{MethodName}"".");
 
         private static readonly Action<ILogger, string, string, Exception> _connectionBadRequest =
-            LoggerMessage.Define<string, string>(LogLevel.Information, new EventId(4, nameof(ConnectionBadRequest)), @"Connection id ""{ConnectionId}"" bad request data: ""{message}""");
+            LoggerMessage.Define<string, string>(LogLevel.Debug, new EventId(4, nameof(ConnectionBadRequest)), @"Connection id ""{ConnectionId}"" bad request data: ""{message}""");
 
         public static void ConnectionDisconnect(ILogger logger, string connectionId)
         {

--- a/src/Servers/IIS/IIS/test/IIS.Tests/MaxRequestBodySizeTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/MaxRequestBodySizeTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.IIS;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 using BadHttpRequestException = Microsoft.AspNetCore.Http.BadHttpRequestException;
@@ -53,6 +54,7 @@ public class MaxRequestBodySizeTests : LoggedTest
         }
 
         Assert.Equal(CoreStrings.BadRequest_RequestBodyTooLarge, exception.Message);
+        VerifyLogs();
     }
 
     [ConditionalFact]
@@ -95,6 +97,7 @@ public class MaxRequestBodySizeTests : LoggedTest
         }
 
         Assert.Equal(CoreStrings.BadRequest_RequestBodyTooLarge, exception.Message);
+        VerifyLogs();
     }
 
     [ConditionalFact]
@@ -304,6 +307,7 @@ public class MaxRequestBodySizeTests : LoggedTest
 
         Assert.NotNull(exception);
         Assert.Equal(CoreStrings.BadRequest_RequestBodyTooLarge, exception.Message);
+        VerifyLogs();
     }
 
     [ConditionalFact]
@@ -340,5 +344,12 @@ public class MaxRequestBodySizeTests : LoggedTest
         Assert.NotNull(requestRejectedEx2);
         Assert.Equal(CoreStrings.BadRequest_RequestBodyTooLarge, requestRejectedEx1.Message);
         Assert.Equal(CoreStrings.BadRequest_RequestBodyTooLarge, requestRejectedEx2.Message);
+        VerifyLogs();
+    }
+
+    private void VerifyLogs()
+    {
+        var log = Assert.Single(TestSink.Writes, w => w.LoggerName == "Microsoft.AspNetCore.Server.IIS.Core.IISHttpServer" && w.LogLevel > LogLevel.Debug);
+        Assert.Equal(new EventId(2, "ApplicationError"), log.EventId);
     }
 }


### PR DESCRIPTION
Kestrel logs these same exceptions at the debug level which is the normal way of handling bad requests. If the exception is uncaught or rethrown by the application, it will still be logged at the error level as an "ApplicationError" same as Kestrel.

Fixes #39907
