### PR TITLE
Error when Http/1.0 attempts to upgrade

### DIFF
--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -250,7 +250,7 @@ internal sealed partial class Request
     public string Scheme => IsHttps ? Constants.HttpsScheme : Constants.HttpScheme;
 
     // HTTP.Sys allows you to upgrade anything to opaque unless content-length > 0 or chunked are specified.
-    internal bool IsUpgradable => ProtocolVersion < HttpVersion.Version20 && !HasEntityBody && ComNetOS.IsWin8orLater;
+    internal bool IsUpgradable => ProtocolVersion > HttpVersion.Version10 && ProtocolVersion < HttpVersion.Version20 && !HasEntityBody && ComNetOS.IsWin8orLater;
 
     internal WindowsPrincipal User { get; }
 

--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -250,7 +250,7 @@ internal sealed partial class Request
     public string Scheme => IsHttps ? Constants.HttpsScheme : Constants.HttpScheme;
 
     // HTTP.Sys allows you to upgrade anything to opaque unless content-length > 0 or chunked are specified.
-    internal bool IsUpgradable => ProtocolVersion > HttpVersion.Version10 && ProtocolVersion < HttpVersion.Version20 && !HasEntityBody && ComNetOS.IsWin8orLater;
+    internal bool IsUpgradable => ProtocolVersion == HttpVersion.Version11 && !HasEntityBody && ComNetOS.IsWin8orLater;
 
     internal WindowsPrincipal User { get; }
 

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
@@ -87,11 +87,11 @@ internal partial class RequestContext : NativeRequestContext, IThreadPoolWorkIte
     {
         if (!IsUpgradableRequest)
         {
-            if (Request.ProtocolVersion < System.Net.HttpVersion.Version11)
+            if (Request.ProtocolVersion != System.Net.HttpVersion.Version11)
             {
-                throw new InvalidOperationException("Upgrade is not valid on connections targeting HTTP/1.0 or lower.");
+                throw new InvalidOperationException("Upgrade requires HTTP/1.1.");
             }
-            throw new InvalidOperationException("This request cannot be upgraded, it is incompatible.");
+            throw new InvalidOperationException("This request cannot be upgraded, because it has a body.");
         }
         if (Response.HasStarted)
         {

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
@@ -87,6 +87,10 @@ internal partial class RequestContext : NativeRequestContext, IThreadPoolWorkIte
     {
         if (!IsUpgradableRequest)
         {
+            if (Request.ProtocolVersion < System.Net.HttpVersion.Version11)
+            {
+                throw new InvalidOperationException("Upgrade is not valid on connections targeting HTTP/1.0 or lower.");
+            }
             throw new InvalidOperationException("This request cannot be upgraded, it is incompatible.");
         }
         if (Response.HasStarted)

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
@@ -91,7 +91,7 @@ internal partial class RequestContext : NativeRequestContext, IThreadPoolWorkIte
             {
                 throw new InvalidOperationException("Upgrade requires HTTP/1.1.");
             }
-            throw new InvalidOperationException("This request cannot be upgraded, because it has a body.");
+            throw new InvalidOperationException("This request cannot be upgraded because it has a body.");
         }
         if (Response.HasStarted)
         {

--- a/src/Servers/HttpSys/test/FunctionalTests/OpaqueUpgradeTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/OpaqueUpgradeTests.cs
@@ -334,7 +334,7 @@ public class OpaqueUpgradeTests
 
                 // Send an HTTP GET request
                 StringBuilder builder = new StringBuilder();
-                builder.Append("connect");
+                builder.Append("GET");
                 builder.Append(" ");
                 builder.Append(uri.PathAndQuery);
                 builder.Append(" HTTP/1.0");
@@ -351,7 +351,7 @@ public class OpaqueUpgradeTests
                 await stream.WriteAsync(requestBytes, 0, requestBytes.Length);
 
                 var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => upgrade.Task);
-                Assert.Equal("Upgrade is not valid on connections targeting HTTP/1.0 or lower.", ex.Message);
+                Assert.Equal("Upgrade requires HTTP/1.1.", ex.Message);
 
                 // Read the response headers, fail if it's not a 101
                 ex = await Assert.ThrowsAsync<InvalidOperationException>(() => ParseResponseAsync(stream));

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
@@ -263,7 +263,7 @@ internal partial class IISHttpContext : IFeatureCollection,
     // Http/2 does not support the upgrade mechanic.
     // Http/1.x upgrade requests may have a request body, but that's not allowed in our main scenario (WebSockets) and much
     // more complicated to support. See https://tools.ietf.org/html/rfc7230#section-6.7, https://tools.ietf.org/html/rfc7540#section-3.2
-    bool IHttpUpgradeFeature.IsUpgradableRequest => !RequestCanHaveBody && HttpVersion < System.Net.HttpVersion.Version20;
+    bool IHttpUpgradeFeature.IsUpgradableRequest => !RequestCanHaveBody && HttpVersion == System.Net.HttpVersion.Version11;
 
     bool IFeatureCollection.IsReadOnly => false;
 
@@ -340,6 +340,10 @@ internal partial class IISHttpContext : IFeatureCollection,
     {
         if (!((IHttpUpgradeFeature)this).IsUpgradableRequest)
         {
+            if (HttpVersion != System.Net.HttpVersion.Version11)
+            {
+                throw new InvalidOperationException(CoreStrings.UpdateWithWrongProtocolVersion);
+            }
             throw new InvalidOperationException(CoreStrings.CannotUpgradeNonUpgradableRequest);
         }
 

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
@@ -261,7 +261,7 @@ internal partial class IISHttpContext : IFeatureCollection,
     }
 
     // Http/2 does not support the upgrade mechanic.
-    // Http/1.x upgrade requests may have a request body, but that's not allowed in our main scenario (WebSockets) and much
+    // Http/1.1 upgrade requests may have a request body, but that's not allowed in our main scenario (WebSockets) and much
     // more complicated to support. See https://tools.ietf.org/html/rfc7230#section-6.7, https://tools.ietf.org/html/rfc7540#section-3.2
     bool IHttpUpgradeFeature.IsUpgradableRequest => !RequestCanHaveBody && HttpVersion == System.Net.HttpVersion.Version11;
 
@@ -342,7 +342,7 @@ internal partial class IISHttpContext : IFeatureCollection,
         {
             if (HttpVersion != System.Net.HttpVersion.Version11)
             {
-                throw new InvalidOperationException(CoreStrings.UpdateWithWrongProtocolVersion);
+                throw new InvalidOperationException(CoreStrings.UpgradeWithWrongProtocolVersion);
             }
             throw new InvalidOperationException(CoreStrings.CannotUpgradeNonUpgradableRequest);
         }

--- a/src/Servers/IIS/IIS/src/CoreStrings.resx
+++ b/src/Servers/IIS/IIS/src/CoreStrings.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -147,7 +147,7 @@
   <data name="ParameterReadOnlyAfterResponseStarted" xml:space="preserve">
     <value>{name} cannot be set because the response has already started.</value>
   </data>
-    <data name="BadRequest_RequestBodyTooLarge" xml:space="preserve">
+  <data name="BadRequest_RequestBodyTooLarge" xml:space="preserve">
     <value>Request body too large.</value>
   </data>
   <data name="MaxRequestBodySizeCannotBeModifiedAfterRead" xml:space="preserve">
@@ -164,5 +164,8 @@
   </data>
   <data name="MaxRequestLimitWarning" xml:space="preserve">
     <value>Increasing the MaxRequestBodySize conflicts with the max value for IIS limit maxAllowedContentLength. HTTP requests that have a content length greater than maxAllowedContentLength will still be rejected by IIS. You can disable the limit by either removing or setting the maxAllowedContentLength value to a higher limit.</value>
+  </data>
+  <data name="UpdateWithWrongProtocolVersion" xml:space="preserve">
+    <value>Upgrade requires HTTP/1.1.</value>
   </data>
 </root>

--- a/src/Servers/IIS/IIS/src/CoreStrings.resx
+++ b/src/Servers/IIS/IIS/src/CoreStrings.resx
@@ -165,7 +165,7 @@
   <data name="MaxRequestLimitWarning" xml:space="preserve">
     <value>Increasing the MaxRequestBodySize conflicts with the max value for IIS limit maxAllowedContentLength. HTTP requests that have a content length greater than maxAllowedContentLength will still be rejected by IIS. You can disable the limit by either removing or setting the maxAllowedContentLength value to a higher limit.</value>
   </data>
-  <data name="UpdateWithWrongProtocolVersion" xml:space="preserve">
+  <data name="UpgradeWithWrongProtocolVersion" xml:space="preserve">
     <value>Upgrade requires HTTP/1.1.</value>
   </data>
 </root>

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/WebSocketTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/WebSocketTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
@@ -76,6 +77,67 @@ public class WebSocketsTests
             await SendMessage(cws, mesage);
             await ReceiveMessage(cws, mesage);
         }
+    }
+
+    [ConditionalFact]
+    public async Task Http1_0_Request_NotUpgradable()
+    {
+        Uri uri = new Uri(_requestUri + "WebSocketNotUpgradable");
+        using TcpClient client = new TcpClient();
+
+        await client.ConnectAsync(uri.Host, uri.Port);
+        NetworkStream stream = client.GetStream();
+
+        await SendHttp10Request(stream, uri);
+
+        StreamReader reader = new StreamReader(stream);
+        string statusLine = await reader.ReadLineAsync();
+        string[] parts = statusLine.Split(' ');
+        if (int.Parse(parts[1], CultureInfo.InvariantCulture) != 200)
+        {
+            throw new InvalidOperationException("The response status code was incorrect: " + statusLine);
+        }
+    }
+
+    [ConditionalFact]
+    public async Task Http1_0_Request_UpgradeErrors()
+    {
+        Uri uri = new Uri(_requestUri + "WebSocketUpgradeFails");
+        using TcpClient client = new TcpClient();
+
+        await client.ConnectAsync(uri.Host, uri.Port);
+        NetworkStream stream = client.GetStream();
+
+        await SendHttp10Request(stream, uri);
+
+        StreamReader reader = new StreamReader(stream);
+        string statusLine = await reader.ReadLineAsync();
+        string[] parts = statusLine.Split(' ');
+        if (int.Parse(parts[1], CultureInfo.InvariantCulture) != 200)
+        {
+            throw new InvalidOperationException("The response status code was incorrect: " + statusLine);
+        }
+    }
+
+    private async Task SendHttp10Request(NetworkStream stream, Uri uri)
+    {
+        // Send an HTTP GET request
+        StringBuilder builder = new StringBuilder();
+        builder.Append("GET");
+        builder.Append(" ");
+        builder.Append(uri.PathAndQuery);
+        builder.Append(" HTTP/1.0");
+        builder.AppendLine();
+
+        builder.Append("Host: ");
+        builder.Append(uri.Host);
+        builder.Append(':');
+        builder.Append(uri.Port);
+        builder.AppendLine();
+
+        builder.AppendLine();
+        var requestBytes = Encoding.ASCII.GetBytes(builder.ToString());
+        await stream.WriteAsync(requestBytes, 0, requestBytes.Length);
     }
 
     private async Task SendMessage(ClientWebSocket webSocket, string message)

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.WebSockets.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.WebSockets.cs
@@ -25,7 +25,6 @@ public partial class Startup
     {
         app.Run(context =>
         {
-
             var upgradeFeature = context.Features.Get<IHttpUpgradeFeature>();
             Assert.False(upgradeFeature.IsUpgradableRequest);
             return Task.CompletedTask;
@@ -36,7 +35,6 @@ public partial class Startup
     {
         app.Run(context =>
         {
-
             var upgradeFeature = context.Features.Get<IHttpUpgradeFeature>();
             Assert.True(upgradeFeature.IsUpgradableRequest);
             return Task.CompletedTask;
@@ -47,7 +45,6 @@ public partial class Startup
     {
         app.Run(async context =>
         {
-
             var singleByteArray = new byte[1];
             Assert.Equal(0, await context.Request.Body.ReadAsync(singleByteArray, 0, 1));
 
@@ -75,7 +72,6 @@ public partial class Startup
     {
         app.Run(async context =>
         {
-
             var messages = new List<string>();
 
             context.Response.OnStarting(() =>
@@ -89,6 +85,16 @@ public partial class Startup
             messages.Add("Upgraded");
 
             await SendMessages(ws, messages.ToArray());
+        });
+    }
+
+    private void WebSocketUpgradeFails(IApplicationBuilder app)
+    {
+        app.Run(async context =>
+        {
+            var upgradeFeature = context.Features.Get<IHttpUpgradeFeature>();
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => upgradeFeature.UpgradeAsync());
+            Assert.Equal("Upgrade requires HTTP/1.1.", ex.Message);
         });
     }
 


### PR DESCRIPTION
Want to check if this is the behavior we like and then will apply it to IIS too.
Also, what's the reason we don't want to do it in Kestrel?

Fixes https://github.com/dotnet/aspnetcore/issues/32674