### PR TITLE
Do not build when publishing in Helix CI jobs (alternative)

### DIFF
--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test" TreatAsLocalProperty="ProjectToBuild">
-
   <PropertyGroup>
     <!--
       When invoking helix.proj for the whole repo with build.cmd, ProjectToBuild will be set to the path to this project.
@@ -120,11 +119,18 @@
   </Target>
 
   <Target Name="Gather" BeforeTargets="Build">
+    <!--
+      In CI builds, do not rebuild test projects; they were built in previous build step. Test projects that use
+      the MSBuild task to publish _and build_ test assets need to override NoBuild for correct operation.
+    -->
+    <PropertyGroup Condition=" '$(IsHelixJob)' == 'true' ">
+      <_OverrideNoBuild>NoBuild=true</_OverrideNoBuild>
+    </PropertyGroup>
     <MSBuild Projects="@(ProjectToBuild)"
-              Targets="CreateHelixPayload"
-              SkipNonexistentTargets="true">
+             Properties="$(_OverrideNoBuild)"
+             Targets="CreateHelixPayload"
+             SkipNonexistentTargets="true">
       <Output TaskParameter="TargetOutputs" ItemName="HelixWorkItem" />
     </MSBuild>
   </Target>
-
 </Project>

--- a/eng/targets/FunctionalTestWithAssets.props
+++ b/eng/targets/FunctionalTestWithAssets.props
@@ -14,7 +14,6 @@
       <RelativeFolder>%(Filename)</RelativeFolder>
       <!-- Whether to _only_ publish the test asset into the test project's folders. -->
       <SkipBuild>false</SkipBuild>
-      <AdditionalProperties Condition=" '%(SkipBuild)' == 'true' ">NoBuild=true</AdditionalProperties>
     </TestAssetProjectReference>
   </ItemDefinitionGroup>
 </Project>

--- a/eng/targets/FunctionalTestWithAssets.targets
+++ b/eng/targets/FunctionalTestWithAssets.targets
@@ -7,12 +7,26 @@
   <Target Name="PublishTestAssets"
       BeforeTargets="Publish;RunTests;VSTest"
       Condition=" '@(TestAssetProjectReference->Count())' != 0 ">
-    <!-- Build and Publish test assets into folders relative to test project. -->
     <ItemGroup>
       <_ProjectsToPublish Include="@(TestAssetProjectReference)" />
+
+      <!-- Always Publish test assets relative to test project's output. -->
       <_ProjectsToPublish AdditionalProperties="%(_ProjectsToPublish.AdditionalProperties);
-          OutputPath=$(OutputPath)%(RelativeFolder);
           PublishDir=$(PublishDir)%(RelativeFolder)" />
+
+      <!-- Do not build when publishing if SkipBuild requested. -->
+      <_ProjectsToPublish Condition=" '%(SkipBuild)' == 'true' "
+          AdditionalProperties="%(_ProjectsToPublish.AdditionalProperties);NoBuild=true" />
+
+      <!--
+        Otherwise, both Build and Publish test assets into folders relative to test project's output. Reset
+        NoBuild if helix.proj set the property to true.
+      -->
+      <_ProjectsToPublish Condition=" '%(SkipBuild)' != 'true' "
+          AdditionalProperties="%(_ProjectsToPublish.AdditionalProperties);
+            OutputPath=$(OutputPath)%(RelativeFolder)" />
+      <_ProjectsToPublish Condition=" '%(SkipBuild)' != 'true' AND '$(IsHelixJob)' == 'true' "
+          AdditionalProperties="%(_ProjectsToPublish.AdditionalProperties);NoBuild=false" />
     </ItemGroup>
 
     <!--

--- a/src/Mvc/test/WebSites/Directory.Build.props
+++ b/src/Mvc/test/WebSites/Directory.Build.props
@@ -1,4 +1,4 @@
-<Project>
+<Project TreatAsLocalProperty="NoBuild">
   <PropertyGroup>
     <IsTestAssetProject>true</IsTestAssetProject>
     <!--
@@ -6,7 +6,15 @@
       We do not want the path mangling (e.g. _content/MyClassLib) that comes with SWA.
     -->
     <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
+
+    <!--
+      The Razor SDK does not execute RazorCompile after PrepareForPublish when NoBuild is true. The result is
+      over-publication (for some reason) and that confuses tests. Undo the helix.proj NoBuild override if in a
+      Helix CI job.
+    -->
+    <NoBuild Condition=" '$(RazorCompileOnPublish)' == 'true' AND '$(IsHelixJob)' == 'true' ">false</NoBuild>
   </PropertyGroup>
+
   <!-- Skip the parent folder to prevent getting test package references. -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\..\, Directory.Build.props))\Directory.Build.props" />
 </Project>

--- a/src/Servers/IIS/IIS/test/FunctionalTest.props
+++ b/src/Servers/IIS/IIS/test/FunctionalTest.props
@@ -1,25 +1,24 @@
 <Project>
-
   <ItemGroup>
     <Content Include="..\Common.FunctionalTests\Infrastructure\*.config" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <Target Name="BuildAssets" AfterTargets="Build" Condition="'$(ExcludeFromBuild)' != 'true'">
-    <MSBuild Projects="@(ProjectReference)" Targets="PublishTestsAssets" SkipNonexistentTargets="true" BuildInParallel="True">
+  <Target Name="CopyAssets" BeforeTargets="Publish">
+    <MSBuild Projects="@(ProjectReference)"
+        Targets="PublishTestsAssets"
+        SkipNonexistentTargets="true"
+        BuildInParallel="True">
       <Output TaskParameter="TargetOutputs" ItemName="PublishedTestAsset" />
     </MSBuild>
-  </Target>
 
-  <Target Name="CopyAssets" AfterTargets="Publish" Condition="'@(PublishedTestAsset->Count())' != '0'">
-
-    <ItemGroup>
+    <ItemGroup Condition=" @(PublishedTestAsset->Count()) != 0 ">
      <_FilesToCopy Include="%(PublishedTestAsset.Path)\**\*">
         <DestinationDir>$(PublishDir)\%(PublishedTestAsset.Identity)\</DestinationDir>
       </_FilesToCopy>
     </ItemGroup>
 
-    <Copy SourceFiles="@(_FilesToCopy)" DestinationFiles="@(_FilesToCopy->'%(DestinationDir)%(RecursiveDir)%(FileName)%(Extension)')" />
-
+    <Copy SourceFiles="@(_FilesToCopy)"
+        Condition=" @(PublishedTestAsset->Count()) != 0 "
+        DestinationFiles="@(_FilesToCopy->'%(DestinationDir)%(RecursiveDir)%(FileName)%(Extension)')" />
   </Target>
-
 </Project>

--- a/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
@@ -59,4 +59,9 @@
     </PackageReference>
     <Reference Include="xunit.assert" />
   </ItemGroup>
+
+  <!-- Repeat Build target for win-x64 to allow later Publish w/ NoBuild=true. -->
+  <Target Name="BuildX64" BeforeTargets="Build" Condition=" '$(RuntimeIdentifier)' != 'win-x64' ">
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Properties="RuntimeIdentifier=win-x64" Targets="Build" />
+  </Target>
 </Project>

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/InProcessWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/InProcessWebSite.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
   <Import Project="..\..\..\..\build\testsite.props" />
 
   <PropertyGroup>
@@ -32,4 +31,8 @@
     <Reference Include="xunit.assert" />
   </ItemGroup>
 
+  <!-- Repeat Build target for win-x64 to allow later Publish w/ NoBuild=true. -->
+  <Target Name="BuildX64" BeforeTargets="Build" Condition=" '$(RuntimeIdentifier)' != 'win-x64' ">
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Properties="RuntimeIdentifier=win-x64" Targets="Build" />
+  </Target>
 </Project>


### PR DESCRIPTION
- wastefully repeated work done in previous build step
- but allow builds of the few test asset projects where they're required when publishing
  - or, for IIS test assets, perform all builds needed for their profiles during Build
- merge separate targets into one in FunctionalTest.props to make items available

nits:
- move `NoBuild=true` setting out of FunctionalTestWithAssets.props
- use `BeforeTargets` in FunctionalTest.props to improve determinism