### PR TITLE
FileBufferingReadStream - CanRead + CanSeek checks _disposed

### DIFF
--- a/src/Http/WebUtilities/src/FileBufferingReadStream.cs
+++ b/src/Http/WebUtilities/src/FileBufferingReadStream.cs
@@ -186,13 +186,13 @@ public class FileBufferingReadStream : Stream
     /// <inheritdoc/>
     public override bool CanRead
     {
-        get { return true; }
+        get { return !_disposed; }
     }
 
     /// <inheritdoc/>
     public override bool CanSeek
     {
-        get { return true; }
+        get { return !_disposed; }
     }
 
     /// <inheritdoc/>

--- a/src/Http/WebUtilities/test/FileBufferingReadStreamTests.cs
+++ b/src/Http/WebUtilities/test/FileBufferingReadStreamTests.cs
@@ -17,9 +17,11 @@ public class FileBufferingReadStreamTests
     [Fact]
     public void FileBufferingReadStream_Properties_ExpectedValues()
     {
-        var inner = MakeStream(1024 * 2);
-        using (var stream = new FileBufferingReadStream(inner, 1024, null, Directory.GetCurrentDirectory()))
+        using var inner = MakeStream(1024 * 2);
+        System.IO.Stream bufferSteam;
         {
+            using var stream = new FileBufferingReadStream(inner, 1024, null, Directory.GetCurrentDirectory());
+            bufferSteam = stream;
             Assert.True(stream.CanRead);
             Assert.True(stream.CanSeek);
             Assert.False(stream.CanWrite);
@@ -28,6 +30,10 @@ public class FileBufferingReadStreamTests
             Assert.True(stream.InMemory);
             Assert.Null(stream.TempFileName);
         }
+        Assert.False(bufferSteam.CanRead);  // Buffered Stream now disposed
+        Assert.False(bufferSteam.CanSeek);
+        Assert.True(inner.CanRead);         // Inner Stream not disposed
+        Assert.True(inner.CanSeek);
     }
 
     [Fact]


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. See #39939

## Description

Updated properties `CanRead` + `CanSeek` to check _disposed