### PR TITLE
Better way to detect "Failed to start the HttpConnection before stop() was called."

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/HubConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnection.ts
@@ -3,6 +3,7 @@
 
 import { HandshakeProtocol, HandshakeRequestMessage, HandshakeResponseMessage } from "./HandshakeProtocol";
 import { IConnection } from "./IConnection";
+import { AbortError } from "./Errors";
 import { CancelInvocationMessage, CompletionMessage, IHubProtocol, InvocationMessage, MessageType, StreamInvocationMessage, StreamItemMessage } from "./IHubProtocol";
 import { ILogger, LogLevel } from "./ILogger";
 import { IRetryPolicy } from "./IRetryPolicy";
@@ -296,7 +297,7 @@ export class HubConnection {
 
         this._cleanupTimeout();
         this._cleanupPingTimer();
-        this._stopDuringStartError = error || new Error("The connection was stopped before the hub handshake could complete.");
+        this._stopDuringStartError = error || new AbortError("The connection was stopped before the hub handshake could complete.");
 
         // HttpConnection.stop() should not complete until after either HttpConnection.start() fails
         // or the onclose callback is invoked. The onclose callback will transition the HubConnection
@@ -698,7 +699,7 @@ export class HubConnection {
         this._logger.log(LogLevel.Debug, `HubConnection.connectionClosed(${error}) called while in state ${this._connectionState}.`);
 
         // Triggering this.handshakeRejecter is insufficient because it could already be resolved without the continuation having run yet.
-        this._stopDuringStartError = this._stopDuringStartError || error || new Error("The underlying connection was closed before the hub handshake could complete.");
+        this._stopDuringStartError = this._stopDuringStartError || error || new AbortError("The underlying connection was closed before the hub handshake could complete.");
 
         // If the handshake is in progress, start will be waiting for the handshake promise, so we complete it.
         // If it has already completed, this should just noop.

--- a/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
@@ -7,7 +7,7 @@ import { IHttpConnectionOptions } from "../src/IHttpConnectionOptions";
 import { HttpTransportType, ITransport, TransferFormat } from "../src/ITransport";
 import { getUserAgentHeader } from "../src/Utils";
 
-import { HttpError } from "../src/Errors";
+import { AbortError, HttpError } from "../src/Errors";
 import { ILogger, LogLevel } from "../src/ILogger";
 import { NullLogger } from "../src/Loggers";
 import { EventSourceConstructor, WebSocketConstructor } from "../src/Polyfills";
@@ -161,9 +161,12 @@ describe("HttpConnection", () => {
 
             await stopPromise;
 
-            await expect(startPromise)
-                .rejects
-                .toThrow("The connection was stopped during negotiation.");
+            try {
+                await startPromise
+            } catch (e) {
+                expect(e).toBeInstanceOf(AbortError);
+                expect((e as AbortError).message).toBe("The connection was stopped during negotiation.");
+            }
         },
         "Failed to start the connection: Error: The connection was stopped during negotiation.");
     });


### PR DESCRIPTION
# Use specifically typed error when connection failed to start 

The AbortError is used to mark a situation when a stop() method is being invoked before a call to start() succeeds.

## Description

As proposed in the issue the specific error is returned in case stop was called before start ended in the HttpConnection and HubConnection classes

Fixes #38893
