### PR TITLE
Renaming DisableImplicitFromServicesParameters option

### DIFF
--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -70,7 +70,7 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
             _maximumMessageSize = _hubOptions.MaximumReceiveMessageSize;
             _enableDetailedErrors = _hubOptions.EnableDetailedErrors ?? _enableDetailedErrors;
             _maxParallelInvokes = _hubOptions.MaximumParallelInvocationsPerClient;
-            disableImplicitFromServiceParameters = _hubOptions.DisableImplicitFromServiceParameters;
+            disableImplicitFromServiceParameters = _hubOptions.DisableImplicitFromServicesParameters;
 
             if (_hubOptions.HubFilters != null)
             {
@@ -82,7 +82,7 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
             _maximumMessageSize = _globalHubOptions.MaximumReceiveMessageSize;
             _enableDetailedErrors = _globalHubOptions.EnableDetailedErrors ?? _enableDetailedErrors;
             _maxParallelInvokes = _globalHubOptions.MaximumParallelInvocationsPerClient;
-            disableImplicitFromServiceParameters = _globalHubOptions.DisableImplicitFromServiceParameters;
+            disableImplicitFromServiceParameters = _globalHubOptions.DisableImplicitFromServicesParameters;
 
             if (_globalHubOptions.HubFilters != null)
             {

--- a/src/SignalR/server/Core/src/HubOptions.cs
+++ b/src/SignalR/server/Core/src/HubOptions.cs
@@ -81,5 +81,5 @@ public class HubOptions
     /// <remarks>
     /// False by default. Hub method arguments will be resolved from a DI container if possible.
     /// </remarks>
-    public bool DisableImplicitFromServiceParameters { get; set; }
+    public bool DisableImplicitFromServicesParameters { get; set; }
 }

--- a/src/SignalR/server/Core/src/HubOptionsSetup`T.cs
+++ b/src/SignalR/server/Core/src/HubOptionsSetup`T.cs
@@ -37,7 +37,7 @@ public class HubOptionsSetup<THub> : IConfigureOptions<HubOptions<THub>> where T
         options.MaximumReceiveMessageSize = _hubOptions.MaximumReceiveMessageSize;
         options.StreamBufferCapacity = _hubOptions.StreamBufferCapacity;
         options.MaximumParallelInvocationsPerClient = _hubOptions.MaximumParallelInvocationsPerClient;
-        options.DisableImplicitFromServiceParameters = _hubOptions.DisableImplicitFromServiceParameters;
+        options.DisableImplicitFromServicesParameters = _hubOptions.DisableImplicitFromServicesParameters;
 
         options.UserHasSetValues = true;
 

--- a/src/SignalR/server/Core/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/server/Core/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 #nullable enable
-Microsoft.AspNetCore.SignalR.HubOptions.DisableImplicitFromServiceParameters.get -> bool
-Microsoft.AspNetCore.SignalR.HubOptions.DisableImplicitFromServiceParameters.set -> void
+Microsoft.AspNetCore.SignalR.HubOptions.DisableImplicitFromServicesParameters.get -> bool
+Microsoft.AspNetCore.SignalR.HubOptions.DisableImplicitFromServicesParameters.set -> void

--- a/src/SignalR/server/SignalR/test/AddSignalRTests.cs
+++ b/src/SignalR/server/SignalR/test/AddSignalRTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             Assert.Equal(globalHubOptions.SupportedProtocols, hubOptions.SupportedProtocols);
             Assert.Equal(globalHubOptions.ClientTimeoutInterval, hubOptions.ClientTimeoutInterval);
             Assert.Equal(globalHubOptions.MaximumParallelInvocationsPerClient, hubOptions.MaximumParallelInvocationsPerClient);
-            Assert.Equal(globalHubOptions.DisableImplicitFromServiceParameters, hubOptions.DisableImplicitFromServiceParameters);
+            Assert.Equal(globalHubOptions.DisableImplicitFromServicesParameters, hubOptions.DisableImplicitFromServicesParameters);
             Assert.True(hubOptions.UserHasSetValues);
         }
 
@@ -146,7 +146,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 options.SupportedProtocols = null;
                 options.ClientTimeoutInterval = TimeSpan.FromSeconds(1);
                 options.MaximumParallelInvocationsPerClient = 3;
-                options.DisableImplicitFromServiceParameters = true;
+                options.DisableImplicitFromServicesParameters = true;
             });
 
             var serviceProvider = serviceCollection.BuildServiceProvider();
@@ -160,7 +160,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             Assert.Null(globalOptions.SupportedProtocols);
             Assert.Equal(3, globalOptions.MaximumParallelInvocationsPerClient);
             Assert.Equal(TimeSpan.FromSeconds(1), globalOptions.ClientTimeoutInterval);
-            Assert.True(globalOptions.DisableImplicitFromServiceParameters);
+            Assert.True(globalOptions.DisableImplicitFromServicesParameters);
         }
 
         [Fact]

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -4695,7 +4695,7 @@ public class HubConnectionHandlerTests : VerifiableLoggedTest
             provider.AddSignalR(options =>
             {
                 options.EnableDetailedErrors = true;
-                options.DisableImplicitFromServiceParameters = true;
+                options.DisableImplicitFromServicesParameters = true;
             });
             provider.AddSingleton<Service1>();
         });
@@ -4738,10 +4738,10 @@ public class HubConnectionHandlerTests : VerifiableLoggedTest
             provider.AddSignalR(options =>
             {
                 options.EnableDetailedErrors = true;
-                options.DisableImplicitFromServiceParameters = true;
+                options.DisableImplicitFromServicesParameters = true;
             }).AddHubOptions<ServicesHub>(options =>
             {
-                options.DisableImplicitFromServiceParameters = false;
+                options.DisableImplicitFromServicesParameters = false;
             });
             provider.AddSingleton<Service1>();
         });
@@ -4763,7 +4763,7 @@ public class HubConnectionHandlerTests : VerifiableLoggedTest
             provider.AddSignalR(options =>
             {
                 options.EnableDetailedErrors = true;
-                options.DisableImplicitFromServiceParameters = true;
+                options.DisableImplicitFromServicesParameters = true;
             });
             provider.AddSingleton<Service1>();
             provider.AddSingleton<Service2>();


### PR DESCRIPTION
Renaming `DisableImplicitFromServiceParameters` to `DisableImplicitFromService*s*Parameters`

Related #39667