### PR TITLE
Quarantine ShadowCopyIgnoresItsOwnDirectoryWithRelativePathSegmentWhenCopying

### DIFF
--- a/src/Servers/IIS/IIS/test/IIS.ShadowCopy.Tests/ShadowCopyTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.ShadowCopy.Tests/ShadowCopyTests.cs
@@ -252,6 +252,7 @@ public class ShadowCopyTests : IISFunctionalTestBase
     }
 
     [ConditionalFact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/40059")]
     public async Task ShadowCopyIgnoresItsOwnDirectoryWithRelativePathSegmentWhenCopying()
     {
         using var directory = TempDirectory.Create();


### PR DESCRIPTION
See https://github.com/dotnet/aspnetcore/issues/40059