### PR TITLE
Do not install the JDK in quarantined pipelines

### DIFF
--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -51,6 +51,7 @@ jobs:
     jobName: Helix_quarantined_x64
     jobDisplayName: 'Tests: Helix'
     agentOs: Windows
+    installJdk: false
     timeoutInMinutes: 120
     steps:
     # Build the shared framework
@@ -76,6 +77,7 @@ jobs:
     jobName: Windows_Quarantined_x64
     jobDisplayName: 'Tests: Windows x64'
     agentOs: Windows
+    installJdk: false
     timeoutInMinutes: 90
     isAzDOTestingJob: true
     enablePublishTestResults: false

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -22,6 +22,7 @@ jobs:
     jobName: Helix_quarantined_x64
     jobDisplayName: 'Tests: Helix'
     agentOs: Windows
+    installJdk: false
     timeoutInMinutes: 480
     steps:
     # Build the shared framework

--- a/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
+++ b/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
@@ -1,7 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!--
+      Skip building and running the Components E2E tests in CI unless explicitly configured otherwise via
+      EXECUTE_COMPONENTS_E2E_TESTS. At least build the Components E2E tests locally unless SkipTestBuild is set.
+    -->
+    <_BuildAndTest>false</_BuildAndTest>
+    <_BuildAndTest
+        Condition=" '$(ContinuousIntegrationBuild)' == true AND '$(EXECUTE_COMPONENTS_E2E_TESTS)' == true ">true</_BuildAndTest>
+    <_BuildAndTest
+        Condition=" '$(ContinuousIntegrationBuild)' != true AND '$(SkipTestBuild)' != true ">true</_BuildAndTest>
+    <ExcludeFromBuild Condition=" !$(_BuildAndTest) ">true</ExcludeFromBuild>
+    <SkipTests Condition=" !$(_BuildAndTest) ">true</SkipTests>
+  </PropertyGroup>
 
   <!-- Shared testing infrastructure for running E2E tests using selenium -->
-  <Import Condition="'$(SkipTestBuild)' != 'true'" Project="$(SharedSourceRoot)E2ETesting\E2ETesting.props" />
+  <Import Condition=" $(_BuildAndTest) " Project="$(SharedSourceRoot)E2ETesting\E2ETesting.props" />
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
@@ -10,17 +23,11 @@
     <!-- https://github.com/dotnet/aspnetcore/issues/6857 -->
     <BuildHelixPayload>false</BuildHelixPayload>
 
-    <!-- Run on platforms where we support Selenium -->
-    <SkipTests Condition="'$(SeleniumE2ETestsSupported)' != 'true'">true</SkipTests>
-    <SkipTests Condition="'$(SeleniumE2ETestsSupported)' == 'true'">false</SkipTests>
-
-    <!-- Skip building and running the Components E2E tests in CI unless explicitly configured otherwise via EXECUTE_COMPONENTS_E2E_TESTS -->
-    <ExcludeFromBuild Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(EXECUTE_COMPONENTS_E2E_TESTS)' != 'true'">true</ExcludeFromBuild>
-    <SkipTests Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(EXECUTE_COMPONENTS_E2E_TESTS)' != 'true'">true</SkipTests>
+    <!-- Run only on platforms where we support Selenium. -->
+    <SkipTests Condition=" '$(SeleniumE2ETestsSupported)' != true ">true</SkipTests>
 
     <!-- Tests do not work on Helix or when bin/ directory is not in project directory due to undeclared dependency on test content. -->
     <BaseOutputPath />
-
     <OutputPath />
 
     <!-- This project references the shared framework transitively. Prevent restore errors by setting this flag. -->
@@ -82,7 +89,7 @@
   </ItemGroup>
 
   <!-- Shared testing infrastructure for running E2E tests using selenium -->
-  <Import Condition="'$(SkipTestBuild)' != 'true'" Project="$(SharedSourceRoot)E2ETesting\E2ETesting.targets" />
+  <Import Condition=" '$(SkipTests)' != true " Project="$(SharedSourceRoot)E2ETesting\E2ETesting.targets" />
 
   <ItemGroup>
     <!-- Shared descriptor infrastructure with MVC -->
@@ -110,5 +117,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
+++ b/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
@@ -6,9 +6,9 @@
     -->
     <_BuildAndTest>false</_BuildAndTest>
     <_BuildAndTest
-        Condition=" '$(ContinuousIntegrationBuild)' == true AND '$(EXECUTE_COMPONENTS_E2E_TESTS)' == true ">true</_BuildAndTest>
+        Condition=" '$(ContinuousIntegrationBuild)' == 'true' AND '$(EXECUTE_COMPONENTS_E2E_TESTS)' == 'true' ">true</_BuildAndTest>
     <_BuildAndTest
-        Condition=" '$(ContinuousIntegrationBuild)' != true AND '$(SkipTestBuild)' != true ">true</_BuildAndTest>
+        Condition=" '$(ContinuousIntegrationBuild)' != 'true' AND '$(SkipTestBuild)' != 'true' ">true</_BuildAndTest>
     <ExcludeFromBuild Condition=" !$(_BuildAndTest) ">true</ExcludeFromBuild>
     <SkipTests Condition=" !$(_BuildAndTest) ">true</SkipTests>
   </PropertyGroup>
@@ -24,7 +24,7 @@
     <BuildHelixPayload>false</BuildHelixPayload>
 
     <!-- Run only on platforms where we support Selenium. -->
-    <SkipTests Condition=" '$(SeleniumE2ETestsSupported)' != true ">true</SkipTests>
+    <SkipTests Condition=" '$(SeleniumE2ETestsSupported)' != 'true' ">true</SkipTests>
 
     <!-- Tests do not work on Helix or when bin/ directory is not in project directory due to undeclared dependency on test content. -->
     <BaseOutputPath />
@@ -89,7 +89,7 @@
   </ItemGroup>
 
   <!-- Shared testing infrastructure for running E2E tests using selenium -->
-  <Import Condition=" '$(SkipTests)' != true " Project="$(SharedSourceRoot)E2ETesting\E2ETesting.targets" />
+  <Import Condition=" '$(SkipTests)' != 'true' " Project="$(SharedSourceRoot)E2ETesting\E2ETesting.targets" />
 
   <ItemGroup>
     <!-- Shared descriptor infrastructure with MVC -->


### PR DESCRIPTION
- was mainly used to confirm support for Components E2E tests
- those tests built more often than required

nit: do not set `$(SkipTests)` to `false`