### PR TITLE
`overrideDefaultText` for `DisableOpenAPI` in WebApi-CSharp Template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/ide.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/ide.host.json
@@ -42,7 +42,8 @@
         "overrideDefaultText": true
       },
       "description": {
-        "text": "Enables OpenAPI (Swagger) support"
+        "text": "Enables OpenAPI (Swagger) support",
+        "overrideDefaultText": true
       },
       "invertBoolean": true,
       "isVisible": true,


### PR DESCRIPTION
@phenning caught a missed `overrideDefaultText` for the `WebApi-CSharp` template's `DisableOpenAPI.description` property. Adding it in as a (minor) extension to https://github.com/dotnet/aspnetcore/pull/40105.

Before:
![image](https://user-images.githubusercontent.com/14852843/153475410-e1b044f6-affd-4a03-8be4-d61cbadcf892.png)

After:
![image](https://user-images.githubusercontent.com/14852843/153477233-cf02ee03-c056-49e0-82b3-8dcc1693285b.png)
