### PR TITLE
Skip Playwright Tests Running in Quarantined Pipeline

### DIFF
--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorServerTemplateTest.cs
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorServerTemplateTest.cs
@@ -25,9 +25,8 @@ public class BlazorServerTemplateTest : BlazorTemplateTest
 
     public override string ProjectType { get; } = "blazorserver";
 
-    [Theory]
+    [Theory(Skip = "https://github.com/dotnet/aspnetcore/issues/30761")]
     [InlineData(BrowserKind.Chromium)]
-    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/30761")]
     public async Task BlazorServerTemplateWorks_NoAuth(BrowserKind browserKind)
     {
         var project = await CreateBuildPublishAsync("blazorservernoauth" + browserKind);
@@ -81,9 +80,8 @@ public class BlazorServerTemplateTest : BlazorTemplateTest
     public static IEnumerable<object[]> BlazorServerTemplateWorks_IndividualAuthData =>
             BrowserManager.WithBrowsers(new[] { BrowserKind.Chromium }, true, false);
 
-    [Theory]
+    [Theory(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     [MemberData(nameof(BlazorServerTemplateWorks_IndividualAuthData))]
-    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/30825", Queues = "All.OSX")]
     public async Task BlazorServerTemplateWorks_IndividualAuth(BrowserKind browserKind, bool useLocalDB)
     {
@@ -182,13 +180,12 @@ public class BlazorServerTemplateTest : BlazorTemplateTest
         Assert.Equal(5, await page.Locator("p+table>tbody>tr").CountAsync());
     }
 
-    [Theory]
+    [Theory(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     [InlineData("IndividualB2C", null)]
     [InlineData("IndividualB2C", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
     [InlineData("SingleOrg", null)]
     [InlineData("SingleOrg", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
     [InlineData("SingleOrg", new string[] { "--calls-graph" })]
-    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     public Task BlazorServerTemplate_IdentityWeb_BuildAndPublish(string auth, string[] args)
         => CreateBuildPublishAsync("blazorserveridweb" + Guid.NewGuid().ToString().Substring(0, 10).ToLowerInvariant(), auth, args);
 

--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorServerTemplateTest.cs
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorServerTemplateTest.cs
@@ -27,7 +27,7 @@ public class BlazorServerTemplateTest : BlazorTemplateTest
 
     [Theory]
     [InlineData(BrowserKind.Chromium)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/30761")]
+    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/30761")]
     public async Task BlazorServerTemplateWorks_NoAuth(BrowserKind browserKind)
     {
         var project = await CreateBuildPublishAsync("blazorservernoauth" + browserKind);
@@ -83,7 +83,7 @@ public class BlazorServerTemplateTest : BlazorTemplateTest
 
     [Theory]
     [MemberData(nameof(BlazorServerTemplateWorks_IndividualAuthData))]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/30882")]
+    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/30825", Queues = "All.OSX")]
     public async Task BlazorServerTemplateWorks_IndividualAuth(BrowserKind browserKind, bool useLocalDB)
     {
@@ -188,7 +188,7 @@ public class BlazorServerTemplateTest : BlazorTemplateTest
     [InlineData("SingleOrg", null)]
     [InlineData("SingleOrg", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
     [InlineData("SingleOrg", new string[] { "--calls-graph" })]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/30882")]
+    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     public Task BlazorServerTemplate_IdentityWeb_BuildAndPublish(string auth, string[] args)
         => CreateBuildPublishAsync("blazorserveridweb" + Guid.NewGuid().ToString().Substring(0, 10).ToLowerInvariant(), auth, args);
 

--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorWasmTemplateTest.cs
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorWasmTemplateTest.cs
@@ -23,9 +23,8 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
 
     public override string ProjectType { get; } = "blazorwasm";
 
-    [Theory]
+    [Theory(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     [InlineData(BrowserKind.Chromium)]
-    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     public async Task BlazorWasmStandaloneTemplate_Works(BrowserKind browserKind)
     {
         var project = await CreateBuildPublishAsync("blazorstandalone" + browserKind);
@@ -60,9 +59,8 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
         return page;
     }
 
-    [Theory]
+    [Theory(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     [InlineData(BrowserKind.Chromium)]
-    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     public async Task BlazorWasmHostedTemplate_Works(BrowserKind browserKind)
     {
         var project = await CreateBuildPublishAsync("blazorhosted" + BrowserKind.Chromium, args: new[] { "--hosted" }, serverProject: true);
@@ -109,9 +107,8 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
         Assert.Equal(expectedEncoding, response.Content.Headers.ContentEncoding.Single());
     }
 
-    [Theory]
+    [Theory(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     [InlineData(BrowserKind.Chromium)]
-    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     public async Task BlazorWasmStandalonePwaTemplate_Works(BrowserKind browserKind)
     {
         var project = await CreateBuildPublishAsync("blazorstandalonepwa", args: new[] { "--pwa" });
@@ -145,9 +142,8 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
         }
     }
 
-    [Theory]
+    [Theory(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     [InlineData(BrowserKind.Chromium)]
-    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     public async Task BlazorWasmHostedPwaTemplate_Works(BrowserKind browserKind)
     {
         var project = await CreateBuildPublishAsync("blazorhostedpwa", args: new[] { "--hosted", "--pwa" }, serverProject: true);
@@ -216,18 +212,16 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
         Assert.True(serviceWorkerContents.Contains($"/* Manifest version: {serviceWorkerAssetsManifestVersion} */", StringComparison.Ordinal));
     }
 
-    [ConditionalTheory]
+    [ConditionalTheory(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     [InlineData(BrowserKind.Chromium)]
     // LocalDB doesn't work on non Windows platforms
     [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
-    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     public Task BlazorWasmHostedTemplate_IndividualAuth_Works_WithLocalDB(BrowserKind browserKind)
         => BlazorWasmHostedTemplate_IndividualAuth_Works(browserKind, true);
 
     // This test depends on BlazorWasmTemplate_CreateBuildPublish_IndividualAuthNoLocalDb running first
-    [Theory]
+    [Theory(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     [InlineData(BrowserKind.Chromium)]
-    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/30825", Queues = "All.OSX")]
     public Task BlazorWasmHostedTemplate_IndividualAuth_Works_WithOutLocalDB(BrowserKind browserKind)
         => BlazorWasmHostedTemplate_IndividualAuth_Works(browserKind, false);
@@ -379,9 +373,8 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
         public string[] Arguments { get; }
     }
 
-    [Theory]
+    [Theory(Skip = "https://github.com/dotnet/aspnetcore/issues/37782")]
     [MemberData(nameof(TemplateData))]
-    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/37782")]
     public Task BlazorWasmHostedTemplate_AzureActiveDirectoryTemplate_Works(TemplateInstance instance)
         => CreateBuildPublishAsync(instance.Name, args: instance.Arguments, targetFramework: "netstandard2.1");
 

--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorWasmTemplateTest.cs
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorWasmTemplateTest.cs
@@ -25,7 +25,7 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
 
     [Theory]
     [InlineData(BrowserKind.Chromium)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/30882")]
+    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     public async Task BlazorWasmStandaloneTemplate_Works(BrowserKind browserKind)
     {
         var project = await CreateBuildPublishAsync("blazorstandalone" + browserKind);
@@ -62,7 +62,7 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
 
     [Theory]
     [InlineData(BrowserKind.Chromium)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/30882")]
+    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     public async Task BlazorWasmHostedTemplate_Works(BrowserKind browserKind)
     {
         var project = await CreateBuildPublishAsync("blazorhosted" + BrowserKind.Chromium, args: new[] { "--hosted" }, serverProject: true);
@@ -111,7 +111,7 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
 
     [Theory]
     [InlineData(BrowserKind.Chromium)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/30882")]
+    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     public async Task BlazorWasmStandalonePwaTemplate_Works(BrowserKind browserKind)
     {
         var project = await CreateBuildPublishAsync("blazorstandalonepwa", args: new[] { "--pwa" });
@@ -147,7 +147,7 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
 
     [Theory]
     [InlineData(BrowserKind.Chromium)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/30882")]
+    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     public async Task BlazorWasmHostedPwaTemplate_Works(BrowserKind browserKind)
     {
         var project = await CreateBuildPublishAsync("blazorhostedpwa", args: new[] { "--hosted", "--pwa" }, serverProject: true);
@@ -220,14 +220,14 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
     [InlineData(BrowserKind.Chromium)]
     // LocalDB doesn't work on non Windows platforms
     [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/30882")]
+    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     public Task BlazorWasmHostedTemplate_IndividualAuth_Works_WithLocalDB(BrowserKind browserKind)
         => BlazorWasmHostedTemplate_IndividualAuth_Works(browserKind, true);
 
     // This test depends on BlazorWasmTemplate_CreateBuildPublish_IndividualAuthNoLocalDb running first
     [Theory]
     [InlineData(BrowserKind.Chromium)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/30882")]
+    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/30882")]
     [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/30825", Queues = "All.OSX")]
     public Task BlazorWasmHostedTemplate_IndividualAuth_Works_WithOutLocalDB(BrowserKind browserKind)
         => BlazorWasmHostedTemplate_IndividualAuth_Works(browserKind, false);
@@ -381,7 +381,7 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
 
     [Theory]
     [MemberData(nameof(TemplateData))]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/37782")]
+    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/37782")]
     public Task BlazorWasmHostedTemplate_AzureActiveDirectoryTemplate_Works(TemplateInstance instance)
         => CreateBuildPublishAsync(instance.Name, args: instance.Arguments, targetFramework: "netstandard2.1");
 


### PR DESCRIPTION
Skips Playwright tests from running in quarantined pipelines given we know they'll fail. Saves resources & test execution time.

Fixes: https://github.com/dotnet/aspnetcore/issues/40051

Will be unskipped via https://github.com/dotnet/aspnetcore/issues/38818.
