### PR TITLE
Do less copying / zipping for Helix

### DIFF
--- a/eng/helix/content/RunTests/TestRunner.cs
+++ b/eng/helix/content/RunTests/TestRunner.cs
@@ -43,9 +43,6 @@ namespace RunTests
                 var dotnetEFFullPath = Path.Combine(nugetRestore, helixDir, "dotnet-ef.exe");
                 Console.WriteLine($"Set DotNetEfFullPath: {dotnetEFFullPath}");
                 EnvironmentVariables.Add("DotNetEfFullPath", dotnetEFFullPath);
-                var appRuntimePath = $"{Options.DotnetRoot}/shared/Microsoft.AspNetCore.App/{Options.RuntimeVersion}";
-                Console.WriteLine($"Set ASPNET_RUNTIME_PATH: {appRuntimePath}");
-                EnvironmentVariables.Add("ASPNET_RUNTIME_PATH", appRuntimePath);
                 var dumpPath = Environment.GetEnvironmentVariable("HELIX_DUMP_FOLDER");
                 Console.WriteLine($"Set VSTEST_DUMP_PATH: {dumpPath}");
                 EnvironmentVariables.Add("VSTEST_DUMP_PATH", dumpPath);

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -52,7 +52,7 @@
     <When Condition=" '$(ContinuousIntegrationBuild)' == 'true' ">
       <PropertyGroup>
         <!-- Creator is not valid for internal queues -->
-        <Creator Condition="'$(_UseHelixOpenQueues)' == 'true'">aspnetcore</Creator>
+        <Creator Condition=" '$(_UseHelixOpenQueues)' == 'true' ">aspnetcore</Creator>
 
         <HelixType>ci</HelixType>
         <HelixBuild>$(BUILD_BUILDNUMBER).$(SYSTEM_JOBATTEMPT)</HelixBuild>
@@ -61,8 +61,8 @@
     <Otherwise>
       <PropertyGroup>
         <!-- Creator is not valid for internal queues -->
-        <Creator Condition="'$(_UseHelixOpenQueues)' == 'true'">$(USERNAME)</Creator>
-        <Creator Condition="'$(USERNAME)' == '' AND '$(_UseHelixOpenQueues)' == 'true'">$(USER)</Creator>
+        <Creator Condition=" '$(_UseHelixOpenQueues)' == 'true' ">$(USERNAME)</Creator>
+        <Creator Condition=" '$(_UseHelixOpenQueues)' == 'true' AND '$(USERNAME)' == '' ">$(USER)</Creator>
 
         <HelixType>dev</HelixType>
         <HelixBuild>$([System.DateTime]::Now.ToString('yyyyMMddHHmm'))</HelixBuild>
@@ -83,9 +83,12 @@
     <HelixProperties Condition="'$(RunQuarantinedTests)' != 'true'" Include="runType" Value="unquarantined" />
   </ItemGroup>
 
-  <Target Name="IncludeAspNetRuntime" BeforeTargets="Gather"
-    Condition="'$(DoNotRequireSharedFxHelix)' != 'true' OR
-    EXISTS('$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\Microsoft.AspNetCore.App.Runtime.$(TargetRuntimeIdentifier).$(SharedFxVersion).nupkg')">
+  <!--
+    In inner (per-queue) builds, tell the Helix SDK to pack up our just-built App.Ref / App.Runtime layouts w/
+    the current versions. Warning: When using RunHelix.ps1, .dotnet/ folder may contain older App.Ref and
+    App.Runtime layouts.
+  -->
+  <Target Name="IncludeAspNetRuntime" BeforeTargets="Gather">
     <MSBuild Projects="$(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
         Properties="DisableYarnCheck=true;ExcludeFromBuild=false"
         Targets="_GetPackageVersionInfo">
@@ -94,32 +97,39 @@
 
     <PropertyGroup>
       <SharedFxVersion>@(_ResolvedProductVersionInfo->'%(PackageVersion)')</SharedFxVersion>
+      <_AppRefSubPath>packs\Microsoft.AspNetCore.App.Ref\$(SharedFxVersion)</_AppRefSubPath>
+      <_AppRuntimeSubPath>shared\Microsoft.AspNetCore.App\$(SharedFxVersion)</_AppRuntimeSubPath>
+      <_AppRefPath>$(RepoRoot).dotnet\$(_AppRefSubPath)</_AppRefPath>
+      <_AppRuntimePath>$(RepoRoot).dotnet\$(_AppRuntimeSubPath)</_AppRuntimePath>
+
+      <!--
+        Don't bother checking for App.Runtime layout because we want both and App.Ref project depends on the
+        App.Runtime project.
+      -->
+      <_AppRefPathExists Condition=" EXISTS('$(_AppRefPath)') ">true</_AppRefPathExists>
+      <_AppRefPathExists Condition=" '$(_AppRefPathExists)' == '' ">false</_AppRefPathExists>
     </PropertyGroup>
 
-    <!-- Use package because .dotnet/ folder doesn't contain RuntimeList.xml file and SharedFxTests checks that. -->
-    <Unzip
-       SourceFiles="$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\Microsoft.AspNetCore.App.Runtime.$(TargetRuntimeIdentifier).$(SharedFxVersion).nupkg"
-       DestinationFolder="$(OutputPath)\SharedFx.Unzip" />
-    <ItemGroup>
-      <_appRuntimeFiles Include="$(OutputPath)\SharedFx.Unzip\**\*.txt" />
-      <_appRuntimeFiles Include="$(OutputPath)\SharedFx.Unzip\**\*.json" />
-      <_appRuntimeFiles Include="$(OutputPath)\SharedFx.Unzip\**\*.dll" />
-      <_appRuntimeFiles Include="$(OutputPath)\SharedFx.Unzip\**\RuntimeList.xml" />
-    </ItemGroup>
-    <Copy SourceFiles="@(_appRuntimeFiles)"
-        DestinationFolder="$(OutputPath)\SharedFx.Layout\shared\Microsoft.AspNetCore.App\$(SharedFxVersion)" />
-    <Copy SourceFiles="$(OutputPath)\SharedFx.Unzip\Microsoft.AspNetCore.App.versions.txt"
-        DestinationFiles="$(OutputPath)\SharedFx.Layout\shared\Microsoft.AspNetCore.App\$(SharedFxVersion)\.version" />
+    <!-- After complaining about missing App.Ref layout, do nothing else in this target.  -->
+    <Warning Text="Targeting path location '$(_AppRefPath)' does not exist."
+        Condition=" !$(_AppRefPathExists) AND '$(DoNotRequireSharedFxHelix)' == true " />
+    <Error Text="Targeting path location '$(_AppRefPath)' does not exist."
+        Condition=" !$(_AppRefPathExists) AND '$(DoNotRequireSharedFxHelix)' != true " />
 
-    <Unzip Condition="Exists('$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\Microsoft.AspNetCore.App.Ref.$(SharedFxVersion).nupkg')"
-      SourceFiles="$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\Microsoft.AspNetCore.App.Ref.$(SharedFxVersion).nupkg"
-      DestinationFolder="$(OutputPath)\SharedFx.Layout\packs\Microsoft.AspNetCore.App.Ref\$(SharedFxVersion)" />
-    <ZipDirectory Condition="Exists('$(OutputPath)\SharedFx.Layout')"
-      SourceDirectory="$(OutputPath)\SharedFx.Layout"
-      DestinationFile="$(OutputPath)\SharedFx.Layout.zip" Overwrite="true" />
-
-    <ItemGroup>
-      <HelixCorrelationPayload Include="$(OutputPath)\SharedFx.Layout.zip" Destination="$(DotNetCliDestination)" />
+    <!-- Grab only the portions of the .dotnet/ tree built in this run and have Helix zip that up. -->
+    <ItemGroup Condition=" $(_AppRefPathExists) ">
+      <HelixCorrelationPayload Include="$(_AppRefPath)"
+          Condition=" $(IsWindowsHelixQueue) "
+          Destination="$(DotNetCliDestination)\$(_AppRefSubPath)" />
+      <HelixCorrelationPayload Include="$(_AppRefPath)"
+          Condition=" !$(IsWindowsHelixQueue) "
+          Destination="$(DotNetCliDestination)/$(_AppRefSubPath.Replace('\','/'))" />
+      <HelixCorrelationPayload Include="$(_AppRuntimePath)"
+          Condition=" $(IsWindowsHelixQueue) "
+          Destination="$(DotNetCliDestination)\$(_AppRuntimeSubPath)" />
+      <HelixCorrelationPayload Include="$(_AppRuntimePath)"
+          Condition=" !$(IsWindowsHelixQueue) "
+          Destination="$(DotNetCliDestination)/$(_AppRuntimeSubPath.Replace('\','/'))" />
     </ItemGroup>
   </Target>
 

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -112,9 +112,10 @@
     </PropertyGroup>
 
     <!-- After complaining about missing App.Ref layout, do nothing else in this target.  -->
-    <Warning Text="Targeting path location '$(_AppRefPath)' does not exist."
+    <Message Importance="High"
+        Text="Targeting path location '$(_AppRefPath)' does not exist and tests will use the SDK's bundled runtimes and targeting pack."
         Condition=" !$(_AppRefPathExists) AND '$(DoNotRequireSharedFxHelix)' == true " />
-    <Error Text="Targeting path location '$(_AppRefPath)' does not exist."
+    <Error Text="Targeting path location '$(_AppRefPath)' does not exist and some tests are guaranteed to fail."
         Condition=" !$(_AppRefPathExists) AND '$(DoNotRequireSharedFxHelix)' != true " />
 
     <!-- Grab only the portions of the .dotnet/ tree built in this run and have Helix zip that up. -->

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -35,7 +35,8 @@
     <DotNetCliChannel>Current</DotNetCliChannel>
 
     <!-- Similar to ProjectLayout.props in the Arcade SDK. The Helix SDK contains nothing similar. -->
-    <OutputPath Condition=" '$(OutputPath)' == '' ">$(RepoRoot)artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition=" '$(OutputPath)' == '' "
+        >$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'bin', '$(MSBuildProjectName)'))</OutputPath>
   </PropertyGroup>
 
   <!-- Specify the .NET runtime we need which will be included as a correlation payload. -->
@@ -97,10 +98,10 @@
 
     <PropertyGroup>
       <SharedFxVersion>@(_ResolvedProductVersionInfo->'%(PackageVersion)')</SharedFxVersion>
-      <_AppRefSubPath>packs\Microsoft.AspNetCore.App.Ref\$(SharedFxVersion)</_AppRefSubPath>
-      <_AppRuntimeSubPath>shared\Microsoft.AspNetCore.App\$(SharedFxVersion)</_AppRuntimeSubPath>
-      <_AppRefPath>$(RepoRoot).dotnet\$(_AppRefSubPath)</_AppRefPath>
-      <_AppRuntimePath>$(RepoRoot).dotnet\$(_AppRuntimeSubPath)</_AppRuntimePath>
+      <_AppRefSubPath>$([System.IO.Path]::Combine('packs', 'Microsoft.AspNetCore.App.Ref', '$(SharedFxVersion)'))</_AppRefSubPath>
+      <_AppRuntimeSubPath>$([System.IO.Path]::Combine('shared', 'Microsoft.AspNetCore.App', '$(SharedFxVersion)'))</_AppRuntimeSubPath>
+      <_AppRefPath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', '.dotnet', '$(_AppRefSubPath)'))</_AppRefPath>
+      <_AppRuntimePath>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', '.dotnet', '$(_AppRuntimeSubPath)'))</_AppRuntimePath>
 
       <!--
         Don't bother checking for App.Runtime layout because we want both and App.Ref project depends on the

--- a/eng/targets/Helix.props
+++ b/eng/targets/Helix.props
@@ -14,8 +14,12 @@
     <LoggingTestingDisableFileLogging Condition="'$(IsHelixJob)' == 'true'">false</LoggingTestingDisableFileLogging>
     <NodeVersion>16.11.0</NodeVersion>
 
-    <!-- Have all tests depend on the latest runtimes until we get a net7.0 SDK -->
-    <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
+    <!--
+      Many tests depend on the .dotnet/ layouts but only a few (those that restore or test packages) require
+      packages. This should be sufficient for most test projects even as we switch to new major versions or TFMs.
+    -->
+    <TestDependsOnAspNetPackages>false</TestDependsOnAspNetPackages>
+    <TestDependsOnAspNetAppPackages>false</TestDependsOnAspNetAppPackages>
     <TestDependsOnAspNetRuntime>true</TestDependsOnAspNetRuntime>
   </PropertyGroup>
 

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -60,12 +60,10 @@
   -->
   <ItemGroup>
     <!-- Grab all shipping packages. -->
-    <HelixContent
-        Include="$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\*$(SharedFxVersion).nupkg"
+    <HelixContent Include="$(ArtifactsShippingPackagesDir)*$(SharedFxVersion).nupkg"
         Condition=" $(TestDependsOnAspNetPackages) "/>
     <!-- Grab just the App.Ref and App.Runtime packages. -->
-    <HelixContent
-        Include="$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\Microsoft.AspNetCore.App.*$(SharedFxVersion).nupkg"
+    <HelixContent Include="$(ArtifactsShippingPackagesDir)Microsoft.AspNetCore.App.*$(SharedFxVersion).nupkg"
         Condition=" $(TestDependsOnAspNetAppPackages) "/>
   </ItemGroup>
 

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -47,13 +47,26 @@
     <HelixPreCommand Include="call RunPowershell.cmd InstallNode.ps1 $(NodeVersion) || exit /b 1" />
   </ItemGroup>
 
-  <!-- $(TestDependsOnAspNetRuntime) implies $(TestDependsOnAspNetPackages). Separate for the App.UnitTests case. -->
-  <PropertyGroup Condition=" $(TestDependsOnAspNetRuntime) AND !$(TestDependsOnAspNetPackages) ">
-    <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
+  <!-- $(TestDependsOnAspNetPackages) implies $(TestDependsOnAspNetRuntime). -->
+  <PropertyGroup Condition=" $(TestDependsOnAspNetPackages) AND !$(TestDependsOnAspNetRuntime) ">
+    <TestDependsOnAspNetRuntime>true</TestDependsOnAspNetRuntime>
   </PropertyGroup>
-  <ItemGroup Condition=" $(TestDependsOnAspNetPackages) ">
+
+  <!--
+    Note wildcards mean work items may be submitted without necessary packages when using RunHelix.ps1. Without
+    the packages, the RunHelix.ps1 build won't fail fast and tests will fail on the Helix agents.
+    Similarly, the artifacts/packages/ folder may contain old packages e.g. some built on
+    another local branch when using RunHelix.ps1, invalidating tests to some extent.
+  -->
+  <ItemGroup>
     <!-- Grab all shipping packages. -->
-    <HelixContent Include="$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\*$(SharedFxVersion).nupkg" />
+    <HelixContent
+        Include="$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\*$(SharedFxVersion).nupkg"
+        Condition=" $(TestDependsOnAspNetPackages) "/>
+    <!-- Grab just the App.Ref and App.Runtime packages. -->
+    <HelixContent
+        Include="$(RepoRoot)artifacts\packages\$(Configuration)\Shipping\Microsoft.AspNetCore.App.*$(SharedFxVersion).nupkg"
+        Condition=" $(TestDependsOnAspNetAppPackages) "/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
+++ b/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
@@ -1,14 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <RootNamespace>Microsoft.AspNetCore</RootNamespace>
     <VerifyAncmBinary Condition="'$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' != 'arm'">true</VerifyAncmBinary>
-    <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
+    <TestDependsOnAspNetAppPackages>true</TestDependsOnAspNetAppPackages>
     <SkipHelixArm>true</SkipHelixArm>
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Grab RuntimeList.xml because it's not placed in the .dotnet/ folder. -->
+    <None Include="$(ArtifactsObjDir)Microsoft.AspNetCore.App.Runtime\RuntimeList.xml"
+        CopyToOutputDirectory="PreserveNewest" />
+
     <!-- Ignore aspnetcorev2_inprocess because tests expect only managed assemblies in this item group. -->
     <_SharedFrameworkBinariesFromRepo Include="@(AspNetCoreAppReference);@(AspNetCoreAppReferenceAndPackage)" />
 
@@ -48,16 +51,12 @@
       <_Parameter2>@(_ExpectedSharedFrameworkBinaries)</_Parameter2>
     </AssemblyAttribute>
     <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
-      <_Parameter1>SharedFrameworkLayoutRoot</_Parameter1>
-      <_Parameter2>$(SharedFrameworkLayoutRoot)</_Parameter2>
-    </AssemblyAttribute>
-    <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
-      <_Parameter1>TargetingPackLayoutRoot</_Parameter1>
-      <_Parameter2>$(TargetingPackLayoutRoot)</_Parameter2>
-    </AssemblyAttribute>
-    <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
       <_Parameter1>VerifyAncmBinary</_Parameter1>
       <_Parameter2>$(VerifyAncmBinary)</_Parameter2>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
+      <_Parameter1>PackagesFolder</_Parameter1>
+      <_Parameter2>$(ArtifactsShippingPackagesDir)</_Parameter2>
     </AssemblyAttribute>
   </ItemGroup>
 
@@ -112,17 +111,6 @@
         <_Parameter1>RepositoryCommit</_Parameter1>
         <_Parameter2>$(SourceRevisionId)</_Parameter2>
       </AssemblyAttribute>
-
-      <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
-        <_Parameter1>RuntimePackageVersion</_Parameter1>
-        <_Parameter2>$(SharedFxVersion)</_Parameter2>
-      </AssemblyAttribute>
-
-      <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">
-        <_Parameter1>TargetingPackVersion</_Parameter1>
-        <_Parameter2>$(TargetingPackVersion)</_Parameter2>
-      </AssemblyAttribute>
     </ItemGroup>
   </Target>
-
 </Project>

--- a/src/Framework/test/TestData.cs
+++ b/src/Framework/test/TestData.cs
@@ -310,8 +310,10 @@ public static class TestData
 
     public static string GetAspNetCoreTargetingPackDependencies() => GetTestDataValue("AspNetCoreTargetingPackDependencies");
 
+    public static string GetPackagesFolder() => GetTestDataValue("PackagesFolder");
+
     public static bool VerifyAncmBinary() => string.Equals(GetTestDataValue("VerifyAncmBinary"), "true", StringComparison.OrdinalIgnoreCase);
 
-    public static string GetTestDataValue(string key)
+    private static string GetTestDataValue(string key)
          => typeof(TestData).Assembly.GetCustomAttributes<TestDataAttribute>().Single(d => d.Key == key).Value;
 }

--- a/src/Grpc/test/InteropTests/InteropTests.csproj
+++ b/src/Grpc/test/InteropTests/InteropTests.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <ContainsFunctionalTestAssets>true</ContainsFunctionalTestAssets>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
-    <TestDependsOnAspNetRuntime>true</TestDependsOnAspNetRuntime>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplates.Tests.csproj
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplates.Tests.csproj
@@ -16,7 +16,7 @@
     <!-- TestTemplateCreationFolder is the folder where the templates will be created. Will point out to $(OutputDir)$(TestTemplateCreationFolder) -->
     <TestTemplateCreationFolder>TestTemplates\</TestTemplateCreationFolder>
     <TestPackageRestorePath>$([MSBuild]::EnsureTrailingSlash('$(RepoRoot)'))obj\template-restore\</TestPackageRestorePath>
-    <TestDependsOnAspNetRuntime>true</TestDependsOnAspNetRuntime>
+    <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
     <TestDependsOnMssql>true</TestDependsOnMssql>
     <TestDependsOnPlaywright>true</TestDependsOnPlaywright>
   </PropertyGroup>

--- a/src/ProjectTemplates/test/ProjectTemplates.Tests.csproj
+++ b/src/ProjectTemplates/test/ProjectTemplates.Tests.csproj
@@ -18,7 +18,7 @@
     <!-- TestTemplateCreationFolder is the folder where the templates will be created. Will point out to $(OutputDir)$(TestTemplateCreationFolder) -->
     <TestTemplateCreationFolder>TestTemplates\</TestTemplateCreationFolder>
     <TestPackageRestorePath>$([MSBuild]::EnsureTrailingSlash('$(RepoRoot)'))obj\template-restore\</TestPackageRestorePath>
-    <TestDependsOnAspNetRuntime>true</TestDependsOnAspNetRuntime>
+    <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SignalR/clients/ts/client-ts.npmproj
+++ b/src/SignalR/clients/ts/client-ts.npmproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <IsUnitTestProject>true</IsUnitTestProject>
     <TestDependsOnAspNetRuntime>false</TestDependsOnAspNetRuntime>
-    <TestDependsOnAspNetPackages>false</TestDependsOnAspNetPackages>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />


### PR DESCRIPTION
- use .dotnet/ folders instead of App.Ref/App.Runtime packages for dotnet-cli layouts
  - no need to unzip files into another layout
  - fail fast or emit message when layouts don't exist
- set `$(TestDependsOnAspNetPackages)` to `false` by default
  - no need to copy all packages into publish/ folders of most test projects
    - upload very few times per queue (2 today, maybe 4 in the future), not for _every_ work item
    - reduce the size of most work item payloads, saving bandwidth and time
    - reduction should not cause problems, even around major version and TFM changes (see .dotnet/ folders)
  - add `$(TestDependsOnAspNetAppPackages)` for the App.UnitTests case; just 2 packages needed there
- get App.UnitTests working in local builds
  - grab RuntimeList.xml file from App.Runtime's obj/ folder
  - find needed packages whether running locally or on Helix agents; should always exist

nits:
- remove test infrastructure we don't need anymore
  - use one property for shared Fx and targeting pack versions; always the same
  - remove `$env:ASPNET_RUNTIME_PATH`
- rename silly ...ListListsContains... tests
- remove extra `$(TestDependsOnAspNetXyz)` settings to their new default values
- add more comments