### PR TITLE
RenderTreeDiffBuilder – components after components with @key are oft…

### DIFF
--- a/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
+++ b/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
@@ -143,6 +143,11 @@ internal static class RenderTreeDiffBuilder
                             // If we've run out of new items, we must be looking at just an old item, so delete it
                             action = DiffAction.Delete;
                         }
+                        else if (!oldKeyIsInNewTree && (newKey == null))
+                        {
+                            // If the old key not in the tree anymore we prefer deletion of the old element (the following elements will not be recreated and won't lost their state).
+                            action = DiffAction.Delete;
+                        }
                         else
                         {
                             // It's an insertion or a deletion, or both

--- a/src/Components/Components/test/RenderTreeDiffBuilderTest.cs
+++ b/src/Components/Components/test/RenderTreeDiffBuilderTest.cs
@@ -284,6 +284,38 @@ public class RenderTreeDiffBuilderTest : IDisposable
     }
 
     [Fact]
+    public void RecognizesKeyedComponentDeletionsBeforeUnchangedNonKeyedComponent()
+    {
+        // Arrange
+        oldTree.OpenComponent<FakeComponent>(0);
+        oldTree.SetKey("will delete");
+        oldTree.AddAttribute(1, nameof(FakeComponent.StringProperty), "Will delete");
+        oldTree.CloseComponent();
+
+        oldTree.OpenComponent<FakeComponent>(2);
+        oldTree.AddAttribute(3, nameof(FakeComponent.StringProperty), "Retained param value");
+        oldTree.CloseComponent();
+
+        // Instantiate initial components
+        using var initial = new RenderTreeBuilder();
+        GetRenderedBatch(initial, oldTree, false);
+        var oldComponents = GetComponents(oldTree);
+
+        newTree.OpenComponent<FakeComponent>(2);
+        newTree.AddAttribute(3, nameof(FakeComponent.StringProperty), "Retained param value");
+        newTree.CloseComponent();
+
+        // Act
+        var (result, referenceFrames) = GetSingleUpdatedComponent();
+        var newComponent = GetComponents(newTree).Single();
+
+        // Assert
+        Assert.Same(oldComponents[1], newComponent);
+        Assert.Collection(result.Edits,
+            entry => AssertEdit(entry, RenderTreeEditType.RemoveFrame, 0));
+    }
+
+    [Fact]
     public void RecognizesSimultaneousKeyedComponentInsertionsAndDeletions()
     {
         // Arrange
@@ -485,9 +517,9 @@ public class RenderTreeDiffBuilderTest : IDisposable
         // Assert
         Assert.Collection(result.Edits,
             // Insert new
-            edit => AssertEdit(edit, RenderTreeEditType.PrependFrame, 0),
+            edit => AssertEdit(edit, RenderTreeEditType.RemoveFrame, 0),
             // Delete old
-            edit => AssertEdit(edit, RenderTreeEditType.RemoveFrame, 1));
+            edit => AssertEdit(edit, RenderTreeEditType.PrependFrame, 0));
     }
 
     [Fact]


### PR DESCRIPTION
Modified RenderTreeDiffBuilder to prefer Delete operation before Insert operation

* Modified RenderTreeDiffBuilder to prefer Delete operation before Insert operation when frame with key is removed
* This allows the further components to not be recreated -> so they do not loose the state
* Performance degradation by 0.6% in the RenderTreeDiffBuilder (meassured changes on 6.0.2)
* Savings in not recreating elements not measured.

Fixes #39053
