### PR TITLE
Add ReaderThrowsResetExceptionOnInvalidBody to retry

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -9,6 +9,7 @@
     {"testName": {"contains": "ServerShutsDownWhenMainExitsStress" }},
     {"testName": {"contains": "AddressRegistrationTests" }},
     {"testName": {"contains": "MaxRequestBufferSizeTests.LargeUpload" }},
+    {"testName": {"contains": "ReaderThrowsResetExceptionOnInvalidBody" }},
     {"failureMessage": "network disconnected" }
   ],
   "failOnRules": [


### PR DESCRIPTION
Based on https://github.com/dotnet/aspnetcore/pull/39659#issuecomment-1018747153, adding ReaderThrowsResetExceptionOnInvalidBody to the helix retry list as it's been failing outside of quarantine
