### PR TITLE
Improve IIS tests

### DIFF
--- a/eng/targets/Helix.props
+++ b/eng/targets/Helix.props
@@ -9,7 +9,7 @@
   </ItemDefinitionGroup>
 
   <PropertyGroup>
-    <HelixTimeout>00:30:00</HelixTimeout>
+    <HelixTimeout>00:45:00</HelixTimeout>
     <HelixTestName>$(MSBuildProjectName)--$(TargetFramework)</HelixTestName>
     <LoggingTestingDisableFileLogging Condition="'$(IsHelixJob)' == 'true'">false</LoggingTestingDisableFileLogging>
     <NodeVersion>16.11.0</NodeVersion>

--- a/src/Servers/IIS/IIS/test/IIS.FunctionalTests/Http2TrailersResetTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.FunctionalTests/Http2TrailersResetTests.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http2Cat;
+using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Server.IntegrationTesting.Common;
 using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
@@ -24,7 +25,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 /// on IIS Express even on the new Windows versions because IIS Express has its own outdated copy of IIS.
 /// </summary>
 [Collection(IISHttpsTestSiteCollection.Name)]
-public class Http2TrailerResetTests
+public class Http2TrailerResetTests : FunctionalTestsBase
 {
     private const string WindowsVersionForTrailers = "10.0.20238";
 

--- a/src/Servers/IIS/IIS/test/IIS.FunctionalTests/Http3Tests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.FunctionalTests/Http3Tests.cs
@@ -11,6 +11,7 @@ using System.Net.Quic;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 using Microsoft.AspNetCore.Server.IntegrationTesting.Common;
 using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
@@ -26,7 +27,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 [MsQuicSupported]
 [HttpSysHttp3Supported]
 [Collection(IISHttpsTestSiteCollection.Name)]
-public class Http3Tests
+public class Http3Tests : FunctionalTestsBase
 {
     public Http3Tests(IISTestSiteFixture fixture)
     {


### PR DESCRIPTION
Couple IIS tests aren't creating logs, there is a test failure with Reset_DuringRequestBody_Resets but there is no info about it because of the lack of logs.

Also, increasing Helix timeout, IIS.NewHandler.FunctionalTests have been hitting the timeout occasionally (averaging 14 minutes but sometimes it is slower).