### PR TITLE
GenerateDisplay doc: what is additionalViewData

### DIFF
--- a/src/Mvc/Mvc.ViewFeatures/src/HtmlHelper.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/HtmlHelper.cs
@@ -512,7 +512,7 @@ public class HtmlHelper : IHtmlHelper, IViewContextAware
     /// <param name="modelExplorer">The <see cref="ModelExplorer"/>.</param>
     /// <param name="htmlFieldName">The name of the html field.</param>
     /// <param name="templateName">The name of the template.</param>
-    /// <param name="additionalViewData">The additional view data.</param>
+    /// <param name="additionalViewData">The additional view data, either an <see cref="IDictionary{String, Object}"/> or some other object whose public properties will be merged with the <see cref="T:ViewDataDictionary" />.</param>
     /// <returns><see cref="IHtmlContent"/>.</returns>
     protected virtual IHtmlContent GenerateDisplay(
         ModelExplorer modelExplorer,


### PR DESCRIPTION
# [GenerateDisplay](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.viewfeatures.htmlhelper.generatedisplay#microsoft-aspnetcore-mvc-viewfeatures-htmlhelper-generatedisplay(microsoft-aspnetcore-mvc-viewfeatures-modelexplorer-system-string-system-string-system-object)) doc: what `additionalViewData` is

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Since I we do not want to reference [ObjectToDictionary](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.viewfeatures.htmlhelper.objecttodictionary#microsoft-aspnetcore-mvc-viewfeatures-htmlhelper-objecttodictionary(system-object)), we need to tell the reader how the parameter `additionalViewData` will be interpreted.
