### PR TITLE
Allow custom cookie consent value

### DIFF
--- a/src/Security/CookiePolicy/src/CookiePolicyOptions.cs
+++ b/src/Security/CookiePolicy/src/CookiePolicyOptions.cs
@@ -11,6 +11,8 @@ namespace Microsoft.AspNetCore.Builder;
 /// </summary>
 public class CookiePolicyOptions
 {
+    private string _consentCookieValue = "yes";
+
     /// <summary>
     /// Affects the cookie's same site attribute.
     /// </summary>
@@ -42,7 +44,18 @@ public class CookiePolicyOptions
     /// cookie use policy.
     /// </summary>
     /// <value>Defaults to <c>yes</c>.</value>
-    public string ConsentCookieValue { get; set; } = "yes";
+    public string ConsentCookieValue
+    {
+        get => _consentCookieValue;
+        set
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                throw new ArgumentException("Value cannot be null or empty string.", nameof(value));
+            }
+            _consentCookieValue = value;
+        }
+    }
 
     /// <summary>
     /// Checks if consent policies should be evaluated on this request. The default is false.

--- a/src/Security/CookiePolicy/src/CookiePolicyOptions.cs
+++ b/src/Security/CookiePolicy/src/CookiePolicyOptions.cs
@@ -38,6 +38,12 @@ public class CookiePolicyOptions
     };
 
     /// <summary>
+    /// Gets or sets the consent value that is used to track if the user consented to the
+    /// cookie use policy. The default is yes.
+    /// </summary>
+    public string ConsentCookieValue { get; set; } = "yes";
+
+    /// <summary>
     /// Checks if consent policies should be evaluated on this request. The default is false.
     /// </summary>
     public Func<HttpContext, bool>? CheckConsentNeeded { get; set; }

--- a/src/Security/CookiePolicy/src/CookiePolicyOptions.cs
+++ b/src/Security/CookiePolicy/src/CookiePolicyOptions.cs
@@ -38,9 +38,10 @@ public class CookiePolicyOptions
     };
 
     /// <summary>
-    /// Gets or sets the consent value that is used to track if the user consented to the
-    /// cookie use policy. The default is yes.
+    /// Gets or sets the value for the cookie used to track if the user consented to the
+    /// cookie use policy.
     /// </summary>
+    /// <value>Defaults to <c>yes</c>.</value>
     public string ConsentCookieValue { get; set; } = "yes";
 
     /// <summary>

--- a/src/Security/CookiePolicy/src/PublicAPI.Shipped.txt
+++ b/src/Security/CookiePolicy/src/PublicAPI.Shipped.txt
@@ -7,8 +7,6 @@ Microsoft.AspNetCore.Builder.CookiePolicyOptions.CheckConsentNeeded.get -> Syste
 Microsoft.AspNetCore.Builder.CookiePolicyOptions.CheckConsentNeeded.set -> void
 Microsoft.AspNetCore.Builder.CookiePolicyOptions.ConsentCookie.get -> Microsoft.AspNetCore.Http.CookieBuilder!
 Microsoft.AspNetCore.Builder.CookiePolicyOptions.ConsentCookie.set -> void
-Microsoft.AspNetCore.Builder.CookiePolicyOptions.ConsentCookieValue.get -> string!
-Microsoft.AspNetCore.Builder.CookiePolicyOptions.ConsentCookieValue.set -> void
 Microsoft.AspNetCore.Builder.CookiePolicyOptions.CookiePolicyOptions() -> void
 Microsoft.AspNetCore.Builder.CookiePolicyOptions.HttpOnly.get -> Microsoft.AspNetCore.CookiePolicy.HttpOnlyPolicy
 Microsoft.AspNetCore.Builder.CookiePolicyOptions.HttpOnly.set -> void

--- a/src/Security/CookiePolicy/src/PublicAPI.Shipped.txt
+++ b/src/Security/CookiePolicy/src/PublicAPI.Shipped.txt
@@ -7,6 +7,8 @@ Microsoft.AspNetCore.Builder.CookiePolicyOptions.CheckConsentNeeded.get -> Syste
 Microsoft.AspNetCore.Builder.CookiePolicyOptions.CheckConsentNeeded.set -> void
 Microsoft.AspNetCore.Builder.CookiePolicyOptions.ConsentCookie.get -> Microsoft.AspNetCore.Http.CookieBuilder!
 Microsoft.AspNetCore.Builder.CookiePolicyOptions.ConsentCookie.set -> void
+Microsoft.AspNetCore.Builder.CookiePolicyOptions.ConsentCookieValue.get -> string!
+Microsoft.AspNetCore.Builder.CookiePolicyOptions.ConsentCookieValue.set -> void
 Microsoft.AspNetCore.Builder.CookiePolicyOptions.CookiePolicyOptions() -> void
 Microsoft.AspNetCore.Builder.CookiePolicyOptions.HttpOnly.get -> Microsoft.AspNetCore.CookiePolicy.HttpOnlyPolicy
 Microsoft.AspNetCore.Builder.CookiePolicyOptions.HttpOnly.set -> void

--- a/src/Security/CookiePolicy/src/PublicAPI.Unshipped.txt
+++ b/src/Security/CookiePolicy/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Builder.CookiePolicyOptions.ConsentCookieValue.get -> string!
+Microsoft.AspNetCore.Builder.CookiePolicyOptions.ConsentCookieValue.set -> void

--- a/src/Security/CookiePolicy/src/ResponseCookiesWrapper.cs
+++ b/src/Security/CookiePolicy/src/ResponseCookiesWrapper.cs
@@ -12,7 +12,6 @@ namespace Microsoft.AspNetCore.CookiePolicy;
 
 internal class ResponseCookiesWrapper : IResponseCookies, ITrackingConsentFeature
 {
-    private const string DefaultConsentValue = "yes";
     private readonly ILogger _logger;
     private bool? _isConsentNeeded;
     private bool? _hasConsent;

--- a/src/Security/CookiePolicy/src/ResponseCookiesWrapper.cs
+++ b/src/Security/CookiePolicy/src/ResponseCookiesWrapper.cs
@@ -23,11 +23,6 @@ internal class ResponseCookiesWrapper : IResponseCookies, ITrackingConsentFeatur
         Feature = feature;
         Options = options;
         _logger = logger;
-
-        if (string.IsNullOrWhiteSpace(Options.ConsentCookieValue))
-        {
-            Options.ConsentCookieValue = DefaultConsentValue;
-        }
     }
 
     private HttpContext Context { get; }

--- a/src/Security/CookiePolicy/src/ResponseCookiesWrapper.cs
+++ b/src/Security/CookiePolicy/src/ResponseCookiesWrapper.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.CookiePolicy;
 
 internal class ResponseCookiesWrapper : IResponseCookies, ITrackingConsentFeature
 {
-    private const string ConsentValue = "yes";
+    private const string DefaultConsentValue = "yes";
     private readonly ILogger _logger;
     private bool? _isConsentNeeded;
     private bool? _hasConsent;
@@ -23,6 +23,11 @@ internal class ResponseCookiesWrapper : IResponseCookies, ITrackingConsentFeatur
         Feature = feature;
         Options = options;
         _logger = logger;
+
+        if (string.IsNullOrWhiteSpace(Options.ConsentCookieValue))
+        {
+            Options.ConsentCookieValue = DefaultConsentValue;
+        }
     }
 
     private HttpContext Context { get; }
@@ -55,7 +60,7 @@ internal class ResponseCookiesWrapper : IResponseCookies, ITrackingConsentFeatur
             if (!_hasConsent.HasValue)
             {
                 var cookie = Context.Request.Cookies[Options.ConsentCookie.Name!];
-                _hasConsent = string.Equals(cookie, ConsentValue, StringComparison.Ordinal);
+                _hasConsent = string.Equals(cookie, Options.ConsentCookieValue, StringComparison.Ordinal);
                 _logger.HasConsent(_hasConsent.Value);
             }
 
@@ -71,7 +76,7 @@ internal class ResponseCookiesWrapper : IResponseCookies, ITrackingConsentFeatur
         {
             var cookieOptions = Options.ConsentCookie.Build(Context);
             // Note policy will be applied. We don't want to bypass policy because we want HttpOnly, Secure, etc. to apply.
-            Append(Options.ConsentCookie.Name!, ConsentValue, cookieOptions);
+            Append(Options.ConsentCookie.Name!, Options.ConsentCookieValue, cookieOptions);
             _logger.ConsentGranted();
         }
         _hasConsent = true;
@@ -93,7 +98,7 @@ internal class ResponseCookiesWrapper : IResponseCookies, ITrackingConsentFeatur
     public string CreateConsentCookie()
     {
         var key = Options.ConsentCookie.Name;
-        var value = ConsentValue;
+        var value = Options.ConsentCookieValue;
         var options = Options.ConsentCookie.Build(Context);
 
         Debug.Assert(key != null);

--- a/src/Security/CookiePolicy/test/CookieConsentTests.cs
+++ b/src/Security/CookiePolicy/test/CookieConsentTests.cs
@@ -683,51 +683,6 @@ public class CookieConsentTests
         Assert.NotNull(manualCookie.Expires); // Expires may not exactly match to the second.
     }
 
-    [Fact]
-    public async Task CreateConsentCookieMatchesGrantConsentCookieWhenCookieValueIsMissing()
-    {
-        var httpContext = await RunTestAsync(options =>
-        {
-            options.CheckConsentNeeded = context => true;
-            options.ConsentCookieValue = "";
-        },
-        requestContext => { },
-        context =>
-        {
-            var feature = context.Features.Get<ITrackingConsentFeature>();
-            Assert.True(feature.IsConsentNeeded);
-            Assert.False(feature.HasConsent);
-            Assert.False(feature.CanTrack);
-
-            feature.GrantConsent();
-
-            Assert.True(feature.IsConsentNeeded);
-            Assert.True(feature.HasConsent);
-            Assert.True(feature.CanTrack);
-
-            var cookie = feature.CreateConsentCookie();
-            context.Response.Headers["ManualCookie"] = cookie;
-
-            return Task.CompletedTask;
-        });
-
-        var cookies = SetCookieHeaderValue.ParseList(httpContext.Response.Headers.SetCookie);
-        Assert.Equal(1, cookies.Count);
-        var consentCookie = cookies[0];
-        Assert.Equal(".AspNet.Consent", consentCookie.Name);
-        Assert.Equal("yes", consentCookie.Value);
-        Assert.Equal(Net.Http.Headers.SameSiteMode.Unspecified, consentCookie.SameSite);
-        Assert.NotNull(consentCookie.Expires);
-
-        cookies = SetCookieHeaderValue.ParseList(httpContext.Response.Headers["ManualCookie"]);
-        Assert.Equal(1, cookies.Count);
-        var manualCookie = cookies[0];
-        Assert.Equal(consentCookie.Name, manualCookie.Name);
-        Assert.Equal(consentCookie.Value, manualCookie.Value);
-        Assert.Equal(consentCookie.SameSite, manualCookie.SameSite);
-        Assert.NotNull(manualCookie.Expires); // Expires may not exactly match to the second.
-    }
-
     private async Task<HttpContext> RunTestAsync(Action<CookiePolicyOptions> configureOptions, Action<HttpContext> configureRequest, RequestDelegate handleRequest)
     {
         var host = new HostBuilder()

--- a/src/Security/CookiePolicy/test/CookieConsentTests.cs
+++ b/src/Security/CookiePolicy/test/CookieConsentTests.cs
@@ -691,7 +691,7 @@ public class CookieConsentTests
     {
         var options = new CookiePolicyOptions();
 
-        ExceptionAssert.ThrowsArgument<ArgumentException>(
+        ExceptionAssert.ThrowsArgument(
             () => options.ConsentCookieValue = value,
             "value",
             "Value cannot be null or empty string.");

--- a/src/Security/CookiePolicy/test/CookieConsentTests.cs
+++ b/src/Security/CookiePolicy/test/CookieConsentTests.cs
@@ -683,6 +683,17 @@ public class CookieConsentTests
         Assert.NotNull(manualCookie.Expires); // Expires may not exactly match to the second.
     }
 
+    [Fact]
+    public void CreateCookiePolicyOptionsWithEmptyConsentCookieValueThrows()
+    {
+        var options = new CookiePolicyOptions();
+
+        var exceptionWhenEmpty = Assert.Throws<ArgumentException>(() => options.ConsentCookieValue = "");
+        var exceptionWhenNull = Assert.Throws<ArgumentException>(() => options.ConsentCookieValue = null);
+        Assert.Equal("Value cannot be null or empty string. (Parameter 'value')", exceptionWhenEmpty.Message);
+        Assert.Equal("Value cannot be null or empty string. (Parameter 'value')", exceptionWhenNull.Message);
+    }
+
     private async Task<HttpContext> RunTestAsync(Action<CookiePolicyOptions> configureOptions, Action<HttpContext> configureRequest, RequestDelegate handleRequest)
     {
         var host = new HostBuilder()

--- a/src/Security/CookiePolicy/test/CookieConsentTests.cs
+++ b/src/Security/CookiePolicy/test/CookieConsentTests.cs
@@ -638,6 +638,96 @@ public class CookieConsentTests
         Assert.NotNull(manualCookie.Expires); // Expires may not exactly match to the second.
     }
 
+    [Fact]
+    public async Task CreateConsentCookieMatchesGrantConsentCookieWhenCookieValueIsCustom()
+    {
+        var httpContext = await RunTestAsync(options =>
+        {
+            options.CheckConsentNeeded = context => true;
+            options.ConsentCookieValue = "true";
+        },
+        requestContext => { },
+        context =>
+        {
+            var feature = context.Features.Get<ITrackingConsentFeature>();
+            Assert.True(feature.IsConsentNeeded);
+            Assert.False(feature.HasConsent);
+            Assert.False(feature.CanTrack);
+
+            feature.GrantConsent();
+
+            Assert.True(feature.IsConsentNeeded);
+            Assert.True(feature.HasConsent);
+            Assert.True(feature.CanTrack);
+
+            var cookie = feature.CreateConsentCookie();
+            context.Response.Headers["ManualCookie"] = cookie;
+
+            return Task.CompletedTask;
+        });
+
+        var cookies = SetCookieHeaderValue.ParseList(httpContext.Response.Headers.SetCookie);
+        Assert.Equal(1, cookies.Count);
+        var consentCookie = cookies[0];
+        Assert.Equal(".AspNet.Consent", consentCookie.Name);
+        Assert.Equal("true", consentCookie.Value);
+        Assert.Equal(Net.Http.Headers.SameSiteMode.Unspecified, consentCookie.SameSite);
+        Assert.NotNull(consentCookie.Expires);
+
+        cookies = SetCookieHeaderValue.ParseList(httpContext.Response.Headers["ManualCookie"]);
+        Assert.Equal(1, cookies.Count);
+        var manualCookie = cookies[0];
+        Assert.Equal(consentCookie.Name, manualCookie.Name);
+        Assert.Equal(consentCookie.Value, manualCookie.Value);
+        Assert.Equal(consentCookie.SameSite, manualCookie.SameSite);
+        Assert.NotNull(manualCookie.Expires); // Expires may not exactly match to the second.
+    }
+
+    [Fact]
+    public async Task CreateConsentCookieMatchesGrantConsentCookieWhenCookieValueIsMissing()
+    {
+        var httpContext = await RunTestAsync(options =>
+        {
+            options.CheckConsentNeeded = context => true;
+            options.ConsentCookieValue = "";
+        },
+        requestContext => { },
+        context =>
+        {
+            var feature = context.Features.Get<ITrackingConsentFeature>();
+            Assert.True(feature.IsConsentNeeded);
+            Assert.False(feature.HasConsent);
+            Assert.False(feature.CanTrack);
+
+            feature.GrantConsent();
+
+            Assert.True(feature.IsConsentNeeded);
+            Assert.True(feature.HasConsent);
+            Assert.True(feature.CanTrack);
+
+            var cookie = feature.CreateConsentCookie();
+            context.Response.Headers["ManualCookie"] = cookie;
+
+            return Task.CompletedTask;
+        });
+
+        var cookies = SetCookieHeaderValue.ParseList(httpContext.Response.Headers.SetCookie);
+        Assert.Equal(1, cookies.Count);
+        var consentCookie = cookies[0];
+        Assert.Equal(".AspNet.Consent", consentCookie.Name);
+        Assert.Equal("yes", consentCookie.Value);
+        Assert.Equal(Net.Http.Headers.SameSiteMode.Unspecified, consentCookie.SameSite);
+        Assert.NotNull(consentCookie.Expires);
+
+        cookies = SetCookieHeaderValue.ParseList(httpContext.Response.Headers["ManualCookie"]);
+        Assert.Equal(1, cookies.Count);
+        var manualCookie = cookies[0];
+        Assert.Equal(consentCookie.Name, manualCookie.Name);
+        Assert.Equal(consentCookie.Value, manualCookie.Value);
+        Assert.Equal(consentCookie.SameSite, manualCookie.SameSite);
+        Assert.NotNull(manualCookie.Expires); // Expires may not exactly match to the second.
+    }
+
     private async Task<HttpContext> RunTestAsync(Action<CookiePolicyOptions> configureOptions, Action<HttpContext> configureRequest, RequestDelegate handleRequest)
     {
         var host = new HostBuilder()

--- a/src/Security/CookiePolicy/test/CookieConsentTests.cs
+++ b/src/Security/CookiePolicy/test/CookieConsentTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Net.Http.Headers;
@@ -683,15 +684,17 @@ public class CookieConsentTests
         Assert.NotNull(manualCookie.Expires); // Expires may not exactly match to the second.
     }
 
-    [Fact]
-    public void CreateCookiePolicyOptionsWithEmptyConsentCookieValueThrows()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void CreateCookiePolicyOptionsWithEmptyConsentCookieValueThrows(string value)
     {
         var options = new CookiePolicyOptions();
 
-        var exceptionWhenEmpty = Assert.Throws<ArgumentException>(() => options.ConsentCookieValue = "");
-        var exceptionWhenNull = Assert.Throws<ArgumentException>(() => options.ConsentCookieValue = null);
-        Assert.Equal("Value cannot be null or empty string. (Parameter 'value')", exceptionWhenEmpty.Message);
-        Assert.Equal("Value cannot be null or empty string. (Parameter 'value')", exceptionWhenNull.Message);
+        ExceptionAssert.ThrowsArgument<ArgumentException>(
+            () => options.ConsentCookieValue = value,
+            "value",
+            "Value cannot be null or empty string.");
     }
 
     private async Task<HttpContext> RunTestAsync(Action<CookiePolicyOptions> configureOptions, Action<HttpContext> configureRequest, RequestDelegate handleRequest)


### PR DESCRIPTION
# Allow customizing the cookie consent value

Allows setting a custom value for the cookie consent.

## Description

Currently, the cookie consent validation performs an equality comparison against the constant cookie value `yes`. It will add more flexibility if the value can be customized, especially when supporting an already existing cookie consent.

Fixes #40164
