### PR TITLE
In diffing, optimize unkeyed frames after keyed frames

### DIFF
--- a/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
+++ b/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
@@ -143,6 +143,11 @@ internal static class RenderTreeDiffBuilder
                             // If we've run out of new items, we must be looking at just an old item, so delete it
                             action = DiffAction.Delete;
                         }
+                        else if (!oldKeyIsInNewTree && (newKey == null))
+                        {
+                            // If the old key not in the tree anymore we prefer deletion of the old element (the following elements will not be recreated and won't lost their state).
+                            action = DiffAction.Delete;
+                        }
                         else
                         {
                             // It's an insertion or a deletion, or both

--- a/src/Components/Components/test/RenderTreeDiffBuilderTest.cs
+++ b/src/Components/Components/test/RenderTreeDiffBuilderTest.cs
@@ -284,6 +284,38 @@ public class RenderTreeDiffBuilderTest : IDisposable
     }
 
     [Fact]
+    public void RecognizesKeyedComponentDeletionsBeforeUnchangedNonKeyedComponent()
+    {
+        // Arrange
+        oldTree.OpenComponent<FakeComponent>(0);
+        oldTree.SetKey("will delete");
+        oldTree.AddAttribute(1, nameof(FakeComponent.StringProperty), "Will delete");
+        oldTree.CloseComponent();
+
+        oldTree.OpenComponent<FakeComponent>(2);
+        oldTree.AddAttribute(3, nameof(FakeComponent.StringProperty), "Retained param value");
+        oldTree.CloseComponent();
+
+        // Instantiate initial components
+        using var initial = new RenderTreeBuilder();
+        GetRenderedBatch(initial, oldTree, false);
+        var oldComponents = GetComponents(oldTree);
+
+        newTree.OpenComponent<FakeComponent>(2);
+        newTree.AddAttribute(3, nameof(FakeComponent.StringProperty), "Retained param value");
+        newTree.CloseComponent();
+
+        // Act
+        var (result, referenceFrames) = GetSingleUpdatedComponent();
+        var newComponent = GetComponents(newTree).Single();
+
+        // Assert
+        Assert.Same(oldComponents[1], newComponent);
+        Assert.Collection(result.Edits,
+            entry => AssertEdit(entry, RenderTreeEditType.RemoveFrame, 0));
+    }
+
+    [Fact]
     public void RecognizesSimultaneousKeyedComponentInsertionsAndDeletions()
     {
         // Arrange
@@ -485,9 +517,9 @@ public class RenderTreeDiffBuilderTest : IDisposable
         // Assert
         Assert.Collection(result.Edits,
             // Insert new
-            edit => AssertEdit(edit, RenderTreeEditType.PrependFrame, 0),
+            edit => AssertEdit(edit, RenderTreeEditType.RemoveFrame, 0),
             // Delete old
-            edit => AssertEdit(edit, RenderTreeEditType.RemoveFrame, 1));
+            edit => AssertEdit(edit, RenderTreeEditType.PrependFrame, 0));
     }
 
     [Fact]


### PR DESCRIPTION
This is a continuation of https://github.com/dotnet/aspnetcore/pull/40142, retaining the commit from @jirikanda.

Previously, the diffing system handled unkeyed-after-keyed frames in a legal way, but the diff output was suboptimal as it didn't retain the unkeyed components as often as it could. The PR #40142 improves the diffing output in this case.

After seeing the change in #40142, I found it hard to reason about why it was correct, as the new condition looked fairly arbitrary to me and I couldn't immediately intuit why we only wanted to check for this situation when it comes to deletions and not for insertions. I added another unit test for the insertion case and observed that the #40142 logic produced an optimal result, but it still wasn't obvious why we'd have this asymmetry in the logic.

To make this more maintainable in the future, I've broken up the key-based diffing logic in a different way. This is a lot more explicit now, has comments explaining each of the decisions, and turns out to be more symmetrical across both insertion and deletion. It also involves one fewer check at runtime, since several of the cases coalesce into an identical criterion.

I'm not saying it's easy to understand now, because there's still a lot going on, but I've spent hours thinking about how best to express this in code for human readability and it's the clearest I've got to.