### PR TITLE
Ensure `AccessToken` is not trimmed away

### DIFF
--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Services/RemoteAuthenticationService.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Services/RemoteAuthenticationService.cs
@@ -165,6 +165,7 @@ public class RemoteAuthenticationService<
     }
 
     /// <inheritdoc />
+    [DynamicDependency(JsonSerialized, typeof(AccessToken))]
     [DynamicDependency(JsonSerialized, typeof(AccessTokenRequestOptions))]
     public virtual async ValueTask<AccessTokenResult> RequestAccessToken(AccessTokenRequestOptions options)
     {
@@ -243,7 +244,6 @@ public class RemoteAuthenticationService<
 }
 
 // Internal for testing purposes
-[DynamicDependency(JsonSerialized, typeof(AccessToken))]
 internal struct InternalAccessTokenResult
 {
     public string Status { get; set; }

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Services/RemoteAuthenticationService.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Services/RemoteAuthenticationService.cs
@@ -165,7 +165,6 @@ public class RemoteAuthenticationService<
     }
 
     /// <inheritdoc />
-    [DynamicDependency(JsonSerialized, typeof(AccessToken))]
     [DynamicDependency(JsonSerialized, typeof(AccessTokenRequestOptions))]
     public virtual async ValueTask<AccessTokenResult> RequestAccessToken(AccessTokenRequestOptions options)
     {
@@ -244,6 +243,7 @@ public class RemoteAuthenticationService<
 }
 
 // Internal for testing purposes
+[DynamicDependency(JsonSerialized, typeof(AccessToken))]
 internal struct InternalAccessTokenResult
 {
     public string Status { get; set; }

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Services/RemoteAuthenticationService.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Services/RemoteAuthenticationService.cs
@@ -165,6 +165,7 @@ public class RemoteAuthenticationService<
     }
 
     /// <inheritdoc />
+    [DynamicDependency(JsonSerialized, typeof(AccessToken))]
     [DynamicDependency(JsonSerialized, typeof(AccessTokenRequestOptions))]
     public virtual async ValueTask<AccessTokenResult> RequestAccessToken(AccessTokenRequestOptions options)
     {


### PR DESCRIPTION
Fixes: https://github.com/aspnet/AspNetCore-ManualTests/issues/1182

Likely a result of https://github.com/dotnet/aspnetcore/pull/39838

<details>

```
crit: Microsoft.AspNetCore.Components.WebAssembly.Rendering.WebAssemblyRenderer[100]
      Unhandled exception rendering component: An exception occurred executing JS interop: DeserializeNoConstructor, JsonConstructorAttribute, Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken Path: $.token | LineNumber: 0 | BytePositionInLine: 29.. See InnerException for more details.
Microsoft.JSInterop.JSException: An exception occurred executing JS interop: DeserializeNoConstructor, JsonConstructorAttribute, Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken Path: $.token | LineNumber: 0 | BytePositionInLine: 29.. See InnerException for more details.
 ---> System.NotSupportedException: DeserializeNoConstructor, JsonConstructorAttribute, Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken Path: $.token | LineNumber: 0 | BytePositionInLine: 29.
 ---> System.NotSupportedException: DeserializeNoConstructor, JsonConstructorAttribute, Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken
   Exception_EndOfInnerExceptionStack
   at System.Text.Json.ThrowHelper.ThrowNotSupportedException(ReadStack& , Utf8JsonReader& , NotSupportedException )
   at System.Text.Json.ThrowHelper.ThrowNotSupportedException_DeserializeNoConstructor(Type , Utf8JsonReader& , ReadStack& )
   at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1[[Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken, Microsoft.AspNetCore.Components.WebAssembly.Authentication, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60]].OnTryRead(Utf8JsonReader& , Type , JsonSerializerOptions , ReadStack& , AccessToken& )
   at System.Text.Json.Serialization.JsonConverter`1[[Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken, Microsoft.AspNetCore.Components.WebAssembly.Authentication, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60]].TryRead(Utf8JsonReader& , Type , JsonSerializerOptions , ReadStack& , AccessToken& )
   at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1[[Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessToken, Microsoft.AspNetCore.Components.WebAssembly.Authentication, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60]].ReadJsonAndSetMember(Object , ReadStack& , Utf8JsonReader& )
   at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1[[Microsoft.AspNetCore.Components.WebAssembly.Authentication.InternalAccessTokenResult, Microsoft.AspNetCore.Components.WebAssembly.Authentication, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60]].OnTryRead(Utf8JsonReader& , Type , JsonSerializerOptions , ReadStack& , InternalAccessTokenResult& )
   at System.Text.Json.Serialization.JsonConverter`1[[Microsoft.AspNetCore.Components.WebAssembly.Authentication.InternalAccessTokenResult, Microsoft.AspNetCore.Components.WebAssembly.Authentication, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60]].TryRead(Utf8JsonReader& , Type , JsonSerializerOptions , ReadStack& , InternalAccessTokenResult& )
   at System.Text.Json.Serialization.JsonConverter`1[[Microsoft.AspNetCore.Components.WebAssembly.Authentication.InternalAccessTokenResult, Microsoft.AspNetCore.Components.WebAssembly.Authentication, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60]].ReadCore(Utf8JsonReader& , JsonSerializerOptions , ReadStack& )
   at System.Text.Json.Serialization.JsonConverter`1[[Microsoft.AspNetCore.Components.WebAssembly.Authentication.InternalAccessTokenResult, Microsoft.AspNetCore.Components.WebAssembly.Authentication, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60]].ReadCoreAsObject(Utf8JsonReader& , JsonSerializerOptions , ReadStack& )
   at System.Text.Json.JsonSerializer.ReadCore[Object](JsonConverter , Utf8JsonReader& , JsonSerializerOptions , ReadStack& )
   at System.Text.Json.JsonSerializer.Read[Object](Utf8JsonReader& , JsonTypeInfo )
   at System.Text.Json.JsonSerializer.Deserialize(Utf8JsonReader& , Type , JsonSerializerOptions )
   at Microsoft.JSInterop.JSRuntime.EndInvokeJS(Int64 , Boolean , Utf8JsonReader& )
   Exception_EndOfInnerExceptionStack
   at Microsoft.JSInterop.JSRuntime.<InvokeAsync>d__16`1[[Microsoft.AspNetCore.Components.WebAssembly.Authentication.InternalAccessTokenResult, Microsoft.AspNetCore.Components.WebAssembly.Authentication, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60]].MoveNext()
   at Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService`3.<RequestAccessToken>d__22[[Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationState, Microsoft.AspNetCore.Components.WebAssembly.Authentication, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount, Microsoft.AspNetCore.Components.WebAssembly.Authentication, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[Microsoft.AspNetCore.Components.WebAssembly.Authentication.ApiAuthorizationProviderOptions, Microsoft.AspNetCore.Components.WebAssembly.Authentication, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60]].MoveNext()
   at Microsoft.AspNetCore.Components.WebAssembly.Authentication.AuthorizationMessageHandler.SendAsync(HttpRequestMessage , CancellationToken )
   at Microsoft.Extensions.Http.Logging.LoggingScopeHttpMessageHandler.SendAsync(HttpRequestMessage , CancellationToken )
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage , HttpCompletionOption , CancellationTokenSource , Boolean , CancellationTokenSource , CancellationToken )
   at System.Net.Http.Json.HttpClientJsonExtensions.<GetFromJsonAsyncCore>d__13`1[[BlazorApp1.Shared.WeatherForecast[], BlazorApp1.Shared, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]].MoveNext()
   at BlazorApp1.Client.Pages.FetchData.OnInitializedAsync()
   at Microsoft.AspNetCore.Components.ComponentBase.RunInitAndSetParametersAsync()
   at Microsoft.AspNetCore.Components.RenderTree.Renderer.GetErrorHandledTask(Task , ComponentState )
u @ blazor.webassembly.js:1
(anonymous) @ blazor.webassembly.js:1
kt @ blazor.webassembly.js:1
mono_wasm_invoke_js_blazor @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:3
_mono_wasm_invoke_js_blazor @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:12
$func194 @ 008c609a:0x17786
$func165 @ 008c609a:0x16d84
$func105 @ 008c609a:0x71fc
$func104 @ 008c609a:0x60b7
$func7266 @ 008c609a:0x18187e
$func1535 @ 008c609a:0x715af
$func1539 @ 008c609a:0x71cda
$mono_wasm_invoke_method @ 008c609a:0x1b3a1f
Module._mono_wasm_invoke_method @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:12
_Microsoft_AspNetCore_Components_WebAssembly__Microsoft_AspNetCore_Components_WebAssembly_Services_DefaultWebAssemblyJSRuntime_EndInvokeJS @ _Microsoft_AspNetCore_Components_WebAssembly__Microsoft_AspNetCore_Components_WebAssembly_Services_DefaultWebAssemblyJSRuntime_EndInvokeJS:23
endInvokeJSFromDotNet @ blazor.webassembly.js:1
(anonymous) @ blazor.webassembly.js:1
Promise.then (async)
beginInvokeJSFromDotNet @ blazor.webassembly.js:1
kt @ blazor.webassembly.js:1
mono_wasm_invoke_js_blazor @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:3
_mono_wasm_invoke_js_blazor @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:12
$func194 @ 008c609a:0x17786
$func165 @ 008c609a:0x16d84
$func105 @ 008c609a:0x71fc
$func104 @ 008c609a:0x60b7
$func7266 @ 008c609a:0x18187e
$func1535 @ 008c609a:0x715af
$func1539 @ 008c609a:0x71cda
$mono_wasm_invoke_method @ 008c609a:0x1b3a1f
Module._mono_wasm_invoke_method @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:12
_Microsoft_AspNetCore_Components_WebAssembly__Microsoft_AspNetCore_Components_WebAssembly_Services_DefaultWebAssemblyJSRuntime_EndInvokeJS @ _Microsoft_AspNetCore_Components_WebAssembly__Microsoft_AspNetCore_Components_WebAssembly_Services_DefaultWebAssemblyJSRuntime_EndInvokeJS:23
endInvokeJSFromDotNet @ blazor.webassembly.js:1
(anonymous) @ blazor.webassembly.js:1
Promise.then (async)
beginInvokeJSFromDotNet @ blazor.webassembly.js:1
kt @ blazor.webassembly.js:1
mono_wasm_invoke_js_blazor @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:3
_mono_wasm_invoke_js_blazor @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:12
$func194 @ 008c609a:0x17786
$func165 @ 008c609a:0x16d84
$func105 @ 008c609a:0x71fc
$func104 @ 008c609a:0x60b7
$func7266 @ 008c609a:0x18187e
$func1535 @ 008c609a:0x715af
$func1533 @ 008c609a:0x71521
$func992 @ 008c609a:0x530ae
$func194 @ 008c609a:0x1773f
$func165 @ 008c609a:0x16d84
$func105 @ 008c609a:0x71fc
$func104 @ 008c609a:0x60b7
$func7266 @ 008c609a:0x18187e
$func1535 @ 008c609a:0x715af
$func1539 @ 008c609a:0x71cda
$mono_wasm_invoke_method @ 008c609a:0x1b3a1f
Module._mono_wasm_invoke_method @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:12
_Microsoft_AspNetCore_Components_WebAssembly__Microsoft_AspNetCore_Components_WebAssembly_Services_DefaultWebAssemblyJSRuntime_EndInvokeJS @ _Microsoft_AspNetCore_Components_WebAssembly__Microsoft_AspNetCore_Components_WebAssembly_Services_DefaultWebAssemblyJSRuntime_EndInvokeJS:23
endInvokeJSFromDotNet @ blazor.webassembly.js:1
(anonymous) @ blazor.webassembly.js:1
Promise.then (async)
beginInvokeJSFromDotNet @ blazor.webassembly.js:1
kt @ blazor.webassembly.js:1
mono_wasm_invoke_js_blazor @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:3
_mono_wasm_invoke_js_blazor @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:12
$func194 @ 008c609a:0x17786
$func165 @ 008c609a:0x16d84
$func105 @ 008c609a:0x71fc
$func104 @ 008c609a:0x60b7
$func7266 @ 008c609a:0x18187e
$func1535 @ 008c609a:0x715af
$func1539 @ 008c609a:0x71cda
$mono_wasm_invoke_method @ 008c609a:0x1b3a1f
Module._mono_wasm_invoke_method @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:12
_Microsoft_AspNetCore_Components_WebAssembly__Microsoft_AspNetCore_Components_WebAssembly_Services_DefaultWebAssemblyJSRuntime_EndInvokeJS @ _Microsoft_AspNetCore_Components_WebAssembly__Microsoft_AspNetCore_Components_WebAssembly_Services_DefaultWebAssemblyJSRuntime_EndInvokeJS:23
endInvokeJSFromDotNet @ blazor.webassembly.js:1
(anonymous) @ blazor.webassembly.js:1
Promise.then (async)
beginInvokeJSFromDotNet @ blazor.webassembly.js:1
kt @ blazor.webassembly.js:1
mono_wasm_invoke_js_blazor @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:3
_mono_wasm_invoke_js_blazor @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:12
$func194 @ 008c609a:0x17786
$func165 @ 008c609a:0x16d84
$func105 @ 008c609a:0x71fc
$func104 @ 008c609a:0x60b7
$func7266 @ 008c609a:0x18187e
$func1535 @ 008c609a:0x715af
$func1539 @ 008c609a:0x71cda
$mono_wasm_invoke_method @ 008c609a:0x1b3a1f
Module._mono_wasm_invoke_method @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:12
_Microsoft_AspNetCore_Components_WebAssembly__Microsoft_AspNetCore_Components_WebAssembly_Services_DefaultWebAssemblyJSRuntime_EndInvokeJS @ _Microsoft_AspNetCore_Components_WebAssembly__Microsoft_AspNetCore_Components_WebAssembly_Services_DefaultWebAssemblyJSRuntime_EndInvokeJS:23
endInvokeJSFromDotNet @ blazor.webassembly.js:1
(anonymous) @ blazor.webassembly.js:1
Promise.then (async)
beginInvokeJSFromDotNet @ blazor.webassembly.js:1
kt @ blazor.webassembly.js:1
mono_wasm_invoke_js_blazor @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:3
_mono_wasm_invoke_js_blazor @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:12
$func194 @ 008c609a:0x17786
$func165 @ 008c609a:0x16d84
$func105 @ 008c609a:0x71fc
$func104 @ 008c609a:0x60b7
$func7266 @ 008c609a:0x18187e
$func1535 @ 008c609a:0x715af
$func1539 @ 008c609a:0x71cda
$mono_wasm_invoke_method @ 008c609a:0x1b3a1f
Module._mono_wasm_invoke_method @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:12
_Microsoft_AspNetCore_Components_WebAssembly__Microsoft_AspNetCore_Components_WebAssembly_Services_DefaultWebAssemblyJSRuntime_EndInvokeJS @ _Microsoft_AspNetCore_Components_WebAssembly__Microsoft_AspNetCore_Components_WebAssembly_Services_DefaultWebAssemblyJSRuntime_EndInvokeJS:23
endInvokeJSFromDotNet @ blazor.webassembly.js:1
(anonymous) @ blazor.webassembly.js:1
Promise.then (async)
beginInvokeJSFromDotNet @ blazor.webassembly.js:1
kt @ blazor.webassembly.js:1
mono_wasm_invoke_js_blazor @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:3
_mono_wasm_invoke_js_blazor @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:12
$func194 @ 008c609a:0x17786
$func165 @ 008c609a:0x16d84
$func105 @ 008c609a:0x71fc
$func104 @ 008c609a:0x60b7
$func7266 @ 008c609a:0x18187e
$func1535 @ 008c609a:0x715af
$func1539 @ 008c609a:0x71cda
$mono_wasm_invoke_method @ 008c609a:0x1b3a1f
Module._mono_wasm_invoke_method @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:12
BINDINGS_SetTaskSourceResult @ BINDINGS_SetTaskSourceResult:24
o.<computed> @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:3
(anonymous) @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:3
Promise.then (async)
_wrap_js_thenable_as_task @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:3
_js_to_mono_obj @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:3
js_to_mono_obj @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:3
(anonymous) @ blazor.webassembly.js:1
kt @ blazor.webassembly.js:1
mono_wasm_invoke_js_blazor @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:3
_mono_wasm_invoke_js_blazor @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:12
$func194 @ 008c609a:0x17786
$func165 @ 008c609a:0x16d84
$func105 @ 008c609a:0x71fc
$func104 @ 008c609a:0x60b7
$func7266 @ 008c609a:0x18187e
$func1535 @ 008c609a:0x715af
$func1539 @ 008c609a:0x71cda
$mono_wasm_invoke_method @ 008c609a:0x1b3a1f
Module._mono_wasm_invoke_method @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:12
_call_method_with_converted_args @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:3
call_method @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:3
(anonymous) @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:3
mono_call_assembly_entry_point @ dotnet.7.0.0-preview.2.22103.2.n9t5r83lkh.js:3
callEntryPoint @ blazor.webassembly.js:1
Nt @ blazor.webassembly.js:1
await in Nt (async)
(anonymous) @ blazor.webassembly.js:1
(anonymous) @ blazor.webassembly.js:1
```

</details>

Based on https://github.com/dotnet/aspnetcore/pull/32398