### PR TITLE
Added the FabricBot configuration file

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,0 +1,3274 @@
+[
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isOpen",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "created"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Status: No Recent Activity"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Needs: Author Feedback"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "noActivitySince",
+                "parameters": {
+                  "days": 7
+                }
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isCloseAndComment",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": {
+                "type": "author"
+              }
+            }
+          },
+          {
+            "name": "activitySenderHasPermissions",
+            "parameters": {
+              "permissions": "none"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "taskName": "[Idle Issue Management] For issues closed due to inactivity, re-open an issue if issue author posts a reply within 7 days.",
+      "actions": [
+        {
+          "name": "reopenIssue",
+          "parameters": {}
+        },
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        },
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Needs: Author Feedback"
+          }
+        },
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "Needs: Attention :wave:"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "created"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isOpen",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "name": "activitySenderHasPermissions",
+            "parameters": {
+              "permissions": "none"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 7
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isCloseAndComment",
+                "parameters": {}
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "taskName": "[Closed Issue Management] For issues closed with no activity over 7 days, ask non-contributor to consider opening a new issue instead.",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Hello lovely human, thank you for your comment on this issue. Because this issue has been closed for a period of time, please strongly consider opening a new issue linking to this issue instead to ensure better visibility of your comment. Thank you!\n\nSee [our Issue Management Policies](https://aka.ms/aspnet/issue-policies) for more information."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            1,
+            4,
+            7,
+            10,
+            13,
+            16,
+            19,
+            22
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            1,
+            4,
+            7,
+            10,
+            13,
+            16,
+            19,
+            22
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            1,
+            4,
+            7,
+            10,
+            13,
+            16,
+            19,
+            22
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            1,
+            4,
+            7,
+            10,
+            13,
+            16,
+            19,
+            22
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            1,
+            4,
+            7,
+            10,
+            13,
+            16,
+            19,
+            22
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            1,
+            4,
+            7,
+            10,
+            13,
+            16,
+            19,
+            22
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            1,
+            4,
+            7,
+            10,
+            13,
+            16,
+            19,
+            22
+          ],
+          "timezoneOffset": -8
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isClosed",
+          "parameters": {}
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 30
+          }
+        },
+        {
+          "name": "isUnlocked",
+          "parameters": {}
+        },
+        {
+          "name": "isIssue",
+          "parameters": {}
+        },
+        {
+          "name": "noLabel",
+          "parameters": {
+            "label": "Bot: Do Not Lock"
+          }
+        }
+      ],
+      "taskName": "[Closed Issue Management] Lock issues closed without activity for over 30 days",
+      "actions": [
+        {
+          "name": "lockIssue",
+          "parameters": {
+            "reason": "resolved"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "[Idle Issue Management] Replace needs author feedback label with needs attention label when the author comments on an issue",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "created"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Needs: Author Feedback"
+            }
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "Author: Migration Bot :robot:"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "activitySenderHasPermissions",
+                        "parameters": {
+                          "permissions": "write"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "isActivitySender",
+                "parameters": {
+                  "user": {
+                    "type": "author"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "Needs: Attention :wave:"
+          }
+        },
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Needs: Author Feedback"
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "[Closed Issue Management] Remove no recent activity label from issues",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "closed"
+                }
+              }
+            ]
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Status: No Recent Activity"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "[Idle Issue Management] Remove no recent activity label when an issue is commented on",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Status: No Recent Activity"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "taskName": "[Idle Issue Management] Close stale issues",
+      "frequency": [
+        {
+          "weekDay": 1,
+          "hours": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ]
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ]
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ]
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ]
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ]
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isIssue",
+          "parameters": {}
+        },
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "Needs: Author Feedback"
+          }
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 3
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "closeIssue",
+          "parameters": {}
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "taskName": "[Idle Issue Management] Add no recent activity label to issues",
+      "frequency": [
+        {
+          "weekDay": 1,
+          "hours": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ]
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ]
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ]
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ]
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ]
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isIssue",
+          "parameters": {}
+        },
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "Needs: Author Feedback"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 4
+          }
+        },
+        {
+          "name": "noLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        },
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "This issue has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **4 days**. It will be closed if no further activity occurs **within 3 days of this comment**. If it *is* closed, feel free to comment when you are able to provide the additional information and we will re-investigate.\n\nSee [our Issue Management Policies](https://aka.ms/aspnet/issue-policies) for more information."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "taskName": "[Resolved Issue Management] Close resolved issues",
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": -8
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isIssue",
+          "parameters": {}
+        },
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "Status: Resolved"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 1
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "This issue has been resolved and has not had any activity for **1 day**. It will be closed for housekeeping purposes.\n\nSee [our Issue Management Policies](https://aka.ms/aspnet/issue-policies) for more information."
+          }
+        },
+        {
+          "name": "closeIssue",
+          "parameters": {}
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "isActivitySender",
+                "parameters": {
+                  "user": "vsfeedback"
+                }
+              },
+              {
+                "name": "bodyContains",
+                "parameters": {
+                  "bodyPattern": "Copied from original issue"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Migration Bots] Tag issues opened by migration bots",
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "Author: Migration Bot :robot:"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "addedToMilestone",
+            "parameters": {
+              "milestoneName": "Discussions"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Discussions Management] Remove Workflow Labels when moved to Discussions",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Needs: Author Feedback"
+          }
+        },
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Status: No Recent Activity"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "dotnet-maestro[bot]",
+              "association": "CONTRIBUTOR"
+            }
+          },
+          {
+            "name": "titleContains",
+            "parameters": {
+              "titlePattern": "Update dependencies"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Infrastructure PRs] Add area-infrastructure label to dependency update Pull Requests",
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "area-infrastructure"
+          }
+        },
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "Type: Dependency Update :arrow_up_small:"
+          }
+        },
+        {
+          "name": "approvePullRequest",
+          "parameters": {
+            "comment": "Auto-approving dependency update."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "dotnet-maestro-bot"
+            }
+          },
+          {
+            "name": "titleContains",
+            "parameters": {
+              "titlePattern": "Merge branch"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Infrastructure PRs] Add area-infrastructure label to auto-merge Pull Requests",
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "area-infrastructure"
+          }
+        },
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "Type: Merge Forward :fast_forward:"
+          }
+        },
+        {
+          "name": "approvePullRequest",
+          "parameters": {
+            "comment": "Auto-approving branch merge."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "or",
+        "operands": [
+          {
+            "name": "labelAdded",
+            "parameters": {
+              "label": ":heavy_check_mark: Resolution: Answered"
+            }
+          },
+          {
+            "name": "labelAdded",
+            "parameters": {
+              "label": ":heavy_check_mark: Resolution: By Design"
+            }
+          },
+          {
+            "name": "labelAdded",
+            "parameters": {
+              "label": ":heavy_check_mark: Resolution: Duplicate"
+            }
+          },
+          {
+            "name": "labelAdded",
+            "parameters": {
+              "label": ":heavy_check_mark: Resolution: Won't Fix"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Resolved Issue Management] Apply Resolved label",
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "Status: Resolved"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "prIncludesModifiedFile",
+                "parameters": {
+                  "pathFilter": "src/Shared/Runtime"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Shared Code PRs] Flag PRs that affect shared code src/Shared/Runtime",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Greetings human! You've submitted a PR that modifies code that is shared with https://github.com/dotnet/runtime . Please make sure you synchronize this code with the changes in that repo!"
+          }
+        },
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "Attention: Shared Code Modified"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": -8
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "isIssue",
+          "parameters": {}
+        },
+        {
+          "name": "isPartOfMilestone",
+          "parameters": {
+            "label": "question",
+            "milestone": "Discussions"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 60
+          }
+        },
+        {
+          "name": "noLabel",
+          "parameters": {
+            "label": "announcement"
+          }
+        }
+      ],
+      "taskName": "[Discussions Management] Closed with no activity",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Thank you for contacting us. Due to a lack of activity on this discussion issue we're closing it in an effort to keep our backlog clean. If you believe there is a concern related to the ASP.NET Core framework, which hasn't been addressed yet, please file a new issue.\n\nThis issue will be locked after 30 more days of inactivity. If you still wish to discuss this subject after then, please create a new issue!"
+          }
+        },
+        {
+          "name": "closeIssue",
+          "parameters": {}
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "PrAutoLabel",
+    "subCapability": "Path",
+    "version": "1.0",
+    "config": {
+      "taskName": "[PR Labelling] Apply `area-` labels to PRs",
+      "configs": [
+        {
+          "label": "area-blazor",
+          "pathFilter": [
+            "src/Components/",
+            "src/ProjectTemplates/BlazorWasm.ProjectTemplates/"
+          ]
+        },
+        {
+          "label": "area-commandlinetools",
+          "pathFilter": [
+            "src/Tools/"
+          ]
+        },
+        {
+          "label": "area-dataprotection",
+          "pathFilter": [
+            "src/DataProtection/"
+          ]
+        },
+        {
+          "label": "area-identity",
+          "pathFilter": [
+            "src/Identity/"
+          ]
+        },
+        {
+          "label": "area-infrastructure",
+          "pathFilter": [
+            "global.json",
+            ".azure",
+            ".config",
+            "eng",
+            "src/Framework/",
+            "src/Installers/"
+          ]
+        },
+        {
+          "label": "area-mvc",
+          "pathFilter": [
+            "src/ProjectTemplates/",
+            "src/Razor/",
+            "src/MusicStore/",
+            "src/Mvc/"
+          ]
+        },
+        {
+          "label": "area-security",
+          "pathFilter": [
+            "src/Security/",
+            "src/Azure/AzureAD/"
+          ]
+        },
+        {
+          "label": "area-runtime",
+          "pathFilter": [
+            "src/Servers/",
+            "src/Http/",
+            "src/Azure/AzureAppServicesIntegration/",
+            "src/Azure/AzureAppServices.HostingStartup/",
+            "src/Middleware/",
+            "src/HttpClientFactory/",
+            "src/Hosting/",
+            "src/SiteExtensions/",
+            "src/DefaultBuilder/"
+          ]
+        },
+        {
+          "label": "area-signalr",
+          "pathFilter": [
+            "src/SignalR/"
+          ]
+        },
+        {
+          "label": "blazor-wasm",
+          "pathFilter": [
+            "src/ProjectTemplates/BlazorWasm.ProjectTemplates/"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "AutoMerge",
+    "subCapability": "AutoMerge",
+    "version": "1.0",
+    "config": {
+      "taskName": "Auto Merge PRs",
+      "label": "auto-merge",
+      "minMinutesOpen": "60",
+      "mergeType": "squash",
+      "removeLabelOnPush": true,
+      "conditionalMergeTypes": [
+        {
+          "mergeType": "merge",
+          "condition": {
+            "placeholder": "labels",
+            "operator": "contains",
+            "label_name": "Type: Merge Forward :fast_forward:"
+          }
+        }
+      ],
+      "deleteBranches": true
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "labelAdded",
+            "parameters": {
+              "label": "api-ready-for-review"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[API Review] PR Marked Ready",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Thank you for your API proposal. I'm removing the `api-ready-for-review` label. API Proposals should be submitted for review through Issues based on [this](https://github.com/dotnet/aspnetcore/issues/new?assignees=&labels=api-suggestion&template=25_api_proposal.md&title=]) template."
+          }
+        },
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "api-ready-for-review"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "addedToMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Comment: Issue moved to Backlog",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "We've moved this issue to the Backlog milestone. This means that it is not going to be worked on for the coming release. We will reassess the backlog following the current release and consider this item at that time. To learn more about our issue management process and to have better expectation regarding different types of issues you can read our [Triage Process](https://github.com/dotnet/aspnetcore/blob/main/docs/TriageProcess.md)."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "addedToMilestone",
+            "parameters": {
+              "milestoneName": ".NET 7 Planning"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "investigate"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Comment when an investigation issue moved to .NET 7 Planning",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Thanks for contacting us.\nWe're moving this issue to the `.NET 7 Planning` milestone for future evaluation / consideration. Because it's not immediately obvious that this is a bug in our framework, we would like to keep this around to collect more feedback, which can later help us determine the impact of it. We will re-evaluate this issue, during our next planning meeting(s). \nIf we later determine, that the issue has no community involvement, or it's very rare and low-impact issue, we will close it - so that the team can focus on more important and high impact issues.\nTo learn more about what to expect next and how this issue will be handled you can read more about our triage process [here](https://github.com/dotnet/aspnetcore/blob/main/docs/TriageProcess.md)."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "closed"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Working"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Issue management: mark working issues as done when closed]",
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "Done"
+          }
+        },
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Working"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestCommentResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isOpen",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "created"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isCloseAndComment",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "Tratcher"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "pranavkm"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "SteveSandersonMS"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "captainsafia"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "HaoK"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "javiercn"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "dougbu"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "halter73"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "davidfowl"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "JamesNK"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "Pilchie"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "sebastienros"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "NTaylorMullen"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "BrennanConroy"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "jkotalik"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "TanayParikh"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "ryanbrandenburg"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "mkArtakMSFT"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "wtgodbe"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "github-actions[bot]"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "rafikiassumaniMSFT"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "adityamandaleeka"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "taskName": "Comment on a closed PR",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Hi @${contextualAuthor}. It looks like you just commented on a closed PR. The team will most probably miss it. If you'd like to bring something important up to their attention, consider filing a new issue and add enough details to build context."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "dotnet-maestro-bot"
+            }
+          },
+          {
+            "name": "titleContains",
+            "parameters": {
+              "titlePattern": "Merge branch"
+            }
+          },
+          {
+            "name": "prTargetsBranch",
+            "parameters": {
+              "branchName": "main"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Infrastructure PRs] Add auto-merge label to branch merge Pull Requests in main",
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "auto-merge"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            1,
+            4,
+            7,
+            10,
+            13,
+            16,
+            19,
+            22
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            1,
+            4,
+            7,
+            10,
+            13,
+            16,
+            19,
+            22
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            1,
+            4,
+            7,
+            10,
+            13,
+            16,
+            19,
+            22
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            1,
+            4,
+            7,
+            10,
+            13,
+            16,
+            19,
+            22
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            1,
+            4,
+            7,
+            10,
+            13,
+            16,
+            19,
+            22
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            1,
+            4,
+            7,
+            10,
+            13,
+            16,
+            19,
+            22
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            1,
+            4,
+            7,
+            10,
+            13,
+            16,
+            19,
+            22
+          ],
+          "timezoneOffset": -8
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "isPr",
+          "parameters": {}
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "pr: pending author input"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 10
+          }
+        },
+        {
+          "name": "noLabel",
+          "parameters": {
+            "label": "stale"
+          }
+        }
+      ],
+      "taskName": "Stale PR reminder",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Hi @${issueAuthor}.\nIt seems you haven't touched this PR for the last two weeks. To avoid accumulating old PRs, we're marking it as `stale`.  As a result, it will be closed if no further activity occurs **within 4 days of this comment**. You can learn more about our Issue Management Policies [here](https://aka.ms/aspnet/issue-policies)."
+          }
+        },
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "stale"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -8
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "isPr",
+          "parameters": {}
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "pr: pending author input"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 4
+          }
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "stale"
+          }
+        }
+      ],
+      "taskName": "Close stale PRs",
+      "actions": [
+        {
+          "name": "closeIssue",
+          "parameters": {}
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "stale"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "pr: pending author input"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": {
+                "type": "author"
+              }
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "activitySenderHasPermissions",
+                "parameters": {
+                  "permissions": "write"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Revitalize stale PR and reopen",
+      "actions": [
+        {
+          "name": "reopenIssue",
+          "parameters": {}
+        },
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "stale"
+          }
+        },
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "pr: pending author input"
+          }
+        },
+        {
+          "name": "reopenIssue",
+          "parameters": {}
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "labelAdded",
+            "parameters": {
+              "label": "Needs: Author Feedback"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Replace `Needs Author Feedback` by `pr: pending author input` for PRs",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Hello. I see that you've just added `Needs: Author Feedback` label to this PR.\nThat label is for Issues and not for PRs. Don't worry, I'm going to replace it with the correct one."
+          }
+        },
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Needs: Author Feedback"
+          }
+        },
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "pr: pending author input"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          },
+          {
+            "name": "activitySenderHasPermissions",
+            "parameters": {
+              "permissions": "read"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isActivitySender",
+                "parameters": {
+                  "user": "dotnet-maestro"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isActivitySender",
+                "parameters": {
+                  "user": "dotnet-maestro-bot "
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Label community PRs with `community contribution` label",
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "community-contribution"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "merged"
+            }
+          },
+          {
+            "name": "prTargetsBranch",
+            "parameters": {
+              "branchName": "main"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "actions": [
+        {
+          "name": "addMilestone",
+          "parameters": {
+            "milestoneName": "7.0-preview2"
+          }
+        }
+      ],
+      "taskName": "Assign `Current Milestone` to PRs merged to main"
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "addedToProjectColumn",
+            "parameters": {
+              "projectName": " ASP.NET Core 7 Web UI",
+              "columnName": "In Progress"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "Working"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "Working"
+          }
+        }
+      ],
+      "taskName": "Add `Working` label to items moved to `In Progress` column on the ` ASP.NET Core 7 Web UI` project"
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "addedToMilestone",
+            "parameters": {
+              "milestoneName": ".NET 7 Planning"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "investigate"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Comment when an issue is moved to `.NET 7 Planning` milestone",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Thanks for contacting us.\n\nWe're moving this issue to the `.NET 7 Planning` milestone for future evaluation / consideration. We would like to keep this around to collect more feedback, which can help us with prioritizing this work. We will re-evaluate this issue, during our next planning meeting(s). \nIf we later determine, that the issue has no community involvement, or it's very rare and low-impact issue, we will close it - so that the team can focus on more important and high impact issues.\nTo learn more about what to expect next and how this issue will be handled you can read more about our triage process [here](https://github.com/dotnet/aspnetcore/blob/main/docs/TriageProcess.md)."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "labeled"
+            }
+          },
+          {
+            "name": "labelAdded",
+            "parameters": {
+              "label": "feature-blazor-debugging"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "INTERNAL: Debug"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Provide Blazor WASM Debugging Troubleshooting link",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Thanks for contacting us.\nIt looks like this issue is related to debugging in Blazor WebAssembly application.\nBecause there are different components involved in providing debugging experience, we've put together a small troubleshooting guide that you can follow, to help us better understand where to direct this issue to, to get a faster resolution.\nYou can find it [here](https://docs.microsoft.com/en-us/aspnet/core/blazor/debug?view=aspnetcore-5.0&tabs=visual-studio#troubleshoot).\nIf these troubleshooting docs resolve your problem, please close the issue. Otherwise we'll follow up."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "labelAdded",
+            "parameters": {
+              "label": "api-ready-for-review"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "API Proposal Ready For Review",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Thank you for submitting this for API review. This will be reviewed by @dotnet/aspnet-api-review at the next meeting of the ASP.NET Core API Review group. Please ensure you take a look at [the API review process documentation](https://github.com/dotnet/aspnetcore/blob/main/docs/APIReviewProcess.md) and ensure that:\n\n* The PR contains changes to the reference-assembly that describe the API change. **Or**, you have included a snippet of reference-assembly-style code that illustrates the API change.\n* The PR describes the impact to users, both positive (useful new APIs) and negative (breaking changes).\n* Someone is assigned to \"champion\" this change in the meeting, and they understand the impact and design of the change."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "merged"
+            }
+          },
+          {
+            "name": "prTargetsBranch",
+            "parameters": {
+              "branchName": "release/6.0"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Assign milestone to PRs merged to \"release/6.0\"",
+      "actions": [
+        {
+          "name": "addMilestone",
+          "parameters": {
+            "milestoneName": "6.0.2"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "labelAdded",
+            "parameters": {
+              "label": "Servicing-consider"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Use servicing template for `servicing-consider` issues",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Hi @${issueAuthor}. Please make sure you've updated the PR description to use the [Shiproom Template](https://aka.ms/aspnet/servicing/template). Also, make sure this PR is not marked as a draft and is ready-to-merge.\n\nTo learn more about how to prepare a servicing PR [click here](https://aka.ms/aspnet/servicing)."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Servicing-consider"
+            }
+          },
+          {
+            "name": "labelAdded",
+            "parameters": {
+              "label": "Servicing-approved"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Remove the `Servicing-consider` label, when `Servicing-approved` label added",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "Servicing-consider"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "labelAdded",
+            "parameters": {
+              "label": "Needs: Author Feedback"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Add comment when 'Needs Author Feedback' is applied to issue",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Hi @${issueAuthor}. We have added the \"Needs: Author Feedback\" label to this issue, which indicates that we have an open question for you before we can take further action. This issue will be closed automatically in 7 days if we do not hear back from you by then - please feel free to re-open it if you come back to this issue after that time."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "addedToMilestone",
+            "parameters": {
+              "milestoneName": "6.0.x"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInProject",
+                "parameters": {
+                  "projectName": "Servicing"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Add 6.0 servicing issues to the servicing project board",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Servicing",
+            "columnName": "6.0.x"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "addedToMilestone",
+            "parameters": {
+              "milestoneName": "5.0.x"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInProject",
+                "parameters": {
+                  "projectName": "Servicing"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Add 5.0 servicing issues to the servicing project board",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Servicing",
+            "columnName": "5.0.x"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "addedToMilestone",
+            "parameters": {
+              "milestoneName": "3.1.x"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInProject",
+                "parameters": {
+                  "projectName": "Servicing"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Add 3.1 servicing issues to the servicing project board",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Servicing",
+            "columnName": "3.1.x"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInProject",
+                "parameters": {
+                  "projectName": "Servicing"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "addedToMilestone",
+                "parameters": {
+                  "milestoneName": "6.0.x"
+                }
+              },
+              {
+                "name": "addedToMilestone",
+                "parameters": {
+                  "milestoneName": "5.0.x"
+                }
+              },
+              {
+                "name": "addedToMilestone",
+                "parameters": {
+                  "milestoneName": "3.1.x"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Add servicing PRs to the servicing project board",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Servicing",
+            "columnName": "In Progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "prTargetsBranch",
+            "parameters": {
+              "branchName": "release/3.1"
+            }
+          },
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Add release/3.1 targeting PRs to the servicing project",
+      "actions": [
+        {
+          "name": "addMilestone",
+          "parameters": {
+            "milestoneName": "3.1.x"
+          }
+        },
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Servicing",
+            "columnName": "In Progress"
+          }
+        },
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Hi @${issueAuthor}. If this is not a tell-mode PR, please make sure to follow the instructions laid out in the [servicing process](https://aka.ms/aspnet/servicing) document.\nOtherwise, please add `tell-mode` label."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          },
+          {
+            "name": "prTargetsBranch",
+            "parameters": {
+              "branchName": "release/5.0"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Add release/5.0 targeting PRs to the servicing project",
+      "actions": [
+        {
+          "name": "addMilestone",
+          "parameters": {
+            "milestoneName": "5.0.x"
+          }
+        },
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Servicing",
+            "columnName": "In Progress"
+          }
+        },
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Hi @${issueAuthor}. If this is not a tell-mode PR, please make sure to follow the instructions laid out in the [servicing process](https://aka.ms/aspnet/servicing) document.\nOtherwise, please add `tell-mode` label."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          },
+          {
+            "name": "prTargetsBranch",
+            "parameters": {
+              "branchName": "release/6.0"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Add release/6.0 targeting PRs to the servicing project",
+      "actions": [
+        {
+          "name": "addMilestone",
+          "parameters": {
+            "milestoneName": "6.0.x"
+          }
+        },
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Servicing",
+            "columnName": "In Progress"
+          }
+        },
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Hi @${issueAuthor}. If this is not a tell-mode PR, please make sure to follow the instructions laid out in the [servicing process](https://aka.ms/aspnet/servicing) document.\nOtherwise, please add `tell-mode` label."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          },
+          {
+            "name": "prTargetsBranch",
+            "parameters": {
+              "branchName": "release/2.1"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Add release/2.1 targeting PRs to the servicing project",
+      "actions": [
+        {
+          "name": "addMilestone",
+          "parameters": {
+            "milestoneName": "2.1.x"
+          }
+        },
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Servicing",
+            "columnName": "In Progress"
+          }
+        },
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Hi @${issueAuthor}. If this is not a tell-mode PR, please make sure to follow the instructions laid out in the [servicing process](https://aka.ms/aspnet/servicing) document.\nOtherwise, please add `tell-mode` label."
+          }
+        }
+      ]
+    }
+  }
+]

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -2540,7 +2540,7 @@
         {
           "name": "addMilestone",
           "parameters": {
-            "milestoneName": "7.0-preview2"
+            "milestoneName": "7.0-preview3"
           }
         }
       ],


### PR DESCRIPTION
Fabric Bot now supports code-based configuration. That means, as soon as this change is merged, Fabric Bot will be using this configuration going forward, instead of the one in the portal.

For now the values in this file can't reference any variables known to the build system - Version.props.
But I've reached out to the FabricBot team and they've agreed that the scenario makes sense and added [an item to their backlog](https://mseng.visualstudio.com/1ES/_workitems/edit/1919391) to support this in the future.

Also, for now there is no support for per-branch configuration, but support for it is also coming. They're already working on that.

This change also impacts the branching instructions. PR for the change is here: https://github.com/dotnet/aspnetcore-internal/pull/4010