### PR TITLE
Bump Polly to 7.2.3

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -260,7 +260,7 @@
     <PhotinoNETVersion>1.1.6</PhotinoNETVersion>
     <MicrosoftPlaywrightVersion>1.17.3</MicrosoftPlaywrightVersion>
     <PollyExtensionsHttpVersion>3.0.0</PollyExtensionsHttpVersion>
-    <PollyVersion>7.2.2</PollyVersion>
+    <PollyVersion>7.2.3</PollyVersion>
     <SeleniumSupportVersion>4.1.0</SeleniumSupportVersion>
     <SeleniumWebDriverChromeDriverVersion>97.0.4692.7100</SeleniumWebDriverChromeDriverVersion>
     <SeleniumWebDriverVersion>4.1.0</SeleniumWebDriverVersion>


### PR DESCRIPTION
# Bump Polly to 7.2.3

Update the package reference for Polly to 7.2.3.

## Description

Update the package reference for Polly to its [latest release](https://github.com/App-vNext/Polly/releases/tag/7.2.3%2B24).

This package version might need to be added to the AzDo feed to compile.
