### PR TITLE
Use WixBundleName instead of WixBundle

### DIFF
--- a/src/Installers/Windows/SharedFrameworkBundle/1028/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1028/thm.wxl
@@ -59,6 +59,6 @@
   <String Id="FilesInUseOkButton">確定(&amp;O)</String>
   <String Id="FilesInUseCancelButton">取消(&amp;C)</String>
 
-  <String Id="Welcome">歡迎使用 [WixBundle] 安裝程式。</String>
+  <String Id="Welcome">歡迎使用 [WixBundleName] 安裝程式。</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;授權條款&lt;/a&gt;和&lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;隱私權聲明&lt;/a&gt;。</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/1029/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1029/thm.wxl
@@ -59,6 +59,6 @@
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Zrušit</String>
 
-  <String Id="Welcome">Vítá vás instalační program produktu [WixBundle]</String>
+  <String Id="Welcome">Vítá vás instalační program produktu [WixBundleName]</String>
   <String Id="EulaPrivacy">[WixBundleName] – &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;licenční podmínky&lt;/a&gt; a &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;prohlášení o zásadách ochrany osobních údajů&lt;/a&gt;</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/1031/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1031/thm.wxl
@@ -59,6 +59,6 @@
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Abbrechen</String>
 
-  <String Id="Welcome">Willkommen beim Setup von [WixBundle].</String>
+  <String Id="Welcome">Willkommen beim Setup von [WixBundleName].</String>
   <String Id="EulaPrivacy">&lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Lizenzbedingungen&lt;/a&gt; und &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;Datenschutzerklärung&lt;/a&gt; für [WixBundleName].</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/1033/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1033/thm.wxl
@@ -59,6 +59,6 @@
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
 
-  <String Id="Welcome">Welcome to the [WixBundle] Setup.</String>
+  <String Id="Welcome">Welcome to the [WixBundleName] Setup.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/1036/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1036/thm.wxl
@@ -59,6 +59,6 @@
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Annuler</String>
 
-  <String Id="Welcome">Bienvenue dans le programme d'installation de [WixBundle].</String>
+  <String Id="Welcome">Bienvenue dans le programme d'installation de [WixBundleName].</String>
   <String Id="EulaPrivacy">&lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Termes du contrat de licence&lt;/a&gt; et &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;déclaration de confidentialité&lt;/a&gt; de [WixBundleName].</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/1040/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1040/thm.wxl
@@ -59,6 +59,6 @@
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Annulla</String>
 
-  <String Id="Welcome">Installazione di [WixBundle].</String>
+  <String Id="Welcome">Installazione di [WixBundleName].</String>
   <String Id="EulaPrivacy">&lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Condizioni di licenza&lt;/a&gt; e &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;informativa sulla privacy&lt;/a&gt; di [WixBundleName].</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/1041/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1041/thm.wxl
@@ -60,6 +60,6 @@
   <String Id="FilesInUseOkButton">OK(&amp;O)</String>
   <String Id="FilesInUseCancelButton">キャンセル(&amp;C)</String>
 
-  <String Id="Welcome">[WixBundle] のセットアップへようこそ。</String>
+  <String Id="Welcome">[WixBundleName] のセットアップへようこそ。</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;ライセンス条項&lt;/a&gt;および&lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;プライバシーに関する声明&lt;/a&gt;。</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/1042/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1042/thm.wxl
@@ -59,6 +59,6 @@
   <String Id="FilesInUseOkButton">확인(&amp;O)</String>
   <String Id="FilesInUseCancelButton">취소(&amp;C)</String>
 
-  <String Id="Welcome">[WixBundle] 설치를 시작합니다.</String>
+  <String Id="Welcome">[WixBundleName] 설치를 시작합니다.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;사용 조건&lt;/a&gt; 및 &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;개인정보처리방침&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/1045/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1045/thm.wxl
@@ -59,6 +59,6 @@
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Anuluj</String>
 
-  <String Id="Welcome">Witamy w instalatorze produktu [WixBundle].</String>
+  <String Id="Welcome">Witamy w instalatorze produktu [WixBundleName].</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;postanowienia licencyjne&lt;/a&gt; i &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;oświadczenie o ochronie prywatności&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/1046/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1046/thm.wxl
@@ -59,6 +59,6 @@
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancelar</String>
 
-  <String Id="Welcome">Bem-vindo à Instalação do [WixBundle].</String>
+  <String Id="Welcome">Bem-vindo à Instalação do [WixBundleName].</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;termos de licença&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;política de privacidade&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/1049/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1049/thm.wxl
@@ -59,6 +59,6 @@
   <String Id="FilesInUseOkButton">О&amp;К</String>
   <String Id="FilesInUseCancelButton">&amp;Отмена</String>
 
-  <String Id="Welcome">Вас приветствует мастер установки [WixBundle].</String>
+  <String Id="Welcome">Вас приветствует мастер установки [WixBundleName].</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;условия лицензии&lt;/a&gt; и &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;заявление о конфиденциальности&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/1055/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1055/thm.wxl
@@ -59,6 +59,6 @@
   <String Id="FilesInUseOkButton">&amp;Tamam</String>
   <String Id="FilesInUseCancelButton">&amp;İptal</String>
 
-  <String Id="Welcome">[WixBundle] Kurulumu'na Hoş Geldiniz.</String>
+  <String Id="Welcome">[WixBundleName] Kurulumu'na Hoş Geldiniz.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;lisans koşulları&lt;/a&gt; ve &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;gizlilik bildirimi&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/2052/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/2052/thm.wxl
@@ -59,6 +59,6 @@
   <String Id="FilesInUseOkButton">确定(&amp;O)</String>
   <String Id="FilesInUseCancelButton">取消(&amp;C)</String>
 
-  <String Id="Welcome">欢迎使用 [WixBundle] 安装程序。</String>
+  <String Id="Welcome">欢迎使用 [WixBundleName] 安装程序。</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;许可条件&lt;/a&gt;和&lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;隐私声明&lt;/a&gt;。</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/3082/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/3082/thm.wxl
@@ -59,6 +59,6 @@
   <String Id="FilesInUseOkButton">&amp;Aceptar</String>
   <String Id="FilesInUseCancelButton">&amp;Cancelar</String>
 
-  <String Id="Welcome">Programa de instalación de [WixBundle].</String>
+  <String Id="Welcome">Programa de instalación de [WixBundleName].</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Términos de licencia&lt;/a&gt; y &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;declaración de privacidad&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/thm.wxl
@@ -59,6 +59,6 @@
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
 
-  <String Id="Welcome">Welcome to the [WixBundle] Setup.</String>
+  <String Id="Welcome">Welcome to the [WixBundleName] Setup.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
 </WixLocalization>


### PR DESCRIPTION
The predefined variable is named `WixBundleName`, but we've been using `WixBundle` in the SharedFx, which causes its installer to have the text "Welcome to the  setup"

https://wixtoolset.org/documentation/manual/v3/bundle/bundle_built_in_variables.html
![wuix](https://user-images.githubusercontent.com/14283640/154742638-0839bce1-3885-4dba-9288-cf65501d0dfb.png)

