### PR TITLE
Only enable trailers/reset/goaway on OSs that support them

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
@@ -439,13 +439,7 @@ internal partial class IISHttpContext : IFeatureCollection,
 
     internal IHttpResponseTrailersFeature? GetResponseTrailersFeature()
     {
-        // Check version is above 2.
-        if (HttpVersion >= System.Net.HttpVersion.Version20 && NativeMethods.HttpHasResponse4(_requestNativeHandle))
-        {
-            return this;
-        }
-
-        return null;
+        return AdvancedHttp2FeaturesSupported ? this : null;
     }
 
     IHeaderDictionary IHttpResponseTrailersFeature.Trailers
@@ -458,13 +452,7 @@ internal partial class IISHttpContext : IFeatureCollection,
 
     internal IHttpResetFeature? GetResetFeature()
     {
-        // Check version is above 2.
-        if (HttpVersion >= System.Net.HttpVersion.Version20 && NativeMethods.HttpHasResponse4(_requestNativeHandle))
-        {
-            return this;
-        }
-
-        return null;
+        return AdvancedHttp2FeaturesSupported ? this : null;
     }
 
     void IHttpResetFeature.Reset(int errorCode)

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
@@ -439,7 +439,7 @@ internal partial class IISHttpContext : IFeatureCollection,
 
     internal IHttpResponseTrailersFeature? GetResponseTrailersFeature()
     {
-        return AdvancedHttp2FeaturesSupported ? this : null;
+        return AdvancedHttp2FeaturesSupported() ? this : null;
     }
 
     IHeaderDictionary IHttpResponseTrailersFeature.Trailers
@@ -452,7 +452,7 @@ internal partial class IISHttpContext : IFeatureCollection,
 
     internal IHttpResetFeature? GetResetFeature()
     {
-        return AdvancedHttp2FeaturesSupported ? this : null;
+        return AdvancedHttp2FeaturesSupported() ? this : null;
     }
 
     void IHttpResetFeature.Reset(int errorCode)

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -395,6 +395,12 @@ internal abstract partial class IISHttpContext : NativeRequestContext, IThreadPo
         await _bodyOutput.FlushAsync(default);
     }
 
+    // Response trailers, reset, and GOAWAY are only on HTTP/2+ and require IIS support
+    // that is only available on Win 11/Server 2022 or later.
+    protected bool AdvancedHttp2FeaturesSupported => OperatingSystem.IsWindowsVersionAtLeast(10, 0, 20348, 0) &&
+                                                   HttpVersion >= System.Net.HttpVersion.Version20 &&
+                                                   NativeMethods.HttpHasResponse4(_requestNativeHandle);
+
     public unsafe void SetResponseHeaders()
     {
         // Verifies we have sent the statuscode before writing a header
@@ -403,7 +409,7 @@ internal abstract partial class IISHttpContext : NativeRequestContext, IThreadPo
         // This copies data into the underlying buffer
         NativeMethods.HttpSetResponseStatusCode(_requestNativeHandle, (ushort)StatusCode, reasonPhrase);
 
-        if (HttpVersion >= System.Net.HttpVersion.Version20 && NativeMethods.HttpHasResponse4(_requestNativeHandle))
+        if (AdvancedHttp2FeaturesSupported)
         {
             // Check if connection close is set, if so setting goaway
             if (string.Equals(ConnectionClose, HttpResponseHeaders[HeaderNames.Connection], StringComparison.OrdinalIgnoreCase))

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -397,7 +397,7 @@ internal abstract partial class IISHttpContext : NativeRequestContext, IThreadPo
 
     // Response trailers, reset, and GOAWAY are only on HTTP/2+ and require IIS support
     // that is only available on Win 11/Server 2022 or later.
-    protected static readonly bool isCompatibleOsVersion = OperatingSystem.IsWindowsVersionAtLeast(10, 0, 20348, 0);
+    private static readonly bool isCompatibleOsVersion = OperatingSystem.IsWindowsVersionAtLeast(10, 0, 20348, 0);
     protected bool AdvancedHttp2FeaturesSupported => isCompatibleOsVersion &&
         HttpVersion >= System.Net.HttpVersion.Version20 &&
         NativeMethods.HttpHasResponse4(_requestNativeHandle);

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -397,9 +397,10 @@ internal abstract partial class IISHttpContext : NativeRequestContext, IThreadPo
 
     // Response trailers, reset, and GOAWAY are only on HTTP/2+ and require IIS support
     // that is only available on Win 11/Server 2022 or later.
-    protected bool AdvancedHttp2FeaturesSupported => OperatingSystem.IsWindowsVersionAtLeast(10, 0, 20348, 0) &&
-                                                   HttpVersion >= System.Net.HttpVersion.Version20 &&
-                                                   NativeMethods.HttpHasResponse4(_requestNativeHandle);
+    protected static readonly bool isCompatibleOsVersion = OperatingSystem.IsWindowsVersionAtLeast(10, 0, 20348, 0);
+    protected bool AdvancedHttp2FeaturesSupported => isCompatibleOsVersion &&
+        HttpVersion >= System.Net.HttpVersion.Version20 &&
+        NativeMethods.HttpHasResponse4(_requestNativeHandle);
 
     public unsafe void SetResponseHeaders()
     {

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContextOfT.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContextOfT.cs
@@ -60,7 +60,7 @@ internal class IISHttpContextOfT<TContext> : IISHttpContext where TContext : not
                 // Dispose
             }
 
-            if (!success && HasResponseStarted && NativeMethods.HttpHasResponse4(_requestNativeHandle))
+            if (!success && HasResponseStarted && AdvancedHttp2FeaturesSupported)
             {
                 // HTTP/2 INTERNAL_ERROR = 0x2 https://tools.ietf.org/html/rfc7540#section-7
                 // Otherwise the default is Cancel = 0x8 (h2) or 0x010c (h3).

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContextOfT.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContextOfT.cs
@@ -60,7 +60,7 @@ internal class IISHttpContextOfT<TContext> : IISHttpContext where TContext : not
                 // Dispose
             }
 
-            if (!success && HasResponseStarted && AdvancedHttp2FeaturesSupported)
+            if (!success && HasResponseStarted && AdvancedHttp2FeaturesSupported())
             {
                 // HTTP/2 INTERNAL_ERROR = 0x2 https://tools.ietf.org/html/rfc7540#section-7
                 // Otherwise the default is Cancel = 0x8 (h2) or 0x010c (h3).


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/37831

Before this change, we were relying on the presence of the `IHttpResponse4` extended interface to determine whether H2 features like response trailers, reset, and GOAWAY are supported when running on IIS/IIS Express.

However, this is not sufficient since when running on IIS Express, we may have cases where the interface is present but the underlying OS networking stack isn't new enough to support these features. This can manifest as errors and disconnects on flush when these features are used.

This change adds a minimum OS version check so we only use these features on OS's where they'll work.
