### PR TITLE
Add EndpointMetadataCollection.GetRequiredMetadata #39921

### DIFF
--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 *REMOVED*abstract Microsoft.AspNetCore.Http.HttpResponse.ContentType.get -> string!
+Microsoft.AspNetCore.Http.EndpointMetadataCollection.GetRequiredMetadata<T>() -> T!
 Microsoft.AspNetCore.Http.Metadata.IFromFormMetadata
 Microsoft.AspNetCore.Http.Metadata.IFromFormMetadata.Name.get -> string?
 abstract Microsoft.AspNetCore.Http.HttpResponse.ContentType.get -> string?

--- a/src/Http/Http.Abstractions/src/Routing/EndpointMetadataCollection.cs
+++ b/src/Http/Http.Abstractions/src/Routing/EndpointMetadataCollection.cs
@@ -127,6 +127,20 @@ public sealed class EndpointMetadataCollection : IReadOnlyList<object>
     }
 
     /// <summary>
+    /// Gets the most significant metadata item of type <typeparamref name="T"/>.
+    /// Throws an <see cref="InvalidOperationException"/> if the metadata is not found.
+    /// </summary>
+    /// <typeparam name="T">The type of metadata to retrieve.</typeparam>
+    /// <returns>
+    /// The most significant metadata of type <typeparamref name="T"/>.
+    /// </returns>
+    public T GetRequiredMetadata<T>() where T : class
+    {
+        var metadata = GetMetadata<T>();
+        return metadata == null ? throw new InvalidOperationException($"Metadata '{typeof(T)}' is not found.") : metadata;
+    }
+
+    /// <summary>
     /// Gets an <see cref="IEnumerator"/> of all metadata items.
     /// </summary>
     /// <returns>An <see cref="IEnumerator"/> of all metadata items.</returns>

--- a/src/Http/Http.Abstractions/src/Routing/EndpointMetadataCollection.cs
+++ b/src/Http/Http.Abstractions/src/Routing/EndpointMetadataCollection.cs
@@ -134,6 +134,7 @@ public sealed class EndpointMetadataCollection : IReadOnlyList<object>
     /// <returns>
     /// The most significant metadata of type <typeparamref name="T"/>.
     /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public T GetRequiredMetadata<T>() where T : class
     {
         var metadata = GetMetadata<T>();

--- a/src/Http/Http.Abstractions/src/Routing/EndpointMetadataCollection.cs
+++ b/src/Http/Http.Abstractions/src/Routing/EndpointMetadataCollection.cs
@@ -137,7 +137,7 @@ public sealed class EndpointMetadataCollection : IReadOnlyList<object>
     public T GetRequiredMetadata<T>() where T : class
     {
         var metadata = GetMetadata<T>();
-        return metadata == null ? throw new InvalidOperationException($"Metadata '{typeof(T)}' is not found.") : metadata;
+        return metadata ?? throw new InvalidOperationException($"Metadata '{typeof(T)}' is not found.");
     }
 
     /// <summary>

--- a/src/Http/Http.Abstractions/test/EndpointMetadataCollectionTests.cs
+++ b/src/Http/Http.Abstractions/test/EndpointMetadataCollectionTests.cs
@@ -67,4 +67,26 @@ public class EndpointMetadataCollectionTests
         Assert.Same(ordered1, ordered2);
         Assert.Equal(new string[] { "1", "2" }, ordered1);
     }
+
+    [Fact]
+    public void GetRequiredMetadata_CanReturnMetadata()
+    {
+        // Arrange
+        var metadata = new EndpointMetadataCollection(1, "2");
+
+        // Act
+        var requiredMetadata = metadata.GetRequiredMetadata<string>();
+
+        Assert.Equal("2", requiredMetadata);
+    }
+
+    [Fact]
+    public void GetRequiredMetadata_ThrowsWhenMetadataNotFound()
+    {
+        // Arrange
+        var metadata = new EndpointMetadataCollection(1, 2);
+
+        // Act
+        Assert.Throws<InvalidOperationException>(() => metadata.GetRequiredMetadata<string>());
+    }
 }

--- a/src/Http/Routing.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Routing.Abstractions/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.AspNetCore.Http.EndpointMetadataCollection.GetRequiredMetadata<T>() -> T! (forwarded, contained in Microsoft.AspNetCore.Http.Abstractions)


### PR DESCRIPTION
# Add EndpointMetadataCollection.GetRequiredMetadata

I've added GetRequiredMetadata<T>() method to  Microsoft.AspNetCore.Http.EndpointMetadataCollection. It throws InvalidOperationException when metadata of type T is not found.

## Description
Fixes #39921

