### PR TITLE
On platforms that don't support Quic, allow PlatformNotSupportedException

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/src/WebHostBuilderQuicExtensions.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/WebHostBuilderQuicExtensions.cs
@@ -20,7 +20,7 @@ public static class WebHostBuilderQuicExtensions
     /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
     public static IWebHostBuilder UseQuic(this IWebHostBuilder hostBuilder)
     {
-        if (QuicImplementationProviders.Default.IsSupported)
+        if (IsQuicSupported())
         {
             return hostBuilder.ConfigureServices(services =>
             {
@@ -43,5 +43,19 @@ public static class WebHostBuilderQuicExtensions
         {
             services.Configure(configureOptions);
         });
+    }
+
+    private static bool IsQuicSupported()
+    {
+        try
+        {
+            return QuicImplementationProviders.Default.IsSupported;
+        }
+        catch (PlatformNotSupportedException)
+        {
+            // On some platforms, System.Net.Quic is just a stub assembly in which every method throws PlatformNotSupportedException,
+            // including the QuicImplementationProviders.Default.IsSupported getter.
+            return false;
+        }
     }
 }


### PR DESCRIPTION
On platforms other than Windows/Linux/OSX/FreeBSD, the runtime repo builds `System.Net.Quic` as a stub assembly that simply throws `PlatformNotSupportedException` when any method is invoked (including `get_Default`).

I have a prototype of running ASP.NET Core on WASI, and fixing this one small detail has so far been enough to make it work.