### PR TITLE
Change 'Blazor component' naming

### DIFF
--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -230,7 +230,7 @@ public partial class Router : IComponent, IHandleAfterRender, IDisposable
     {
         // Cancel the CTS instead of disposing it, since disposing does not
         // actually cancel and can cause unintended Object Disposed Exceptions.
-        // This effectivelly cancels the previously running task and completes it.
+        // This effectively cancels the previously running task and completes it.
         _onNavigateCts?.Cancel();
         // Then make sure that the task has been completely cancelled or completed
         // before starting the next one. This avoid race conditions where the cancellation

--- a/src/Components/README.md
+++ b/src/Components/README.md
@@ -8,9 +8,9 @@ This folder contains the component model shared between the WebAssembly and Serv
 
 The following contains a description of each sub-directory in the `Components` directory.
 
-- `Analyzers`: Contains a collection of Rosyln analyzers for Blazor components
+- `Analyzers`: Contains a collection of Rosyln analyzers for Razor components
 - `Authorization`: Contains source files associated with auth-related components and services in Blazor
-- `Components`: Contains the implementation for the Blazor component model
+- `Components`: Contains the implementation for Blazor's component model
 - `Forms`: Contains source files for Form components in Blazor
 - `Samples`: Contains a collection of sample apps in Blazor
 - `Server`: Contains the implementation for Blazor Server-specific components

--- a/src/Components/Web.JS/src/Rendering/LogicalElements.ts
+++ b/src/Components/Web.JS/src/Rendering/LogicalElements.ts
@@ -10,7 +10,7 @@
   LogicalElement APIs take care of tracking hierarchical relationships separately. The point
   of this is to permit a logical tree structure in which parent/child relationships don't
   have to be materialized in terms of DOM element parent/child relationships. And the reason
-  why we want that is so that hierarchies of Blazor components can be tracked even when those
+  why we want that is so that hierarchies of Razor components can be tracked even when those
   components' render output need not be a single literal DOM element.
 
   Consumers of the API don't need to know about the implementation, but how it's done is:

--- a/src/Components/WebView/WebView/src/WebViewManager.cs
+++ b/src/Components/WebView/WebView/src/WebViewManager.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.FileProviders;
 namespace Microsoft.AspNetCore.Components.WebView;
 
 /// <summary>
-/// Manages activities within a web view that hosts Blazor components. Platform authors
+/// Manages activities within a web view that hosts Razor components. Platform authors
 /// should subclass this to wire up the abstract and protected methods to the APIs of
 /// the platform's web view.
 /// </summary>

--- a/src/Components/test/testassets/BasicTestApp/DynamicallyAddedRootComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/DynamicallyAddedRootComponent.razor
@@ -3,7 +3,7 @@
 
 <div class="dynamic-root-component" style="border: 1px dashed purple">
     <p>
-        This is a Blazor component.
+        This is a Razor component.
     </p>
     <p>
         Click count: <strong class="click-count">@clicks</strong>

--- a/src/Components/test/testassets/BasicTestApp/ExternalContentPackage.razor
+++ b/src/Components/test/testassets/BasicTestApp/ExternalContentPackage.razor
@@ -23,7 +23,7 @@
 <hr />
 
 <p>
-    Additionally, NuGet packages can contain Blazor components, and even
+    Additionally, NuGet packages can contain Razor components, and even
     static resources such as CSS files and images.
 </p>
 


### PR DESCRIPTION
# Change 'Blazor component' naming

## Description

* Updates a few instances to 'Razor component' to align with formal naming and Blazor docs.
* Although updates to code comments and samples are optional because we mostly care about API docs, I suggest standardized naming *everywhere*.
* Didn't address grammar & style. 🙈 *Yikes! I'm gonna have nightmares!* 🎃😆 However, I did fix a misspelled word here.

Fixes #40344
