### PR TITLE
Remove downlevel runtimes from global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,10 +5,10 @@
   "tools": {
     "dotnet": "7.0.100-preview.2.22114.1",
     "runtimes": {
-      "dotnet": [
+      "dotnet/x86": [
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"
       ],
-      "dotnet/x86": [
+      "dotnet": [
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"
       ]
     },

--- a/global.json
+++ b/global.json
@@ -6,14 +6,10 @@
     "dotnet": "7.0.100-preview.2.22114.1",
     "runtimes": {
       "dotnet": [
-        "2.1.30",
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"
       ],
       "dotnet/x86": [
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"
-      ],
-      "aspnetcore": [
-        "3.1.21"
       ]
     },
     "Git": "2.22.0",


### PR DESCRIPTION
Instead rely on the implicit versions in the SDK, which stay up-to-date anyways (see https://github.com/dotnet/installer/blob/b6c29ddce6f3d0472e3449bb65fef6c08b9bd644/src/redist/targets/GenerateBundledVersions.targets#L27-L32). Allows for building on platforms that weren't supported on older runtimes, like Apple M1 Silicon (see https://github.com/dotnet/aspnetcore/issues/40109)