### PR TITLE
Error when Hubs are registered as Singletons

### DIFF
--- a/src/SignalR/server/SignalR/src/HubEndpointRouteBuilderExtensions.cs
+++ b/src/SignalR/server/SignalR/src/HubEndpointRouteBuilderExtensions.cs
@@ -46,6 +46,16 @@ public static class HubEndpointRouteBuilderExtensions
                                                 "'IServiceCollection.AddSignalR' inside the call to 'ConfigureServices(...)' in the application startup code.");
         }
 
+        using var scope1 = endpoints.ServiceProvider.CreateScope();
+        var hub1 = scope1.ServiceProvider.GetService<THub>();
+        using var scope2 = endpoints.ServiceProvider.CreateScope();
+        var hub2 = scope2.ServiceProvider.GetService<THub>();
+        if (hub1 is not null && hub2 is not null &&
+            hub1 == hub2)
+        {
+            throw new InvalidOperationException($"'{typeof(THub).Name}' is registered as a Singleton which is not supported.");
+        }
+
         var options = new HttpConnectionDispatcherOptions();
         configureOptions?.Invoke(options);
 


### PR DESCRIPTION
I've seen enough people register Hubs as Singletons (which will not work as expected) that I was wondering if we could do something to tell them "NO!".

I'm not as familiar with DI concepts (and other containers) as either of you so let me know if there are issues with this.