### PR TITLE
Speed up contended HTTP/2 frame writing

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1668,7 +1668,7 @@ internal partial class Http2Connection : IHttp2StreamLifetimeHandler, IHttpStrea
         // write operations. This essentially doubles the MaxResponseBufferSize for HTTP/2 connections compared to
         // HTTP/1.x. This seems reasonable given HTTP/2's support for many concurrent streams per connection. We don't
         // want every write to return an incomplete ValueTask now that we're dispatching TLS write operations which
-        // would likely happen with a pauseWriterThreashold of 1, but we still need to respect connection back pressure.
+        // would likely happen with a pauseWriterThreshold of 1, but we still need to respect connection back pressure.
         var pauseWriterThreshold = _context.ServiceContext.ServerOptions.Limits.MaxResponseBufferSize switch
         {
             // null means that we have no back pressure
@@ -1680,7 +1680,7 @@ internal partial class Http2Connection : IHttp2StreamLifetimeHandler, IHttpStrea
 
         var resumeWriterThreshold = pauseWriterThreshold switch
         {
-            // The resumeWriterThreashould must be at least 1 to ever resume after pausing.
+            // The resumeWriterThreshold must be at least 1 to ever resume after pausing.
             1 => 1,
             long limit => limit / 2,
         };

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -125,8 +125,8 @@ internal partial class Http2Connection : IHttp2StreamLifetimeHandler, IHttpStrea
 
         _scheduleInline = context.ServiceContext.Scheduler == PipeScheduler.Inline;
 
-        _inputTask = CopyPipe(_context.Transport.Input, _input.Writer);
-        _outputTask = CopyPipe(_output.Reader, _context.Transport.Output);
+        _inputTask = CopyPipeAsync(_context.Transport.Input, _input.Writer);
+        _outputTask = CopyPipeAsync(_output.Reader, _context.Transport.Output);
     }
 
     public string ConnectionId => _context.ConnectionId;
@@ -1694,7 +1694,7 @@ internal partial class Http2Connection : IHttp2StreamLifetimeHandler, IHttpStrea
             useSynchronizationContext: false);
     }
 
-    private async Task CopyPipe(PipeReader reader, PipeWriter writer)
+    private async Task CopyPipeAsync(PipeReader reader, PipeWriter writer)
     {
         Exception? error = null;
         try


### PR DESCRIPTION
This PR changes Http2Connection/Http2FrameWriter so that it dispatches `SslStream.WriteAsync` to the thread pool and releases the `Http2FrameWriter._writeLock` immediately. This improves our "gRPC h2 70x1" scenario (70 streams over one HTTP/2 connection with TLS) by **500%** as measured by RPS.

The following YARP profile focused on `Http2OutputProducer.WriteDataToPipeAsync` shows how much time is currently spent spinning on the `_writeLock` and waiting on TLS operations given many streams writing to a single HTTP/2 connection.

<img width="1410" alt="Screen Shot 2022-02-24 at 4 36 48 PM" src="https://user-images.githubusercontent.com/54385/155634724-c9a33649-ab74-4172-b100-ac8190c3eaae.png">

This partially addresses #30235. It doesn't go as far as using Channels as suggested in the issue, so HPACK encoding and frame writing/copying still happens with the `_writeLock`. However, the more expensive TLS operations do get dispatched. This allows contending streams to more quickly write their own frames to an output buffer or await without spinning on a lock as frequently.

This does introduce an extra copy similar to what we already have for HTTP/2 input, but the benchmark results clearly show this is worthwhile in order to offload the TLS work to a thread that doesn't block other HTTP/2 streams. We could avoid this copy by updating `ConcurrentPipeWriter` to dispatch calls to `FlushAsync` and `WriteAsync`. I didn't do that for this initial iteration because we'd want to use a pooled `IValueTaskSource` to support this. We'd also want to make `ConcurrentPipeWriter` aware of the `MaxResponseBufferSize` so it wouldn't *always* return incomplete ValueTasks for dispatched writes.

```
> crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/grpc.benchmarks.yml --scenario grpcaspnetcoreserver-grpcnetclient --profile aspnet-citrine-lin --variable protocol=h2 --variable connections=1 --variable streams=70
```


| application           | baseline                   | Current                    |          |
| --------------------- | -------------------------- | -------------------------- | -------- |
| CPU Usage (%)         |                         13 |                         48 | +269.23% |
| Cores usage (%)       |                        370 |                      1,355 | +266.22% |
| Working Set (MB)      |                        189 |                        411 | +117.46% |
| Private Memory (MB)   |                      1,195 |                      1,418 |  +18.66% |
| Build Time (ms)       |                      4,624 |                      4,432 |   -4.15% |
| Start Time (ms)       |                        309 |                        347 |  +12.30% |
| Published Size (KB)   |                     91,293 |                     91,293 |    0.00% |
| .NET Core SDK Version | 7.0.100-preview.3.22123.26 | 7.0.100-preview.3.22123.26 |          |


| load                  | baseline | Current |          |
| --------------------- | -------- | ------- | -------- |
| CPU Usage (%)         |       28 |      90 | +221.43% |
| Cores usage (%)       |      781 |   2,512 | +221.64% |
| Working Set (MB)      |      386 |     414 |   +7.25% |
| Private Memory (MB)   |    1,397 |   1,422 |   +1.79% |
| Build Time (ms)       |    4,660 |   4,573 |   -1.87% |
| Start Time (ms)       |      183 |     186 |   +1.64% |
| Published Size (KB)   |   80,367 |  80,367 |    0.00% |
| .NET Core SDK Version |  6.0.200 | 6.0.200 |          |
| Max RPS               |   14,485 |  86,983 | +500.49% |
| Requests              |   72,413 | 434,308 | +499.77% |
| Bad responses         |        0 |       0 |          |
| Mean latency (ms)     |     4.83 |    0.80 |  -83.36% |
| Max latency (ms)      |    37.28 |    8.31 |  -77.71% |

Even when the client can open multiple connections to reduce contention, this improves performance.

```
crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/grpc.benchmarks.yml --scenario grpcaspnetcoreserver-grpcnetclient --profile aspnet-citrine-lin --variable protocol=h2 --variable streams=70
```

| application           | baseline100                | Current                    |         |
| --------------------- | -------------------------- | -------------------------- | ------- |
| CPU Usage (%)         |                         66 |                         84 | +27.27% |
| Cores usage (%)       |                      1,856 |                      2,361 | +27.21% |
| Working Set (MB)      |                      1,610 |                      1,843 | +14.47% |
| Private Memory (MB)   |                      2,658 |                      3,184 | +19.79% |
| Build Time (ms)       |                      4,624 |                      4,933 |  +6.68% |
| Start Time (ms)       |                        303 |                        336 | +10.89% |
| Published Size (KB)   |                     91,293 |                     91,293 |   0.00% |
| .NET Core SDK Version | 7.0.100-preview.3.22123.26 | 7.0.100-preview.3.22123.26 |         |


| load                  | baseline100 | Current   |          |
| --------------------- | ----------- | --------- | -------- |
| CPU Usage (%)         |          88 |        97 |  +10.23% |
| Cores usage (%)       |       2,459 |     2,715 |  +10.41% |
| Working Set (MB)      |       3,470 |     4,126 |  +18.90% |
| Private Memory (MB)   |       4,551 |     5,130 |  +12.72% |
| Build Time (ms)       |       4,287 |     4,658 |   +8.65% |
| Start Time (ms)       |         181 |       177 |   -2.21% |
| Published Size (KB)   |      80,367 |    80,367 |    0.00% |
| .NET Core SDK Version |     6.0.200 |   6.0.200 |          |
| Max RPS               |     339,472 |   426,355 |  +25.59% |
| Requests              |   1,714,671 | 2,158,208 |  +25.87% |
| Bad responses         |           0 |         0 |          |
| Mean latency (ms)     |       20.52 |     16.35 |  -20.32% |
| Max latency (ms)      |       91.55 |    186.20 | +103.38% |

I also verified the non-TLS "h2c" performance does not regress.