### PR TITLE
Clarify sort order for known headers

### DIFF
--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -143,8 +143,8 @@ public class KnownHeaders
             HeaderNames.Baggage,
         })
         .Concat(corsRequestHeaders)
-        .OrderBy(header => header)
         .OrderBy(header => !requestPrimaryHeaders.Contains(header))
+        .ThenBy(header => header)
         .Select((header, index) => new KnownHeader
         {
             Name = header,
@@ -212,8 +212,8 @@ public class KnownHeaders
             HeaderNames.Trailer,
         })
         .Concat(corsResponseHeaders)
-        .OrderBy(header => header)
         .OrderBy(header => !responsePrimaryHeaders.Contains(header))
+        .ThenBy(header => header)
         .Select((header, index) => new KnownHeader
         {
             Name = header,
@@ -237,8 +237,8 @@ public class KnownHeaders
             HeaderNames.GrpcMessage,
             HeaderNames.GrpcStatus
         }
-        .OrderBy(header => header)
         .OrderBy(header => !responsePrimaryHeaders.Contains(header))
+        .ThenBy(header => header)
         .Select((header, index) => new KnownHeader
         {
             Name = header,


### PR DESCRIPTION
Related to #40062

See https://github.com/dotnet/aspnetcore/issues/40062#issuecomment-1050525483

This change is just a minor modification to make the sort order a bit clearer. I suppose in theory it's also a tiny bit more efficient but this code is run during development time so that doesn't matter.

I ran the generator and confirmed that there were no diffs on the generated file.