### PR TITLE
Intermittent System.NullReferenceException thrown at Microsoft.AspNetCore.Mvc.ViewFeatures.Filters.SaveTempDataFilter.OnStarting #40267

### DIFF
--- a/src/Mvc/Mvc.ViewFeatures/src/Filters/SaveTempDataFilter.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Filters/SaveTempDataFilter.cs
@@ -50,7 +50,7 @@ internal class SaveTempDataFilter : IResourceFilter, IResultFilter
     private static Task OnStarting(HttpContext httpContext)
     {
         var saveTempDataContext = GetTempDataContext(httpContext);
-        if (saveTempDataContext.RequestHasUnhandledException)
+        if (saveTempDataContext == null || saveTempDataContext.RequestHasUnhandledException)
         {
             return Task.CompletedTask;
         }

--- a/src/Mvc/Mvc.ViewFeatures/src/Filters/SaveTempDataFilter.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Filters/SaveTempDataFilter.cs
@@ -50,7 +50,7 @@ internal class SaveTempDataFilter : IResourceFilter, IResultFilter
     private static Task OnStarting(HttpContext httpContext)
     {
         var saveTempDataContext = GetTempDataContext(httpContext);
-        if (saveTempDataContext == null || saveTempDataContext.RequestHasUnhandledException)
+        if (saveTempDataContext is null || saveTempDataContext.RequestHasUnhandledException)
         {
             return Task.CompletedTask;
         }


### PR DESCRIPTION
# Intermittent System.NullReferenceException thrown at Microsoft.AspNetCore.Mvc.ViewFeatures.Filters.SaveTempDataFilter.OnStarting #40267

**Check List**
- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

 Null check added to the OnStarting method of Data filter 

Fixes 
#40267
