### PR TITLE
Update MvcCoreLoggerExtensions to use LoggerMessageAttribute

### DIFF
--- a/src/Mvc/Mvc.Core/src/ChallengeResult.cs
+++ b/src/Mvc/Mvc.Core/src/ChallengeResult.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -10,7 +11,7 @@ namespace Microsoft.AspNetCore.Mvc;
 /// <summary>
 /// An <see cref="ActionResult"/> that on execution invokes <see cref="M:HttpContext.ChallengeAsync"/>.
 /// </summary>
-public class ChallengeResult : ActionResult
+public partial class ChallengeResult : ActionResult
 {
     /// <summary>
     /// Initializes a new instance of <see cref="ChallengeResult"/>.
@@ -97,8 +98,7 @@ public class ChallengeResult : ActionResult
         var httpContext = context.HttpContext;
         var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
         var logger = loggerFactory.CreateLogger<ChallengeResult>();
-
-        logger.ChallengeResultExecuting(AuthenticationSchemes);
+        Log.ChallengeResultExecuting(logger, AuthenticationSchemes);
 
         if (AuthenticationSchemes != null && AuthenticationSchemes.Count > 0)
         {
@@ -111,5 +111,19 @@ public class ChallengeResult : ActionResult
         {
             await httpContext.ChallengeAsync(Properties);
         }
+    }
+
+    private static partial class Log
+    {
+        public static void ChallengeResultExecuting(ILogger logger, IList<string> schemes)
+        {
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                ChallengeResultExecuting(logger, schemes.ToArray());
+            }
+        }
+
+        [LoggerMessage(1, LogLevel.Information, "Executing ChallengeResult with authentication schemes ({Schemes}).", EventName = "ChallengeResultExecuting", SkipEnabledCheck = true)]
+        private static partial void ChallengeResultExecuting(ILogger logger, string[] schemes);
     }
 }

--- a/src/Mvc/Mvc.Core/src/ForbidResult.cs
+++ b/src/Mvc/Mvc.Core/src/ForbidResult.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -10,7 +11,7 @@ namespace Microsoft.AspNetCore.Mvc;
 /// <summary>
 /// An <see cref="ActionResult"/> that on execution invokes <see cref="M:HttpContext.ForbidAsync"/>.
 /// </summary>
-public class ForbidResult : ActionResult
+public partial class ForbidResult : ActionResult
 {
     /// <summary>
     /// Initializes a new instance of <see cref="ForbidResult"/>.
@@ -98,8 +99,7 @@ public class ForbidResult : ActionResult
 
         var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
         var logger = loggerFactory.CreateLogger<ForbidResult>();
-
-        logger.ForbidResultExecuting(AuthenticationSchemes);
+        Log.ForbidResultExecuting(logger, AuthenticationSchemes);
 
         if (AuthenticationSchemes != null && AuthenticationSchemes.Count > 0)
         {
@@ -112,5 +112,19 @@ public class ForbidResult : ActionResult
         {
             await httpContext.ForbidAsync(Properties);
         }
+    }
+
+    private static partial class Log
+    {
+        public static void ForbidResultExecuting(ILogger logger, IList<string> authenticationSchemes)
+        {
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                ForbidResultExecuting(logger, authenticationSchemes.ToArray());
+            }
+        }
+
+        [LoggerMessage(1, LogLevel.Information, $"Executing {nameof(ForbidResult)} with authentication schemes ({{Schemes}}).", EventName = "ForbidResultExecuting", SkipEnabledCheck =  true)]
+        private static partial void ForbidResultExecuting(ILogger logger, string[] schemes);
     }
 }

--- a/src/Mvc/Mvc.Core/src/Formatters/FormatFilter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/FormatFilter.cs
@@ -110,7 +110,7 @@ public partial class FormatFilter : IFormatFilter, IResourceFilter, IResultFilte
         // type than requested e.g. OK if "text/*" requested and action supports "text/plain".
         if (!IsSuperSetOfAnySupportedMediaType(contentType, supportedMediaTypes))
         {
-            _logger.ActionDoesNotSupportFormatFilterContentType(contentType, supportedMediaTypes);
+            Log.ActionDoesNotSupportFormatFilterContentType(_logger, contentType, supportedMediaTypes);
             context.Result = new NotFoundResult();
         }
     }
@@ -184,6 +184,9 @@ public partial class FormatFilter : IFormatFilter, IResourceFilter, IResultFilte
     {
         [LoggerMessage(1, LogLevel.Debug, "Could not find a media type for the format '{FormatFilterContentType}'.", EventName = "UnsupportedFormatFilterContentType")]
         public static partial void UnsupportedFormatFilterContentType(ILogger logger, string formatFilterContentType);
+
+        [LoggerMessage(2, LogLevel.Debug, "Current action does not support the content type '{FormatFilterContentType}'. The supported content types are '{SupportedMediaTypes}'.", EventName = "ActionDoesNotSupportFormatFilterContentType")]
+        public static partial void ActionDoesNotSupportFormatFilterContentType(ILogger logger, string formatFilterContentType, MediaTypeCollection supportedMediaTypes);
 
         [LoggerMessage(3, LogLevel.Debug, "Cannot apply content type '{FormatFilterContentType}' to the response as current action had explicitly set a preferred content type.", EventName = "CannotApplyFormatFilterContentType")]
         public static partial void CannotApplyFormatFilterContentType(ILogger logger, string formatFilterContentType);

--- a/src/Mvc/Mvc.Core/src/Infrastructure/ClientErrorResultFilter.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ClientErrorResultFilter.cs
@@ -1,14 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Mvc.Infrastructure;
 
-internal class ClientErrorResultFilter : IAlwaysRunResultFilter, IOrderedFilter
+internal partial class ClientErrorResultFilter : IAlwaysRunResultFilter, IOrderedFilter
 {
     internal const int FilterOrder = -2000;
     private readonly IClientErrorFactory _clientErrorFactory;
@@ -56,7 +54,13 @@ internal class ClientErrorResultFilter : IAlwaysRunResultFilter, IOrderedFilter
             return;
         }
 
-        _logger.TransformingClientError(context.Result.GetType(), result.GetType(), clientError.StatusCode);
+        Log.TransformingClientError(_logger, context.Result.GetType(), result.GetType(), clientError.StatusCode);
         context.Result = result;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(49, LogLevel.Trace, "Replacing {InitialActionResultType} with status code {StatusCode} with {ReplacedActionResultType}.", EventName = "ClientErrorResultFilter")]
+        public static partial void TransformingClientError(ILogger logger, Type initialActionResultType, Type replacedActionResultType, int? statusCode);
     }
 }

--- a/src/Mvc/Mvc.Core/src/Infrastructure/DefaultOutputFormatterSelector.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/DefaultOutputFormatterSelector.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System.Collections.ObjectModel;
+using System.Globalization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Core;
 using Microsoft.AspNetCore.Mvc.Formatters;
@@ -157,7 +158,7 @@ public partial class DefaultOutputFormatterSelector : OutputFormatterSelector
 
         if (selectedFormatter != null)
         {
-            _logger.FormatterSelected(selectedFormatter, context);
+            Log.FormatterSelected(_logger, selectedFormatter, context);
         }
 
         return selectedFormatter;
@@ -299,6 +300,21 @@ public partial class DefaultOutputFormatterSelector : OutputFormatterSelector
 
     private static partial class Log
     {
+        public static void FormatterSelected(
+            ILogger logger,
+            IOutputFormatter outputFormatter,
+            OutputFormatterCanWriteContext context)
+        {
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                var contentType = Convert.ToString(context.ContentType, CultureInfo.InvariantCulture);
+                FormatterSelected(logger, outputFormatter, contentType);
+            }
+        }
+
+        [LoggerMessage(2, LogLevel.Debug, "Selected output formatter '{OutputFormatter}' and content type '{ContentType}' to write the response.", EventName = "FormatterSelected", SkipEnabledCheck = true)]
+        public static partial void FormatterSelected(ILogger logger, IOutputFormatter outputFormatter, string? contentType);
+
         [LoggerMessage(4, LogLevel.Debug, "No information found on request to perform content negotiation.", EventName = "NoAcceptForNegotiation")]
         public static partial void NoAcceptForNegotiation(ILogger logger);
 

--- a/src/Mvc/Mvc.Core/src/Infrastructure/FileContentResultExecutor.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/FileContentResultExecutor.cs
@@ -35,7 +35,7 @@ public partial class FileContentResultExecutor : FileResultExecutorBase, IAction
             throw new ArgumentNullException(nameof(result));
         }
 
-        Logger.ExecutingFileResult(result);
+        Log.ExecutingFileResult(Logger, result);
 
         var (range, rangeLength, serveBody) = SetHeadersAndLog(
             context,
@@ -88,6 +88,18 @@ public partial class FileContentResultExecutor : FileResultExecutorBase, IAction
 
     private static partial class Log
     {
+        public static void ExecutingFileResult(ILogger logger, FileResult fileResult)
+        {
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                var fileResultType = fileResult.GetType().Name;
+                ExecutingFileResultWithNoFileName(logger, fileResultType, fileResult.FileDownloadName);
+            }
+        }
+
+        [LoggerMessage(2, LogLevel.Information, "Executing {FileResultType}, sending file with download name '{FileDownloadName}' ...", EventName = "ExecutingFileResultWithNoFileName", SkipEnabledCheck = true)]
+        private static partial void ExecutingFileResultWithNoFileName(ILogger logger, string fileResultType, string fileDownloadName);
+
         [LoggerMessage(17, LogLevel.Debug, "Writing the requested range of bytes to the body...", EventName = "WritingRangeToBody")]
         public static partial void WritingRangeToBody(ILogger logger);
     }

--- a/src/Mvc/Mvc.Core/src/Infrastructure/FileStreamResultExecutor.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/FileStreamResultExecutor.cs
@@ -37,7 +37,7 @@ public partial class FileStreamResultExecutor : FileResultExecutorBase, IActionR
 
         using (result.FileStream)
         {
-            Logger.ExecutingFileResult(result);
+            Log.ExecutingFileResult(Logger, result);
 
             long? fileLength = null;
             if (result.FileStream.CanSeek)
@@ -100,6 +100,18 @@ public partial class FileStreamResultExecutor : FileResultExecutorBase, IActionR
 
     private static partial class Log
     {
+        public static void ExecutingFileResult(ILogger logger, FileResult fileResult)
+        {
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                var fileResultType = fileResult.GetType().Name;
+                ExecutingFileResultWithNoFileName(logger, fileResultType, fileResult.FileDownloadName);
+            }
+        }
+
+        [LoggerMessage(1, LogLevel.Information, "Executing {FileResultType}, sending file with download name '{FileDownloadName}' ...", EventName = "ExecutingFileResultWithNoFileName", SkipEnabledCheck = true)]
+        private static partial void ExecutingFileResultWithNoFileName(ILogger logger, string fileResultType, string fileDownloadName);
+
         [LoggerMessage(17, LogLevel.Debug, "Writing the requested range of bytes to the body...", EventName = "WritingRangeToBody")]
         public static partial void WritingRangeToBody(ILogger logger);
     }

--- a/src/Mvc/Mvc.Core/src/Infrastructure/ModelStateInvalidFilter.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ModelStateInvalidFilter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure;
 /// added to all types and actions annotated with <see cref="ApiControllerAttribute"/>.
 /// See <see cref="ApiBehaviorOptions"/> for ways to configure this filter.
 /// </summary>
-public class ModelStateInvalidFilter : IActionFilter, IOrderedFilter
+public partial class ModelStateInvalidFilter : IActionFilter, IOrderedFilter
 {
     internal const int FilterOrder = -2000;
 
@@ -75,8 +75,14 @@ public class ModelStateInvalidFilter : IActionFilter, IOrderedFilter
     {
         if (context.Result == null && !context.ModelState.IsValid)
         {
-            _logger.ModelStateInvalidFilterExecuting();
+            Log.ModelStateInvalidFilterExecuting(_logger);
             context.Result = _apiBehaviorOptions.InvalidModelStateResponseFactory(context);
         }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(1, LogLevel.Debug, "The request has model state errors, returning an error response.", EventName = "ModelStateInvalidFilterExecuting")]
+        public static partial void ModelStateInvalidFilterExecuting(ILogger logger);
     }
 }

--- a/src/Mvc/Mvc.Core/src/Infrastructure/ObjectResultExecutor.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ObjectResultExecutor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters;
@@ -13,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure;
 /// <summary>
 /// Executes an <see cref="ObjectResult"/> to write to the response.
 /// </summary>
-public class ObjectResultExecutor : IActionResultExecutor<ObjectResult>
+public partial class ObjectResultExecutor : IActionResultExecutor<ObjectResult>
 {
     /// <summary>
     /// Creates a new <see cref="ObjectResultExecutor"/>.
@@ -111,13 +112,13 @@ public class ObjectResultExecutor : IActionResultExecutor<ObjectResult>
         if (selectedFormatter == null)
         {
             // No formatter supports this.
-            Logger.NoFormatter(formatterContext, result.ContentTypes);
+            Log.NoFormatter(Logger, formatterContext, result.ContentTypes);
 
             context.HttpContext.Response.StatusCode = StatusCodes.Status406NotAcceptable;
             return Task.CompletedTask;
         }
 
-        Logger.ObjectResultExecuting(result, value);
+        Log.ObjectResultExecuting(Logger, result, value);
 
         result.OnFormatting(context);
         return selectedFormatter.WriteAsync(formatterContext);
@@ -142,6 +143,41 @@ public class ObjectResultExecutor : IActionResultExecutor<ObjectResult>
         }
     }
 
-    // Removed Log.
-    // new EventId(1, "BufferingAsyncEnumerable")
+    // Internal for unit testing
+    internal static partial class Log
+    {
+        // Removed Log.
+        // new EventId(1, "BufferingAsyncEnumerable")
+
+        public static void ObjectResultExecuting(ILogger logger, ObjectResult result, object? value)
+        {
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                var objectResultType = result.GetType().Name;
+                var valueType = value == null ? "null" : value.GetType().FullName;
+                ObjectResultExecuting(logger, objectResultType, valueType);
+            }
+        }
+
+        [LoggerMessage(1, LogLevel.Information, "Executing {ObjectResultType}, writing value of type '{Type}'.", EventName = "ObjectResultExecuting", SkipEnabledCheck = true)]
+        private static partial void ObjectResultExecuting(ILogger logger, string objectResultType, string? type);
+
+        public static void NoFormatter(ILogger logger, OutputFormatterCanWriteContext context, MediaTypeCollection contentTypes)
+        {
+            if (logger.IsEnabled(LogLevel.Warning))
+            {
+                var considered = new List<string?>(contentTypes);
+
+                if (context.ContentType.HasValue)
+                {
+                    considered.Add(Convert.ToString(context.ContentType, CultureInfo.InvariantCulture));
+                }
+
+                NoFormatter(logger, considered);
+            }
+        }
+
+        [LoggerMessage(2, LogLevel.Warning, "No output formatter was found for content types '{ContentTypes}' to write the response.", EventName = "NoFormatter", SkipEnabledCheck = true)]
+        private static partial void NoFormatter(ILogger logger, List<string?> contentTypes);
+    }
 }

--- a/src/Mvc/Mvc.Core/src/Infrastructure/PhysicalFileResultExecutor.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/PhysicalFileResultExecutor.cs
@@ -42,7 +42,7 @@ public partial class PhysicalFileResultExecutor : FileResultExecutorBase, IActio
                 Resources.FormatFileResult_InvalidPath(result.FileName), result.FileName);
         }
 
-        Logger.ExecutingFileResult(result, result.FileName);
+        Log.ExecutingFileResult(Logger, result, result.FileName);
 
         var lastModified = result.LastModified ?? fileInfo.LastModified;
         var (range, rangeLength, serveBody) = SetHeadersAndLog(
@@ -179,6 +179,18 @@ public partial class PhysicalFileResultExecutor : FileResultExecutorBase, IActio
 
     private static partial class Log
     {
+        public static void ExecutingFileResult(ILogger logger, FileResult fileResult, string fileName)
+        {
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                var fileResultType = fileResult.GetType().Name;
+                ExecutingFileResult(logger, fileResultType, fileName, fileResult.FileDownloadName);
+            }
+        }
+
+        [LoggerMessage(1, LogLevel.Information, "Executing {FileResultType}, sending file '{FileDownloadPath}' with download name '{FileDownloadName}' ...", EventName = "ExecutingFileResult", SkipEnabledCheck = true)]
+        private static partial void ExecutingFileResult(ILogger logger, string fileResultType, string fileDownloadPath, string fileDownloadName);
+
         [LoggerMessage(17, LogLevel.Debug, "Writing the requested range of bytes to the body...", EventName = "WritingRangeToBody")]
         public static partial void WritingRangeToBody(ILogger logger);
     }

--- a/src/Mvc/Mvc.Core/src/Infrastructure/ResourceInvoker.Log.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ResourceInvoker.Log.cs
@@ -1,0 +1,119 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Internal;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Mvc.Infrastructure;
+
+internal partial class ResourceInvoker
+{
+    // Internal for unit testing
+    internal static partial class Log
+    {
+        public static void ExecutingAction(ILogger logger, ActionDescriptor action)
+        {
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                var routeKeys = action.RouteValues.Keys.ToArray();
+                var routeValues = action.RouteValues.Values.ToArray();
+                var stringBuilder = new StringBuilder();
+                stringBuilder.Append('{');
+                for (var i = 0; i < routeValues.Length; i++)
+                {
+                    if (i == routeValues.Length - 1)
+                    {
+                        stringBuilder.Append(FormattableString.Invariant($"{routeKeys[i]} = \"{routeValues[i]}\""));
+                    }
+                    else
+                    {
+                        stringBuilder.Append(FormattableString.Invariant($"{routeKeys[i]} = \"{routeValues[i]}\", "));
+                    }
+                }
+                stringBuilder.Append('}');
+
+                if (action.RouteValues.TryGetValue("page", out var page) && page != null)
+                {
+                    PageExecuting(logger, stringBuilder.ToString(), action.DisplayName);
+                }
+                else
+                {
+                    if (action is ControllerActionDescriptor controllerActionDescriptor)
+                    {
+                        var controllerType = controllerActionDescriptor.ControllerTypeInfo.AsType();
+                        var controllerName = TypeNameHelper.GetTypeDisplayName(controllerType);
+                        ControllerActionExecuting(
+                            logger,
+                            stringBuilder.ToString(),
+                            controllerActionDescriptor.MethodInfo,
+                            controllerName,
+                            controllerType.Assembly.GetName().Name);
+                    }
+                    else
+                    {
+                        ActionExecuting(logger, stringBuilder.ToString(), action.DisplayName);
+                    }
+                }
+            }
+        }
+
+        [LoggerMessage(101, LogLevel.Information, "Route matched with {RouteData}. Executing action {ActionName}", EventName = "ActionExecuting", SkipEnabledCheck = true)]
+        private static partial void ActionExecuting(ILogger logger, string routeData, string? actionName);
+
+        [LoggerMessage(102, LogLevel.Information, "Route matched with {RouteData}. Executing controller action with signature {MethodInfo} on controller {Controller} ({AssemblyName}).", EventName = "ControllerActionExecuting", SkipEnabledCheck = true)]
+        private static partial void ControllerActionExecuting(ILogger logger, string routeData, MethodInfo methodInfo, string controller, string? assemblyName);
+
+        [LoggerMessage(103, LogLevel.Information, "Route matched with {RouteData}. Executing page {PageName}", EventName = "PageExecuting", SkipEnabledCheck = true)]
+        private static partial void PageExecuting(ILogger logger, string routeData, string? pageName);
+
+        [LoggerMessage(3, LogLevel.Information, "Authorization failed for the request at filter '{AuthorizationFilter}'.", EventName = "AuthorizationFailure")]
+        public static partial void AuthorizationFailure(ILogger logger, IFilterMetadata authorizationFilter);
+
+        [LoggerMessage(4, LogLevel.Debug, "Request was short circuited at resource filter '{ResourceFilter}'.", EventName = "ResourceFilterShortCircuit")]
+        public static partial void ResourceFilterShortCircuited(ILogger logger, IFilterMetadata resourceFilter);
+
+        [LoggerMessage(5, LogLevel.Trace, "Before executing action result {ActionResult}.", EventName = "BeforeExecutingActionResult")]
+        private static partial void BeforeExecutingActionResult(ILogger logger, Type actionResult);
+
+        public static void BeforeExecutingActionResult(ILogger logger, IActionResult actionResult)
+        {
+            BeforeExecutingActionResult(logger, actionResult.GetType());
+        }
+
+        [LoggerMessage(6, LogLevel.Trace, "After executing action result {ActionResult}.", EventName = "AfterExecutingActionResult")]
+        private static partial void AfterExecutingActionResult(ILogger logger, Type actionResult);
+
+        public static void AfterExecutingActionResult(ILogger logger, IActionResult actionResult)
+        {
+            AfterExecutingActionResult(logger, actionResult.GetType());
+        }
+
+        public static void ExecutedAction(ILogger logger, ActionDescriptor action, TimeSpan timeSpan)
+        {
+            // Don't log if logging wasn't enabled at start of request as time will be wildly wrong.
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                if (action.RouteValues.TryGetValue("page", out var page) && page != null)
+                {
+                    PageExecuted(logger, action.DisplayName, timeSpan.TotalMilliseconds);
+                }
+                else
+                {
+                    ActionExecuted(logger, action.DisplayName, timeSpan.TotalMilliseconds);
+                }
+            }
+        }
+
+        [LoggerMessage(104, LogLevel.Information, "Executed page {PageName} in {ElapsedMilliseconds}ms", EventName = "PageExecuted", SkipEnabledCheck = true)]
+        private static partial void PageExecuted(ILogger logger, string? pageName, double elapsedMilliseconds);
+
+        [LoggerMessage(105, LogLevel.Information, "Executed action {ActionName} in {ElapsedMilliseconds}ms", EventName = "ActionExecuted", SkipEnabledCheck = true)]
+        private static partial void ActionExecuted(ILogger logger, string? actionName, double elapsedMilliseconds);
+    }
+}

--- a/src/Mvc/Mvc.Core/src/Infrastructure/ResourceInvoker.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ResourceInvoker.cs
@@ -108,7 +108,7 @@ internal abstract partial class ResourceInvoker
 
                 var actionScope = logger.ActionScope(actionContext.ActionDescriptor);
 
-                logger.ExecutingAction(actionContext.ActionDescriptor);
+                Log.ExecutingAction(logger, actionContext.ActionDescriptor);
 
                 var filters = invoker._filters;
                 logger.AuthorizationFiltersExecutionPlan(filters);
@@ -126,7 +126,7 @@ internal abstract partial class ResourceInvoker
                 finally
                 {
                     await invoker.ReleaseResourcesCore(actionScope);
-                    logger.ExecutedAction(actionContext.ActionDescriptor, stopwatch.GetElapsedTime());
+                    Log.ExecutedAction(logger, actionContext.ActionDescriptor, stopwatch.GetElapsedTime());
                 }
             }
             finally
@@ -1601,30 +1601,5 @@ internal abstract partial class ResourceInvoker
     private sealed class AuthorizationFilterContextSealed : AuthorizationFilterContext
     {
         public AuthorizationFilterContextSealed(ActionContext actionContext, IList<IFilterMetadata> filters) : base(actionContext, filters) { }
-    }
-
-    private static partial class Log
-    {
-        [LoggerMessage(3, LogLevel.Information, "Authorization failed for the request at filter '{AuthorizationFilter}'.", EventName = "AuthorizationFailure")]
-        public static partial void AuthorizationFailure(ILogger logger, IFilterMetadata authorizationFilter);
-
-        [LoggerMessage(4, LogLevel.Debug, "Request was short circuited at resource filter '{ResourceFilter}'.", EventName = "ResourceFilterShortCircuit")]
-        public static partial void ResourceFilterShortCircuited(ILogger logger, IFilterMetadata resourceFilter);
-
-        [LoggerMessage(5, LogLevel.Trace, "Before executing action result {ActionResult}.", EventName = "BeforeExecutingActionResult")]
-        private static partial void BeforeExecutingActionResult(ILogger logger, Type actionResult);
-
-        public static void BeforeExecutingActionResult(ILogger logger, IActionResult actionResult)
-        {
-            BeforeExecutingActionResult(logger, actionResult.GetType());
-        }
-
-        [LoggerMessage(6, LogLevel.Trace, "After executing action result {ActionResult}.", EventName = "AfterExecutingActionResult")]
-        private static partial void AfterExecutingActionResult(ILogger logger, Type actionResult);
-
-        public static void AfterExecutingActionResult(ILogger logger, IActionResult actionResult)
-        {
-            AfterExecutingActionResult(logger, actionResult.GetType());
-        }
     }
 }

--- a/src/Mvc/Mvc.Core/src/Infrastructure/VirtualFileResultExecutor.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/VirtualFileResultExecutor.cs
@@ -53,7 +53,7 @@ public partial class VirtualFileResultExecutor : FileResultExecutorBase, IAction
                 Resources.FormatFileResult_InvalidPath(result.FileName), result.FileName);
         }
 
-        Logger.ExecutingFileResult(result, result.FileName);
+        Log.ExecutingFileResult(Logger, result, result.FileName);
 
         var lastModified = result.LastModified ?? fileInfo.LastModified;
         var (range, rangeLength, serveBody) = SetHeadersAndLog(
@@ -161,6 +161,18 @@ public partial class VirtualFileResultExecutor : FileResultExecutorBase, IAction
 
     private static partial class Log
     {
+        public static void ExecutingFileResult(ILogger logger, FileResult fileResult, string fileName)
+        {
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                var fileResultType = fileResult.GetType().Name;
+                ExecutingFileResult(logger, fileResultType, fileName, fileResult.FileDownloadName);
+            }
+        }
+
+        [LoggerMessage(1, LogLevel.Information, "Executing {FileResultType}, sending file '{FileDownloadPath}' with download name '{FileDownloadName}' ...", EventName = "ExecutingFileResult", SkipEnabledCheck = true)]
+        private static partial void ExecutingFileResult(ILogger logger, string fileResultType, string fileDownloadPath, string fileDownloadName);
+
         [LoggerMessage(17, LogLevel.Debug, "Writing the requested range of bytes to the body...", EventName = "WritingRangeToBody")]
         public static partial void WritingRangeToBody(ILogger logger);
     }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexObjectModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexObjectModelBinder.cs
@@ -656,7 +656,7 @@ public sealed partial class ComplexObjectModelBinder : IModelBinder
             return GreedyPropertiesMayHaveData;
         }
 
-        _logger.CannotBindToComplexType(bindingContext);
+        Log.CannotBindToComplexType(_logger, bindingContext);
 
         return NoDataAvailable;
     }
@@ -747,5 +747,11 @@ public sealed partial class ComplexObjectModelBinder : IModelBinder
         {
             NoPublicSettableItems(logger, bindingContext.ModelName, bindingContext.ModelType);
         }
+
+        public static void CannotBindToComplexType(ILogger logger, ModelBindingContext bindingContext)
+            => CannotBindToComplexType(logger, bindingContext.ModelType);
+
+        [LoggerMessage(18, LogLevel.Debug, "Could not bind to model of type '{ModelType}' as there were no values in the request for any of the properties.", EventName = "CannotBindToComplexType")]
+        private static partial void CannotBindToComplexType(ILogger logger, Type modelType);
     }
 }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexTypeModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexTypeModelBinder.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 /// <see cref="IModelBinder"/> implementation for binding complex types.
 /// </summary>
 [Obsolete("This type is obsolete and will be removed in a future version. Use ComplexObjectModelBinder instead.")]
-public class ComplexTypeModelBinder : IModelBinder
+public partial class ComplexTypeModelBinder : IModelBinder
 {
     // Don't want a new public enum because communication between the private and internal methods of this class
     // should not be exposed. Can't use an internal enum because types of [TheoryData] values must be public.
@@ -358,7 +358,7 @@ public class ComplexTypeModelBinder : IModelBinder
         // level object. So we return false.
         if (bindingContext.ModelMetadata.Properties.Count == 0)
         {
-            _logger.NoPublicSettableProperties(bindingContext);
+            Log.NoPublicSettableProperties(_logger, bindingContext);
             return NoDataAvailable;
         }
 
@@ -424,7 +424,7 @@ public class ComplexTypeModelBinder : IModelBinder
             return GreedyPropertiesMayHaveData;
         }
 
-        _logger.CannotBindToComplexType(bindingContext);
+        Log.CannotBindToComplexType(_logger, bindingContext);
 
         return NoDataAvailable;
     }
@@ -591,5 +591,20 @@ public class ComplexTypeModelBinder : IModelBinder
         {
             modelState.AddModelError(modelName, exception, bindingContext.ModelMetadata);
         }
+    }
+
+    private static partial class Log
+    {
+        public static void NoPublicSettableProperties(ILogger logger, ModelBindingContext bindingContext)
+            => NoPublicSettableProperties(logger, bindingContext.ModelName, bindingContext.ModelType);
+
+        [LoggerMessage(17, LogLevel.Debug, "Could not bind to model with name '{ModelName}' and type '{ModelType}' as the type has no public settable properties.", EventName = "NoPublicSettableProperties")]
+        private static partial void NoPublicSettableProperties(ILogger logger, string modelName, Type modelType);
+
+        public static void CannotBindToComplexType(ILogger logger, ModelBindingContext bindingContext)
+            => CannotBindToComplexType(logger, bindingContext.ModelType);
+
+        [LoggerMessage(18, LogLevel.Debug, "Could not bind to model of type '{ModelType}' as there were no values in the request for any of the properties.", EventName = "CannotBindToComplexType")]
+        private static partial void CannotBindToComplexType(ILogger logger, Type modelType);
     }
 }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DictionaryModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DictionaryModelBinder.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 /// </summary>
 /// <typeparam name="TKey">Type of keys in the dictionary.</typeparam>
 /// <typeparam name="TValue">Type of values in the dictionary.</typeparam>
-public class DictionaryModelBinder<TKey, TValue> : CollectionModelBinder<KeyValuePair<TKey, TValue?>> where TKey : notnull
+public partial class DictionaryModelBinder<TKey, TValue> : CollectionModelBinder<KeyValuePair<TKey, TValue?>> where TKey : notnull
 {
     private readonly IModelBinder _valueBinder;
 
@@ -140,7 +140,7 @@ public class DictionaryModelBinder<TKey, TValue> : CollectionModelBinder<KeyValu
             return;
         }
 
-        Logger.NoKeyValueFormatForDictionaryModelBinder(bindingContext);
+        Log.NoKeyValueFormatForDictionaryModelBinder(Logger, bindingContext);
 
         if (bindingContext.ValueProvider is not IEnumerableValueProvider enumerableValueProvider)
         {
@@ -261,5 +261,14 @@ public class DictionaryModelBinder<TKey, TValue> : CollectionModelBinder<KeyValu
         }
 
         return base.CanCreateInstance(targetType);
+    }
+
+    private static partial class Log
+    {
+        public static void NoKeyValueFormatForDictionaryModelBinder(ILogger logger, ModelBindingContext bindingContext)
+            => NoKeyValueFormatForDictionaryModelBinder(logger, bindingContext.ModelName);
+
+        [LoggerMessage(33, LogLevel.Debug, "Attempting to bind model with name '{ModelName}' using the format {ModelName}[key1]=value1&{ModelName}[key2]=value2", EventName = "NoKeyValueFormatForDictionaryModelBinder")]
+        private static partial void NoKeyValueFormatForDictionaryModelBinder(ILogger logger, string modelName);
     }
 }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/ParameterBinder.Log.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/ParameterBinder.Log.cs
@@ -1,0 +1,255 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding;
+
+public partial class ParameterBinder
+{
+    private static partial class Log
+    {
+        public static void AttemptingToBindParameterOrProperty(
+            ILogger logger,
+            ParameterDescriptor parameter,
+            ModelMetadata modelMetadata)
+        {
+            if (!logger.IsEnabled(LogLevel.Debug))
+            {
+                return;
+            }
+
+            switch (modelMetadata.MetadataKind)
+            {
+                case ModelMetadataKind.Parameter:
+                    AttemptingToBindParameter(logger, modelMetadata.ParameterName, modelMetadata.ModelType);
+                    break;
+                case ModelMetadataKind.Property:
+                    AttemptingToBindProperty(
+                        logger,
+                        modelMetadata.ContainerType,
+                        modelMetadata.PropertyName,
+                        modelMetadata.ModelType);
+                    break;
+                case ModelMetadataKind.Type:
+                    if (parameter is ControllerParameterDescriptor parameterDescriptor)
+                    {
+                        AttemptingToBindParameter(
+                            logger,
+                            parameterDescriptor.ParameterInfo.Name,
+                            modelMetadata.ModelType);
+                    }
+                    else
+                    {
+                        // Likely binding a page handler parameter. Due to various special cases, parameter.Name may
+                        // be empty. No way to determine actual name.
+                        AttemptingToBindParameter(logger, parameter.Name, modelMetadata.ModelType);
+                    }
+                    break;
+            }
+        }
+
+        [LoggerMessage(22, LogLevel.Debug, "Attempting to bind parameter '{ParameterName}' of type '{ModelType}' ...", EventName = "AttemptingToBindParameter", SkipEnabledCheck = true)]
+        private static partial void AttemptingToBindParameter(ILogger logger, string? parameterName, Type modelType);
+
+        [LoggerMessage(39, LogLevel.Debug, "Attempting to bind property '{PropertyContainerType}.{PropertyName}' of type '{ModelType}' ...", EventName = "AttemptingToBindProperty", SkipEnabledCheck = true)]
+        private static partial void AttemptingToBindProperty(ILogger logger, Type? propertyContainerType, string? propertyName, Type modelType);
+
+        public static void DoneAttemptingToBindParameterOrProperty(
+           ILogger logger,
+           ParameterDescriptor parameter,
+           ModelMetadata modelMetadata)
+        {
+            if (!logger.IsEnabled(LogLevel.Debug))
+            {
+                return;
+            }
+
+            switch (modelMetadata.MetadataKind)
+            {
+                case ModelMetadataKind.Parameter:
+                    DoneAttemptingToBindParameter(logger, modelMetadata.ParameterName, modelMetadata.ModelType);
+                    break;
+                case ModelMetadataKind.Property:
+                    DoneAttemptingToBindProperty(
+                        logger,
+                        modelMetadata.ContainerType,
+                        modelMetadata.PropertyName,
+                        modelMetadata.ModelType);
+                    break;
+                case ModelMetadataKind.Type:
+                    if (parameter is ControllerParameterDescriptor parameterDescriptor)
+                    {
+                        DoneAttemptingToBindParameter(
+                            logger,
+                            parameterDescriptor.ParameterInfo.Name,
+                            modelMetadata.ModelType);
+                    }
+                    else
+                    {
+                        // Likely binding a page handler parameter. Due to various special cases, parameter.Name may
+                        // be empty. No way to determine actual name.
+                        DoneAttemptingToBindParameter(logger, parameter.Name, modelMetadata.ModelType);
+                    }
+                    break;
+            }
+        }
+
+        [LoggerMessage(23, LogLevel.Debug, "Done attempting to bind parameter '{ParameterName}' of type '{ModelType}'.", EventName = "DoneAttemptingToBindParameter", SkipEnabledCheck = true)]
+        private static partial void DoneAttemptingToBindParameter(ILogger logger, string? parameterName, Type modelType);
+
+        [LoggerMessage(40, LogLevel.Debug, "Done attempting to bind property '{PropertyContainerType}.{PropertyName}' of type '{ModelType}'.", EventName = "DoneAttemptingToBindProperty", SkipEnabledCheck = true)]
+        private static partial void DoneAttemptingToBindProperty(ILogger logger, Type? propertyContainerType, string? propertyName, Type modelType);
+
+        public static void AttemptingToValidateParameterOrProperty(
+            ILogger logger,
+            ParameterDescriptor parameter,
+            ModelMetadata modelMetadata)
+        {
+            if (!logger.IsEnabled(LogLevel.Debug))
+            {
+                return;
+            }
+
+            switch (modelMetadata.MetadataKind)
+            {
+                case ModelMetadataKind.Parameter:
+                    AttemptingToValidateParameter(logger, modelMetadata.ParameterName, modelMetadata.ModelType);
+                    break;
+                case ModelMetadataKind.Property:
+                    AttemptingToValidateProperty(
+                        logger,
+                        modelMetadata.ContainerType,
+                        modelMetadata.PropertyName,
+                        modelMetadata.ModelType);
+                    break;
+                case ModelMetadataKind.Type:
+                    if (parameter is ControllerParameterDescriptor parameterDescriptor)
+                    {
+                        AttemptingToValidateParameter(
+                            logger,
+                            parameterDescriptor.ParameterInfo.Name,
+                            modelMetadata.ModelType);
+                    }
+                    else
+                    {
+                        // Likely binding a page handler parameter. Due to various special cases, parameter.Name may
+                        // be empty. No way to determine actual name. This case is less likely than for binding logging
+                        // (above). Should occur only with a legacy IModelMetadataProvider implementation.
+                        AttemptingToValidateParameter(logger, parameter.Name, modelMetadata.ModelType);
+                    }
+                    break;
+            }
+        }
+
+        [LoggerMessage(26, LogLevel.Debug, "Attempting to validate the bound parameter '{ParameterName}' of type '{ModelType}' ...", EventName = "AttemptingToValidateParameter", SkipEnabledCheck = true)]
+        private static partial void AttemptingToValidateParameter(ILogger logger, string? parameterName, Type modelType);
+
+        [LoggerMessage(41, LogLevel.Debug, "Attempting to validate the bound property '{PropertyContainerType}.{PropertyName}' of type '{ModelType}' ...", EventName = "AttemptingToValidateProperty", SkipEnabledCheck = true)]
+        private static partial void AttemptingToValidateProperty(ILogger logger, Type? propertyContainerType, string? propertyName, Type modelType);
+
+        public static void DoneAttemptingToValidateParameterOrProperty(
+            ILogger logger,
+            ParameterDescriptor parameter,
+            ModelMetadata modelMetadata)
+        {
+            if (!logger.IsEnabled(LogLevel.Debug))
+            {
+                return;
+            }
+
+            switch (modelMetadata.MetadataKind)
+            {
+                case ModelMetadataKind.Parameter:
+                    DoneAttemptingToValidateParameter(
+                        logger,
+                        modelMetadata.ParameterName,
+                        modelMetadata.ModelType);
+                    break;
+                case ModelMetadataKind.Property:
+                    DoneAttemptingToValidateProperty(
+                        logger,
+                        modelMetadata.ContainerType,
+                        modelMetadata.PropertyName,
+                        modelMetadata.ModelType);
+                    break;
+                case ModelMetadataKind.Type:
+                    if (parameter is ControllerParameterDescriptor parameterDescriptor)
+                    {
+                        DoneAttemptingToValidateParameter(
+                            logger,
+                            parameterDescriptor.ParameterInfo.Name,
+                            modelMetadata.ModelType);
+                    }
+                    else
+                    {
+                        // Likely binding a page handler parameter. Due to various special cases, parameter.Name may
+                        // be empty. No way to determine actual name. This case is less likely than for binding logging
+                        // (above). Should occur only with a legacy IModelMetadataProvider implementation.
+                        DoneAttemptingToValidateParameter(logger, parameter.Name, modelMetadata.ModelType);
+                    }
+                    break;
+            }
+        }
+
+        [LoggerMessage(27, LogLevel.Debug, "Done attempting to validate the bound parameter '{ParameterName}' of type '{ModelType}'.", EventName = "DoneAttemptingToValidateParameter")]
+        private static partial void DoneAttemptingToValidateParameter(ILogger logger, string? parameterName, Type modelType);
+
+        [LoggerMessage(42, LogLevel.Debug, "Done attempting to validate the bound property '{PropertyContainerType}.{PropertyName}' of type '{ModelType}'.", EventName = "DoneAttemptingToValidateProperty")]
+        private static partial void DoneAttemptingToValidateProperty(ILogger logger, Type? propertyContainerType, string? propertyName, Type modelType);
+
+        public static void ParameterBinderRequestPredicateShortCircuit(
+            ILogger logger,
+            ParameterDescriptor parameter,
+            ModelMetadata modelMetadata)
+        {
+            if (!logger.IsEnabled(LogLevel.Debug))
+            {
+                return;
+            }
+
+            switch (modelMetadata.MetadataKind)
+            {
+                case ModelMetadataKind.Parameter:
+                    ParameterBinderRequestPredicateShortCircuitOfParameter(
+                        logger,
+                        modelMetadata.ParameterName);
+                    break;
+                case ModelMetadataKind.Property:
+                    ParameterBinderRequestPredicateShortCircuitOfProperty(
+                        logger,
+                        modelMetadata.ContainerType,
+                        modelMetadata.PropertyName);
+                    break;
+                case ModelMetadataKind.Type:
+                    if (parameter is ControllerParameterDescriptor controllerParameterDescriptor)
+                    {
+                        ParameterBinderRequestPredicateShortCircuitOfParameter(
+                            logger,
+                            controllerParameterDescriptor.ParameterInfo.Name);
+                    }
+                    else
+                    {
+                        // Likely binding a page handler parameter. Due to various special cases, parameter.Name may
+                        // be empty. No way to determine actual name. This case is less likely than for binding logging
+                        // (above). Should occur only with a legacy IModelMetadataProvider implementation.
+                        ParameterBinderRequestPredicateShortCircuitOfParameter(logger, parameter.Name);
+                    }
+                    break;
+            }
+        }
+
+        [LoggerMessage(47, LogLevel.Debug, "Skipped binding property '{PropertyContainerType}.{PropertyName}' since its binding information disallowed it for the current request.",
+            EventName = "ParameterBinderRequestPredicateShortCircuitOfProperty",
+            SkipEnabledCheck = true)]
+        private static partial void ParameterBinderRequestPredicateShortCircuitOfProperty(ILogger logger, Type? propertyContainerType, string? propertyName);
+
+        [LoggerMessage(48, LogLevel.Debug, "Skipped binding parameter '{ParameterName}' since its binding information disallowed it for the current request.",
+            EventName = "ParameterBinderRequestPredicateShortCircuitOfParameter",
+            SkipEnabledCheck = true)]
+        private static partial void ParameterBinderRequestPredicateShortCircuitOfParameter(ILogger logger, string? parameterName);
+    }
+}

--- a/src/Mvc/Mvc.Core/src/ModelBinding/ParameterBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/ParameterBinder.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
@@ -14,7 +12,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding;
 /// <summary>
 /// Binds and validates models specified by a <see cref="ParameterDescriptor"/>.
 /// </summary>
-public class ParameterBinder
+public partial class ParameterBinder
 {
     private readonly IModelMetadataProvider _modelMetadataProvider;
     private readonly IModelBinderFactory _modelBinderFactory;
@@ -136,11 +134,11 @@ public class ParameterBinder
             throw new ArgumentNullException(nameof(metadata));
         }
 
-        Logger.AttemptingToBindParameterOrProperty(parameter, metadata);
+        Log.AttemptingToBindParameterOrProperty(Logger, parameter, metadata);
 
         if (parameter.BindingInfo?.RequestPredicate?.Invoke(actionContext) == false)
         {
-            Logger.ParameterBinderRequestPredicateShortCircuit(parameter, metadata);
+            Log.ParameterBinderRequestPredicateShortCircuit(Logger, parameter, metadata);
             return ModelBindingResult.Failed();
         }
 
@@ -171,13 +169,13 @@ public class ParameterBinder
 
         await modelBinder.BindModelAsync(modelBindingContext);
 
-        Logger.DoneAttemptingToBindParameterOrProperty(parameter, metadata);
+        Log.DoneAttemptingToBindParameterOrProperty(Logger, parameter, metadata);
 
         var modelBindingResult = modelBindingContext.Result;
 
         if (_objectModelValidator is ObjectModelValidator baseObjectValidator)
         {
-            Logger.AttemptingToValidateParameterOrProperty(parameter, metadata);
+            Log.AttemptingToValidateParameterOrProperty(Logger, parameter, metadata);
 
             EnforceBindRequiredAndValidate(
                 baseObjectValidator,
@@ -188,7 +186,7 @@ public class ParameterBinder
                 modelBindingResult,
                 container);
 
-            Logger.DoneAttemptingToValidateParameterOrProperty(parameter, metadata);
+            Log.DoneAttemptingToValidateParameterOrProperty(Logger, parameter, metadata);
         }
         else
         {

--- a/src/Mvc/Mvc.Core/src/MvcCoreLoggerExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/MvcCoreLoggerExtensions.cs
@@ -1,24 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-#pragma warning disable CA1810 // Initialize all static fields inline.
-
 using System.Collections;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using Microsoft.AspNetCore.Mvc.Abstractions;
-using Microsoft.AspNetCore.Mvc.ApplicationModels;
-using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
-using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
-using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Mvc;
 
@@ -27,484 +17,9 @@ internal static partial class MvcCoreLoggerExtensions
     public const string ActionFilter = "Action Filter";
     private static readonly string[] _noFilters = new[] { "None" };
 
-    private static readonly Action<ILogger, string, string, Exception> _controllerFactoryExecuting;
-    private static readonly Action<ILogger, string, string, Exception> _controllerFactoryExecuted;
-
-    private static readonly Action<ILogger, string, string, Exception> _actionExecuting;
-    private static readonly Action<ILogger, string, MethodInfo, string, string, Exception> _controllerActionExecuting;
-    private static readonly Action<ILogger, string, double, Exception> _actionExecuted;
-
-    private static readonly Action<ILogger, string, string, Exception> _pageExecuting;
-    private static readonly Action<ILogger, string, double, Exception> _pageExecuted;
-
-    private static readonly Action<ILogger, string[], Exception> _challengeResultExecuting;
-    private static readonly Action<ILogger, string, ModelValidationState, Exception> _actionMethodExecuting;
-    private static readonly Action<ILogger, string, string[], Exception> _actionMethodExecutingWithArguments;
-    private static readonly Action<ILogger, string, string, double, Exception> _actionMethodExecuted;
-
-    private static readonly Action<ILogger, string, string[], Exception> _logFilterExecutionPlan;
-    private static readonly Action<ILogger, string, string, Type, Exception> _beforeExecutingMethodOnFilter;
-    private static readonly Action<ILogger, string, string, Type, Exception> _afterExecutingMethodOnFilter;
-    private static readonly Action<ILogger, string, string, string, Exception> _executingFileResult;
-    private static readonly Action<ILogger, string, string, Exception> _executingFileResultWithNoFileName;
-    private static readonly Action<ILogger, object, Exception> _resultFilterShortCircuit;
-    private static readonly Action<ILogger, object, Exception> _actionFilterShortCircuit;
-    private static readonly Action<ILogger, object, Exception> _exceptionFilterShortCircuit;
-
-    private static readonly Action<ILogger, string[], Exception> _forbidResultExecuting;
-    private static readonly Action<ILogger, string[], Exception> _signOutResultExecuting;
-    private static readonly Action<ILogger, string, string, Exception> _objectResultExecuting;
-    private static readonly Action<ILogger, IEnumerable<string>, Exception> _noFormatter;
-    private static readonly Action<ILogger, IOutputFormatter, string, Exception> _formatterSelected;
-    private static readonly Action<ILogger, IInputFormatter, string, Exception> _inputFormatterSelected;
-    private static readonly Action<ILogger, IInputFormatter, string, Exception> _inputFormatterRejected;
-    private static readonly Action<ILogger, string, Exception> _noInputFormatterSelected;
-    private static readonly Action<ILogger, string, string, Exception> _removeFromBodyAttribute;
-    private static readonly Action<ILogger, string[], Exception> _noActionsMatched;
-    private static readonly Action<ILogger, Exception> _modelStateInvalidFilterExecuting;
-
-    private static readonly Action<ILogger, MethodInfo, string, string, Exception> _inferredParameterSource;
-    private static readonly Action<ILogger, string, Type, string, Type, Exception> _foundNoValueForPropertyInRequest;
-    private static readonly Action<ILogger, string, string, Type, Exception> _foundNoValueForParameterInRequest;
-    private static readonly Action<ILogger, string, Type, Exception> _foundNoValueInRequest;
-    private static readonly Action<ILogger, Type, string, Exception> _parameterBinderRequestPredicateShortCircuitOfProperty;
-    private static readonly Action<ILogger, string, Exception> _parameterBinderRequestPredicateShortCircuitOfParameter;
-    private static readonly Action<ILogger, string, Type, Exception> _noPublicSettableProperties;
-    private static readonly Action<ILogger, Type, Exception> _cannotBindToComplexType;
-    private static readonly Action<ILogger, string, Type, Exception> _cannotBindToFilesCollectionDueToUnsupportedContentType;
-    private static readonly Action<ILogger, Type, Exception> _cannotCreateHeaderModelBinderCompatVersion_2_0;
-    private static readonly Action<ILogger, string, string, Exception> _noNonIndexBasedFormatFoundForCollection;
-    private static readonly Action<ILogger, string, string, string, string, string, string, Exception> _attemptingToBindCollectionUsingIndices;
-    private static readonly Action<ILogger, string, string, string, string, string, string, Exception> _attemptingToBindCollectionOfKeyValuePair;
-    private static readonly Action<ILogger, string, string, string, Exception> _noKeyValueFormatForDictionaryModelBinder;
-    private static readonly Action<ILogger, string, Type, string, Exception> _attemptingToBindParameterModel;
-    private static readonly Action<ILogger, string, Type, Exception> _doneAttemptingToBindParameterModel;
-    private static readonly Action<ILogger, Type, string, Type, string, Exception> _attemptingToBindPropertyModel;
-    private static readonly Action<ILogger, Type, string, Type, Exception> _doneAttemptingToBindPropertyModel;
-    private static readonly Action<ILogger, Type, string, Exception> _attemptingToBindModel;
-    private static readonly Action<ILogger, Type, string, Exception> _doneAttemptingToBindModel;
-    private static readonly Action<ILogger, string, Type, Exception> _attemptingToBindParameter;
-    private static readonly Action<ILogger, string, Type, Exception> _doneAttemptingToBindParameter;
-    private static readonly Action<ILogger, Type, string, Type, Exception> _attemptingToBindProperty;
-    private static readonly Action<ILogger, Type, string, Type, Exception> _doneAttemptingToBindProperty;
-    private static readonly Action<ILogger, Type, string, Type, Exception> _attemptingToValidateProperty;
-    private static readonly Action<ILogger, Type, string, Type, Exception> _doneAttemptingToValidateProperty;
-    private static readonly Action<ILogger, string, Type, Exception> _attemptingToValidateParameter;
-    private static readonly Action<ILogger, string, Type, Exception> _doneAttemptingToValidateParameter;
-    private static readonly Action<ILogger, string, MediaTypeCollection, Exception> _actionDoesNotSupportFormatFilterContentType;
-    private static readonly Action<ILogger, DateTimeOffset?, DateTimeOffset?, Exception> _ifUnmodifiedSincePreconditionFailed;
-    private static readonly Action<ILogger, DateTimeOffset?, DateTimeOffset?, Exception> _ifRangeLastModifiedPreconditionFailed;
-    private static readonly Action<ILogger, EntityTagHeaderValue, EntityTagHeaderValue, Exception> _ifRangeETagPreconditionFailed;
-    private static readonly Action<ILogger, Type, int?, Type, Exception> _transformingClientError;
-
-    static MvcCoreLoggerExtensions()
-    {
-        LogDefineOptions SkipEnabledCheckLogOptions = new() { SkipEnabledCheck = true };
-        _controllerFactoryExecuting = LoggerMessage.Define<string, string>(
-            LogLevel.Debug,
-            new EventId(1, "ControllerFactoryExecuting"),
-            "Executing controller factory for controller {Controller} ({AssemblyName})",
-            SkipEnabledCheckLogOptions);
-
-        _controllerFactoryExecuted = LoggerMessage.Define<string, string>(
-            LogLevel.Debug,
-            new EventId(2, "ControllerFactoryExecuted"),
-            "Executed controller factory for controller {Controller} ({AssemblyName})",
-            SkipEnabledCheckLogOptions);
-
-        _actionExecuting = LoggerMessage.Define<string, string>(
-            LogLevel.Information,
-            new EventId(1, "ActionExecuting"),
-            "Route matched with {RouteData}. Executing action {ActionName}",
-            SkipEnabledCheckLogOptions);
-
-        _controllerActionExecuting = LoggerMessage.Define<string, MethodInfo, string, string>(
-            LogLevel.Information,
-            new EventId(3, "ControllerActionExecuting"),
-            "Route matched with {RouteData}. Executing controller action with signature {MethodInfo} on controller {Controller} ({AssemblyName}).",
-            SkipEnabledCheckLogOptions);
-
-        _actionExecuted = LoggerMessage.Define<string, double>(
-            LogLevel.Information,
-            new EventId(2, "ActionExecuted"),
-            "Executed action {ActionName} in {ElapsedMilliseconds}ms",
-            SkipEnabledCheckLogOptions);
-
-        _pageExecuting = LoggerMessage.Define<string, string>(
-            LogLevel.Information,
-            new EventId(3, "PageExecuting"),
-            "Route matched with {RouteData}. Executing page {PageName}",
-            SkipEnabledCheckLogOptions);
-
-        _pageExecuted = LoggerMessage.Define<string, double>(
-            LogLevel.Information,
-            new EventId(4, "PageExecuted"),
-            "Executed page {PageName} in {ElapsedMilliseconds}ms",
-            SkipEnabledCheckLogOptions);
-
-        _challengeResultExecuting = LoggerMessage.Define<string[]>(
-            LogLevel.Information,
-            new EventId(1, "ChallengeResultExecuting"),
-            "Executing ChallengeResult with authentication schemes ({Schemes}).",
-            SkipEnabledCheckLogOptions);
-        _actionMethodExecuting = LoggerMessage.Define<string, ModelValidationState>(
-            LogLevel.Information,
-            new EventId(1, "ActionMethodExecuting"),
-            "Executing action method {ActionName} - Validation state: {ValidationState}",
-            SkipEnabledCheckLogOptions);
-
-        _actionMethodExecutingWithArguments = LoggerMessage.Define<string, string[]>(
-            LogLevel.Trace,
-            new EventId(1, "ActionMethodExecutingWithArguments"),
-            "Executing action method {ActionName} with arguments ({Arguments})",
-            SkipEnabledCheckLogOptions);
-
-        _actionMethodExecuted = LoggerMessage.Define<string, string, double>(
-            LogLevel.Information,
-            new EventId(2, "ActionMethodExecuted"),
-            "Executed action method {ActionName}, returned result {ActionResult} in {ElapsedMilliseconds}ms.",
-            SkipEnabledCheckLogOptions);
-
-        _logFilterExecutionPlan = LoggerMessage.Define<string, string[]>(
-            LogLevel.Debug,
-            new EventId(1, "FilterExecutionPlan"),
-            "Execution plan of {FilterType} filters (in the following order): {Filters}",
-            SkipEnabledCheckLogOptions);
-
-        _beforeExecutingMethodOnFilter = LoggerMessage.Define<string, string, Type>(
-            LogLevel.Trace,
-            new EventId(2, "BeforeExecutingMethodOnFilter"),
-            "{FilterType}: Before executing {Method} on filter {Filter}.");
-
-        _afterExecutingMethodOnFilter = LoggerMessage.Define<string, string, Type>(
-            LogLevel.Trace,
-            new EventId(3, "AfterExecutingMethodOnFilter"),
-            "{FilterType}: After executing {Method} on filter {Filter}.");
-        _executingFileResult = LoggerMessage.Define<string, string, string>(
-            LogLevel.Information,
-            new EventId(1, "ExecutingFileResult"),
-            "Executing {FileResultType}, sending file '{FileDownloadPath}' with download name '{FileDownloadName}' ...",
-            SkipEnabledCheckLogOptions);
-
-        _executingFileResultWithNoFileName = LoggerMessage.Define<string, string>(
-            LogLevel.Information,
-            new EventId(2, "ExecutingFileResultWithNoFileName"),
-            "Executing {FileResultType}, sending file with download name '{FileDownloadName}' ...",
-            SkipEnabledCheckLogOptions);
-        _resultFilterShortCircuit = LoggerMessage.Define<object>(
-            LogLevel.Debug,
-            new EventId(5, "ResultFilterShortCircuit"),
-            "Request was short circuited at result filter '{ResultFilter}'.");
-
-        _actionFilterShortCircuit = LoggerMessage.Define<object>(
-            LogLevel.Debug,
-            new EventId(3, "ActionFilterShortCircuit"),
-            "Request was short circuited at action filter '{ActionFilter}'.");
-
-        _exceptionFilterShortCircuit = LoggerMessage.Define<object>(
-            LogLevel.Debug,
-            new EventId(4, "ExceptionFilterShortCircuit"),
-            "Request was short circuited at exception filter '{ExceptionFilter}'.");
-
-        _forbidResultExecuting = LoggerMessage.Define<string[]>(
-            LogLevel.Information,
-            new EventId(1, "ForbidResultExecuting"),
-            formatString: $"Executing {nameof(ForbidResult)} with authentication schemes ({{Schemes}}).",
-            SkipEnabledCheckLogOptions);
-        _signOutResultExecuting = LoggerMessage.Define<string[]>(
-            LogLevel.Information,
-            new EventId(1, "SignOutResultExecuting"),
-            formatString: $"Executing {nameof(SignOutResult)} with authentication schemes ({{Schemes}}).",
-            SkipEnabledCheckLogOptions);
-        _noFormatter = LoggerMessage.Define<IEnumerable<string>>(
-            LogLevel.Warning,
-            new EventId(1, "NoFormatter"),
-            "No output formatter was found for content types '{ContentTypes}' to write the response.",
-            SkipEnabledCheckLogOptions);
-
-        _objectResultExecuting = LoggerMessage.Define<string, string>(
-            LogLevel.Information,
-            new EventId(1, "ObjectResultExecuting"),
-            "Executing {ObjectResultType}, writing value of type '{Type}'.",
-            SkipEnabledCheckLogOptions);
-
-        _formatterSelected = LoggerMessage.Define<IOutputFormatter, string>(
-            LogLevel.Debug,
-            new EventId(2, "FormatterSelected"),
-            "Selected output formatter '{OutputFormatter}' and content type '{ContentType}' to write the response.",
-            SkipEnabledCheckLogOptions);
-        _inputFormatterSelected = LoggerMessage.Define<IInputFormatter, string>(
-            LogLevel.Debug,
-            new EventId(1, "InputFormatterSelected"),
-            "Selected input formatter '{InputFormatter}' for content type '{ContentType}'.",
-            SkipEnabledCheckLogOptions);
-
-        _inputFormatterRejected = LoggerMessage.Define<IInputFormatter, string>(
-            LogLevel.Debug,
-            new EventId(2, "InputFormatterRejected"),
-            "Rejected input formatter '{InputFormatter}' for content type '{ContentType}'.",
-            SkipEnabledCheckLogOptions);
-
-        _noInputFormatterSelected = LoggerMessage.Define<string>(
-            LogLevel.Debug,
-            new EventId(3, "NoInputFormatterSelected"),
-            "No input formatter was found to support the content type '{ContentType}' for use with the [FromBody] attribute.",
-            SkipEnabledCheckLogOptions);
-
-        _removeFromBodyAttribute = LoggerMessage.Define<string, string>(
-            LogLevel.Debug,
-            new EventId(4, "RemoveFromBodyAttribute"),
-            "To use model binding, remove the [FromBody] attribute from the property or parameter named '{ModelName}' with model type '{ModelType}'.",
-            SkipEnabledCheckLogOptions);
-        _noActionsMatched = LoggerMessage.Define<string[]>(
-            LogLevel.Debug,
-            new EventId(3, "NoActionsMatched"),
-            "No actions matched the current request. Route values: {RouteValues}",
-            SkipEnabledCheckLogOptions);
-        _modelStateInvalidFilterExecuting = LoggerMessage.Define(
-            LogLevel.Debug,
-            new EventId(1, "ModelStateInvalidFilterExecuting"),
-            "The request has model state errors, returning an error response.");
-
-        _inferredParameterSource = LoggerMessage.Define<MethodInfo, string, string>(
-            LogLevel.Debug,
-            new EventId(1, "InferredParameterSource"),
-            "Inferred binding source for '{ParameterName}` on `{ActionName}` as {BindingSource}.",
-            SkipEnabledCheckLogOptions);
-        _actionDoesNotSupportFormatFilterContentType = LoggerMessage.Define<string, MediaTypeCollection>(
-            LogLevel.Debug,
-            new EventId(2, "ActionDoesNotSupportFormatFilterContentType"),
-            "Current action does not support the content type '{FormatFilterContentType}'. The supported content types are '{SupportedMediaTypes}'.");
-        _attemptingToBindPropertyModel = LoggerMessage.Define<Type, string, Type, string>(
-           LogLevel.Debug,
-            new EventId(13, "AttemptingToBindPropertyModel"),
-           "Attempting to bind property '{PropertyContainerType}.{PropertyName}' of type '{ModelType}' using the name '{ModelName}' in request data ...",
-            SkipEnabledCheckLogOptions);
-
-        _doneAttemptingToBindPropertyModel = LoggerMessage.Define<Type, string, Type>(
-           LogLevel.Debug,
-            new EventId(14, "DoneAttemptingToBindPropertyModel"),
-           "Done attempting to bind property '{PropertyContainerType}.{PropertyName}' of type '{ModelType}'.",
-            SkipEnabledCheckLogOptions);
-
-        _foundNoValueForPropertyInRequest = LoggerMessage.Define<string, Type, string, Type>(
-           LogLevel.Debug,
-            new EventId(15, "FoundNoValueForPropertyInRequest"),
-           "Could not find a value in the request with name '{ModelName}' for binding property '{PropertyContainerType}.{ModelFieldName}' of type '{ModelType}'.",
-            SkipEnabledCheckLogOptions);
-
-        _foundNoValueForParameterInRequest = LoggerMessage.Define<string, string, Type>(
-           LogLevel.Debug,
-            new EventId(16, "FoundNoValueForParameterInRequest"),
-           "Could not find a value in the request with name '{ModelName}' for binding parameter '{ModelFieldName}' of type '{ModelType}'.",
-            SkipEnabledCheckLogOptions);
-
-        _noPublicSettableProperties = LoggerMessage.Define<string, Type>(
-           LogLevel.Debug,
-            new EventId(17, "NoPublicSettableProperties"),
-           "Could not bind to model with name '{ModelName}' and type '{ModelType}' as the type has no public settable properties.");
-
-        _cannotBindToComplexType = LoggerMessage.Define<Type>(
-           LogLevel.Debug,
-            new EventId(18, "CannotBindToComplexType"),
-           "Could not bind to model of type '{ModelType}' as there were no values in the request for any of the properties.");
-
-        _cannotBindToFilesCollectionDueToUnsupportedContentType = LoggerMessage.Define<string, Type>(
-           LogLevel.Debug,
-            new EventId(19, "CannotBindToFilesCollectionDueToUnsupportedContentType"),
-           "Could not bind to model with name '{ModelName}' and type '{ModelType}' as the request did not have a content type of either 'application/x-www-form-urlencoded' or 'multipart/form-data'.");
-        _attemptingToBindParameter = LoggerMessage.Define<string, Type>(
-            LogLevel.Debug,
-            new EventId(22, "AttemptingToBindParameter"),
-            "Attempting to bind parameter '{ParameterName}' of type '{ModelType}' ...",
-            SkipEnabledCheckLogOptions);
-
-        _doneAttemptingToBindParameter = LoggerMessage.Define<string, Type>(
-            LogLevel.Debug,
-            new EventId(23, "DoneAttemptingToBindParameter"),
-            "Done attempting to bind parameter '{ParameterName}' of type '{ModelType}'.",
-            SkipEnabledCheckLogOptions);
-
-        _attemptingToBindModel = LoggerMessage.Define<Type, string>(
-            LogLevel.Debug,
-            new EventId(24, "AttemptingToBindModel"),
-            "Attempting to bind model of type '{ModelType}' using the name '{ModelName}' in request data ...",
-            SkipEnabledCheckLogOptions);
-
-        _doneAttemptingToBindModel = LoggerMessage.Define<Type, string>(
-            LogLevel.Debug,
-            new EventId(25, "DoneAttemptingToBindModel"),
-            "Done attempting to bind model of type '{ModelType}' using the name '{ModelName}'.",
-            SkipEnabledCheckLogOptions);
-
-        _attemptingToValidateParameter = LoggerMessage.Define<string, Type>(
-            LogLevel.Debug,
-            new EventId(26, "AttemptingToValidateParameter"),
-            "Attempting to validate the bound parameter '{ParameterName}' of type '{ModelType}' ...",
-            SkipEnabledCheckLogOptions);
-
-        _doneAttemptingToValidateParameter = LoggerMessage.Define<string, Type>(
-            LogLevel.Debug,
-            new EventId(27, "DoneAttemptingToValidateParameter"),
-            "Done attempting to validate the bound parameter '{ParameterName}' of type '{ModelType}'.",
-            SkipEnabledCheckLogOptions);
-
-        _noNonIndexBasedFormatFoundForCollection = LoggerMessage.Define<string, string>(
-            LogLevel.Debug,
-            new EventId(28, "NoNonIndexBasedFormatFoundForCollection"),
-            "Could not bind to collection using a format like {ModelName}=value1&{ModelName}=value2");
-
-        _attemptingToBindCollectionUsingIndices = LoggerMessage.Define<string, string, string, string, string, string>(
-            LogLevel.Debug,
-            new EventId(29, "AttemptingToBindCollectionUsingIndices"),
-            "Attempting to bind model using indices. Example formats include: " +
-            "[0]=value1&[1]=value2, " +
-            "{ModelName}[0]=value1&{ModelName}[1]=value2, " +
-            "{ModelName}.index=zero&{ModelName}.index=one&{ModelName}[zero]=value1&{ModelName}[one]=value2",
-            SkipEnabledCheckLogOptions);
-
-        _attemptingToBindCollectionOfKeyValuePair = LoggerMessage.Define<string, string, string, string, string, string>(
-            LogLevel.Debug,
-            new EventId(30, "AttemptingToBindCollectionOfKeyValuePair"),
-            "Attempting to bind collection of KeyValuePair. Example formats include: " +
-            "[0].Key=key1&[0].Value=value1&[1].Key=key2&[1].Value=value2, " +
-            "{ModelName}[0].Key=key1&{ModelName}[0].Value=value1&{ModelName}[1].Key=key2&{ModelName}[1].Value=value2, " +
-            "{ModelName}[key1]=value1&{ModelName}[key2]=value2",
-            SkipEnabledCheckLogOptions);
-
-        _noKeyValueFormatForDictionaryModelBinder = LoggerMessage.Define<string, string, string>(
-            LogLevel.Debug,
-            new EventId(33, "NoKeyValueFormatForDictionaryModelBinder"),
-            "Attempting to bind model with name '{ModelName}' using the format {ModelName}[key1]=value1&{ModelName}[key2]=value2");
-        _ifUnmodifiedSincePreconditionFailed = LoggerMessage.Define<DateTimeOffset?, DateTimeOffset?>(
-            LogLevel.Debug,
-            new EventId(35, "IfUnmodifiedSincePreconditionFailed"),
-            "Current request's If-Unmodified-Since header check failed as the file was modified (at '{lastModified}') after the If-Unmodified-Since date '{IfUnmodifiedSinceDate}'.");
-
-        _ifRangeLastModifiedPreconditionFailed = LoggerMessage.Define<DateTimeOffset?, DateTimeOffset?>(
-            LogLevel.Debug,
-            new EventId(36, "IfRangeLastModifiedPreconditionFailed"),
-            "Could not serve range as the file was modified (at {LastModified}) after the if-Range's last modified date '{IfRangeLastModified}'.");
-
-        _ifRangeETagPreconditionFailed = LoggerMessage.Define<EntityTagHeaderValue, EntityTagHeaderValue>(
-            LogLevel.Debug,
-            new EventId(37, "IfRangeETagPreconditionFailed"),
-            "Could not serve range as the file's current etag '{CurrentETag}' does not match the If-Range etag '{IfRangeETag}'.");
-        _attemptingToBindProperty = LoggerMessage.Define<Type, string, Type>(
-            LogLevel.Debug,
-            new EventId(39, "AttemptingToBindProperty"),
-            "Attempting to bind property '{PropertyContainerType}.{PropertyName}' of type '{ModelType}' ...",
-            SkipEnabledCheckLogOptions);
-
-        _doneAttemptingToBindProperty = LoggerMessage.Define<Type, string, Type>(
-            LogLevel.Debug,
-            new EventId(40, "DoneAttemptingToBindProperty"),
-            "Done attempting to bind property '{PropertyContainerType}.{PropertyName}' of type '{ModelType}'.",
-            SkipEnabledCheckLogOptions);
-
-        _attemptingToValidateProperty = LoggerMessage.Define<Type, string, Type>(
-            LogLevel.Debug,
-            new EventId(41, "AttemptingToValidateProperty"),
-            "Attempting to validate the bound property '{PropertyContainerType}.{PropertyName}' of type '{ModelType}' ...",
-            SkipEnabledCheckLogOptions);
-
-        _doneAttemptingToValidateProperty = LoggerMessage.Define<Type, string, Type>(
-            LogLevel.Debug,
-            new EventId(42, "DoneAttemptingToValidateProperty"),
-            "Done attempting to validate the bound property '{PropertyContainerType}.{PropertyName}' of type '{ModelType}'.",
-            SkipEnabledCheckLogOptions);
-
-        _cannotCreateHeaderModelBinderCompatVersion_2_0 = LoggerMessage.Define<Type>(
-           LogLevel.Debug,
-            new EventId(43, "CannotCreateHeaderModelBinderCompatVersion20"),
-           "Could not create a binder for type '{ModelType}' as this binder only supports 'System.String' type or a collection of 'System.String'.");
-
-        _attemptingToBindParameterModel = LoggerMessage.Define<string, Type, string>(
-            LogLevel.Debug,
-            new EventId(44, "AttemptingToBindParameterModel"),
-            "Attempting to bind parameter '{ParameterName}' of type '{ModelType}' using the name '{ModelName}' in request data ...",
-            SkipEnabledCheckLogOptions);
-
-        _doneAttemptingToBindParameterModel = LoggerMessage.Define<string, Type>(
-           LogLevel.Debug,
-            new EventId(45, "DoneAttemptingToBindParameterModel"),
-           "Done attempting to bind parameter '{ParameterName}' of type '{ModelType}'.",
-            SkipEnabledCheckLogOptions);
-
-        _foundNoValueInRequest = LoggerMessage.Define<string, Type>(
-           LogLevel.Debug,
-            new EventId(46, "FoundNoValueInRequest"),
-           "Could not find a value in the request with name '{ModelName}' of type '{ModelType}'.",
-            SkipEnabledCheckLogOptions);
-
-        _parameterBinderRequestPredicateShortCircuitOfProperty = LoggerMessage.Define<Type, string>(
-           LogLevel.Debug,
-            new EventId(47, "ParameterBinderRequestPredicateShortCircuitOfProperty"),
-           "Skipped binding property '{PropertyContainerType}.{PropertyName}' since its binding information disallowed it for the current request.",
-            SkipEnabledCheckLogOptions);
-
-        _parameterBinderRequestPredicateShortCircuitOfParameter = LoggerMessage.Define<string>(
-           LogLevel.Debug,
-            new EventId(48, "ParameterBinderRequestPredicateShortCircuitOfParameter"),
-           "Skipped binding parameter '{ParameterName}' since its binding information disallowed it for the current request.",
-            SkipEnabledCheckLogOptions);
-
-        _transformingClientError = LoggerMessage.Define<Type, int?, Type>(
-            LogLevel.Trace,
-            new EventId(49, "ClientErrorResultFilter"),
-            "Replacing {InitialActionResultType} with status code {StatusCode} with {ReplacedActionResultType}.");
-    }
-
     public static IDisposable ActionScope(this ILogger logger, ActionDescriptor action)
     {
         return logger.BeginScope(new ActionLogScope(action));
-    }
-
-    public static void ExecutingAction(this ILogger logger, ActionDescriptor action)
-    {
-        if (logger.IsEnabled(LogLevel.Information))
-        {
-            var routeKeys = action.RouteValues.Keys.ToArray();
-            var routeValues = action.RouteValues.Values.ToArray();
-            var stringBuilder = new StringBuilder();
-            stringBuilder.Append('{');
-            for (var i = 0; i < routeValues.Length; i++)
-            {
-                if (i == routeValues.Length - 1)
-                {
-                    stringBuilder.Append(FormattableString.Invariant($"{routeKeys[i]} = \"{routeValues[i]}\""));
-                }
-                else
-                {
-                    stringBuilder.Append(FormattableString.Invariant($"{routeKeys[i]} = \"{routeValues[i]}\", "));
-                }
-            }
-            stringBuilder.Append('}');
-
-            if (action.RouteValues.TryGetValue("page", out var page) && page != null)
-            {
-                _pageExecuting(logger, stringBuilder.ToString(), action.DisplayName, null);
-            }
-            else
-            {
-                if (action is ControllerActionDescriptor controllerActionDescriptor)
-                {
-                    var controllerType = controllerActionDescriptor.ControllerTypeInfo.AsType();
-                    var controllerName = TypeNameHelper.GetTypeDisplayName(controllerType);
-                    _controllerActionExecuting(
-                        logger,
-                        stringBuilder.ToString(),
-                        controllerActionDescriptor.MethodInfo,
-                        controllerName,
-                        controllerType.Assembly.GetName().Name,
-                        null);
-                }
-                else
-                {
-                    _actionExecuting(logger, stringBuilder.ToString(), action.DisplayName, null);
-                }
-            }
-        }
     }
 
     public static void AuthorizationFiltersExecutionPlan(this ILogger logger, IEnumerable<IFilterMetadata> filters)
@@ -562,274 +77,38 @@ internal static partial class MvcCoreLoggerExtensions
         LogFilterExecutionPlan(logger, "result", resultFilters);
     }
 
-    public static void BeforeExecutingMethodOnFilter(
-        this ILogger logger,
-        string filterType,
-        string methodName,
-        IFilterMetadata filter)
-    {
-        _beforeExecutingMethodOnFilter(logger, filterType, methodName, filter.GetType(), null);
-    }
+    [LoggerMessage(52, LogLevel.Trace, "{FilterType}: Before executing {Method} on filter {Filter}.", EventName = "BeforeExecutingMethodOnFilter")]
+    public static partial void BeforeExecutingMethodOnFilter(this ILogger logger, string filterType, string method, IFilterMetadata filter);
 
-    public static void AfterExecutingMethodOnFilter(
-        this ILogger logger,
-        string filterType,
-        string methodName,
-        IFilterMetadata filter)
-    {
-        _afterExecutingMethodOnFilter(logger, filterType, methodName, filter.GetType(), null);
-    }
+    [LoggerMessage(53, LogLevel.Trace, "{FilterType}: After executing {Method} on filter {Filter}.", EventName = "AfterExecutingMethodOnFilter")]
+    public static partial void AfterExecutingMethodOnFilter(this ILogger logger, string filterType, string method, IFilterMetadata filter);
 
-    public static void ExecutedAction(this ILogger logger, ActionDescriptor action, TimeSpan timeSpan)
-    {
-        // Don't log if logging wasn't enabled at start of request as time will be wildly wrong.
-        if (logger.IsEnabled(LogLevel.Information))
-        {
-            if (action.RouteValues.TryGetValue("page", out var page) && page != null)
-            {
-                _pageExecuted(logger, action.DisplayName, timeSpan.TotalMilliseconds, null);
-            }
-            else
-            {
-                _actionExecuted(logger, action.DisplayName, timeSpan.TotalMilliseconds, null);
-            }
-        }
-    }
-
-    public static void NoActionsMatched(this ILogger logger, IDictionary<string, object> routeValueDictionary)
+    public static void NoActionsMatched(this ILogger logger, IDictionary<string, object?> routeValueDictionary)
     {
         if (logger.IsEnabled(LogLevel.Debug))
         {
-            string[] routeValues = null;
-            if (routeValueDictionary != null)
+            string[]? routeValues = null;
+            if (routeValueDictionary is not null)
             {
                 routeValues = routeValueDictionary
                     .Select(pair => pair.Key + "=" + Convert.ToString(pair.Value, CultureInfo.InvariantCulture))
                     .ToArray();
             }
-            _noActionsMatched(logger, routeValues, null);
+            NoActionsMatched(logger, routeValues);
         }
     }
 
-    public static void ChallengeResultExecuting(this ILogger logger, IList<string> schemes)
-    {
-        if (logger.IsEnabled(LogLevel.Information))
-        {
-            _challengeResultExecuting(logger, schemes.ToArray(), null);
-        }
-    }
+    [LoggerMessage(3, LogLevel.Debug, "No actions matched the current request. Route values: {RouteValues}", EventName = "NoActionsMatched", SkipEnabledCheck = true)]
+    private static partial void NoActionsMatched(ILogger logger, string[]? routeValues);
 
-    public static void ActionMethodExecuting(this ILogger logger, ControllerContext context, object[] arguments)
-    {
-        if (logger.IsEnabled(LogLevel.Information))
-        {
-            var actionName = context.ActionDescriptor.DisplayName;
+    [LoggerMessage(5, LogLevel.Debug, "Request was short circuited at result filter '{ResultFilter}'.", EventName = "ResultFilterShortCircuit")]
+    public static partial void ResultFilterShortCircuited(this ILogger logger, IFilterMetadata resultFilter);
 
-            var validationState = context.ModelState.ValidationState;
-            _actionMethodExecuting(logger, actionName, validationState, null);
+    [LoggerMessage(4, LogLevel.Debug, "Request was short circuited at exception filter '{ExceptionFilter}'.", EventName = "ExceptionFilterShortCircuit")]
+    public static partial void ExceptionFilterShortCircuited(this ILogger logger, IFilterMetadata exceptionFilter);
 
-            if (arguments != null && logger.IsEnabled(LogLevel.Trace))
-            {
-                var convertedArguments = new string[arguments.Length];
-                for (var i = 0; i < arguments.Length; i++)
-                {
-                    convertedArguments[i] = Convert.ToString(arguments[i], CultureInfo.InvariantCulture);
-                }
-
-                _actionMethodExecutingWithArguments(logger, actionName, convertedArguments, null);
-            }
-        }
-    }
-
-    public static void ActionMethodExecuted(this ILogger logger, ControllerContext context, IActionResult result, TimeSpan timeSpan)
-    {
-        if (logger.IsEnabled(LogLevel.Information))
-        {
-            var actionName = context.ActionDescriptor.DisplayName;
-            _actionMethodExecuted(logger, actionName, Convert.ToString(result, CultureInfo.InvariantCulture), timeSpan.TotalMilliseconds, null);
-        }
-    }
-
-    public static void ExecutingFileResult(this ILogger logger, FileResult fileResult)
-    {
-        if (logger.IsEnabled(LogLevel.Information))
-        {
-            var fileResultType = fileResult.GetType().Name;
-            _executingFileResultWithNoFileName(logger, fileResultType, fileResult.FileDownloadName, null);
-        }
-    }
-
-    public static void ExecutingFileResult(this ILogger logger, FileResult fileResult, string fileName)
-    {
-        if (logger.IsEnabled(LogLevel.Information))
-        {
-            var fileResultType = fileResult.GetType().Name;
-            _executingFileResult(logger, fileResultType, fileName, fileResult.FileDownloadName, null);
-        }
-    }
-
-    public static void ResultFilterShortCircuited(
-        this ILogger logger,
-        IFilterMetadata filter)
-    {
-        _resultFilterShortCircuit(logger, filter, null);
-    }
-
-    public static void ExceptionFilterShortCircuited(
-        this ILogger logger,
-        IFilterMetadata filter)
-    {
-        _exceptionFilterShortCircuit(logger, filter, null);
-    }
-
-    public static void ActionFilterShortCircuited(
-        this ILogger logger,
-        IFilterMetadata filter)
-    {
-        _actionFilterShortCircuit(logger, filter, null);
-    }
-
-    public static void ForbidResultExecuting(this ILogger logger, IList<string> authenticationSchemes)
-    {
-        if (logger.IsEnabled(LogLevel.Information))
-        {
-            _forbidResultExecuting(logger, authenticationSchemes.ToArray(), null);
-        }
-    }
-
-    public static void SignOutResultExecuting(this ILogger logger, IList<string> authenticationSchemes)
-    {
-        if (logger.IsEnabled(LogLevel.Information))
-        {
-            _signOutResultExecuting(logger, authenticationSchemes.ToArray(), null);
-        }
-    }
-
-    public static void ObjectResultExecuting(this ILogger logger, ObjectResult result, object value)
-    {
-        if (logger.IsEnabled(LogLevel.Information))
-        {
-            var objectResultType = result.GetType().Name;
-            var valueType = value == null ? "null" : value.GetType().FullName;
-            _objectResultExecuting(logger, objectResultType, valueType, null);
-        }
-    }
-
-    public static void NoFormatter(
-        this ILogger logger,
-        OutputFormatterCanWriteContext context,
-        MediaTypeCollection contentTypes)
-    {
-        if (logger.IsEnabled(LogLevel.Warning))
-        {
-            var considered = new List<string>(contentTypes);
-
-            if (context.ContentType.HasValue)
-            {
-                considered.Add(Convert.ToString(context.ContentType, CultureInfo.InvariantCulture));
-            }
-
-            _noFormatter(logger, considered, null);
-        }
-    }
-
-    public static void FormatterSelected(
-        this ILogger logger,
-        IOutputFormatter outputFormatter,
-        OutputFormatterCanWriteContext context)
-    {
-        if (logger.IsEnabled(LogLevel.Debug))
-        {
-            var contentType = Convert.ToString(context.ContentType, CultureInfo.InvariantCulture);
-            _formatterSelected(logger, outputFormatter, contentType, null);
-        }
-    }
-
-    public static void InputFormatterSelected(
-       this ILogger logger,
-       IInputFormatter inputFormatter,
-       InputFormatterContext formatterContext)
-    {
-        if (logger.IsEnabled(LogLevel.Debug))
-        {
-            var contentType = formatterContext.HttpContext.Request.ContentType;
-            _inputFormatterSelected(logger, inputFormatter, contentType, null);
-        }
-    }
-
-    public static void InputFormatterRejected(
-        this ILogger logger,
-        IInputFormatter inputFormatter,
-        InputFormatterContext formatterContext)
-    {
-        if (logger.IsEnabled(LogLevel.Debug))
-        {
-            var contentType = formatterContext.HttpContext.Request.ContentType;
-            _inputFormatterRejected(logger, inputFormatter, contentType, null);
-        }
-    }
-
-    public static void NoInputFormatterSelected(
-        this ILogger logger,
-        InputFormatterContext formatterContext)
-    {
-        if (logger.IsEnabled(LogLevel.Debug))
-        {
-            var contentType = formatterContext.HttpContext.Request.ContentType;
-            _noInputFormatterSelected(logger, contentType, null);
-            if (formatterContext.HttpContext.Request.HasFormContentType)
-            {
-                var modelType = formatterContext.ModelType.FullName;
-                var modelName = formatterContext.ModelName;
-                _removeFromBodyAttribute(logger, modelName, modelType, null);
-            }
-        }
-    }
-
-    public static void ActionDoesNotSupportFormatFilterContentType(
-        this ILogger logger,
-        string format,
-        MediaTypeCollection supportedMediaTypes)
-    {
-        _actionDoesNotSupportFormatFilterContentType(logger, format, supportedMediaTypes, null);
-    }
-
-    public static void ModelStateInvalidFilterExecuting(this ILogger logger) => _modelStateInvalidFilterExecuting(logger, null);
-
-    public static void InferredParameterBindingSource(
-        this ILogger logger,
-        ParameterModel parameterModel,
-        BindingSource bindingSource)
-    {
-        if (logger.IsEnabled(LogLevel.Debug))
-        {
-            _inferredParameterSource(logger, parameterModel.Action.ActionMethod, parameterModel.ParameterName, bindingSource.DisplayName, null);
-        }
-    }
-
-    public static void IfUnmodifiedSincePreconditionFailed(
-        this ILogger logger,
-        DateTimeOffset? lastModified,
-        DateTimeOffset? ifUnmodifiedSinceDate)
-    {
-        _ifUnmodifiedSincePreconditionFailed(logger, lastModified, ifUnmodifiedSinceDate, null);
-    }
-
-    public static void IfRangeLastModifiedPreconditionFailed(
-        this ILogger logger,
-        DateTimeOffset? lastModified,
-        DateTimeOffset? ifRangeLastModifiedDate)
-    {
-        _ifRangeLastModifiedPreconditionFailed(logger, lastModified, ifRangeLastModifiedDate, null);
-    }
-
-    public static void IfRangeETagPreconditionFailed(
-        this ILogger logger,
-        EntityTagHeaderValue currentETag,
-        EntityTagHeaderValue ifRangeTag)
-    {
-        _ifRangeETagPreconditionFailed(logger, currentETag, ifRangeTag, null);
-    }
+    [LoggerMessage(63, LogLevel.Debug, "Request was short circuited at action filter '{ActionFilter}'.", EventName = "ActionFilterShortCircuit")]
+    public static partial void ActionFilterShortCircuited(this ILogger logger, IFilterMetadata actionFilter);
 
     public static void FoundNoValueInRequest(this ILogger logger, ModelBindingContext bindingContext)
     {
@@ -842,51 +121,49 @@ internal static partial class MvcCoreLoggerExtensions
         switch (modelMetadata.MetadataKind)
         {
             case ModelMetadataKind.Parameter:
-                _foundNoValueForParameterInRequest(
+                FoundNoValueForParameterInRequest(
                     logger,
                     bindingContext.ModelName,
                     modelMetadata.ParameterName,
-                    bindingContext.ModelType,
-                    null);
+                    bindingContext.ModelType);
                 break;
             case ModelMetadataKind.Property:
-                _foundNoValueForPropertyInRequest(
+                FoundNoValueForPropertyInRequest(
                     logger,
                     bindingContext.ModelName,
                     modelMetadata.ContainerType,
                     modelMetadata.PropertyName,
-                    bindingContext.ModelType,
-                    null);
+                    bindingContext.ModelType);
                 break;
             case ModelMetadataKind.Type:
-                _foundNoValueInRequest(
+                FoundNoValueInRequest(
                     logger,
                     bindingContext.ModelName,
-                    bindingContext.ModelType,
-                    null);
+                    bindingContext.ModelType);
                 break;
         }
     }
 
-    public static void NoPublicSettableProperties(this ILogger logger, ModelBindingContext bindingContext)
-    {
-        _noPublicSettableProperties(logger, bindingContext.ModelName, bindingContext.ModelType, null);
-    }
+    [LoggerMessage(15, LogLevel.Debug, "Could not find a value in the request with name '{ModelName}' for binding property '{PropertyContainerType}.{ModelFieldName}' of type '{ModelType}'.",
+        EventName = "FoundNoValueForPropertyInRequest",
+        SkipEnabledCheck = true)]
+    private static partial void FoundNoValueForPropertyInRequest(ILogger logger, string modelName, Type? propertyContainerType, string? modelFieldName, Type modelType);
 
-    public static void CannotBindToComplexType(this ILogger logger, ModelBindingContext bindingContext)
-    {
-        _cannotBindToComplexType(logger, bindingContext.ModelType, null);
-    }
+    [LoggerMessage(16, LogLevel.Debug, "Could not find a value in the request with name '{ModelName}' for binding parameter '{ModelFieldName}' of type '{ModelType}'.",
+        EventName = "FoundNoValueForParameterInRequest",
+        SkipEnabledCheck = true)]
+    private static partial void FoundNoValueForParameterInRequest(ILogger logger, string modelName, string? modelFieldName, Type modelType);
+
+    [LoggerMessage(46, LogLevel.Debug, "Could not find a value in the request with name '{ModelName}' of type '{ModelType}'.", EventName = "FoundNoValueInRequest", SkipEnabledCheck = true)]
+    private static partial void FoundNoValueInRequest(ILogger logger, string modelName, Type modelType);
 
     public static void CannotBindToFilesCollectionDueToUnsupportedContentType(this ILogger logger, ModelBindingContext bindingContext)
-    {
-        _cannotBindToFilesCollectionDueToUnsupportedContentType(logger, bindingContext.ModelName, bindingContext.ModelType, null);
-    }
+        => CannotBindToFilesCollectionDueToUnsupportedContentType(logger, bindingContext.ModelName, bindingContext.ModelType);
 
-    public static void CannotCreateHeaderModelBinderCompatVersion_2_0(this ILogger logger, Type modelType)
-    {
-        _cannotCreateHeaderModelBinderCompatVersion_2_0(logger, modelType, null);
-    }
+    [LoggerMessage(19, LogLevel.Debug,
+        "Could not bind to model with name '{ModelName}' and type '{ModelType}' as the request did not have a content type of either 'application/x-www-form-urlencoded' or 'multipart/form-data'.",
+        EventName = "CannotBindToFilesCollectionDueToUnsupportedContentType")]
+    private static partial void CannotBindToFilesCollectionDueToUnsupportedContentType(ILogger logger, string modelName, Type modelType);
 
     public static void AttemptingToBindModel(this ILogger logger, ModelBindingContext bindingContext)
     {
@@ -899,28 +176,35 @@ internal static partial class MvcCoreLoggerExtensions
         switch (modelMetadata.MetadataKind)
         {
             case ModelMetadataKind.Parameter:
-                _attemptingToBindParameterModel(
+                AttemptingToBindParameterModel(
                     logger,
                     modelMetadata.ParameterName,
                     modelMetadata.ModelType,
-                    bindingContext.ModelName,
-                    null);
+                    bindingContext.ModelName);
                 break;
             case ModelMetadataKind.Property:
-                _attemptingToBindPropertyModel(
+                AttemptingToBindPropertyModel(
                     logger,
                     modelMetadata.ContainerType,
                     modelMetadata.PropertyName,
                     modelMetadata.ModelType,
-                    bindingContext.ModelName,
-                    null);
+                    bindingContext.ModelName);
                 break;
             case ModelMetadataKind.Type:
-                _attemptingToBindModel(logger, bindingContext.ModelType, bindingContext.ModelName, null);
+                AttemptingToBindModel(logger, bindingContext.ModelType, bindingContext.ModelName);
                 break;
         }
     }
 
+    [LoggerMessage(44, LogLevel.Debug, "Attempting to bind parameter '{ParameterName}' of type '{ModelType}' using the name '{ModelName}' in request data ...", EventName = "AttemptingToBindParameterModel", SkipEnabledCheck = true)]
+    private static partial void AttemptingToBindParameterModel(ILogger logger, string? parameterName, Type modelType, string modelName);
+
+    [LoggerMessage(13, LogLevel.Debug, "Attempting to bind property '{PropertyContainerType}.{PropertyName}' of type '{ModelType}' using the name '{ModelName}' in request data ...", EventName = "AttemptingToBindPropertyModel", SkipEnabledCheck = true)]
+    private static partial void AttemptingToBindPropertyModel(ILogger logger, Type? propertyContainerType, string? propertyName, Type modelType, string modelName);
+
+    [LoggerMessage(24, LogLevel.Debug, "Attempting to bind model of type '{ModelType}' using the name '{ModelName}' in request data ...", EventName = "AttemptingToBindModel", SkipEnabledCheck = true)]
+    private static partial void AttemptingToBindModel(ILogger logger, Type modelType, string modelName);
+    
     public static void DoneAttemptingToBindModel(this ILogger logger, ModelBindingContext bindingContext)
     {
         if (!logger.IsEnabled(LogLevel.Debug))
@@ -932,287 +216,32 @@ internal static partial class MvcCoreLoggerExtensions
         switch (modelMetadata.MetadataKind)
         {
             case ModelMetadataKind.Parameter:
-                _doneAttemptingToBindParameterModel(
+                DoneAttemptingToBindParameterModel(
                     logger,
                     modelMetadata.ParameterName,
-                    modelMetadata.ModelType,
-                    null);
+                    modelMetadata.ModelType);
                 break;
             case ModelMetadataKind.Property:
-                _doneAttemptingToBindPropertyModel(
+                DoneAttemptingToBindPropertyModel(
                     logger,
                     modelMetadata.ContainerType,
                     modelMetadata.PropertyName,
-                    modelMetadata.ModelType,
-                    null);
+                    modelMetadata.ModelType);
                 break;
             case ModelMetadataKind.Type:
-                _doneAttemptingToBindModel(logger, bindingContext.ModelType, bindingContext.ModelName, null);
+                DoneAttemptingToBindModel(logger, bindingContext.ModelType, bindingContext.ModelName);
                 break;
         }
     }
 
-    public static void AttemptingToBindParameterOrProperty(
-        this ILogger logger,
-        ParameterDescriptor parameter,
-        ModelMetadata modelMetadata)
-    {
-        if (!logger.IsEnabled(LogLevel.Debug))
-        {
-            return;
-        }
+    [LoggerMessage(14, LogLevel.Debug, "Done attempting to bind property '{PropertyContainerType}.{PropertyName}' of type '{ModelType}'.", EventName = "DoneAttemptingToBindPropertyModel")]
+    private static partial void DoneAttemptingToBindPropertyModel(ILogger logger, Type? propertyContainerType, string? propertyName, Type modelType);
 
-        switch (modelMetadata.MetadataKind)
-        {
-            case ModelMetadataKind.Parameter:
-                _attemptingToBindParameter(logger, modelMetadata.ParameterName, modelMetadata.ModelType, null);
-                break;
-            case ModelMetadataKind.Property:
-                _attemptingToBindProperty(
-                    logger,
-                    modelMetadata.ContainerType,
-                    modelMetadata.PropertyName,
-                    modelMetadata.ModelType,
-                    null);
-                break;
-            case ModelMetadataKind.Type:
-                if (parameter is ControllerParameterDescriptor parameterDescriptor)
-                {
-                    _attemptingToBindParameter(
-                        logger,
-                        parameterDescriptor.ParameterInfo.Name,
-                        modelMetadata.ModelType,
-                        null);
-                }
-                else
-                {
-                    // Likely binding a page handler parameter. Due to various special cases, parameter.Name may
-                    // be empty. No way to determine actual name.
-                    _attemptingToBindParameter(logger, parameter.Name, modelMetadata.ModelType, null);
-                }
-                break;
-        }
-    }
+    [LoggerMessage(25, LogLevel.Debug, "Done attempting to bind model of type '{ModelType}' using the name '{ModelName}'.", EventName = "DoneAttemptingToBindModel", SkipEnabledCheck = true)]
+    private static partial void DoneAttemptingToBindModel(ILogger logger, Type modelType, string modelName);
 
-    public static void DoneAttemptingToBindParameterOrProperty(
-        this ILogger logger,
-        ParameterDescriptor parameter,
-        ModelMetadata modelMetadata)
-    {
-        if (!logger.IsEnabled(LogLevel.Debug))
-        {
-            return;
-        }
-
-        switch (modelMetadata.MetadataKind)
-        {
-            case ModelMetadataKind.Parameter:
-                _doneAttemptingToBindParameter(logger, modelMetadata.ParameterName, modelMetadata.ModelType, null);
-                break;
-            case ModelMetadataKind.Property:
-                _doneAttemptingToBindProperty(
-                    logger,
-                    modelMetadata.ContainerType,
-                    modelMetadata.PropertyName,
-                    modelMetadata.ModelType,
-                    null);
-                break;
-            case ModelMetadataKind.Type:
-                if (parameter is ControllerParameterDescriptor parameterDescriptor)
-                {
-                    _doneAttemptingToBindParameter(
-                        logger,
-                        parameterDescriptor.ParameterInfo.Name,
-                        modelMetadata.ModelType,
-                        null);
-                }
-                else
-                {
-                    // Likely binding a page handler parameter. Due to various special cases, parameter.Name may
-                    // be empty. No way to determine actual name.
-                    _doneAttemptingToBindParameter(logger, parameter.Name, modelMetadata.ModelType, null);
-                }
-                break;
-        }
-    }
-
-    public static void AttemptingToValidateParameterOrProperty(
-        this ILogger logger,
-        ParameterDescriptor parameter,
-        ModelMetadata modelMetadata)
-    {
-        if (!logger.IsEnabled(LogLevel.Debug))
-        {
-            return;
-        }
-
-        switch (modelMetadata.MetadataKind)
-        {
-            case ModelMetadataKind.Parameter:
-                _attemptingToValidateParameter(logger, modelMetadata.ParameterName, modelMetadata.ModelType, null);
-                break;
-            case ModelMetadataKind.Property:
-                _attemptingToValidateProperty(
-                    logger,
-                    modelMetadata.ContainerType,
-                    modelMetadata.PropertyName,
-                    modelMetadata.ModelType,
-                    null);
-                break;
-            case ModelMetadataKind.Type:
-                if (parameter is ControllerParameterDescriptor parameterDescriptor)
-                {
-                    _attemptingToValidateParameter(
-                        logger,
-                        parameterDescriptor.ParameterInfo.Name,
-                        modelMetadata.ModelType,
-                        null);
-                }
-                else
-                {
-                    // Likely binding a page handler parameter. Due to various special cases, parameter.Name may
-                    // be empty. No way to determine actual name. This case is less likely than for binding logging
-                    // (above). Should occur only with a legacy IModelMetadataProvider implementation.
-                    _attemptingToValidateParameter(logger, parameter.Name, modelMetadata.ModelType, null);
-                }
-                break;
-        }
-    }
-
-    public static void DoneAttemptingToValidateParameterOrProperty(
-        this ILogger logger,
-        ParameterDescriptor parameter,
-        ModelMetadata modelMetadata)
-    {
-        if (!logger.IsEnabled(LogLevel.Debug))
-        {
-            return;
-        }
-
-        switch (modelMetadata.MetadataKind)
-        {
-            case ModelMetadataKind.Parameter:
-                _doneAttemptingToValidateParameter(
-                    logger,
-                    modelMetadata.ParameterName,
-                    modelMetadata.ModelType,
-                    null);
-                break;
-            case ModelMetadataKind.Property:
-                _doneAttemptingToValidateProperty(
-                    logger,
-                    modelMetadata.ContainerType,
-                    modelMetadata.PropertyName,
-                    modelMetadata.ModelType,
-                    null);
-                break;
-            case ModelMetadataKind.Type:
-                if (parameter is ControllerParameterDescriptor parameterDescriptor)
-                {
-                    _doneAttemptingToValidateParameter(
-                        logger,
-                        parameterDescriptor.ParameterInfo.Name,
-                        modelMetadata.ModelType,
-                        null);
-                }
-                else
-                {
-                    // Likely binding a page handler parameter. Due to various special cases, parameter.Name may
-                    // be empty. No way to determine actual name. This case is less likely than for binding logging
-                    // (above). Should occur only with a legacy IModelMetadataProvider implementation.
-                    _doneAttemptingToValidateParameter(logger, parameter.Name, modelMetadata.ModelType, null);
-                }
-                break;
-        }
-    }
-
-    public static void NoNonIndexBasedFormatFoundForCollection(this ILogger logger, ModelBindingContext bindingContext)
-    {
-        var modelName = bindingContext.ModelName;
-        _noNonIndexBasedFormatFoundForCollection(logger, modelName, modelName, null);
-    }
-
-    public static void AttemptingToBindCollectionUsingIndices(this ILogger logger, ModelBindingContext bindingContext)
-    {
-        if (!logger.IsEnabled(LogLevel.Debug))
-        {
-            return;
-        }
-
-        var modelName = bindingContext.ModelName;
-
-        var enumerableType = ClosedGenericMatcher.ExtractGenericInterface(bindingContext.ModelType, typeof(IEnumerable<>));
-        if (enumerableType != null)
-        {
-            var elementType = enumerableType.GenericTypeArguments[0];
-            if (elementType.IsGenericType && elementType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
-            {
-                _attemptingToBindCollectionOfKeyValuePair(logger, modelName, modelName, modelName, modelName, modelName, modelName, null);
-                return;
-            }
-        }
-
-        _attemptingToBindCollectionUsingIndices(logger, modelName, modelName, modelName, modelName, modelName, modelName, null);
-    }
-
-    public static void NoKeyValueFormatForDictionaryModelBinder(this ILogger logger, ModelBindingContext bindingContext)
-    {
-        _noKeyValueFormatForDictionaryModelBinder(
-            logger,
-            bindingContext.ModelName,
-            bindingContext.ModelName,
-            bindingContext.ModelName,
-            null);
-    }
-
-    public static void ParameterBinderRequestPredicateShortCircuit(
-        this ILogger logger,
-        ParameterDescriptor parameter,
-        ModelMetadata modelMetadata)
-    {
-        if (!logger.IsEnabled(LogLevel.Debug))
-        {
-            return;
-        }
-
-        switch (modelMetadata.MetadataKind)
-        {
-            case ModelMetadataKind.Parameter:
-                _parameterBinderRequestPredicateShortCircuitOfParameter(
-                    logger,
-                    modelMetadata.ParameterName,
-                    null);
-                break;
-            case ModelMetadataKind.Property:
-                _parameterBinderRequestPredicateShortCircuitOfProperty(
-                    logger,
-                    modelMetadata.ContainerType,
-                    modelMetadata.PropertyName,
-                    null);
-                break;
-            case ModelMetadataKind.Type:
-                if (parameter is ControllerParameterDescriptor controllerParameterDescriptor)
-                {
-                    _parameterBinderRequestPredicateShortCircuitOfParameter(
-                        logger,
-                        controllerParameterDescriptor.ParameterInfo.Name,
-                        null);
-                }
-                else
-                {
-                    // Likely binding a page handler parameter. Due to various special cases, parameter.Name may
-                    // be empty. No way to determine actual name. This case is less likely than for binding logging
-                    // (above). Should occur only with a legacy IModelMetadataProvider implementation.
-                    _parameterBinderRequestPredicateShortCircuitOfParameter(logger, parameter.Name, null);
-                }
-                break;
-        }
-    }
-
-    public static void TransformingClientError(this ILogger logger, Type initialType, Type replacedType, int? statusCode)
-    {
-        _transformingClientError(logger, initialType, statusCode, replacedType, null);
-    }
+    [LoggerMessage(45, LogLevel.Debug, "Done attempting to bind parameter '{ParameterName}' of type '{ModelType}'.", EventName = "DoneAttemptingToBindParameterModel", SkipEnabledCheck = true)]
+    private static partial void DoneAttemptingToBindParameterModel(ILogger logger, string? parameterName, Type modelType);
 
     private static void LogFilterExecutionPlan(
         ILogger logger,
@@ -1225,32 +254,11 @@ internal static partial class MvcCoreLoggerExtensions
             filterList = GetFilterList(filters);
         }
 
-        _logFilterExecutionPlan(logger, filterType, filterList, null);
+        LogFilterExecutionPlan(logger, filterType, filterList);
     }
 
-    public static void ExecutingControllerFactory(this ILogger logger, ControllerContext context)
-    {
-        if (!logger.IsEnabled(LogLevel.Debug))
-        {
-            return;
-        }
-
-        var controllerType = context.ActionDescriptor.ControllerTypeInfo.AsType();
-        var controllerName = TypeNameHelper.GetTypeDisplayName(controllerType);
-        _controllerFactoryExecuting(logger, controllerName, controllerType.Assembly.GetName().Name, null);
-    }
-
-    public static void ExecutedControllerFactory(this ILogger logger, ControllerContext context)
-    {
-        if (!logger.IsEnabled(LogLevel.Debug))
-        {
-            return;
-        }
-
-        var controllerType = context.ActionDescriptor.ControllerTypeInfo.AsType();
-        var controllerName = TypeNameHelper.GetTypeDisplayName(controllerType);
-        _controllerFactoryExecuted(logger, controllerName, controllerType.Assembly.GetName().Name, null);
-    }
+    [LoggerMessage(1, LogLevel.Debug, "Execution plan of {FilterType} filters (in the following order): {Filters}", EventName = "FilterExecutionPlan", SkipEnabledCheck = true)]
+    private static partial void LogFilterExecutionPlan(ILogger logger, string filterType, string[] filters);
 
     private static string[] GetFilterList(IEnumerable<IFilterMetadata> filters)
     {
@@ -1269,7 +277,7 @@ internal static partial class MvcCoreLoggerExtensions
         return filterList.ToArray();
     }
 
-    private class ActionLogScope : IReadOnlyList<KeyValuePair<string, object>>
+    private sealed class ActionLogScope : IReadOnlyList<KeyValuePair<string, object>>
     {
         private readonly ActionDescriptor _action;
 

--- a/src/Mvc/Mvc.Core/src/SignOutResult.cs
+++ b/src/Mvc/Mvc.Core/src/SignOutResult.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Core;
@@ -12,7 +13,7 @@ namespace Microsoft.AspNetCore.Mvc;
 /// <summary>
 /// An <see cref="ActionResult"/> that on execution invokes <see cref="M:HttpContext.SignOutAsync"/>.
 /// </summary>
-public class SignOutResult : ActionResult, IResult
+public partial class SignOutResult : ActionResult, IResult
 {
     /// <summary>
     /// Initializes a new instance of <see cref="SignOutResult"/> with the default sign out scheme.
@@ -114,8 +115,7 @@ public class SignOutResult : ActionResult, IResult
 
         var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
         var logger = loggerFactory.CreateLogger<SignOutResult>();
-
-        logger.SignOutResultExecuting(AuthenticationSchemes);
+        Log.SignOutResultExecuting(logger, AuthenticationSchemes);
 
         if (AuthenticationSchemes.Count == 0)
         {
@@ -128,5 +128,19 @@ public class SignOutResult : ActionResult, IResult
                 await httpContext.SignOutAsync(AuthenticationSchemes[i], Properties);
             }
         }
+    }
+
+    private static partial class Log
+    {
+        public static void SignOutResultExecuting(ILogger logger, IList<string> authenticationSchemes)
+        {
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                SignOutResultExecuting(logger, authenticationSchemes.ToArray());
+            }
+        }
+
+        [LoggerMessage(1, LogLevel.Information, $"Executing {nameof(SignOutResult)} with authentication schemes ({{Schemes}}).", EventName = "SignOutResultExecuting", SkipEnabledCheck = true)]
+        private static partial void SignOutResultExecuting(ILogger logger, string[] schemes);
     }
 }

--- a/src/Mvc/Mvc.Core/test/MvcCoreLoggerExtensionsTest.cs
+++ b/src/Mvc/Mvc.Core/test/MvcCoreLoggerExtensionsTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.Logging.Testing;
 using Moq;
 
@@ -15,19 +16,19 @@ public class MvcCoreLoggerExtensionsTest
 {
     public static object[][] RouteValuesTestData { get; } = new object[][]
     {
-            new object[]{ "{}" },
-            new object[]{ "{foo = \"bar\"}", new KeyValuePair<string, string>("foo", "bar") },
-            new object[]{ "{foo = \"bar\", other = \"value\"}",
-                new KeyValuePair<string, string>("foo", "bar"),
-                new KeyValuePair<string, string>("other", "value") },
+        new object[]{ "{}" },
+        new object[]{ "{foo = \"bar\"}", new KeyValuePair<string, string>("foo", "bar") },
+        new object[]{ "{foo = \"bar\", other = \"value\"}",
+            new KeyValuePair<string, string>("foo", "bar"),
+            new KeyValuePair<string, string>("other", "value") },
     };
 
     public static object[][] PageRouteValuesTestData { get; } = new object[][]
     {
-            new object[]{ "{page = \"bar\"}", new KeyValuePair<string, string>("page", "bar") },
-            new object[]{ "{page = \"bar\", other = \"value\"}",
-                new KeyValuePair<string, string>("page", "bar"),
-                new KeyValuePair<string, string>("other", "value") },
+        new object[]{ "{page = \"bar\"}", new KeyValuePair<string, string>("page", "bar") },
+        new object[]{ "{page = \"bar\", other = \"value\"}",
+            new KeyValuePair<string, string>("page", "bar"),
+            new KeyValuePair<string, string>("other", "value") },
     };
 
     [Theory]
@@ -52,7 +53,7 @@ public class MvcCoreLoggerExtensionsTest
         }
 
         // Act
-        logger.ExecutingAction(action);
+        ResourceInvoker.Log.ExecutingAction(logger, action);
 
         // Assert
         var write = Assert.Single(testSink.Writes);
@@ -82,7 +83,7 @@ public class MvcCoreLoggerExtensionsTest
         }
 
         // Act
-        logger.ExecutingAction(action);
+        ResourceInvoker.Log.ExecutingAction(logger, action);
 
         // Assert
         var write = Assert.Single(testSink.Writes);
@@ -111,7 +112,7 @@ public class MvcCoreLoggerExtensionsTest
         }
 
         // Act
-        logger.ExecutingAction(action);
+        ResourceInvoker.Log.ExecutingAction(logger, action);
 
         // Assert
         var write = Assert.Single(testSink.Writes);
@@ -412,7 +413,7 @@ public class MvcCoreLoggerExtensionsTest
         context.SetupGet(x => x.ContentType).Returns("application/json");
 
         // Act
-        logger.NoFormatter(context.Object, mediaTypes);
+        ObjectResultExecutor.Log.NoFormatter(logger, context.Object, mediaTypes);
 
         // Assert
         var write = Assert.Single(testSink.Writes);
@@ -441,7 +442,7 @@ public class MvcCoreLoggerExtensionsTest
         };
 
         // Act
-        logger.ExecutingControllerFactory(context);
+        ControllerActionInvoker.Log.ExecutingControllerFactory(logger, context);
 
         // Assert
         var write = Assert.Single(testSink.Writes);
@@ -469,7 +470,7 @@ public class MvcCoreLoggerExtensionsTest
         };
 
         // Act
-        logger.ExecutedControllerFactory(context);
+        ControllerActionInvoker.Log.ExecutedControllerFactory(logger, context);
 
         // Assert
         var write = Assert.Single(testSink.Writes);


### PR DESCRIPTION
MvcCoreLoggerExtensions includes the log messages for a whole slew of MVC types. Consequently
it re-uses event ids and is hard maintain. This PR simultaenously updates the type to use
LoggerMessageAttribute, while also attempts to move as many of the individual log statements to the
appropriate type.

This change unearthed incorrect reuse of event ids within the same type that has also been corrected by assigning
new ids.

Fixes https://github.com/dotnet/aspnetcore/issues/32087
