### PR TITLE
Don't always create log for Response in HttpLoggingMiddleware

### DIFF
--- a/src/Middleware/HttpLogging/src/HttpLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingMiddleware.cs
@@ -212,9 +212,12 @@ internal sealed class HttpLoggingMiddleware
             FilterHeaders(list, response.Headers, options._internalResponseHeaders);
         }
 
-        var httpResponseLog = new HttpResponseLog(list);
+        if (list.Count > 0)
+        {
+            var httpResponseLog = new HttpResponseLog(list);
 
-        logger.ResponseLog(httpResponseLog);
+            logger.ResponseLog(httpResponseLog);
+        }
     }
 
     internal static void FilterHeaders(List<KeyValuePair<string, object?>> keyValues,

--- a/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
@@ -86,6 +86,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
         Assert.DoesNotContain(TestSink.Writes, w => w.Message.Contains("Connection: keep-alive"));
         Assert.DoesNotContain(TestSink.Writes, w => w.Message.Contains("Body: test"));
         Assert.DoesNotContain(TestSink.Writes, w => w.Message.Contains("StatusCode: 200"));
+        Assert.DoesNotContain(TestSink.Writes, w => w.Message.Contains("Response:"));
     }
 
     [Fact]

--- a/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
@@ -77,16 +77,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
 
         await middleware.Invoke(httpContext);
 
-        Assert.DoesNotContain(TestSink.Writes, w => w.Message.Contains("Protocol: HTTP/1.0"));
-        Assert.DoesNotContain(TestSink.Writes, w => w.Message.Contains("Method: GET"));
-        Assert.DoesNotContain(TestSink.Writes, w => w.Message.Contains("Scheme: http"));
-        Assert.DoesNotContain(TestSink.Writes, w => w.Message.Contains("Path: /foo"));
-        Assert.DoesNotContain(TestSink.Writes, w => w.Message.Contains("PathBase: /foo"));
-        Assert.DoesNotContain(TestSink.Writes, w => w.Message.Contains("QueryString: ?foo"));
-        Assert.DoesNotContain(TestSink.Writes, w => w.Message.Contains("Connection: keep-alive"));
-        Assert.DoesNotContain(TestSink.Writes, w => w.Message.Contains("Body: test"));
-        Assert.DoesNotContain(TestSink.Writes, w => w.Message.Contains("StatusCode: 200"));
-        Assert.DoesNotContain(TestSink.Writes, w => w.Message.Contains("Response:"));
+        Assert.Empty(TestSink.Writes);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/40427

Stops us from logging an empty event when response status code/headers are not enabled in HttpLoggingMiddleware:

```
  "Message": "Response:\r\n",
  "State": {
    "Message": "Response:\r\n"
  }
```

After this change, no event is fired for `HttpLoggingMiddleware` when `HttpLoggingFields.None` is selected