### PR TITLE
[7.0 Preview 2] Fix incorrect HTTP/2 method header decoding (#40412)

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1443,7 +1443,7 @@ internal partial class Http2Connection : IHttp2StreamLifetimeHandler, IHttpStrea
                         {
                             UpdateHeaderParsingState(value, GetPseudoHeaderField(staticTableIndex.GetValueOrDefault()));
 
-                            _currentHeadersStream.OnHeader(staticTableIndex.GetValueOrDefault(), indexOnly: true, name, value);
+                            _currentHeadersStream.OnHeader(staticTableIndex.GetValueOrDefault(), indexOnly: false, name, value);
                         }
                         else
                         {

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -314,7 +314,7 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
                         {
                             UpdateHeaderParsingState(value, GetPseudoHeaderField(staticTableIndex.GetValueOrDefault()));
 
-                            OnHeader(staticTableIndex.GetValueOrDefault(), indexOnly: true, name, value);
+                            OnHeader(staticTableIndex.GetValueOrDefault(), indexOnly: false, name, value);
                         }
                         else
                         {

--- a/src/Servers/Kestrel/Core/src/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
+++ b/src/Servers/Kestrel/Core/src/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
@@ -14,6 +14,8 @@
 
   <ItemGroup>
     <Compile Include="$(KestrelSharedSourceRoot)\PooledStreamStack.cs" Link="Internal\PooledStreamStack.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)\HPackHeaderWriter.cs" Link="Internal\Http2\HPackHeaderWriter.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)\Http2HeadersEnumerator.cs" Link="Internal\Http2\Http2HeadersEnumerator.cs" />
     <Compile Include="$(SharedSourceRoot)CertificateGeneration\**\*.cs" />
     <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" />
     <Compile Include="$(SharedSourceRoot)UrlDecoder\**\*.cs" />

--- a/src/Servers/Kestrel/Core/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
+++ b/src/Servers/Kestrel/Core/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TestGroupName>Kestrel.Core.Tests</TestGroupName>
-    <DefineConstants>$(DefineConstants);KESTREL</DefineConstants>
+    <DefineConstants>$(DefineConstants);KESTREL;IS_TESTS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,6 +15,8 @@
     <Content Include="$(KestrelSharedSourceRoot)test\TestCertificates\*.pfx" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="$(KestrelSharedSourceRoot)test\TestCertificates\*.crt" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="$(KestrelSharedSourceRoot)test\TestCertificates\*.key" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />
+    <Compile Include="$(KestrelSharedSourceRoot)\HPackHeaderWriter.cs" Link="Http2\HPackHeaderWriter.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)\Http2HeadersEnumerator.cs" Link="Http2\Http2HeadersEnumerator.cs" />
     <Compile Include="$(RepoRoot)src\Shared\Buffers.MemoryPool\*.cs" LinkBase="MemoryPool" />
     <Compile Include="$(KestrelSharedSourceRoot)\CorrelationIdGenerator.cs" Link="Internal\CorrelationIdGenerator.cs" />
     <Compile Include="$(SharedSourceRoot)test\Shared.Tests\runtime\Http2\*.cs" LinkBase="Shared\runtime\Http2" />

--- a/src/Servers/Kestrel/Kestrel/test/Microsoft.AspNetCore.Server.Kestrel.Tests.csproj
+++ b/src/Servers/Kestrel/Kestrel/test/Microsoft.AspNetCore.Server.Kestrel.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)NullScope.cs" />
-    <Compile Include="$(KestrelSharedSourceRoot)test\*.cs" LinkBase="shared" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TestResources.cs" Link="shared\TestResources.cs" />
     <Content Include="$(KestrelSharedSourceRoot)test\TestCertificates\*.pfx" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="$(KestrelSharedSourceRoot)test\TestCertificates\*.crt" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="$(KestrelSharedSourceRoot)test\TestCertificates\*.key" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />

--- a/src/Servers/Kestrel/Transport.Quic/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests.csproj
+++ b/src/Servers/Kestrel/Transport.Quic/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests.csproj
@@ -8,7 +8,12 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)NullScope.cs" />
-    <Compile Include="$(KestrelSharedSourceRoot)test\*.cs" LinkBase="shared" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\HttpEventSourceListener.cs" Link="shared\HttpEventSourceListener.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TestResources.cs" Link="shared\TestResources.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\StreamExtensions.cs" Link="shared\StreamExtensions.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\KestrelTestLoggerProvider.cs" Link="shared\KestrelTestLoggerProvider.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TestApplicationErrorLoggerLoggedTest.cs" Link="shared\TestApplicationErrorLoggerLoggedTest.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TestApplicationErrorLogger.cs" Link="shared\TestApplicationErrorLogger.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TransportTestHelpers\IHostPortExtensions.cs" Link="shared\TransportTestHelpers\IHostPortExtensions.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TransportTestHelpers\MsQuicSupportedAttribute.cs" Link="shared\TransportTestHelpers\MsQuicSupportedAttribute.cs" />
     <Content Include="$(KestrelSharedSourceRoot)test\TestCertificates\*.pfx" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
@@ -22,6 +22,7 @@ using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
+using Http2HeadersEnumerator = Microsoft.AspNetCore.Server.Kestrel.Core.Tests.Http2HeadersEnumerator;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks;
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2HeadersEnumeratorBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2HeadersEnumeratorBenchmark.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 using Microsoft.Extensions.Primitives;
+using Http2HeadersEnumerator = Microsoft.AspNetCore.Server.Kestrel.Core.Tests.Http2HeadersEnumerator;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks;
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks.csproj
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks.csproj
@@ -6,6 +6,7 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TieredCompilation>false</TieredCompilation>
+    <DefineConstants>$(DefineConstants);IS_BENCHMARKS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,6 +16,8 @@
     <Compile Include="$(KestrelSharedSourceRoot)\CompletionPipeReader.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\CompletionPipeWriter.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\PipeWriterHttp2FrameExtensions.cs" Link="Internal\PipeWriterHttp2FrameExtensions.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)\HPackHeaderWriter.cs" Link="Http2\HPackHeaderWriter.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)\Http2HeadersEnumerator.cs" Link="Http2\Http2HeadersEnumerator.cs" />
     <Compile Include="$(RepoRoot)src\Shared\Buffers.MemoryPool\*.cs" LinkBase="MemoryPool" />
     <Compile Include="$(KestrelSharedSourceRoot)test\KestrelTestLoggerProvider.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TestApplicationErrorLogger.cs" />

--- a/src/Servers/Kestrel/shared/HPackHeaderWriter.cs
+++ b/src/Servers/Kestrel/shared/HPackHeaderWriter.cs
@@ -4,8 +4,14 @@
 using System.Net.Http;
 using System.Net.Http.HPack;
 
+#if !(IS_TESTS || IS_BENCHMARKS)
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
+#else
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
+#endif
 
+// This file is used by Kestrel to write response headers and tests to write request headers.
+// To avoid adding test code to Kestrel this file is shared. Test specifc code is excluded from Kestrel by ifdefs.
 internal static class HPackHeaderWriter
 {
     /// <summary>

--- a/src/Servers/Kestrel/shared/Http2HeadersEnumerator.cs
+++ b/src/Servers/Kestrel/shared/Http2HeadersEnumerator.cs
@@ -7,20 +7,32 @@ using System.Text;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.Extensions.Primitives;
 
+#if !(IS_TESTS || IS_BENCHMARKS)
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
+#else
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
+#endif
 
+#nullable enable
+
+// This file is used by Kestrel to write response headers and tests to write request headers.
+// To avoid adding test code to Kestrel this file is shared. Test specifc code is excluded from Kestrel by ifdefs.
 internal sealed class Http2HeadersEnumerator : IEnumerator<KeyValuePair<string, string>>
 {
     private enum HeadersType : byte
     {
         Headers,
         Trailers,
-        Untyped
+#if IS_TESTS || IS_BENCHMARKS
+        Untyped,
+#endif
     }
     private HeadersType _headersType;
     private HttpResponseHeaders.Enumerator _headersEnumerator;
     private HttpResponseTrailers.Enumerator _trailersEnumerator;
+#if IS_TESTS || IS_BENCHMARKS
     private IEnumerator<KeyValuePair<string, StringValues>>? _genericEnumerator;
+#endif
     private StringValues.Enumerator _stringValuesEnumerator;
     private bool _hasMultipleValues;
     private KnownHeaderType _knownHeaderType;
@@ -47,6 +59,7 @@ internal sealed class Http2HeadersEnumerator : IEnumerator<KeyValuePair<string, 
         _hasMultipleValues = false;
     }
 
+#if IS_TESTS || IS_BENCHMARKS
     public void Initialize(IDictionary<string, StringValues> headers)
     {
         switch (headers)
@@ -67,6 +80,7 @@ internal sealed class Http2HeadersEnumerator : IEnumerator<KeyValuePair<string, 
 
         _hasMultipleValues = false;
     }
+#endif
 
     public bool MoveNext()
     {
@@ -89,11 +103,35 @@ internal sealed class Http2HeadersEnumerator : IEnumerator<KeyValuePair<string, 
         }
         else
         {
+#if IS_TESTS || IS_BENCHMARKS
             return _genericEnumerator!.MoveNext()
-                ? SetCurrent(_genericEnumerator.Current.Key, _genericEnumerator.Current.Value, default)
+                ? SetCurrent(_genericEnumerator.Current.Key, _genericEnumerator.Current.Value, GetKnownRequestHeaderType(_genericEnumerator.Current.Key))
                 : false;
+#else
+            ThrowUnexpectedHeadersType();
+            return false;
+#endif
         }
     }
+
+#if IS_TESTS || IS_BENCHMARKS
+    private static KnownHeaderType GetKnownRequestHeaderType(string headerName)
+    {
+        switch (headerName)
+        {
+            case ":method":
+                return KnownHeaderType.Method;
+            default:
+                return default;
+        }
+    }
+#else
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static void ThrowUnexpectedHeadersType()
+    {
+        throw new InvalidOperationException("Unexpected headers collection type.");
+    }
+#endif
 
     private bool MoveNextOnStringEnumerator(string key)
     {
@@ -134,7 +172,11 @@ internal sealed class Http2HeadersEnumerator : IEnumerator<KeyValuePair<string, 
         }
         else
         {
+#if IS_TESTS || IS_BENCHMARKS
             _genericEnumerator!.Reset();
+#else
+            ThrowUnexpectedHeadersType();
+#endif
         }
         _stringValuesEnumerator = default;
         _knownHeaderType = default;
@@ -199,6 +241,11 @@ internal sealed class Http2HeadersEnumerator : IEnumerator<KeyValuePair<string, 
                 return H2StaticTable.ContentLength;
             default:
                 return -1;
+#if IS_TESTS || IS_BENCHMARKS
+            // Include request headers for tests.
+            case KnownHeaderType.Method:
+                return H2StaticTable.MethodGet;
+#endif
         }
     }
 }

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -107,7 +107,7 @@ internal class Http3InMemory
         if (_inboundControlStream == null)
         {
             var reader = MultiplexedConnectionContext.ToClientAcceptQueue.Reader;
-#if IS_FUNCTIONAL_TESTS
+#if IS_TESTS
             while (await reader.WaitToReadAsync().DefaultTimeout())
 #else
             while (await reader.WaitToReadAsync())
@@ -147,7 +147,7 @@ internal class Http3InMemory
         AssertConnectionError<TException>(expectedErrorCode, matchExpectedErrorMessage, expectedErrorMessage);
 
         // Verify HttpConnection.ProcessRequestsAsync has exited.
-#if IS_FUNCTIONAL_TESTS
+#if IS_TESTS
         await _connectionTask.DefaultTimeout();
 #else
         await _connectionTask;
@@ -461,7 +461,7 @@ internal class Http3StreamBase
     protected static Task FlushAsync(PipeWriter writableBuffer)
     {
         var task = writableBuffer.FlushAsync();
-#if IS_FUNCTIONAL_TESTS
+#if IS_TESTS
         return task.AsTask().DefaultTimeout();
 #else
         return task.GetAsTask();
@@ -477,7 +477,7 @@ internal class Http3StreamBase
         }
     }
 
-#if IS_FUNCTIONAL_TESTS
+#if IS_TESTS
     protected Task<ReadResult> ReadApplicationInputAsync()
     {
         return Pair.Application.Input.ReadAsync().AsTask().DefaultTimeout();

--- a/src/Servers/Kestrel/shared/test/PipeWriterHttp2FrameExtensions.cs
+++ b/src/Servers/Kestrel/shared/test/PipeWriterHttp2FrameExtensions.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Net.Http.HPack;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
+using Http2HeadersEnumerator = Microsoft.AspNetCore.Server.Kestrel.Core.Tests.Http2HeadersEnumerator;
+using HPackHeaderWriter = Microsoft.AspNetCore.Server.Kestrel.Core.Tests.HPackHeaderWriter;
 
 namespace Microsoft.AspNetCore.Testing;
 

--- a/src/Servers/Kestrel/test/FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/ResponseTests.cs
@@ -22,7 +22,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.FunctionalTests;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.AspNetCore.Server.Kestrel.Https.Internal;
-using Microsoft.AspNetCore.Server.Kestrel.Tests;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/InMemory.FunctionalTests.csproj
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/InMemory.FunctionalTests.csproj
@@ -5,7 +5,7 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <TestGroupName>InMemory.FunctionalTests</TestGroupName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants>$(DefineConstants);IS_FUNCTIONAL_TESTS</DefineConstants>
+    <DefineConstants>$(DefineConstants);IS_TESTS</DefineConstants>
    </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +17,8 @@
     <Content Include="$(KestrelSharedSourceRoot)test\TestCertificates\*.crt" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="$(KestrelSharedSourceRoot)test\TestCertificates\*.key" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="$(KestrelSharedSourceRoot)test\TestCertificates\*.pem" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />
+    <Compile Include="$(KestrelSharedSourceRoot)\HPackHeaderWriter.cs" Link="Http2\HPackHeaderWriter.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)\Http2HeadersEnumerator.cs" Link="Http2\Http2HeadersEnumerator.cs" />
     <Compile Include="$(RepoRoot)src\Shared\Buffers.MemoryPool\*.cs" LinkBase="MemoryPool" />
     <Compile Include="$(KestrelSharedSourceRoot)\CompletionPipeReader.cs" Link="Internal\CompletionPipeReader.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)\CompletionPipeWriter.cs" Link="Internal\CompletionPipeWriter.cs" />

--- a/src/Servers/Kestrel/test/Sockets.BindTests/Sockets.BindTests.csproj
+++ b/src/Servers/Kestrel/test/Sockets.BindTests/Sockets.BindTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
@@ -10,7 +10,16 @@
     <Compile Include="..\BindTests\**\*.cs" />
     <Compile Include="..\Sockets.FunctionalTests\TransportSelector.cs" />
     <Compile Include="$(SharedSourceRoot)NullScope.cs" />
-    <Compile Include="$(KestrelSharedSourceRoot)test\*.cs" LinkBase="shared" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TestServiceContext.cs" Link="shared\TestServiceContext.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TestConnection.cs" Link="shared\TestConnection.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\MockSystemClock.cs" Link="shared\MockSystemClock.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TestApplicationErrorLoggerLoggedTest.cs" Link="shared\TestApplicationErrorLoggerLoggedTest.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TestApplicationErrorLogger.cs" Link="shared\TestApplicationErrorLogger.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\StreamBackedTestConnection.cs" Link="shared\StreamBackedTestConnection.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TestResources.cs" Link="shared\TestResources.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TestConstants.cs" Link="shared\TestConstants.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\KestrelTestLoggerProvider.cs" Link="shared\KestrelTestLoggerProvider.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\LifetimeNotImplemented.cs" Link="shared\LifetimeNotImplemented.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TransportTestHelpers\*.cs" LinkBase="shared\TransportTestHelpers" />
     <Content Include="$(KestrelSharedSourceRoot)test\TestCertificates\*.pfx" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/Servers/Kestrel/test/Sockets.FunctionalTests/Sockets.FunctionalTests.csproj
+++ b/src/Servers/Kestrel/test/Sockets.FunctionalTests/Sockets.FunctionalTests.csproj
@@ -11,7 +11,19 @@
   <ItemGroup>
     <Compile Include="..\FunctionalTests\**\*.cs" />
     <Compile Include="$(SharedSourceRoot)NullScope.cs" />
-    <Compile Include="$(KestrelSharedSourceRoot)test\*.cs" LinkBase="shared" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TestServiceContext.cs" Link="shared\TestServiceContext.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TestConnection.cs" Link="shared\TestConnection.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\MockSystemClock.cs" Link="shared\MockSystemClock.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TestApplicationErrorLoggerLoggedTest.cs" Link="shared\TestApplicationErrorLoggerLoggedTest.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TestApplicationErrorLogger.cs" Link="shared\TestApplicationErrorLogger.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\StreamBackedTestConnection.cs" Link="shared\StreamBackedTestConnection.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TestResources.cs" Link="shared\TestResources.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TestConstants.cs" Link="shared\TestConstants.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\KestrelTestLoggerProvider.cs" Link="shared\KestrelTestLoggerProvider.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\LifetimeNotImplemented.cs" Link="shared\LifetimeNotImplemented.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\PassThroughConnectionMiddleware.cs" Link="shared\PassThroughConnectionMiddleware.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\TestApp.cs" Link="shared\TestApp.cs" />
+    <Compile Include="$(KestrelSharedSourceRoot)test\StreamExtensions.cs" Link="shared\StreamExtensions.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TransportTestHelpers\*.cs" LinkBase="shared\TransportTestHelpers" />
     <Content Include="$(KestrelSharedSourceRoot)test\TestCertificates\*.pfx" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>


### PR DESCRIPTION
Porting https://github.com/dotnet/aspnetcore/pull/40412 to 7.0-preview2