### PR TITLE
Delete System.Runtime.CompilerServices.Unsafe package from dependency tracking

### DIFF
--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -75,7 +75,6 @@ and are generated based on the last package release.
     <LatestPackageReference Include="System.Net.Http.Json" />
     <LatestPackageReference Include="System.Net.Sockets" />
     <LatestPackageReference Include="System.Reflection.Metadata" />
-    <LatestPackageReference Include="System.Runtime.CompilerServices.Unsafe" />
     <LatestPackageReference Include="System.Runtime.InteropServices.RuntimeInformation" />
     <LatestPackageReference Include="System.Security.Cryptography.Pkcs" />
     <LatestPackageReference Include="System.Security.Cryptography.Xml" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -213,10 +213,6 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>68fb7fc68cc1af800bee1d38af22b5027bf4ab4e</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="7.0.0-preview.3.22118.9">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>ca6f4206f535458ab82561cd517ded0615728d58</Sha>
-    </Dependency>
     <Dependency Name="System.Security.Cryptography.Pkcs" Version="7.0.0-preview.3.22127.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>68fb7fc68cc1af800bee1d38af22b5027bf4ab4e</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -113,7 +113,6 @@
     <SystemNetHttpWinHttpHandlerVersion>7.0.0-preview.3.22127.1</SystemNetHttpWinHttpHandlerVersion>
     <SystemReflectionMetadataVersion>7.0.0-preview.3.22127.1</SystemReflectionMetadataVersion>
     <SystemResourcesExtensionsVersion>7.0.0-preview.3.22127.1</SystemResourcesExtensionsVersion>
-    <SystemRuntimeCompilerServicesUnsafeVersion>7.0.0-preview.3.22118.9</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemSecurityCryptographyPkcsVersion>7.0.0-preview.3.22127.1</SystemSecurityCryptographyPkcsVersion>
     <SystemSecurityCryptographyXmlVersion>7.0.0-preview.3.22127.1</SystemSecurityCryptographyXmlVersion>
     <SystemSecurityPermissionsVersion>7.0.0-preview.3.22127.1</SystemSecurityPermissionsVersion>

--- a/src/Shared/test/Shared.Tests/Microsoft.AspNetCore.Shared.Tests.csproj
+++ b/src/Shared/test/Shared.Tests/Microsoft.AspNetCore.Shared.Tests.csproj
@@ -40,7 +40,6 @@
     <Reference Include="FSharp.Core" />
     <Reference Include="System.IO.Pipelines" />
     <Reference Include="System.Reflection.Metadata" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Threading.Tasks.Extensions" />
     <Reference Include="Microsoft.AspNetCore.Http.Features" />
     <Reference Include="Microsoft.AspNetCore.Http" />


### PR DESCRIPTION
This package was dropped by https://github.com/dotnet/runtime/pull/64861