### PR TITLE
Update to limit phone number length

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Data/SqlServer/ApplicationDbContextModelSnapshot.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Data/SqlServer/ApplicationDbContextModelSnapshot.cs
@@ -56,7 +56,7 @@ namespace ComponentsWebAssembly_CSharp.Server.Data.Migrations
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("PhoneNumber")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(32)");
 
                     b.Property<bool>("PhoneNumberConfirmed")
                         .HasColumnType("bit");


### PR DESCRIPTION
# Update to limit phone number length

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Update ApplicationDbContextModelSnapshot.cs to limit phone number length. 

Using nvarchar(max) in a nonclustered index is only possible by adding it to some other index key as an include. https://stackoverflow.com/questions/12336821/how-can-i-create-index-on-nvarcharmax-datatype-in-sql

By reducing the length to something a little more reasonable it is possible to create a nonclustered index on phone number directly for better query performance at scale.

The longest phone number is currently 15 digits. I've reduced this field length from NVARCHAR(MAX) to NVARCHAR(32) to allow for adding of indexes if desired and future expansion of digits.

https://en.wikipedia.org/wiki/Telephone_numbering_plan#:~:text=The%20International%20Telecommunication%20Union%20(ITU,15%20digits%20to%20telephone%20numbers.

Fixes #{bug number} (in this specific format)
