### PR TITLE
Add/Modify Url Encoding/Decoding for IIS UrlRewrite

### DIFF
--- a/src/Middleware/Rewrite/src/IISUrlRewrite/InputParser.cs
+++ b/src/Middleware/Rewrite/src/IISUrlRewrite/InputParser.cs
@@ -124,7 +124,14 @@ internal class InputParser
                         }
                     case "UrlDecode":
                         {
-                            throw new NotImplementedException("UrlDecode is not implemented because of no great library available");
+                            var pattern = ParseString(context, uriMatchPart);
+                            results.Add(new UrlDecodeSegment(pattern));
+
+                            if (context.Current != CloseBrace)
+                            {
+                                throw new FormatException(Resources.FormatError_InputParserMissingCloseBrace(context.Index));
+                            }
+                            return;
                         }
                     case "UrlEncode":
                         {

--- a/src/Middleware/Rewrite/src/PatternSegments/UrlDecodeSegment.cs
+++ b/src/Middleware/Rewrite/src/PatternSegments/UrlDecodeSegment.cs
@@ -5,11 +5,11 @@ using System.Text;
 
 namespace Microsoft.AspNetCore.Rewrite.PatternSegments;
 
-internal class UrlEncodeSegment : PatternSegment
+internal class UrlDecodeSegment: PatternSegment
 {
     private readonly Pattern _pattern;
 
-    public UrlEncodeSegment(Pattern pattern)
+    public UrlDecodeSegment(Pattern pattern)
     {
         _pattern = pattern;
     }
@@ -24,6 +24,6 @@ internal class UrlEncodeSegment : PatternSegment
         context.Builder = new StringBuilder(64);
         var pattern = _pattern.Evaluate(context, ruleBackReferences, conditionBackReferences);
         context.Builder = oldBuilder;
-        return Uri.EscapeDataString(pattern);
+        return Uri.UnescapeDataString(pattern);
     }
 }

--- a/src/Middleware/Rewrite/test/IISUrlRewrite/InputParserTests.cs
+++ b/src/Middleware/Rewrite/test/IISUrlRewrite/InputParserTests.cs
@@ -69,6 +69,14 @@ public class InputParserTests
         var result = middle.Evaluate(CreateTestRewriteContext(), CreateTestRuleBackReferences(), CreateTestCondBackReferences());
         Assert.Equal(expected, result);
     }
+    [Theory]
+    [InlineData("hey/{UrlDecode:%3Chey%3E}","hey/<hey>")]
+    public void EvaluateUriDecodeRule(string testString, string expected)
+    {
+        var middle = new InputParser().ParseInputString(testString, UriMatchPart.Path);
+        var result = middle.Evaluate(CreateTestRewriteContext(), CreateTestRuleBackReferences(), CreateTestCondBackReferences());
+        Assert.Equal(expected, result);
+    }
 
     [Theory]
     [InlineData("{")]

--- a/src/Middleware/Rewrite/test/IISUrlRewrite/InputParserTests.cs
+++ b/src/Middleware/Rewrite/test/IISUrlRewrite/InputParserTests.cs
@@ -65,6 +65,7 @@ public class InputParserTests
 
     [Theory]
     [InlineData("hey/{UrlEncode:<hey>}", "hey/%3Chey%3E")]
+    [InlineData("hey/?returnUrl={UrlEncode:http://domain.com?query=résumé}", "hey/?returnUrl=http%3A%2F%2Fdomain.com%3Fquery%3Dr%C3%A9sum%C3%A9")]
     public void EvaluatUriEncodeRule(string testString, string expected)
     {
         var middle = new InputParser().ParseInputString(testString, UriMatchPart.Path);
@@ -73,6 +74,7 @@ public class InputParserTests
     }
     [Theory]
     [InlineData("hey/{UrlDecode:%3Chey%3E}","hey/<hey>")]
+    [InlineData("{UrlDecode:http%3A%2F%2Fdomain.com%3Fquery%3Dr%C3%A9sum%C3%A9}", "http://domain.com?query=résumé")]
     public void EvaluateUriDecodeRule(string testString, string expected)
     {
         var middle = new InputParser().ParseInputString(testString, UriMatchPart.Path);

--- a/src/Middleware/Rewrite/test/IISUrlRewrite/InputParserTests.cs
+++ b/src/Middleware/Rewrite/test/IISUrlRewrite/InputParserTests.cs
@@ -3,8 +3,10 @@
 
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Rewrite.IISUrlRewrite;
 using Microsoft.AspNetCore.Rewrite.PatternSegments;
+using Microsoft.AspNetCore.Rewrite.Tests.IISUrlRewrite;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.AspNetCore.Rewrite.Tests.UrlRewrite;
@@ -75,6 +77,25 @@ public class InputParserTests
     {
         var middle = new InputParser().ParseInputString(testString, UriMatchPart.Path);
         var result = middle.Evaluate(CreateTestRewriteContext(), CreateTestRuleBackReferences(), CreateTestCondBackReferences());
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("hey/{HTTP_URL}","hey/TEST_VARIABLE")]
+    public void ParseString_WithContextContainingServerVariableString_ShouldReturnResultContainingValueOfVariable(string testString, string expected)
+    {
+        var variablesDict = new Dictionary<string, string>()
+        {
+            { "HTTP_URL", "TEST_VARIABLE"}
+        };
+        var features = new FeatureCollection(1);
+        features.Set<IServerVariablesFeature>(new TestServerVariablesFeature(variablesDict));
+
+        var rewriteContext= new RewriteContext { HttpContext = new DefaultHttpContext(features), StaticFileProvider = null, Logger = NullLogger.Instance };
+
+        var middle = new InputParser().ParseInputString(testString, UriMatchPart.Path);
+        var result = middle.Evaluate(rewriteContext, CreateTestRuleBackReferences(), CreateTestCondBackReferences());
+
         Assert.Equal(expected, result);
     }
 

--- a/src/Middleware/Rewrite/test/PatternSegments/UrlDecodeSegmentTests.cs
+++ b/src/Middleware/Rewrite/test/PatternSegments/UrlDecodeSegmentTests.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Rewrite.PatternSegments;
+
+namespace Microsoft.AspNetCore.Rewrite.Tests.PatternSegments;
+
+public class UrlDecodeSegmentTests
+{
+    [Theory]
+    [InlineData("%20", " ")]
+    [InlineData("x%26y", "x&y")]
+    [InlineData("hey", "hey")]
+    public void FromLower_AssertLowerCaseWorksAppropriately(string input, string expected)
+    {
+        // Arrange
+        var pattern = new Pattern(new List<PatternSegment>());
+        pattern.PatternSegments.Add(new LiteralSegment(input));
+        var segement = new UrlDecodeSegment(pattern);
+        var context = new RewriteContext();
+
+        // Act
+        var results = segement.Evaluate(context, null, null);
+
+        // Assert
+        Assert.Equal(expected, results);
+    }
+}


### PR DESCRIPTION
Add Url encoding and modify url Encoding for IIS UrlRewrite

Add Segment Decode class using Uri.UnescapeDataString and plug it into Input Parser.
Modify Url Encode so that it uses Uri.DecodeDataString.

## Description

As was suggested I have changed Decode Data String to Unescape Data String which is recommended by docs. 
For Url Decoding I have used analogical function  UnescapeDataString. I have written unit tests for decoding covering opposite cases to encoding. I have also written tests for InputParser checking whether decode parameter goes into correct case and correct rule is added.

I wasn't sure if I was supposed to write performance tests since the motivation of changing from UrlEncode was that it's slow. If these test are desired I can add them.

Fixes #5985
