### PR TITLE
Ensure error boundary service is registered as part of call to AddBlazorWebView

### DIFF
--- a/src/Components/WebView/WebView/src/ComponentsWebViewServiceCollectionExtensions.cs
+++ b/src/Components/WebView/WebView/src/ComponentsWebViewServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebView.Services;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.JSInterop;
@@ -25,6 +26,7 @@ public static class ComponentsWebViewServiceCollectionExtensions
         services.TryAddScoped<IJSRuntime, WebViewJSRuntime>();
         services.TryAddScoped<INavigationInterception, WebViewNavigationInterception>();
         services.TryAddScoped<NavigationManager, WebViewNavigationManager>();
+        services.TryAddScoped<IErrorBoundaryLogger, WebViewErrorBoundaryLogger>();
         return services;
     }
 }

--- a/src/Components/WebView/WebView/src/Services/WebViewErrorBoundaryLogger.cs
+++ b/src/Components/WebView/WebView/src/Services/WebViewErrorBoundaryLogger.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Components.WebView.Services;
+
+internal sealed class WebViewErrorBoundaryLogger : IErrorBoundaryLogger
+{
+    private readonly ILogger<ErrorBoundary> _errorBoundaryLogger;
+
+    public WebViewErrorBoundaryLogger(ILogger<ErrorBoundary> errorBoundaryLogger)
+    {
+        _errorBoundaryLogger = errorBoundaryLogger;
+    }
+
+    public ValueTask LogErrorAsync(Exception exception)
+    {
+        // For, client-side code, all internal state is visible to the end user. We can just
+        // log directly to the console.
+        _errorBoundaryLogger.LogError(exception, exception.ToString());
+        return ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/maui/issues/4502

* This brings AddBlazorWebView to parity with other AddBlazor* equivalents.
* I was able to verify that the change worked with a 6.0 version of a WinForms app.