### PR TITLE
Ensure error boundary service is registered as part of call to AddBlazorWebView

### DIFF
--- a/src/Components/WebView/WebView/src/ComponentsWebViewServiceCollectionExtensions.cs
+++ b/src/Components/WebView/WebView/src/ComponentsWebViewServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebView.Services;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.JSInterop;
@@ -25,6 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddScoped<IJSRuntime, WebViewJSRuntime>();
             services.TryAddScoped<INavigationInterception, WebViewNavigationInterception>();
             services.TryAddScoped<NavigationManager, WebViewNavigationManager>();
+            services.TryAddScoped<IErrorBoundaryLogger, WebViewErrorBoundaryLogger>();
             return services;
         }
     }

--- a/src/Components/WebView/WebView/src/Services/WebViewErrorBoundaryLogger.cs
+++ b/src/Components/WebView/WebView/src/Services/WebViewErrorBoundaryLogger.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Components.WebView.Services;
+
+internal sealed class WebViewErrorBoundaryLogger : IErrorBoundaryLogger
+{
+    private readonly ILogger<ErrorBoundary> _errorBoundaryLogger;
+
+    public WebViewErrorBoundaryLogger(ILogger<ErrorBoundary> errorBoundaryLogger)
+    {
+        _errorBoundaryLogger = errorBoundaryLogger;
+    }
+
+    public ValueTask LogErrorAsync(Exception exception)
+    {
+        // For, client-side code, all internal state is visible to the end user. We can just
+        // log directly to the console.
+        _errorBoundaryLogger.LogError(exception, exception.ToString());
+        return ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
# Ensure error boundary service is registered as part of call to AddBlazorWebView

As part of testing the Blazor WebView, we discovered that a service required by the ErrorBoundary component that is part of the Blazor framework, is not registered by default. This service is registered by default by Blazor Server and Blazor Webassembly. This missing service results in a runtime exception when the ErrorBoundary component is used.

This change adds an implementation for the service and registers it by default in Blazor WebView scenario.

Fixes https://github.com/dotnet/maui/issues/4502

## Customer Impact

Allows use of ErrorBoundary component in Blazor MAUI / WinForms and WPF apps.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The change is limited to Blazor WebView / MAUI scenarios.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

