### PR TITLE
Restore use of ParameterDefaultValue in ActivatorUtilities

### DIFF
--- a/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
+++ b/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
@@ -22,6 +22,7 @@ Microsoft.AspNetCore.Http.HttpResponse</Description>
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
 
     <Compile Include="$(SharedSourceRoot)ActivatorUtilities\*.cs" />
+    <Compile Include="$(SharedSourceRoot)ParameterDefaultValue\*.cs" />
     <Compile Include="$(SharedSourceRoot)PropertyHelper\**\*.cs" />
     <Compile Include="$(SharedSourceRoot)\UrlDecoder\UrlDecoder.cs" Link="UrlDecoder.cs" />
     <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" />

--- a/src/Shared/ActivatorUtilities/ActivatorUtilities.cs
+++ b/src/Shared/ActivatorUtilities/ActivatorUtilities.cs
@@ -153,13 +153,12 @@ internal static class ActivatorUtilities
                     var value = provider.GetService(parameter.ParameterType);
                     if (value is null)
                     {
-                        if (!parameter.HasDefaultValue)
+                        if (!ParameterDefaultValue.TryGetDefaultValue(parameter, out var defaultValue))
                         {
-
                             throw new InvalidOperationException($"Unable to resolve service for type '{_parameters[index].ParameterType}' while attempting to activate '{_constructor.DeclaringType}'.");
                         }
 
-                        value = parameter.DefaultValue;
+                        value = defaultValue;
                     }
 
                     _parameterValues[index] = value;

--- a/src/Shared/ParameterDefaultValue/ParameterDefaultValue.cs
+++ b/src/Shared/ParameterDefaultValue/ParameterDefaultValue.cs
@@ -1,56 +1,50 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+// Based on https://github.com/dotnet/runtime/blob/28a7265ae309f4dc5b23c3a1ef0b49aa1df020ee/src/libraries/Common/src/Extensions/ParameterDefaultValue/ParameterDefaultValue.cs
+
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+
+#if NETFRAMEWORK || NETSTANDARD2_0
+using System.Runtime.Serialization;
+#else
+using System.Runtime.CompilerServices;
+#endif
 
 namespace Microsoft.Extensions.Internal;
 
-internal class ParameterDefaultValue
+internal static partial class ParameterDefaultValue
 {
-    private static readonly Type _nullable = typeof(Nullable<>);
-
     public static bool TryGetDefaultValue(ParameterInfo parameter, out object? defaultValue)
     {
-        bool hasDefaultValue;
-        var tryToGetDefaultValue = true;
+        var hasDefaultValue = CheckHasDefaultValue(parameter, out var tryToGetDefaultValue);
         defaultValue = null;
 
-        try
-        {
-            hasDefaultValue = parameter.HasDefaultValue;
-        }
-        catch (FormatException) when (parameter.ParameterType == typeof(DateTime))
-        {
-            // Workaround for https://github.com/dotnet/corefx/issues/12338
-            // If HasDefaultValue throws FormatException for DateTime
-            // we expect it to have default value
-            hasDefaultValue = true;
-            tryToGetDefaultValue = false;
-        }
-
-        if (hasDefaultValue)
+        if (parameter.HasDefaultValue)
         {
             if (tryToGetDefaultValue)
             {
                 defaultValue = parameter.DefaultValue;
             }
 
-            // Workaround for https://github.com/dotnet/corefx/issues/11797
-            if (defaultValue == null && parameter.ParameterType.IsValueType)
+            bool isNullableParameterType = parameter.ParameterType.IsGenericType &&
+                parameter.ParameterType.GetGenericTypeDefinition() == typeof(Nullable<>);
+
+            // Workaround for https://github.com/dotnet/runtime/issues/18599
+            if (defaultValue == null && parameter.ParameterType.IsValueType
+                && !isNullableParameterType) // Nullable types should be left null
             {
-                defaultValue = Activator.CreateInstance(parameter.ParameterType);
+                defaultValue = CreateValueType(parameter.ParameterType);
             }
 
             // Handle nullable enums
-            if (defaultValue != null &&
-                parameter.ParameterType.IsGenericType &&
-                parameter.ParameterType.GetGenericTypeDefinition() == _nullable
-                )
+            if (defaultValue != null && isNullableParameterType)
             {
-                var underlyingType = Nullable.GetUnderlyingType(parameter.ParameterType);
+                Type? underlyingType = Nullable.GetUnderlyingType(parameter.ParameterType);
                 if (underlyingType != null && underlyingType.IsEnum)
                 {
                     defaultValue = Enum.ToObject(underlyingType, defaultValue);
@@ -60,4 +54,36 @@ internal class ParameterDefaultValue
 
         return hasDefaultValue;
     }
+
+#if NETFRAMEWORK || NETSTANDARD
+    private static bool CheckHasDefaultValue(ParameterInfo parameter, out bool tryToGetDefaultValue)
+    {
+        tryToGetDefaultValue = true;
+        try
+        {
+            return parameter.HasDefaultValue;
+        }
+        catch (FormatException) when (parameter.ParameterType == typeof(DateTime))
+        {
+            // Workaround for https://github.com/dotnet/runtime/issues/18844
+            // If HasDefaultValue throws FormatException for DateTime
+            // we expect it to have default value
+            tryToGetDefaultValue = false;
+            return true;
+        }
+    }
+
+    private static object? CreateValueType(Type t) => FormatterServices.GetSafeUninitializedObject(t);
+
+#else
+    private static bool CheckHasDefaultValue(ParameterInfo parameter, out bool tryToGetDefaultValue)
+    {
+        tryToGetDefaultValue = true;
+        return parameter.HasDefaultValue;
+    }
+
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2067:UnrecognizedReflectionPattern",
+        Justification = "CreateValueType is only called on a ValueType. You can always create an instance of a ValueType.")]
+    private static object? CreateValueType(Type t) => RuntimeHelpers.GetUninitializedObject(t);
+#endif
 }

--- a/src/Shared/ParameterDefaultValue/ParameterDefaultValue.cs
+++ b/src/Shared/ParameterDefaultValue/ParameterDefaultValue.cs
@@ -9,7 +9,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if NETFRAMEWORK || NETSTANDARD
 using System.Runtime.Serialization;
 #else
 using System.Runtime.CompilerServices;


### PR DESCRIPTION
Made an incorrect merge as part of https://github.com/dotnet/aspnetcore/pull/40430 where I dropped some of my changes to ActivatorUtilities / ParameterDefaultValue. This fixes it up.
