### PR TITLE
Sealed DelegateRouteHandlerFilter

### DIFF
--- a/src/Http/Routing/src/Builder/DelegateRouteHandlerFilter.cs
+++ b/src/Http/Routing/src/Builder/DelegateRouteHandlerFilter.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.AspNetCore.Http;
 
-internal class DelegateRouteHandlerFilter : IRouteHandlerFilter
+internal sealed class DelegateRouteHandlerFilter : IRouteHandlerFilter
 {
     private readonly Func<RouteHandlerFilterContext, Func<RouteHandlerFilterContext, ValueTask<object?>>, ValueTask<object?>> _routeHandlerFilter;
 


### PR DESCRIPTION
Sealed `DelegateRouteHandlerFilter` since it's an internal type and no inherited types

Contributes to [#49403](https://github.com/dotnet/aspnetcore/pull/40491)
