### PR TITLE
In JS interop, handle ValueTask equivalently as Task (#40198)

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -370,10 +370,10 @@ public static class DotNetDispatcher
         Justification = "https://github.com/mono/linker/issues/1727")]
     private static Task GetTaskByType(Type type, object obj)
     {
-        var assemblyMethods = _cachedConvertToTaskByType.GetOrAdd(type, (Type t)=>
+        var converterDelegate = _cachedConvertToTaskByType.GetOrAdd(type, (Type t) =>
             _taskConverterMethodInfo.MakeGenericMethod(t).CreateDelegate<Func<object, Task>>());
 
-        return assemblyMethods.Invoke(obj);
+        return converterDelegate.Invoke(obj);
     }
     private static readonly MethodInfo _taskConverterMethodInfo = typeof(DotNetDispatcher).GetMethod(nameof(CreateValueTaskConverter), BindingFlags.NonPublic | BindingFlags.Static)!;
     private static Task CreateValueTaskConverter<[DynamicallyAccessedMembers(LinkerFlags.JsonSerialized)] T>(object result) => ((ValueTask<T>)result).AsTask();

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -117,9 +117,11 @@ public static class DotNetDispatcher
         {
             valueTaskResult.AsTask().ContinueWith(t => EndInvokeDotNetAfterTask(t, jsRuntime, invocationInfo), TaskScheduler.Current);
         }
-        else if (syncResult?.GetType().IsGenericType ?? false && syncResult?.GetType().GetGenericTypeDefinition() == typeof(ValueTask<>))
+        else if (syncResult?.GetType() is { IsGenericType: true } syncResultType
+            && syncResultType.GetGenericTypeDefinition() == typeof(ValueTask<>))
         {
-            var innerTask = GetTaskByType(syncResult.GetType().GenericTypeArguments[0], syncResult);
+            // It's a ValueTask<T>. We'll coerce it to a Task so that we can attach a continuation.
+            var innerTask = GetTaskByType(syncResultType.GenericTypeArguments[0], syncResult);
 
             innerTask!.ContinueWith(t => EndInvokeDotNetAfterTask(t, jsRuntime, invocationInfo), TaskScheduler.Current);
         }

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -108,6 +108,15 @@ public static class DotNetDispatcher
             // Returned a task - we need to continue that task and then report an exception
             // or return the value.
             task.ContinueWith(t => EndInvokeDotNetAfterTask(t, jsRuntime, invocationInfo), TaskScheduler.Current);
+
+        }
+        else if (syncResult?.GetType().GetGenericTypeDefinition() == typeof(ValueTask<>))
+        {
+            //since syncResult is generic we have to get AsTask method for its type
+            var valueTaskAsTaskMethod = syncResult.GetType().GetMethod("AsTask");
+            var innerTask = valueTaskAsTaskMethod!.Invoke(syncResult, Array.Empty<object>()) as Task;
+
+            innerTask!.ContinueWith(t => EndInvokeDotNetAfterTask(t, jsRuntime, invocationInfo), TaskScheduler.Current);
         }
         else
         {

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -10,6 +10,7 @@ using System.Reflection.Metadata;
 using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Text.Json;
+using Microsoft.AspNetCore.Internal;
 
 [assembly: MetadataUpdateHandler(typeof(Microsoft.JSInterop.Infrastructure.DotNetDispatcher))]
 
@@ -369,7 +370,7 @@ public static class DotNetDispatcher
         return assemblyMethods.Invoke(obj);
     }
     private static readonly MethodInfo _taskConverterMethodInfo = typeof(DotNetDispatcher).GetMethod(nameof(CreateValueTaskConverter), BindingFlags.NonPublic | BindingFlags.Static)!;
-    private static Task CreateValueTaskConverter<T>(object? result) => ((ValueTask<T>)result!).AsTask();
+    private static Task CreateValueTaskConverter<[DynamicallyAccessedMembers(LinkerFlags.JsonSerialized)] T>(object result) => ((ValueTask<T>)result).AsTask();
     
     private static (MethodInfo methodInfo, Type[] parameterTypes) GetCachedMethodInfo(IDotNetObjectReference objectReference, string methodIdentifier)
     {

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -116,7 +116,7 @@ public static class DotNetDispatcher
         {
             valueTaskResult.AsTask().ContinueWith(t => EndInvokeDotNetAfterTask(t, jsRuntime, invocationInfo), TaskScheduler.Current);
         }
-        else if (syncResult?.GetType().GetGenericTypeDefinition()== typeof(ValueTask<>))
+        else if (syncResult?.GetType().IsGenericType ?? false && syncResult?.GetType().GetGenericTypeDefinition() == typeof(ValueTask<>))
         {
             var innerTask = GetTaskByType(syncResult.GetType().GenericTypeArguments[0], syncResult);
 

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -370,8 +370,8 @@ public static class DotNetDispatcher
         Justification = "https://github.com/mono/linker/issues/1727")]
     private static Task GetTaskByType(Type type, object obj)
     {
-        var converterDelegate = _cachedConvertToTaskByType.GetOrAdd(type, (Type t) =>
-            _taskConverterMethodInfo.MakeGenericMethod(t).CreateDelegate<Func<object, Task>>());
+        var converterDelegate = _cachedConvertToTaskByType.GetOrAdd(type, (Type t, MethodInfo taskConverterMethodInfo) =>
+            taskConverterMethodInfo.MakeGenericMethod(t).CreateDelegate<Func<object, Task>>(), _taskConverterMethodInfo);
 
         return converterDelegate.Invoke(obj);
     }

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -362,6 +362,10 @@ public static class DotNetDispatcher
         }
     }
 
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2060:MakeGenericMethod",
+        Justification = "https://github.com/mono/linker/issues/1727")]
     private static Task GetTaskByType(Type type, object obj)
     {
         var assemblyMethods = _cachedConvertToTaskByType.GetOrAdd(type, (Type t)=>

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -113,7 +113,12 @@ public static class DotNetDispatcher
         else if (syncResult?.GetType().GetGenericTypeDefinition() == typeof(ValueTask<>))
         {
             //since syncResult is generic we have to get AsTask method for its type
-            var valueTaskAsTaskMethod = syncResult.GetType().GetMethod("AsTask");
+            var valueTaskAsTaskMethod = syncResult.GetType().GetMethod("AsTask", BindingFlags.Instance | BindingFlags.Public);
+            if (valueTaskAsTaskMethod == null)
+            {
+                throw new MissingMethodException("AsTask method was expected on type ValueTask<>");
+            }
+
             var innerTask = valueTaskAsTaskMethod!.Invoke(syncResult, Array.Empty<object>()) as Task;
 
             innerTask!.ContinueWith(t => EndInvokeDotNetAfterTask(t, jsRuntime, invocationInfo), TaskScheduler.Current);

--- a/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.WarningSuppressions.xml
+++ b/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.WarningSuppressions.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <linker>
   <assembly fullname="Microsoft.JSInterop, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
@@ -41,7 +41,7 @@
       <argument>ILLink</argument>
       <argument>IL2060</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.JSInterop.Infrastructure.DotNetDispatcher.&lt;&gt;c.&lt;GetTaskByType&gt;b__13_0(System.Type)</property>
+      <property name="Target">M:Microsoft.JSInterop.Infrastructure.DotNetDispatcher.&lt;&gt;c.&lt;GetTaskByType&gt;b__13_0(System.Type,System.Reflection.MethodInfo)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>

--- a/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.WarningSuppressions.xml
+++ b/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.WarningSuppressions.xml
@@ -39,6 +39,12 @@
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
+      <argument>IL2060</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.JSInterop.Infrastructure.DotNetDispatcher.&lt;&gt;c.&lt;GetTaskByType&gt;b__13_0(System.Type)</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
       <argument>IL2065</argument>
       <property name="Scope">member</property>
       <property name="Target">M:Microsoft.JSInterop.Infrastructure.DotNetDispatcher.ScanAssemblyForCallableMethods(Microsoft.JSInterop.Infrastructure.DotNetDispatcher.AssemblyKey)</property>

--- a/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetDispatcherTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetDispatcherTest.cs
@@ -663,7 +663,6 @@ public class DotNetDispatcherTest
             Assert.True(jsRuntime.LastCompletionResult.Success);
         }
 
-
     [Fact]
     public async Task CanInvokeSyncThrowingMethod()
     {
@@ -937,7 +936,7 @@ public class DotNetDispatcherTest
         public async ValueTask<InvokableAsyncMethodResult> InvokableAsyncMethodReturningValueTask(TestDTO dtoViaJson, DotNetObjectReference<TestDTO> dtoByRefWrapper)
         {
             var dtoByRef = dtoByRefWrapper.Value;
-            return new InvokableAsyncMethodResult
+            return await new ValueTask<InvokableAsyncMethodResult>( new InvokableAsyncMethodResult()
             {
                 SomeDTO = new TestDTO // Return via JSON
                 {
@@ -949,12 +948,13 @@ public class DotNetDispatcherTest
                     StringVal = dtoByRef.StringVal.ToUpperInvariant(),
                     IntVal = dtoByRef.IntVal * 2,
                 })
-            };
+            });
         }
 
         [JSInvokable]
         public async ValueTask InvokableAsyncMethodReturningValueTaskNonGeneric()
         {
+            await Task.CompletedTask;
             return;
         }
 


### PR DESCRIPTION
# In JS interop, handle ValueTask equivalently as Task 

Add logic for handling async JSInvokable methods returning ValueType in DotnetDispatcher

## Description

Since we can't do pattern matching as was done with Task since ValueTask apparently doesn't have non generic type we can use here I had to do reflection check if asyncResult is of generic type ValueTask<>. Then I proceeded to get AsTask method allowing me to use the same flow as was used for Task.

Fixes #40198
