### PR TITLE
Skip dotnet-install

### DIFF
--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -287,6 +287,18 @@ function InstallDotNet([string] $dotnetRoot,
   [string] $runtimeSourceFeedKey = '',
   [switch] $noPath) {
 
+  $runtimePath = $dotnetRoot
+
+  $runtimePath = $runtimePath + "\shared"
+  if ($runtime -eq "dotnet") { $runtimePath = $runtimePath + "\Microsoft.NETCore.App" }
+  if ($runtime -eq "aspnetcore") { $runtimePath = $runtimePath + "\Microsoft.AspNetCore.App" }
+  $runtimePath = $runtimePath + "\" + $version
+
+  if (Test-Path $runtimePath) {
+    $installSuccess = $true
+    Exit
+  }
+
   $installScript = GetDotNetInstallScript $dotnetRoot
   $installParameters = @{
     Version = $version


### PR DESCRIPTION
Whenever I build locally it tries to install all the required runtimes even if they are present. It seems like dotnet-install is not very optimal in verifying it's already done. This change will skip dotnet-install if we know the runtime is already there. On my machine it saves 10 seconds on each build.

We can't merge this PR but this is to get some feedback.

Before

```
Detected JDK in C:\code\aspnetcore60\eng\..\.tools\jdk\win-x64\ (via local repo convention)

  Determining projects to restore...
  Tool 'dotnet-serve' (version '1.8.15') was restored. Available commands: dotnet-serve
  Tool 'microsoft.playwright.cli' (version '1.2.2') was restored. Available commands: playwright

  Restore was successful.
  All projects are up-to-date for restore.
  Determining projects to restore...
  All projects are up-to-date for restore.
  GenerateFiles -> C:\code\aspnetcore60\artifacts\bin\GenerateFiles\Directory.Build.props
  GenerateFiles -> C:\code\aspnetcore60\artifacts\bin\GenerateFiles\Directory.Build.targets
Attempting to install dotnet from public location.
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.

dotnet-install: .NET Core Runtime with version '2.1.30' is already installed.
dotnet-install: Adding to current process PATH: "C:\code\aspnetcore60\.dotnet\". Note: This change will not be visible if PowerShell was run as a child process.
Attempting to install dotnet from public location.
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.

dotnet-install: .NET Core Runtime with version '7.0.0-preview.3.22127.1' is already installed.
dotnet-install: Adding to current process PATH: "C:\code\aspnetcore60\.dotnet\". Note: This change will not be visible if PowerShell was run as a child process.
Attempting to install dotnet from public location.
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.

dotnet-install: .NET Core Runtime with version '7.0.0-preview.3.22127.1' is already installed.
dotnet-install: Adding to current process PATH: "C:\code\aspnetcore60\.dotnet\x86\". Note: This change will not be visible if PowerShell was run as a child process.
Attempting to install dotnet from public location.
dotnet-install: Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
dotnet-install: - The SDK needs to be installed without user interaction and without admin rights.
dotnet-install: - The SDK installation doesn't need to persist across multiple CI runs.
dotnet-install: To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.

dotnet-install: ASP.NET Core Runtime with version '3.1.21' is already installed.
dotnet-install: Adding to current process PATH: "C:\code\aspnetcore60\.dotnet\". Note: This change will not be visible if PowerShell was run as a child process.
  Determining projects to restore...
  All projects are up-to-date for restore.
  RepoTasks -> C:\code\aspnetcore60\artifacts\bin\RepoTasks\Release\net7.0\RepoTasks.dll
  RepoTasks -> C:\code\aspnetcore60\artifacts\bin\RepoTasks\Release\net472\RepoTasks.dll
```

After

```
Detected JDK in C:\code\aspnetcore60\eng\..\.tools\jdk\win-x64\ (via local repo convention)

  Determining projects to restore...
  Tool 'dotnet-serve' (version '1.8.15') was restored. Available commands: dotnet-serve
  Tool 'microsoft.playwright.cli' (version '1.2.2') was restored. Available commands: playwright

  Restore was successful.
  All projects are up-to-date for restore.
  Determining projects to restore...
  All projects are up-to-date for restore.
  GenerateFiles -> C:\code\aspnetcore60\artifacts\bin\GenerateFiles\Directory.Build.props
  GenerateFiles -> C:\code\aspnetcore60\artifacts\bin\GenerateFiles\Directory.Build.targets
```