### PR TITLE
Signal IsCompleted from Response.BodyWriter after abort

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -40,7 +40,6 @@ internal class Http1OutputProducer : IHttpOutputProducer, IDisposable
 
     private bool _pipeWriterCompleted;
     private bool _aborted;
-    private bool _pendingFlushCanceled;
     private long _unflushedBytes;
     private int _currentMemoryPrefixBytes;
 
@@ -145,10 +144,6 @@ internal class Http1OutputProducer : IHttpOutputProducer, IDisposable
             if (_pipeWriterCompleted)
             {
                 return new ValueTask<FlushResult>(new FlushResult(false, true));
-            }
-            if (_pendingFlushCanceled)
-            {
-                return new ValueTask<FlushResult>(new FlushResult(true, false));
             }
 
             if (_autoChunk)
@@ -284,7 +279,6 @@ internal class Http1OutputProducer : IHttpOutputProducer, IDisposable
     public void CancelPendingFlush()
     {
         _pipeWriter.CancelPendingFlush();
-        _pendingFlushCanceled = true;
     }
 
     // This method is for chunked http responses that directly call response.WriteAsync
@@ -492,7 +486,7 @@ internal class Http1OutputProducer : IHttpOutputProducer, IDisposable
 
             if (_pipeWriterCompleted)
             {
-                return default;
+                return new ValueTask<FlushResult>(new FlushResult(false,true));
             }
 
             // Uses same BufferWriter to write response headers and response
@@ -512,7 +506,7 @@ internal class Http1OutputProducer : IHttpOutputProducer, IDisposable
 
             if (_pipeWriterCompleted)
             {
-                return default;
+                return new ValueTask<FlushResult>(new FlushResult(false, true));
             }
 
             // Uses same BufferWriter to write response headers and chunk
@@ -550,7 +544,7 @@ internal class Http1OutputProducer : IHttpOutputProducer, IDisposable
 
             if (_pipeWriterCompleted)
             {
-                return default;
+                return new ValueTask<FlushResult>(new FlushResult(false, true));
             }
 
             var writer = new BufferWriter<PipeWriter>(_pipeWriter);

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -143,7 +143,7 @@ internal class Http1OutputProducer : IHttpOutputProducer, IDisposable
         {
             if (_pipeWriterCompleted)
             {
-                return default;
+                return new ValueTask<FlushResult>(new FlushResult(false, true));
             }
 
             if (_autoChunk)

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -149,10 +149,9 @@ internal class Http2OutputProducer : IHttpOutputProducer, IHttpOutputAborter, IV
         lock (_dataWriterLock)
         {
             ThrowIfSuffixSentOrCompleted();
-
             if (_streamCompleted)
             {
-                return default;
+                return new ValueTask<FlushResult>(new FlushResult(false, true));
             }
 
             if (_startedWritingDataFrames)

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3OutputProducer.cs
@@ -163,7 +163,7 @@ internal class Http3OutputProducer : IHttpOutputProducer, IHttpOutputAborter
 
             if (_streamCompleted)
             {
-                return default;
+                return new ValueTask<FlushResult>(new FlushResult(false, true));
             }
 
             if (_startedWritingDataFrames)

--- a/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
@@ -697,7 +697,20 @@ public class Http1ConnectionTests : Http1ConnectionTestsBase
     }
 
     [Fact]
-    public async void BodyWriter_OnAbortedConnection_ReturnsFlushResultWithIsCanceledTrue()
+    public async void BodyWriter_OnAbortedConnection_ReturnsFlushResultWithIsCompletedTrue()
+    {
+        var payload = Encoding.UTF8.GetBytes("hello, web browser" + new string(' ', 512) + "\n");
+        var writer = _application.Output;
+
+        var successResult= await writer.WriteAsync(payload);
+        Assert.False(successResult.IsCompleted);
+
+        _http1Connection.Abort(new ConnectionAbortedException());
+        var failResult= await _http1Connection.FlushPipeAsync(new CancellationToken());
+        Assert.True(failResult.IsCompleted);
+    }
+    [Fact]
+    public async void BodyWriter_OnConnectionWithCanceledPendingFlush_ReturnsFlushResultWithIsCanceledTrue()
     {
         var payload = Encoding.UTF8.GetBytes("hello, web browser" + new string(' ', 512) + "\n");
         var writer = _application.Output;
@@ -705,9 +718,10 @@ public class Http1ConnectionTests : Http1ConnectionTestsBase
         var successResult= await writer.WriteAsync(payload);
         Assert.False(successResult.IsCanceled);
 
-        _http1Connection.Abort(new ConnectionAbortedException());
+        _http1Connection.CancelPendingFlush();
+
         var failResult= await _http1Connection.FlushPipeAsync(new CancellationToken());
-        Assert.True(failResult.IsCompleted);
+        Assert.True(failResult.IsCanceled);
     }
 
     [Fact]

--- a/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
@@ -720,8 +720,12 @@ public class Http1ConnectionTests : Http1ConnectionTestsBase
 
         _http1Connection.CancelPendingFlush();
 
-        var failResult= await _http1Connection.FlushPipeAsync(new CancellationToken());
-        Assert.True(failResult.IsCanceled);
+        var canceledResult= await _http1Connection.FlushPipeAsync(new CancellationToken());
+        Assert.True(canceledResult.IsCanceled);
+
+        //Cancel pending should cancel only next flush
+        var goodResult= await _http1Connection.FlushPipeAsync(new CancellationToken());
+        Assert.False(goodResult.IsCanceled);
     }
 
     [Fact]

--- a/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
@@ -702,29 +702,30 @@ public class Http1ConnectionTests : Http1ConnectionTestsBase
         var payload = Encoding.UTF8.GetBytes("hello, web browser" + new string(' ', 512) + "\n");
         var writer = _application.Output;
 
-        var successResult= await writer.WriteAsync(payload);
+        var successResult = await writer.WriteAsync(payload);
         Assert.False(successResult.IsCompleted);
 
         _http1Connection.Abort(new ConnectionAbortedException());
-        var failResult= await _http1Connection.FlushPipeAsync(new CancellationToken());
+        var failResult = await _http1Connection.FlushPipeAsync(new CancellationToken());
         Assert.True(failResult.IsCompleted);
     }
+
     [Fact]
     public async void BodyWriter_OnConnectionWithCanceledPendingFlush_ReturnsFlushResultWithIsCanceledTrue()
     {
         var payload = Encoding.UTF8.GetBytes("hello, web browser" + new string(' ', 512) + "\n");
         var writer = _application.Output;
 
-        var successResult= await writer.WriteAsync(payload);
+        var successResult = await writer.WriteAsync(payload);
         Assert.False(successResult.IsCanceled);
 
         _http1Connection.CancelPendingFlush();
 
-        var canceledResult= await _http1Connection.FlushPipeAsync(new CancellationToken());
+        var canceledResult = await _http1Connection.FlushPipeAsync(new CancellationToken());
         Assert.True(canceledResult.IsCanceled);
 
         //Cancel pending should cancel only next flush
-        var goodResult= await _http1Connection.FlushPipeAsync(new CancellationToken());
+        var goodResult = await _http1Connection.FlushPipeAsync(new CancellationToken());
         Assert.False(goodResult.IsCanceled);
     }
 

--- a/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
@@ -697,6 +697,20 @@ public class Http1ConnectionTests : Http1ConnectionTestsBase
     }
 
     [Fact]
+    public async void BodyWriter_OnAbortedConnection_ReturnsFlushResultWithIsCanceledTrue()
+    {
+        var payload = Encoding.UTF8.GetBytes("hello, web browser" + new string(' ', 512) + "\n");
+        var writer = _application.Output;
+
+        var successResult= await writer.WriteAsync(payload);
+        Assert.False(successResult.IsCanceled);
+
+        _http1Connection.Abort(new ConnectionAbortedException());
+        var failResult= await _http1Connection.FlushPipeAsync(new CancellationToken());
+        Assert.True(failResult.IsCompleted);
+    }
+
+    [Fact]
     public async Task RequestAbortedTokenIsResetBeforeLastWriteAsyncAwaitedWithContentLength()
     {
         _http1Connection.ResponseHeaders["Content-Length"] = "12";

--- a/src/Servers/Kestrel/Core/test/Http1/Http1OutputProducerTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1OutputProducerTests.cs
@@ -75,12 +75,13 @@ public class Http1OutputProducerTests : IDisposable
         socketOutput.Dispose();
 
         await socketOutput.WriteDataAsync(new byte[] { 1, 2, 3, 4 }, default);
-        var cancelResult = await socketOutput.FlushAsync();
-        Assert.True(cancelResult.IsCompleted);
+        var completedResult = await socketOutput.FlushAsync();
+        Assert.True(completedResult.IsCompleted);
 
         socketOutput.Pipe.Writer.Complete();
         socketOutput.Pipe.Reader.Complete();
     }
+
     [Fact]
     public async Task FlushAsync_OnSocketWithCanceledPendingFlush_ReturnsResultWithIsCanceledTrue()
     {

--- a/src/Servers/Kestrel/Core/test/Http1/Http1OutputProducerTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1OutputProducerTests.cs
@@ -101,8 +101,7 @@ public class Http1OutputProducerTests : IDisposable
         // Close
         socketOutput.CancelPendingFlush();
 
-        await socketOutput.WriteDataAsync(new byte[] { 1, 2, 3, 4 }, default);
-        var cancelResult = await socketOutput.FlushAsync();
+        var cancelResult = await socketOutput.WriteDataToPipeAsync(new byte[] { 1, 2, 3, 4 }, default);
         Assert.True(cancelResult.IsCanceled);
 
         socketOutput.Pipe.Writer.Complete();

--- a/src/Servers/Kestrel/Core/test/Http1/Http1OutputProducerTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1OutputProducerTests.cs
@@ -104,6 +104,10 @@ public class Http1OutputProducerTests : IDisposable
         var cancelResult = await socketOutput.WriteDataToPipeAsync(new byte[] { 1, 2, 3, 4 }, default);
         Assert.True(cancelResult.IsCanceled);
 
+        // only one flush should be cancelled
+        var goodResult = await socketOutput.WriteDataToPipeAsync(new byte[] { 1, 2, 3, 4 }, default);
+        Assert.False(goodResult.IsCanceled);
+
         socketOutput.Pipe.Writer.Complete();
         socketOutput.Pipe.Reader.Complete();
     }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -430,50 +430,6 @@ public class Http2ConnectionTests : Http2TestBase
     }
 
     [Fact]
-    public async Task FlushAsync_OnAbortedRequest_ReturnsResultWithIsCompletedTrue()
-    {
-        // Add stream to Http2Connection._completedStreams inline with SetResult().
-        var serverTcs = new TaskCompletionSource();
-
-        await InitializeConnectionAsync(async context =>
-        {
-            await serverTcs.Task;
-        });
-
-        await StartStreamAsync(1, _browserRequestHeaders, endStream: false);
-
-        var stream = _connection._streams[1];
-        stream.Abort(new IOException());
-
-        var output = (Http2OutputProducer)stream.Output;
-        var result = await output.FlushAsync(new CancellationToken());
-
-        Assert.True(result.IsCompleted);
-    }
-    [Fact]
-    public async Task FlushAsync_OnCanceledPendingFlush_ReturnsResultWithIsCanceledTrue()
-    {
-        // Add stream to Http2Connection._completedStreams inline with SetResult().
-        var serverTcs = new TaskCompletionSource();
-
-        await InitializeConnectionAsync(async context =>
-        {
-            await serverTcs.Task;
-        });
-
-        await StartStreamAsync(1, _browserRequestHeaders, endStream: false);
-
-        var stream = _connection._streams[1];
-
-        var output = (Http2OutputProducer)stream.Output;
-        output.CancelPendingFlush();
-
-        var result = await output.FlushAsync(new CancellationToken());
-
-        Assert.True(result.IsCanceled);
-    }
-
-    [Fact]
     public async Task StreamPool_MultipleStreamsConcurrent_StreamsReturnedToPool()
     {
         await InitializeConnectionAsync(_echoApplication);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -430,6 +430,28 @@ public class Http2ConnectionTests : Http2TestBase
     }
 
     [Fact]
+    public async Task FlushAsync_OnAbortedRequest_ReturnsResultWithIsCanceledTrue()
+    {
+        // Add stream to Http2Connection._completedStreams inline with SetResult().
+        var serverTcs = new TaskCompletionSource();
+
+        await InitializeConnectionAsync(async context =>
+        {
+            await serverTcs.Task;
+        });
+
+        await StartStreamAsync(1, _browserRequestHeaders, endStream: false);
+
+        var stream = _connection._streams[1];
+        stream.Abort(new IOException());
+
+        var output = (Http2OutputProducer)stream.Output;
+        var result = await output.FlushAsync(new CancellationToken());
+
+        Assert.True(result.IsCompleted);
+    }
+
+    [Fact]
     public async Task StreamPool_MultipleStreamsConcurrent_StreamsReturnedToPool()
     {
         await InitializeConnectionAsync(_echoApplication);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -3625,6 +3625,84 @@ public class Http2StreamTests : Http2TestBase
     }
 
     [Fact]
+    public async Task BodyWriterWriteAsync_OnAbortedRequest_ReturnsResultWithIsCompletedTrue()
+    {
+        var appTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var headers = new[]
+        {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+        };
+        await InitializeConnectionAsync(async httpContext =>
+        {
+            try
+            {
+                httpContext.Abort();
+                var payload = Encoding.ASCII.GetBytes("hello,");
+                var result = await httpContext.Response.BodyWriter.WriteAsync(payload);
+                Assert.True(result.IsCompleted);
+                appTcs.SetResult();
+            }
+            catch (Exception e)
+            {
+                appTcs.SetException(e);
+            }
+        });
+
+        await StartStreamAsync(1, headers, endStream: true);
+        await ExpectAsync(Http2FrameType.RST_STREAM,
+            withLength: 4,
+            withFlags: (byte)Http2HeadersFrameFlags.NONE,
+            withStreamId: 1);
+
+        await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: true);
+        await appTcs.Task;
+    }
+
+    [Fact]
+    public async Task BodyWriterWriteAsync_OnCanceledPendingFlush_ReturnsResultWithIsCanceled()
+    {
+        var headers = new[]
+        {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+        };
+        await InitializeConnectionAsync(async httpContext =>
+        {
+            httpContext.Response.BodyWriter.CancelPendingFlush();
+            var payload = Encoding.ASCII.GetBytes("hello,");
+            var cancelledResult = await httpContext.Response.BodyWriter.WriteAsync(payload);
+            Assert.True(cancelledResult.IsCanceled);
+
+            var secondPayload = Encoding.ASCII.GetBytes(" world");
+            var goodResult = await httpContext.Response.BodyWriter.WriteAsync(secondPayload);
+            Assert.False(goodResult.IsCanceled);
+        });
+
+        await StartStreamAsync(1, headers, endStream: true);
+        await ExpectAsync(Http2FrameType.HEADERS,
+            withLength: 32,
+            withFlags: (byte)Http2HeadersFrameFlags.END_HEADERS,
+            withStreamId: 1);
+        await ExpectAsync(Http2FrameType.DATA,
+            withLength: 6,
+            withFlags: (byte)Http2DataFrameFlags.NONE,
+            withStreamId: 1);
+        await ExpectAsync(Http2FrameType.DATA,
+            withLength: 6,
+            withFlags: (byte)Http2DataFrameFlags.NONE,
+            withStreamId: 1);
+        await ExpectAsync(Http2FrameType.DATA,
+            withLength: 0,
+            withFlags: (byte)Http2DataFrameFlags.END_STREAM,
+            withStreamId: 1);
+
+        await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: true);
+    }
+
+    [Fact]
     public async Task WriteAsync_BothPipeAndStreamWorks()
     {
         var headers = new[]
@@ -3632,7 +3710,7 @@ public class Http2StreamTests : Http2TestBase
                 new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
                 new KeyValuePair<string, string>(HeaderNames.Path, "/"),
                 new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
-            };
+        };
         await InitializeConnectionAsync(async httpContext =>
         {
             var response = httpContext.Response;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
@@ -81,7 +81,7 @@ public class Http3ConnectionTests : Http3TestBase
     }
 
     [Fact]
-    public async Task FlushPipeAsync_OnStoppedHttp3Stream_ReturnsFlushResultWithIsCanceledTrue()
+    public async Task FlushPipeAsync_OnStoppedHttp3Stream_ReturnsFlushResultWithIsCompletedTrue()
     {
         await Http3Api.InitializeConnectionAsync(_echoApplication);
         KeyValuePair<string, string>[] requestHeaders = new[]
@@ -104,8 +104,36 @@ public class Http3ConnectionTests : Http3TestBase
         http3Stream.Output.Stop();
 
         var result= await http3Stream.FlushPipeAsync(new CancellationToken());
-
         Assert.True(result.IsCompleted);
+
+        http3Stream.CancelPendingFlush();
+    }
+
+    [Fact]
+    public async Task FlushPipeAsync_OnCanceledPendingFlush_ReturnsFlushResultWithIsCanceledTrue()
+    {
+        await Http3Api.InitializeConnectionAsync(_echoApplication);
+        KeyValuePair<string, string>[] requestHeaders = new[]
+        {
+            new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+            new KeyValuePair<string, string>(HeaderNames.Path, "/hello"),
+            new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
+            new KeyValuePair<string, string>(HeaderNames.ContentType, "application/json")
+        };
+
+        //var z=await MakeRequestAsync(0, requestHeaders1, sendData: false, waitForServerDispose: false);
+        var requestStream = await Http3Api.CreateRequestStream();
+        var streamContext = requestStream.StreamContext;
+
+        await requestStream.SendHeadersAsync(requestHeaders, endStream: false);
+
+        //requestStream.Connection.Abort(new ConnectionAbortedException());
+        var http3Stream = (Http3Stream)streamContext.Features.Get<IPersistentStateFeature>().State[Http3Connection.StreamPersistentStateKey];
+
+        http3Stream.CancelPendingFlush();
+        var result= await http3Stream.FlushPipeAsync(new CancellationToken());
+        Assert.True(result.IsCanceled);
     }
 
     [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
@@ -9,8 +9,6 @@ using System.Globalization;
 using System.Net.Http;
 using System.Reflection;
 using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http;
@@ -78,62 +76,6 @@ public class Http3ConnectionTests : Http3TestBase
 
         await requestStream.OnDisposedTask.DefaultTimeout();
         Assert.True(requestStream.Disposed);
-    }
-
-    [Fact]
-    public async Task FlushPipeAsync_OnStoppedHttp3Stream_ReturnsFlushResultWithIsCompletedTrue()
-    {
-        await Http3Api.InitializeConnectionAsync(_echoApplication);
-        KeyValuePair<string, string>[] requestHeaders = new[]
-        {
-            new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
-            new KeyValuePair<string, string>(HeaderNames.Path, "/hello"),
-            new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
-            new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
-            new KeyValuePair<string, string>(HeaderNames.ContentType, "application/json")
-        };
-
-        //var z=await MakeRequestAsync(0, requestHeaders1, sendData: false, waitForServerDispose: false);
-        var requestStream = await Http3Api.CreateRequestStream();
-        var streamContext = requestStream.StreamContext;
-
-        await requestStream.SendHeadersAsync(requestHeaders, endStream: false);
-
-        //requestStream.Connection.Abort(new ConnectionAbortedException());
-        var http3Stream = (Http3Stream)streamContext.Features.Get<IPersistentStateFeature>().State[Http3Connection.StreamPersistentStateKey];
-        http3Stream.Output.Stop();
-
-        var result= await http3Stream.FlushPipeAsync(new CancellationToken());
-        Assert.True(result.IsCompleted);
-
-        http3Stream.CancelPendingFlush();
-    }
-
-    [Fact]
-    public async Task FlushPipeAsync_OnCanceledPendingFlush_ReturnsFlushResultWithIsCanceledTrue()
-    {
-        await Http3Api.InitializeConnectionAsync(_echoApplication);
-        KeyValuePair<string, string>[] requestHeaders = new[]
-        {
-            new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
-            new KeyValuePair<string, string>(HeaderNames.Path, "/hello"),
-            new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
-            new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
-            new KeyValuePair<string, string>(HeaderNames.ContentType, "application/json")
-        };
-
-        //var z=await MakeRequestAsync(0, requestHeaders1, sendData: false, waitForServerDispose: false);
-        var requestStream = await Http3Api.CreateRequestStream();
-        var streamContext = requestStream.StreamContext;
-
-        await requestStream.SendHeadersAsync(requestHeaders, endStream: false);
-
-        //requestStream.Connection.Abort(new ConnectionAbortedException());
-        var http3Stream = (Http3Stream)streamContext.Features.Get<IPersistentStateFeature>().State[Http3Connection.StreamPersistentStateKey];
-
-        http3Stream.CancelPendingFlush();
-        var result= await http3Stream.FlushPipeAsync(new CancellationToken());
-        Assert.True(result.IsCanceled);
     }
 
     [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
@@ -81,7 +81,7 @@ public class Http3ConnectionTests : Http3TestBase
     }
 
     [Fact]
-    public async Task FlushPipeAsync_OnStoppedHttp3Stream_ReturnsFlushResultWithIsCanceledTrue()
+    public async Task FlushPipeAsync_OnStoppedHttp3Stream_ReturnsFlushResultWithIsCompletedTrue()
     {
         await Http3Api.InitializeConnectionAsync(_echoApplication);
         KeyValuePair<string, string>[] requestHeaders = new[]
@@ -104,8 +104,35 @@ public class Http3ConnectionTests : Http3TestBase
         http3Stream.Output.Stop();
 
         var result= await http3Stream.FlushPipeAsync(new CancellationToken());
-
         Assert.True(result.IsCompleted);
+
+        http3Stream.CancelPendingFlush();
+    }
+
+    [Fact]
+    public async Task FlushPipeAsync_OnCanceledPendingFlush_ReturnsFlushResultWithIsCanceledTrue()
+    {
+        await Http3Api.InitializeConnectionAsync(_echoApplication);
+        KeyValuePair<string, string>[] requestHeaders = new[]
+        {
+            new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+            new KeyValuePair<string, string>(HeaderNames.Path, "/hello"),
+            new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            new KeyValuePair<string, string>(HeaderNames.Authority, "localhost:80"),
+            new KeyValuePair<string, string>(HeaderNames.ContentType, "application/json")
+        };
+
+        //var z=await MakeRequestAsync(0, requestHeaders1, sendData: false, waitForServerDispose: false);
+        var requestStream = await Http3Api.CreateRequestStream();
+        var streamContext = requestStream.StreamContext;
+
+        await requestStream.SendHeadersAsync(requestHeaders, endStream: false);
+
+        var http3Stream = (Http3Stream)streamContext.Features.Get<IPersistentStateFeature>().State[Http3Connection.StreamPersistentStateKey];
+
+        http3Stream.CancelPendingFlush();
+        var result= await http3Stream.FlushPipeAsync(new CancellationToken());
+        Assert.True(result.IsCanceled);
     }
 
     [Fact]


### PR DESCRIPTION
# After RequestAborted, Response.BodyWriter does not signal IsCompleted/IsCanceled

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->
<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->
**In Progress!** - IIS fix in progress
Change logic returning FlushResult when interacting with OutputProducer to be more consistent. 
For now Changes fix only Kestrel case, with IIS I have problems debugging and can't find routine responsible for creating FlushResults


## Description

Add logic for keeping track of if output producer pending flush was canceled. Modify FlushResult returned by FlushAsync to retun IsCompleted and IsCanceled for if stream was completed and stream had pending flush canceled respectively. I implemented it on http 1 2 3 and have written tests for them. I am not sure if tests are in the correct classes so feel free to correct me here.

Fixes #32331 
