### PR TITLE
Update HttpContextAccessor.cs

### DIFF
--- a/src/Http/Http/src/HttpContextAccessor.cs
+++ b/src/Http/Http/src/HttpContextAccessor.cs
@@ -20,17 +20,17 @@ public class HttpContextAccessor : IHttpContextAccessor
         set
         {
             var holder = _httpContextCurrent.Value;
-            if (holder != null)
-            {
-                // Clear current HttpContext trapped in the AsyncLocals, as its done.
-                holder.Context = null;
-            }
 
             if (value != null)
             {
                 // Use an object indirection to hold the HttpContext in the AsyncLocal,
                 // so it can be cleared in all ExecutionContexts when its cleared.
                 _httpContextCurrent.Value = new HttpContextHolder { Context = value };
+            }
+            else if (holder != null)
+            {
+                // Clear current HttpContext trapped in the AsyncLocals, as its done.
+                holder.Context = null;
             }
         }
     }


### PR DESCRIPTION
Delete HttpContext only if value is really null

# {HttpContextAccessor does not keep value after new value was set}

## Description
The problem is that if you need to override this HttpContext to call another Api controller with a different user (AuthorizationToken) the HttpContext should be reset to the old value with the old user (AuthorizationToken).

This behavior is also the default for AsyncLocal used inside the HttpContextAccessor, but the HttpContextAccessor sets the HttpContext to null when a new value is assigned. -> This PR will fix this -> This will fix this unusual behavior.

