### PR TITLE
Add ServerReady event to HostingEventSource

### DIFF
--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostedService.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostedService.cs
@@ -135,6 +135,7 @@ internal sealed partial class GenericWebHostService : IHostedService
         var httpApplication = new HostingApplication(application, Logger, DiagnosticListener, ActivitySource, Propagator, HttpContextFactory);
 
         await Server.StartAsync(httpApplication, cancellationToken);
+        HostingEventSource.Log.ServerReady();
 
         if (addresses != null)
         {

--- a/src/Hosting/Hosting/src/Internal/HostingEventSource.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingEventSource.cs
@@ -72,6 +72,12 @@ internal sealed class HostingEventSource : EventSource
         WriteEvent(5);
     }
 
+    [Event(6, Level = EventLevel.Informational)]
+    public void ServerReady()
+    {
+        WriteEvent(6);
+    }
+
     internal void RequestFailed()
     {
         Interlocked.Increment(ref _failedRequests);


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/40238

I didn't see existing tests for HostingEventSource events so I tested this locally with an event listener I added to Kestrel.SampleApp.