### PR TITLE
Fixed "unary operator expected" error in startvscode.sh

### DIFF
--- a/startvscode.sh
+++ b/startvscode.sh
@@ -20,7 +20,7 @@ if [ ! -f "$DOTNET_ROOT/dotnet" ]; then
     exit 1
 fi
 
-if [ $1 = "" ]; then
+if [[ $1 == "" ]]; then
   code .
 else
   code $1


### PR DESCRIPTION
# Fixed "unary operator expected" error in startvscode.sh

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Fixed the "unary operator expected" error which happens when we use the startvscode.sh without any extra arg.
