### PR TITLE
Support tabs in headers in Kestrel

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpCharacters.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpCharacters.cs
@@ -107,6 +107,9 @@ internal static class HttpCharacters
     {
         // field-value https://tools.ietf.org/html/rfc7230#section-3.2
         var fieldValue = new bool[_tableSize];
+
+        fieldValue[0x9] = true; // HTAB
+
         for (var c = 0x20; c <= 0x7e; c++) // VCHAR and SP
         {
             fieldValue[c] = true;

--- a/src/Servers/Kestrel/Core/test/HttpHeadersTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpHeadersTests.cs
@@ -289,28 +289,36 @@ public class HttpHeadersTests
     }
 
     [Theory]
-    [InlineData("foo", "bar", true)]
-    [InlineData("foo", "ba\tr", true)]
-    [InlineData("foo", "ba r", true)]
-    [InlineData("foo", "ba\rr", false)]
-    [InlineData("foo", "ba\r\nr", false)]
-    [InlineData("foo", "ba\nr", false)]
-    [InlineData("fo\to", "bar", false)]
-    public void TestParseCustomHeaderValues(string headerName, string headerValue, bool expectSuccess)
+    [InlineData("foo", true)]
+    [InlineData("fo\to", false)]
+    public void TestParseCustomHeaderNames(string headerName, bool expectSuccess)
     {
         if (expectSuccess)
         {
-            ValidateHeaderNameAndValue();
+            HttpHeaders.ValidateHeaderNameCharacters(headerName);
         }
         else
         {
-            Assert.Throws<InvalidOperationException>(() => ValidateHeaderNameAndValue());
+            Assert.Throws<InvalidOperationException>(() => HttpHeaders.ValidateHeaderNameCharacters(headerName));
         }
+    }
 
-        void ValidateHeaderNameAndValue()
+    [Theory]
+    [InlineData("bar", true)]
+    [InlineData("ba\tr", true)]
+    [InlineData("ba r", true)]
+    [InlineData("ba\rr", false)]
+    [InlineData("ba\r\nr", false)]
+    [InlineData("ba\nr", false)]
+    public void TestParseCustomHeaderValues(string headerValue, bool expectSuccess)
+    {
+        if (expectSuccess)
         {
-            HttpHeaders.ValidateHeaderNameCharacters(headerName);
             HttpHeaders.ValidateHeaderValueCharacters(headerValue, false);
+        }
+        else
+        {
+            Assert.Throws<InvalidOperationException>(() => HttpHeaders.ValidateHeaderValueCharacters(headerValue, false));
         }
     }
 }

--- a/src/Servers/Kestrel/Core/test/HttpHeadersTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpHeadersTests.cs
@@ -287,4 +287,30 @@ public class HttpHeadersTests
         Assert.Null(httpHeaders.ContentLength);
         Assert.False(httpHeaders.ContentLength.HasValue);
     }
+
+    [Theory]
+    [InlineData("foo", "bar", true)]
+    [InlineData("foo", "ba\tr", true)]
+    [InlineData("foo", "ba r", true)]
+    [InlineData("foo", "ba\rr", false)]
+    [InlineData("foo", "ba\r\nr", false)]
+    [InlineData("foo", "ba\nr", false)]
+    [InlineData("fo\to", "bar", false)]
+    public void TestParseCustomHeaderValues(string headerName, string headerValue, bool expectSuccess)
+    {
+        if (expectSuccess)
+        {
+            ValidateHeaderNameAndValue();
+        }
+        else
+        {
+            Assert.Throws<InvalidOperationException>(() => ValidateHeaderNameAndValue());
+        }
+
+        void ValidateHeaderNameAndValue()
+        {
+            HttpHeaders.ValidateHeaderNameCharacters(headerName);
+            HttpHeaders.ValidateHeaderValueCharacters(headerValue, false);
+        }
+    }
 }


### PR DESCRIPTION
This covers the Kestrel part of #40599. HTTP.sys will be addressed in a separate PR (so we can make the servicing decisions independently).