### PR TITLE
Unquarantine GET_GracefulServerShutdown_AbortRequestsAfterHostTimeout

### DIFF
--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -1471,7 +1471,6 @@ public class Http3RequestTests : LoggedTest
     [MsQuicSupported]
     [InlineData(HttpProtocols.Http3)]
     [InlineData(HttpProtocols.Http2)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/39985")]
     public async Task GET_GracefulServerShutdown_AbortRequestsAfterHostTimeout(HttpProtocols protocol)
     {
         // Arrange


### PR DESCRIPTION
This test now has a 100% 30 day pass rate:

<img width="1274" alt="image" src="https://user-images.githubusercontent.com/14852843/157378025-548c01b4-99cd-4a49-8852-d46129f5b9dc.png">

Fixes: https://github.com/dotnet/aspnetcore/issues/39985
