### PR TITLE
Fix arm64 exports

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/managedexports.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/managedexports.cpp
@@ -57,7 +57,7 @@ public:
 //
 // Initialization export
 //
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 register_callbacks(
     _In_ IN_PROCESS_APPLICATION* pInProcessApplication,
@@ -88,7 +88,7 @@ register_callbacks(
     return S_OK;
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HTTP_REQUEST*
 http_get_raw_request(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler
@@ -97,7 +97,7 @@ http_get_raw_request(
     return pInProcessHandler->QueryHttpContext()->GetRequest()->GetRawHttpRequest();
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HTTP_RESPONSE*
 http_get_raw_response(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler
@@ -106,7 +106,7 @@ http_get_raw_response(
     return pInProcessHandler->QueryHttpContext()->GetResponse()->GetRawHttpResponse();
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_get_server_variable(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -137,7 +137,7 @@ Finished:
     return hr;
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_set_server_variable(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -150,7 +150,7 @@ http_set_server_variable(
         ->SetServerVariable(pszVariableName, pszVariableValue);
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_set_response_status_code(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -162,7 +162,7 @@ http_set_response_status_code(
         true); // fTrySkipCustomErrors
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_post_completion(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -172,7 +172,7 @@ http_post_completion(
     return pInProcessHandler->QueryHttpContext()->PostCompletion(cbBytes);
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_set_completion_status(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -186,7 +186,7 @@ http_set_completion_status(
     return hr;
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_set_managed_context(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -200,7 +200,7 @@ http_set_managed_context(
     return hr;
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 VOID
 http_indicate_completion(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -210,7 +210,7 @@ http_indicate_completion(
     pInProcessHandler->QueryHttpContext()->IndicateCompletion(notificationStatus);
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 VOID
 http_get_completion_info(
     _In_ IHttpCompletionInfo2* info,
@@ -238,7 +238,7 @@ struct IISConfigurationData
     DWORD maxRequestBodySize;
 };
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_get_application_properties(
     _In_ IISConfigurationData* pIISConfigurationData
@@ -265,7 +265,7 @@ http_get_application_properties(
     return S_OK;
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_read_request_bytes(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -307,7 +307,7 @@ http_read_request_bytes(
     return hr;
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_write_response_bytes(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -332,7 +332,7 @@ http_write_response_bytes(
     return hr;
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_flush_response_bytes(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -353,7 +353,7 @@ http_flush_response_bytes(
     return hr;
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_websockets_read_bytes(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -381,7 +381,7 @@ http_websockets_read_bytes(
     return hr;
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_websockets_write_bytes(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -411,7 +411,7 @@ http_websockets_write_bytes(
     return hr;
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_websockets_flush_bytes(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -436,7 +436,7 @@ http_websockets_flush_bytes(
     return hr;
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_enable_websockets(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler
@@ -448,7 +448,7 @@ http_enable_websockets(
     return S_OK;
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_cancel_io(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler
@@ -457,7 +457,7 @@ http_cancel_io(
     return pInProcessHandler->QueryHttpContext()->CancelIo();
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_disable_buffering(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler
@@ -468,7 +468,7 @@ http_disable_buffering(
     return S_OK;
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_close_connection(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler
@@ -478,7 +478,7 @@ http_close_connection(
     return S_OK;
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_response_set_unknown_header(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -491,7 +491,7 @@ http_response_set_unknown_header(
     return pInProcessHandler->QueryHttpContext()->GetResponse()->SetHeader(pszHeaderName, pszHeaderValue, usHeaderValueLength, fReplace);
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_response_set_known_header(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -504,7 +504,7 @@ http_response_set_known_header(
     return pInProcessHandler->QueryHttpContext()->GetResponse()->SetHeader(dwHeaderId, pszHeaderValue, usHeaderValueLength, fReplace);
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_get_authentication_information(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -518,7 +518,7 @@ http_get_authentication_information(
     return S_OK;
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_stop_calls_into_managed(_In_ IN_PROCESS_APPLICATION* pInProcessApplication)
 {
@@ -531,7 +531,7 @@ http_stop_calls_into_managed(_In_ IN_PROCESS_APPLICATION* pInProcessApplication)
     return S_OK;
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_stop_incoming_requests(_In_ IN_PROCESS_APPLICATION* pInProcessApplication)
 {
@@ -544,7 +544,7 @@ http_stop_incoming_requests(_In_ IN_PROCESS_APPLICATION* pInProcessApplication)
     return S_OK;
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 VOID
 set_main_handler(_In_ hostfxr_main_fn main)
 {
@@ -553,7 +553,7 @@ set_main_handler(_In_ hostfxr_main_fn main)
     IN_PROCESS_APPLICATION::SetMainCallback(main);
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 VOID
 http_set_startup_error_page_content(_In_ byte* errorPageContent, int length)
 {
@@ -561,7 +561,7 @@ http_set_startup_error_page_content(_In_ byte* errorPageContent, int length)
     memcpy(&g_errorPageContent[0], errorPageContent, length);
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_has_response4(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -576,7 +576,7 @@ http_has_response4(
     return 0;
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_response_set_trailer(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -590,7 +590,7 @@ http_response_set_trailer(
     return pHttpResponse->SetTrailer(pszHeaderName, pszHeaderValue, usHeaderValueLength, fReplace);
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 VOID
 http_reset_stream(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler,
@@ -601,7 +601,7 @@ http_reset_stream(
     pHttpResponse->ResetStream(errorCode);
 }
 
-EXTERN_C __MIDL_DECLSPEC_DLLEXPORT
+EXTERN_C __declspec(dllexport)
 HRESULT
 http_response_set_need_goaway(
     _In_ IN_PROCESS_HANDLER* pInProcessHandler


### PR DESCRIPTION
Arm64 dlls were missing all the native exports due to some weird macro we were using that doesn't like ARM64

Before:

![image](https://user-images.githubusercontent.com/6537861/157532145-bdc4a118-28a1-43a3-8625-b2252626e745.png)

After:

![image](https://user-images.githubusercontent.com/6537861/157532219-3eb853ba-7cd4-4bf3-b49f-c13162955ec0.png)
