### PR TITLE
Support tab characters in headers and unify validation code between servers

### DIFF
--- a/src/Servers/HttpSys/src/Microsoft.AspNetCore.Server.HttpSys.csproj
+++ b/src/Servers/HttpSys/src/Microsoft.AspNetCore.Server.HttpSys.csproj
@@ -18,6 +18,7 @@
     <Compile Include="$(SharedSourceRoot)HttpSys\**\*.cs" />
     <Compile Include="$(SharedSourceRoot)Buffers.MemoryPool\*.cs" LinkBase="MemoryPool" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\StringUtilities.cs" LinkBase="ServerInfrastructure\StringUtilities.cs" />
+    <Compile Include="$(SharedSourceRoot)ServerInfrastructure\HttpCharacters.cs" LinkBase="ServerInfrastructure\HttpCharacters.cs" />
     <Compile Include="$(SharedSourceRoot)TaskToApm.cs" />
   </ItemGroup>
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.IO.Pipelines;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
@@ -8,7 +8,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -5,6 +5,7 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Primitives;
+using HttpCharacters = Microsoft.AspNetCore.Http.HttpCharacters;
 using HttpMethods = Microsoft.AspNetCore.Http.HttpMethods;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using HttpMethod = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod;
 using HttpMethods = Microsoft.AspNetCore.Http.HttpMethods;
+using HttpCharacters = Microsoft.AspNetCore.Http.HttpCharacters;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
 

--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;

--- a/src/Servers/Kestrel/Core/test/HttpResponseHeadersTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpResponseHeadersTests.cs
@@ -159,17 +159,16 @@ public class HttpResponseHeadersTests
         });
     }
 
-    [Theory]
-    [InlineData("Da\tta")]
-    public void AddingTabCharactersToHeaderPropertyWorks(string value)
+    [Fact]
+    public void AddingTabCharactersToHeaderPropertyWorks()
     {
         var responseHeaders = (IHeaderDictionary)new HttpResponseHeaders();
 
         // Known special header
-        responseHeaders.Allow = value;
+        responseHeaders.Allow = "Da\tta";
 
         // Unknown header fallback
-        responseHeaders.Accept = value;
+        responseHeaders.Accept = "Da\tta";
     }
 
     [Theory]

--- a/src/Servers/Kestrel/Core/test/HttpResponseHeadersTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpResponseHeadersTests.cs
@@ -160,6 +160,19 @@ public class HttpResponseHeadersTests
     }
 
     [Theory]
+    [InlineData("Da\tta")]
+    public void AddingTabCharactersToHeaderPropertyWorks(string value)
+    {
+        var responseHeaders = (IHeaderDictionary)new HttpResponseHeaders();
+
+        // Known special header
+        responseHeaders.Allow = value;
+
+        // Unknown header fallback
+        responseHeaders.Accept = value;
+    }
+
+    [Theory]
     [InlineData("\r\nData")]
     [InlineData("\0Data")]
     [InlineData("Data\r")]

--- a/src/Shared/HttpSys/RequestProcessing/HeaderCollection.cs
+++ b/src/Shared/HttpSys/RequestProcessing/HeaderCollection.cs
@@ -272,12 +272,10 @@ internal class HeaderCollection : IHeaderDictionary
     {
         if (headerCharacters != null)
         {
-            foreach (var ch in headerCharacters)
+            var invalid = HttpCharacters.IndexOfInvalidFieldValueChar(headerCharacters);
+            if (invalid >= 0)
             {
-                if (ch < 0x20)
-                {
-                    throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "Invalid control character in header: 0x{0:X2}", (byte)ch));
-                }
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "Invalid control character in header: 0x{0:X2}", headerCharacters[invalid]));
             }
         }
     }

--- a/src/Shared/ServerInfrastructure/HttpCharacters.cs
+++ b/src/Shared/ServerInfrastructure/HttpCharacters.cs
@@ -3,7 +3,7 @@
 
 using System.Runtime.CompilerServices;
 
-namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+namespace Microsoft.AspNetCore.Http;
 
 internal static class HttpCharacters
 {
@@ -107,6 +107,9 @@ internal static class HttpCharacters
     {
         // field-value https://tools.ietf.org/html/rfc7230#section-3.2
         var fieldValue = new bool[_tableSize];
+
+        fieldValue[0x9] = true; // HTAB
+
         for (var c = 0x20; c <= 0x7e; c++) // VCHAR and SP
         {
             fieldValue[c] = true;

--- a/src/Shared/ServerInfrastructure/HttpCharacters.cs
+++ b/src/Shared/ServerInfrastructure/HttpCharacters.cs
@@ -185,7 +185,8 @@ internal static class HttpCharacters
         return -1;
     }
 
-    // Disallows control characters and anything more than 0x7F
+    // Follows field-value rules in https://tools.ietf.org/html/rfc7230#section-3.2
+    // Disallows characters > 0x7E.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int IndexOfInvalidFieldValueChar(string s)
     {
@@ -203,7 +204,7 @@ internal static class HttpCharacters
         return -1;
     }
 
-    // Disallows control characters but allows extended characters > 0x7F
+    // Follows field-value rules for chars <= 0x7F. Allows extended characters > 0x7F.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int IndexOfInvalidFieldValueCharExtended(string s)
     {


### PR DESCRIPTION
While looking into IIS/Http.sys for #40599 I realized that we can share `HeaderCharacters` across the projects to reduce duplication of logic. Having header character validation be in two separate places caused divergence in the past (before this change, IIS/Http.sys weren't rejecting non-ASCII chars for instance, even though that change was made in Kestrel).

This PR fixes #40599 on all the servers and if we are happy with it, we can get rid of PR #40604 (marking that no-merge for now).