### PR TITLE
Fix race condition when caching for a type of QueryParameterValueSupplier

### DIFF
--- a/src/Components/Components/src/Routing/QueryParameterValueSupplier.cs
+++ b/src/Components/Components/src/Routing/QueryParameterValueSupplier.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.AspNetCore.Components.Reflection;
@@ -15,7 +16,7 @@ internal sealed class QueryParameterValueSupplier
 {
     public static void ClearCache() => _cacheByType.Clear();
 
-    private static readonly Dictionary<Type, QueryParameterValueSupplier?> _cacheByType = new();
+    private static readonly ConcurrentDictionary<Type, QueryParameterValueSupplier?> _cacheByType = new();
 
     // These two arrays contain the same number of entries, and their corresponding positions refer to each other.
     // Holding the info like this means we can use Array.BinarySearch with less custom implementation.
@@ -24,18 +25,13 @@ internal sealed class QueryParameterValueSupplier
 
     public static QueryParameterValueSupplier? ForType([DynamicallyAccessedMembers(Component)] Type componentType)
     {
-        lock (_cacheByType)
+        return _cacheByType.GetOrAdd(componentType, static (componentType) =>
         {
-            if (!_cacheByType.TryGetValue(componentType, out var instanceOrNull))
-            {
-                // If the component doesn't have any query parameters, store a null value for it
-                // so we know the upstream code can't try to render query parameter frames for it.
-                var sortedMappings = GetSortedMappings(componentType);
-                instanceOrNull = sortedMappings == null ? null : new QueryParameterValueSupplier(sortedMappings);
-                _cacheByType.TryAdd(componentType, instanceOrNull);
-            }
-            return instanceOrNull;
-        }
+            // If the component doesn't have any query parameters, store a null value for it
+            // so we know the upstream code can't try to render query parameter frames for it.
+            var sortedMappings = GetSortedMappings(componentType);
+            return sortedMappings == null ? null : new QueryParameterValueSupplier(sortedMappings);
+        });
     }
 
     private QueryParameterValueSupplier(QueryParameterMapping[] sortedMappings)

--- a/src/Components/Components/src/Routing/QueryParameterValueSupplier.cs
+++ b/src/Components/Components/src/Routing/QueryParameterValueSupplier.cs
@@ -25,13 +25,16 @@ internal sealed class QueryParameterValueSupplier
 
     public static QueryParameterValueSupplier? ForType([DynamicallyAccessedMembers(Component)] Type componentType)
     {
-        return _cacheByType.GetOrAdd(componentType, static (componentType) =>
+        if (!_cacheByType.TryGetValue(componentType, out var instanceOrNull))
         {
             // If the component doesn't have any query parameters, store a null value for it
             // so we know the upstream code can't try to render query parameter frames for it.
             var sortedMappings = GetSortedMappings(componentType);
-            return sortedMappings == null ? null : new QueryParameterValueSupplier(sortedMappings);
-        });
+            instanceOrNull = sortedMappings == null ? null : new QueryParameterValueSupplier(sortedMappings);
+            _cacheByType.TryAdd(componentType, instanceOrNull);
+        }
+
+        return instanceOrNull;
     }
 
     private QueryParameterValueSupplier(QueryParameterMapping[] sortedMappings)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

Fixes #40595

`QueryParameterValueSupplier.ForType` static method caches a `QueryParameterValueSupplier` in the Dictionary for each type.

The Dictionary for this cache is not locked and will be broken if multiple requests hit it on the first access.
This can also happen under heavy workloads or in cases such as health checks from load balancers at start-up.

It can be reproduced randomly by starting the Blazor Server with the following code running in a separate process.

```csharp
var httpClient = new HttpClient();
var tasks = Enumerable.Range(0, 10).Select(async x =>
{
    while (true)
    {
        try
        {
            await httpClient.GetStringAsync("http://localhost:5167/");
        }
        catch {}
    }
})
.ToArray();
await Task.WhenAll(tasks);
```

```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at Microsoft.AspNetCore.Components.Routing.QueryParameterValueSupplier.ForType(Type componentType) in C:\Users\UserName\source\repos\GitHub\mayuki-aspnetcore\src\Components\Components\src\Routing\QueryParameterValueSupplier.cs:line 35
   at Microsoft.AspNetCore.Components.RouteView.RenderPageWithParameters(RenderTreeBuilder builder) in C:\Users\UserName\source\repos\GitHub\mayuki-aspnetcore\src\Components\Components\src\RouteView.cs:line 95
   at Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddContent(Int32 sequence, RenderFragment fragment) in C:\Users\UserName\source\repos\GitHub\mayuki-aspnetcore\src\Components\Components\src\Rendering\RenderTreeBuilder.cs:line 113
   at BlazorApp4.Shared.MainLayout.BuildRenderTree(RenderTreeBuilder __builder) in C:\Users\UserName\source\repos\Sandbox\BlazorApp4\BlazorApp4\Shared\MainLayout.razor:line 16
   at Microsoft.AspNetCore.Components.ComponentBase.<.ctor>b__6_0(RenderTreeBuilder builder) in C:\Users\UserName\source\repos\GitHub\mayuki-aspnetcore\src\Components\Components\src\ComponentBase.cs:line 40
   at Microsoft.AspNetCore.Components.Rendering.ComponentState.RenderIntoBatch(RenderBatchBuilder batchBuilder, RenderFragment renderFragment, Exception& renderFragmentException) in C:\Users\UserName\source\repos\GitHub\mayuki-aspnetcore\src\Components\Components\src\Rendering\ComponentState.cs:line 69
```