### PR TITLE
Fix denial of service in ASP.NET Core via FormPipeReader

### DIFF
--- a/src/Http/WebUtilities/src/FormPipeReader.cs
+++ b/src/Http/WebUtilities/src/FormPipeReader.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO.Pipelines;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -249,8 +250,8 @@ public class FormPipeReader
             {
                 if (!isFinalBlock)
                 {
-                    // Don't buffer indefinitely
-                    if ((uint)(sequenceReader.Consumed - consumedBytes) > (uint)KeyLengthLimit + (uint)ValueLengthLimit)
+                    // +2 to account for '&' and '='
+                    if ((sequenceReader.Length - consumedBytes) > (long)KeyLengthLimit + (long)ValueLengthLimit + 2) 
                     {
                         ThrowKeyOrValueTooLargeException();
                     }
@@ -314,17 +315,30 @@ public class FormPipeReader
 
     private void ThrowKeyOrValueTooLargeException()
     {
-        throw new InvalidDataException($"Form key length limit {KeyLengthLimit} or value length limit {ValueLengthLimit} exceeded.");
+        throw new InvalidDataException(
+            string.Format(
+                CultureInfo.CurrentCulture,
+                Resources.FormPipeReader_KeyOrValueTooLarge,
+                KeyLengthLimit,
+                ValueLengthLimit));
     }
 
     private void ThrowKeyTooLargeException()
     {
-        throw new InvalidDataException($"Form key length limit {KeyLengthLimit} exceeded.");
+        throw new InvalidDataException(
+            string.Format(
+                CultureInfo.CurrentCulture,
+                Resources.FormPipeReader_KeyTooLarge,
+                KeyLengthLimit));
     }
 
     private void ThrowValueTooLargeException()
     {
-        throw new InvalidDataException($"Form value length limit {ValueLengthLimit} exceeded.");
+        throw new InvalidDataException(
+            string.Format(
+                CultureInfo.CurrentCulture,
+                Resources.FormPipeReader_ValueTooLarge,
+                ValueLengthLimit));
     }
 
     [SkipLocalsInit]

--- a/src/Http/WebUtilities/src/Resources.resx
+++ b/src/Http/WebUtilities/src/Resources.resx
@@ -117,6 +117,15 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="FormPipeReader_KeyOrValueTooLarge" xml:space="preserve">
+    <value>Form key length limit {0} or value length limit {1} exceeded.</value>
+  </data>
+  <data name="FormPipeReader_KeyTooLarge" xml:space="preserve">
+    <value>Form key length limit {0} exceeded.</value>
+  </data>
+  <data name="FormPipeReader_ValueTooLarge" xml:space="preserve">
+    <value>Form value length limit {0} exceeded.</value>
+  </data>
   <data name="HttpRequestStreamReader_StreamNotReadable" xml:space="preserve">
     <value>The stream must support reading.</value>
   </data>

--- a/src/Http/WebUtilities/test/FormPipeReaderTests.cs
+++ b/src/Http/WebUtilities/test/FormPipeReaderTests.cs
@@ -213,7 +213,7 @@ public class FormPipeReaderTests
     [Fact]
     public void ReadFormAsync_ChunkedDataNoDelimiter_ThrowsEarly()
     {
-        var bytes = CreateBytes_NoDelimiter((10 * 1024) + 2);
+        var bytes = CreateBytes_NoDelimiter(10 * 1024);
         var readOnlySequence = ReadOnlySequenceFactory.SegmentPerByteFactory.CreateWithContent(bytes);
         KeyValueAccumulator accumulator = default;
         var valueLengthLimit = 1024;

--- a/src/Http/WebUtilities/test/FormPipeReaderTests.cs
+++ b/src/Http/WebUtilities/test/FormPipeReaderTests.cs
@@ -213,7 +213,7 @@ public class FormPipeReaderTests
     [Fact]
     public void ReadFormAsync_ChunkedDataNoDelimiter_ThrowsEarly()
     {
-        byte[] bytes = CreateBytes_NoDelimiter((10 * 1024) + 2);
+        var bytes = CreateBytes_NoDelimiter((10 * 1024) + 2);
         var readOnlySequence = ReadOnlySequenceFactory.SegmentPerByteFactory.CreateWithContent(bytes);
         KeyValueAccumulator accumulator = default;
         var valueLengthLimit = 1024;

--- a/src/Http/WebUtilities/test/FormPipeReaderTests.cs
+++ b/src/Http/WebUtilities/test/FormPipeReaderTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Globalization;
 using System.IO.Pipelines;
 using System.Text;
 using Microsoft.Extensions.Primitives;
@@ -207,6 +208,30 @@ public class FormPipeReaderTests
         // The body pipe is still readable and has not advanced.
         var readResult = await bodyPipe.Reader.ReadAsync();
         Assert.Equal(Encoding.UTF8.GetBytes("baz=12345678901"), readResult.Buffer.ToArray());
+    }
+
+    [Fact]
+    public void ReadFormAsync_ChunkedDataNoDelimiter_ThrowsEarly()
+    {
+        byte[] bytes = CreateBytes_NoDelimiter((10 * 1024) + 2);
+        var readOnlySequence = ReadOnlySequenceFactory.SegmentPerByteFactory.CreateWithContent(bytes);
+        KeyValueAccumulator accumulator = default;
+        var valueLengthLimit = 1024;
+        var keyLengthLimit = 10;
+        var formReader = new FormPipeReader(null!)
+        {
+            ValueLengthLimit = valueLengthLimit,
+            KeyLengthLimit = keyLengthLimit
+        };
+        var exception = Assert.Throws<InvalidDataException>(
+            () => formReader.ParseFormValues(ref readOnlySequence, ref accumulator, isFinalBlock: false));
+        // Make sure that FormPipeReader throws an exception after hitting KeyLengthLimit + ValueLengthLimit,
+        // Rather than after reading the entire request.
+        Assert.Equal(string.Format(
+            CultureInfo.CurrentCulture,
+            Resources.FormPipeReader_KeyOrValueTooLarge,
+            keyLengthLimit,
+            valueLengthLimit), exception.Message);
     }
 
     // https://en.wikipedia.org/wiki/Percent-encoding
@@ -609,5 +634,17 @@ public class FormPipeReaderTests
         // Complete the writer so the reader will complete after processing all data.
         bodyPipe.Writer.Complete();
         return bodyPipe.Reader;
+    }
+
+    private static byte[] CreateBytes_NoDelimiter(int n)
+    {
+        //Create the bytes of "key=vvvvvvvv....", of length n
+        var keyValue = new char[n];
+        Array.Fill(keyValue, 'v');
+        keyValue[0] = 'k';
+        keyValue[1] = 'e';
+        keyValue[2] = 'y';
+        keyValue[3] = '=';
+        return Encoding.UTF8.GetBytes(keyValue);
     }
 }


### PR DESCRIPTION
When chunked data without a delimiter is sent to FormPipeReader, FormPipeReader will read the entire stream of data, starting from the beginning each time, without honoring configured length limits. This is because, after each read, it checks if SequenceReader.Consumed is greater than the configured limit, but SequenceReader.Consumed is 0 when no delimiter was found. Therefore the check against the length limit is never honored, and we continue to read data indefinitely, starting from the beginning of the stream each time. Fix is to use `sequenceReader.Length` instead of `sequenceReader.Consumed`.