### PR TITLE
Fix installer build

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -60,11 +60,11 @@
       </ItemGroup>
     </When>
     <Otherwise>
-      <ItemGroup Condition=" '$(BuildInstallers)' == 'true' AND '$(TargetOsName)' == 'win' AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64') OR '$(TargetArchitecture)' == 'arm64') ">
+      <ItemGroup Condition=" '$(BuildInstallers)' == 'true' AND '$(TargetOsName)' == 'win' AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64' OR '$(TargetArchitecture)' == 'arm64') ">
         <!-- Build the ANCM custom action -->
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=x64" />
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=Win32" />
-        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=arm64" />
+        <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=ARM64" />
 
         <!-- Build the ANCM msis -->
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\ANCMIISExpressV2\AncmIISExpressV2.wixproj" AdditionalProperties="Platform=x64" />

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -60,7 +60,7 @@
       </ItemGroup>
     </When>
     <Otherwise>
-      <ItemGroup Condition=" '$(BuildInstallers)' == 'true' AND '$(TargetOsName)' == 'win' AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64') ">
+      <ItemGroup Condition=" '$(BuildInstallers)' == 'true' AND '$(TargetOsName)' == 'win' AND ('$(TargetArchitecture)' == 'x86' OR '$(TargetArchitecture)' == 'x64') OR '$(TargetArchitecture)' == 'arm64') ">
         <!-- Build the ANCM custom action -->
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=x64" />
         <ProjectToBuild Include="$(RepoRoot)src\Installers\Windows\AspNetCoreModule-Setup\CustomAction\aspnetcoreCA.vcxproj" AdditionalProperties="Platform=Win32" />


### PR DESCRIPTION
Platform seems to be case sensitive, ARM64 and arm64 were being built which might be what was causing the race conditions, see https://dev.azure.com/dnceng/public/_build/results?buildId=1658219&view=logs&j=1b89928a-2219-5ef9-602f-f95beb3da4dc&t=1c817b4a-09bb-50b1-4e28-0ca26186c59a

bad example previously which was building 4x:
```
  aspnetcoreCA.vcxproj -> D:\a\_work\1\s\artifacts\bin\aspnetcoreCA\Win32\Release\aspnetcoreCA.dll
 aspnetcoreCA.vcxproj -> D:\a\_work\1\s\artifacts\bin\aspnetcoreCA\x64\Release\aspnetcoreCA.dll
 aspnetcoreCA.vcxproj -> D:\a\_work\1\s\artifacts\bin\aspnetcoreCA\arm64\Release\aspnetcoreCA.dll
aspnetcoreCA.vcxproj -> D:\a\_work\1\s\artifacts\bin\aspnetcoreCA\ARM64\Release\aspnetcoreCA.dll
```

The fact that we use ARM64(vcxproj) and arm64 (wixproj) and it matters sometimes is concerning