### PR TITLE
[Blazor] Fix race condition when caching for a type of QueryParameterValueSupplier (#40636)

### DIFF
--- a/src/Components/Components/src/Routing/QueryParameterValueSupplier.cs
+++ b/src/Components/Components/src/Routing/QueryParameterValueSupplier.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Buffers;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.AspNetCore.Components.Reflection;
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Components.Routing
     {
         public static void ClearCache() => _cacheByType.Clear();
 
-        private static readonly Dictionary<Type, QueryParameterValueSupplier?> _cacheByType = new();
+        private static readonly ConcurrentDictionary<Type, QueryParameterValueSupplier?> _cacheByType = new();
 
         // These two arrays contain the same number of entries, and their corresponding positions refer to each other.
         // Holding the info like this means we can use Array.BinarySearch with less custom implementation.


### PR DESCRIPTION
## Description

We were using a regular dictionary on an internal cache that can be accessed concurrently.

#40595

## Customer Impact

If two or more threads try to populate the cache concurrently, it can cause the app to fail.

## Regression?

- [ ] Yes
- [X] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [X] Low

It's switching the underlying dictionary type used.

## Verification

- [ ] Manual (required)
- [X] Automated

We have extensive E2E and unit tests for this behavior.

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A