### PR TITLE
Add architecture to targeting pack archives

### DIFF
--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -92,8 +92,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <LocalInstallationOutputPath>$(LocalDotNetRoot)$(TargetingPackSubPath)</LocalInstallationOutputPath>
 
     <ArchiveOutputFileName>aspnetcore-targeting-pack-$(PackageVersion)-$(TargetRuntimeIdentifier)</ArchiveOutputFileName>
-    <ZipArchiveOutputPath>$(InstallersOutputPath)$(ArchiveOutputFileName).zip</ZipArchiveOutputPath>
-    <TarArchiveOutputPath>$(InstallersOutputPath)$(ArchiveOutputFileName).tar.gz</TarArchiveOutputPath>
+    <ArchiveOutputPath>$(InstallersOutputPath)$(ArchiveOutputFileName)$(ArchiveExtension)</ArchiveOutputPath>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -259,30 +258,18 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   </Target>
 
   <Target Name="_CreateTargetingPackArchive"
-          Condition=" '$(IsPackable)' == 'true' "
           Inputs="@(RefPackContent)"
-          Outputs="$(ZipArchiveOutputPath);$(TarArchiveOutputPath)">
-    <PropertyGroup>
-      <_TarCommand>tar</_TarCommand>
-      <_TarCommand Condition="Exists('$(RepoRoot).tools\tar.exe')">"$(RepoRoot).tools\tar.exe"</_TarCommand>
-
-      <!-- For the tar packed with git, transform e.g. "C:\root\AspNetCore\File.tar.gz" to "/C/root/AspNetCore/File.tar.gz". -->
-      <_TarArchiveOutputPath>$(TarArchiveOutputPath)</_TarArchiveOutputPath>
-      <_TarArchiveOutputPath
-          Condition="Exists('$(repoRoot)\.tools\tar.fromGit')">/$(TarArchiveOutputPath.Replace('\','/').Replace(':',''))</_TarArchiveOutputPath>
-    </PropertyGroup>
-
+          Outputs="$(ArchiveOutputPath)">
     <ZipDirectory
       SourceDirectory="$(TargetingPackLayoutRoot)"
-      DestinationFile="$(ZipArchiveOutputPath)"
-      Overwrite="true" />
-
-    <!-- Requires Windows 10 version 1803 or newer -->
-    <Message Importance="High" Text="Executing: $(_TarCommand) -czf &quot;$(_TarArchiveOutputPath)&quot; ." />
-    <Exec Command="$(_TarCommand) -czf &quot;$(_TarArchiveOutputPath)&quot; ."
-        WorkingDirectory="$(TargetingPackLayoutRoot)" />
-
-    <Message Importance="High" Text="$(MSBuildProjectName) -> $(TarArchiveOutputPath)" />
+      DestinationFile="$(ArchiveOutputPath)"
+      Overwrite="true"
+      Condition="'$(ArchiveExtension)' == '.zip'" />
+    <Exec
+      Command="tar -czf $(ArchiveOutputPath) ."
+      WorkingDirectory="$(TargetingPackLayoutRoot)"
+      Condition="'$(ArchiveExtension)' == '.tar.gz'" />
+    <Message Importance="High" Text="$(MSBuildProjectName) -> $(ArchiveOutputPath)" />
   </Target>
 
   <Target Name="GenerateFrameworkListFile">

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -91,7 +91,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <LayoutTargetDir>$(TargetingPackLayoutRoot)$(TargetingPackSubPath)</LayoutTargetDir>
     <LocalInstallationOutputPath>$(LocalDotNetRoot)$(TargetingPackSubPath)</LocalInstallationOutputPath>
 
-    <ArchiveOutputFileName>aspnetcore-targeting-pack-$(PackageVersion)</ArchiveOutputFileName>
+    <ArchiveOutputFileName>aspnetcore-targeting-pack-$(PackageVersion)-$(TargetRuntimeIdentifier)</ArchiveOutputFileName>
     <ZipArchiveOutputPath>$(InstallersOutputPath)$(ArchiveOutputFileName).zip</ZipArchiveOutputPath>
     <TarArchiveOutputPath>$(InstallersOutputPath)$(ArchiveOutputFileName).tar.gz</TarArchiveOutputPath>
   </PropertyGroup>

--- a/src/Installers/Debian/TargetingPack/Debian.TargetingPack.debproj
+++ b/src/Installers/Debian/TargetingPack/Debian.TargetingPack.debproj
@@ -37,7 +37,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 
   <PropertyGroup>
-    <TargetFileName>$(TargetingPackInstallerBaseName)-$(TargetingPackVersion).deb</TargetFileName>
+    <TargetFileName>$(TargetingPackInstallerBaseName)-$(TargetingPackVersion)-$(TargetArchitecture).deb</TargetFileName>
     <TargetPath>$(TargetDir)$(TargetFileName)</TargetPath>
 
     <DebPackageVersion>$(TargetingPackVersionPrefix)</DebPackageVersion>

--- a/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
+++ b/src/Installers/Windows/TargetingPack/TargetingPack.wixproj
@@ -66,7 +66,7 @@
       <TargetingPackHarvestRoot Condition="'$(TargetingPackHarvestRoot)' == ''">$(InstallersOutputPath)</TargetingPackHarvestRoot>
       <TargetingPackZipVersion>$(TargetingPackVersionPrefix)</TargetingPackZipVersion>
       <TargetingPackZipVersion Condition="'$(VersionSuffix)' != ''">$(TargetingPackZipVersion)-$(VersionSuffix)</TargetingPackZipVersion>
-      <IntermediateTargetingPackZip>$(TargetingPackHarvestRoot)aspnetcore-targeting-pack-$(TargetingPackZipVersion).zip</IntermediateTargetingPackZip>
+      <IntermediateTargetingPackZip>$(TargetingPackHarvestRoot)aspnetcore-targeting-pack-$(TargetingPackZipVersion)-$(TargetRuntimeIdentifier).zip</IntermediateTargetingPackZip>
     </PropertyGroup>
 
     <Unzip SourceFiles="$(IntermediateTargetingPackZip)" DestinationFolder="$(HarvestSource)" />


### PR DESCRIPTION
Add `os-arch` to targeting pack .zip/.tar.gz's and `arch` to .deb's

test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1659229&view=results