### PR TITLE
Add the PublishArgs back

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -244,6 +244,7 @@ stages:
                 -noBuildNative
                 /p:DotNetSignType=$(_SignType)
                 $(_BuildArgs)
+                $(_PublishArgs)
                 $(_InternalRuntimeDownloadArgs)
                 $(WindowsInstallersLogArgs)
         displayName: Build Installers


### PR DESCRIPTION
Was removed accidentally when we got rid of the arm64 installers build