### PR TITLE
Support tab characters in headers and unify validation code between servers.

### DIFF
--- a/src/Servers/HttpSys/src/Microsoft.AspNetCore.Server.HttpSys.csproj
+++ b/src/Servers/HttpSys/src/Microsoft.AspNetCore.Server.HttpSys.csproj
@@ -18,6 +18,7 @@
     <Compile Include="$(SharedSourceRoot)HttpSys\**\*.cs" />
     <Compile Include="$(SharedSourceRoot)Buffers.MemoryPool\*.cs" LinkBase="MemoryPool" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\StringUtilities.cs" LinkBase="ServerInfrastructure\StringUtilities.cs" />
+    <Compile Include="$(SharedSourceRoot)ServerInfrastructure\HttpCharacters.cs" LinkBase="ServerInfrastructure\HttpCharacters.cs" />
     <Compile Include="$(SharedSourceRoot)TaskToApm.cs" />
   </ItemGroup>
 

--- a/src/Servers/HttpSys/test/FunctionalTests/ResponseHeaderTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ResponseHeaderTests.cs
@@ -114,6 +114,27 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         }
 
         [ConditionalFact]
+        public async Task ResponseHeaders_ServerSendsNonAsciiHeaders_Success()
+        {
+            string address;
+            using (Utilities.CreateHttpServer(out address, httpContext =>
+            {
+                var responseInfo = httpContext.Features.Get<IHttpResponseFeature>();
+                var responseHeaders = responseInfo.Headers;
+                responseHeaders["Custom-Header1"] = new string[] { "Dašta" };
+                return Task.FromResult(0);
+            }))
+            {
+                var socketsHttpHandler = new SocketsHttpHandler() { ResponseHeaderEncodingSelector = (_, _) => Encoding.UTF8 };
+                var httpClient = new HttpClient(socketsHttpHandler);
+                var response = await httpClient.GetAsync(address);
+                response.EnsureSuccessStatusCode();
+                Assert.True(response.Headers.TryGetValues("Custom-Header1", out var header));
+                Assert.Equal("Dašta", header.Single());
+            }
+        }
+
+        [ConditionalFact]
         public async Task ResponseHeaders_ServerSendsConnectionClose_Closed()
         {
             string address;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.IO.Pipelines;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
@@ -10,7 +10,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -6,6 +6,7 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
+using HttpCharacters = Microsoft.AspNetCore.Http.HttpCharacters;
 using HttpMethods = Microsoft.AspNetCore.Http.HttpMethods;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
+using HttpCharacters = Microsoft.AspNetCore.Http.HttpCharacters;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 {

--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;

--- a/src/Servers/Kestrel/Core/test/HttpResponseHeadersTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpResponseHeadersTests.cs
@@ -242,6 +242,18 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         }
 
         [Fact]
+        public void AddingTabCharactersToHeaderPropertyWorks()
+        {
+            var responseHeaders = (IHeaderDictionary)new HttpResponseHeaders();
+
+            // Known special header
+            responseHeaders.Allow = "Da\tta";
+
+            // Unknown header fallback
+            responseHeaders.Accept = "Da\tta";
+        }
+
+        [Fact]
         public void ThrowsWhenAddingHeaderAfterReadOnlyIsSet()
         {
             var headers = new HttpResponseHeaders();

--- a/src/Shared/HttpSys/RequestProcessing/HeaderCollection.cs
+++ b/src/Shared/HttpSys/RequestProcessing/HeaderCollection.cs
@@ -272,7 +272,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             if (headerCharacters != null)
             {
-                var invalid = HttpCharacters.IndexOfInvalidFieldValueChar(headerCharacters);
+                var invalid = HttpCharacters.IndexOfInvalidFieldValueCharExtended(headerCharacters);
                 if (invalid >= 0)
                 {
                     throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "Invalid control character in header: 0x{0:X2}", headerCharacters[invalid]));

--- a/src/Shared/HttpSys/RequestProcessing/HeaderCollection.cs
+++ b/src/Shared/HttpSys/RequestProcessing/HeaderCollection.cs
@@ -272,12 +272,10 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             if (headerCharacters != null)
             {
-                foreach (var ch in headerCharacters)
+                var invalid = HttpCharacters.IndexOfInvalidFieldValueChar(headerCharacters);
+                if (invalid >= 0)
                 {
-                    if (ch < 0x20)
-                    {
-                        throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "Invalid control character in header: 0x{0:X2}", (byte)ch));
-                    }
+                    throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "Invalid control character in header: 0x{0:X2}", headerCharacters[invalid]));
                 }
             }
         }

--- a/src/Shared/ServerInfrastructure/HttpCharacters.cs
+++ b/src/Shared/ServerInfrastructure/HttpCharacters.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Runtime.CompilerServices;
 
-namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
+namespace Microsoft.AspNetCore.Http
 {
     internal static class HttpCharacters
     {
@@ -107,6 +107,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         {
             // field-value https://tools.ietf.org/html/rfc7230#section-3.2
             var fieldValue = new bool[_tableSize];
+
+            fieldValue[0x9] = true; // HTAB
+
             for (var c = 0x20; c <= 0x7e; c++) // VCHAR and SP
             {
                 fieldValue[c] = true;
@@ -182,7 +185,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             return -1;
         }
 
-        // Disallows control characters and anything more than 0x7F
+        // Follows field-value rules in https://tools.ietf.org/html/rfc7230#section-3.2
+        // Disallows characters > 0x7E.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOfInvalidFieldValueChar(string s)
         {
@@ -200,7 +204,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
             return -1;
         }
 
-        // Disallows control characters but allows extended characters > 0x7F
+        // Follows field-value rules for chars <= 0x7F. Allows extended characters > 0x7F.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOfInvalidFieldValueCharExtended(string s)
         {


### PR DESCRIPTION
Port of #40633 to release/6.0.

Fixes #40599

## Customer Impact

Tabs are valid in headers (https://tools.ietf.org/html/rfc7230#section-3.2). Without this change, customers get an InvalidOperationException ("Invalid non-ASCII or control character in header: 0x0009") when a header is added that contains a tab character.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The change is small and targeted at fixing this one correctness issue.

## Verification

- [x] Manual
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
























