### PR TITLE
Publish version files again

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -246,6 +246,7 @@ stages:
                 $(_BuildArgs)
                 $(_PublishArgs)
                 $(_InternalRuntimeDownloadArgs)
+                /p:PublishInstallerBaseVersion=true
                 $(WindowsInstallersLogArgs)
         displayName: Build Installers
 


### PR DESCRIPTION
Should unblock https://github.com/dotnet/installer/pull/13376. We're not publishing our version marker files currently.