### PR TITLE
Revert "Remove downlevel runtimes from global.json"

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,11 +5,15 @@
   "tools": {
     "dotnet": "7.0.100-preview.3.22163.1",
     "runtimes": {
+      "dotnet": [
+        "2.1.30",
+        "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"
+      ],
       "dotnet/x86": [
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"
       ],
-      "dotnet": [
-        "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"
+      "aspnetcore": [
+        "3.1.21"
       ]
     },
     "Git": "2.22.0",


### PR DESCRIPTION
Broke internal builds because `BinLogToSln` requires 3.1, which we're not restoring now - we just try to run that thing with our local `.dotnet` folder, which doesn't have the 3.1 runtime

https://github.com/dotnet/aspnetcore/blob/371c81a6945aa71fd7a73f1842c24d2aa26672e6/.azure/pipelines/ci.yml#L291-L303

> Tool 'binlogtosln' (version '1.0.1-20210614.1') was successfully installed.
It was not possible to find any compatible framework version
The framework 'Microsoft.NETCore.App', version '3.1.0' (x64) was not found.
  - The following frameworks were found:
      7.0.0-preview.3.22151.6 at [D:\a\_work\1\s\.dotnet\shared\Microsoft.NETCore.App]
      7.0.0-preview.3.22163.2 at [D:\a\_work\1\s\.dotnet\shared\Microsoft.NETCore.App]

CC @dotnet/dnceng 