### PR TITLE
Disable SBOMs for linux musl for now

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -515,6 +515,7 @@ stages:
       installNodeJs: false
       disableComponentGovernance: true
       skipComponentGovernanceDetection: true
+      enableSbom: false
       artifacts:
       - name: Linux_musl_x64_Logs
         path: artifacts/log/

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -69,6 +69,7 @@ parameters:
   timeoutInMinutes: 180
   testRunTitle: $(AgentOsName)-$(BuildConfiguration)
   useHostedUbuntu: true
+  enableSbom: true
 
   # We need longer than the default amount of 5 minutes to upload our logs/artifacts. (We currently take around 5 mins in the best case).
   # This makes sure we have time to upload everything in the case of a build timeout - really important for investigating a build
@@ -98,6 +99,7 @@ jobs:
     mergeTestResults: true
     testRunTitle: ${{ parameters.testRunTitle }}
     enableTelemetry: true
+    enableSbom: ${{ parameters.enableSbom }}
     helixRepo: dotnet/aspnetcore
     helixType: build.product/
     workspace:


### PR DESCRIPTION
Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1662807&view=results

Will re-enable once https://github.com/microsoft/dropvalidator/issues/397 is fixed. Will open an issue against myself if this is approved.