### PR TITLE
Revert "Revert "Remove downlevel runtimes from global.json""

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -290,6 +290,13 @@ stages:
         $(_InternalRuntimeDownloadArgs)
       ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(parameters.testSourceIndexing, 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
         afterBuild:
+        - task: UseDotNet@2
+          displayName: Use .NET Core sdk 3.1
+          inputs:
+            packageType: sdk
+            version: 3.1.x
+            installationPath: $(Build.SourcesDirectory)/dotnet
+            workingDirectory: $(Build.SourcesDirectory)
         - powershell: . $(Build.SourcesDirectory)/activate.ps1;
             dotnet tool install BinLogToSln
             --version $(SourceIndexPackageVersion)

--- a/global.json
+++ b/global.json
@@ -5,15 +5,11 @@
   "tools": {
     "dotnet": "7.0.100-preview.3.22163.1",
     "runtimes": {
-      "dotnet": [
-        "2.1.30",
-        "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"
-      ],
       "dotnet/x86": [
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"
       ],
-      "aspnetcore": [
-        "3.1.21"
+      "dotnet": [
+        "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"
       ]
     },
     "Git": "2.22.0",


### PR DESCRIPTION
Reverts dotnet/aspnetcore#40699 & adds an explicit 3.1 restore before trying to use `BinlogToSln`