### PR TITLE
Preserve non-ASCII header value char treatment in HTTP.sys.

### DIFF
--- a/src/Shared/HttpSys/RequestProcessing/HeaderCollection.cs
+++ b/src/Shared/HttpSys/RequestProcessing/HeaderCollection.cs
@@ -272,7 +272,7 @@ internal class HeaderCollection : IHeaderDictionary
     {
         if (headerCharacters != null)
         {
-            var invalid = HttpCharacters.IndexOfInvalidFieldValueChar(headerCharacters);
+            var invalid = HttpCharacters.IndexOfInvalidFieldValueCharExtended(headerCharacters);
             if (invalid >= 0)
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "Invalid control character in header: 0x{0:X2}", headerCharacters[invalid]));


### PR DESCRIPTION
#40633 made HTTP.sys/IIS match Kestrel's default behavior of rejecting chars > 0x7E, but allowing them was actually intentional since the default encoding for HTTP.sys uses UTF-8 without a BOM.

This fix re-enables the non-ASCII chars and adds a test for this scenario. This change already went into 6.0 during the backport process and I'm now doing it in main.

@Tratcher 