### PR TITLE
Fix typo

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -295,7 +295,7 @@ stages:
           inputs:
             packageType: sdk
             version: 3.1.x
-            installationPath: $(Build.SourcesDirectory)/dotnet
+            installationPath: $(Build.SourcesDirectory)./dotnet
             workingDirectory: $(Build.SourcesDirectory)
         - powershell: . $(Build.SourcesDirectory)/activate.ps1;
             dotnet tool install BinLogToSln


### PR DESCRIPTION
Path for dotnet install should be `.dotnet` instead of `dotnet` relative to the repo dir