### PR TITLE
Get richnav.yml building again

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -175,7 +175,7 @@ stages:
                 $(_BuildArgs)
                 $(_InternalRuntimeDownloadArgs)
                 $(Windows64LogArgs)
-        displayName: Build x64/arm64
+        displayName: Build x64
 
       # Build the x86 shared framework
       # This is going to actually build x86 native assets.

--- a/.azure/pipelines/richnav.yml
+++ b/.azure/pipelines/richnav.yml
@@ -6,10 +6,11 @@
 trigger:
   branches:
     include:
-    - blazor-wasm
     - main
     - release/*
-    - internal/release/*
+
+# Do not run this pipeline for PR validation.
+pr: none
 
 variables:
 - name: _BuildArgs

--- a/.azure/pipelines/richnav.yml
+++ b/.azure/pipelines/richnav.yml
@@ -14,32 +14,32 @@ trigger:
 variables:
 - name: _BuildArgs
   value: '/p:SkipTestBuild=true'
-- name: Windows86LogArgs
+- name: WindowsNonX64LogArgs
   value: -ExcludeCIBinaryLog
 
 stages:
 - stage: build
   displayName: Build
   jobs:
-  # Build Windows (x64/x86)
+  # Build Windows (x64/x86/arm64)
   - template: jobs/default-build.yml
     parameters:
       jobName: Windows_build
-      jobDisplayName: "Build: Windows x64/x86"
+      jobDisplayName: "Build: Windows x64/x86/arm64"
       enableRichCodeNavigation: true
       agentOs: Windows
       steps:
-      - script: ./build.cmd
+      - script: ./eng/build.cmd
                 -ci
-                -all
                 -arch x64
+                -all
                 /p:EnableRichCodeNavigation=true
                 $(_BuildArgs)
         displayName: Build x64
 
       # Build the x86 shared framework
       # This is going to actually build x86 native assets.
-      - script: ./build.cmd
+      - script: ./eng/build.cmd
                 -ci
                 -noBuildRepoTasks
                 -arch x86
@@ -47,17 +47,31 @@ stages:
                 -noBuildJava
                 -noBuildNative
                 /p:EnableRichCodeNavigation=true
+                /p:OnlyPackPlatformSpecificPackages=true
                 $(_BuildArgs)
-                $(Windows86LogArgs)
+                $(WindowsNonX64LogArgs)
         displayName: Build x86
 
-      # Windows installers bundle both x86 and x64 assets
-      - script: ./build.cmd
+      # Build the arm64 shared framework
+      - script: ./eng/build.cmd
+                -ci
+                -noBuildRepoTasks
+                -arch arm64
+                -noBuildJava
+                -noBuildNative
+                /p:EnableRichCodeNavigation=true
+                /p:OnlyPackPlatformSpecificPackages=true
+                $(_BuildArgs)
+                $(WindowsNonX64LogArgs)
+        displayName: Build ARM64
+
+      # Windows installers bundle x86/x64/arm64 assets
+      - script: ./eng/build.cmd
                 -ci
                 -noBuildRepoTasks
                 -buildInstallers
                 -noBuildNative
-                /p:AssetManifestFileName=aspnetcore-win-x64-x86.xml
                 /p:EnableRichCodeNavigation=true
                 $(_BuildArgs)
+                $(WindowsNonX64LogArgs)
         displayName: Build Installers

--- a/.azure/pipelines/richnav.yml
+++ b/.azure/pipelines/richnav.yml
@@ -34,15 +34,16 @@ stages:
                 -ci
                 -arch x64
                 -buildNative
+                /p:EnableRichCodeNavigation=false
                 $(_BuildArgs)
         displayName: Build x64 native assets
+
       - script: ./eng/build.cmd
                 -ci
                 -arch x64
                 -all
                 -noBuildNative
                 -noBuildRepoTasks
-                /p:EnableRichCodeNavigation=true
                 $(_BuildArgs)
         displayName: Build x64
 
@@ -55,8 +56,6 @@ stages:
                 -noBuildJava
                 -noBuildNative
                 -noBuildRepoTasks
-                /p:EnableRichCodeNavigation=true
-                /p:OnlyPackPlatformSpecificPackages=true
                 $(_BuildArgs)
                 $(WindowsNonX64LogArgs)
         displayName: Build x86
@@ -68,20 +67,7 @@ stages:
                 -noBuildJava
                 -noBuildNative
                 -noBuildRepoTasks
-                /p:EnableRichCodeNavigation=true
-                /p:OnlyPackPlatformSpecificPackages=true
                 $(_BuildArgs)
                 $(WindowsNonX64LogArgs)
         displayName: Build ARM64
 
-      # Windows installers bundle x86/x64/arm64 assets
-      - script: ./eng/build.cmd
-                -ci
-                -buildInstallers
-                -noBuildJava
-                -noBuildNative
-                -noBuildRepoTasks
-                /p:EnableRichCodeNavigation=true
-                $(_BuildArgs)
-                $(WindowsNonX64LogArgs)
-        displayName: Build Installers

--- a/.azure/pipelines/richnav.yml
+++ b/.azure/pipelines/richnav.yml
@@ -33,7 +33,15 @@ stages:
       - script: ./eng/build.cmd
                 -ci
                 -arch x64
+                -buildNative
+                $(_BuildArgs)
+        displayName: Build x64 native assets
+      - script: ./eng/build.cmd
+                -ci
+                -arch x64
                 -all
+                -noBuildNative
+                -noBuildRepoTasks
                 /p:EnableRichCodeNavigation=true
                 $(_BuildArgs)
         displayName: Build x64
@@ -42,11 +50,11 @@ stages:
       # This is going to actually build x86 native assets.
       - script: ./eng/build.cmd
                 -ci
-                -noBuildRepoTasks
                 -arch x86
                 -all
                 -noBuildJava
                 -noBuildNative
+                -noBuildRepoTasks
                 /p:EnableRichCodeNavigation=true
                 /p:OnlyPackPlatformSpecificPackages=true
                 $(_BuildArgs)
@@ -56,10 +64,10 @@ stages:
       # Build the arm64 shared framework
       - script: ./eng/build.cmd
                 -ci
-                -noBuildRepoTasks
                 -arch arm64
                 -noBuildJava
                 -noBuildNative
+                -noBuildRepoTasks
                 /p:EnableRichCodeNavigation=true
                 /p:OnlyPackPlatformSpecificPackages=true
                 $(_BuildArgs)
@@ -69,9 +77,10 @@ stages:
       # Windows installers bundle x86/x64/arm64 assets
       - script: ./eng/build.cmd
                 -ci
-                -noBuildRepoTasks
                 -buildInstallers
+                -noBuildJava
                 -noBuildNative
+                -noBuildRepoTasks
                 /p:EnableRichCodeNavigation=true
                 $(_BuildArgs)
                 $(WindowsNonX64LogArgs)


### PR DESCRIPTION
- correct build.cmd location
- generally align richnav.yml with ci.yml
  - ignore signing, internal download args, and publish args

nit: correct name of one build step in ci.yml