### PR TITLE
Support falling back to ConnectionId when RawConnectionId is 0 on HTTP.sys

### DIFF
--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -115,8 +115,8 @@ internal sealed partial class Request
     internal ulong RawConnectionId { get; }
 
     // No ulongs in public APIs...
-    public long ConnectionId => (long)RawConnectionId;
-
+    public long ConnectionId => RawConnectionId != 0 ? (long)RawConnectionId : (long)ConnectionId;
+    
     internal ulong RequestId { get; }
 
     private SslStatus SslStatus { get; }

--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -115,7 +115,7 @@ internal sealed partial class Request
     internal ulong RawConnectionId { get; }
 
     // No ulongs in public APIs...
-    public long ConnectionId => RawConnectionId != 0 ? (long)RawConnectionId : (long)ConnectionId;
+    public long ConnectionId => RawConnectionId != 0 ? (long)RawConnectionId : (long)UConnectionId;
     
     internal ulong RequestId { get; }
 


### PR DESCRIPTION
# Support falling back to ConnectionId when RawConnectionId is 0 on HTTP.sys

## Description

Currently, on HTTP.sys, HttpContext.Connection.Id always returns a value of 0 on Windows Server 2019 and below. It is populated on Server 2022.

HttpContext.Connection.Id returns RawConnectionId

https://github.com/dotnet/aspnetcore/blob/371c81a6945aa71fd7a73f1842c24d2aa26672e6/src/Shared/HttpSys/NativeInterop/HttpApiTypes.cs#L533

If RawConnectionId is 0, this change ensures that HttpContext.Connection.Id falls back to ConnectionId

https://github.com/dotnet/aspnetcore/blob/371c81a6945aa71fd7a73f1842c24d2aa26672e6/src/Shared/HttpSys/NativeInterop/HttpApiTypes.cs#L518

Fixes #40728 
