### PR TITLE
Avoiding `ParameterBindingMethodCache` exceptions in MVC

### DIFF
--- a/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
+++ b/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
@@ -359,18 +359,29 @@ public class ParameterBindingMethodCacheTests
         Assert.Null(await parseHttpContext(httpContext));
     }
 
+    public static TheoryData<Type> InvalidTryParseStringTypesData
+    {
+        get
+        {
+            return new TheoryData<Type>
+            {
+                typeof(InvalidVoidReturnTryParseStruct),
+                typeof(InvalidVoidReturnTryParseClass),
+                typeof(InvalidWrongTypeTryParseStruct),
+                typeof(InvalidWrongTypeTryParseClass),
+                typeof(InvalidTryParseNullableStruct),
+                typeof(InvalidTooFewArgsTryParseStruct),
+                typeof(InvalidTooFewArgsTryParseClass),
+                typeof(InvalidNonStaticTryParseStruct),
+                typeof(InvalidNonStaticTryParseClass),
+                typeof(TryParseWrongTypeInheritClass),
+                typeof(TryParseWrongTypeFromInterface),
+            };
+        }
+    }
+
     [Theory]
-    [InlineData(typeof(InvalidVoidReturnTryParseStruct))]
-    [InlineData(typeof(InvalidVoidReturnTryParseClass))]
-    [InlineData(typeof(InvalidWrongTypeTryParseStruct))]
-    [InlineData(typeof(InvalidWrongTypeTryParseClass))]
-    [InlineData(typeof(InvalidTryParseNullableStruct))]
-    [InlineData(typeof(InvalidTooFewArgsTryParseStruct))]
-    [InlineData(typeof(InvalidTooFewArgsTryParseClass))]
-    [InlineData(typeof(InvalidNonStaticTryParseStruct))]
-    [InlineData(typeof(InvalidNonStaticTryParseClass))]
-    [InlineData(typeof(TryParseWrongTypeInheritClass))]
-    [InlineData(typeof(TryParseWrongTypeFromInterface))]
+    [MemberData(nameof(InvalidTryParseStringTypesData))]
     public void FindTryParseMethod_ThrowsIfInvalidTryParseOnType(Type type)
     {
         var ex = Assert.Throws<InvalidOperationException>(
@@ -381,17 +392,7 @@ public class ParameterBindingMethodCacheTests
     }
 
     [Theory]
-    [InlineData(typeof(InvalidVoidReturnTryParseStruct))]
-    [InlineData(typeof(InvalidVoidReturnTryParseClass))]
-    [InlineData(typeof(InvalidWrongTypeTryParseStruct))]
-    [InlineData(typeof(InvalidWrongTypeTryParseClass))]
-    [InlineData(typeof(InvalidTryParseNullableStruct))]
-    [InlineData(typeof(InvalidTooFewArgsTryParseStruct))]
-    [InlineData(typeof(InvalidTooFewArgsTryParseClass))]
-    [InlineData(typeof(InvalidNonStaticTryParseStruct))]
-    [InlineData(typeof(InvalidNonStaticTryParseClass))]
-    [InlineData(typeof(TryParseWrongTypeInheritClass))]
-    [InlineData(typeof(TryParseWrongTypeFromInterface))]
+    [MemberData(nameof(InvalidTryParseStringTypesData))]
     public void FindTryParseMethod_DoesNotThrowIfInvalidTryParseOnType_WhenThrowOnInvalidFalse(Type type)
     {
         Assert.Null(new ParameterBindingMethodCache(throwOnInvalidMethod: false).FindTryParseMethod(type));
@@ -420,15 +421,26 @@ public class ParameterBindingMethodCacheTests
         Assert.NotNull(method);
     }
 
+    public static TheoryData<Type> InvalidBindAsyncTypesData
+    {
+        get
+        {
+            return new TheoryData<Type>
+            {
+                typeof(InvalidWrongReturnBindAsyncStruct),
+                typeof(InvalidWrongReturnBindAsyncClass),
+                typeof(InvalidWrongParamBindAsyncStruct),
+                typeof(InvalidWrongParamBindAsyncClass),
+                typeof(BindAsyncWrongTypeInherit),
+                typeof(BindAsyncWithParameterInfoWrongTypeInherit),
+                typeof(BindAsyncWrongTypeFromInterface),
+                typeof(BindAsyncBothBadMethods),
+            };
+        }
+    }
+
     [Theory]
-    [InlineData(typeof(InvalidWrongReturnBindAsyncStruct))]
-    [InlineData(typeof(InvalidWrongReturnBindAsyncClass))]
-    [InlineData(typeof(InvalidWrongParamBindAsyncStruct))]
-    [InlineData(typeof(InvalidWrongParamBindAsyncClass))]
-    [InlineData(typeof(BindAsyncWrongTypeInherit))]
-    [InlineData(typeof(BindAsyncWithParameterInfoWrongTypeInherit))]
-    [InlineData(typeof(BindAsyncWrongTypeFromInterface))]
-    [InlineData(typeof(BindAsyncBothBadMethods))]
+    [MemberData(nameof(InvalidBindAsyncTypesData))]
     public void FindBindAsyncMethod_ThrowsIfInvalidBindAsyncOnType(Type type)
     {
         var cache = new ParameterBindingMethodCache();
@@ -443,14 +455,7 @@ public class ParameterBindingMethodCacheTests
     }
 
     [Theory]
-    [InlineData(typeof(InvalidWrongReturnBindAsyncStruct))]
-    [InlineData(typeof(InvalidWrongReturnBindAsyncClass))]
-    [InlineData(typeof(InvalidWrongParamBindAsyncStruct))]
-    [InlineData(typeof(InvalidWrongParamBindAsyncClass))]
-    [InlineData(typeof(BindAsyncWrongTypeInherit))]
-    [InlineData(typeof(BindAsyncWithParameterInfoWrongTypeInherit))]
-    [InlineData(typeof(BindAsyncWrongTypeFromInterface))]
-    [InlineData(typeof(BindAsyncBothBadMethods))]
+    [MemberData(nameof(InvalidBindAsyncTypesData))]
     public void FindBindAsyncMethod_DoesNotThrowIfInvalidBindAsyncOnType_WhenThrowOnInvalidFalse(Type type)
     {
         var cache = new ParameterBindingMethodCache(throwOnInvalidMethod: false);

--- a/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
+++ b/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
@@ -380,12 +380,35 @@ public class ParameterBindingMethodCacheTests
         Assert.Contains($"bool TryParse(string, out {TypeNameHelper.GetTypeDisplayName(type, fullName: false)})", ex.Message);
     }
 
+    [Theory]
+    [InlineData(typeof(InvalidVoidReturnTryParseStruct))]
+    [InlineData(typeof(InvalidVoidReturnTryParseClass))]
+    [InlineData(typeof(InvalidWrongTypeTryParseStruct))]
+    [InlineData(typeof(InvalidWrongTypeTryParseClass))]
+    [InlineData(typeof(InvalidTryParseNullableStruct))]
+    [InlineData(typeof(InvalidTooFewArgsTryParseStruct))]
+    [InlineData(typeof(InvalidTooFewArgsTryParseClass))]
+    [InlineData(typeof(InvalidNonStaticTryParseStruct))]
+    [InlineData(typeof(InvalidNonStaticTryParseClass))]
+    [InlineData(typeof(TryParseWrongTypeInheritClass))]
+    [InlineData(typeof(TryParseWrongTypeFromInterface))]
+    public void FindTryParseMethod_DoesNotThrowIfInvalidTryParseOnType_WhenThrowOnInvalidFalse(Type type)
+    {
+        Assert.Null(new ParameterBindingMethodCache(throwOnInvalidMethod: false).FindTryParseMethod(type));
+    }
+
     [Fact]
     public void FindTryParseMethod_ThrowsIfMultipleInterfacesMatch()
     {
         var ex = Assert.Throws<InvalidOperationException>(
             () => new ParameterBindingMethodCache().FindTryParseMethod(typeof(TryParseFromMultipleInterfaces)));
         Assert.Equal("TryParseFromMultipleInterfaces implements multiple interfaces defining a static Boolean TryParse(System.String, TryParseFromMultipleInterfaces ByRef) method causing ambiguity.", ex.Message);
+    }
+
+    [Fact]
+    public void FindTryParseMethod_DoesNotThrowIfMultipleInterfacesMatch_WhenThrowOnInvalidFalse()
+    {
+        Assert.Null(new ParameterBindingMethodCache(throwOnInvalidMethod: false).FindTryParseMethod(typeof(TryParseFromMultipleInterfaces)));
     }
 
     [Theory]
@@ -419,6 +442,23 @@ public class ParameterBindingMethodCacheTests
         Assert.Contains($"ValueTask<{TypeNameHelper.GetTypeDisplayName(type, fullName: false)}?> BindAsync(HttpContext context)", ex.Message);
     }
 
+    [Theory]
+    [InlineData(typeof(InvalidWrongReturnBindAsyncStruct))]
+    [InlineData(typeof(InvalidWrongReturnBindAsyncClass))]
+    [InlineData(typeof(InvalidWrongParamBindAsyncStruct))]
+    [InlineData(typeof(InvalidWrongParamBindAsyncClass))]
+    [InlineData(typeof(BindAsyncWrongTypeInherit))]
+    [InlineData(typeof(BindAsyncWithParameterInfoWrongTypeInherit))]
+    [InlineData(typeof(BindAsyncWrongTypeFromInterface))]
+    [InlineData(typeof(BindAsyncBothBadMethods))]
+    public void FindBindAsyncMethod_DoesNotThrowIfInvalidBindAsyncOnType_WhenThrowOnInvalidFalse(Type type)
+    {
+        var cache = new ParameterBindingMethodCache(throwOnInvalidMethod: false);
+        var parameter = new MockParameterInfo(type, "anything");
+        var (expression, _) = cache.FindBindAsyncMethod(parameter);
+        Assert.Null(expression);
+    }
+
     [Fact]
     public void FindBindAsyncMethod_ThrowsIfMultipleInterfacesMatch()
     {
@@ -426,6 +466,15 @@ public class ParameterBindingMethodCacheTests
         var parameter = new MockParameterInfo(typeof(BindAsyncFromMultipleInterfaces), "anything");
         var ex = Assert.Throws<InvalidOperationException>(() => cache.FindBindAsyncMethod(parameter));
         Assert.Equal("BindAsyncFromMultipleInterfaces implements multiple interfaces defining a static System.Threading.Tasks.ValueTask`1[Microsoft.AspNetCore.Http.Extensions.Tests.ParameterBindingMethodCacheTests+BindAsyncFromMultipleInterfaces] BindAsync(Microsoft.AspNetCore.Http.HttpContext) method causing ambiguity.", ex.Message);
+    }
+
+    [Fact]
+    public void FindBindAsyncMethod_DoesNotThrowIfMultipleInterfacesMatch_WhenThrowOnInvalidFalse()
+    {
+        var cache = new ParameterBindingMethodCache(throwOnInvalidMethod: false);
+        var parameter = new MockParameterInfo(typeof(BindAsyncFromMultipleInterfaces), "anything");
+        var (expression, _) = cache.FindBindAsyncMethod(parameter);
+        Assert.Null(expression);
     }
 
     [Theory]

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
@@ -27,7 +27,8 @@ public abstract class ModelMetadata : IEquatable<ModelMetadata?>, IModelMetadata
     /// </summary>
     public static readonly int DefaultOrder = 10000;
 
-    private static readonly ParameterBindingMethodCache ParameterBindingMethodCache = new();
+    private static readonly ParameterBindingMethodCache ParameterBindingMethodCache
+        = new(throwOnInvalidMethod: false);
 
     private int? _hashCode;
     private IReadOnlyList<ModelMetadata>? _boundProperties;
@@ -545,7 +546,7 @@ public abstract class ModelMetadata : IEquatable<ModelMetadata?>, IModelMetadata
     internal static Func<ParameterExpression, Expression, Expression>? FindTryParseMethod(Type modelType)
     {
         modelType = Nullable.GetUnderlyingType(modelType) ?? modelType;
-        return ParameterBindingMethodCache.FindTryParseMethod(modelType, throwOnInvalidMethod: false);
+        return ParameterBindingMethodCache.FindTryParseMethod(modelType);
     }
 
     [MemberNotNull(nameof(_parameterMapping), nameof(_boundConstructorPropertyMapping))]
@@ -644,7 +645,7 @@ public abstract class ModelMetadata : IEquatable<ModelMetadata?>, IModelMetadata
         Debug.Assert(ModelType != null);
 
         IsConvertibleType = TypeDescriptor.GetConverter(ModelType).CanConvertFrom(typeof(string));
-        IsParseableType = ModelMetadata.FindTryParseMethod(ModelType) is not null;
+        IsParseableType = FindTryParseMethod(ModelType) is not null;
         IsNullableValueType = Nullable.GetUnderlyingType(ModelType) != null;
         IsReferenceOrNullableType = !ModelType.IsValueType || IsNullableValueType;
         UnderlyingOrModelType = Nullable.GetUnderlyingType(ModelType) ?? ModelType;

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
@@ -544,18 +544,8 @@ public abstract class ModelMetadata : IEquatable<ModelMetadata?>, IModelMetadata
 
     internal static Func<ParameterExpression, Expression, Expression>? FindTryParseMethod(Type modelType)
     {
-        try
-        {
-            modelType = Nullable.GetUnderlyingType(modelType) ?? modelType;
-            return ParameterBindingMethodCache.FindTryParseMethod(modelType);
-        }
-        catch (InvalidOperationException)
-        {
-            // The ParameterBindingMethodCache.FindTryParseMethod throws an exception
-            // when an wrong try/parse method is detected
-            // but we don't need this behavior here and return null is enough
-            return null;
-        }
+        modelType = Nullable.GetUnderlyingType(modelType) ?? modelType;
+        return ParameterBindingMethodCache.FindTryParseMethod(modelType, throwOnInvalidMethod: false);
     }
 
     [MemberNotNull(nameof(_parameterMapping), nameof(_boundConstructorPropertyMapping))]

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -43,16 +43,16 @@ internal sealed class ParameterBindingMethodCache
         _enumTryParseMethod = GetEnumTryParseMethod(preferNonGenericEnumParseOverload);
     }
 
-    public bool HasTryParseMethod(Type type)
+    public bool HasTryParseMethod(Type type, bool throwOnInvalidMethod = true)
     {
         var nonNullableParameterType = Nullable.GetUnderlyingType(type) ?? type;
-        return FindTryParseMethod(nonNullableParameterType) is not null;
+        return FindTryParseMethod(nonNullableParameterType, throwOnInvalidMethod) is not null;
     }
 
     public bool HasBindAsyncMethod(ParameterInfo parameter) =>
         FindBindAsyncMethod(parameter).Expression is not null;
 
-    public Func<ParameterExpression, Expression, Expression>? FindTryParseMethod(Type type)
+    public Func<ParameterExpression, Expression, Expression>? FindTryParseMethod(Type type, bool throwOnInvalidMethod = true)
     {
         Func<ParameterExpression, Expression, Expression>? Finder(Type type)
         {
@@ -144,7 +144,7 @@ internal sealed class ParameterBindingMethodCache
                 return (expression, formatProvider) => Expression.Call(methodInfo, TempSourceStringExpr, expression);
             }
 
-            if (GetAnyMethodFromHierarchy(type, "TryParse") is MethodInfo invalidMethod)
+            if (throwOnInvalidMethod && GetAnyMethodFromHierarchy(type, "TryParse") is MethodInfo invalidMethod)
             {
                 var stringBuilder = new StringBuilder();
                 stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"TryParse method found on {TypeNameHelper.GetTypeDisplayName(type, fullName: false)} with incorrect format. Must be a static method with format");

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -26,6 +26,7 @@ internal sealed class ParameterBindingMethodCache
     internal static readonly ParameterExpression HttpContextExpr = Expression.Parameter(typeof(HttpContext), "httpContext");
 
     private readonly MethodInfo _enumTryParseMethod;
+    private readonly bool _throwOnInvalidMethod;
 
     // Since this is shared source, the cache won't be shared between RequestDelegateFactory and the ApiDescriptionProvider sadly :(
     private readonly ConcurrentDictionary<Type, Func<ParameterExpression, Expression, Expression>?> _stringMethodCallCache = new();
@@ -33,26 +34,29 @@ internal sealed class ParameterBindingMethodCache
 
     // If IsDynamicCodeSupported is false, we can't use the static Enum.TryParse<T> since there's no easy way for
     // this code to generate the specific instantiation for any enums used
-    public ParameterBindingMethodCache() : this(preferNonGenericEnumParseOverload: !RuntimeFeature.IsDynamicCodeSupported)
+    public ParameterBindingMethodCache(bool throwOnInvalidMethod = true)
+        : this(preferNonGenericEnumParseOverload: !RuntimeFeature.IsDynamicCodeSupported,
+              throwOnInvalidMethod)
     {
     }
 
     // This is for testing
-    public ParameterBindingMethodCache(bool preferNonGenericEnumParseOverload)
+    public ParameterBindingMethodCache(bool preferNonGenericEnumParseOverload, bool throwOnInvalidMethod = true)
     {
         _enumTryParseMethod = GetEnumTryParseMethod(preferNonGenericEnumParseOverload);
+        _throwOnInvalidMethod = throwOnInvalidMethod;
     }
 
-    public bool HasTryParseMethod(Type type, bool throwOnInvalidMethod = true)
+    public bool HasTryParseMethod(Type type)
     {
         var nonNullableParameterType = Nullable.GetUnderlyingType(type) ?? type;
-        return FindTryParseMethod(nonNullableParameterType, throwOnInvalidMethod) is not null;
+        return FindTryParseMethod(nonNullableParameterType) is not null;
     }
 
     public bool HasBindAsyncMethod(ParameterInfo parameter) =>
         FindBindAsyncMethod(parameter).Expression is not null;
 
-    public Func<ParameterExpression, Expression, Expression>? FindTryParseMethod(Type type, bool throwOnInvalidMethod = true)
+    public Func<ParameterExpression, Expression, Expression>? FindTryParseMethod(Type type)
     {
         Func<ParameterExpression, Expression, Expression>? Finder(Type type)
         {
@@ -126,7 +130,7 @@ internal sealed class ParameterBindingMethodCache
                     expression);
             }
 
-            methodInfo = GetStaticMethodFromHierarchy(type, "TryParse", new[] { typeof(string), typeof(IFormatProvider), type.MakeByRefType() }, ValidateReturnType);
+            methodInfo = GetStaticMethodFromHierarchy(type, "TryParse", new[] { typeof(string), typeof(IFormatProvider), type.MakeByRefType() }, ValidateReturnType, _throwOnInvalidMethod);
 
             if (methodInfo is not null)
             {
@@ -137,14 +141,14 @@ internal sealed class ParameterBindingMethodCache
                     expression);
             }
 
-            methodInfo = GetStaticMethodFromHierarchy(type, "TryParse", new[] { typeof(string), type.MakeByRefType() }, ValidateReturnType);
+            methodInfo = GetStaticMethodFromHierarchy(type, "TryParse", new[] { typeof(string), type.MakeByRefType() }, ValidateReturnType, _throwOnInvalidMethod);
 
             if (methodInfo is not null)
             {
                 return (expression, formatProvider) => Expression.Call(methodInfo, TempSourceStringExpr, expression);
             }
 
-            if (throwOnInvalidMethod && GetAnyMethodFromHierarchy(type, "TryParse") is MethodInfo invalidMethod)
+            if (_throwOnInvalidMethod && GetAnyMethodFromHierarchy(type, "TryParse") is MethodInfo invalidMethod)
             {
                 var stringBuilder = new StringBuilder();
                 stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"TryParse method found on {TypeNameHelper.GetTypeDisplayName(type, fullName: false)} with incorrect format. Must be a static method with format");
@@ -170,15 +174,15 @@ internal sealed class ParameterBindingMethodCache
 
     public (Expression? Expression, int ParamCount) FindBindAsyncMethod(ParameterInfo parameter)
     {
-        static (Func<ParameterInfo, Expression>?, int) Finder(Type nonNullableParameterType)
+        (Func<ParameterInfo, Expression>?, int) Finder(Type nonNullableParameterType)
         {
             var hasParameterInfo = true;
             // There should only be one BindAsync method with these parameters since C# does not allow overloading on return type.
-            var methodInfo = GetStaticMethodFromHierarchy(nonNullableParameterType, "BindAsync", new[] { typeof(HttpContext), typeof(ParameterInfo) }, ValidateReturnType);
+            var methodInfo = GetStaticMethodFromHierarchy(nonNullableParameterType, "BindAsync", new[] { typeof(HttpContext), typeof(ParameterInfo) }, ValidateReturnType, _throwOnInvalidMethod);
             if (methodInfo is null)
             {
                 hasParameterInfo = false;
-                methodInfo = GetStaticMethodFromHierarchy(nonNullableParameterType, "BindAsync", new[] { typeof(HttpContext) }, ValidateReturnType);
+                methodInfo = GetStaticMethodFromHierarchy(nonNullableParameterType, "BindAsync", new[] { typeof(HttpContext) }, ValidateReturnType, _throwOnInvalidMethod);
             }
 
             // We're looking for a method with the following signatures:
@@ -230,7 +234,7 @@ internal sealed class ParameterBindingMethodCache
                 }
             }
 
-            if (GetAnyMethodFromHierarchy(nonNullableParameterType, "BindAsync") is MethodInfo invalidBindMethod)
+            if (_throwOnInvalidMethod && GetAnyMethodFromHierarchy(nonNullableParameterType, "BindAsync") is MethodInfo invalidBindMethod)
             {
                 var stringBuilder = new StringBuilder();
                 stringBuilder.AppendLine(CultureInfo.InvariantCulture, $"BindAsync method found on {TypeNameHelper.GetTypeDisplayName(nonNullableParameterType, fullName: false)} with incorrect format. Must be a static method with format");
@@ -259,7 +263,7 @@ internal sealed class ParameterBindingMethodCache
         }
     }
 
-    private static MethodInfo? GetStaticMethodFromHierarchy(Type type, string name, Type[] parameterTypes, Func<MethodInfo, bool> validateReturnType)
+    private static MethodInfo? GetStaticMethodFromHierarchy(Type type, string name, Type[] parameterTypes, Func<MethodInfo, bool> validateReturnType, bool throwOnInvalidMethod)
     {
         bool IsMatch(MethodInfo? method) => method is not null && !method.IsAbstract && validateReturnType(method);
 
@@ -281,7 +285,8 @@ internal sealed class ParameterBindingMethodCache
             {
                 if (candidateInterfaceMethodInfo is not null)
                 {
-                    throw new InvalidOperationException($"{TypeNameHelper.GetTypeDisplayName(type, fullName: false)} implements multiple interfaces defining a static {interfaceMethod} method causing ambiguity.");
+                    return !throwOnInvalidMethod ? null :
+                        throw new InvalidOperationException($"{TypeNameHelper.GetTypeDisplayName(type, fullName: false)} implements multiple interfaces defining a static {interfaceMethod} method causing ambiguity.");
                 }
 
                 candidateInterfaceMethodInfo = interfaceMethod;

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -130,7 +130,7 @@ internal sealed class ParameterBindingMethodCache
                     expression);
             }
 
-            methodInfo = GetStaticMethodFromHierarchy(type, "TryParse", new[] { typeof(string), typeof(IFormatProvider), type.MakeByRefType() }, ValidateReturnType, _throwOnInvalidMethod);
+            methodInfo = GetStaticMethodFromHierarchy(type, "TryParse", new[] { typeof(string), typeof(IFormatProvider), type.MakeByRefType() }, ValidateReturnType);
 
             if (methodInfo is not null)
             {
@@ -141,7 +141,7 @@ internal sealed class ParameterBindingMethodCache
                     expression);
             }
 
-            methodInfo = GetStaticMethodFromHierarchy(type, "TryParse", new[] { typeof(string), type.MakeByRefType() }, ValidateReturnType, _throwOnInvalidMethod);
+            methodInfo = GetStaticMethodFromHierarchy(type, "TryParse", new[] { typeof(string), type.MakeByRefType() }, ValidateReturnType);
 
             if (methodInfo is not null)
             {
@@ -178,11 +178,11 @@ internal sealed class ParameterBindingMethodCache
         {
             var hasParameterInfo = true;
             // There should only be one BindAsync method with these parameters since C# does not allow overloading on return type.
-            var methodInfo = GetStaticMethodFromHierarchy(nonNullableParameterType, "BindAsync", new[] { typeof(HttpContext), typeof(ParameterInfo) }, ValidateReturnType, _throwOnInvalidMethod);
+            var methodInfo = GetStaticMethodFromHierarchy(nonNullableParameterType, "BindAsync", new[] { typeof(HttpContext), typeof(ParameterInfo) }, ValidateReturnType);
             if (methodInfo is null)
             {
                 hasParameterInfo = false;
-                methodInfo = GetStaticMethodFromHierarchy(nonNullableParameterType, "BindAsync", new[] { typeof(HttpContext) }, ValidateReturnType, _throwOnInvalidMethod);
+                methodInfo = GetStaticMethodFromHierarchy(nonNullableParameterType, "BindAsync", new[] { typeof(HttpContext) }, ValidateReturnType);
             }
 
             // We're looking for a method with the following signatures:
@@ -263,7 +263,7 @@ internal sealed class ParameterBindingMethodCache
         }
     }
 
-    private static MethodInfo? GetStaticMethodFromHierarchy(Type type, string name, Type[] parameterTypes, Func<MethodInfo, bool> validateReturnType, bool throwOnInvalidMethod)
+    private MethodInfo? GetStaticMethodFromHierarchy(Type type, string name, Type[] parameterTypes, Func<MethodInfo, bool> validateReturnType)
     {
         bool IsMatch(MethodInfo? method) => method is not null && !method.IsAbstract && validateReturnType(method);
 
@@ -285,7 +285,7 @@ internal sealed class ParameterBindingMethodCache
             {
                 if (candidateInterfaceMethodInfo is not null)
                 {
-                    return !throwOnInvalidMethod ? null :
+                    return !_throwOnInvalidMethod ? null :
                         throw new InvalidOperationException($"{TypeNameHelper.GetTypeDisplayName(type, fullName: false)} implements multiple interfaces defining a static {interfaceMethod} method causing ambiguity.");
                 }
 

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -285,8 +285,12 @@ internal sealed class ParameterBindingMethodCache
             {
                 if (candidateInterfaceMethodInfo is not null)
                 {
-                    return !_throwOnInvalidMethod ? null :
+                    if (_throwOnInvalidMethod)
+                    {
                         throw new InvalidOperationException($"{TypeNameHelper.GetTypeDisplayName(type, fullName: false)} implements multiple interfaces defining a static {interfaceMethod} method causing ambiguity.");
+                    }
+
+                    return null;
                 }
 
                 candidateInterfaceMethodInfo = interfaceMethod;


### PR DESCRIPTION
In MVC, we don't need to throw an `InvalidOperationException` when an invalid `TryParse` is detected, since it will fallback to a `Converter` if one exists or to the previous behavior treating the type as a complex type. Also, the exception is already swallowed.

This PR includes a small change to the `Microsoft.AspNetCore.Http.ParameterBindingMethodCache` to avoid throwing and handling the exception in MVC.

The change consists of adding a new optional parameter to the constructor:

```diff
-public ParameterBindingMethodCache()
+public ParameterBindingMethodCache(bool throwOnInvalidMethod = true)
```

```diff
-public ParameterBindingMethodCache(bool preferNonGenericEnumParseOverload)
+public ParameterBindingMethodCache(bool preferNonGenericEnumParseOverload, bool throwOnInvalidMethod = true)
```

And the usage of this new information to avoid the exception to be thrown, eg:

```diff
if (candidateInterfaceMethodInfo is not null)
{  
-      throw new InvalidOperationException($"{TypeNameHelper.GetTypeDisplayName(type, fullName: false)} implements multiple interfaces defining a static {interfaceMethod} method causing ambiguity.");
+      return !throwOnInvalidMethod ? null : 
+                 throw new InvalidOperationException($"{TypeNameHelper.GetTypeDisplayName(type, fullName: false)} implements multiple interfaces defining a static {interfaceMethod} method causing ambiguity.");
}
```

Related PR: #40233