### PR TITLE
Support falling back to ConnectionId when RawConnectionId is 0 on HTTP.sys

### DIFF
--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         internal ulong RawConnectionId { get; }
 
         // No ulongs in public APIs...
-        public long ConnectionId => (long)RawConnectionId;
+        public long ConnectionId => RawConnectionId != 0 ? (long)RawConnectionId : (long)UConnectionId;
 
         internal ulong RequestId { get; }
 


### PR DESCRIPTION
# Support falling back to ConnectionId when RawConnectionId is 0 on HTTP.sys

## Description

#38059 changed the ConnectionId property to pull data from a field that's more accurate for HTTP/2. Unfortunately, that new field is only populated on newer OS versions, so this started returning 0 on old versions.

Fixes https://github.com/dotnet/aspnetcore/issues/40728

## Customer Impact

Customers are unable to track connections on older OSs. This information is used for diagnostics and stats such as measuring the average connection re-use for performance reasons.

## Regression?

- [x] Yes
- [ ] No

Regressed in 6.0.1 by https://github.com/dotnet/aspnetcore/pull/38059

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Falls back to prior behavior.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

