### PR TITLE
WPF/WinForms Blazor WebView Exception Handling

### DIFF
--- a/src/Components/README.md
+++ b/src/Components/README.md
@@ -26,6 +26,7 @@ The following contains a description of each sub-directory in the `Components` d
   - `Server`: Contains the implementation for WASM-specific extension methods and the launch logic for the debugging proxy
   - `WebAssembly`: Contains WebAssembly-specific implementations of the renderer, HostBuilder, etc.
   - `WebAssembly.Authentication`: Contains the WASM-specific implementations
+- `WebView`: Contains the source files to support [Blazor Hybrid](https://github.com/dotnet/maui/tree/main/src/BlazorWebView) within [`dotnet/maui`](https://github.com/dotnet/maui). Changes in this project can be tested with `dotnet/maui` following [this guide](https://github.com/dotnet/maui/wiki/Blazor-Desktop#aspnet-core).
 
 ## Development Setup
 

--- a/src/Components/WebView/WebView/src/IpcSender.cs
+++ b/src/Components/WebView/WebView/src/IpcSender.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.JSInterop;
@@ -62,8 +63,12 @@ namespace Microsoft.AspNetCore.Components.WebView
 
         public void NotifyUnhandledException(Exception exception)
         {
+            // Send the serialized exception to the WebView for display
             var message = IpcCommon.Serialize(IpcCommon.OutgoingMessageType.NotifyUnhandledException, exception.Message, exception.StackTrace);
             _dispatcher.InvokeAsync(() => _messageDispatcher(message));
+            
+            // Also rethrow so the AppDomain's UnhandledException handler gets notified
+            _dispatcher.InvokeAsync(() => ExceptionDispatchInfo.Capture(exception).Throw());
         }
 
         private void DispatchMessageWithErrorHandling(string message)

--- a/src/Components/WebView/WebView/src/Services/WebViewRenderer.cs
+++ b/src/Components/WebView/WebView/src/Services/WebViewRenderer.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.ExceptionServices;
 using System.Text.Json;
 using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.AspNetCore.Components.Web;
@@ -38,9 +37,6 @@ namespace Microsoft.AspNetCore.Components.WebView.Services
         {
             // Notify the JS code so it can show the in-app UI
             _ipcSender.NotifyUnhandledException(exception);
-
-            // Also rethrow so the AppDomain's UnhandledException handler gets notified
-            ExceptionDispatchInfo.Capture(exception).Throw();
         }
 
         protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)


### PR DESCRIPTION
# WPF/WinForms Blazor WebView Exception Handling

Currently exceptions within Blazor code are not fatal to the underlying application, resulting in inconsistent behavior and a challenging debugging experience for developers.

## Description

Updated exception handling mechanism to throw exceptions from the platform dispatch context instead of directly, so they can be consumed in WPF/WinForms applications using the standard [`AppDomain.CurrentDomain.UnhandledException`](https://docs.microsoft.com/en-us/dotnet/api/system.appdomain.unhandledexception?view=net-6.0) API.


<details>
<summary>Other details</summary>

- Previously the re-thrown exception was being lost and we just saw the `Unhandled Exception` yellow bar within the webview. This had a serialized exception stack trace with limited additional information, making debugging the error more challenging.
- Now we're able to pass the exception along to the platform's exception handling mechanism (for WPF/WinForms)

```csharp
AppDomain.CurrentDomain.UnhandledException += (sender, error) =>
{
    MessageBox.Show(text: error.ExceptionObject.ToString(), caption: "Error");
};
```

Helpful blogs on error handling within WPF:
- https://thecolorofcode.com/2019/08/11/how-to-show-an-unhandled-exception-window-in-wpf/
- https://blog.danskingdom.com/Catch-and-display-unhandled-exceptions-in-your-WPF-app/

Please note, this is specifically for WPF/WinForms scenarios. It's not entirely clear if there's a canonical way we can do this on MAUI yet (related discussion https://github.com/dotnet/maui/discussions/653).
</details>

Fixes https://github.com/dotnet/maui/issues/4441

## Customer Impact

Provides developers with improved insights on application errors, and increased control over exception handling. When an exception occurs, the app will crash and close, instead of remaining open in a corrupted state.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Changes are specific to WebView for use with Blazor Hybrid. The intention of this change set is to _guarantee_ the application _DOES_ crash. 

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A