### PR TITLE
Use navigator.userAgentData in Javascript Mono Debugger 

### DIFF
--- a/src/Components/Web.JS/src/Platform/Mono/MonoDebugger.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoDebugger.ts
@@ -3,15 +3,19 @@
 
 import { WebAssemblyResourceLoader } from '../WebAssemblyResourceLoader';
 
+const navigatorUA = navigator as MonoNavigatorUserAgent;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const currentBrowserIsChrome = (window as any).chrome
-  && navigator.userAgent.indexOf('Edge') < 0; // Edge pretends to be Chrome
+const currentBrowserIsChromeOrEdge = navigatorUA.userAgentData && navigatorUA.userAgentData.brands ?
+     (navigatorUA.userAgentData.brands.some(b => b.brand === 'Google Chrome') ||
+      navigatorUA.userAgentData.brands.some(b => b.brand === 'Microsoft Edge'))
+      : (window as any).chrome && navigator.userAgent.indexOf('Edge') < 0; // Edge pretends to be Chrome
+const platform = navigatorUA.userAgentData ? navigatorUA.userAgentData.platform : navigator.platform;
 
 let hasReferencedPdbs = false;
 let debugBuild = false;
 
 export function hasDebuggingEnabled(): boolean {
-  return (hasReferencedPdbs || debugBuild) && currentBrowserIsChrome;
+  return (hasReferencedPdbs || debugBuild) && currentBrowserIsChromeOrEdge;
 }
 
 export function attachDebuggerHotkey(resourceLoader: WebAssemblyResourceLoader): void {
@@ -19,7 +23,7 @@ export function attachDebuggerHotkey(resourceLoader: WebAssemblyResourceLoader):
   debugBuild = resourceLoader.bootConfig.debugBuild;
   // Use the combination shift+alt+D because it isn't used by the major browsers
   // for anything else by default
-  const altKeyName = navigator.platform.match(/^Mac/i) ? 'Cmd' : 'Alt';
+  const altKeyName = platform.match(/^Mac/i) ? 'Cmd' : 'Alt';
   if (hasDebuggingEnabled()) {
     console.info(`Debugging hotkey: Shift+${altKeyName}+D (when application has focus)`);
   }
@@ -29,7 +33,7 @@ export function attachDebuggerHotkey(resourceLoader: WebAssemblyResourceLoader):
     if (evt.shiftKey && (evt.metaKey || evt.altKey) && evt.code === 'KeyD') {
       if (!debugBuild && !hasReferencedPdbs) {
         console.error('Cannot start debugging, because the application was not compiled with debugging enabled.');
-      } else if (!currentBrowserIsChrome) {
+      } else if (!currentBrowserIsChromeOrEdge) {
         console.error('Currently, only Microsoft Edge (80+), or Google Chrome, are supported for debugging.');
       } else {
         launchDebugger();

--- a/src/Components/Web.JS/src/Platform/Mono/MonoDebugger.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoDebugger.ts
@@ -7,7 +7,7 @@ const navigatorUA = navigator as MonoNavigatorUserAgent;
 const brands = navigatorUA.userAgentData && navigatorUA.userAgentData.brands;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const currentBrowserIsChromeOrEdge = brands
-  ? (navigatorUA.userAgentData.brands.some(b => b.brand === 'Google Chrome' || b.brand === 'Microsoft Edge'))
+  ? brands.some(b => b.brand === 'Google Chrome' || b.brand === 'Microsoft Edge')
   : (window as any).chrome;
 const platform = navigatorUA.userAgentData ? navigatorUA.userAgentData.platform : navigator.platform;
 

--- a/src/Components/Web.JS/src/Platform/Mono/MonoDebugger.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoDebugger.ts
@@ -4,11 +4,11 @@
 import { WebAssemblyResourceLoader } from '../WebAssemblyResourceLoader';
 
 const navigatorUA = navigator as MonoNavigatorUserAgent;
+const brands = navigatorUA.userAgentData && navigatorUA.userAgentData.brands;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const currentBrowserIsChromeOrEdge = navigatorUA.userAgentData && navigatorUA.userAgentData.brands ?
-     (navigatorUA.userAgentData.brands.some(b => b.brand === 'Google Chrome') ||
-      navigatorUA.userAgentData.brands.some(b => b.brand === 'Microsoft Edge'))
-      : (window as any).chrome && navigator.userAgent.indexOf('Edge') < 0; // Edge pretends to be Chrome
+const currentBrowserIsChromeOrEdge = brands
+  ? (navigatorUA.userAgentData.brands.some(b => b.brand === 'Google Chrome' || b.brand === 'Microsoft Edge'))
+  : (window as any).chrome;
 const platform = navigatorUA.userAgentData ? navigatorUA.userAgentData.platform : navigator.platform;
 
 let hasReferencedPdbs = false;

--- a/src/Components/Web.JS/src/Platform/Mono/MonoNavigatorUserAgentData.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoNavigatorUserAgentData.ts
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// can be removed once userAgentData is part of lib.dom.d.ts
+declare interface MonoNavigatorUserAgent extends Navigator {
+    readonly userAgentData: MonoUserAgentData;
+}
+
+declare interface MonoUserAgentData {
+    readonly brands: ReadonlyArray<MonoUserAgentDataBrandVersion>;
+    readonly platform: string;
+}
+
+declare interface MonoUserAgentDataBrandVersion {
+    brand?: string;
+    version?: string;
+}


### PR DESCRIPTION
Use the new navigator.userAgentData in favor of window.chrome / navigator.platform / navigator.userAgent. Avoids an warning a user gets in the Issues tab when using the Mono Debugger (see picture). Added a fallback for Edge/Chrome 80-90 using the previous code.

![image](https://user-images.githubusercontent.com/4984486/158978348-0fdbbb76-62f0-4f15-bc08-b5ec50b0cf0f.png)

## Description
As can be seen in the screenshot, starting with Chrome 101 the amount of information will be reduced in the User Agent string. We are at 99 so maybe it's time to do something about it :-). 

Implementation notes:
- Add a minimal Typescript definition for the userAgentData as the PR for the DOM definition has not been merged yet.
- Note that the "brands" array was only added in Chrome 84, so the code has extra check if this array exists before falling back. 
- Fallbacks could be removed but that would basically be dropping support for Chrome < 90.
- The `platform` value differs from navigator or userAgentData, e.g. 'Win32' vs 'Windows'. For macOS the case insensitive match should cover both cases, but its good to keep in mind. 

Some resources used:
- https://caniuse.com/?search=userAgentData
- https://wicg.github.io/ua-client-hints/
- https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/1028/
- https://medium.com/naver-fe-platform/prepare-for-client-hints-freezing-user-agent-9c0ea1ddd02c

Fixes #37128
