### PR TITLE
Bump Swashbuckle to latest stable for templates

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -269,7 +269,7 @@
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
     <StackExchangeRedisVersion>2.2.4</StackExchangeRedisVersion>
     <SystemReactiveLinqVersion>5.0.0</SystemReactiveLinqVersion>
-    <SwashbuckleAspNetCoreVersion>6.2.3</SwashbuckleAspNetCoreVersion>
+    <SwashbuckleAspNetCoreVersion>6.3.0</SwashbuckleAspNetCoreVersion>
     <XunitAbstractionsVersion>2.0.3</XunitAbstractionsVersion>
     <XunitAnalyzersVersion>0.10.0</XunitAnalyzersVersion>
     <XunitVersion>2.4.1</XunitVersion>


### PR DESCRIPTION
# Bump Swashbuckle package to latest stable for WebAPI templates

### Summary of the changes (Less than 80 chars)
Just a dependency bump to latest Swashbuckle package for WebAPI templates to remove immediate warnings when someone creates a new application.

Fixes #40778 
