### PR TITLE
Revert "[release/6.0] Build ProjectTemplates in Source-Build"

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,9 +30,6 @@
           $(MSBuildProjectName.EndsWith('.Test')) OR
           $(MSBuildProjectName.EndsWith('.FunctionalTest')) ) ">true</IsUnitTestProject>
     <IsTestAssetProject Condition=" $(RepoRelativeProjectDir.Contains('testassets')) OR $(MSBuildProjectName.Contains('TestCommon'))">true</IsTestAssetProject>
-    <IsProjectTemplateProject Condition=" ($(RepoRelativeProjectDir.Contains('ProjectTemplates')) OR $(MSBuildProjectName.Contains('ProjectTemplates')) ) AND
-        '$(IsUnitTestProject)' != 'true' AND
-        '$(IsTestAssetProject)' != 'true' ">true</IsProjectTemplateProject>
     <IsSampleProject Condition=" $(RepoRelativeProjectDir.ToUpperInvariant().Contains('SAMPLE')) ">true</IsSampleProject>
     <IsAnalyzersProject Condition="$(MSBuildProjectName.EndsWith('.Analyzers'))">true</IsAnalyzersProject>
     <IsShipping Condition=" '$(IsSampleProject)' == 'true' OR

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,15 +1,10 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <!-- Only build Microsoft.AspNetCore.App, Microsoft.AspNetCore.App.Ref, ref/ assemblies, and ProjectTemplates in source build. -->
+    <!-- Only build Microsoft.AspNetCore.App, Microsoft.AspNetCore.App.Ref, and ref/ assemblies in source build. -->
     <!-- Analyzer package are needed in source build for WebSDK -->
     <ExcludeFromSourceBuild
-        Condition="'$(ExcludeFromSourceBuild)' == '' and 
-            '$(DotNetBuildFromSource)' == 'true' and 
-            '$(IsAspNetCoreApp)' != 'true' and 
-            '$(MSBuildProjectName)' != '$(TargetingPackName)' and 
-            '$(IsAnalyzersProject)' != 'true' and 
-            '$(IsProjectTemplateProject)' != 'true'">true</ExcludeFromSourceBuild>
+        Condition="'$(ExcludeFromSourceBuild)' == '' and '$(DotNetBuildFromSource)' == 'true' and '$(IsAspNetCoreApp)' != 'true' and '$(MSBuildProjectName)' != '$(TargetingPackName)' and '$(IsAnalyzersProject)' != 'true'">true</ExcludeFromSourceBuild>
 
     <!-- If the user has specified that they want to skip building any test related projects with SkipTestBuild,
      suppress all targets for TestProjects using ExcludeFromBuild. -->


### PR DESCRIPTION
This broke source build - we should re-introduce this in May after we get yarn.msbuild included in source-build.