### PR TITLE
Ignore hash when supplying querystring parameters

### DIFF
--- a/src/Components/Components/src/RouteView.cs
+++ b/src/Components/Components/src/RouteView.cs
@@ -98,8 +98,13 @@ public class RouteView : IComponent
             // Since this component does accept some parameters from query, we must supply values for all of them,
             // even if the querystring in the URI is empty. So don't skip the following logic.
             var url = NavigationManager.Uri;
+            ReadOnlyMemory<char> query = default;
             var queryStartPos = url.IndexOf('?');
-            var query = queryStartPos < 0 ? default : url.AsMemory(queryStartPos);
+            if (queryStartPos >= 0)
+            {
+                var queryEndPos = url.IndexOf('#', queryStartPos);
+                query = url.AsMemory(queryStartPos..(queryEndPos < 0 ? url.Length : queryEndPos));
+            }
             queryParameterSupplier.RenderParametersFromQueryString(builder, query);
         }
 

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -783,7 +783,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
     [Fact]
     public void CanArriveAtQueryStringPageWithStringQuery()
     {
-        SetUrlViaPushState("/WithQueryParameters/Abc?stringvalue=Hello+there");
+        SetUrlViaPushState("/WithQueryParameters/Abc?stringvalue=Hello+there#123");
 
         var app = Browser.MountTestComponent<TestRouter>();
         Assert.Equal("Hello Abc .", app.FindElement(By.Id("test-info")).Text);


### PR DESCRIPTION
Fixes #40806
