### PR TITLE
Add ElementReference to InputRadio

### DIFF
--- a/src/Components/Web/src/Forms/InputRadio.cs
+++ b/src/Components/Web/src/Forms/InputRadio.cs
@@ -33,6 +33,14 @@ public class InputRadio<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTyp
     /// </summary>
     [Parameter] public string? Name { get; set; }
 
+    /// <summary>
+    /// Gets or sets the associated <see cref="ElementReference"/>.
+    /// <para>
+    /// May be <see langword="null"/> if accessed before the component is rendered.
+    /// </para>
+    /// </summary>
+    [DisallowNull] public ElementReference? Element { get; protected set; }
+
     [CascadingParameter] private InputRadioContext? CascadedContext { get; set; }
 
     /// <inheritdoc />
@@ -60,6 +68,7 @@ public class InputRadio<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTyp
         builder.AddAttribute(5, "value", BindConverter.FormatValue(Value?.ToString()));
         builder.AddAttribute(6, "checked", Context.CurrentValue?.Equals(Value));
         builder.AddAttribute(7, "onchange", Context.ChangeEventCallback);
+        builder.AddElementReferenceCapture(8, __inputReference => Element = __inputReference);
         builder.CloseElement();
     }
 }

--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.Element.get -> Microsoft.AspNetCore.Components.ElementReference?
+Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.Element.set -> void

--- a/src/Components/Web/test/Forms/InputRadioTest.cs
+++ b/src/Components/Web/test/Forms/InputRadioTest.cs
@@ -55,6 +55,21 @@ public class InputRadioTest
         Assert.All(inputRadioComponents, inputRadio => Assert.Equal(groupName, inputRadio.GroupName));
     }
 
+    [Fact]
+    public async Task InputElementIsAssignedSuccessfully()
+    {
+        var model = new TestModel();
+        var rootComponent = new TestInputRadioHostComponent<TestEnum>
+        {
+            EditContext = new EditContext(model),
+            InnerContent = RadioButtonsWithGroup(null, () => model.TestEnum)
+        };
+
+        var inputRadioComponents = await RenderAndGetTestInputComponentAsync(rootComponent);
+
+        Assert.All(inputRadioComponents, inputRadio => Assert.NotNull(inputRadio.Element));
+    }
+
     private static RenderFragment RadioButtonsWithoutGroup(string name) => (builder) =>
     {
         foreach (var selectedValue in (TestEnum[])Enum.GetValues(typeof(TestEnum)))

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/InputFocusComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/InputFocusComponent.razor
@@ -45,7 +45,15 @@
         <button @onclick="async () => await inputCheckboxReference.Element.Value.FocusAsync()">Focus</button>
     </p>
 
-    
+    <p class="select-bool-values input-group">
+        T/F: 77 + 33 = 100<br>
+        <InputRadioGroup @bind-Value="person.IsSelectMathStatementTrue">
+            <InputRadio Value="true" @ref="inputRadioReference" class="input-control" />true<br>
+            <InputRadio Value="false" />false<br>
+        </InputRadioGroup>
+        <button @onclick="async () => await inputRadioReference.Element.Value.FocusAsync()">Focus</button>
+    </p>
+
 </EditForm>
 
 @code {
@@ -55,6 +63,7 @@
     InputDate<DateTime> inputDateReference;
     InputSelect<TicketClass> inputSelectReference;
     InputCheckbox inputCheckboxReference;
+    InputRadio<bool> inputRadioReference;
     InputFile inputFile;
 
     Person person = new Person();
@@ -74,6 +83,8 @@
         public DateTime RenewalDate { get; set; } = DateTime.Now;
 
         public bool AcceptsTerms { get; set; }
+
+        public bool IsSelectMathStatementTrue { get; set; }
 
         public string Description { get; set; }
 


### PR DESCRIPTION
## Description

Add `Element` property to `InputRadio` just like the input fields in https://github.com/dotnet/aspnetcore/pull/29555
Since `InputRadioGroup` does not use an actual DOM element I left it out.
https://github.com/dotnet/aspnetcore/blob/82e6b60edbeb9c247d6e2b82ea69306eefb613f4/src/Components/Web/src/Forms/InputRadioGroup.cs#L53-L63

Fixes https://github.com/dotnet/aspnetcore/issues/40804
