### PR TITLE
Prevent cookie middleware from redirecting API requests

### DIFF
--- a/src/Security/Authentication/Cookies/src/CookieAuthenticationEvents.cs
+++ b/src/Security/Authentication/Cookies/src/CookieAuthenticationEvents.cs
@@ -105,7 +105,8 @@ public class CookieAuthenticationEvents
     private static bool IsAjaxRequest(HttpRequest request)
     {
         return string.Equals(request.Query[HeaderNames.XRequestedWith], "XMLHttpRequest", StringComparison.Ordinal) ||
-            string.Equals(request.Headers.XRequestedWith, "XMLHttpRequest", StringComparison.Ordinal);
+            string.Equals(request.Headers.XRequestedWith, "XMLHttpRequest", StringComparison.Ordinal) ||
+            request.Headers.Accept.ToString().Contains("application/json");
     }
 
     /// <summary>


### PR DESCRIPTION
# Prevent cookie middleware from redirecting API requests

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Prevent the cookie middleware from redirecting API requests.

## Description

Add a conditional check to determine if a request is an API request in order to not redirect it.
It is considered to be an API request if the HTTP Accept header contains the string "application/json".

Fixes #9039
