### PR TITLE
Allow leading CR/LF in HTTP request lines in Kestrel

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -57,7 +57,12 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
     {
         // Skip any leading \r or \n on the request line. This is not technically allowed, but
         // but apparently there are enough clients relying on this that it's worth allowing.
-        reader.AdvancePastAny(ByteCR, ByteLF);
+        // Peek first as a minor performance optimization; it's a quick inlined check.
+        if (reader.TryPeek(out byte b) && (b == ByteCR || b == ByteLF))
+        {
+            reader.AdvancePastAny(ByteCR, ByteLF);
+        }
+
         if (reader.TryReadTo(out ReadOnlySpan<byte> requestLine, ByteLF, advancePastDelimiter: true))
         {
             ParseRequestLine(handler, requestLine);

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -55,7 +55,7 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
     /// </summary>
     public bool ParseRequestLine(TRequestHandler handler, ref SequenceReader<byte> reader)
     {
-        // Skip any leading \r or \n on the request line. This is not technically allowed, but
+        // Skip any leading \r or \n on the request line. This is not technically allowed,
         // but apparently there are enough clients relying on this that it's worth allowing.
         // Peek first as a minor performance optimization; it's a quick inlined check.
         if (reader.TryPeek(out byte b) && (b == ByteCR || b == ByteLF))

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -55,6 +55,9 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
     /// </summary>
     public bool ParseRequestLine(TRequestHandler handler, ref SequenceReader<byte> reader)
     {
+        // Skip any leading \r or \n on the request line. This is not technically allowed, but
+        // but apparently there are enough clients relying on this that it's worth allowing.
+        reader.AdvancePastAny((byte)'\r', (byte)'\n');
         if (reader.TryReadTo(out ReadOnlySpan<byte> requestLine, ByteLF, advancePastDelimiter: true))
         {
             ParseRequestLine(handler, requestLine);

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -57,7 +57,7 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
     {
         // Skip any leading \r or \n on the request line. This is not technically allowed, but
         // but apparently there are enough clients relying on this that it's worth allowing.
-        reader.AdvancePastAny((byte)'\r', (byte)'\n');
+        reader.AdvancePastAny(ByteCR, ByteLF);
         if (reader.TryReadTo(out ReadOnlySpan<byte> requestLine, ByteLF, advancePastDelimiter: true))
         {
             ParseRequestLine(handler, requestLine);

--- a/src/Servers/Kestrel/Core/test/StartLineTests.cs
+++ b/src/Servers/Kestrel/Core/test/StartLineTests.cs
@@ -516,6 +516,27 @@ public class StartLineTests : IDisposable
         DifferentFormsWorkTogether();
     }
 
+    [Theory]
+    [InlineData("\r")]
+    [InlineData("\n")]
+    [InlineData("\r\r\r\r\r")]
+    [InlineData("\r\n")]
+    [InlineData("\n\r")]
+    [InlineData("\r\n\n")]
+    public void LeadingCrLfAreAllowed(string startOfRequestLine)
+    {
+        var rawTarget = "http://localhost/path1?q=123&w=xyzw";
+        Http1Connection.Reset();
+        // RawTarget, Path, QueryString are null after reset
+        Assert.Null(Http1Connection.RawTarget);
+        Assert.Null(Http1Connection.Path);
+        Assert.Null(Http1Connection.QueryString);
+
+        var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"{startOfRequestLine}CONNECT {rawTarget} HTTP/1.1\r\n"));
+        var reader = new SequenceReader<byte>(ros);
+        Assert.True(Parser.ParseRequestLine(ParsingHandler, ref reader));
+    }
+
     public StartLineTests()
     {
         MemoryPool = PinnedBlockMemoryPoolFactory.Create();


### PR DESCRIPTION
Fix https://github.com/dotnet/aspnetcore/issues/40747

Changing this in main first, will backport to 6 after review/merge.