### PR TITLE
[6.0] Allow leading CR/LF in HTTP request lines in Kestrel

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -38,6 +38,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
 
         public bool ParseRequestLine(TRequestHandler handler, ref SequenceReader<byte> reader)
         {
+            // Skip any leading \r or \n on the request line. This is not technically allowed,
+            // but apparently there are enough clients relying on this that it's worth allowing.
+            // Peek first as a minor performance optimization; it's a quick inlined check.
+            if (reader.TryPeek(out byte b) && (b == ByteCR || b == ByteLF))
+            {
+                reader.AdvancePastAny(ByteCR, ByteLF);
+            }
+
             if (reader.TryReadTo(out ReadOnlySpan<byte> requestLine, ByteLF, advancePastDelimiter: true))
             {
                 ParseRequestLine(handler, requestLine);

--- a/src/Servers/Kestrel/Core/test/StartLineTests.cs
+++ b/src/Servers/Kestrel/Core/test/StartLineTests.cs
@@ -6,6 +6,7 @@ using System.Buffers;
 using System.IO.Pipelines;
 using System.Text;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
@@ -514,6 +515,55 @@ namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests
             Assert.NotEqual(prevRequestUrl, Http1Connection.RawTarget);
 
             DifferentFormsWorkTogether();
+        }
+
+        public static IEnumerable<object[]> GetCrLfAndMethodCombinations()
+        {
+            // HTTP methods to test
+            var methods = new string[] {
+                HttpMethods.Connect,
+                HttpMethods.Delete,
+                HttpMethods.Get,
+                HttpMethods.Head,
+                HttpMethods.Options,
+                HttpMethods.Patch,
+                HttpMethods.Post,
+                HttpMethods.Put,
+                HttpMethods.Trace
+            };
+
+            // Prefixes to test
+            var crLfPrefixes = new string[] {
+                "\r",
+                "\n",
+                "\r\r\r\r\r",
+                "\r\n",
+                "\n\r"
+            };
+
+            foreach (var method in methods)
+            {
+                foreach (var prefix in crLfPrefixes)
+                {
+                    yield return new object[] { prefix, method };
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCrLfAndMethodCombinations))]
+        public void LeadingCrLfAreAllowed(string startOfRequestLine, string httpMethod)
+        {
+            var rawTarget = "http://localhost/path1?q=123&w=xyzw";
+            Http1Connection.Reset();
+            // RawTarget, Path, QueryString are null after reset
+            Assert.Null(Http1Connection.RawTarget);
+            Assert.Null(Http1Connection.Path);
+            Assert.Null(Http1Connection.QueryString);
+
+            var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"{startOfRequestLine}{httpMethod} {rawTarget} HTTP/1.1\r\n"));
+            var reader = new SequenceReader<byte>(ros);
+            Assert.True(Parser.ParseRequestLine(ParsingHandler, ref reader));
         }
 
         public StartLineTests()


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/40833 to release/6.0

## Description

Some clients send \r or \n characters before the start of the HTTP request line. While this isn't technically allowed per spec, it's common enough that other servers support it.

Fixes #40747

## Customer Impact

Without this change, a `BadHttpRequestException` is thrown when clients send such requests.

## Regression?

- [ ] Yes
- [x] No


## Risk

- [ ] High
- [ ] Medium
- [x] Low

This is accepted by other servers (including IIS).

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
