### PR TITLE
Use UtcNow instead of Now in W3CLogger Tests

### DIFF
--- a/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
@@ -16,7 +16,7 @@ public class W3CLoggerTests
     public async Task WritesDateTime()
     {
         var path = Path.GetTempFileName() + "_";
-        var now = DateTime.Now;
+        var now = DateTime.UtcNow;
         var options = new W3CLoggerOptions()
         {
             LoggingFields = W3CLoggingFields.Date | W3CLoggingFields.Time,

--- a/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
@@ -85,7 +85,7 @@ public class W3CLoggingMiddlewareTests
         httpContext.Request.Headers["Cookie"] = "Snickerdoodle";
         httpContext.Response.StatusCode = 200;
 
-        var now = DateTime.Now;
+        var now = DateTime.UtcNow;
         await middleware.Invoke(httpContext);
         await logger.Processor.WaitForWrites(4).DefaultTimeout();
 
@@ -119,7 +119,7 @@ public class W3CLoggingMiddlewareTests
 
         var httpContext = new DefaultHttpContext();
 
-        var now = DateTime.Now;
+        var now = DateTime.UtcNow;
         await middleware.Invoke(httpContext);
         await logger.Processor.WaitForWrites(4).DefaultTimeout();
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/40844