### PR TITLE
Increase a few IIS test timeouts

### DIFF
--- a/src/Hosting/Server.IntegrationTesting/src/Common/DeploymentResult.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/DeploymentResult.cs
@@ -62,5 +62,9 @@ public class DeploymentResult
     /// <param name="baseHandler"></param>
     /// <returns></returns>
     public HttpClient CreateHttpClient(HttpMessageHandler baseHandler) =>
-        new HttpClient(new LoggingHandler(_loggerFactory, baseHandler)) { BaseAddress = new Uri(ApplicationBaseUri) };
+        new HttpClient(new LoggingHandler(_loggerFactory, baseHandler))
+        {
+            BaseAddress = new Uri(ApplicationBaseUri),
+            Timeout = TimeSpan.FromSeconds(200),
+        };
 }

--- a/src/Hosting/Server.IntegrationTesting/src/Deployers/NginxDeployer.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Deployers/NginxDeployer.cs
@@ -77,6 +77,7 @@ public class NginxDeployer : SelfHostDeployer
             // Target actual address to avoid going through Nginx proxy
             using (var httpClient = new HttpClient())
             {
+                httpClient.Timeout = TimeSpan.FromSeconds(200);
                 var response = await RetryHelper.RetryRequest(() =>
                 {
                     return httpClient.GetAsync(redirectUri);

--- a/src/Hosting/Server.IntegrationTesting/src/Deployers/RemoteWindowsDeployer/RemoteWindowsDeployer.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Deployers/RemoteWindowsDeployer/RemoteWindowsDeployer.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -254,8 +254,8 @@ public class RemoteWindowsDeployer : ApplicationDeployer
 
                 runScriptsOnRemoteServerProcess.StartAndCaptureOutAndErrToLogger(serverAction, Logger);
 
-                // Wait a second for the script to run or fail. The StartServer script will only terminate when the Deployer is disposed,
-                // so we don't want to wait for it to terminate here because it would deadlock.
+                // Wait a minute for the script to run or fail. The StartServer script will only terminate when the
+                // Deployer is disposed, so we don't want to wait for it to terminate here because it would deadlock.
                 await Task.Delay(TimeSpan.FromMinutes(1));
 
                 if (runScriptsOnRemoteServerProcess.HasExited && runScriptsOnRemoteServerProcess.ExitCode != 0)

--- a/src/Hosting/Server.IntegrationTesting/src/Deployers/SelfHostDeployer.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Deployers/SelfHostDeployer.cs
@@ -192,10 +192,10 @@ public class SelfHostDeployer : ApplicationDeployer
             // Host may not write startup messages, in which case assume it started
             if (DeploymentParameters.StatusMessagesEnabled)
             {
-                // The timeout here is large, because we don't know how long the test could need
-                // We cover a lot of error cases above, but I want to make sure we eventually give up and don't hang the build
-                // just in case we missed one -anurse
-                await started.Task.TimeoutAfter(TimeSpan.FromMinutes(10));
+                // The timeout here is large, because we don't know how long the test could need. We cover a lot
+                // of error cases above, but I want to make sure we eventually give up and don't hang the build
+                // just in case we missed one.
+                await started.Task.TimeoutAfter(TimeSpan.FromMinutes(15));
             }
 
             return (url: actualUrl ?? hintUrl, hostExitToken: hostExitTokenSource.Token);

--- a/src/Hosting/TestHost/src/TestServer.cs
+++ b/src/Hosting/TestHost/src/TestServer.cs
@@ -152,7 +152,11 @@ public class TestServer : IServer
     /// </summary>
     public HttpClient CreateClient()
     {
-        return new HttpClient(CreateHandler()) { BaseAddress = BaseAddress };
+        return new HttpClient(CreateHandler())
+        {
+            BaseAddress = BaseAddress,
+            Timeout = TimeSpan.FromSeconds(200),
+        };
     }
 
     /// <summary>

--- a/src/Servers/IIS/IIS/perf/Microbenchmarks/PlaintextBenchmark.cs
+++ b/src/Servers/IIS/IIS/perf/Microbenchmarks/PlaintextBenchmark.cs
@@ -27,7 +27,8 @@ public class PlaintextBenchmark
         // Recreate client, TestServer.Client has additional logging that can hurt performance
         _client = new HttpClient()
         {
-            BaseAddress = _server.HttpClient.BaseAddress
+            BaseAddress = _server.HttpClient.BaseAddress,
+            Timeout = TimeSpan.FromSeconds(200),
         };
     }
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/CompressionTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/CompressionTests.cs
@@ -130,6 +130,7 @@ public class CompressionTests : FixtureLoggedTest
         var client = new HttpClient(handler)
         {
             BaseAddress = _fixture.Client.BaseAddress,
+            Timeout = TimeSpan.FromSeconds(200),
         };
         client.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
         client.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue("identity", 0));

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/FrebTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/FrebTests.cs
@@ -90,10 +90,7 @@ public class FrebTests : IISFunctionalTestBase
         AssertFrebLogs(result, new FrebLogItem("ANCM_INPROC_ASYNC_COMPLETION_COMPLETION", "2"));
     }
 
-    // I think this test is flaky due to freb file not being created quickly enough.
-    // Adding extra logging, marking as flaky, and repeating should help
     [ConditionalFact]
-    [Repeat(10)]
     [RequiresIIS(IISCapability.FailedRequestTracingModule)]
     public async Task CheckFrebDisconnect()
     {

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Http2Tests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Http2Tests.cs
@@ -356,7 +356,7 @@ public class Http2Tests
     {
         var handler = new HttpClientHandler();
         handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
-        using HttpClient client = new HttpClient(handler);
+        using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(200) };
         client.DefaultRequestVersion = HttpVersion.Version11;
         var response = await client.GetStringAsync(Fixture.Client.BaseAddress + "Reset_Http1_NotSupported");
         Assert.Equal("Hello World", response);
@@ -370,7 +370,7 @@ public class Http2Tests
     {
         var handler = new HttpClientHandler();
         handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
-        using HttpClient client = new HttpClient(handler);
+        using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(200) };
         client.DefaultRequestVersion = HttpVersion.Version20;
         var response = await client.GetStringAsync(Fixture.Client.BaseAddress + "Reset_PriorOSVersions_NotSupported");
         Assert.Equal("Hello World", response);
@@ -390,7 +390,7 @@ public class Http2Tests
         var handler = new HttpClientHandler();
         handler.MaxResponseHeadersLength = 128;
         handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
-        using var client = new HttpClient(handler);
+        using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(200) };
         client.DefaultRequestVersion = http2 ? HttpVersion.Version20 : HttpVersion.Version11;
         return await client.GetAsync(uri);
     }

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/EventLogHelpers.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/EventLogHelpers.cs
@@ -88,7 +88,7 @@ public class EventLogHelpers
         var processIdString = $"Process Id: {deploymentResult.HostProcess.Id}.";
 
         // Event log messages round down to the nearest second, so subtract 5 seconds to make sure we get event logs
-        var processStartTime = deploymentResult.HostProcess.StartTime.AddSeconds(-5);
+        var processStartTime = deploymentResult.HostProcess.StartTime.AddSeconds(-10);
         for (var i = eventLog.Entries.Count - 1; i >= 0; i--)
         {
             var eventLogEntry = eventLog.Entries[i];

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/Helpers.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/Helpers.cs
@@ -40,7 +40,11 @@ public static class Helpers
     {
         async Task RunRequests()
         {
-            var connection = new HttpClient() { BaseAddress = httpClient.BaseAddress };
+            var connection = new HttpClient()
+            {
+                BaseAddress = httpClient.BaseAddress,
+                Timeout = TimeSpan.FromSeconds(200),
+            };
 
             for (int j = 0; j < 10; j++)
             {

--- a/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
@@ -1354,7 +1354,8 @@ public class StartupTests : IISFunctionalTestBase
         };
         var client = new HttpClient(handler)
         {
-            BaseAddress = new Uri(deploymentParameters.ApplicationBaseUriHint)
+            BaseAddress = new Uri(deploymentParameters.ApplicationBaseUriHint),
+            Timeout = TimeSpan.FromSeconds(200),
         };
 
         if (DeployerSelector.HasNewHandler)

--- a/src/Servers/IIS/IIS/test/IIS.FunctionalTests/Http2TrailersResetTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.FunctionalTests/Http2TrailersResetTests.cs
@@ -503,7 +503,7 @@ public class Http2TrailerResetTests : FunctionalTestsBase
         var handler = new HttpClientHandler();
         handler.MaxResponseHeadersLength = 128;
         handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
-        var client = new HttpClient(handler);
+        var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(200) };
         return client;
     }
 
@@ -512,7 +512,7 @@ public class Http2TrailerResetTests : FunctionalTestsBase
         var handler = new HttpClientHandler();
         handler.MaxResponseHeadersLength = 128;
         handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
-        using var client = new HttpClient(handler);
+        using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(200) };
         client.DefaultRequestVersion = http2 ? HttpVersion.Version20 : HttpVersion.Version11;
         return await client.GetAsync(uri);
     }

--- a/src/Servers/IIS/IIS/test/IIS.FunctionalTests/Http3Tests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.FunctionalTests/Http3Tests.cs
@@ -173,6 +173,6 @@ public class Http3Tests : FunctionalTestsBase
         var handler = new HttpClientHandler();
         // Needed on CI, the IIS Express cert we use isn't trusted there.
         handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
-        return new HttpClient(handler);
+        return new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(200) };
     }
 }

--- a/src/Servers/IIS/IIS/test/IIS.Tests/Utilities/TestServer.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/Utilities/TestServer.cs
@@ -106,7 +106,8 @@ public class TestServer : IDisposable
 
         HttpClient = new HttpClient(new LoggingHandler(new SocketsHttpHandler(), _loggerFactory.CreateLogger<TestServer>()))
         {
-            BaseAddress = BaseUri
+            BaseAddress = BaseUri,
+            Timeout = TimeSpan.FromSeconds(200),
         };
     }
 

--- a/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/WebSocketTests.cs
+++ b/src/Servers/IIS/IIS/test/IISExpress.FunctionalTests/InProcess/WebSocketTests.cs
@@ -31,7 +31,7 @@ public class WebSocketsTests
     [ConditionalFact]
     public async Task RequestWithBody_NotUpgradable()
     {
-        using var client = new HttpClient();
+        using var client = new HttpClient() { Timeout = TimeSpan.FromSeconds(200) };
         using var response = await client.PostAsync(_requestUri + "WebSocketNotUpgradable", new StringContent("Hello World"));
         response.EnsureSuccessStatusCode();
     }
@@ -39,7 +39,7 @@ public class WebSocketsTests
     [ConditionalFact]
     public async Task RequestWithoutBody_Upgradable()
     {
-        using var client = new HttpClient();
+        using var client = new HttpClient() { Timeout = TimeSpan.FromSeconds(200) };
         // POST with Content-Length: 0 counts as not having a body.
         using var response = await client.PostAsync(_requestUri + "WebSocketUpgradable", new StringContent(""));
         response.EnsureSuccessStatusCode();

--- a/src/Servers/IIS/IIS/test/testassets/IIS.Common.TestLib/TestConnections.cs
+++ b/src/Servers/IIS/IIS/test/testassets/IIS.Common.TestLib/TestConnections.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting;
 /// </summary>
 public class TestConnection : IDisposable
 {
-    private static readonly TimeSpan Timeout = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan Timeout = TimeSpan.FromMinutes(2);
 
     private readonly bool _ownsSocket;
     private readonly Socket _socket;

--- a/src/Servers/IIS/IIS/test/testassets/IIS.Common.TestLib/TimeoutExtensions.cs
+++ b/src/Servers/IIS/IIS/test/testassets/IIS.Common.TestLib/TimeoutExtensions.cs
@@ -10,5 +10,5 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting;
 
 public static class TimeoutExtensions
 {
-    public static TimeSpan DefaultTimeoutValue = TimeSpan.FromSeconds(300);
+    public static TimeSpan DefaultTimeoutValue = TimeSpan.FromMinutes(10);
 }

--- a/src/Servers/IIS/IISIntegration/test/Tests/IISMiddlewareTests.cs
+++ b/src/Servers/IIS/IISIntegration/test/Tests/IISMiddlewareTests.cs
@@ -135,7 +135,7 @@ public class IISMiddlewareTests
         request.Headers.TryAddWithoutValidation("MS-ASPNETCORE-EVENT", shutdownEvent);
         var response = await server.CreateClient().SendAsync(request);
 
-        await applicationStoppingFired.Task.TimeoutAfter(TimeSpan.FromSeconds(5));
+        await applicationStoppingFired.Task.TimeoutAfter(TimeSpan.FromSeconds(10));
         Assert.False(requestExecuted.Task.IsCompleted);
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
     }
@@ -195,7 +195,7 @@ public class IISMiddlewareTests
         var response = await server.CreateClient().SendAsync(request);
 
         Assert.False(applicationStoppingFired.Task.IsCompleted);
-        await requestExecuted.Task.TimeoutAfter(TimeSpan.FromSeconds(1));
+        await requestExecuted.Task.TimeoutAfter(TimeSpan.FromSeconds(2));
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
@@ -240,7 +240,7 @@ public class IISMiddlewareTests
         var response = await server.CreateClient().SendAsync(request);
 
         Assert.False(applicationStoppingFired.Task.IsCompleted);
-        await requestExecuted.Task.TimeoutAfter(TimeSpan.FromSeconds(1));
+        await requestExecuted.Task.TimeoutAfter(TimeSpan.FromSeconds(2));
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
@@ -285,7 +285,7 @@ public class IISMiddlewareTests
         var response = await server.CreateClient().SendAsync(request);
 
         Assert.False(applicationStoppingFired.Task.IsCompleted);
-        await requestExecuted.Task.TimeoutAfter(TimeSpan.FromSeconds(1));
+        await requestExecuted.Task.TimeoutAfter(TimeSpan.FromSeconds(2));
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeploymentResult.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeploymentResult.cs
@@ -33,7 +33,8 @@ public class IISDeploymentResult : DeploymentResult
     {
         return new HttpClient(new LoggingHandler(messageHandler, Logger))
         {
-            BaseAddress = base.HttpClient.BaseAddress
+            BaseAddress = base.HttpClient.BaseAddress,
+            Timeout = TimeSpan.FromSeconds(200),
         };
     }
 

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
@@ -21,7 +21,7 @@ public class IISExpressDeployer : IISDeployerBase
     private const string FailedToInitializeBindingsMessage = "Failed to initialize site bindings";
     private const string UnableToStartIISExpressMessage = "Unable to start iisexpress.";
     private const int MaximumAttempts = 5;
-    private readonly TimeSpan ShutdownTimeSpan = Debugger.IsAttached ? TimeSpan.FromMinutes(60) : TimeSpan.FromMinutes(1);
+    private readonly TimeSpan ShutdownTimeSpan = Debugger.IsAttached ? TimeSpan.FromMinutes(60) : TimeSpan.FromMinutes(2);
     private static readonly Regex UrlDetectorRegex = new Regex(@"^\s*Successfully registered URL ""(?<url>[^""]+)"" for site.*$");
 
     private Process _hostProcess;
@@ -234,10 +234,10 @@ public class IISExpressDeployer : IISDeployerBase
                 }
 
                 // Wait for the app to start
-                // The timeout here is large, because we don't know how long the test could need
-                // We cover a lot of error cases above, but I want to make sure we eventually give up and don't hang the build
+                // The timeout here is large, because we don't know how long the test could need. We cover a lot
+                // of error cases above, but I want to make sure we eventually give up and don't hang the build
                 // just in case we missed one -anurse
-                if (!await started.Task.TimeoutAfter(TimeSpan.FromMinutes(10)))
+                if (!await started.Task.TimeoutAfter(TimeSpan.FromMinutes(15)))
                 {
                     Logger.LogInformation("iisexpress Process {pid} failed to bind to port {port}, trying again", process.Id, port);
 


### PR DESCRIPTION
- double all `HttpClient.Timeout` values
- increate max. `TimeoutAfter(...)` timeout to 15 minutes (from 10)
  - double values that weren't 10 minutes
- double `TestConnection.Timeout` and `IISExpressDeployer.ShutdownTimeSpan`
  - problems acquiring logs after shutdown seem common
- nearly double `TimeoutExtensions.DefaultTimeoutValue`
- remove `[Repeat]` on `CheckFrebDisconnect(...)` because it makes test _more_ flaky
- check more events in `EventLogHelpers`

nit: Update a couple of timeout-related comments