### PR TITLE
[release/6.0] Unquarantine test

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/StartupTests.cs
@@ -468,7 +468,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
 
         [ConditionalFact]
         [RequiresNewHandler]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/40036")]
         public async Task StartupTimeoutIsApplied()
         {
             // From what we can tell, this failure is due to ungraceful shutdown.


### PR DESCRIPTION
Per discussion with @adityamandaleeka for https://github.com/dotnet/aspnetcore/issues/40036 we decided to keep these tests running since it was a one off random failure

@dougbu I assume we need to wait for a servicing window to get this in?