### PR TITLE
Virtual method for OnCheckSlidingExpiration

### DIFF
--- a/src/Security/Authentication/Cookies/src/CookieAuthenticationEvents.cs
+++ b/src/Security/Authentication/Cookies/src/CookieAuthenticationEvents.cs
@@ -109,10 +109,16 @@ public class CookieAuthenticationEvents
     }
 
     /// <summary>
-    /// Invoked to validate the prinicipal.
+    /// Invoked to validate the principal.
     /// </summary>
     /// <param name="context">The <see cref="CookieValidatePrincipalContext"/>.</param>
     public virtual Task ValidatePrincipal(CookieValidatePrincipalContext context) => OnValidatePrincipal(context);
+    
+    /// <summary>
+    /// Invoked to check if the cookie should be renewed.
+    /// </summary>
+    /// <param name="context">The <see cref="CookieSlidingExpirationContext"/>.</param>
+    public virtual Task CheckSlidingExpiration(CookieSlidingExpirationContext context) => OnCheckSlidingExpiration(context);
 
     /// <summary>
     /// Invoked during sign in.

--- a/src/Security/Authentication/Cookies/src/CookieAuthenticationHandler.cs
+++ b/src/Security/Authentication/Cookies/src/CookieAuthenticationHandler.cs
@@ -93,7 +93,7 @@ public class CookieAuthenticationHandler : SignInAuthenticationHandler<CookieAut
             {
                 ShouldRenew = timeRemaining < timeElapsed,
             };
-            await Options.Events.OnCheckSlidingExpiration(eventContext);
+            await Options.Events.CheckSlidingExpiration(eventContext);
 
             if (eventContext.ShouldRenew)
             {

--- a/src/Security/Authentication/Cookies/src/PublicAPI.Shipped.txt
+++ b/src/Security/Authentication/Cookies/src/PublicAPI.Shipped.txt
@@ -125,5 +125,4 @@ virtual Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationEvents.S
 virtual Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationEvents.SigningIn(Microsoft.AspNetCore.Authentication.Cookies.CookieSigningInContext! context) -> System.Threading.Tasks.Task!
 virtual Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationEvents.SigningOut(Microsoft.AspNetCore.Authentication.Cookies.CookieSigningOutContext! context) -> System.Threading.Tasks.Task!
 virtual Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationEvents.ValidatePrincipal(Microsoft.AspNetCore.Authentication.Cookies.CookieValidatePrincipalContext! context) -> System.Threading.Tasks.Task!
-virtual Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationEvents.CheckSlidingExpiration(Microsoft.AspNetCore.Authentication.Cookies.CookieSlidingExpirationContext! context) -> System.Threading.Tasks.Task!
 virtual Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationHandler.FinishResponseAsync() -> System.Threading.Tasks.Task!

--- a/src/Security/Authentication/Cookies/src/PublicAPI.Shipped.txt
+++ b/src/Security/Authentication/Cookies/src/PublicAPI.Shipped.txt
@@ -125,4 +125,5 @@ virtual Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationEvents.S
 virtual Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationEvents.SigningIn(Microsoft.AspNetCore.Authentication.Cookies.CookieSigningInContext! context) -> System.Threading.Tasks.Task!
 virtual Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationEvents.SigningOut(Microsoft.AspNetCore.Authentication.Cookies.CookieSigningOutContext! context) -> System.Threading.Tasks.Task!
 virtual Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationEvents.ValidatePrincipal(Microsoft.AspNetCore.Authentication.Cookies.CookieValidatePrincipalContext! context) -> System.Threading.Tasks.Task!
+virtual Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationEvents.CheckSlidingExpiration(Microsoft.AspNetCore.Authentication.Cookies.CookieSlidingExpirationContext! context) -> System.Threading.Tasks.Task!
 virtual Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationHandler.FinishResponseAsync() -> System.Threading.Tasks.Task!

--- a/src/Security/Authentication/Cookies/src/PublicAPI.Unshipped.txt
+++ b/src/Security/Authentication/Cookies/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
 *REMOVED*Microsoft.AspNetCore.Authentication.Cookies.PostConfigureCookieAuthenticationOptions.PostConfigure(string! name, Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationOptions! options) -> void
 Microsoft.AspNetCore.Authentication.Cookies.PostConfigureCookieAuthenticationOptions.PostConfigure(string? name, Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationOptions! options) -> void
+virtual Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationEvents.CheckSlidingExpiration(Microsoft.AspNetCore.Authentication.Cookies.CookieSlidingExpirationContext! context) -> System.Threading.Tasks.Task!


### PR DESCRIPTION
- Add virtual method for CheckSlidingExpiration
- Typo fix ~~prinicipal~~ **prinicipal**

# Virtual method for OnCheckSlidingExpiration

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] ~~You've included unit or integration tests for your change, where applicable.~~
- [x] ~~You've included inline docs for your change, where applicable.~~
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Added virtual method for OnCheckSlidingExpiration

## Description

CheckSlidingExpiration

Fixes #{[40899](https://github.com/dotnet/aspnetcore/issues/40899)}