### PR TITLE
Add option to enable binlogs for manual internal builds

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -91,7 +91,7 @@ variables:
   - name: sourceIndexPackageSource
     value: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   - group: source-dot-net stage1 variables
-- ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')), eq(parameters.produceBinlogs, 'true') }}:
+- ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), eq(parameters.produceBinlogs, 'true')) }}:
   - name: _BuildArgs
     value: '/p:SkipTestBuild=true /p:PostBuildSign=$(PostBuildSign)'
   - name: _PublishArgs

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -24,6 +24,11 @@ parameters:
   default: false
   displayName: Skip tests?
   type: boolean
+# Choose whether to enable binlogs when running pipeline manually.
+- name: produceBinlogs
+  default: false
+  displayName: Produce binlogs?
+  type: boolean
 # Choose whether to test source indexing. Ignored in public builds.
 # Will cause inaccessible links on https://source.dot.net/ unless commits are also available in GitHub.
 - name: testSourceIndexing
@@ -86,7 +91,7 @@ variables:
   - name: sourceIndexPackageSource
     value: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   - group: source-dot-net stage1 variables
-- ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')), eq(parameters.produceBinlogs, 'true') }}:
   - name: _BuildArgs
     value: '/p:SkipTestBuild=true /p:PostBuildSign=$(PostBuildSign)'
   - name: _PublishArgs


### PR DESCRIPTION
Makes it easier to grab binlogs for failures that are specific to internal builds. By default, binlogs are still off in internal builds.