### PR TITLE
Use Microsoft.JSInterop to calculate package version

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -97,8 +97,9 @@
     Condition=" '$(PublishInstallerBaseVersion)' == 'true'">
     <!--
       This target is defined in eng/targets/Packaging.targets and Npm.Common.targets and included in every C#, F#,
-      and npm project. We use Microsoft.AspNetCore.App.Runtime.csproj because it is shipping (we need a stable
-      version string to use for productVersion.txt).
+      and npm project. We use Microsoft.JSInterop.JS.npmproj because it is shipping (we need a stable
+      version string to use for productVersion.txt), and because it won't break when the SDK requires a newer
+      desktop MSBuild than exists on the build machine.
     -->
     <MSBuild Projects="$(RepoRoot)src\JSInterop\Microsoft.JSInterop.JS\src\Microsoft.JSInterop.JS.npmproj"
         Properties="DisableYarnCheck=true;ExcludeFromBuild=false"

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -100,7 +100,7 @@
       and npm project. We use Microsoft.AspNetCore.App.Runtime.csproj because it is shipping (we need a stable
       version string to use for productVersion.txt).
     -->
-    <MSBuild Projects="$(RepoRoot)src\Framework\App.Runtime\src\Microsoft.AspNetCore.App.Runtime.csproj"
+    <MSBuild Projects="$(RepoRoot)src\JSInterop\Microsoft.JSInterop.JS\src\Microsoft.JSInterop.JS.npmproj"
         Properties="DisableYarnCheck=true;ExcludeFromBuild=false"
         Targets="_GetPackageVersionInfo">
       <Output TaskParameter="TargetOutputs" ItemName="_ResolvedProductVersionInfo" />


### PR DESCRIPTION
Should fix the broken internal builds - the SDK requires a newer MSBuild than is on the build machines, so we get the version info from a project that doesn't use the SDK.

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1686377&view=results