### PR TITLE
Fix W3CLogger tests

### DIFF
--- a/src/Middleware/HttpLogging/src/W3CLoggerProcessor.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggerProcessor.cs
@@ -22,7 +22,7 @@ internal class W3CLoggerProcessor : FileLoggerProcessor
     {
         await WriteMessageAsync("#Version: 1.0", streamWriter, cancellationToken);
 
-        await WriteMessageAsync("#Start-Date: " + DateTimeOffset.UtcNow.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture), streamWriter, cancellationToken);
+        await WriteMessageAsync("#Start-Date: " + DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture), streamWriter, cancellationToken);
 
         await WriteMessageAsync(GetFieldsDirective(), streamWriter, cancellationToken);
     }

--- a/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
@@ -39,7 +39,8 @@ public class W3CLoggerTests
                 Assert.StartsWith("#Start-Date: ", lines[1]);
                 var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
                 // Assert that the log was written in the last 10 seconds
-                Assert.True(now.Subtract(startDate).TotalSeconds < 10);
+                var delta = now.Subtract(startDate).TotalSeconds;
+                Assert.True(delta < 10 && delta >= 0);
 
                 Assert.Equal("#Fields: date time", lines[2]);
 
@@ -80,7 +81,8 @@ public class W3CLoggerTests
                 Assert.StartsWith("#Start-Date: ", lines[1]);
                 var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
                 // Assert that the log was written in the last 10 seconds
-                Assert.True(now.Subtract(startDate).TotalSeconds < 10);
+                var delta = now.Subtract(startDate).TotalSeconds;
+                Assert.True(delta < 10 && delta >= 0);
 
                 Assert.Equal("#Fields: cs-uri-query sc-status cs-host", lines[2]);
                 Assert.Equal("- - -", lines[3]);

--- a/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
@@ -40,7 +40,7 @@ public class W3CLoggerTests
                 var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
                 // Assert that the log was written in the last 10 seconds
                 var delta = now.Subtract(startDate).TotalSeconds;
-                Assert.Range(delta, 0, 10);
+                Assert.InRange(delta, 0, 10);
 
                 Assert.Equal("#Fields: date time", lines[2]);
 
@@ -82,7 +82,7 @@ public class W3CLoggerTests
                 var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
                 // Assert that the log was written in the last 10 seconds
                 var delta = now.Subtract(startDate).TotalSeconds;
-                Assert.Range(delta, 0, 10);
+                Assert.InRange(delta, 0, 10);
 
                 Assert.Equal("#Fields: cs-uri-query sc-status cs-host", lines[2]);
                 Assert.Equal("- - -", lines[3]);

--- a/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
@@ -39,7 +39,7 @@ public class W3CLoggerTests
                 Assert.StartsWith("#Start-Date: ", lines[1]);
                 var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
                 // Assert that the log was written in the last 10 seconds
-                var delta = now.Subtract(startDate).TotalSeconds;
+                var delta = startDate.Subtract(now).TotalSeconds;
                 Assert.InRange(delta, 0, 10);
 
                 Assert.Equal("#Fields: date time", lines[2]);
@@ -81,7 +81,7 @@ public class W3CLoggerTests
                 Assert.StartsWith("#Start-Date: ", lines[1]);
                 var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
                 // Assert that the log was written in the last 10 seconds
-                var delta = now.Subtract(startDate).TotalSeconds;
+                var delta = startDate.Subtract(now).TotalSeconds;
                 Assert.InRange(delta, 0, 10);
 
                 Assert.Equal("#Fields: cs-uri-query sc-status cs-host", lines[2]);

--- a/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
@@ -40,7 +40,7 @@ public class W3CLoggerTests
                 var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
                 // Assert that the log was written in the last 10 seconds
                 var delta = now.Subtract(startDate).TotalSeconds;
-                Assert.True(delta < 10 && delta >= 0);
+                Assert.Range(delta, 0, 10);
 
                 Assert.Equal("#Fields: date time", lines[2]);
 
@@ -82,7 +82,7 @@ public class W3CLoggerTests
                 var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
                 // Assert that the log was written in the last 10 seconds
                 var delta = now.Subtract(startDate).TotalSeconds;
-                Assert.True(delta < 10 && delta >= 0);
+                Assert.Range(delta, 0, 10);
 
                 Assert.Equal("#Fields: cs-uri-query sc-status cs-host", lines[2]);
                 Assert.Equal("- - -", lines[3]);

--- a/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
@@ -39,8 +39,9 @@ public class W3CLoggerTests
                 Assert.StartsWith("#Start-Date: ", lines[1]);
                 var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
                 // Assert that the log was written in the last 10 seconds
+                // W3CLogger writes start-time to second precision, so delta could be as low as -0.999...
                 var delta = startDate.Subtract(now).TotalSeconds;
-                Assert.InRange(delta, 0, 10);
+                Assert.InRange(delta, -1, 10);
 
                 Assert.Equal("#Fields: date time", lines[2]);
 
@@ -81,8 +82,9 @@ public class W3CLoggerTests
                 Assert.StartsWith("#Start-Date: ", lines[1]);
                 var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
                 // Assert that the log was written in the last 10 seconds
+                // W3CLogger writes start-time to second precision, so delta could be as low as -0.999...
                 var delta = startDate.Subtract(now).TotalSeconds;
-                Assert.InRange(delta, 0, 10);
+                Assert.InRange(delta, -1, 10);
 
                 Assert.Equal("#Fields: cs-uri-query sc-status cs-host", lines[2]);
                 Assert.Equal("- - -", lines[3]);

--- a/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
@@ -96,7 +96,7 @@ public class W3CLoggingMiddlewareTests
         var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
         // Assert that the log was written in the last 10 seconds
         var delta = now.Subtract(startDate).TotalSeconds;
-        Assert.Range(delta, 0, 10);
+        Assert.InRange(delta, 0, 10);
 
         Assert.Equal("#Fields: date time c-ip s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status time-taken cs-version cs-host cs(User-Agent) cs(Referer)", lines[2]);
         Assert.DoesNotContain(lines[3], "Snickerdoodle");
@@ -131,7 +131,7 @@ public class W3CLoggingMiddlewareTests
         var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
         // Assert that the log was written in the last 10 seconds
         var delta = now.Subtract(startDate).TotalSeconds;
-        Assert.Range(delta, 0, 10);
+        Assert.InRange(delta, 0, 10);
 
         Assert.Equal("#Fields: time-taken", lines[2]);
         double num;

--- a/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
@@ -95,7 +95,7 @@ public class W3CLoggingMiddlewareTests
         Assert.StartsWith("#Start-Date: ", lines[1]);
         var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
         // Assert that the log was written in the last 10 seconds
-        var delta = now.Subtract(startDate).TotalSeconds;
+        var delta = startDate.Subtract(now).TotalSeconds;
         Assert.InRange(delta, 0, 10);
 
         Assert.Equal("#Fields: date time c-ip s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status time-taken cs-version cs-host cs(User-Agent) cs(Referer)", lines[2]);
@@ -130,7 +130,7 @@ public class W3CLoggingMiddlewareTests
         Assert.StartsWith("#Start-Date: ", lines[1]);
         var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
         // Assert that the log was written in the last 10 seconds
-        var delta = now.Subtract(startDate).TotalSeconds;
+        var delta = startDate.Subtract(now).TotalSeconds;
         Assert.InRange(delta, 0, 10);
 
         Assert.Equal("#Fields: time-taken", lines[2]);

--- a/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
@@ -95,8 +95,9 @@ public class W3CLoggingMiddlewareTests
         Assert.StartsWith("#Start-Date: ", lines[1]);
         var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
         // Assert that the log was written in the last 10 seconds
+        // W3CLogger writes start-time to second precision, so delta could be as low as -0.999...
         var delta = startDate.Subtract(now).TotalSeconds;
-        Assert.InRange(delta, 0, 10);
+        Assert.InRange(delta, -1, 10);
 
         Assert.Equal("#Fields: date time c-ip s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status time-taken cs-version cs-host cs(User-Agent) cs(Referer)", lines[2]);
         Assert.DoesNotContain(lines[3], "Snickerdoodle");
@@ -130,8 +131,9 @@ public class W3CLoggingMiddlewareTests
         Assert.StartsWith("#Start-Date: ", lines[1]);
         var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
         // Assert that the log was written in the last 10 seconds
+        // W3CLogger writes start-time to second precision, so delta could be as low as -0.999...
         var delta = startDate.Subtract(now).TotalSeconds;
-        Assert.InRange(delta, 0, 10);
+        Assert.InRange(delta, -1, 10);
 
         Assert.Equal("#Fields: time-taken", lines[2]);
         double num;

--- a/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
@@ -96,7 +96,7 @@ public class W3CLoggingMiddlewareTests
         var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
         // Assert that the log was written in the last 10 seconds
         var delta = now.Subtract(startDate).TotalSeconds;
-        Assert.True(delta < 10 && delta >= 0);
+        Assert.Range(delta, 0, 10);
 
         Assert.Equal("#Fields: date time c-ip s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status time-taken cs-version cs-host cs(User-Agent) cs(Referer)", lines[2]);
         Assert.DoesNotContain(lines[3], "Snickerdoodle");
@@ -131,7 +131,7 @@ public class W3CLoggingMiddlewareTests
         var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
         // Assert that the log was written in the last 10 seconds
         var delta = now.Subtract(startDate).TotalSeconds;
-        Assert.True(delta < 10 && delta >= 0);
+        Assert.Range(delta, 0, 10);
 
         Assert.Equal("#Fields: time-taken", lines[2]);
         double num;

--- a/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
@@ -95,7 +95,8 @@ public class W3CLoggingMiddlewareTests
         Assert.StartsWith("#Start-Date: ", lines[1]);
         var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
         // Assert that the log was written in the last 10 seconds
-        Assert.True(now.Subtract(startDate).TotalSeconds < 10);
+        var delta = now.Subtract(startDate).TotalSeconds;
+        Assert.True(delta < 10 && delta >= 0);
 
         Assert.Equal("#Fields: date time c-ip s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status time-taken cs-version cs-host cs(User-Agent) cs(Referer)", lines[2]);
         Assert.DoesNotContain(lines[3], "Snickerdoodle");
@@ -129,7 +130,8 @@ public class W3CLoggingMiddlewareTests
         Assert.StartsWith("#Start-Date: ", lines[1]);
         var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
         // Assert that the log was written in the last 10 seconds
-        Assert.True(now.Subtract(startDate).TotalSeconds < 10);
+        var delta = now.Subtract(startDate).TotalSeconds;
+        Assert.True(delta < 10 && delta >= 0);
 
         Assert.Equal("#Fields: time-taken", lines[2]);
         double num;


### PR DESCRIPTION
Discovered as part of https://github.com/dotnet/aspnetcore/issues/40844 - the tests just check if the time delta is less than 10 seconds, which means they still passed when the number was negative. That explains why they failed on some machines and not others before we unified on using `UTCNow` - they'd fail in time zones that were ahead of UTC.