### PR TITLE
Fix Kestrel conn close on shutdown while response is writing

### DIFF
--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2FrameWriterBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2FrameWriterBenchmark.cs
@@ -20,6 +20,7 @@ public class Http2FrameWriterBenchmark
     private Pipe _pipe;
     private Http2FrameWriter _frameWriter;
     private HttpResponseHeaders _responseHeaders;
+    private Http2Stream _stream;
 
     [GlobalSetup]
     public void GlobalSetup()
@@ -45,6 +46,8 @@ public class Http2FrameWriterBenchmark
             _memoryPool,
             serviceContext);
 
+        _stream = new MockHttp2Stream(TestContextFactory.CreateHttp2StreamContext(streamId: 0));
+
         _responseHeaders = new HttpResponseHeaders();
         var headers = (IHeaderDictionary)_responseHeaders;
         headers.ContentType = "application/json";
@@ -54,7 +57,7 @@ public class Http2FrameWriterBenchmark
     [Benchmark]
     public void WriteResponseHeaders()
     {
-        _frameWriter.WriteResponseHeaders(0, 200, Http2HeadersFrameFlags.END_HEADERS, _responseHeaders);
+        _frameWriter.WriteResponseHeaders(_stream, 200, endStream: true, _responseHeaders);
     }
 
     [GlobalCleanup]
@@ -62,5 +65,17 @@ public class Http2FrameWriterBenchmark
     {
         _pipe.Writer.Complete();
         _memoryPool?.Dispose();
+    }
+
+    private class MockHttp2Stream : Http2Stream
+    {
+        public MockHttp2Stream(Http2StreamContext context)
+        {
+            Initialize(context);
+        }
+
+        public override void Execute()
+        {
+        }
     }
 }

--- a/src/Servers/Kestrel/shared/test/TestContextFactory.cs
+++ b/src/Servers/Kestrel/shared/test/TestContextFactory.cs
@@ -155,7 +155,7 @@ internal static class TestContextFactory
             localEndPoint: localEndPoint,
             remoteEndPoint: remoteEndPoint,
             streamId: streamId ?? 0,
-            streamLifetimeHandler: streamLifetimeHandler,
+            streamLifetimeHandler: streamLifetimeHandler ?? new TestHttp2StreamLifetimeHandler(),
             clientPeerSettings: clientPeerSettings ?? new Http2PeerSettings(),
             serverPeerSettings: serverPeerSettings ?? new Http2PeerSettings(),
             frameWriter: frameWriter,
@@ -199,6 +199,17 @@ internal static class TestContextFactory
         context.Transport = transport;
 
         return context;
+    }
+
+    private class TestHttp2StreamLifetimeHandler : IHttp2StreamLifetimeHandler
+    {
+        public void DecrementActiveClientStreamCount()
+        {
+        }
+
+        public void OnStreamCompleted(Http2Stream stream)
+        {
+        }
     }
 
     private class TestMultiplexedConnectionContext : MultiplexedConnectionContext

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
@@ -3,11 +3,16 @@
 
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Headers;
+using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Interop.FunctionalTests.Http2;
 
@@ -35,6 +40,92 @@ public class Http2RequestTests : LoggedTest
             Assert.Equal(HttpStatusCode.BadRequest, responseMessage.StatusCode);
             Assert.Equal("An HTTP/1.x request was sent to an HTTP/2 only endpoint.", await responseMessage.Content.ReadAsStringAsync());
         }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task GET_RequestReturnsLargeData_GracefulShutdownDuringRequest_RequestGracefullyCompletes(bool hasTrailers)
+    {
+        // Arrange
+        const int DataLength = 500_000;
+        var randomBytes = Enumerable.Range(1, DataLength).Select(i => (byte)((i % 10) + 48)).ToArray();
+
+        var syncPoint = new SyncPoint();
+
+        ILogger logger = null;
+        IHostApplicationLifetime hostApplicationLifetime = null;
+        var builder = CreateHostBuilder(
+            async c =>
+            {
+                await syncPoint.WaitToContinue();
+
+                var memory = c.Response.BodyWriter.GetMemory(randomBytes.Length);
+
+                logger.LogInformation($"Server writing {randomBytes.Length} bytes response");
+                randomBytes.CopyTo(memory);
+
+                logger.LogInformation($"Server advancing {randomBytes.Length} bytes response");
+                c.Response.BodyWriter.Advance(randomBytes.Length);
+
+                if (hasTrailers)
+                {
+                    c.Response.AppendTrailer("test-trailer", "value!");
+                }
+            },
+            protocol: HttpProtocols.Http2);
+
+        using var host = builder.Build();
+        logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Test");
+        hostApplicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+
+        var client = HttpHelpers.CreateClient();
+
+        // Act
+        await host.StartAsync().DefaultTimeout();
+
+        var longRunningTask = StartLongRunningRequestAsync(logger, host, client);
+
+        logger.LogInformation("Waiting for request on server");
+        await syncPoint.WaitForSyncPoint().DefaultTimeout();
+
+        logger.LogInformation("Stopping server");
+        var stopTask = host.StopAsync();
+
+        syncPoint.Continue();
+
+        var (readData, trailers) = await longRunningTask.DefaultTimeout();
+        await stopTask.DefaultTimeout();
+
+        // Assert
+        Assert.Equal(randomBytes, readData);
+        if (hasTrailers)
+        {
+            Assert.Equal("value!", trailers.GetValues("test-trailer").Single());
+        }
+    }
+
+    private static async Task<(byte[], HttpResponseHeaders)> StartLongRunningRequestAsync(ILogger logger, IHost host, HttpMessageInvoker client)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, $"https://127.0.0.1:{host.GetPort()}/");
+        request.Version = HttpVersion.Version20;
+
+        var responseMessage = await client.SendAsync(request, CancellationToken.None).DefaultTimeout();
+        responseMessage.EnsureSuccessStatusCode();
+
+        var responseStream = await responseMessage.Content.ReadAsStreamAsync();
+
+        var data = new List<byte>();
+        var buffer = new byte[1024 * 128];
+        int readCount;
+        while ((readCount = await responseStream.ReadAsync(buffer)) != 0)
+        {
+            data.AddRange(buffer.AsMemory(0, readCount).ToArray());
+            logger.LogInformation($"Received {readCount} bytes. Total {data.Count} bytes.");
+        }
+        logger.LogInformation($"Finished reading response content");
+
+        return (data.ToArray(), responseMessage.TrailingHeaders);
     }
 
     private IHostBuilder CreateHostBuilder(RequestDelegate requestDelegate, HttpProtocols? protocol = null, Action<KestrelServerOptions> configureKestrel = null, bool? plaintext = null)

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
@@ -54,7 +54,6 @@ public class Http2RequestTests : LoggedTest
         var syncPoint = new SyncPoint();
 
         ILogger logger = null;
-        IHostApplicationLifetime hostApplicationLifetime = null;
         var builder = CreateHostBuilder(
             async c =>
             {
@@ -65,6 +64,8 @@ public class Http2RequestTests : LoggedTest
                 logger.LogInformation($"Server writing {randomBytes.Length} bytes response");
                 randomBytes.CopyTo(memory);
 
+                // It's important for this test that the large write is the last data written to
+                // the response and it's not awaited by the request delegate.
                 logger.LogInformation($"Server advancing {randomBytes.Length} bytes response");
                 c.Response.BodyWriter.Advance(randomBytes.Length);
 
@@ -78,7 +79,6 @@ public class Http2RequestTests : LoggedTest
 
         using var host = builder.Build();
         logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Test");
-        hostApplicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
 
         var client = HttpHelpers.CreateClient();
 

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
@@ -73,7 +73,8 @@ public class Http2RequestTests : LoggedTest
                     c.Response.AppendTrailer("test-trailer", "value!");
                 }
             },
-            protocol: HttpProtocols.Http2);
+            protocol: HttpProtocols.Http2,
+            plaintext: true);
 
         using var host = builder.Build();
         logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Test");
@@ -107,8 +108,9 @@ public class Http2RequestTests : LoggedTest
 
     private static async Task<(byte[], HttpResponseHeaders)> StartLongRunningRequestAsync(ILogger logger, IHost host, HttpMessageInvoker client)
     {
-        var request = new HttpRequestMessage(HttpMethod.Get, $"https://127.0.0.1:{host.GetPort()}/");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"http://127.0.0.1:{host.GetPort()}/");
         request.Version = HttpVersion.Version20;
+        request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
 
         var responseMessage = await client.SendAsync(request, CancellationToken.None).DefaultTimeout();
         responseMessage.EnsureSuccessStatusCode();

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpHelpers.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpHelpers.cs
@@ -81,7 +81,7 @@ internal static class HttpHelpers
                 }
                 else
                 {
-                    o.ShutdownTimeout = TimeSpan.FromSeconds(1);
+                    o.ShutdownTimeout = TimeSpan.FromSeconds(5);
                 }
             });
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/40932

Kestrel decreases the active stream count before a response has finished writing all its data. This is a problem when:

1. A graceful shutdown of the server starts while a request is in progress
2. The request sends a large amount of data in the response
3. The active stream count is decreased before all data is sent **<- PROBLEM**
4. The connection sees a graceful shutdown has started and it has zero active streams so it begins to close itself
5. The connection stops receiving frames, including WINDOW_UPDATE frames (aka flow control)
6. The large amount of data being written in the final response runs out of flow control and the response hangs
7. Graceful shutdown times out, the connection is forcefully terminated

The fix is to decrease the active stream count after the response ~writes data by awaiting the flush~ has verified it has flow control capacity but before it writes STREAM_END flag to the response. This avoids a race condition between the client receiving stream end notification and the server decreasing it.