### PR TITLE
Friendlier exception when invoking JS from outside a WebView context

### DIFF
--- a/src/Components/WebView/WebView/src/Services/WebViewJSRuntime.cs
+++ b/src/Components/WebView/WebView/src/Services/WebViewJSRuntime.cs
@@ -30,6 +30,11 @@ internal class WebViewJSRuntime : JSRuntime
 
     protected override void BeginInvokeJS(long taskId, string identifier, string argsJson, JSCallResultType resultType, long targetInstanceId)
     {
+        if (_ipcSender is null)
+        {
+            throw new InvalidOperationException("Cannot invoke JavaScript outside of a WebView context.");
+        }
+
         _ipcSender.BeginInvokeJS(taskId, identifier, argsJson, resultType, targetInstanceId);
     }
 


### PR DESCRIPTION
# Friendlier exception when invoking JS from outside a WebView context

Attempting to invoke JS from outside a WebView context (e.g. calling `IJSRuntime` methods in a `WPF` or `WinForms` application outside a Razor component) previously resulted in a `NullReferenceException` getting thrown. This PR throws a different exception that helps the developer understand that what they're attempting to do is not allowed.

Fixes https://github.com/dotnet/maui/issues/1245
