### PR TITLE
updating date in weatherforcast from 2018 to 2022

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/sample-data/weather.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/sample-data/weather.json
@@ -1,26 +1,26 @@
 ﻿[
   {
-    "date": "2018-05-06",
+    "date": "2022-01-06",
     "temperatureC": 1,
     "summary": "Freezing"
   },
   {
-    "date": "2018-05-07",
+    "date": "2022-01-07",
     "temperatureC": 14,
     "summary": "Bracing"
   },
   {
-    "date": "2018-05-08",
+    "date": "2022-01-08",
     "temperatureC": -13,
     "summary": "Freezing"
   },
   {
-    "date": "2018-05-09",
+    "date": "2022-01-09",
     "temperatureC": -16,
     "summary": "Balmy"
   },
   {
-    "date": "2018-05-10",
+    "date": "2022-01-10",
     "temperatureC": -2,
     "summary": "Chilly"
   }


### PR DESCRIPTION
# Update dates for WeatherForcast from 2018 to 2022

Simple change to update the dates that are used in the Blazor WASM template to 2022 instead of 2018.

cc @DamianEdwards @phenning 
