### PR TITLE
Flow IContractResolver through JsonPatch method calls

### DIFF
--- a/src/Features/JsonPatch/src/Internal/DictionaryAdapterOfTU.cs
+++ b/src/Features/JsonPatch/src/Internal/DictionaryAdapterOfTU.cs
@@ -120,7 +120,6 @@ public class DictionaryAdapter<TKey, TValue> : IAdapter
         }
 
         if (!TryConvertValue(value, contractResolver, out var convertedValue, out errorMessage))
-        //if (!TryConvertValue(value, out var convertedValue, out errorMessage))
         {
             return false;
         }

--- a/src/Features/JsonPatch/src/Internal/DictionaryAdapterOfTU.cs
+++ b/src/Features/JsonPatch/src/Internal/DictionaryAdapterOfTU.cs
@@ -31,7 +31,7 @@ public class DictionaryAdapter<TKey, TValue> : IAdapter
             return false;
         }
 
-        if (!TryConvertValue(value, out var convertedValue, out errorMessage))
+        if (!TryConvertValue(value, contractResolver, out var convertedValue, out errorMessage))
         {
             return false;
         }
@@ -119,7 +119,8 @@ public class DictionaryAdapter<TKey, TValue> : IAdapter
             return false;
         }
 
-        if (!TryConvertValue(value, out var convertedValue, out errorMessage))
+        if (!TryConvertValue(value, contractResolver, out var convertedValue, out errorMessage))
+        //if (!TryConvertValue(value, out var convertedValue, out errorMessage))
         {
             return false;
         }
@@ -153,7 +154,7 @@ public class DictionaryAdapter<TKey, TValue> : IAdapter
             return false;
         }
 
-        if (!TryConvertValue(value, out var convertedValue, out errorMessage))
+        if (!TryConvertValue(value, contractResolver, out var convertedValue, out errorMessage))
         {
             return false;
         }
@@ -229,7 +230,12 @@ public class DictionaryAdapter<TKey, TValue> : IAdapter
 
     protected virtual bool TryConvertValue(object value, out TValue convertedValue, out string errorMessage)
     {
-        var conversionResult = ConversionResultProvider.ConvertTo(value, typeof(TValue));
+        return TryConvertValue(value, null, out convertedValue, out errorMessage);
+    }
+
+    protected virtual bool TryConvertValue(object value, IContractResolver contractResolver, out TValue convertedValue, out string errorMessage)
+    {
+        var conversionResult = ConversionResultProvider.ConvertTo(value, typeof(TValue), contractResolver);
         if (conversionResult.CanBeConverted)
         {
             errorMessage = null;

--- a/src/Features/JsonPatch/src/Internal/DynamicObjectAdapter.cs
+++ b/src/Features/JsonPatch/src/Internal/DynamicObjectAdapter.cs
@@ -92,7 +92,7 @@ public class DynamicObjectAdapter : IAdapter
             return false;
         }
 
-        if (!TryConvertValue(value, property.GetType(), out var convertedValue))
+        if (!TryConvertValue(value, property.GetType(), contractResolver, out var convertedValue))
         {
             errorMessage = Resources.FormatInvalidValueForProperty(value);
             return false;
@@ -124,7 +124,7 @@ public class DynamicObjectAdapter : IAdapter
             return false;
         }
 
-        if (!TryConvertValue(value, property.GetType(), out var convertedValue))
+        if (!TryConvertValue(value, property.GetType(), contractResolver, out var convertedValue))
         {
             errorMessage = Resources.FormatInvalidValueForProperty(value);
             return false;
@@ -236,7 +236,12 @@ public class DynamicObjectAdapter : IAdapter
 
     protected virtual bool TryConvertValue(object value, Type propertyType, out object convertedValue)
     {
-        var conversionResult = ConversionResultProvider.ConvertTo(value, propertyType);
+        return TryConvertValue(value, propertyType, null, out convertedValue);
+    }
+
+    protected virtual bool TryConvertValue(object value, Type propertyType, IContractResolver contractResolver, out object convertedValue)
+    {
+        var conversionResult = ConversionResultProvider.ConvertTo(value, propertyType, contractResolver);
         if (!conversionResult.CanBeConverted)
         {
             convertedValue = null;

--- a/src/Features/JsonPatch/src/Internal/PocoAdapter.cs
+++ b/src/Features/JsonPatch/src/Internal/PocoAdapter.cs
@@ -223,6 +223,11 @@ public class PocoAdapter : IAdapter
         return false;
     }
 
+    protected virtual bool TryConvertValue(object value, Type propertyType, out object convertedValue)
+    {
+        return TryConvertValue(value, propertyType, out convertedValue, null); 
+    }
+
     protected virtual bool TryConvertValue(object value, Type propertyType, out object convertedValue, IContractResolver contractResolver)
     {
         var conversionResult = ConversionResultProvider.ConvertTo(value, propertyType, contractResolver);

--- a/src/Features/JsonPatch/src/Internal/PocoAdapter.cs
+++ b/src/Features/JsonPatch/src/Internal/PocoAdapter.cs
@@ -34,7 +34,7 @@ public class PocoAdapter : IAdapter
             return false;
         }
 
-        if (!TryConvertValue(value, jsonProperty.PropertyType, out var convertedValue))
+        if (!TryConvertValue(value, jsonProperty.PropertyType, out var convertedValue, contractResolver))
         {
             errorMessage = Resources.FormatInvalidValueForProperty(value);
             return false;
@@ -125,7 +125,7 @@ public class PocoAdapter : IAdapter
             return false;
         }
 
-        if (!TryConvertValue(value, jsonProperty.PropertyType, out var convertedValue))
+        if (!TryConvertValue(value, jsonProperty.PropertyType, out var convertedValue, contractResolver))
         {
             errorMessage = Resources.FormatInvalidValueForProperty(value);
             return false;
@@ -157,7 +157,7 @@ public class PocoAdapter : IAdapter
             return false;
         }
 
-        if (!TryConvertValue(value, jsonProperty.PropertyType, out var convertedValue))
+        if (!TryConvertValue(value, jsonProperty.PropertyType, out var convertedValue, contractResolver))
         {
             errorMessage = Resources.FormatInvalidValueForProperty(value);
             return false;
@@ -223,9 +223,9 @@ public class PocoAdapter : IAdapter
         return false;
     }
 
-    protected virtual bool TryConvertValue(object value, Type propertyType, out object convertedValue)
+    protected virtual bool TryConvertValue(object value, Type propertyType, out object convertedValue, IContractResolver contractResolver)
     {
-        var conversionResult = ConversionResultProvider.ConvertTo(value, propertyType);
+        var conversionResult = ConversionResultProvider.ConvertTo(value, propertyType, contractResolver);
         if (!conversionResult.CanBeConverted)
         {
             convertedValue = null;

--- a/src/Features/JsonPatch/src/Internal/PocoAdapter.cs
+++ b/src/Features/JsonPatch/src/Internal/PocoAdapter.cs
@@ -34,7 +34,7 @@ public class PocoAdapter : IAdapter
             return false;
         }
 
-        if (!TryConvertValue(value, jsonProperty.PropertyType, out var convertedValue, contractResolver))
+        if (!TryConvertValue(value, jsonProperty.PropertyType, contractResolver, out var convertedValue))
         {
             errorMessage = Resources.FormatInvalidValueForProperty(value);
             return false;
@@ -125,7 +125,7 @@ public class PocoAdapter : IAdapter
             return false;
         }
 
-        if (!TryConvertValue(value, jsonProperty.PropertyType, out var convertedValue, contractResolver))
+        if (!TryConvertValue(value, jsonProperty.PropertyType, contractResolver, out var convertedValue))
         {
             errorMessage = Resources.FormatInvalidValueForProperty(value);
             return false;
@@ -157,7 +157,7 @@ public class PocoAdapter : IAdapter
             return false;
         }
 
-        if (!TryConvertValue(value, jsonProperty.PropertyType, out var convertedValue, contractResolver))
+        if (!TryConvertValue(value, jsonProperty.PropertyType, contractResolver, out var convertedValue))
         {
             errorMessage = Resources.FormatInvalidValueForProperty(value);
             return false;
@@ -225,10 +225,10 @@ public class PocoAdapter : IAdapter
 
     protected virtual bool TryConvertValue(object value, Type propertyType, out object convertedValue)
     {
-        return TryConvertValue(value, propertyType, out convertedValue, null); 
+        return TryConvertValue(value, propertyType, null, out convertedValue); 
     }
 
-    protected virtual bool TryConvertValue(object value, Type propertyType, out object convertedValue, IContractResolver contractResolver)
+    protected virtual bool TryConvertValue(object value, Type propertyType, IContractResolver contractResolver, out object convertedValue)
     {
         var conversionResult = ConversionResultProvider.ConvertTo(value, propertyType, contractResolver);
         if (!conversionResult.CanBeConverted)

--- a/src/Features/JsonPatch/src/PublicAPI.Shipped.txt
+++ b/src/Features/JsonPatch/src/PublicAPI.Shipped.txt
@@ -154,7 +154,7 @@
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.ListAdapter.TryTest(object target, string segment, Newtonsoft.Json.Serialization.IContractResolver contractResolver, object value, out string errorMessage) -> bool
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.ListAdapter.TryTraverse(object target, string segment, Newtonsoft.Json.Serialization.IContractResolver contractResolver, out object value, out string errorMessage) -> bool
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryAdd(object target, string segment, Newtonsoft.Json.Serialization.IContractResolver contractResolver, object value, out string errorMessage) -> bool
-~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryConvertValue(object value, System.Type propertyType, out object convertedValue) -> bool
+~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryConvertValue(object value, System.Type propertyType, out object convertedValue, IContractResolver contractResolver) -> bool
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryGet(object target, string segment, Newtonsoft.Json.Serialization.IContractResolver contractResolver, out object value, out string errorMessage) -> bool
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryGetJsonProperty(object target, Newtonsoft.Json.Serialization.IContractResolver contractResolver, string segment, out Newtonsoft.Json.Serialization.JsonProperty jsonProperty) -> bool
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryRemove(object target, string segment, Newtonsoft.Json.Serialization.IContractResolver contractResolver, out string errorMessage) -> bool

--- a/src/Features/JsonPatch/src/PublicAPI.Shipped.txt
+++ b/src/Features/JsonPatch/src/PublicAPI.Shipped.txt
@@ -154,7 +154,7 @@
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.ListAdapter.TryTest(object target, string segment, Newtonsoft.Json.Serialization.IContractResolver contractResolver, object value, out string errorMessage) -> bool
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.ListAdapter.TryTraverse(object target, string segment, Newtonsoft.Json.Serialization.IContractResolver contractResolver, out object value, out string errorMessage) -> bool
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryAdd(object target, string segment, Newtonsoft.Json.Serialization.IContractResolver contractResolver, object value, out string errorMessage) -> bool
-~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryConvertValue(object value, System.Type propertyType, out object convertedValue, IContractResolver contractResolver) -> bool
+~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryConvertValue(object value, System.Type propertyType, out object convertedValue, Newtonsoft.Json.Serialization.IContractResolver contractResolver) -> bool
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryGet(object target, string segment, Newtonsoft.Json.Serialization.IContractResolver contractResolver, out object value, out string errorMessage) -> bool
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryGetJsonProperty(object target, Newtonsoft.Json.Serialization.IContractResolver contractResolver, string segment, out Newtonsoft.Json.Serialization.JsonProperty jsonProperty) -> bool
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryRemove(object target, string segment, Newtonsoft.Json.Serialization.IContractResolver contractResolver, out string errorMessage) -> bool

--- a/src/Features/JsonPatch/src/PublicAPI.Shipped.txt
+++ b/src/Features/JsonPatch/src/PublicAPI.Shipped.txt
@@ -154,7 +154,7 @@
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.ListAdapter.TryTest(object target, string segment, Newtonsoft.Json.Serialization.IContractResolver contractResolver, object value, out string errorMessage) -> bool
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.ListAdapter.TryTraverse(object target, string segment, Newtonsoft.Json.Serialization.IContractResolver contractResolver, out object value, out string errorMessage) -> bool
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryAdd(object target, string segment, Newtonsoft.Json.Serialization.IContractResolver contractResolver, object value, out string errorMessage) -> bool
-~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryConvertValue(object value, System.Type propertyType, out object convertedValue, Newtonsoft.Json.Serialization.IContractResolver contractResolver) -> bool
+~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryConvertValue(object value, System.Type propertyType, out object convertedValue) -> bool
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryGet(object target, string segment, Newtonsoft.Json.Serialization.IContractResolver contractResolver, out object value, out string errorMessage) -> bool
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryGetJsonProperty(object target, Newtonsoft.Json.Serialization.IContractResolver contractResolver, string segment, out Newtonsoft.Json.Serialization.JsonProperty jsonProperty) -> bool
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryRemove(object target, string segment, Newtonsoft.Json.Serialization.IContractResolver contractResolver, out string errorMessage) -> bool

--- a/src/Features/JsonPatch/src/PublicAPI.Unshipped.txt
+++ b/src/Features/JsonPatch/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryConvertValue(object value, System.Type propertyType, out object convertedValue, Newtonsoft.Json.Serialization.IContractResolver contractResolver) -> bool

--- a/src/Features/JsonPatch/src/PublicAPI.Unshipped.txt
+++ b/src/Features/JsonPatch/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 #nullable enable
-~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryConvertValue(object value, System.Type propertyType, out object convertedValue, Newtonsoft.Json.Serialization.IContractResolver contractResolver) -> bool
+~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryConvertValue(object value, System.Type propertyType, Newtonsoft.Json.Serialization.IContractResolver contractResolver, out object convertedValue) -> bool

--- a/src/Features/JsonPatch/src/PublicAPI.Unshipped.txt
+++ b/src/Features/JsonPatch/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 #nullable enable
+~virtual Microsoft.AspNetCore.JsonPatch.Internal.DictionaryAdapter<TKey, TValue>.TryConvertValue(object value, Newtonsoft.Json.Serialization.IContractResolver contractResolver, out TValue convertedValue, out string errorMessage) -> bool
+~virtual Microsoft.AspNetCore.JsonPatch.Internal.DynamicObjectAdapter.TryConvertValue(object value, System.Type propertyType, Newtonsoft.Json.Serialization.IContractResolver contractResolver, out object convertedValue) -> bool
 ~virtual Microsoft.AspNetCore.JsonPatch.Internal.PocoAdapter.TryConvertValue(object value, System.Type propertyType, Newtonsoft.Json.Serialization.IContractResolver contractResolver, out object convertedValue) -> bool

--- a/src/Features/JsonPatch/test/Internal/DictionaryAdapterTest.cs
+++ b/src/Features/JsonPatch/test/Internal/DictionaryAdapterTest.cs
@@ -4,6 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
 using Xunit;
 
@@ -226,6 +229,29 @@ public class DictionaryAdapterTest
         Assert.False(removeStatus);
         Assert.Equal("The target location specified by path segment 'Name' was not found.", message);
         Assert.Empty(dictionary);
+    }
+
+    [Fact]
+    public void ReplaceUsesCustomConverter()
+    {
+        // Arrange
+        var nameKey = "Name";
+        var dictionary = new Dictionary<string, Rectangle>(StringComparer.Ordinal);
+        dictionary.Add(nameKey, new Rectangle()
+        {
+            RectangleProperty = "Mike"
+        });
+        var dictionaryAdapter = new DictionaryAdapter<string, Rectangle>();
+        var resolver = new RectangleContractResolver();
+
+        // Act
+        var replaceStatus = dictionaryAdapter.TryReplace(dictionary, nameKey, resolver, "James", out var message);
+
+        // Assert
+        Assert.True(replaceStatus);
+        Assert.True(string.IsNullOrEmpty(message), "Expected no error message");
+        Assert.Single(dictionary);
+        Assert.Equal("James", dictionary[nameKey].RectangleProperty);
     }
 
     [Fact]

--- a/src/Features/JsonPatch/test/Internal/DictionaryAdapterTest.cs
+++ b/src/Features/JsonPatch/test/Internal/DictionaryAdapterTest.cs
@@ -232,7 +232,7 @@ public class DictionaryAdapterTest
     }
 
     [Fact]
-    public void ReplaceUsesCustomConverter()
+    public void Replace_UsesCustomConverter()
     {
         // Arrange
         var nameKey = "Name";

--- a/src/Features/JsonPatch/test/Internal/DynamicObjectAdapterTest.cs
+++ b/src/Features/JsonPatch/test/Internal/DynamicObjectAdapterTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -181,6 +181,27 @@ public class DynamicObjectAdapterTest
         // Assert
         Assert.False(status);
         Assert.Equal($"The value 'test' is invalid for target location.", errorMessage);
+    }
+
+    [Fact]
+    public void TryReplace_UsesCustomConverter()
+    {
+        // Arrange
+        var adapter = new DynamicObjectAdapter();
+        dynamic target = new WriteOnceDynamicTestObject();
+        target.NewProperty = new Rectangle();
+        var segment = "NewProperty";
+        var resolver = new RectangleContractResolver();
+
+        // Act
+        var status = adapter.TryReplace(target, segment, resolver, "new", out string errorMessage);
+
+        // Assert
+        Assert.True(status);
+        Assert.Null(errorMessage);
+        Assert.True(target.NewProperty is Rectangle);
+        var rect = (Rectangle)target.NewProperty;
+        Assert.Equal("new", rect.RectangleProperty);
     }
 
     [Theory]

--- a/src/Features/JsonPatch/test/Internal/PocoAdapterTest.cs
+++ b/src/Features/JsonPatch/test/Internal/PocoAdapterTest.cs
@@ -267,38 +267,3 @@ public class PocoAdapterTest
         public int Age { get; set; }
     }
 }
-
-public class RectangleContractResolver : DefaultContractResolver
-{
-    protected override JsonConverter ResolveContractConverter(Type objectType)
-    {
-        if (objectType == typeof(Rectangle))
-        {
-            return new RectangleJsonConverter();
-        }
-
-        return base.ResolveContractConverter(objectType);
-    }
-}
-
-public class RectangleJsonConverter : CustomCreationConverter<Rectangle>
-{
-    public override bool CanRead => true;
-
-    public override Rectangle Create(Type objectType)
-    {
-        throw new NotImplementedException();
-    }
-
-    public override object ReadJson(
-        JsonReader reader,
-        Type objectType,
-        object existingValue,
-        JsonSerializer serializer)
-    {
-        return new Rectangle()
-        {
-            RectangleProperty = reader.Value.ToString()
-        };
-    }
-}

--- a/src/Features/JsonPatch/test/Internal/PocoAdapterTest.cs
+++ b/src/Features/JsonPatch/test/Internal/PocoAdapterTest.cs
@@ -283,8 +283,6 @@ public class RectangleContractResolver : DefaultContractResolver
 
 public class RectangleJsonConverter : CustomCreationConverter<Rectangle>
 {
-    private const string TypeProperty = "Type";
-
     public override bool CanRead => true;
 
     public override Rectangle Create(Type objectType)

--- a/src/Features/JsonPatch/test/TestObjectModels/HeterogenousCollection.cs
+++ b/src/Features/JsonPatch/test/TestObjectModels/HeterogenousCollection.cs
@@ -1,7 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.AspNetCore.JsonPatch;
 
@@ -28,4 +32,39 @@ public class Square : Shape
 public class Canvas
 {
     public IList<Shape> Items { get; set; }
+}
+
+public class RectangleContractResolver : DefaultContractResolver
+{
+    protected override JsonConverter ResolveContractConverter(Type objectType)
+    {
+        if (objectType == typeof(Rectangle))
+        {
+            return new RectangleJsonConverter();
+        }
+
+        return base.ResolveContractConverter(objectType);
+    }
+}
+
+public class RectangleJsonConverter : CustomCreationConverter<Rectangle>
+{
+    public override bool CanRead => true;
+
+    public override Rectangle Create(Type objectType)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override object ReadJson(
+        JsonReader reader,
+        Type objectType,
+        object existingValue,
+        JsonSerializer serializer)
+    {
+        return new Rectangle()
+        {
+            RectangleProperty = reader.Value.ToString()
+        };
+    }
 }

--- a/src/Features/JsonPatch/test/TestObjectModels/HeterogenousCollection.cs
+++ b/src/Features/JsonPatch/test/TestObjectModels/HeterogenousCollection.cs
@@ -20,6 +20,11 @@ public class Rectangle : Shape
     public string RectangleProperty { get; set; }
 }
 
+public class Square : Shape
+{
+    public Rectangle Rectangle { get; set; }
+}
+
 public class Canvas
 {
     public IList<Shape> Items { get; set; }


### PR DESCRIPTION
# Adding support for custom JsonConverter(s) when deserializing JSON patches to generic object types

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

When trying to apply JSON patches on objects using custom converters, we were getting errors applying those changes to objects that use custom converter logic. PocoAdapter.cs was not using the ContractResolver passed into TryReplace when attempting to convert the patch object types. 

I updated the code in PocoAdapter.cs to use the ContractResolver so that custom converters can be used. 

Partially fixes #16690
