### PR TITLE
updating showprofile to use correct icon

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Shared/NavMenu.CallsMicrosoftGraph.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Shared/NavMenu.CallsMicrosoftGraph.razor
@@ -26,7 +26,7 @@
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="showprofile">
-                <span class="oi oi-list-rich" aria-hidden="true"></span> Show profile
+                <span class="oi oi-person" aria-hidden="true"></span> Show profile
             </NavLink>
         </div>
     </nav>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Shared/NavMenu.CallsMicrosoftGraph.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Shared/NavMenu.CallsMicrosoftGraph.razor
@@ -26,7 +26,7 @@
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="showProfile">
-                <span class="oi oi-list-rich" aria-hidden="true"></span> Show Profile
+                <span class="oi oi-person" aria-hidden="true"></span> Show Profile
             </NavLink>
         </div>
     </nav>


### PR DESCRIPTION
The showprofile is using the `oi-list-rich`, better would be to use `oi-person` instead. 

oi-person
![image](https://user-images.githubusercontent.com/1283154/161132812-d1676815-b6e2-4a64-a91c-3f06a4ccd499.png)

oi-list-rich
![image](https://user-images.githubusercontent.com/1283154/161132838-32f998d4-632b-4488-aefa-3d289fc09b84.png)

cc @DamianEdwards @danroth27 @vijayrkn 