### PR TITLE
Consolidate Blazor Server Template Directives

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Pages/FetchData.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Pages/FetchData.razor
@@ -1,9 +1,8 @@
 ﻿@page "/fetchdata"
-
-<PageTitle>Weather forecast</PageTitle>
-
 @using BlazorServerWeb_CSharp.Data
 @inject WeatherForecastService ForecastService
+
+<PageTitle>Weather forecast</PageTitle>
 
 <h1>Weather forecast</h1>
 


### PR DESCRIPTION
@davidwengier pointed out this issue with interspersed directives:

![MicrosoftTeams-image (3)](https://user-images.githubusercontent.com/14852843/161153501-8f04a908-2f12-45bd-a1ea-8802ab91ed0a.png)


I don't believe this was intentional...
