### PR TITLE
Update V3 password hashing to use SHA512 with 100k iterations

### DIFF
--- a/src/Identity/Extensions.Core/src/PasswordHasher.cs
+++ b/src/Identity/Extensions.Core/src/PasswordHasher.cs
@@ -26,7 +26,7 @@ public class PasswordHasher<TUser> : IPasswordHasher<TUser> where TUser : class
      * Format: { 0x00, salt, subkey }
      *
      * Version 3:
-     * PBKDF2 with HMAC-SHA256, 128-bit salt, 256-bit subkey, 10000 iterations.
+     * PBKDF2 with HMAC-SHA512, 128-bit salt, 256-bit subkey, 100000 iterations.
      * Format: { 0x01, prf (UInt32), iter count (UInt32), salt length (UInt32), salt, subkey }
      * (All UInt32s are stored big-endian.)
      */
@@ -132,7 +132,7 @@ public class PasswordHasher<TUser> : IPasswordHasher<TUser> where TUser : class
     private byte[] HashPasswordV3(string password, RandomNumberGenerator rng)
     {
         return HashPasswordV3(password, rng,
-            prf: KeyDerivationPrf.HMACSHA256,
+            prf: KeyDerivationPrf.HMACSHA512,
             iterCount: _iterCount,
             saltSize: 128 / 8,
             numBytesRequested: 256 / 8);
@@ -153,14 +153,6 @@ public class PasswordHasher<TUser> : IPasswordHasher<TUser> where TUser : class
         Buffer.BlockCopy(salt, 0, outputBytes, 13, salt.Length);
         Buffer.BlockCopy(subkey, 0, outputBytes, 13 + saltSize, subkey.Length);
         return outputBytes;
-    }
-
-    private static uint ReadNetworkByteOrder(byte[] buffer, int offset)
-    {
-        return ((uint)(buffer[offset + 0]) << 24)
-            | ((uint)(buffer[offset + 1]) << 16)
-            | ((uint)(buffer[offset + 2]) << 8)
-            | ((uint)(buffer[offset + 3]));
     }
 
     /// <summary>
@@ -205,13 +197,21 @@ public class PasswordHasher<TUser> : IPasswordHasher<TUser> where TUser : class
                 }
 
             case 0x01:
-                int embeddedIterCount;
-                if (VerifyHashedPasswordV3(decodedHashedPassword, providedPassword, out embeddedIterCount))
+                if (VerifyHashedPasswordV3(decodedHashedPassword, providedPassword, out int embeddedIterCount, out KeyDerivationPrf prf))
                 {
                     // If this hasher was configured with a higher iteration count, change the entry now.
-                    return (embeddedIterCount < _iterCount)
-                        ? PasswordVerificationResult.SuccessRehashNeeded
-                        : PasswordVerificationResult.Success;
+                    if (embeddedIterCount < _iterCount)
+                    {
+                        return PasswordVerificationResult.SuccessRehashNeeded;
+                    }
+
+                    // V3 now requires SHA512. If the old PRF is SHA1 or SHA256, upgrade to SHA512 and rehash.
+                    if (prf == KeyDerivationPrf.HMACSHA1 || prf == KeyDerivationPrf.HMACSHA256)
+                    {
+                        return PasswordVerificationResult.SuccessRehashNeeded;
+                    }
+
+                    return PasswordVerificationResult.Success;
                 }
                 else
                 {
@@ -253,14 +253,15 @@ public class PasswordHasher<TUser> : IPasswordHasher<TUser> where TUser : class
 #endif
     }
 
-    private static bool VerifyHashedPasswordV3(byte[] hashedPassword, string password, out int iterCount)
+    private static bool VerifyHashedPasswordV3(byte[] hashedPassword, string password, out int iterCount, out KeyDerivationPrf prf)
     {
         iterCount = default(int);
+        prf = default(KeyDerivationPrf);
 
         try
         {
             // Read header information
-            KeyDerivationPrf prf = (KeyDerivationPrf)ReadNetworkByteOrder(hashedPassword, 1);
+            prf = (KeyDerivationPrf)ReadNetworkByteOrder(hashedPassword, 1);
             iterCount = (int)ReadNetworkByteOrder(hashedPassword, 5);
             int saltLength = (int)ReadNetworkByteOrder(hashedPassword, 9);
 
@@ -298,6 +299,14 @@ public class PasswordHasher<TUser> : IPasswordHasher<TUser> where TUser : class
             // implies verification failed.
             return false;
         }
+    }
+
+    private static uint ReadNetworkByteOrder(byte[] buffer, int offset)
+    {
+        return ((uint)(buffer[offset + 0]) << 24)
+            | ((uint)(buffer[offset + 1]) << 16)
+            | ((uint)(buffer[offset + 2]) << 8)
+            | ((uint)(buffer[offset + 3]));
     }
 
     private static void WriteNetworkByteOrder(byte[] buffer, int offset, uint value)

--- a/src/Identity/Extensions.Core/src/PasswordHasherOptions.cs
+++ b/src/Identity/Extensions.Core/src/PasswordHasherOptions.cs
@@ -21,7 +21,7 @@ public class PasswordHasherOptions
     public PasswordHasherCompatibilityMode CompatibilityMode { get; set; } = PasswordHasherCompatibilityMode.IdentityV3;
 
     /// <summary>
-    /// Gets or sets the number of iterations used when hashing passwords using PBKDF2. Default is 10,000.
+    /// Gets or sets the number of iterations used when hashing passwords using PBKDF2. Default is 100,000.
     /// </summary>
     /// <value>
     /// The number of iterations used when hashing passwords using PBKDF2.
@@ -30,7 +30,7 @@ public class PasswordHasherOptions
     /// This value is only used when the compatibility mode is set to 'V3'.
     /// The value must be a positive integer.
     /// </remarks>
-    public int IterationCount { get; set; } = 10000;
+    public int IterationCount { get; set; } = 100_000;
 
     // for unit testing
     internal RandomNumberGenerator Rng { get; set; } = _defaultRng;

--- a/src/Identity/test/Identity.Test/PasswordHasherTest.cs
+++ b/src/Identity/test/Identity.Test/PasswordHasherTest.cs
@@ -8,6 +8,20 @@ namespace Microsoft.AspNetCore.Identity.Test;
 
 public class PasswordHasherTest
 {
+    // Password used in these tests
+    public const string Plaintext_Password = "my password";
+
+    // V2 Hashed versions of Plaintext_Password
+    public const string V2_SHA1_1000iter_128salt_256subkey = "AAABAgMEBQYHCAkKCwwNDg+ukCEMDf0yyQ29NYubggHIVY0sdEUfdyeM+E1LtH1uJg==";
+
+    // V3 Hashed versions of Plaintext_Password
+    public const string V3_SHA1_250iter_128salt_128subkey = "AQAAAAAAAAD6AAAAEAhftMyfTJylOlZT+eEotFXd1elee8ih5WsjXaR3PA9M";
+    public const string V3_SHA256_250000iter_256salt_256subkey = "AQAAAAEAA9CQAAAAIESkQuj2Du8Y+kbc5lcN/W/3NiAZFEm11P27nrSN5/tId+bR1SwV8CO1Jd72r4C08OLvplNlCDc3oQZ8efcW+jQ=";
+    public const string V3_SHA512_50iter_128salt_128subkey = "AQAAAAIAAAAyAAAAEOMwvh3+FZxqkdMBz2ekgGhwQ4B6pZWND6zgESBuWiHw";
+    public const string V3_SHA512_250iter_256salt_512subkey = "AQAAAAIAAAD6AAAAIJbVi5wbMR+htSfFp8fTw8N8GOS/Sje+S/4YZcgBfU7EQuqv4OkVYmc4VJl9AGZzmRTxSkP7LtVi9IWyUxX8IAAfZ8v+ZfhjCcudtC1YERSqE1OEdXLW9VukPuJWBBjLuw==";
+    public const string V3_SHA512_10000iter_128salt_256subkey = "AQAAAAIAACcQAAAAEAABAgMEBQYHCAkKCwwNDg9B0Oxwty+PGIDSp95gcCfzeDvA4sGapUIUov8usXfD6A==";
+    public const string V3_SHA512_100000iter_128salt_256subkey = "AQAAAAIAAYagAAAAEAABAgMEBQYHCAkKCwwNDg/Q8A0WMKbtHQJQ2DHCdoEeeFBrgNlldq6vH4qX/CGqGQ==";
+
     [Fact]
     public void Ctor_InvalidCompatMode_Throws()
     {
@@ -57,10 +71,10 @@ public class PasswordHasherTest
         var hasher = new PasswordHasher(compatMode: null);
 
         // Act
-        string retVal = hasher.HashPassword(null, "my password");
+        string retVal = hasher.HashPassword(null, Plaintext_Password);
 
         // Assert
-        Assert.Equal("AQAAAAEAACcQAAAAEAABAgMEBQYHCAkKCwwNDg+yWU7rLgUwPZb1Itsmra7cbxw2EFpwpVFIEtP+JIuUEw==", retVal);
+        Assert.Equal(V3_SHA512_100000iter_128salt_256subkey, retVal);
     }
 
     [Fact]
@@ -70,10 +84,10 @@ public class PasswordHasherTest
         var hasher = new PasswordHasher(compatMode: PasswordHasherCompatibilityMode.IdentityV2);
 
         // Act
-        string retVal = hasher.HashPassword(null, "my password");
+        string retVal = hasher.HashPassword(null, Plaintext_Password);
 
         // Assert
-        Assert.Equal("AAABAgMEBQYHCAkKCwwNDg+ukCEMDf0yyQ29NYubggHIVY0sdEUfdyeM+E1LtH1uJg==", retVal);
+        Assert.Equal(V2_SHA1_1000iter_128salt_256subkey, retVal);
     }
 
     [Fact]
@@ -83,10 +97,10 @@ public class PasswordHasherTest
         var hasher = new PasswordHasher(compatMode: PasswordHasherCompatibilityMode.IdentityV3);
 
         // Act
-        string retVal = hasher.HashPassword(null, "my password");
+        string retVal = hasher.HashPassword(null, Plaintext_Password);
 
         // Assert
-        Assert.Equal("AQAAAAEAACcQAAAAEAABAgMEBQYHCAkKCwwNDg+yWU7rLgUwPZb1Itsmra7cbxw2EFpwpVFIEtP+JIuUEw==", retVal);
+        Assert.Equal(V3_SHA512_100000iter_128salt_256subkey, retVal);
     }
 
     [Theory]
@@ -94,7 +108,7 @@ public class PasswordHasherTest
     [InlineData("AAABAgMEBQYHCAkKCwwNDg+uAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALtH1uJg==")] // incorrect password
     [InlineData("AAABAgMEBQYHCAkKCwwNDg+ukCEMDf0yyQ29NYubggE=")] // too short
     [InlineData("AAABAgMEBQYHCAkKCwwNDg+ukCEMDf0yyQ29NYubggHIVY0sdEUfdyeM+E1LtH1uJgAAAAAAAAAAAAA=")] // extra data at end
-                                                                                                     // Version 3 payloads
+    // Version 3 payloads
     [InlineData("AQAAAAAAAAD6AAAAEAhftMyfTJyAAAAAAAAAAAAAAAAAAAih5WsjXaR3PA9M")] // incorrect password
     [InlineData("AQAAAAIAAAAyAAAAEOMwvh3+FZxqkdMBz2ekgGhwQ4A=")] // too short
     [InlineData("AQAAAAIAAAAyAAAAEOMwvh3+FZxqkdMBz2ekgGhwQ4B6pZWND6zgESBuWiHwAAAAAAAAAAAA")] // extra data at end
@@ -104,7 +118,7 @@ public class PasswordHasherTest
         var hasher = new PasswordHasher();
 
         // Act
-        var result = hasher.VerifyHashedPassword(null, hashedPassword, "my password");
+        var result = hasher.VerifyHashedPassword(null, hashedPassword, Plaintext_Password);
 
         // Assert
         Assert.Equal(PasswordVerificationResult.Failed, result);
@@ -112,19 +126,18 @@ public class PasswordHasherTest
 
     [Theory]
     // Version 2 payloads
-    [InlineData("ANXrDknc7fGPpigibZXXZFMX4aoqz44JveK6jQuwY3eH/UyPhvr5xTPeGYEckLxz9A==")] // SHA1, 1000 iterations, 128-bit salt, 256-bit subkey
-                                                                                         // Version 3 payloads
-    [InlineData("AQAAAAIAAAAyAAAAEOMwvh3+FZxqkdMBz2ekgGhwQ4B6pZWND6zgESBuWiHw")] // SHA512, 50 iterations, 128-bit salt, 128-bit subkey
-    [InlineData("AQAAAAIAAAD6AAAAIJbVi5wbMR+htSfFp8fTw8N8GOS/Sje+S/4YZcgBfU7EQuqv4OkVYmc4VJl9AGZzmRTxSkP7LtVi9IWyUxX8IAAfZ8v+ZfhjCcudtC1YERSqE1OEdXLW9VukPuJWBBjLuw==")] // SHA512, 250 iterations, 256-bit salt, 512-bit subkey
-    [InlineData("AQAAAAAAAAD6AAAAEAhftMyfTJylOlZT+eEotFXd1elee8ih5WsjXaR3PA9M")] // SHA1, 250 iterations, 128-bit salt, 128-bit subkey
-    [InlineData("AQAAAAEAA9CQAAAAIESkQuj2Du8Y+kbc5lcN/W/3NiAZFEm11P27nrSN5/tId+bR1SwV8CO1Jd72r4C08OLvplNlCDc3oQZ8efcW+jQ=")] // SHA256, 250000 iterations, 256-bit salt, 256-bit subkey
+    [InlineData(V2_SHA1_1000iter_128salt_256subkey)]
+    // Version 3 payloads
+    [InlineData(V3_SHA512_50iter_128salt_128subkey)]
+    [InlineData(V3_SHA512_250iter_256salt_512subkey)]
+    [InlineData(V3_SHA512_100000iter_128salt_256subkey)]
     public void VerifyHashedPassword_Version2CompatMode_SuccessCases(string hashedPassword)
     {
         // Arrange
         var hasher = new PasswordHasher(compatMode: PasswordHasherCompatibilityMode.IdentityV2);
 
         // Act
-        var result = hasher.VerifyHashedPassword(null, hashedPassword, "my password");
+        var result = hasher.VerifyHashedPassword(null, hashedPassword, Plaintext_Password);
 
         // Assert
         Assert.Equal(PasswordVerificationResult.Success, result);
@@ -132,19 +145,21 @@ public class PasswordHasherTest
 
     [Theory]
     // Version 2 payloads
-    [InlineData("ANXrDknc7fGPpigibZXXZFMX4aoqz44JveK6jQuwY3eH/UyPhvr5xTPeGYEckLxz9A==", PasswordVerificationResult.SuccessRehashNeeded)] // SHA1, 1000 iterations, 128-bit salt, 256-bit subkey
-                                                                                                                                         // Version 3 payloads
-    [InlineData("AQAAAAIAAAAyAAAAEOMwvh3+FZxqkdMBz2ekgGhwQ4B6pZWND6zgESBuWiHw", PasswordVerificationResult.SuccessRehashNeeded)] // SHA512, 50 iterations, 128-bit salt, 128-bit subkey
-    [InlineData("AQAAAAIAAAD6AAAAIJbVi5wbMR+htSfFp8fTw8N8GOS/Sje+S/4YZcgBfU7EQuqv4OkVYmc4VJl9AGZzmRTxSkP7LtVi9IWyUxX8IAAfZ8v+ZfhjCcudtC1YERSqE1OEdXLW9VukPuJWBBjLuw==", PasswordVerificationResult.SuccessRehashNeeded)] // SHA512, 250 iterations, 256-bit salt, 512-bit subkey
-    [InlineData("AQAAAAAAAAD6AAAAEAhftMyfTJylOlZT+eEotFXd1elee8ih5WsjXaR3PA9M", PasswordVerificationResult.SuccessRehashNeeded)] // SHA1, 250 iterations, 128-bit salt, 128-bit subkey
-    [InlineData("AQAAAAEAA9CQAAAAIESkQuj2Du8Y+kbc5lcN/W/3NiAZFEm11P27nrSN5/tId+bR1SwV8CO1Jd72r4C08OLvplNlCDc3oQZ8efcW+jQ=", PasswordVerificationResult.Success)] // SHA256, 250000 iterations, 256-bit salt, 256-bit subkey
+    [InlineData(V2_SHA1_1000iter_128salt_256subkey, PasswordVerificationResult.SuccessRehashNeeded)]
+    // Version 3 payloads
+    [InlineData(V3_SHA1_250iter_128salt_128subkey, PasswordVerificationResult.SuccessRehashNeeded)]
+    [InlineData(V3_SHA256_250000iter_256salt_256subkey, PasswordVerificationResult.SuccessRehashNeeded)]
+    [InlineData(V3_SHA512_50iter_128salt_128subkey, PasswordVerificationResult.SuccessRehashNeeded)]
+    [InlineData(V3_SHA512_250iter_256salt_512subkey, PasswordVerificationResult.SuccessRehashNeeded)]
+    [InlineData(V3_SHA512_10000iter_128salt_256subkey, PasswordVerificationResult.SuccessRehashNeeded)]
+    [InlineData(V3_SHA512_100000iter_128salt_256subkey, PasswordVerificationResult.Success)]
     public void VerifyHashedPassword_Version3CompatMode_SuccessCases(string hashedPassword, PasswordVerificationResult expectedResult)
     {
         // Arrange
         var hasher = new PasswordHasher(compatMode: PasswordHasherCompatibilityMode.IdentityV3);
 
         // Act
-        var actualResult = hasher.VerifyHashedPassword(null, hashedPassword, "my password");
+        var actualResult = hasher.VerifyHashedPassword(null, hashedPassword, Plaintext_Password);
 
         // Assert
         Assert.Equal(expectedResult, actualResult);
@@ -191,5 +206,4 @@ public class PasswordHasherTest
     {
         public PasswordHasherOptions Value { get; } = new PasswordHasherOptions();
     }
-
 }


### PR DESCRIPTION
Fix https://github.com/dotnet/aspnetcore/issues/37032

- [x] Verified that passwords created on 6 get accepted and rehashed on 7.
- [x] Verified that passwords rehashed with SHA512/100k iters are still accepted when running on 6.

I did some performance measurements locally and SHA512 appears to be faster per-iteration than SHA256, at least on my machine (presumably benefiting from AVX). That said, increasing the iteration count tenfold does have a performance impact, so hashing a password will be slower now.

![c9709dbf-c339-486e-ae6f-76f31f1d6942](https://user-images.githubusercontent.com/219224/161176095-1ecb1f8b-eb8f-4e93-9671-69943beda3f4.jpg)

We should still take this change since this is an SDL requirement.