### PR TITLE
Add IgnoreQueryString parameter to NavLink

### DIFF
--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
 Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.Element.get -> Microsoft.AspNetCore.Components.ElementReference?
 Microsoft.AspNetCore.Components.Forms.InputRadio<TValue>.Element.set -> void
+Microsoft.AspNetCore.Components.Routing.NavLink.IgnoreQueryString.get -> bool
+Microsoft.AspNetCore.Components.Routing.NavLink.IgnoreQueryString.set -> void

--- a/src/Components/Web/src/Routing/NavLink.cs
+++ b/src/Components/Web/src/Routing/NavLink.cs
@@ -202,5 +202,18 @@ public class NavLink : ComponentBase, IDisposable
     }
 
     private static string RemoveQueryString(string path)
-        => path.Contains('?') ? path.Split('?')[0] : path;
+    {
+        if (!path.Contains('?'))
+        {
+            return path;
+        }
+
+        var pathWithoutQuery = path.Split('?')[0];
+
+        // We remove trailing slashes to ensure the following matches:
+        //   - "/abc/?value=123" matches "/abc"
+        //   - "/abc/def?value=123" matches "/abc/def"
+        //   - "/abc/def/?value=123" matches "/abc/def"
+        return pathWithoutQuery.EndsWith('/') ? pathWithoutQuery.TrimEnd('/') : pathWithoutQuery;
+    }
 }

--- a/src/Components/Web/src/Routing/NavLink.cs
+++ b/src/Components/Web/src/Routing/NavLink.cs
@@ -45,6 +45,12 @@ public class NavLink : ComponentBase, IDisposable
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
+    /// Gets or sets a flag to indicate whether route matching should ignore the query string.
+    /// </summary>
+    [Parameter]
+    public bool IgnoreQueryString { get; set; }
+
+    /// <summary>
     /// Gets or sets a value representing the URL matching behavior.
     /// </summary>
     [Parameter]
@@ -113,13 +119,15 @@ public class NavLink : ComponentBase, IDisposable
             return false;
         }
 
-        if (EqualsHrefExactlyOrIfTrailingSlashAdded(currentUriAbsolute))
+        var matchingUri = IgnoreQueryString ? RemoveQueryString(currentUriAbsolute) : currentUriAbsolute;
+
+        if (EqualsHrefExactlyOrIfTrailingSlashAdded(matchingUri))
         {
             return true;
         }
 
         if (Match == NavLinkMatch.Prefix
-            && IsStrictlyPrefixWithSeparator(currentUriAbsolute, _hrefAbsolute))
+            && IsStrictlyPrefixWithSeparator(matchingUri, _hrefAbsolute))
         {
             return true;
         }
@@ -192,4 +200,7 @@ public class NavLink : ComponentBase, IDisposable
             return false;
         }
     }
+
+    private static string RemoveQueryString(string path)
+        => path.Contains('?') ? path.Split('?')[0] : path;
 }

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -880,6 +880,46 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
         AssertHighlightedLinks("With query parameters (none)", "With query parameters (passing string value)");
     }
 
+    [Fact]
+    public void IgnoresQueryString()
+    {
+        SetUrlViaPushState("/WithQueryParameters/IgnoreQueryString?intvalue=123");
+
+        var app = Browser.MountTestComponent<TestRouter>();
+        Assert.Equal("123", app.FindElement(By.Id("value-QueryInt")).Text);
+        AssertHighlightedLinks("Base IgnoreQueryString URL");
+    }
+
+    [Fact]
+    public void IgnoresQueryStringWithTrailingSlash()
+    {
+        SetUrlViaPushState("/WithQueryParameters/IgnoreQueryString/?intvalue=123");
+
+        var app = Browser.MountTestComponent<TestRouter>();
+        Assert.Equal("123", app.FindElement(By.Id("value-QueryInt")).Text);
+        AssertHighlightedLinks("Base IgnoreQueryString URL");
+    }
+
+    [Fact]
+    public void DoesNotIgnoreQueryString()
+    {
+        SetUrlViaPushState("/WithQueryParameters/DoNotIgnoreQueryString?intvalue=123");
+
+        var app = Browser.MountTestComponent<TestRouter>();
+        Assert.Equal("123", app.FindElement(By.Id("value-QueryInt")).Text);
+        AssertHighlightedLinks("With query parameters (matches all and does not ignore query string)");
+    }
+
+    [Fact]
+    public void DoesNotIgnoreQueryStringWithTrailingSlash()
+    {
+        SetUrlViaPushState("/WithQueryParameters/DoNotIgnoreQueryString/?intvalue=123");
+
+        var app = Browser.MountTestComponent<TestRouter>();
+        Assert.Equal("123", app.FindElement(By.Id("value-QueryInt")).Text);
+        AssertHighlightedLinks("With query parameters (matches all and does not ignore query string with trailing slash)");
+    }
+
     private long BrowserScrollY
     {
         get => (long)((IJavaScriptExecutor)Browser).ExecuteScript("return window.scrollY");

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/Links.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/Links.razor
@@ -30,6 +30,12 @@
     <li><a href="/subdir/images/blazor_logo_1000x.png" download>Download Me</a></li>
     <li><NavLink>Null href never matches</NavLink></li>
     <li><custom-link-with-shadow-root target-url="Other"></custom-link-with-shadow-root></li>
+    <li><NavLink href="/subdir/WithQueryParameters/IgnoreQueryString" Match=NavLinkMatch.All IgnoreQueryString=@true>Base IgnoreQueryString URL</NavLink></li>
+    <li><NavLink href="/subdir/WithQueryParameters/IgnoreQueryString?intvalue=123" Match=NavLinkMatch.All IgnoreQueryString=@true>With query parameters (matches all and ignores query string)</NavLink></li>
+    <li><NavLink href="/subdir/WithQueryParameters/IgnoreQueryString/?intvalue=123" Match=NavLinkMatch.All IgnoreQueryString=@true>With query parameters (matches all and ignores query string with trailing slash)</NavLink></li>
+    <li><NavLink href="/subdir/WithQueryParameters/DoNotIgnoreQueryString" Match=NavLinkMatch.All IgnoreQueryString=@false>Base DoNotIgnoreQueryString URL</NavLink></li>
+    <li><NavLink href="/subdir/WithQueryParameters/DoNotIgnoreQueryString?intvalue=123" Match=NavLinkMatch.All IgnoreQueryString=@false>With query parameters (matches all and does not ignore query string)</NavLink></li>
+    <li><NavLink href="/subdir/WithQueryParameters/DoNotIgnoreQueryString/?intvalue=123" Match=NavLinkMatch.All IgnoreQueryString=@false>With query parameters (matches all and does not ignore query string with trailing slash)</NavLink></li>
 </ul>
 
 <button id="do-navigation" @onclick=@(x => NavigationManager.NavigateTo("Other"))>


### PR DESCRIPTION
# Add `IgnoreQueryString` parameter to `NavLink`

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

I've repurposed a stale PR (#32168) that gives users more control on `NavLink` matches when query strings are present. Do note that while writing the missing E2E tests, I noticed that the original implementation would not cover the case where a query string followed a trailing slash (i.e. `/abc/?value=123`). This is now covered by trimming a trailing slash if it is present when the user asks for the query string to be ignored.

Fixes #31312
