### PR TITLE
Remove BuildX64 target

### DIFF
--- a/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessNewShimWebSite/InProcessNewShimWebSite.csproj
@@ -63,13 +63,4 @@
     </PackageReference>
     <Reference Include="xunit.assert" />
   </ItemGroup>
-
-  <!-- Repeat Build target for win-x64 to allow later Publish w/ NoBuild=true. -->
-  <Target Name="BuildX64"
-      BeforeTargets="Build"
-      Condition=" '$(RuntimeIdentifier)' != 'win-x64' AND '$(TargetArchitecture)' != 'arm' ">
-    <MSBuild Projects="$(MSBuildProjectFullPath)"
-        Properties="RuntimeIdentifier=win-x64;ReferenceTestTasks=false"
-        Targets="Build" />
-  </Target>
 </Project>

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/InProcessWebSite.csproj
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/InProcessWebSite.csproj
@@ -34,13 +34,4 @@
     <Reference Include="Microsoft.Extensions.Logging.Console" />
     <Reference Include="xunit.assert" />
   </ItemGroup>
-
-  <!-- Repeat Build target for win-x64 to allow later Publish w/ NoBuild=true. -->
-  <Target Name="BuildX64"
-      BeforeTargets="Build"
-      Condition=" '$(RuntimeIdentifier)' != 'win-x64' AND '$(TargetArchitecture)' != 'arm' ">
-    <MSBuild Projects="$(MSBuildProjectFullPath)"
-        Properties="RuntimeIdentifier=win-x64;ReferenceTestTasks=false"
-        Targets="Build" />
-  </Target>
 </Project>


### PR DESCRIPTION
I'm opening this draft PR to see how removing the BuildX64 target in InProcessWebSite added in https://github.com/dotnet/aspnetcore/pull/39998 causes `dotnet publish --no-build` to fail when running tests on the CI. During dev ops I saw a lot of file copy failures and the deleted call to `<MSBuild Projects="$(MSBuildProjectFullPath)" Properties="RuntimeIdentifier=win-x64;ReferenceTestTasks=false" Targets="Build" />` seems to be to blame.

![image](https://user-images.githubusercontent.com/54385/161656319-b281d7a2-c590-4024-8167-68073208d394.png)

- https://dev.azure.com/dnceng/public/_build/results?buildId=1698630&view=logs&j=6c33d704-163a-5170-38fa-caa7bc99f17c&t=4a2ac175-72f0-54eb-c8b6-eb1e5d86c7d5
- https://dev.azure.com/dnceng/public/_build/results?buildId=1698912&view=logs&j=6c33d704-163a-5170-38fa-caa7bc99f17c&t=4a2ac175-72f0-54eb-c8b6-eb1e5d86c7d5
- https://dev.azure.com/dnceng/public/_build/results?buildId=1698798&view=logs&j=6c33d704-163a-5170-38fa-caa7bc99f17c&t=4a2ac175-72f0-54eb-c8b6-eb1e5d86c7d5&l=2699

https://github.com/dotnet/aspnetcore/issues/32219 We've had a bunch of things cause issues with file locks on the CI, but this seems especially frequent during my build ops rotation.