### PR TITLE
Add option to not cache assembly references in runtime razor compilation

### DIFF
--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/MvcRazorRuntimeCompilationOptions.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/MvcRazorRuntimeCompilationOptions.cs
@@ -29,4 +29,13 @@ public class MvcRazorRuntimeCompilationOptions
     /// uses to compile a Razor file. This API allows providing additional references to the compiler.
     /// </remarks>
     public IList<string> AdditionalReferencePaths { get; } = new List<string>();
+
+    /// <summary>
+    /// Configures whether assembly references should be cached or not.
+    /// </summary>
+    /// <remarks>
+    /// By default, all reference assemblies are cached. If set to false, this API
+    /// provides you with the option to use dynamically loaded assemblies.
+    /// </remarks>
+    public bool CacheAssemblyReferences { get; set; } = true;
 }

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/PublicAPI.Shipped.txt
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/PublicAPI.Shipped.txt
@@ -7,6 +7,8 @@ Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.FileProviderRazorProjectItem.F
 Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.MvcRazorRuntimeCompilationOptions
 Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.MvcRazorRuntimeCompilationOptions.AdditionalReferencePaths.get -> System.Collections.Generic.IList<string!>!
 Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.MvcRazorRuntimeCompilationOptions.FileProviders.get -> System.Collections.Generic.IList<Microsoft.Extensions.FileProviders.IFileProvider!>!
+Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.MvcRazorRuntimeCompilationOptions.CacheAssemblyReferences.set -> void
+Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.MvcRazorRuntimeCompilationOptions.CacheAssemblyReferences.get -> bool
 Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.MvcRazorRuntimeCompilationOptions.MvcRazorRuntimeCompilationOptions() -> void
 Microsoft.Extensions.DependencyInjection.RazorRuntimeCompilationMvcBuilderExtensions
 Microsoft.Extensions.DependencyInjection.RazorRuntimeCompilationMvcCoreBuilderExtensions

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RazorReferenceManager.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RazorReferenceManager.cs
@@ -29,11 +29,11 @@ internal class RazorReferenceManager
     {
         get
         {
-            return LazyInitializer.EnsureInitialized(
+            return _options.CacheAssemblyReferences ? LazyInitializer.EnsureInitialized(
                 ref _compilationReferences,
                 ref _compilationReferencesInitialized,
                 ref _compilationReferencesLock,
-                GetCompilationReferences)!;
+                GetCompilationReferences)! : GetCompilationReferences();
         }
     }
 

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/test/RazorReferenceManagerTest.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/test/RazorReferenceManagerTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
@@ -33,6 +33,34 @@ public class RazorReferenceManagerTest
         Assert.Equal(expected, references);
     }
 
+    [Fact]
+    public void CompilationReferences_ShouldCache_WhenCacheIsEnabled()
+    {
+        (RazorReferenceManager referenceManager, ApplicationPartManager applicationPartManager) = SetupCacheTest();
+
+        applicationPartManager.ApplicationParts.Add(new AssemblyPart(typeof(RazorReferenceManager).Assembly));
+
+        Assert.True(referenceManager.CompilationReferences.Count == 1);
+
+        applicationPartManager.ApplicationParts.Add(new AssemblyPart(typeof(object).Assembly));
+
+        Assert.True(referenceManager.CompilationReferences.Count == 1);
+    }
+
+    [Fact]
+    public void CompilationReferences_ShouldNotCache_WhenCacheIsDisabled()
+    {
+        (RazorReferenceManager referenceManager, ApplicationPartManager applicationPartManager) = SetupCacheTest(false);
+
+        applicationPartManager.ApplicationParts.Add(new AssemblyPart(typeof(RazorReferenceManager).Assembly));
+
+        Assert.True(referenceManager.CompilationReferences.Count == 1);
+
+        applicationPartManager.ApplicationParts.Add(new AssemblyPart(typeof(object).Assembly));
+
+        Assert.True(referenceManager.CompilationReferences.Count == 2);
+    }
+
     private static ApplicationPartManager GetApplicationPartManager()
     {
         var applicationPartManager = new ApplicationPartManager();
@@ -45,5 +73,16 @@ public class RazorReferenceManagerTest
         applicationPartManager.ApplicationParts.Add(part.Object);
 
         return applicationPartManager;
+    }
+
+    private static (RazorReferenceManager, ApplicationPartManager) SetupCacheTest(bool cacheEnabled = true)
+    {
+        var options = new MvcRazorRuntimeCompilationOptions { CacheAssemblyReferences = cacheEnabled };
+        var applicationPartManager = new ApplicationPartManager();
+        var referenceManager = new RazorReferenceManager(
+            applicationPartManager,
+            Options.Create(options));
+
+        return (referenceManager, applicationPartManager);
     }
 }


### PR DESCRIPTION
# Add option to not cache assembly references in runtime razor compilation

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Fixes #40377
