### PR TITLE
Create .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# Use file scope namespace
+a450cb69b5e4549f5515cdb057a68771f56cefd7


### PR DESCRIPTION
Prevents refactoring commits from showing up in "git blame" pages/commands.

c.f. https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

