### PR TITLE
Enable Latin1 request targets

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/PathNormalizer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/PathNormalizer.cs
@@ -13,12 +13,31 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
     {
         private const byte ByteSlash = (byte)'/';
         private const byte ByteDot = (byte)'.';
+        private const char Slash = '/';
+        private const char Dot = '.';
 
-        public static string DecodePath(Span<byte> path, bool pathEncoded, string rawTarget, int queryLength)
+        public static string DecodePath(Span<byte> path, bool pathEncoded, string rawTarget, int queryLength, bool useLatin1 = false)
         {
             int pathLength;
             if (pathEncoded)
             {
+                if (useLatin1)
+                {
+                    // We can't combine Latin1 and UTF-8, do Latin1 first and then decode the UTF-8 separately.
+                    var pathChars = path.GetLatin1StringNonNullCharacters().ToCharArray();
+                    pathLength = UrlDecoder.DecodeInPlace(pathChars);
+                    pathLength = RemoveDotSegments(pathChars.AsSpan()[..pathLength]);
+
+                    if (path.Length == pathLength && queryLength == 0)
+                    {
+                        // If no decoding was required, no dot segments were removed and
+                        // there is no query, the request path is the same as the raw target
+                        return rawTarget;
+                    }
+
+                    return new string(pathChars[..pathLength]);
+                }
+
                 // URI was encoded, unescape and then parse as UTF-8
                 pathLength = UrlDecoder.DecodeInPlace(path, isFormEncoding: false);
 
@@ -47,7 +66,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 return rawTarget;
             }
 
-            return path.Slice(0, pathLength).GetAsciiStringNonNullCharacters();
+            path = path[..pathLength];
+            if (useLatin1)
+            {
+                return path.GetLatin1StringNonNullCharacters();
+            }
+
+            return path.GetAsciiStringNonNullCharacters();
         }
 
         // In-place implementation of the algorithm from https://tools.ietf.org/html/rfc3986#section-5.2.4
@@ -193,6 +218,197 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 Debug.Assert(ch1 == '/', "Path segment must always start with a '/'");
 
                 byte ch2, ch3, ch4;
+
+                switch (end - src)
+                {
+                    case 1:
+                        break;
+                    case 2:
+                        ch2 = *(src + 1);
+
+                        if (ch2 == ByteDot)
+                        {
+                            return true;
+                        }
+
+                        break;
+                    case 3:
+                        ch2 = *(src + 1);
+                        ch3 = *(src + 2);
+
+                        if ((ch2 == ByteDot && ch3 == ByteDot) ||
+                            (ch2 == ByteDot && ch3 == ByteSlash))
+                        {
+                            return true;
+                        }
+
+                        break;
+                    default:
+                        ch2 = *(src + 1);
+                        ch3 = *(src + 2);
+                        ch4 = *(src + 3);
+
+                        if ((ch2 == ByteDot && ch3 == ByteDot && ch4 == ByteSlash) ||
+                            (ch2 == ByteDot && ch3 == ByteSlash))
+                        {
+                            return true;
+                        }
+
+                        break;
+                }
+
+                do
+                {
+                    ch1 = *++src;
+                } while (src < end && ch1 != ByteSlash);
+            }
+
+            return false;
+        }
+
+        // In-place implementation of the algorithm from https://tools.ietf.org/html/rfc3986#section-5.2.4
+        public static unsafe int RemoveDotSegments(Span<char> input)
+        {
+            fixed (char* start = input)
+            {
+                var end = start + input.Length;
+                return RemoveDotSegments(start, end);
+            }
+        }
+
+        public static unsafe int RemoveDotSegments(char* start, char* end)
+        {
+            if (!ContainsDotSegments(start, end))
+            {
+                return (int)(end - start);
+            }
+
+            var src = start;
+            var dst = start;
+
+            while (src < end)
+            {
+                var ch1 = *src;
+                Debug.Assert(ch1 == '/', "Path segment must always start with a '/'");
+
+                char ch2, ch3, ch4;
+
+                switch (end - src)
+                {
+                    case 1:
+                        break;
+                    case 2:
+                        ch2 = *(src + 1);
+
+                        if (ch2 == Dot)
+                        {
+                            // B.  if the input buffer begins with a prefix of "/./" or "/.",
+                            //     where "." is a complete path segment, then replace that
+                            //     prefix with "/" in the input buffer; otherwise,
+                            src += 1;
+                            *src = Slash;
+                            continue;
+                        }
+
+                        break;
+                    case 3:
+                        ch2 = *(src + 1);
+                        ch3 = *(src + 2);
+
+                        if (ch2 == Dot && ch3 == Dot)
+                        {
+                            // C.  if the input buffer begins with a prefix of "/../" or "/..",
+                            //     where ".." is a complete path segment, then replace that
+                            //     prefix with "/" in the input buffer and remove the last
+                            //     segment and its preceding "/" (if any) from the output
+                            //     buffer; otherwise,
+                            src += 2;
+                            *src = Slash;
+
+                            if (dst > start)
+                            {
+                                do
+                                {
+                                    dst--;
+                                } while (dst > start && *dst != Slash);
+                            }
+
+                            continue;
+                        }
+                        else if (ch2 == Dot && ch3 == Slash)
+                        {
+                            // B.  if the input buffer begins with a prefix of "/./" or "/.",
+                            //     where "." is a complete path segment, then replace that
+                            //     prefix with "/" in the input buffer; otherwise,
+                            src += 2;
+                            continue;
+                        }
+
+                        break;
+                    default:
+                        ch2 = *(src + 1);
+                        ch3 = *(src + 2);
+                        ch4 = *(src + 3);
+
+                        if (ch2 == Dot && ch3 == Dot && ch4 == Slash)
+                        {
+                            // C.  if the input buffer begins with a prefix of "/../" or "/..",
+                            //     where ".." is a complete path segment, then replace that
+                            //     prefix with "/" in the input buffer and remove the last
+                            //     segment and its preceding "/" (if any) from the output
+                            //     buffer; otherwise,
+                            src += 3;
+
+                            if (dst > start)
+                            {
+                                do
+                                {
+                                    dst--;
+                                } while (dst > start && *dst != Slash);
+                            }
+
+                            continue;
+                        }
+                        else if (ch2 == Dot && ch3 == Slash)
+                        {
+                            // B.  if the input buffer begins with a prefix of "/./" or "/.",
+                            //     where "." is a complete path segment, then replace that
+                            //     prefix with "/" in the input buffer; otherwise,
+                            src += 2;
+                            continue;
+                        }
+
+                        break;
+                }
+
+                // E.  move the first path segment in the input buffer to the end of
+                //     the output buffer, including the initial "/" character (if
+                //     any) and any subsequent characters up to, but not including,
+                //     the next "/" character or the end of the input buffer.
+                do
+                {
+                    *dst++ = ch1;
+                    ch1 = *++src;
+                } while (src < end && ch1 != Slash);
+            }
+
+            if (dst == start)
+            {
+                *dst++ = Slash;
+            }
+
+            return (int)(dst - start);
+        }
+
+        public static unsafe bool ContainsDotSegments(char* start, char* end)
+        {
+            var src = start;
+            while (src < end)
+            {
+                var ch1 = *src;
+                Debug.Assert(ch1 == '/', "Path segment must always start with a '/'");
+
+                char ch2, ch3, ch4;
 
                 switch (end - src)
                 {

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
@@ -106,6 +106,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure
         public static string GetAsciiStringNonNullCharacters(this Span<byte> span)
             => StringUtilities.GetAsciiStringNonNullCharacters(span);
 
+        public static string GetLatin1StringNonNullCharacters(this Span<byte> span)
+            => StringUtilities.GetLatin1StringNonNullCharacters(span);
+
         public static string GetAsciiOrUTF8StringNonNullCharacters(this ReadOnlySpan<byte> span)
             => StringUtilities.GetAsciiOrUTF8StringNonNullCharacters(span, DefaultRequestHeaderEncoding);
 

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -51,6 +51,21 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core
             set => _enableInsecureAbsoluteFormHostOverride = value;
         }
 
+        private bool? _enableInsecureLatin1RequestTargets;
+        internal bool EnableInsecureLatin1RequestTargets
+        {
+            get
+            {
+                if (!_enableInsecureLatin1RequestTargets.HasValue)
+                {
+                    _enableInsecureLatin1RequestTargets =
+                        AppContext.TryGetSwitch("Microsoft.AspNetCore.Server.Kestrel.EnableInsecureLatin1RequestTargets", out var enabled) && enabled;
+                }
+                return _enableInsecureLatin1RequestTargets.Value;
+            }
+            set => _enableInsecureLatin1RequestTargets = value;
+        }
+
         // The following two lists configure the endpoints that Kestrel should listen to. If both lists are empty, the "urls" config setting (e.g. UseUrls) is used.
         internal List<ListenOptions> CodeBackedListenOptions { get; } = new List<ListenOptions>();
         internal List<ListenOptions> ConfigurationBackedListenOptions { get; } = new List<ListenOptions>();

--- a/src/Servers/Kestrel/shared/test/HttpParsingData.cs
+++ b/src/Servers/Kestrel/shared/test/HttpParsingData.cs
@@ -345,6 +345,7 @@ namespace Microsoft.AspNetCore.Testing
                     "/\0",
                     "/\0\0",
                     "/%C8\0",
+                    "http://host/\0"
                 }.Concat(QueryStringWithNullCharData);
             }
         }


### PR DESCRIPTION
Enables Kestrel to accept requests where the target (uri, path, query, etc.) is improperly encoded using Latin1 rather than ASCII + UTF-8 Percent escaping.
Also addresses #41071 (error handling)

Starting as draft to get feedback on the approach.