### PR TITLE
Introduce IBindableFromHttpContext<TSelf>

### DIFF
--- a/src/Http/Http.Abstractions/src/IBindableFromHttpContextOfT.cs
+++ b/src/Http/Http.Abstractions/src/IBindableFromHttpContextOfT.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+
+namespace Microsoft.AspNetCore.Http;
+
+/// <summary>
+/// Defines a mechanism for creating an instance of a type from an <see cref="HttpContext"/> when binding parameters for an endpoint
+/// route handler delegate.
+/// </summary>
+/// <typeparam name="TSelf">The type that implements this interface.</typeparam>
+public interface IBindableFromHttpContext<TSelf>
+    where TSelf : IBindableFromHttpContext<TSelf>
+{
+    /// <summary>
+    /// Creates an instance of <typeparamref name="TSelf"/> from the <see cref="HttpContext"/>.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> for the current request.</param>
+    /// <param name="parameter">The <see cref="ParameterInfo"/> for the parameter of the route handler delegate the returned instance will populate.</param>
+    /// <returns>The instance of the type.</returns>
+    static abstract ValueTask<TSelf?> BindAsync(HttpContext context, ParameterInfo parameter);
+}

--- a/src/Http/Http.Abstractions/src/IBindableFromHttpContextOfT.cs
+++ b/src/Http/Http.Abstractions/src/IBindableFromHttpContextOfT.cs
@@ -12,11 +12,11 @@ namespace Microsoft.AspNetCore.Http;
 /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
 public interface IBindableFromHttpContext<TSelf> where TSelf : IBindableFromHttpContext<TSelf>
 {
-   /// <summary>
-   /// Creates an instance of <typeparamref name="TSelf"/> from the <see cref="HttpContext"/>.
-   /// </summary>
-   /// <param name="context">The <see cref="HttpContext"/> for the current request.</param>
-   /// <param name="parameter">The <see cref="ParameterInfo"/> for the parameter of the route handler delegate the returned instance will populate.</param>
-   /// <returns>The instance of <typeparamref name="TSelf"/>.</returns>
-   static abstract ValueTask<TSelf?> BindAsync(HttpContext context, ParameterInfo parameter);
+    /// <summary>
+    /// Creates an instance of <typeparamref name="TSelf"/> from the <see cref="HttpContext"/>.
+    /// </summary>
+    /// <param name="context">The <see cref="HttpContext"/> for the current request.</param>
+    /// <param name="parameter">The <see cref="ParameterInfo"/> for the parameter of the route handler delegate the returned instance will populate.</param>
+    /// <returns>The instance of <typeparamref name="TSelf"/>.</returns>
+    static abstract ValueTask<TSelf?> BindAsync(HttpContext context, ParameterInfo parameter);
 }

--- a/src/Http/Http.Abstractions/src/IBindableFromHttpContextOfT.cs
+++ b/src/Http/Http.Abstractions/src/IBindableFromHttpContextOfT.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Http;
 /// route handler delegate.
 /// </summary>
 /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
-public interface IBindableFromHttpContext<TSelf> where TSelf : class?, IBindableFromHttpContext<TSelf>
+public interface IBindableFromHttpContext<TSelf> where TSelf : class, IBindableFromHttpContext<TSelf>
 {
     /// <summary>
     /// Creates an instance of <typeparamref name="TSelf"/> from the <see cref="HttpContext"/>.

--- a/src/Http/Http.Abstractions/src/IBindableFromHttpContextOfT.cs
+++ b/src/Http/Http.Abstractions/src/IBindableFromHttpContextOfT.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Http;
 /// route handler delegate.
 /// </summary>
 /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
-public interface IBindableFromHttpContext<TSelf> where TSelf : IBindableFromHttpContext<TSelf>
+public interface IBindableFromHttpContext<TSelf> where TSelf : class?, IBindableFromHttpContext<TSelf>
 {
     /// <summary>
     /// Creates an instance of <typeparamref name="TSelf"/> from the <see cref="HttpContext"/>.

--- a/src/Http/Http.Abstractions/src/IBindableFromHttpContextOfT.cs
+++ b/src/Http/Http.Abstractions/src/IBindableFromHttpContextOfT.cs
@@ -10,14 +10,13 @@ namespace Microsoft.AspNetCore.Http;
 /// route handler delegate.
 /// </summary>
 /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
-public interface IBindableFromHttpContext<TSelf>
-    where TSelf : IBindableFromHttpContext<TSelf>
+public interface IBindableFromHttpContext<TSelf> where TSelf : IBindableFromHttpContext<TSelf>
 {
-    /// <summary>
-    /// Creates an instance of <typeparamref name="TSelf"/> from the <see cref="HttpContext"/>.
-    /// </summary>
-    /// <param name="context">The <see cref="HttpContext"/> for the current request.</param>
-    /// <param name="parameter">The <see cref="ParameterInfo"/> for the parameter of the route handler delegate the returned instance will populate.</param>
-    /// <returns>The instance of the type.</returns>
-    static abstract ValueTask<TSelf?> BindAsync(HttpContext context, ParameterInfo parameter);
+   /// <summary>
+   /// Creates an instance of <typeparamref name="TSelf"/> from the <see cref="HttpContext"/>.
+   /// </summary>
+   /// <param name="context">The <see cref="HttpContext"/> for the current request.</param>
+   /// <param name="parameter">The <see cref="ParameterInfo"/> for the parameter of the route handler delegate the returned instance will populate.</param>
+   /// <returns>The instance of <typeparamref name="TSelf"/>.</returns>
+   static abstract ValueTask<TSelf?> BindAsync(HttpContext context, ParameterInfo parameter);
 }

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -9,6 +9,8 @@ Microsoft.AspNetCore.Http.DefaultRouteHandlerInvocationContext
 Microsoft.AspNetCore.Http.DefaultRouteHandlerInvocationContext.DefaultRouteHandlerInvocationContext(Microsoft.AspNetCore.Http.HttpContext! httpContext, params object![]! arguments) -> void
 Microsoft.AspNetCore.Http.EndpointMetadataCollection.Enumerator.Current.get -> object!
 Microsoft.AspNetCore.Http.EndpointMetadataCollection.GetRequiredMetadata<T>() -> T!
+Microsoft.AspNetCore.Http.IBindableFromHttpContext<TSelf>
+Microsoft.AspNetCore.Http.IBindableFromHttpContext<TSelf>.BindAsync(Microsoft.AspNetCore.Http.HttpContext! context, System.Reflection.ParameterInfo! parameter) -> System.Threading.Tasks.ValueTask<TSelf?>
 Microsoft.AspNetCore.Http.IRouteHandlerFilter.InvokeAsync(Microsoft.AspNetCore.Http.RouteHandlerInvocationContext! context, Microsoft.AspNetCore.Http.RouteHandlerFilterDelegate! next) -> System.Threading.Tasks.ValueTask<object?>
 Microsoft.AspNetCore.Http.Metadata.IFromFormMetadata
 Microsoft.AspNetCore.Http.Metadata.IFromFormMetadata.Name.get -> string?

--- a/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
+++ b/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
@@ -321,10 +321,35 @@ public class ParameterBindingMethodCacheTests
     }
 
     [Fact]
+    public void HasBindAsyncMethod_ReturnsTrueForClassImplementingIBindableFromHttpContext()
+    {
+        var parameterInfo = GetFirstParameter((BindAsyncFromStaticAbstractInterface arg) => BindAsyncFromStaticAbstractInterfaceMethod(arg));
+        Assert.True(new ParameterBindingMethodCache().HasBindAsyncMethod(parameterInfo));
+    }
+
+    [Fact]
     public void FindBindAsyncMethod_FindsNonNullableReturningBindAsyncMethodGivenNullableType()
     {
         var parameterInfo = GetFirstParameter((BindAsyncStruct? arg) => BindAsyncNullableStructMethod(arg));
         Assert.True(new ParameterBindingMethodCache().HasBindAsyncMethod(parameterInfo));
+    }
+
+    [Fact]
+    public async Task FindBindAsyncMethod_FindsForClassImplementingIBindableFromHttpContext()
+    {
+        var parameterInfo = GetFirstParameter((BindAsyncFromStaticAbstractInterface arg) => BindAsyncFromStaticAbstractInterfaceMethod(arg));
+        var cache = new ParameterBindingMethodCache();
+        Assert.True(cache.HasBindAsyncMethod(parameterInfo));
+        var methodFound = cache.FindBindAsyncMethod(parameterInfo);
+
+        var parseHttpContext = Expression.Lambda<Func<HttpContext, ValueTask<object?>>>(methodFound.Expression!,
+            ParameterBindingMethodCache.HttpContextExpr).Compile();
+
+        var httpContext = new DefaultHttpContext();
+
+        var result = await parseHttpContext(httpContext);
+        Assert.NotNull(result);
+        Assert.IsType<BindAsyncFromStaticAbstractInterface>(result);
     }
 
     [Fact]
@@ -627,7 +652,6 @@ public class ParameterBindingMethodCacheTests
     private static void BindAsyncStructMethod(BindAsyncStruct arg) { }
     private static void BindAsyncNullableStructMethod(BindAsyncStruct? arg) { }
     private static void NullableReturningBindAsyncStructMethod(NullableReturningBindAsyncStruct arg) { }
-
     private static void BindAsyncSingleArgRecordMethod(BindAsyncSingleArgRecord arg) { }
     private static void BindAsyncSingleArgStructMethod(BindAsyncSingleArgStruct arg) { }
     private static void InheritBindAsyncMethod(InheritBindAsync arg) { }
@@ -639,6 +663,7 @@ public class ParameterBindingMethodCacheTests
     private static void BindAsyncFromInterfaceWithParameterInfoMethod(BindAsyncFromInterfaceWithParameterInfo args) { }
     private static void BindAsyncFallbackMethod(BindAsyncFallsBack? arg) { }
     private static void BindAsyncBadMethodMethod(BindAsyncBadMethod? arg) { }
+    private static void BindAsyncFromStaticAbstractInterfaceMethod(BindAsyncFromStaticAbstractInterface arg) { }
 
     private static ParameterInfo GetFirstParameter<T>(Expression<Action<T>> expr)
     {
@@ -1344,6 +1369,14 @@ public class ParameterBindingMethodCacheTests
         public RecordStructWithInvalidConstructors(int foo, int bar)
         {
             Foo = foo;
+        }
+    }
+
+    private class BindAsyncFromStaticAbstractInterface : IBindableFromHttpContext<BindAsyncFromStaticAbstractInterface>
+    {
+        public static ValueTask<BindAsyncFromStaticAbstractInterface?> BindAsync(HttpContext context, ParameterInfo parameter)
+        {
+            return ValueTask.FromResult<BindAsyncFromStaticAbstractInterface?>(new());
         }
     }
 

--- a/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
+++ b/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
@@ -336,20 +336,6 @@ public class ParameterBindingMethodCacheTests
     }
 
     [Fact]
-    public void HasBindAsyncMethod_ReturnsTrueForNonNullableStructImplicitlyImplementingIBindableFromHttpContext()
-    {
-        var parameterInfo = GetFirstParameter((BindAsyncFromStaticAbstractImplicitInterfaceNonNullableStruct arg) => BindAsyncFromNonNullableStructImplicitStaticAbstractInterfaceMethod(arg));
-        Assert.True(new ParameterBindingMethodCache().HasBindAsyncMethod(parameterInfo));
-    }
-
-    [Fact]
-    public void HasBindAsyncMethod_ReturnsTrueForNonNullableStructExplicitlyImplementingIBindableFromHttpContext()
-    {
-        var parameterInfo = GetFirstParameter((BindAsyncFromStaticAbstractExplicitInterfaceNonNullableStruct arg) => BindAsyncFromNonNullableStructExplicitStaticAbstractInterfaceMethod(arg));
-        Assert.True(new ParameterBindingMethodCache().HasBindAsyncMethod(parameterInfo));
-    }
-
-    [Fact]
     public void FindBindAsyncMethod_FindsNonNullableReturningBindAsyncMethodGivenNullableType()
     {
         var parameterInfo = GetFirstParameter((BindAsyncStruct? arg) => BindAsyncNullableStructMethod(arg));
@@ -390,42 +376,6 @@ public class ParameterBindingMethodCacheTests
         var result = await parseHttpContext(httpContext);
         Assert.NotNull(result);
         Assert.IsType<BindAsyncFromExplicitStaticAbstractInterface>(result);
-    }
-
-    [Fact]
-    public async Task FindBindAsyncMethod_FindsForNonNullableStructImplicitlyImplementingIBindableFromHttpContext()
-    {
-        var parameterInfo = GetFirstParameter((BindAsyncFromStaticAbstractImplicitInterfaceNonNullableStruct arg) => BindAsyncFromNonNullableStructImplicitStaticAbstractInterfaceMethod(arg));
-        var cache = new ParameterBindingMethodCache();
-        Assert.True(cache.HasBindAsyncMethod(parameterInfo));
-        var methodFound = cache.FindBindAsyncMethod(parameterInfo);
-
-        var parseHttpContext = Expression.Lambda<Func<HttpContext, ValueTask<object?>>>(methodFound.Expression!,
-            ParameterBindingMethodCache.HttpContextExpr).Compile();
-
-        var httpContext = new DefaultHttpContext();
-
-        var result = await parseHttpContext(httpContext);
-        Assert.NotNull(result);
-        Assert.IsType<BindAsyncFromStaticAbstractImplicitInterfaceNonNullableStruct>(result);
-    }
-
-    [Fact]
-    public async Task FindBindAsyncMethod_FindsForNonNullableStructExplicitlyImplementingIBindableFromHttpContext()
-    {
-        var parameterInfo = GetFirstParameter((BindAsyncFromStaticAbstractExplicitInterfaceNonNullableStruct arg) => BindAsyncFromNonNullableStructExplicitStaticAbstractInterfaceMethod(arg));
-        var cache = new ParameterBindingMethodCache();
-        Assert.True(cache.HasBindAsyncMethod(parameterInfo));
-        var methodFound = cache.FindBindAsyncMethod(parameterInfo);
-
-        var parseHttpContext = Expression.Lambda<Func<HttpContext, ValueTask<object?>>>(methodFound.Expression!,
-            ParameterBindingMethodCache.HttpContextExpr).Compile();
-
-        var httpContext = new DefaultHttpContext();
-
-        var result = await parseHttpContext(httpContext);
-        Assert.NotNull(result);
-        Assert.IsType<BindAsyncFromStaticAbstractExplicitInterfaceNonNullableStruct>(result);
     }
 
     [Fact]
@@ -600,8 +550,7 @@ public class ParameterBindingMethodCacheTests
                 typeof(BindAsyncWithParameterInfoWrongTypeInherit),
                 typeof(BindAsyncWrongTypeFromInterface),
                 typeof(BindAsyncBothBadMethods),
-                typeof(BindAsyncFromStaticAbstractInterfaceWrongType),
-                typeof(NonNullableBindAsyncFromStaticAbstractInterfaceStructWrongType)
+                typeof(BindAsyncFromStaticAbstractInterfaceWrongType)
             };
         }
     }
@@ -744,8 +693,6 @@ public class ParameterBindingMethodCacheTests
     private static void BindAsyncFromImplicitStaticAbstractInterfaceMethod(BindAsyncFromImplicitStaticAbstractInterface arg) { }
     private static void BindAsyncFromExplicitStaticAbstractInterfaceMethod(BindAsyncFromExplicitStaticAbstractInterface arg) { }
     private static void BindAsyncFromStaticAbstractInterfaceWrongTypeMethod(BindAsyncFromStaticAbstractInterfaceWrongType arg) { }
-    private static void BindAsyncFromNonNullableStructImplicitStaticAbstractInterfaceMethod(BindAsyncFromStaticAbstractImplicitInterfaceNonNullableStruct arg) { }
-    private static void BindAsyncFromNonNullableStructExplicitStaticAbstractInterfaceMethod(BindAsyncFromStaticAbstractExplicitInterfaceNonNullableStruct arg) { }
 
     private static ParameterInfo GetFirstParameter<T>(Expression<Action<T>> expr)
     {
@@ -1475,30 +1422,6 @@ public class ParameterBindingMethodCacheTests
         public static ValueTask<BindAsyncFromImplicitStaticAbstractInterface?> BindAsync(HttpContext context, ParameterInfo parameter)
         {
             return ValueTask.FromResult<BindAsyncFromImplicitStaticAbstractInterface?>(new());
-        }
-    }
-
-    private record struct BindAsyncFromStaticAbstractImplicitInterfaceNonNullableStruct() : IBindableFromHttpContext<BindAsyncFromStaticAbstractImplicitInterfaceNonNullableStruct>
-    {
-        public static ValueTask<BindAsyncFromStaticAbstractImplicitInterfaceNonNullableStruct> BindAsync(HttpContext context, ParameterInfo parameter)
-        {
-            return ValueTask.FromResult<BindAsyncFromStaticAbstractImplicitInterfaceNonNullableStruct>(new());
-        }
-    }
-
-    private record struct BindAsyncFromStaticAbstractExplicitInterfaceNonNullableStruct() : IBindableFromHttpContext<BindAsyncFromStaticAbstractExplicitInterfaceNonNullableStruct>
-    {
-        static ValueTask<BindAsyncFromStaticAbstractExplicitInterfaceNonNullableStruct> IBindableFromHttpContext<BindAsyncFromStaticAbstractExplicitInterfaceNonNullableStruct>.BindAsync(HttpContext context, ParameterInfo parameter)
-        {
-            return ValueTask.FromResult<BindAsyncFromStaticAbstractExplicitInterfaceNonNullableStruct>(new());
-        }
-    }
-
-    private record struct NonNullableBindAsyncFromStaticAbstractInterfaceStructWrongType() : IBindableFromHttpContext<BindAsyncFromStaticAbstractImplicitInterfaceNonNullableStruct>
-    {
-        public static ValueTask<BindAsyncFromStaticAbstractImplicitInterfaceNonNullableStruct> BindAsync(HttpContext context, ParameterInfo parameter)
-        {
-            return ValueTask.FromResult<BindAsyncFromStaticAbstractImplicitInterfaceNonNullableStruct>(new());
         }
     }
 

--- a/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
+++ b/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
@@ -424,7 +424,7 @@ public class ParameterBindingMethodCacheTests
     [Fact]
     public async Task FindBindAsyncMethod_FindsMethodFromStaticAbstractInterfaceWhenValidNonInterfaceMethodAlsoExists()
     {
-        var parameterInfo = GetFirstParameter((BindAsyncFromStaticAbstractInterfaceAndBindAsync? arg) => BindAsyncFromImplicitStaticAbstractInterfaceMethodInsteadOfReflectionMatchedMethod(arg));
+        var parameterInfo = GetFirstParameter((BindAsyncFromStaticAbstractInterfaceAndBindAsync arg) => BindAsyncFromImplicitStaticAbstractInterfaceMethodInsteadOfReflectionMatchedMethod(arg));
         var cache = new ParameterBindingMethodCache();
         Assert.True(cache.HasBindAsyncMethod(parameterInfo));
         var methodFound = cache.FindBindAsyncMethod(parameterInfo);

--- a/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
+++ b/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
@@ -550,6 +550,7 @@ public class ParameterBindingMethodCacheTests
                 typeof(BindAsyncWithParameterInfoWrongTypeInherit),
                 typeof(BindAsyncWrongTypeFromInterface),
                 typeof(BindAsyncBothBadMethods),
+                typeof(BindAsyncFromStaticAbstractInterfaceWrongType)
             };
         }
     }
@@ -691,6 +692,7 @@ public class ParameterBindingMethodCacheTests
     private static void BindAsyncBadMethodMethod(BindAsyncBadMethod? arg) { }
     private static void BindAsyncFromImplicitStaticAbstractInterfaceMethod(BindAsyncFromImplicitStaticAbstractInterface arg) { }
     private static void BindAsyncFromExplicitStaticAbstractInterfaceMethod(BindAsyncFromExplicitStaticAbstractInterface arg) { }
+    private static void BindAsyncFromStaticAbstractInterfaceWrongTypeMethod(BindAsyncFromStaticAbstractInterfaceWrongType arg) { }
 
     private static ParameterInfo GetFirstParameter<T>(Expression<Action<T>> expr)
     {
@@ -1412,6 +1414,14 @@ public class ParameterBindingMethodCacheTests
         static ValueTask<BindAsyncFromExplicitStaticAbstractInterface?> IBindableFromHttpContext<BindAsyncFromExplicitStaticAbstractInterface>.BindAsync(HttpContext context, ParameterInfo parameter)
         {
             return ValueTask.FromResult<BindAsyncFromExplicitStaticAbstractInterface?>(new());
+        }
+    }
+
+    private class BindAsyncFromStaticAbstractInterfaceWrongType : IBindableFromHttpContext<BindAsyncFromImplicitStaticAbstractInterface>
+    {
+        public static ValueTask<BindAsyncFromImplicitStaticAbstractInterface?> BindAsync(HttpContext context, ParameterInfo parameter)
+        {
+            return ValueTask.FromResult<BindAsyncFromImplicitStaticAbstractInterface?>(new());
         }
     }
 

--- a/src/Http/samples/MinimalSample/Program.cs
+++ b/src/Http/samples/MinimalSample/Program.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Http.HttpResults;
+using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -63,6 +64,19 @@ app.MapGet("/problem/{problemType}", (string problemType) => problemType switch
 
     });
 
+app.MapPost("/todos", (TodoBindable todo) => todo);
+
 app.Run();
 
 internal record Todo(int Id, string Title);
+public class TodoBindable : IBindableFromHttpContext<TodoBindable>
+{
+    public int Id { get; set; }
+    public string Title { get; set; }
+    public bool IsComplete { get; set; }
+
+    public static ValueTask<TodoBindable> BindAsync(HttpContext context, ParameterInfo parameter)
+    {
+        return ValueTask.FromResult(new TodoBindable { Id = 1, Title = "I was bound from IBindableFromHttpContext<TodoBindable>.BindAsync!" });
+    }
+}

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -383,12 +383,12 @@ internal sealed class ParameterBindingMethodCache
     private static MethodInfo? GetIBindableFromHttpContextMethod(Type type)
     {
         // Check if parameter is bindable via static abstract method on IBindableFromHttpContext<TSelf>
-        var isBindableViaInterface = type.GetInterfaces()
-            .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IBindableFromHttpContext<>) && i.GetGenericArguments()[0] == type);
-
-        if (isBindableViaInterface)
+        foreach (var i in type.GetInterfaces())
         {
-            return BindAsyncMethod.MakeGenericMethod(type);
+            if (i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IBindableFromHttpContext<>) && i.GetGenericArguments()[0] == type)
+            {
+                return BindAsyncMethod.MakeGenericMethod(type);
+            }
         }
 
         return null;

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -400,7 +400,6 @@ internal sealed class ParameterBindingMethodCache
         return TValue.BindAsync(httpContext, parameter);
     }
         
-
     private MethodInfo? GetStaticMethodFromHierarchy(Type type, string name, Type[] parameterTypes, Func<MethodInfo, bool> validateReturnType)
     {
         bool IsMatch(MethodInfo? method) => method is not null && !method.IsAbstract && validateReturnType(method);

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -395,7 +395,7 @@ internal sealed class ParameterBindingMethodCache
     }
 
     private static ValueTask<TValue?> BindAsync<TValue>(HttpContext httpContext, ParameterInfo parameter)
-        where TValue : IBindableFromHttpContext<TValue>
+        where TValue : class?, IBindableFromHttpContext<TValue>
     {
         return TValue.BindAsync(httpContext, parameter);
     }


### PR DESCRIPTION
Introduces the new `IBindableFromHttpContext<TSelf> where TSelf : IBindableFromHttpContext<TSelf>` interface that defines a `static abstract` `BindAsync` method.

Fixes #40927