### PR TITLE
fix allocation issue caused by ordering of MVC result executors for Task results

### DIFF
--- a/src/Mvc/Mvc.Core/src/Infrastructure/ActionMethodExecutor.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ActionMethodExecutor.cs
@@ -19,8 +19,9 @@ internal abstract class ActionMethodExecutor
             new SyncObjectResultExecutor(),
 
             // Executors for async methods
-            new AwaitableResultExecutor(),
+
             new TaskResultExecutor(),
+            new AwaitableResultExecutor(),
             new TaskOfIActionResultExecutor(),
             new TaskOfActionResultExecutor(),
             new AwaitableObjectResultExecutor(),

--- a/src/Mvc/Mvc.Core/src/Infrastructure/ActionMethodExecutor.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ActionMethodExecutor.cs
@@ -19,7 +19,6 @@ internal abstract class ActionMethodExecutor
             new SyncObjectResultExecutor(),
 
             // Executors for async methods
-
             new TaskResultExecutor(),
             new AwaitableResultExecutor(),
             new TaskOfIActionResultExecutor(),

--- a/src/Mvc/Mvc.Core/test/Infrastructure/ActionMethodExecutorTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ActionMethodExecutorTest.cs
@@ -1,8 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
 using Microsoft.Extensions.Internal;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.AspNetCore.Mvc.Infrastructure;
 
@@ -21,6 +22,8 @@ public class ActionMethodExecutorTest
         var valueTask = actionMethodExecutor.Execute(mapper, objectMethodExecutor, controller, Array.Empty<object>());
 
         // Assert
+
+        Assert.Equal("VoidResultExecutor", actionMethodExecutor.GetType().Name);
         Assert.True(controller.Executed);
         Assert.IsType<EmptyResult>(valueTask.Result);
     }
@@ -38,6 +41,8 @@ public class ActionMethodExecutorTest
         var valueTask = actionMethodExecutor.Execute(mapper, objectMethodExecutor, controller, Array.Empty<object>());
 
         // Assert
+
+        Assert.Equal("SyncActionResultExecutor", actionMethodExecutor.GetType().Name);
         Assert.True(valueTask.IsCompleted);
         Assert.IsType<ContentResult>(valueTask.Result);
     }
@@ -55,6 +60,7 @@ public class ActionMethodExecutorTest
         var valueTask = actionMethodExecutor.Execute(mapper, objectMethodExecutor, controller, Array.Empty<object>());
 
         // Assert
+        Assert.Equal("SyncActionResultExecutor", actionMethodExecutor.GetType().Name);
         Assert.IsType<ContentResult>(valueTask.Result);
     }
 
@@ -72,6 +78,8 @@ public class ActionMethodExecutorTest
 
         // Assert
         var result = Assert.IsType<ObjectResult>(valueTask.Result);
+
+        Assert.Equal("SyncObjectResultExecutor", actionMethodExecutor.GetType().Name);
         Assert.NotNull(result.Value);
         Assert.IsType<TestModel>(result.Value);
         Assert.Equal(typeof(TestModel), result.DeclaredType);
@@ -91,6 +99,8 @@ public class ActionMethodExecutorTest
 
         // Assert
         var result = Assert.IsType<ObjectResult>(valueTask.Result);
+
+        Assert.Equal("SyncObjectResultExecutor", actionMethodExecutor.GetType().Name);
         Assert.NotNull(result.Value);
         Assert.IsType<TestModel>(result.Value);
         Assert.Equal(typeof(TestModel), result.DeclaredType);
@@ -110,6 +120,8 @@ public class ActionMethodExecutorTest
 
         // Assert
         var result = Assert.IsType<ObjectResult>(valueTask.Result);
+
+        Assert.Equal("SyncObjectResultExecutor", actionMethodExecutor.GetType().Name);
         Assert.NotNull(result.Value);
         Assert.IsType<TestModel>(result.Value);
         Assert.Equal(typeof(object), result.DeclaredType);
@@ -126,8 +138,9 @@ public class ActionMethodExecutorTest
 
         // Act
         var valueTask = actionMethodExecutor.Execute(mapper, objectMethodExecutor, controller, Array.Empty<object>());
-
+     
         // Assert
+        Assert.Equal("SyncActionResultExecutor", actionMethodExecutor.GetType().Name);
         Assert.IsType<ContentResult>(valueTask.Result);
     }
 
@@ -144,6 +157,25 @@ public class ActionMethodExecutorTest
         var valueTask = actionMethodExecutor.Execute(mapper, objectMethodExecutor, controller, Array.Empty<object>());
 
         // Assert
+        Assert.Equal("TaskResultExecutor", actionMethodExecutor.GetType().Name);  
+        Assert.True(controller.Executed);
+        Assert.IsType<EmptyResult>(valueTask.Result);
+    }
+
+    [Fact]
+    public void ActionMethodExecutor_ExecutesActionsReturnAwaitable()
+    {
+        // Arrange
+        var mapper = new ActionResultTypeMapper();
+        var controller = new TestController();
+        var objectMethodExecutor = GetExecutor(nameof(TestController.ReturnsAwaitable));
+        var actionMethodExecutor = ActionMethodExecutor.GetExecutor(objectMethodExecutor);
+
+        // Act
+        var valueTask = actionMethodExecutor.Execute(mapper, objectMethodExecutor, controller, Array.Empty<object>());
+
+        // Assert
+        Assert.Equal("AwaitableResultExecutor", actionMethodExecutor.GetType().Name);
         Assert.True(controller.Executed);
         Assert.IsType<EmptyResult>(valueTask.Result);
     }
@@ -161,6 +193,7 @@ public class ActionMethodExecutorTest
         var valueTask = actionMethodExecutor.Execute(mapper, objectMethodExecutor, controller, Array.Empty<object>());
 
         // Assert
+        Assert.Equal("TaskOfIActionResultExecutor", actionMethodExecutor.GetType().Name);
         Assert.IsType<StatusCodeResult>(valueTask.Result);
     }
 
@@ -178,8 +211,10 @@ public class ActionMethodExecutorTest
 
         // Assert
         await valueTask;
+        Assert.Equal("TaskOfIActionResultExecutor", actionMethodExecutor.GetType().Name);
         Assert.IsType<StatusCodeResult>(valueTask.Result);
     }
+
 
     [Fact]
     public void ActionMethodExecutor_ExecutesActionsAsynchronouslyReturningModel()
@@ -195,6 +230,8 @@ public class ActionMethodExecutorTest
 
         // Assert
         var result = Assert.IsType<ObjectResult>(valueTask.Result);
+
+        Assert.Equal("AwaitableObjectResultExecutor", actionMethodExecutor.GetType().Name);
         Assert.NotNull(result.Value);
         Assert.IsType<TestModel>(result.Value);
         Assert.Equal(typeof(TestModel), result.DeclaredType);
@@ -214,6 +251,8 @@ public class ActionMethodExecutorTest
 
         // Assert
         var result = Assert.IsType<ObjectResult>(valueTask.Result);
+
+        Assert.Equal("AwaitableObjectResultExecutor", actionMethodExecutor.GetType().Name);
         Assert.NotNull(result.Value);
         Assert.IsType<TestModel>(result.Value);
         Assert.Equal(typeof(object), result.DeclaredType);
@@ -232,6 +271,7 @@ public class ActionMethodExecutorTest
         var valueTask = actionMethodExecutor.Execute(mapper, objectMethodExecutor, controller, Array.Empty<object>());
 
         // Assert
+        Assert.Equal("AwaitableObjectResultExecutor", actionMethodExecutor.GetType().Name);
         Assert.IsType<OkResult>(valueTask.Result);
     }
 
@@ -249,6 +289,8 @@ public class ActionMethodExecutorTest
 
         // Assert
         var result = Assert.IsType<ObjectResult>(valueTask.Result);
+
+        Assert.Equal("AwaitableObjectResultExecutor", actionMethodExecutor.GetType().Name);
         Assert.NotNull(result.Value);
         Assert.IsType<TestModel>(result.Value);
         Assert.Equal(typeof(TestModel), result.DeclaredType);
@@ -302,6 +344,12 @@ public class ActionMethodExecutorTest
         {
             Executed = true;
             return Task.CompletedTask;
+        }
+
+        public YieldAwaitable ReturnsAwaitable()
+        {
+            Executed = true;
+            return Task.Yield();
         }
 
         public Task<IActionResult> ReturnIActionResultAsync() => Task.FromResult((IActionResult)new StatusCodeResult(201));

--- a/src/Mvc/Mvc.Core/test/Infrastructure/ActionMethodExecutorTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ActionMethodExecutorTest.cs
@@ -136,7 +136,7 @@ public class ActionMethodExecutorTest
 
         // Act
         var valueTask = actionMethodExecutor.Execute(mapper, objectMethodExecutor, controller, Array.Empty<object>());
-     
+
         // Assert
         Assert.Equal("SyncActionResultExecutor", actionMethodExecutor.GetType().Name);
         Assert.IsType<ContentResult>(valueTask.Result);

--- a/src/Mvc/Mvc.Core/test/Infrastructure/ActionMethodExecutorTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ActionMethodExecutorTest.cs
@@ -22,7 +22,6 @@ public class ActionMethodExecutorTest
         var valueTask = actionMethodExecutor.Execute(mapper, objectMethodExecutor, controller, Array.Empty<object>());
 
         // Assert
-
         Assert.Equal("VoidResultExecutor", actionMethodExecutor.GetType().Name);
         Assert.True(controller.Executed);
         Assert.IsType<EmptyResult>(valueTask.Result);
@@ -41,7 +40,6 @@ public class ActionMethodExecutorTest
         var valueTask = actionMethodExecutor.Execute(mapper, objectMethodExecutor, controller, Array.Empty<object>());
 
         // Assert
-
         Assert.Equal("SyncActionResultExecutor", actionMethodExecutor.GetType().Name);
         Assert.True(valueTask.IsCompleted);
         Assert.IsType<ContentResult>(valueTask.Result);
@@ -172,12 +170,12 @@ public class ActionMethodExecutorTest
         var actionMethodExecutor = ActionMethodExecutor.GetExecutor(objectMethodExecutor);
 
         // Act
-        var valueTask = actionMethodExecutor.Execute(mapper, objectMethodExecutor, controller, Array.Empty<object>());
+        var awaitableResult = actionMethodExecutor.Execute(mapper, objectMethodExecutor, controller, Array.Empty<object>());
 
         // Assert
         Assert.Equal("AwaitableResultExecutor", actionMethodExecutor.GetType().Name);
         Assert.True(controller.Executed);
-        Assert.IsType<EmptyResult>(valueTask.Result);
+        Assert.IsType<EmptyResult>(awaitableResult.Result);
     }
 
     [Fact]

--- a/src/Mvc/Mvc.Core/test/Infrastructure/ActionMethodExecutorTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ActionMethodExecutorTest.cs
@@ -201,7 +201,7 @@ public class ActionMethodExecutorTest
         // Arrange
         var mapper = new ActionResultTypeMapper();
         var controller = new TestController();
-        var objectMethodExecutor = GetExecutor(nameof(TestController.ReturnIActionResultAsync));
+        var objectMethodExecutor = GetExecutor(nameof(TestController.ReturnActionResultAsync));
         var actionMethodExecutor = ActionMethodExecutor.GetExecutor(objectMethodExecutor);
 
         // Act
@@ -209,8 +209,8 @@ public class ActionMethodExecutorTest
 
         // Assert
         await valueTask;
-        Assert.Equal("TaskOfIActionResultExecutor", actionMethodExecutor.GetType().Name);
-        Assert.IsType<StatusCodeResult>(valueTask.Result);
+        Assert.Equal("TaskOfActionResultExecutor", actionMethodExecutor.GetType().Name);
+        Assert.IsType<ViewResult>(valueTask.Result);
     }
 
 
@@ -351,6 +351,8 @@ public class ActionMethodExecutorTest
         }
 
         public Task<IActionResult> ReturnIActionResultAsync() => Task.FromResult((IActionResult)new StatusCodeResult(201));
+
+        public Task<ViewResult> ReturnActionResultAsync() => Task.FromResult(new ViewResult { StatusCode = 200});
 
         public Task<StatusCodeResult> ReturnsIActionResultSubTypeAsync() => Task.FromResult(new StatusCodeResult(200));
 

--- a/src/Mvc/Mvc.Core/test/Infrastructure/ActionMethodExecutorTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ActionMethodExecutorTest.cs
@@ -213,7 +213,6 @@ public class ActionMethodExecutorTest
         Assert.IsType<ViewResult>(valueTask.Result);
     }
 
-
     [Fact]
     public void ActionMethodExecutor_ExecutesActionsAsynchronouslyReturningModel()
     {


### PR DESCRIPTION
# Fix allocation issue caused by ordering of MVC result executors for Task results

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

This PR changes the order of the ActionMethod executors for Task result types and adds tests to ensure the right executor gets chosen based on different action result scenarios. 

## Description

This PR changes the order of the ActionMethod executors so that for the case of `Task` where the result type is known at compile time, we can invoke the `Execute` sync method rather than the `ExecuteAsync` to allow us to "await" directly the result value via type cast.  The `ExecuteAync` method returns a custom awaitable, which can incur extra head allocations. 

Fixes #40364
