### PR TITLE
Add ctors to EndpointMetadataContext/EndpointParameterMetadataContext

### DIFF
--- a/src/Http/Http.Extensions/src/EndpointMetadataContext.cs
+++ b/src/Http/Http.Extensions/src/EndpointMetadataContext.cs
@@ -11,17 +11,30 @@ namespace Microsoft.AspNetCore.Http.Metadata;
 public sealed class EndpointMetadataContext
 {
     /// <summary>
-    /// Gets the <see cref="MethodInfo"/> associated with the current route handler.
+    /// Creates a new instance of the <see cref="EndpointMetadataContext"/> class.
     /// </summary>
-    public MethodInfo Method { get; init; } = null!; // Is initialized when created by RequestDelegateFactory
+    /// <param name="method">The <see cref="MethodInfo"/> of the route handler delegate of the endpoint being created.</param>
+    /// <param name="endpointMetadata">The list of objects that will be added to the metadata of the endpoint.</param>
+    /// <param name="services">The <see cref="IServiceProvider"/> instance used to access application services.</param>
+    public EndpointMetadataContext(MethodInfo method, IList<object> endpointMetadata, IServiceProvider? services)
+    {
+        Method = method;
+        EndpointMetadata = endpointMetadata;
+        Services = services;
+    }
 
     /// <summary>
-    /// Gets the <see cref="IServiceProvider"/> instance used to access application services.
+    /// Gets the <see cref="MethodInfo"/> of the route handler delegate of the endpoint being created.
     /// </summary>
-    public IServiceProvider? Services { get; init; }
+    public MethodInfo Method { get; }
 
     /// <summary>
     /// Gets the list of objects that will be added to the metadata of the endpoint.
     /// </summary>
-    public IList<object> EndpointMetadata { get; init; } = null!; // Is initialized when created by RequestDelegateFactory
+    public IList<object> EndpointMetadata { get; }
+
+    /// <summary>
+    /// Gets the <see cref="IServiceProvider"/> instance used to access application services.
+    /// </summary>
+    public IServiceProvider? Services { get; }
 }

--- a/src/Http/Http.Extensions/src/EndpointMetadataContext.cs
+++ b/src/Http/Http.Extensions/src/EndpointMetadataContext.cs
@@ -18,6 +18,9 @@ public sealed class EndpointMetadataContext
     /// <param name="services">The <see cref="IServiceProvider"/> instance used to access application services.</param>
     public EndpointMetadataContext(MethodInfo method, IList<object> endpointMetadata, IServiceProvider? services)
     {
+        ArgumentNullException.ThrowIfNull(method, nameof(method));
+        ArgumentNullException.ThrowIfNull(endpointMetadata, nameof(endpointMetadata));
+
         Method = method;
         EndpointMetadata = endpointMetadata;
         Services = services;

--- a/src/Http/Http.Extensions/src/EndpointParameterMetadataContext.cs
+++ b/src/Http/Http.Extensions/src/EndpointParameterMetadataContext.cs
@@ -11,17 +11,30 @@ namespace Microsoft.AspNetCore.Http.Metadata;
 public sealed class EndpointParameterMetadataContext
 {
     /// <summary>
-    /// Gets the parameter of the route handler delegate of the endpoint being created.
+    /// Creates a new instance of the <see cref="EndpointParameterMetadataContext"/> class.
     /// </summary>
-    public ParameterInfo Parameter { get; init; } = null!; // Is initialized when created by RequestDelegateFactory
+    /// <param name="parameter">The parameter of the route handler delegate of the endpoint being created.</param>
+    /// <param name="endpointMetadata">The list of objects that will be added to the metadata of the endpoint.</param>
+    /// <param name="services">The <see cref="IServiceProvider"/> instance used to access application services.</param>
+    public EndpointParameterMetadataContext(ParameterInfo parameter, IList<object> endpointMetadata, IServiceProvider? services)
+    {
+        Parameter = parameter;
+        EndpointMetadata = endpointMetadata;
+        Services = services;
+    }
 
     /// <summary>
-    /// Gets the <see cref="MethodInfo"/> associated with the current route handler.
+    /// Gets the parameter of the route handler delegate of the endpoint being created.
     /// </summary>
-    public IServiceProvider? Services { get; init; }
+    public ParameterInfo Parameter { get; }
 
     /// <summary>
     /// Gets the list of objects that will be added to the metadata of the endpoint.
     /// </summary>
-    public IList<object> EndpointMetadata { get; init; } = null!; // Is initialized when created by RequestDelegateFactory
+    public IList<object> EndpointMetadata { get; }
+
+    /// <summary>
+    /// Gets the <see cref="IServiceProvider"/> instance used to access application services.
+    /// </summary>
+    public IServiceProvider? Services { get; }
 }

--- a/src/Http/Http.Extensions/src/EndpointParameterMetadataContext.cs
+++ b/src/Http/Http.Extensions/src/EndpointParameterMetadataContext.cs
@@ -18,6 +18,9 @@ public sealed class EndpointParameterMetadataContext
     /// <param name="services">The <see cref="IServiceProvider"/> instance used to access application services.</param>
     public EndpointParameterMetadataContext(ParameterInfo parameter, IList<object> endpointMetadata, IServiceProvider? services)
     {
+        ArgumentNullException.ThrowIfNull(parameter, nameof(parameter));
+        ArgumentNullException.ThrowIfNull(endpointMetadata, nameof(endpointMetadata));
+
         Parameter = parameter;
         EndpointMetadata = endpointMetadata;
         Services = services;

--- a/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
@@ -1,20 +1,14 @@
 #nullable enable
 Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext
+Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.EndpointMetadataContext(System.Reflection.MethodInfo! method, System.Collections.Generic.IList<object!>! endpointMetadata, System.IServiceProvider? services) -> void
 Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.EndpointMetadata.get -> System.Collections.Generic.IList<object!>!
-Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.EndpointMetadata.init -> void
-Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.EndpointMetadataContext() -> void
 Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.Method.get -> System.Reflection.MethodInfo!
-Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.Method.init -> void
 Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.Services.get -> System.IServiceProvider?
-Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.Services.init -> void
 Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext
+Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.EndpointParameterMetadataContext(System.Reflection.ParameterInfo! parameter, System.Collections.Generic.IList<object!>! endpointMetadata, System.IServiceProvider? services) -> void
 Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.EndpointMetadata.get -> System.Collections.Generic.IList<object!>!
-Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.EndpointMetadata.init -> void
-Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.EndpointParameterMetadataContext() -> void
 Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.Parameter.get -> System.Reflection.ParameterInfo!
-Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.Parameter.init -> void
 Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.Services.get -> System.IServiceProvider?
-Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.Services.init -> void
 Microsoft.AspNetCore.Http.Metadata.IEndpointMetadataProvider
 Microsoft.AspNetCore.Http.Metadata.IEndpointMetadataProvider.PopulateMetadata(Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext! context) -> void
 Microsoft.AspNetCore.Http.Metadata.IEndpointParameterMetadataProvider

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -294,12 +294,7 @@ public static partial class RequestDelegateFactory
             if (typeof(IEndpointParameterMetadataProvider).IsAssignableFrom(parameter.ParameterType))
             {
                 // Parameter type implements IEndpointParameterMetadataProvider
-                var parameterContext = new EndpointParameterMetadataContext
-                {
-                    Parameter = parameter,
-                    EndpointMetadata = metadata,
-                    Services = services
-                };
+                var parameterContext = new EndpointParameterMetadataContext(parameter, metadata, services);
                 invokeArgs ??= new object[1];
                 invokeArgs[0] = parameterContext;
                 PopulateMetadataForParameterMethod.MakeGenericMethod(parameter.ParameterType).Invoke(null, invokeArgs);
@@ -308,12 +303,7 @@ public static partial class RequestDelegateFactory
             if (typeof(IEndpointMetadataProvider).IsAssignableFrom(parameter.ParameterType))
             {
                 // Parameter type implements IEndpointMetadataProvider
-                var context = new EndpointMetadataContext
-                {
-                    Method = methodInfo,
-                    EndpointMetadata = metadata,
-                    Services = services
-                };
+                var context = new EndpointMetadataContext(methodInfo, metadata, services);
                 invokeArgs ??= new object[1];
                 invokeArgs[0] = context;
                 PopulateMetadataForEndpointMethod.MakeGenericMethod(parameter.ParameterType).Invoke(null, invokeArgs);
@@ -324,12 +314,7 @@ public static partial class RequestDelegateFactory
         if (methodInfo.ReturnType is not null && typeof(IEndpointMetadataProvider).IsAssignableFrom(methodInfo.ReturnType))
         {
             // Return type implements IEndpointMetadataProvider
-            var context = new EndpointMetadataContext
-            {
-                Method = methodInfo,
-                EndpointMetadata = metadata,
-                Services = services
-            };
+            var context = new EndpointMetadataContext(methodInfo, metadata, services);
             invokeArgs ??= new object[1];
             invokeArgs[0] = context;
             PopulateMetadataForEndpointMethod.MakeGenericMethod(methodInfo.ReturnType).Invoke(null, invokeArgs);

--- a/src/Http/Http.Extensions/test/EndpointMetadataContextTests.cs
+++ b/src/Http/Http.Extensions/test/EndpointMetadataContextTests.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Metadata;
+
+namespace Microsoft.AspNetCore.Http.Extensions.Tests;
+
+public class EndpointMetadataContextTests
+{
+    [Fact]
+    public void EndpointMetadataContext_Ctor_ThrowsArgumentNullException_WhenMethodInfoIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new EndpointMetadataContext(null, new List<object>(), null));
+    }
+
+    [Fact]
+    public void EndpointMetadataContext_Ctor_ThrowsArgumentNullException_WhenMetadataIsNull()
+    {
+        Delegate handler = (int id) => { };
+        var method = handler.GetMethodInfo();
+
+        Assert.Throws<ArgumentNullException>(() => new EndpointMetadataContext(method, null, null));
+    }
+
+    [Fact]
+    public void EndpointParameterMetadataContext_Ctor_ThrowsArgumentNullException_WhenParameterInfoIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new EndpointParameterMetadataContext(null, new List<object>(), null));
+    }
+
+    [Fact]
+    public void EndpointParameterMetadataContext_Ctor_ThrowsArgumentNullException_WhenMetadataIsNull()
+    {
+        Delegate handler = (int id) => { };
+        var parameter = handler.GetMethodInfo().GetParameters()[0];
+
+        Assert.Throws<ArgumentNullException>(() => new EndpointParameterMetadataContext(parameter, null, null));
+    }
+}

--- a/src/Http/Http.Results/test/ResultsOfTTests.Generated.cs
+++ b/src/Http/Http.Results/test/ResultsOfTTests.Generated.cs
@@ -207,7 +207,7 @@ public partial class ResultsOfTTests
         // Arrange
         Results<ProvidesMetadataResult1, ProvidesMetadataResult2> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext { Method = ((Delegate)MyApi).GetMethodInfo(), EndpointMetadata = metadata };
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
 
         // Act
         PopulateMetadata<Results<ProvidesMetadataResult1, ProvidesMetadataResult2>>(context);
@@ -479,7 +479,7 @@ public partial class ResultsOfTTests
         // Arrange
         Results<ProvidesMetadataResult1, ProvidesMetadataResult2, ProvidesMetadataResult3> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext { Method = ((Delegate)MyApi).GetMethodInfo(), EndpointMetadata = metadata };
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
 
         // Act
         PopulateMetadata<Results<ProvidesMetadataResult1, ProvidesMetadataResult2, ProvidesMetadataResult3>>(context);
@@ -828,7 +828,7 @@ public partial class ResultsOfTTests
         // Arrange
         Results<ProvidesMetadataResult1, ProvidesMetadataResult2, ProvidesMetadataResult3, ProvidesMetadataResult4> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext { Method = ((Delegate)MyApi).GetMethodInfo(), EndpointMetadata = metadata };
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
 
         // Act
         PopulateMetadata<Results<ProvidesMetadataResult1, ProvidesMetadataResult2, ProvidesMetadataResult3, ProvidesMetadataResult4>>(context);
@@ -1262,7 +1262,7 @@ public partial class ResultsOfTTests
         // Arrange
         Results<ProvidesMetadataResult1, ProvidesMetadataResult2, ProvidesMetadataResult3, ProvidesMetadataResult4, ProvidesMetadataResult5> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext { Method = ((Delegate)MyApi).GetMethodInfo(), EndpointMetadata = metadata };
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
 
         // Act
         PopulateMetadata<Results<ProvidesMetadataResult1, ProvidesMetadataResult2, ProvidesMetadataResult3, ProvidesMetadataResult4, ProvidesMetadataResult5>>(context);
@@ -1789,7 +1789,7 @@ public partial class ResultsOfTTests
         // Arrange
         Results<ProvidesMetadataResult1, ProvidesMetadataResult2, ProvidesMetadataResult3, ProvidesMetadataResult4, ProvidesMetadataResult5, ProvidesMetadataResult6> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext { Method = ((Delegate)MyApi).GetMethodInfo(), EndpointMetadata = metadata };
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
 
         // Act
         PopulateMetadata<Results<ProvidesMetadataResult1, ProvidesMetadataResult2, ProvidesMetadataResult3, ProvidesMetadataResult4, ProvidesMetadataResult5, ProvidesMetadataResult6>>(context);

--- a/src/Http/Http.Results/tools/ResultsOfTGenerator/Program.cs
+++ b/src/Http/Http.Results/tools/ResultsOfTGenerator/Program.cs
@@ -810,7 +810,7 @@ public class Program
         //    // Arrange
         //    Results<ProvidesMetadataResult1, ProvidesMetadataResult2> MyApi() { throw new NotImplementedException(); }
         //    var metadata = new List<object>();
-        //    var context = new EndpointMetadataContext { Method = ((Delegate)MyApi).GetMethodInfo(), EndpointMetadata = metadata };
+        //    var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
 
         //    // Act
         //    PopulateMetadata<Results<ProvidesMetadataResult1, ProvidesMetadataResult2>>(context);
@@ -846,7 +846,7 @@ public class Program
         }
         writer.WriteLine("> MyApi() { throw new NotImplementedException(); }");
         writer.WriteIndentedLine(2, "var metadata = new List<object>();");
-        writer.WriteIndentedLine(2, "var context = new EndpointMetadataContext { Method = ((Delegate)MyApi).GetMethodInfo(), EndpointMetadata = metadata };");
+        writer.WriteIndentedLine(2, "var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);");
         writer.WriteLine();
 
         // Act


### PR DESCRIPTION
As discussed in API review, switching the recently added `EndpointMetadataContext` and `EndpointParameterMetadataContext` classes from using `init` properties to `get`-only with a constructor for setting the values.

#41117