### PR TITLE
Add redis startup error handling

### DIFF
--- a/src/SignalR/server/StackExchangeRedis/src/Internal/RedisLog.cs
+++ b/src/SignalR/server/StackExchangeRedis/src/Internal/RedisLog.cs
@@ -58,6 +58,9 @@ internal static partial class RedisLog
     [LoggerMessage(13, LogLevel.Error, "Error forwarding client result with ID '{InvocationID}' to server.", EventName = "ErrorForwardingResult")]
     public static partial void ErrorForwardingResult(ILogger logger, string invocationId, Exception ex);
 
+    [LoggerMessage(14, LogLevel.Error, "Error connecting to Redis.", EventName = "ErrorConnecting")]
+    public static partial void ErrorConnecting(ILogger logger, Exception ex);
+
     // This isn't DefineMessage-based because it's just the simple TextWriter logging from ConnectionMultiplexer
     public static void ConnectionMultiplexerMessage(ILogger logger, string? message)
     {

--- a/src/SignalR/server/StackExchangeRedis/test/RedisHubLifetimeManagerTests.cs
+++ b/src/SignalR/server/StackExchangeRedis/test/RedisHubLifetimeManagerTests.cs
@@ -120,12 +120,9 @@ public class RedisHubLifetimeManagerTests : ScaleoutHubLifetimeManagerTests<Test
         }
 
         var logs = testSink.Writes.ToArray();
-        // Two of the same error logs, one for the pre-emptive attempt to connect to Redis in the ctor, and one during the OnConnectedAsync for the connection
-        Assert.Equal(2, logs.Length);
+        Assert.Single(logs);
         Assert.Equal("Error connecting to Redis.", logs[0].Message);
         Assert.Equal("throw from connect", logs[0].Exception.Message);
-        Assert.Equal("Error connecting to Redis.", logs[1].Message);
-        Assert.Equal("throw from connect", logs[1].Exception.Message);
     }
 
     public override TestRedisServer CreateBackplane()


### PR DESCRIPTION
If the Redis connection hasn't been established yet the `_bus` variable wont be initialized. Normally this is fine, but if a connection comes in and the redis connection throws then you can get a null-ref when `OnDisconnectedAsync` is called.

Additionally, adding logging for if the connection attempt throws.

Likely fixes https://github.com/dotnet/aspnetcore/issues/41104