### PR TITLE
Update `.vsconfig` to match Visual Studio install script config

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -4,8 +4,17 @@
     "Microsoft.Net.Component.4.6.2.TargetingPack",
     "Microsoft.Net.Component.4.7.2.SDK",
     "Microsoft.Net.Component.4.7.2.TargetingPack",
+    "Microsoft.VisualStudio.Component.VC.ATL",
+    "Microsoft.VisualStudio.Component.VC.ATL.ARM64",
+    "Microsoft.VisualStudio.Component.VC.Tools.ARM64",
+    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+    "Microsoft.VisualStudio.Component.VC.14.29.16.11.ARM64",
+    "Microsoft.VisualStudio.Component.VC.14.29.16.11.x86.x64",
+    "Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL.ARM64",
+    "Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL",
+    "Microsoft.VisualStudio.Component.Windows10SDK.18362",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
-    "Microsoft.VisualStudio.Workload.NetCoreTools",
+    "Microsoft.VisualStudio.Workload.NativeDesktop",
     "Microsoft.VisualStudio.Workload.NetWeb",
     "Microsoft.VisualStudio.Workload.VisualStudioExtension"
   ]

--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -74,7 +74,10 @@ Building ASP.NET Core on Windows (10, version 1803 or newer) requires that you h
 
 #### [Visual Studio 2022](https://visualstudio.com)
 
-Visual Studio 2022 (17.1 or above) is required to build the repo locally. If you don't have Visual Studio installed you can run [eng/scripts/InstallVisualStudio.ps1](/eng/scripts/InstallVisualStudio.ps1) to install the exact required dependencies.
+Visual Studio 2022 (17.1 or above) is required to build the repo locally.
+
+If you don't have Visual Studio installed you can run [eng/scripts/InstallVisualStudio.ps1](/eng/scripts/InstallVisualStudio.ps1) to install the exact required dependencies.
+If you do have Visual Studio installed, you can [import the configuration](https://docs.microsoft.com/en-us/visualstudio/install/import-export-installation-configurations?view=vs-2022#import-a-configuration) from the `.vsconfig` file at the root of the repository to ensure you have all of the required components.
 
 > :bulb: By default, the script will install Visual Studio Enterprise Edition, however you can use a different edition by passing the `-Edition` flag.
 > :bulb: To install Visual Studio from the preview channel, you can use the `-Channel` flag to set the channel (`-Channel Preview`).


### PR DESCRIPTION
# Update `.vsconfig` to match Visual Studio install script config



## Description

Updates `.vsconfig` to match the config used by `InstallVisualStudio.ps1`.
This will allow the project to be built on a Visual Studio install configured by the `.vsconfig` file.

Also updates the `BuildFromSource` docs to mention the `.vsconfig`

Fixes #41092
