### PR TITLE
[SignalR] Pass cancellation token to FlushAsync

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -869,19 +869,14 @@ public partial class HubConnection : IAsyncDisposable
         }
     }
 
-#pragma warning disable IDE0060 // Remove unused parameter. Resolving tracked via https://github.com/dotnet/aspnetcore/issues/40475
     private async Task SendHubMessage(ConnectionState connectionState, HubMessage hubMessage, CancellationToken cancellationToken = default)
-#pragma warning restore IDE0060 // Remove unused parameter
     {
         _state.AssertConnectionValid();
         _protocol.WriteMessage(hubMessage, connectionState.Connection.Transport.Output);
 
         Log.SendingMessage(_logger, hubMessage);
 
-#pragma warning disable CA2016 // Forward the 'CancellationToken' parameter to methods
-        // REVIEW: If a token is passed in and is canceled during FlushAsync it seems to break .Complete()...
-        await connectionState.Connection.Transport.Output.FlushAsync().ConfigureAwait(false);
-#pragma warning restore CA2016 // Forward the 'CancellationToken' parameter to methods
+        await connectionState.Connection.Transport.Output.FlushAsync(cancellationToken).ConfigureAwait(false);
         Log.MessageSent(_logger, hubMessage);
 
         // We've sent a message, so don't ping for a while

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionTests.cs
@@ -221,75 +221,6 @@ public partial class HubConnectionTests : VerifiableLoggedTest
         }
     }
 
-    internal class PipeReaderWrapper : PipeReader
-    {
-        private readonly PipeReader _originalPipeReader;
-        private TaskCompletionSource _waitToRead;
-        private readonly object _lock = new object();
-
-        public PipeReaderWrapper(PipeReader pipeReader)
-        {
-            _originalPipeReader = pipeReader;
-            _waitToRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        }
-
-        public override void AdvanceTo(SequencePosition consumed) =>
-            _originalPipeReader.AdvanceTo(consumed);
-
-        public override void AdvanceTo(SequencePosition consumed, SequencePosition examined) =>
-            _originalPipeReader.AdvanceTo(consumed, examined);
-
-        public override void CancelPendingRead() =>
-            _originalPipeReader.CancelPendingRead();
-
-        public override void Complete(Exception exception = null) =>
-            _originalPipeReader.Complete(exception);
-
-        public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
-        {
-            await _waitToRead.Task;
-
-            try
-            {
-                return await _originalPipeReader.ReadAsync(cancellationToken);
-            }
-            finally
-            {
-                lock (_lock)
-                {
-                    _waitToRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                }
-            }
-        }
-
-        public override bool TryRead(out ReadResult result) =>
-            _originalPipeReader.TryRead(out result);
-
-        public void UnblockRead()
-        {
-            lock (_lock)
-            {
-                _waitToRead.SetResult();
-            }
-        }
-    }
-
-    internal class CustomDuplex : IDuplexPipe
-    {
-        private readonly IDuplexPipe _originalDuplexPipe;
-        public readonly PipeReaderWrapper WrappedPipeReader;
-
-        public CustomDuplex(IDuplexPipe duplexPipe)
-        {
-            _originalDuplexPipe = duplexPipe;
-            WrappedPipeReader = new PipeReaderWrapper(_originalDuplexPipe.Input);
-        }
-
-        public PipeReader Input => WrappedPipeReader;
-
-        public PipeWriter Output => _originalDuplexPipe.Output;
-    }
-
     [Fact]
     public async Task SendAsyncCanceledWhenTokenCanceledDuringSend()
     {
@@ -297,12 +228,8 @@ public partial class HubConnectionTests : VerifiableLoggedTest
         {
             // Use pause threshold to block FlushAsync when writing 100+ bytes
             var connection = new TestConnection(pipeOptions: new PipeOptions(readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, pauseWriterThreshold: 100, useSynchronizationContext: false));
-            var wrappedTransport = new CustomDuplex(connection.Transport);
-            connection.Transport = wrappedTransport;
             var hubConnection = CreateHubConnection(connection, loggerFactory: LoggerFactory);
 
-            // Unblock handshake
-            wrappedTransport.WrappedPipeReader.UnblockRead();
             await hubConnection.StartAsync().DefaultTimeout();
 
             var cts = new CancellationTokenSource();
@@ -310,8 +237,6 @@ public partial class HubConnectionTests : VerifiableLoggedTest
             var sendTask = hubConnection.SendAsync("testMethod", new byte[100], cts.Token);
 
             cts.Cancel();
-            // unblock Read triggered by SendAsync, but after cancellation is requested so we test the token is passed to Pipe.FlushAsync in SendAsync
-            wrappedTransport.WrappedPipeReader.UnblockRead();
 
             await Assert.ThrowsAsync<OperationCanceledException>(() => sendTask.DefaultTimeout());
 

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/TestConnection.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/TestConnection.cs
@@ -45,14 +45,14 @@ internal class TestConnection : ConnectionContext, IConnectionInherentKeepAliveF
 
     bool IConnectionInherentKeepAliveFeature.HasInherentKeepAlive => _hasInherentKeepAlive;
 
-    public TestConnection(Func<Task> onStart = null, Func<Task> onDispose = null, bool autoHandshake = true, bool hasInherentKeepAlive = false)
+    public TestConnection(Func<Task> onStart = null, Func<Task> onDispose = null, bool autoHandshake = true, bool hasInherentKeepAlive = false, PipeOptions pipeOptions = null)
     {
         _autoHandshake = autoHandshake;
         _onStart = onStart ?? (() => Task.CompletedTask);
         _onDispose = onDispose ?? (() => Task.CompletedTask);
         _hasInherentKeepAlive = hasInherentKeepAlive;
 
-        var options = new PipeOptions(readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
+        var options = pipeOptions ?? new PipeOptions(readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
 
         var pair = DuplexPipe.CreateConnectionPair(options, options);
         Application = pair.Application;


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/40475

The token wasn't being passed in because of a bug in Pipelines see original change https://github.com/aspnet/SignalR/pull/1718#discussion_r177283449
The bug was fixed a day after the PR was merged and we never reacted 🤣 
https://github.com/dotnet/runtime/issues/25633

For full transparency, this doesn't mean the written Hub message wont be sent to the server. It only means the user has decided they don't want to wait any longer on any backpressure applied by the Pipe. For invokes it also means the client will ignore any CompletionMessage for the canceled invokes (but this isn't new).