### PR TITLE
[release/6.0] Fix diff checks for ContentRoot and WebRoot

### DIFF
--- a/src/DefaultBuilder/src/ConfigureHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureHostBuilder.cs
@@ -62,6 +62,7 @@ namespace Microsoft.AspNetCore.Builder
             var previousApplicationName = _configuration[HostDefaults.ApplicationKey];
             // Use the real content root so we can compare paths
             var previousContentRoot = _context.HostingEnvironment.ContentRootPath;
+            var previousContentRootConfig = _configuration[HostDefaults.ContentRootKey];
             var previousEnvironment = _configuration[HostDefaults.EnvironmentKey];
 
             // Run these immediately so that they are observable by the imperative code
@@ -74,7 +75,8 @@ namespace Microsoft.AspNetCore.Builder
                 throw new NotSupportedException($"The application name changed from \"{previousApplicationName}\" to \"{_configuration[HostDefaults.ApplicationKey]}\". Changing the host configuration using WebApplicationBuilder.Host is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
             }
 
-            if (!string.Equals(previousContentRoot, HostingPathResolver.ResolvePath(_configuration[HostDefaults.ContentRootKey]), StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(previousContentRootConfig, _configuration[HostDefaults.ContentRootKey], StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(previousContentRoot, HostingPathResolver.ResolvePath(_configuration[HostDefaults.ContentRootKey]), StringComparison.OrdinalIgnoreCase))
             {
                 throw new NotSupportedException($"The content root changed from \"{previousContentRoot}\" to \"{HostingPathResolver.ResolvePath(_configuration[HostDefaults.ContentRootKey])}\". Changing the host configuration using WebApplicationBuilder.Host is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
             }

--- a/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
+++ b/src/DefaultBuilder/src/ConfigureWebHostBuilder.cs
@@ -39,7 +39,9 @@ namespace Microsoft.AspNetCore.Builder
         public IWebHostBuilder ConfigureAppConfiguration(Action<WebHostBuilderContext, IConfigurationBuilder> configureDelegate)
         {
             var previousContentRoot = _context.HostingEnvironment.ContentRootPath;
+            var previousContentRootConfig = _configuration[WebHostDefaults.ContentRootKey];
             var previousWebRoot = _context.HostingEnvironment.WebRootPath;
+            var previousWebRootConfig = _configuration[WebHostDefaults.WebRootKey];
             var previousApplication = _configuration[WebHostDefaults.ApplicationKey];
             var previousEnvironment = _configuration[WebHostDefaults.EnvironmentKey];
             var previousHostingStartupAssemblies = _configuration[WebHostDefaults.HostingStartupAssembliesKey];
@@ -48,7 +50,8 @@ namespace Microsoft.AspNetCore.Builder
             // Run these immediately so that they are observable by the imperative code
             configureDelegate(_context, _configuration);
 
-            if (!string.Equals(HostingPathResolver.ResolvePath(previousWebRoot, previousContentRoot), HostingPathResolver.ResolvePath(_configuration[WebHostDefaults.WebRootKey], previousContentRoot), StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(previousWebRootConfig, _configuration[WebHostDefaults.WebRootKey], StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(HostingPathResolver.ResolvePath(previousWebRoot, previousContentRoot), HostingPathResolver.ResolvePath(_configuration[WebHostDefaults.WebRootKey], previousContentRoot), StringComparison.OrdinalIgnoreCase))
             {
                 // Diasllow changing the web root for consistency with other types.
                 throw new NotSupportedException($"The web root changed from \"{HostingPathResolver.ResolvePath(previousWebRoot, previousContentRoot)}\" to \"{HostingPathResolver.ResolvePath(_configuration[WebHostDefaults.WebRootKey], previousContentRoot)}\". Changing the host configuration using WebApplicationBuilder.WebHost is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
@@ -58,7 +61,8 @@ namespace Microsoft.AspNetCore.Builder
                 // Disallow changing any host configuration
                 throw new NotSupportedException($"The application name changed from \"{previousApplication}\" to \"{_configuration[WebHostDefaults.ApplicationKey]}\". Changing the host configuration using WebApplicationBuilder.WebHost is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");
             }
-            else if (!string.Equals(previousContentRoot, HostingPathResolver.ResolvePath(_configuration[WebHostDefaults.ContentRootKey]), StringComparison.OrdinalIgnoreCase))
+            else if (!string.Equals(previousContentRootConfig, _configuration[WebHostDefaults.ContentRootKey], StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(previousContentRoot, HostingPathResolver.ResolvePath(_configuration[WebHostDefaults.ContentRootKey]), StringComparison.OrdinalIgnoreCase))
             {
                 // Disallow changing any host configuration
                 throw new NotSupportedException($"The content root changed from \"{previousContentRoot}\" to \"{HostingPathResolver.ResolvePath(_configuration[WebHostDefaults.ContentRootKey])}\". Changing the host configuration using WebApplicationBuilder.WebHost is not supported. Use WebApplication.CreateBuilder(WebApplicationOptions) instead.");

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -1687,6 +1687,36 @@ namespace Microsoft.AspNetCore.Tests
         }
 
         [Fact]
+        public void EmptyAppConfiguration()
+        {
+            var wwwroot = Path.Combine(AppContext.BaseDirectory, "wwwroot");
+            bool createdDirectory = false;
+            if (!Directory.Exists(wwwroot))
+            {
+                createdDirectory = true;
+                Directory.CreateDirectory(wwwroot);
+            }
+    
+            try
+            {
+                var builder = WebApplication.CreateBuilder();
+    
+                builder.WebHost.ConfigureAppConfiguration((ctx, config) => { });
+    
+                using var app = builder.Build();
+                var hostEnv = app.Services.GetRequiredService<Hosting.IWebHostEnvironment>();
+                Assert.Equal(wwwroot, hostEnv.WebRootPath);
+            }
+            finally
+            {
+                if (createdDirectory)
+                {
+                    Directory.Delete(wwwroot);
+                }
+            }
+        }
+
+        [Fact]
         public void HostConfigurationNotAffectedByConfiguration()
         {
             var builder = WebApplication.CreateBuilder();


### PR DESCRIPTION
# Prevent unnecessary startup errors in WebApplicationBuilder

Without this fix, when a `wwwroot` directory exists, calling the `builder.WebHost.ConfigureAppConfiguration()` method throws a `NotSupportedException` error thinking the web root directory (`wwwroot` by default) was modified when it wasn't.

## Description

Backport of #40095. https://github.com/dotnet/aspnetcore/issues/38212#issuecomment-1095844004 brought this back to my attention.

## Customer Impact

Normally we'd tell customers to use `builder.Configuration` instead of `builder.WebHost.ConfigureAppConfiguration()`, but `builder.WebHost` is an `IWebHostBuilder` adapter for many extension methods like `.UseStaticWebAssets()`.

This bug causes `.UseStaticWebAssets()` and just about any other method calling `ConfigureAppConfiguration()` to throw a `NotSupportedException` when it shouldn't. There is a workaround, but it's hard to discover and shouldn't be necessary.

```csharp
var builder = WebApplication.CreateBuilder(args);
builder.WebHost.UseStaticWebAssets(); // Throws NotSupportedException today
builder.WebHost.UseWebRoot("wwwroot").UseStaticWebAssets(); // Works
```

Fixes #39546 and #38212

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

This change has automated tests and was fixed in 7.0-preview2 and verified by customers.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A