### PR TITLE
Add SocketsHttpHandler logging to gRPC interop tests

### DIFF
--- a/src/Grpc/Interop/test/testassets/InteropClient/InteropClient.cs
+++ b/src/Grpc/Interop/test/testassets/InteropClient/InteropClient.cs
@@ -26,6 +26,7 @@ using Grpc.Auth;
 using Grpc.Core;
 using Grpc.Net.Client;
 using Grpc.Testing;
+using Microsoft.AspNetCore.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
@@ -81,6 +82,7 @@ public class InteropClient : IDisposable
 
     private ServiceProvider serviceProvider;
     private ILoggerFactory loggerFactory;
+    private HttpEventSourceListener httpEventSource;
     private ClientOptions options;
 
     private InteropClient(ClientOptions options)
@@ -103,11 +105,13 @@ public class InteropClient : IDisposable
         serviceProvider = services.BuildServiceProvider();
 
         loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        httpEventSource = new HttpEventSourceListener(loggerFactory);
     }
 
     public void Dispose()
     {
         serviceProvider.Dispose();
+        httpEventSource.Dispose();
     }
 
     public static void Run(string[] args)

--- a/src/Grpc/Interop/test/testassets/InteropClient/InteropClient.csproj
+++ b/src/Grpc/Interop/test/testassets/InteropClient/InteropClient.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -11,6 +11,8 @@
     <Protobuf Include="..\Proto\grpc\testing\empty.proto" GrpcServices="None" Link="Protos\empty.proto" />
     <Protobuf Include="..\Proto\grpc\testing\messages.proto" GrpcServices="None" Link="Protos\messages.proto" />
 
+    <Compile Include="$(SharedSourceRoot)HttpClient\HttpEventSourceListener.cs" />
+    
     <Reference Include="CommandLineParser" />
     <Reference Include="Google.Protobuf" />
     <Reference Include="Grpc.Auth" />

--- a/src/Servers/Kestrel/Transport.Quic/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests.csproj
+++ b/src/Servers/Kestrel/Transport.Quic/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)NullScope.cs" />
-    <Compile Include="$(KestrelSharedSourceRoot)test\HttpEventSourceListener.cs" Link="shared\HttpEventSourceListener.cs" />
+    <Compile Include="$(SharedSourceRoot)HttpClient\HttpEventSourceListener.cs" Link="shared\HttpEventSourceListener.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TestResources.cs" Link="shared\TestResources.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\StreamExtensions.cs" Link="shared\StreamExtensions.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\KestrelTestLoggerProvider.cs" Link="shared\KestrelTestLoggerProvider.cs" />

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
@@ -7,10 +7,10 @@ using System.Net.Quic;
 using System.Text;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging;
-using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests;
 

--- a/src/Servers/Kestrel/samples/Http3SampleApp/Http3SampleApp.csproj
+++ b/src/Servers/Kestrel/samples/Http3SampleApp/Http3SampleApp.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="$(KestrelSharedSourceRoot)test\HttpEventSourceListener.cs" LinkBase="shared" />
+    <Compile Include="$(SharedSourceRoot)HttpClient\HttpEventSourceListener.cs" LinkBase="shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/samples/Http3SampleApp/Program.cs
+++ b/src/Servers/Kestrel/samples/Http3SampleApp/Program.cs
@@ -4,9 +4,9 @@
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
-using Microsoft.AspNetCore.Testing;
 
 namespace Http3SampleApp;
 

--- a/src/Servers/Kestrel/samples/Http3SampleApp/Startup.cs
+++ b/src/Servers/Kestrel/samples/Http3SampleApp/Startup.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AspNetCore.Testing;
-
 namespace Http3SampleApp;
 
 public class Startup

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Interop.FunctionalTests.csproj
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Interop.FunctionalTests.csproj
@@ -18,7 +18,7 @@
     <Compile Include="$(KestrelSharedSourceRoot)test\TransportTestHelpers\IWebHostPortExtensions.cs" LinkBase="shared" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TestConstants.cs" LinkBase="shared" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TestResources.cs" LinkBase="shared" />
-    <Compile Include="$(KestrelSharedSourceRoot)test\HttpEventSourceListener.cs" LinkBase="shared" />
+    <Compile Include="$(SharedSourceRoot)HttpClient\HttpEventSourceListener.cs" LinkBase="shared" />
     <Content Include="$(KestrelSharedSourceRoot)test\TestCertificates\*.pfx" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TransportTestHelpers\MsQuicSupportedAttribute.cs" LinkBase="shared\TransportTestHelpers\MsQuicSupportedAttribute.cs" />
   </ItemGroup>

--- a/src/Shared/HttpClient/HttpEventSourceListener.cs
+++ b/src/Shared/HttpClient/HttpEventSourceListener.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.Tracing;
 using System.Text;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.AspNetCore.Testing;
+namespace Microsoft.AspNetCore.Internal;
 
 public sealed class HttpEventSourceListener : EventListener
 {


### PR DESCRIPTION
Provide more information from client HTTP stack on failures.