### PR TITLE
Fix MapPath and UsePathBase's use of implicit PathStrings 

### DIFF
--- a/src/Http/Http.Abstractions/src/Extensions/MapMiddleware.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/MapMiddleware.cs
@@ -62,7 +62,7 @@ public class MapMiddleware
         return _next(context);
     }
 
-    private async Task InvokeCore(HttpContext context, string matchedPath, string remainingPath)
+    private async Task InvokeCore(HttpContext context, PathString matchedPath, PathString remainingPath)
     {
         var path = context.Request.Path;
         var pathBase = context.Request.PathBase;

--- a/src/Http/Http.Abstractions/src/Extensions/UsePathBaseExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/UsePathBaseExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Builder.Extensions;
@@ -25,7 +25,7 @@ public static class UsePathBaseExtensions
         }
 
         // Strip trailing slashes
-        pathBase = pathBase.Value?.TrimEnd('/');
+        pathBase = new PathString(pathBase.Value?.TrimEnd('/'));
         if (!pathBase.HasValue)
         {
             return app;

--- a/src/Http/Http.Abstractions/src/Extensions/UsePathBaseMiddleware.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/UsePathBaseMiddleware.cs
@@ -53,7 +53,7 @@ public class UsePathBaseMiddleware
         return _next(context);
     }
 
-    private async Task InvokeCore(HttpContext context, string matchedPath, string remainingPath)
+    private async Task InvokeCore(HttpContext context, PathString matchedPath, PathString remainingPath)
     {
         var originalPath = context.Request.Path;
         var originalPathBase = context.Request.PathBase;

--- a/src/Http/Http.Abstractions/test/MapPathMiddlewareTests.cs
+++ b/src/Http/Http.Abstractions/test/MapPathMiddlewareTests.cs
@@ -43,24 +43,27 @@ public class MapPathMiddlewareTests
     }
 
     [Theory]
-    [InlineData("/foo", "", "/foo")]
-    [InlineData("/foo", "", "/foo/")]
-    [InlineData("/foo", "/Bar", "/foo")]
-    [InlineData("/foo", "/Bar", "/foo/cho")]
-    [InlineData("/foo", "/Bar", "/foo/cho/")]
-    [InlineData("/foo/cho", "/Bar", "/foo/cho")]
-    [InlineData("/foo/cho", "/Bar", "/foo/cho/do")]
-    public async Task PathMatchFunc_BranchTaken(string matchPath, string basePath, string requestPath)
+    [InlineData("/foo", "", "/foo", "/foo", "")]
+    [InlineData("/foo", "", "/foo/", "/foo", "/")]
+    [InlineData("/foo", "/Bar", "/foo", "/Bar/foo", "")]
+    [InlineData("/foo", "/Bar", "/foo/cho", "/Bar/foo", "/cho")]
+    [InlineData("/foo", "/Bar", "/foo/cho/", "/Bar/foo", "/cho/")]
+    [InlineData("/foo/cho", "/Bar", "/foo/cho", "/Bar/foo/cho", "")]
+    [InlineData("/foo/cho", "/Bar", "/foo/cho/do", "/Bar/foo/cho", "/do")]
+    [InlineData("/foo%42/cho", "/Bar%42", "/foo%42/cho/do%42", "/Bar%42/foo%42/cho", "/do%42")]
+    public async Task PathMatchFunc_BranchTaken(string matchPath, string basePath, string requestPath, string expectedPathBase, string expectedPath)
     {
         HttpContext context = CreateRequest(basePath, requestPath);
         var builder = new ApplicationBuilder(serviceProvider: null!);
-        builder.Map(matchPath, UseSuccess);
+        builder.Map(new PathString(matchPath), UseSuccess);
         var app = builder.Build();
         await app.Invoke(context);
 
         Assert.Equal(200, context.Response.StatusCode);
         Assert.Equal(basePath, context.Request.PathBase.Value);
         Assert.Equal(requestPath, context.Request.Path.Value);
+        Assert.Equal(expectedPathBase, (string)context.Items["test.PathBase"]!);
+        Assert.Equal(expectedPath, context.Items["test.Path"]);
     }
 
     [Theory]

--- a/src/Http/Http.Abstractions/test/UsePathBaseExtensionsTests.cs
+++ b/src/Http/Http.Abstractions/test/UsePathBaseExtensionsTests.cs
@@ -126,11 +126,23 @@ public class UsePathBaseExtensionsTests
         return TestPathBase(registeredPathBase, pathBase, requestPath, expectedPathBase, expectedPath);
     }
 
+    [Theory]
+    [InlineData("/b%42", "", "/b%42/something%42", "/b%42", "/something%42")]
+    [InlineData("/b%42", "", "/B%42/something%42", "/B%42", "/something%42")]
+    [InlineData("/b%42", "", "/b%42/Something%42", "/b%42", "/Something%42")]
+    [InlineData("/b%42", "/oldb%42", "/b%42/something%42", "/oldb%42/b%42", "/something%42")]
+    [InlineData("/b%42", "/oldb%42", "/b%42/Something%42", "/oldb%42/b%42", "/Something%42")]
+    [InlineData("/b%42", "/oldb%42", "/B%42/something%42", "/oldb%42/B%42", "/something%42")]
+    public Task PathBaseCanHavePercentCharacters(string registeredPathBase, string pathBase, string requestPath, string expectedPathBase, string expectedPath)
+    {
+        return TestPathBase(registeredPathBase, pathBase, requestPath, expectedPathBase, expectedPath);
+    }
+
     private static async Task TestPathBase(string registeredPathBase, string pathBase, string requestPath, string expectedPathBase, string expectedPath)
     {
         HttpContext requestContext = CreateRequest(pathBase, requestPath);
         var builder = CreateBuilder()
-            .UsePathBase(registeredPathBase);
+            .UsePathBase(new PathString(registeredPathBase));
         builder.Run(context =>
         {
             context.Items["test.Path"] = context.Request.Path;


### PR DESCRIPTION
Fixes #41168

An async state machine optimization was made in MapPath and UsePathBase for 6.0 that accidentally changed the field type for paths from PathString to string. There's an implicit converter between the types, but it encodes/decodes the string. This can result in double encoding or decoding.

https://github.com/dotnet/aspnetcore/commit/56d0f2ac95e70742ea93a3b4e944a526ea31dc49#diff-65457624537493466dc6a9609fb01fcb49e5f17e687b04827aa4231daf44c5d6R67

Fix: Make sure the path fields are consistently passed as PathStrings to avoid unnecessary transformations.

Recommended for servicing once this is verified in main.