### PR TITLE
Allow Multiple Wildcard Prefix Server Names of the Same Length in SNI Configuration

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
@@ -221,7 +221,15 @@ internal class SniOptionsSelector
         public int Compare(string? x, string? y)
         {
             // Flip x and y to put the longest instead of the shortest string first in the SortedList.
-            return y!.Length.CompareTo(x!.Length);
+            var lengthResult = y!.Length.CompareTo(x!.Length);
+            if (lengthResult != 0)
+            {
+                return lengthResult;
+            }
+            else
+            {
+                return string.Compare(x, y, StringComparison.OrdinalIgnoreCase);
+            }
         }
     }
 }

--- a/src/Servers/Kestrel/Core/test/SniOptionsSelectorTests.cs
+++ b/src/Servers/Kestrel/Core/test/SniOptionsSelectorTests.cs
@@ -224,11 +224,51 @@ public class SniOptionsSelectorTests
             fallbackHttpProtocols: HttpProtocols.Http1AndHttp2,
             logger: Mock.Of<ILogger<HttpsConnectionMiddleware>>());
 
-        var (baSubdomainOptions, _) = sniOptionsSelector.GetOptions(new MockConnectionContext(), "c.a.example.org");
-        Assert.Equal("a", pathDictionary[baSubdomainOptions.ServerCertificate]);
+        var (aSubdomainOptions, _) = sniOptionsSelector.GetOptions(new MockConnectionContext(), "c.a.example.org");
+        Assert.Equal("a", pathDictionary[aSubdomainOptions.ServerCertificate]);
 
-        var (aSubdomainOptions, _) = sniOptionsSelector.GetOptions(new MockConnectionContext(), "c.b.example.org");
-        Assert.Equal("b", pathDictionary[aSubdomainOptions.ServerCertificate]);
+        var (bSubdomainOptions, _) = sniOptionsSelector.GetOptions(new MockConnectionContext(), "c.b.example.org");
+        Assert.Equal("b", pathDictionary[bSubdomainOptions.ServerCertificate]);
+    }
+
+    [Fact]
+    public void DuplicateWildcardPrefixServerNamesThrowsArgumentException()
+    {
+        var sniDictionary = new Dictionary<string, SniConfig>
+            {
+                {
+                    "*.example.org",
+                    new SniConfig
+                    {
+                        Certificate = new CertificateConfig
+                        {
+                            Path = "a"
+                        }
+                    }
+                },
+                {
+                    "*.EXAMPLE.org",
+                    new SniConfig
+                    {
+                        Certificate = new CertificateConfig
+                        {
+                            Path = "b"
+                        }
+                    }
+                }
+            };
+
+        var mockCertificateConfigLoader = new MockCertificateConfigLoader();
+        var pathDictionary = mockCertificateConfigLoader.CertToPathDictionary;
+
+        var exception = Assert.Throws<ArgumentException>(() => new SniOptionsSelector(
+             "TestEndpointName",
+             sniDictionary,
+             mockCertificateConfigLoader,
+             fallbackHttpsOptions: new HttpsConnectionAdapterOptions(),
+             fallbackHttpProtocols: HttpProtocols.Http1AndHttp2,
+             logger: Mock.Of<ILogger<HttpsConnectionMiddleware>>()));
+        Assert.Equal("An item with the same key has already been added. Key: .EXAMPLE.org (Parameter 'key')", exception.Message);
     }
 
     [Fact]


### PR DESCRIPTION
# Allow Multiple Wildcard Prefix Server Names of the Same Length in SNI Configuration

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

In `SniOptionsSelector.cs` wildcard prefix server names of the same length were being treated as the same server name, which caused an exception to be thrown when two server names of the same length were added. This PR changes the comparer for the sorted list of wildcard prefix options to sort by string length first, and then if the strings are the same length just fallback to a string comparison. The result of this is that strings of the same length are now allowed, but case insensitive duplicates are still not allowed. 

Fixes #41216
