### PR TITLE
Use handler directly in gRPC interop tests

### DIFF
--- a/src/Grpc/Interop/test/testassets/InteropClient/InteropClient.cs
+++ b/src/Grpc/Interop/test/testassets/InteropClient/InteropClient.cs
@@ -167,12 +167,10 @@ public class InteropClient : IDisposable
             httpClientHandler.ClientCertificates.Add(cert);
         }
 
-        var httpClient = new HttpClient(httpClientHandler);
-
         var channel = GrpcChannel.ForAddress($"{scheme}://{options.ServerHost}:{options.ServerPort}", new GrpcChannelOptions
         {
             Credentials = credentials,
-            HttpClient = httpClient,
+            HttpHandler = httpClientHandler,
             LoggerFactory = loggerFactory
         });
 


### PR DESCRIPTION
Using handler is better than HttpClient because HttpClient adds various timeouts and other features that we don't need/want.

A default channel uses handler so this lines up better with real world. Also, matches how interop tests are run elsewhere.