### PR TITLE
Place XML comment hrefs in see elements

### DIFF
--- a/src/Components/Server/src/ProtectedBrowserStorage/ProtectedLocalStorage.cs
+++ b/src/Components/Server/src/ProtectedBrowserStorage/ProtectedLocalStorage.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 /// This data will be scoped to the current user's browser, shared across
 /// all tabs. The data will persist across browser restarts.
 ///
-/// See: https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage
+/// See: <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage"/>.
 /// </summary>
 public sealed class ProtectedLocalStorage : ProtectedBrowserStorage
 {

--- a/src/Components/Server/src/ProtectedBrowserStorage/ProtectedSessionStorage.cs
+++ b/src/Components/Server/src/ProtectedBrowserStorage/ProtectedSessionStorage.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 /// This data will be scoped to the current browser tab. The data will be
 /// discarded if the user closes the browser tab or closes the browser itself.
 ///
-/// See: https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage
+/// See: <see href="https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage"/>.
 /// </summary>
 public sealed class ProtectedSessionStorage : ProtectedBrowserStorage
 {

--- a/src/Components/WebAssembly/WebAssembly/src/Http/BrowserRequestCache.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Http/BrowserRequestCache.cs
@@ -5,7 +5,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Http;
 
 /// <summary>
 /// The cache mode of the request. It controls how the request will interact with the browser's HTTP cache.
-/// See https://developer.mozilla.org/en-US/docs/Web/API/Request/cache
+/// See <see href="https://developer.mozilla.org/en-US/docs/Web/API/Request/cache"/>.
 /// </summary>
 public enum BrowserRequestCache
 {

--- a/src/Components/WebAssembly/WebAssembly/src/Http/WebAssemblyHttpRequestMessageExtensions.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Http/WebAssemblyHttpRequestMessageExtensions.cs
@@ -20,7 +20,7 @@ public static class WebAssemblyHttpRequestMessageExtensions
     /// <param name="requestCredentials">The <see cref="BrowserRequestCredentials"/> option.</param>
     /// <returns>The <see cref="HttpRequestMessage"/>.</returns>
     /// <remarks>
-    /// See https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials
+    /// See <see href="https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials"/>.
     /// </remarks>
     public static HttpRequestMessage SetBrowserRequestCredentials(this HttpRequestMessage requestMessage, BrowserRequestCredentials requestCredentials)
     {
@@ -47,7 +47,7 @@ public static class WebAssemblyHttpRequestMessageExtensions
     /// <param name="requestCache">The <see cref="BrowserRequestCache"/> option.</param>
     /// <returns>The <see cref="HttpRequestMessage"/>.</returns>\
     /// <remarks>
-    /// See https://developer.mozilla.org/en-US/docs/Web/API/Request/cache
+    /// See <see href="https://developer.mozilla.org/en-US/docs/Web/API/Request/cache"/>.
     /// </remarks>
     public static HttpRequestMessage SetBrowserRequestCache(this HttpRequestMessage requestMessage, BrowserRequestCache requestCache)
     {
@@ -77,7 +77,7 @@ public static class WebAssemblyHttpRequestMessageExtensions
     /// <param name="requestMode">The <see cref="BrowserRequestMode"/>.</param>
     /// <returns>The <see cref="HttpRequestMessage"/>.</returns>\
     /// <remarks>
-    /// See https://developer.mozilla.org/en-US/docs/Web/API/Request/mode
+    /// See <see href="https://developer.mozilla.org/en-US/docs/Web/API/Request/mode"/>.
     /// </remarks>
     public static HttpRequestMessage SetBrowserRequestMode(this HttpRequestMessage requestMessage, BrowserRequestMode requestMode)
     {
@@ -105,7 +105,7 @@ public static class WebAssemblyHttpRequestMessageExtensions
     /// <param name="integrity">The subresource integrity descriptor.</param>
     /// <returns>The <see cref="HttpRequestMessage"/>.</returns>
     /// <remarks>
-    /// See https://developer.mozilla.org/en-US/docs/Web/API/Request/integrity
+    /// See <see href="https://developer.mozilla.org/en-US/docs/Web/API/Request/integrity"/>.
     /// </remarks>
     public static HttpRequestMessage SetBrowserRequestIntegrity(this HttpRequestMessage requestMessage, string integrity)
         => SetBrowserRequestOption(requestMessage, "integrity", integrity);
@@ -114,11 +114,11 @@ public static class WebAssemblyHttpRequestMessageExtensions
     /// Configures a value for the HTTP request.
     /// </summary>
     /// <param name="requestMessage">The <see cref="HttpRequestMessage"/>.</param>
-    /// <param name="name">The name of the option, which should correspond to a key defined on https://fetch.spec.whatwg.org/#requestinit</param>
+    /// <param name="name">The name of the option, which should correspond to a key defined on <see href="https://fetch.spec.whatwg.org/#requestinit"/>.</param>
     /// <param name="value">The value, which must be JSON-serializable.</param>
     /// <returns>The <see cref="HttpRequestMessage"/>.</returns>
     /// <remarks>
-    /// See https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch
+    /// See <see href="https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch"/>.
     /// </remarks>
     public static HttpRequestMessage SetBrowserRequestOption(this HttpRequestMessage requestMessage, string name, object value)
     {
@@ -151,7 +151,7 @@ public static class WebAssemblyHttpRequestMessageExtensions
     /// <returns>The <see cref="HttpRequestMessage"/>.</returns>
     /// <remarks>
     /// This API is only effective when the browser HTTP Fetch supports streaming.
-    /// See https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream.
+    /// See <see href="https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream"/>.
     /// </remarks>
     public static HttpRequestMessage SetBrowserResponseStreamingEnabled(this HttpRequestMessage requestMessage, bool streamingEnabled)
     {

--- a/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
@@ -81,7 +81,7 @@ internal sealed class DefaultWebAssemblyJSRuntime : WebAssemblyJSRuntime
     /// Notifies .NET of an array that's available for transfer from JS to .NET
     ///
     /// Ideally that byte array would be transferred directly as a parameter on this
-    /// call, however that's not currently possible due to: https://github.com/dotnet/runtime/issues/53378
+    /// call, however that's not currently possible due to: <see href="https://github.com/dotnet/runtime/issues/53378"/>.
     /// </summary>
     /// <param name="id">Id of the byte array</param>
     public static void NotifyByteArrayAvailable(int id)

--- a/src/DataProtection/DataProtection/src/DataProtectionBuilderExtensions.cs
+++ b/src/DataProtection/DataProtection/src/DataProtectionBuilderExtensions.cs
@@ -409,7 +409,7 @@ public static class DataProtectionBuilderExtensions
     /// <param name="builder">The <see cref="IDataProtectionBuilder"/>.</param>
     /// <returns>A reference to the <see cref="IDataProtectionBuilder" /> after this operation has completed.</returns>
     /// <remarks>
-    /// See https://msdn.microsoft.com/en-us/library/windows/desktop/hh706794(v=vs.85).aspx
+    /// See <see href="https://msdn.microsoft.com/en-us/library/windows/desktop/hh706794(v=vs.85).aspx"/>
     /// for more information on DPAPI-NG. This API is only supported on Windows 8 / Windows Server 2012 and higher.
     /// </remarks>
     [SupportedOSPlatform("windows")]
@@ -434,8 +434,8 @@ public static class DataProtectionBuilderExtensions
     /// The default value of this parameter is <see cref="DpapiNGProtectionDescriptorFlags.None"/>.</param>
     /// <returns>A reference to the <see cref="IDataProtectionBuilder" /> after this operation has completed.</returns>
     /// <remarks>
-    /// See https://msdn.microsoft.com/en-us/library/windows/desktop/hh769091(v=vs.85).aspx
-    /// and https://msdn.microsoft.com/en-us/library/windows/desktop/hh706800(v=vs.85).aspx
+    /// See <see href="https://msdn.microsoft.com/en-us/library/windows/desktop/hh769091(v=vs.85).aspx"/>
+    /// and <see href="https://msdn.microsoft.com/en-us/library/windows/desktop/hh706800(v=vs.85).aspx"/>
     /// for more information on valid values for the the <paramref name="protectionDescriptorRule"/>
     /// and <paramref name="flags"/> arguments.
     /// This API is only supported on Windows 8 / Windows Server 2012 and higher.

--- a/src/DataProtection/DataProtection/src/XmlEncryption/DpapiNGProtectionDescriptorFlags.cs
+++ b/src/DataProtection/DataProtection/src/XmlEncryption/DpapiNGProtectionDescriptorFlags.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.DataProtection.XmlEncryption;
 /// </summary>
 /// <remarks>
 /// These values correspond to the 'dwFlags' parameter on NCryptCreateProtectionDescriptor.
-/// See https://msdn.microsoft.com/en-us/library/windows/desktop/hh706800(v=vs.85).aspx for more information.
+/// See <see href="https://msdn.microsoft.com/en-us/library/windows/desktop/hh706800(v=vs.85).aspx"/> for more information.
 /// </remarks>
 [Flags]
 public enum DpapiNGProtectionDescriptorFlags

--- a/src/Features/JsonPatch/src/Adapters/IObjectAdapter.cs
+++ b/src/Features/JsonPatch/src/Adapters/IObjectAdapter.cs
@@ -28,7 +28,7 @@ public interface IObjectAdapter
     ///
     /// { "op": "add", "path": "/a/b/c", "value": [ "foo", "bar" ] }
     ///
-    /// See RFC 6902 https://tools.ietf.org/html/rfc6902#page-4
+    /// See RFC 6902 <see href="https://tools.ietf.org/html/rfc6902#page-4"/>
     /// </summary>
     /// <param name="operation">The add operation.</param>
     /// <param name="objectToApplyTo">Object to apply the operation to.</param>
@@ -47,7 +47,7 @@ public interface IObjectAdapter
     ///
     ///  { "op": "copy", "from": "/a/b/c", "path": "/a/b/e" }
     ///
-    /// See RFC 6902 https://tools.ietf.org/html/rfc6902#page-7
+    /// See RFC 6902 <see href="https://tools.ietf.org/html/rfc6902#page-7"/>
     /// </summary>
     /// <param name="operation">The copy operation.</param>
     /// <param name="objectToApplyTo">Object to apply the operation to.</param>
@@ -68,7 +68,7 @@ public interface IObjectAdapter
     ///
     /// A location cannot be moved into one of its children.
     ///
-    /// See RFC 6902 https://tools.ietf.org/html/rfc6902#page-6
+    /// See RFC 6902 <see href="https://tools.ietf.org/html/rfc6902#page-6"/>
     /// </summary>
     /// <param name="operation">The move operation.</param>
     /// <param name="objectToApplyTo">Object to apply the operation to.</param>
@@ -86,7 +86,7 @@ public interface IObjectAdapter
     /// If removing an element from an array, any elements above the
     /// specified index are shifted one position to the left.
     ///
-    /// See RFC 6902 https://tools.ietf.org/html/rfc6902#page-6
+    /// See RFC 6902 <see href="https://tools.ietf.org/html/rfc6902#page-6"/>
     /// </summary>
     /// <param name="operation">The remove operation.</param>
     /// <param name="objectToApplyTo">Object to apply the operation to.</param>
@@ -103,7 +103,7 @@ public interface IObjectAdapter
     ///
     /// { "op": "replace", "path": "/a/b/c", "value": 42 }
     ///
-    /// See RFC 6902 https://tools.ietf.org/html/rfc6902#page-6
+    /// See RFC 6902 <see href="https://tools.ietf.org/html/rfc6902#page-6"/>
     /// </summary>
     /// <param name="operation">The replace operation.</param>
     /// <param name="objectToApplyTo">Object to apply the operation to.</param>

--- a/src/Features/JsonPatch/src/Adapters/IObjectAdapterWithTest.cs
+++ b/src/Features/JsonPatch/src/Adapters/IObjectAdapterWithTest.cs
@@ -23,7 +23,7 @@ public interface IObjectAdapterWithTest : IObjectAdapter
     /// For example:
     /// { "op": "test", "path": "/a/b/c", "value": "foo" }
     ///
-    /// See RFC 6902 https://tools.ietf.org/html/rfc6902#page-7
+    /// See RFC 6902 <see href="https://tools.ietf.org/html/rfc6902#page-7"/>
     /// </summary>
     /// <param name="operation">The test operation.</param>
     /// <param name="objectToApplyTo">Object to apply the operation to.</param>

--- a/src/Html.Abstractions/src/HtmlFormattableString.cs
+++ b/src/Html.Abstractions/src/HtmlFormattableString.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Html;
 
 /// <summary>
 /// An <see cref="IHtmlContent"/> implementation of composite string formatting
-/// (see https://msdn.microsoft.com/en-us/library/txafckwd(v=vs.110).aspx) which HTML encodes
+/// (see <see href="https://msdn.microsoft.com/en-us/library/txafckwd(v=vs.110).aspx"/>) which HTML encodes
 /// formatted arguments.
 /// </summary>
 [DebuggerDisplay("{DebuggerToString()}")]

--- a/src/Http/Headers/src/CacheControlHeaderValue.cs
+++ b/src/Http/Headers/src/CacheControlHeaderValue.cs
@@ -116,7 +116,7 @@ public class CacheControlHeaderValue
     /// before using it.
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc7234#section-5.2.1.4</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc7234#section-5.2.1.4"/>.</remarks>
     public bool NoCache
     {
         get { return _noCache; }
@@ -144,7 +144,7 @@ public class CacheControlHeaderValue
     /// Configuring no-store indicates that the response may not be stored in any cache.
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc7234#section-5.2.1.5</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc7234#section-5.2.1.5"/>.</remarks>
     public bool NoStore
     {
         get { return _noStore; }
@@ -157,7 +157,7 @@ public class CacheControlHeaderValue
     /// max-age specifies the maximum amount of time the response is considered fresh.
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc7234#section-5.2.1.1</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc7234#section-5.2.1.1"/>.</remarks>
     public TimeSpan? MaxAge
     {
         get { return _maxAge; }
@@ -170,7 +170,7 @@ public class CacheControlHeaderValue
     /// Overrides <see cref="MaxAge">max-age</see>, but only for shared caches (such as proxies).
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc7234#section-5.2.2.9</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc7234#section-5.2.2.9"/>.</remarks>
     public TimeSpan? SharedMaxAge
     {
         get { return _sharedMaxAge; }
@@ -184,7 +184,7 @@ public class CacheControlHeaderValue
     /// is specified by <see cref="MaxStaleLimit"/>.
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc7234#section-5.2.1.2</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc7234#section-5.2.1.2"/>.</remarks>
     public bool MaxStale
     {
         get { return _maxStale; }
@@ -197,7 +197,7 @@ public class CacheControlHeaderValue
     /// Indicates the maximum duration an HTTP client is willing to accept a response that has exceeded its expiration time.
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc7234#section-5.2.1.2</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc7234#section-5.2.1.2"/>.</remarks>
     public TimeSpan? MaxStaleLimit
     {
         get { return _maxStaleLimit; }
@@ -210,7 +210,7 @@ public class CacheControlHeaderValue
     /// Indicates the freshness lifetime that an HTTP client is willing to accept a response.
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc7234#section-5.2.1.3</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc7234#section-5.2.1.3"/>.</remarks>
     public TimeSpan? MinFresh
     {
         get { return _minFresh; }
@@ -223,7 +223,7 @@ public class CacheControlHeaderValue
     /// Forbids intermediate caches or proxies from editing the response payload.
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc7234#section-5.2.1.6</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc7234#section-5.2.1.6"/>.</remarks>
     public bool NoTransform
     {
         get { return _noTransform; }
@@ -236,7 +236,7 @@ public class CacheControlHeaderValue
     /// Indicates that the client only wishes to obtain a stored response
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc7234#section-5.2.1.7</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc7234#section-5.2.1.7"/>.</remarks>
     public bool OnlyIfCached
     {
         get { return _onlyIfCached; }
@@ -249,7 +249,7 @@ public class CacheControlHeaderValue
     /// Indicates that the response may be stored by any cache.
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc7234#section-5.2.2.5</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc7234#section-5.2.2.5"/>.</remarks>
     public bool Public
     {
         get { return _public; }
@@ -262,7 +262,7 @@ public class CacheControlHeaderValue
     /// Indicates that the response may not be stored by a shared cache.
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc7234#section-5.2.2.6</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc7234#section-5.2.2.6"/>.</remarks>
     public bool Private
     {
         get { return _private; }
@@ -290,7 +290,7 @@ public class CacheControlHeaderValue
     /// Indicates that caches must revalidate the use of stale caches with the origin server before their use.
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc7234#section-5.2.2.1</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc7234#section-5.2.2.1"/>.</remarks>
     public bool MustRevalidate
     {
         get { return _mustRevalidate; }
@@ -303,7 +303,7 @@ public class CacheControlHeaderValue
     /// Indicates that shared caches must revalidate the use of stale caches with the origin server before their use.
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc7234#section-5.2.2.1</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc7234#section-5.2.2.1"/>.</remarks>
     public bool ProxyRevalidate
     {
         get { return _proxyRevalidate; }

--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Net.Http.Headers;
 /// Represents the value of a <c>Content-Disposition</c> header.
 /// </summary>
 /// <remarks>
-/// Note this is for use both in HTTP (https://tools.ietf.org/html/rfc6266) and MIME (https://tools.ietf.org/html/rfc2183)
+/// Note this is for use both in HTTP (<see href="https://tools.ietf.org/html/rfc6266"/>) and MIME (<see href="https://tools.ietf.org/html/rfc2183"/>).
 /// </remarks>
 public class ContentDispositionHeaderValue
 {

--- a/src/Http/Headers/src/EntityTagHeaderValue.cs
+++ b/src/Http/Headers/src/EntityTagHeaderValue.cs
@@ -96,7 +96,7 @@ public class EntityTagHeaderValue
 
     /// <summary>
     /// Check against another <see cref="EntityTagHeaderValue"/> for equality.
-    /// This equality check should not be used to determine if two values match under the RFC specifications (https://tools.ietf.org/html/rfc7232#section-2.3.2).
+    /// This equality check should not be used to determine if two values match under the RFC specifications (<see href="https://tools.ietf.org/html/rfc7232#section-2.3.2"/>).
     /// </summary>
     /// <param name="obj">The other value to check against for equality.</param>
     /// <returns>
@@ -117,7 +117,7 @@ public class EntityTagHeaderValue
     }
 
     /// <summary>
-    /// Compares against another <see cref="EntityTagHeaderValue"/> to see if they match under the RFC specifications (https://tools.ietf.org/html/rfc7232#section-2.3.2).
+    /// Compares against another <see cref="EntityTagHeaderValue"/> to see if they match under the RFC specifications (<see href="https://tools.ietf.org/html/rfc7232#section-2.3.2"/>).
     /// </summary>
     /// <param name="other">The other <see cref="EntityTagHeaderValue"/> to compare against.</param>
     /// <param name="useStrongComparison"><c>true</c> to use a strong comparison, <c>false</c> to use a weak comparison</param>

--- a/src/Http/Headers/src/MediaTypeHeaderValue.cs
+++ b/src/Http/Headers/src/MediaTypeHeaderValue.cs
@@ -370,7 +370,7 @@ public class MediaTypeHeaderValue
     /// <summary>
     /// Gets a value indicating whether this <see cref="MediaTypeHeaderValue"/> is a subset of
     /// <paramref name="otherMediaType"/>. A "subset" is defined as the same or a more specific media type
-    /// according to the precedence described in https://www.ietf.org/rfc/rfc2068.txt section 14.1, Accept.
+    /// according to the precedence described in <see href="https://www.ietf.org/rfc/rfc2068.txt"/> section 14.1, Accept.
     /// </summary>
     /// <param name="otherMediaType">The <see cref="MediaTypeHeaderValue"/> to compare.</param>
     /// <returns>
@@ -439,7 +439,7 @@ public class MediaTypeHeaderValue
     /// <summary>
     /// Gets a value indicating whether <paramref name="otherMediaType"/> is a subset of
     /// this <see cref="MediaTypeHeaderValue"/> in terms of type/subType. A "subset" is defined as the same or a more specific media type
-    /// according to the precedence described in https://www.ietf.org/rfc/rfc2068.txt section 14.1, Accept.
+    /// according to the precedence described in <see href="https://www.ietf.org/rfc/rfc2068.txt"/> section 14.1, Accept.
     /// </summary>
     /// <param name="otherMediaType">The <see cref="StringSegment"/> to compare.</param>
     /// <returns>

--- a/src/Http/Headers/src/SameSiteMode.cs
+++ b/src/Http/Headers/src/SameSiteMode.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Net.Http.Headers;
 
 /// <summary>
 /// Indicates if the client should include a cookie on "same-site" or "cross-site" requests.
-/// RFC Draft: https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.1
+/// RFC Draft: <see href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.1"/>
 /// </summary>
 // This mirrors Microsoft.AspNetCore.Http.SameSiteMode
 public enum SameSiteMode

--- a/src/Http/Headers/src/SetCookieHeaderValue.cs
+++ b/src/Http/Headers/src/SetCookieHeaderValue.cs
@@ -110,7 +110,7 @@ public class SetCookieHeaderValue
     /// represented as the date and time at which the cookie expires.
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc6265#section-4.1.2.1</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc6265#section-4.1.2.1"/>.</remarks>
     public DateTimeOffset? Expires { get; set; }
 
     /// <summary>
@@ -120,7 +120,7 @@ public class SetCookieHeaderValue
     /// represented as the number of seconds until the cookie expires.
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc6265#section-4.1.2.2</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc6265#section-4.1.2.2"/>.</remarks>
     public TimeSpan? MaxAge { get; set; }
 
     /// <summary>
@@ -130,7 +130,7 @@ public class SetCookieHeaderValue
     /// be sent.
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc6265#section-4.1.2.3</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc6265#section-4.1.2.3"/>.</remarks>
     public StringSegment Domain { get; set; }
 
     /// <summary>
@@ -140,7 +140,7 @@ public class SetCookieHeaderValue
     /// be sent.
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc6265#section-4.1.2.4</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc6265#section-4.1.2.4"/>.</remarks>
     public StringSegment Path { get; set; }
 
     /// <summary>
@@ -150,7 +150,7 @@ public class SetCookieHeaderValue
     /// channels.
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc6265#section-4.1.2.5</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc6265#section-4.1.2.5"/>.</remarks>
     public bool Secure { get; set; }
 
     /// <summary>
@@ -160,7 +160,7 @@ public class SetCookieHeaderValue
     /// deployed in strict mode, and when supported by the client.
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05#section-8.8</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05#section-8.8"/>.</remarks>
     public SameSiteMode SameSite { get; set; } = SameSiteMode.Unspecified;
 
     /// <summary>
@@ -171,7 +171,7 @@ public class SetCookieHeaderValue
     /// (such as a web browser API that exposes cookies to scripts).
     /// </para>
     /// </summary>
-    /// <remarks>See https://tools.ietf.org/html/rfc6265#section-4.1.2.6</remarks>
+    /// <remarks>See <see href="https://tools.ietf.org/html/rfc6265#section-4.1.2.6"/>.</remarks>
     public bool HttpOnly { get; set; }
 
     /// <summary>

--- a/src/Http/Http.Extensions/src/ProblemDetails.cs
+++ b/src/Http/Http.Extensions/src/ProblemDetails.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Http;
 namespace Microsoft.AspNetCore.Mvc;
 
 /// <summary>
-/// A machine-readable format for specifying errors in HTTP API responses based on https://tools.ietf.org/html/rfc7807.
+/// A machine-readable format for specifying errors in HTTP API responses based on <see href="https://tools.ietf.org/html/rfc7807"/>.
 /// </summary>
 [JsonConverter(typeof(ProblemDetailsJsonConverter))]
 public class ProblemDetails

--- a/src/Http/Http.Features/src/IHttpRequestFeature.cs
+++ b/src/Http/Http.Features/src/IHttpRequestFeature.cs
@@ -57,7 +57,7 @@ public interface IHttpRequestFeature
     /// Gets or sets the request target as it was sent in the HTTP request.
     /// <para>
     /// This property contains the raw path and full query, as well as other request targets
-    /// such as * for OPTIONS requests (https://tools.ietf.org/html/rfc7230#section-5.3).
+    /// such as * for OPTIONS requests (<see href="https://tools.ietf.org/html/rfc7230#section-5.3"/>).
     /// </para>
     /// </summary>
     /// <remarks>

--- a/src/Http/Http.Features/src/ITlsTokenBindingFeature.cs
+++ b/src/Http/Http.Features/src/ITlsTokenBindingFeature.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Http.Features;
 /// <remarks>
 /// TLS token bindings help mitigate the risk of impersonation by an attacker in the
 /// event an authenticated client's bearer tokens are somehow exfiltrated from the
-/// client's machine. See https://datatracker.ietf.org/doc/draft-popov-token-binding/
+/// client's machine. See <see href="https://datatracker.ietf.org/doc/draft-popov-token-binding/"/>
 /// for more information.
 /// </remarks>
 public interface ITlsTokenBindingFeature

--- a/src/Http/Http.Features/src/SameSiteMode.cs
+++ b/src/Http/Http.Features/src/SameSiteMode.cs
@@ -5,7 +5,7 @@ namespace Microsoft.AspNetCore.Http;
 
 /// <summary>
 /// Used to set the SameSite field on response cookies to indicate if those cookies should be included by the client on future "same-site" or "cross-site" requests.
-/// RFC Draft: https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.1
+/// RFC Draft: <see href="https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.1"/>
 /// </summary>
 // This mirrors Microsoft.Net.Http.Headers.SameSiteMode
 public enum SameSiteMode

--- a/src/Http/Http.Results/src/ProblemHttpResult.cs
+++ b/src/Http/Http.Results/src/ProblemHttpResult.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 /// <summary>
 /// An <see cref="IResult"/> that on execution will write Problem Details
-/// HTTP API responses based on https://tools.ietf.org/html/rfc7807
+/// HTTP API responses based on <see href="https://tools.ietf.org/html/rfc7807"/>
 /// </summary>
 public sealed class ProblemHttpResult : IResult
 {

--- a/src/Http/Routing/src/Internal/DfaGraphWriter.cs
+++ b/src/Http/Routing/src/Internal/DfaGraphWriter.cs
@@ -9,10 +9,10 @@ namespace Microsoft.AspNetCore.Routing.Internal;
 /// <summary>
 /// <para>
 /// A singleton service that can be used to write the route table as a state machine
-/// in GraphViz DOT language https://www.graphviz.org/doc/info/lang.html
+/// in GraphViz DOT language <see href="https://www.graphviz.org/doc/info/lang.html"/>.
 /// </para>
 /// <para>
-/// You can use http://www.webgraphviz.com/ to visualize the results.
+/// You can use <see href="http://www.webgraphviz.com/"/> to visualize the results.
 /// </para>
 /// <para>
 /// This type has no support contract, and may be removed or changed at any time in

--- a/src/HttpClientFactory/Polly/src/PolicyHttpMessageHandler.cs
+++ b/src/HttpClientFactory/Polly/src/PolicyHttpMessageHandler.cs
@@ -15,12 +15,12 @@ namespace Microsoft.Extensions.Http;
 /// </summary>
 /// <remarks>
 /// <para>
-/// This message handler implementation supports the use of policies provided by the Polly library for 
+/// This message handler implementation supports the use of policies provided by the Polly library for
 /// transient-fault-handling and resiliency.
 /// </para>
 /// <para>
-/// The documentation provided here is focused guidance for using Polly together with the <see cref="IHttpClientFactory"/>. 
-/// See the Polly project and its documentation (https://github.com/app-vnext/Polly) for authoritative information on Polly.
+/// The documentation provided here is focused guidance for using Polly together with the <see cref="IHttpClientFactory"/>.
+/// See the Polly project and its documentation (<see href="https://github.com/app-vnext/Polly"/>) for authoritative information on Polly.
 /// </para>
 /// <para>
 /// The extension methods on <see cref="PollyHttpClientBuilderExtensions"/> are designed as a convenient and correct
@@ -53,14 +53,14 @@ namespace Microsoft.Extensions.Http;
 /// your own policies as needed if this does not meet your requirements.
 /// </para>
 /// <para>
-/// Take care when using policies such as Retry or Timeout together as HttpClient provides its own timeout via 
+/// Take care when using policies such as Retry or Timeout together as HttpClient provides its own timeout via
 /// <see cref="HttpClient.Timeout"/>.  When combining Retry and Timeout, <see cref="HttpClient.Timeout"/> will act as a
 /// timeout across all tries; a Polly Timeout policy can be configured after a Retry policy in the configuration sequence,
 /// to provide a timeout-per-try.
 /// </para>
 /// <para>
-/// All policies provided by Polly are designed to be efficient when used in a long-lived way. Certain policies such as the 
-/// Bulkhead and Circuit-Breaker maintain state and should be scoped across calls you wish to share the Bulkhead or Circuit-Breaker state. 
+/// All policies provided by Polly are designed to be efficient when used in a long-lived way. Certain policies such as the
+/// Bulkhead and Circuit-Breaker maintain state and should be scoped across calls you wish to share the Bulkhead or Circuit-Breaker state.
 /// Take care to ensure the correct lifetimes when using policies and message handlers together in custom scenarios. The extension
 /// methods provided by <see cref="PollyHttpClientBuilderExtensions"/> are designed to assign a long lifetime to policies
 /// and ensure that they can be used when the handler rotation feature is active.

--- a/src/Middleware/HttpsPolicy/src/HstsMiddleware.cs
+++ b/src/Middleware/HttpsPolicy/src/HstsMiddleware.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.HttpsPolicy;
 
 /// <summary>
 /// Enables HTTP Strict Transport Security (HSTS)
-/// See https://tools.ietf.org/html/rfc6797.
+/// See <see href="https://tools.ietf.org/html/rfc6797"/>.
 /// </summary>
 public class HstsMiddleware
 {

--- a/src/Middleware/HttpsPolicy/src/HstsOptions.cs
+++ b/src/Middleware/HttpsPolicy/src/HstsOptions.cs
@@ -13,7 +13,7 @@ public class HstsOptions
     /// </summary>
     /// <remarks>
     /// Max-age is required; defaults to 30 days.
-    /// See: https://tools.ietf.org/html/rfc6797#section-6.1.1
+    /// See: <see href="https://tools.ietf.org/html/rfc6797#section-6.1.1"/>
     /// </remarks>
     public TimeSpan MaxAge { get; set; } = TimeSpan.FromDays(30);
 
@@ -21,7 +21,7 @@ public class HstsOptions
     /// Enables includeSubDomain parameter of the Strict-Transport-Security header.
     /// </summary>
     /// <remarks>
-    /// See: https://tools.ietf.org/html/rfc6797#section-6.1.2
+    /// See: <see href="https://tools.ietf.org/html/rfc6797#section-6.1.2"/>
     /// </remarks>
     public bool IncludeSubDomains { get; set; }
 

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
@@ -217,7 +217,7 @@ public abstract class ModelMetadata : IEquatable<ModelMetadata?>, IModelMetadata
     public abstract string? Description { get; }
 
     /// <summary>
-    /// Gets the format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to display the
+    /// Gets the format string (see <see href="https://msdn.microsoft.com/en-us/library/txafckwd.aspx"/>) used to display the
     /// model.
     /// </summary>
     public abstract string? DisplayFormatString { get; }
@@ -228,7 +228,7 @@ public abstract class ModelMetadata : IEquatable<ModelMetadata?>, IModelMetadata
     public abstract string? DisplayName { get; }
 
     /// <summary>
-    /// Gets the format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to edit the model.
+    /// Gets the format string (see <see href="https://msdn.microsoft.com/en-us/library/txafckwd.aspx"/>) used to edit the model.
     /// </summary>
     public abstract string? EditFormatString { get; }
 

--- a/src/Mvc/Mvc.Razor/src/RazorViewEngineOptions.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorViewEngineOptions.cs
@@ -19,7 +19,7 @@ public class RazorViewEngineOptions
     /// <remarks>
     /// <para>
     /// The locations of the views returned from controllers that do not belong to an area.
-    /// Locations are format strings (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) which may contain
+    /// Locations are format strings (see <see href="https://msdn.microsoft.com/en-us/library/txafckwd.aspx"/>) which may contain
     /// the following format items:
     /// </para>
     /// <list type="bullet">
@@ -45,7 +45,7 @@ public class RazorViewEngineOptions
     /// <remarks>
     /// <para>
     /// The locations of the views returned from controllers that belong to an area.
-    /// Locations are format strings (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) which may contain
+    /// Locations are format strings (see <see href="https://msdn.microsoft.com/en-us/library/txafckwd.aspx"/>) which may contain
     /// the following format items:
     /// </para>
     /// <list type="bullet">
@@ -74,7 +74,7 @@ public class RazorViewEngineOptions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Locations are format strings (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) which may contain
+    /// Locations are format strings (see <see href="https://msdn.microsoft.com/en-us/library/txafckwd.aspx"/>) which may contain
     /// the following format items:
     /// </para>
     /// <list type="bullet">
@@ -105,7 +105,7 @@ public class RazorViewEngineOptions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Locations are format strings (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) which may contain
+    /// Locations are format strings (see <see href="https://msdn.microsoft.com/en-us/library/txafckwd.aspx"/>) which may contain
     /// the following format items:
     /// </para>
     /// <list type="bullet">

--- a/src/Mvc/Mvc.TagHelpers/src/InputTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/InputTagHelper.cs
@@ -93,7 +93,7 @@ public class InputTagHelper : TagHelper
     public ModelExpression For { get; set; }
 
     /// <summary>
-    /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to format the
+    /// The format string (see <see href="https://msdn.microsoft.com/en-us/library/txafckwd.aspx"/>) used to format the
     /// <see cref="For"/> result. Sets the generated "value" attribute to that formatted string.
     /// </summary>
     /// <remarks>

--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/HtmlHelperInputExtensions.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/HtmlHelperInputExtensions.cs
@@ -542,7 +542,7 @@ public static class HtmlHelperInputExtensions
     /// <param name="expression">Expression name, relative to the current model.</param>
     /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
     /// <param name="format">
-    /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to format the "value"
+    /// The format string (see <see href="https://msdn.microsoft.com/en-us/library/txafckwd.aspx"/>) used to format the "value"
     /// attribute unless that came from model binding.
     /// </param>
     /// <returns>A new <see cref="IHtmlContent"/> containing the &lt;input&gt; element.</returns>
@@ -647,7 +647,7 @@ public static class HtmlHelperInputExtensions
     /// <param name="htmlHelper">The <see cref="IHtmlHelper{TModel}"/> instance this method extends.</param>
     /// <param name="expression">An expression to be evaluated against the current model.</param>
     /// <param name="format">
-    /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to format the
+    /// The format string (see <see href="https://msdn.microsoft.com/en-us/library/txafckwd.aspx"/>) used to format the
     /// <paramref name="expression"/> value when using that in the "value" attribute.
     /// </param>
     /// <typeparam name="TModel">The type of the model.</typeparam>

--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/HtmlHelperValueExtensions.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/HtmlHelperValueExtensions.cs
@@ -99,7 +99,7 @@ public static class HtmlHelperValueExtensions
     /// </summary>
     /// <param name="htmlHelper">The <see cref="IHtmlHelper"/> instance this method extends.</param>
     /// <param name="format">
-    /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to format the return
+    /// The format string (see <see href="https://msdn.microsoft.com/en-us/library/txafckwd.aspx"/>) used to format the return
     /// value unless that came from model binding.
     /// </param>
     /// <returns>A <see cref="string"/> containing the formatted value.</returns>

--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/IHtmlHelper.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/IHtmlHelper.cs
@@ -346,7 +346,7 @@ public interface IHtmlHelper
     /// </summary>
     /// <param name="value">The value.</param>
     /// <param name="format">
-    /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to format the return
+    /// The format string (see <see href="https://msdn.microsoft.com/en-us/library/txafckwd.aspx"/>) used to format the return
     /// value.
     /// </param>
     /// <returns>A <see cref="string"/> containing the formatted value.</returns>
@@ -645,7 +645,7 @@ public interface IHtmlHelper
     /// <param name="expression">Expression name, relative to the current model.</param>
     /// <param name="value">If non-<c>null</c>, value to include in the element.</param>
     /// <param name="format">
-    /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to format the "value"
+    /// The format string (see <see href="https://msdn.microsoft.com/en-us/library/txafckwd.aspx"/>) used to format the "value"
     /// attribute unless that came from model binding.
     /// </param>
     /// <param name="htmlAttributes">
@@ -722,7 +722,7 @@ public interface IHtmlHelper
     /// </summary>
     /// <param name="expression">Expression name, relative to the current model.</param>
     /// <param name="format">
-    /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to format the return
+    /// The format string (see <see href="https://msdn.microsoft.com/en-us/library/txafckwd.aspx"/>) used to format the return
     /// value unless that came from model binding.
     /// </param>
     /// <returns>A <see cref="string"/> containing the formatted value.</returns>

--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/IHtmlHelperOfT.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/IHtmlHelperOfT.cs
@@ -372,7 +372,7 @@ public interface IHtmlHelper<TModel> : IHtmlHelper
     /// </summary>
     /// <param name="expression">An expression to be evaluated against the current model.</param>
     /// <param name="format">
-    /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to format the
+    /// The format string (see <see href="https://msdn.microsoft.com/en-us/library/txafckwd.aspx"/>) used to format the
     /// <paramref name="expression"/> value when using that in the "value" attribute.
     /// </param>
     /// <param name="htmlAttributes">
@@ -429,7 +429,7 @@ public interface IHtmlHelper<TModel> : IHtmlHelper
     /// </summary>
     /// <param name="expression">An expression to be evaluated against the current model.</param>
     /// <param name="format">
-    /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx) used to format the
+    /// The format string (see <see href="https://msdn.microsoft.com/en-us/library/txafckwd.aspx"/>) used to format the
     /// <paramref name="expression"/> value when returning that value.
     /// </param>
     /// <typeparam name="TResult">The type of the <paramref name="expression"/> result.</typeparam>

--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/TagBuilder.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/TagBuilder.cs
@@ -145,7 +145,7 @@ public class TagBuilder : IHtmlContent
     /// Valid HTML 4.01 "id" attribute value for an element with the given <paramref name="name"/>.
     /// </returns>
     /// <remarks>
-    /// Valid "id" attributes are defined in https://www.w3.org/TR/html401/types.html#type-id.
+    /// Valid "id" attributes are defined in <see href="https://www.w3.org/TR/html401/types.html#type-id"/>.
     /// </remarks>
     public static string CreateSanitizedId(string? name, string invalidCharReplacement)
     {

--- a/src/Mvc/Mvc.ViewFeatures/src/ViewDataDictionary.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/ViewDataDictionary.cs
@@ -378,7 +378,7 @@ public class ViewDataDictionary : IDictionary<string, object?>
     /// </summary>
     /// <param name="expression">Expression name, relative to the current model.</param>
     /// <param name="format">
-    /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx).
+    /// The format string (see <see href="https://msdn.microsoft.com/en-us/library/txafckwd.aspx"/>).
     /// </param>
     /// <returns>
     /// Value of named <paramref name="expression"/> in this <see cref="ViewDataDictionary"/>, formatted using
@@ -399,7 +399,7 @@ public class ViewDataDictionary : IDictionary<string, object?>
     /// </summary>
     /// <param name="value">The value to format.</param>
     /// <param name="format">
-    /// The format string (see https://msdn.microsoft.com/en-us/library/txafckwd.aspx).
+    /// The format string (see <see href="https://msdn.microsoft.com/en-us/library/txafckwd.aspx"/>).
     /// </param>
     /// <returns>The formatted <see cref="string"/>.</returns>
     public static string? FormatValue(object? value, string? format)

--- a/src/Security/Authentication/Certificate/src/CertificateAuthenticationExtensions.cs
+++ b/src/Security/Authentication/Certificate/src/CertificateAuthenticationExtensions.cs
@@ -18,7 +18,7 @@ public static class CertificateAuthenticationAppBuilderExtensions
     /// <para>
     /// Certificate authentication uses a authentication handler that validates client certificate and
     /// raises an event where the certificate is resolved to a <see cref="ClaimsPrincipal"/>.
-    /// See https://tools.ietf.org/html/rfc5246#section-7.4.4 to read more about certificate authentication.
+    /// See <see href="https://tools.ietf.org/html/rfc5246#section-7.4.4"/> to read more about certificate authentication.
     /// </para>
     /// </summary>
     /// <param name="builder">The <see cref="AuthenticationBuilder"/>.</param>
@@ -31,7 +31,7 @@ public static class CertificateAuthenticationAppBuilderExtensions
     /// <para>
     /// Certificate authentication uses a authentication handler that validates client certificate and
     /// raises an event where the certificate is resolved to a <see cref="ClaimsPrincipal"/>.
-    /// See https://tools.ietf.org/html/rfc5246#section-7.4.4 to read more about certificate authentication.
+    /// See <see href="https://tools.ietf.org/html/rfc5246#section-7.4.4"/> to read more about certificate authentication.
     /// </para>
     /// </summary>
     /// <param name="builder">The <see cref="AuthenticationBuilder"/>.</param>
@@ -45,7 +45,7 @@ public static class CertificateAuthenticationAppBuilderExtensions
     /// <para>
     /// Certificate authentication uses a authentication handler that validates client certificate and
     /// raises an event where the certificate is resolved to a <see cref="ClaimsPrincipal"/>.
-    /// See https://tools.ietf.org/html/rfc5246#section-7.4.4 to read more about certificate authentication.
+    /// See <see href="https://tools.ietf.org/html/rfc5246#section-7.4.4"/> to read more about certificate authentication.
     /// </para>
     /// </summary>
     /// <param name="builder">The <see cref="AuthenticationBuilder"/>.</param>
@@ -59,7 +59,7 @@ public static class CertificateAuthenticationAppBuilderExtensions
     /// <para>
     /// Certificate authentication uses a authentication handler that validates client certificate and
     /// raises an event where the certificate is resolved to a <see cref="ClaimsPrincipal"/>.
-    /// See https://tools.ietf.org/html/rfc5246#section-7.4.4 to read more about certificate authentication.
+    /// See <see href="https://tools.ietf.org/html/rfc5246#section-7.4.4"/> to read more about certificate authentication.
     /// </para>
     /// </summary>
     /// <param name="builder">The <see cref="AuthenticationBuilder"/>.</param>
@@ -77,7 +77,7 @@ public static class CertificateAuthenticationAppBuilderExtensions
     /// <para>
     /// Certificate authentication uses a authentication handler that validates client certificate and
     /// raises an event where the certificate is resolved to a <see cref="ClaimsPrincipal"/>.
-    /// See https://tools.ietf.org/html/rfc5246#section-7.4.4 to read more about certicate authentication.
+    /// See <see href="https://tools.ietf.org/html/rfc5246#section-7.4.4"/> to read more about certicate authentication.
     /// </para>
     /// </summary>
     /// <param name="builder">The <see cref="AuthenticationBuilder"/>.</param>

--- a/src/Security/Authentication/Facebook/src/FacebookDefaults.cs
+++ b/src/Security/Authentication/Facebook/src/FacebookDefaults.cs
@@ -22,7 +22,7 @@ public static class FacebookDefaults
     /// The default endpoint used to perform Facebook authentication.
     /// </summary>
     /// <remarks>
-    /// For more details about this endpoint, see https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow#login.
+    /// For more details about this endpoint, see <see href="https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow#login"/>.
     /// </remarks>
     public static readonly string AuthorizationEndpoint = "https://www.facebook.com/v11.0/dialog/oauth";
 

--- a/src/Security/Authentication/Facebook/src/FacebookOptions.cs
+++ b/src/Security/Authentication/Facebook/src/FacebookOptions.cs
@@ -86,14 +86,14 @@ public class FacebookOptions : OAuthOptions
     /// <summary>
     /// Gets or sets if the <c>appsecret_proof</c> should be generated and sent with Facebook API calls.
     /// </summary>
-    /// <remarks>See https://developers.facebook.com/docs/graph-api/security#appsecret_proof for more details.</remarks>
+    /// <remarks>See <see href="https://developers.facebook.com/docs/graph-api/security#appsecret_proof"/> for more details.</remarks>
     /// <value>Defaults to <see langword="true"/>.</value>
     public bool SendAppSecretProof { get; set; }
 
     /// <summary>
     /// The list of fields to retrieve from the UserInformationEndpoint.
-    /// https://developers.facebook.com/docs/graph-api/reference/user
     /// </summary>
+    /// <remarks>See <see href="https://developers.facebook.com/docs/graph-api/reference/user"/> for more details.</remarks>
     /// <value>
     /// Defaults to include the following fields if none are specified: "name", "email", "first_name", and "last_name".
     /// </value>

--- a/src/Security/Authentication/Google/src/GoogleDefaults.cs
+++ b/src/Security/Authentication/Google/src/GoogleDefaults.cs
@@ -22,7 +22,7 @@ public static class GoogleDefaults
     /// The default endpoint used to perform Google authentication.
     /// </summary>
     /// <remarks>
-    /// For more details about this endpoint, see https://developers.google.com/identity/protocols/oauth2/web-server#httprest
+    /// For more details about this endpoint, see <see href="https://developers.google.com/identity/protocols/oauth2/web-server#httprest"/>.
     /// </remarks>
     public static readonly string AuthorizationEndpoint = "https://accounts.google.com/o/oauth2/v2/auth";
 
@@ -35,7 +35,7 @@ public static class GoogleDefaults
     /// The Google endpoint that is used to gather additional user information.
     /// </summary>
     /// <remarks>
-    /// For more details about this endpoint, see https://developers.google.com/apis-explorer/#search/oauth2/oauth2/v2/.
+    /// For more details about this endpoint, see <see href="https://developers.google.com/apis-explorer/#search/oauth2/oauth2/v2/"/>.
     /// </remarks>
     public static readonly string UserInformationEndpoint = "https://www.googleapis.com/oauth2/v2/userinfo";
 }

--- a/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountDefaults.cs
+++ b/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountDefaults.cs
@@ -22,7 +22,7 @@ public static class MicrosoftAccountDefaults
     /// The default endpoint used to perform Microsoft account authentication.
     /// </summary>
     /// <remarks>
-    /// For more details about this endpoint, see https://developer.microsoft.com/en-us/graph/docs/concepts/auth_v2_user
+    /// For more details about this endpoint, see <see href="https://developer.microsoft.com/en-us/graph/docs/concepts/auth_v2_user"/>.
     /// </remarks>
     public static readonly string AuthorizationEndpoint = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize";
 

--- a/src/Security/Authentication/MicrosoftAccount/src/MicrosoftChallengeProperties.cs
+++ b/src/Security/Authentication/MicrosoftAccount/src/MicrosoftChallengeProperties.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.Authentication.MicrosoftAccount;
 
 /// <summary>
 /// <see cref="AuthenticationProperties"/> for Microsoft OAuth challenge request.
-/// See https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code for reference
+/// See <see href="https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code"/> for reference.
 /// </summary>
 public class MicrosoftChallengeProperties : OAuthChallengeProperties
 {

--- a/src/Security/Authentication/OAuth/src/OAuthConstants.cs
+++ b/src/Security/Authentication/OAuth/src/OAuthConstants.cs
@@ -9,22 +9,22 @@ namespace Microsoft.AspNetCore.Authentication.OAuth;
 public static class OAuthConstants
 {
     /// <summary>
-    /// code_verifier defined in https://tools.ietf.org/html/rfc7636
+    /// code_verifier defined in <see href="https://tools.ietf.org/html/rfc7636"/>.
     /// </summary>
     public static readonly string CodeVerifierKey = "code_verifier";
 
     /// <summary>
-    /// code_challenge defined in https://tools.ietf.org/html/rfc7636
+    /// code_challenge defined in <see href="https://tools.ietf.org/html/rfc7636"/>.
     /// </summary>
     public static readonly string CodeChallengeKey = "code_challenge";
 
     /// <summary>
-    /// code_challenge_method defined in https://tools.ietf.org/html/rfc7636
+    /// code_challenge_method defined in <see href="https://tools.ietf.org/html/rfc7636"/>.
     /// </summary>
     public static readonly string CodeChallengeMethodKey = "code_challenge_method";
 
     /// <summary>
-    /// S256 defined in https://tools.ietf.org/html/rfc7636
+    /// S256 defined in <see href="https://tools.ietf.org/html/rfc7636"/>.
     /// </summary>
     public static readonly string CodeChallengeMethodS256 = "S256";
 }

--- a/src/Security/Authentication/OAuth/src/OAuthOptions.cs
+++ b/src/Security/Authentication/OAuth/src/OAuthOptions.cs
@@ -104,7 +104,7 @@ public class OAuthOptions : RemoteAuthenticationOptions
     public ISecureDataFormat<AuthenticationProperties> StateDataFormat { get; set; } = default!;
 
     /// <summary>
-    /// Enables or disables the use of the Proof Key for Code Exchange (PKCE) standard. See https://tools.ietf.org/html/rfc7636.
+    /// Enables or disables the use of the Proof Key for Code Exchange (PKCE) standard. See <see href="https://tools.ietf.org/html/rfc7636"/>.
     /// The default value is `false` but derived handlers should enable this if their provider supports it.
     /// </summary>
     public bool UsePkce { get; set; }

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs
@@ -299,7 +299,7 @@ public class OpenIdConnectOptions : RemoteAuthenticationOptions
     /// <summary>
     /// Enables or disables the use of the Proof Key for Code Exchange (PKCE) standard.
     /// This only applies when the <see cref="ResponseType"/> is set to <see cref="OpenIdConnectResponseType.Code"/>.
-    /// See https://tools.ietf.org/html/rfc7636.
+    /// See <see href="https://tools.ietf.org/html/rfc7636"/>.
     /// The default value is `true`.
     /// </summary>
     public bool UsePkce { get; set; } = true;

--- a/src/Security/Authentication/Twitter/src/TwitterOptions.cs
+++ b/src/Security/Authentication/Twitter/src/TwitterOptions.cs
@@ -54,7 +54,7 @@ public class TwitterOptions : RemoteAuthenticationOptions
     /// Enables the retrieval user details during the authentication process, including
     /// e-mail addresses. Retrieving e-mail addresses requires special permissions
     /// from Twitter Support on a per application basis. The default is false.
-    /// See https://dev.twitter.com/rest/reference/get/account/verify_credentials
+    /// See <see href="https://dev.twitter.com/rest/reference/get/account/verify_credentials"/>.
     /// </summary>
     public bool RetrieveUserDetails { get; set; }
 

--- a/src/Servers/HttpSys/src/IHttpSysRequestInfoFeature.cs
+++ b/src/Servers/HttpSys/src/IHttpSysRequestInfoFeature.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys;
 
 /// <summary>
 /// This exposes the Http.Sys HTTP_REQUEST_INFO extensibility point as opaque data for the caller to interperate.
-/// <see href="https://docs.microsoft.com/en-us/windows/win32/api/http/ns-http-http_request_v2"/>
+/// <see href="https://docs.microsoft.com/en-us/windows/win32/api/http/ns-http-http_request_v2"/>,
 /// <see href="https://docs.microsoft.com/en-us/windows/win32/api/http/ns-http-http_request_info"/>
 /// </summary>
 public interface IHttpSysRequestInfoFeature

--- a/src/Servers/HttpSys/src/IHttpSysRequestInfoFeature.cs
+++ b/src/Servers/HttpSys/src/IHttpSysRequestInfoFeature.cs
@@ -7,8 +7,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys;
 
 /// <summary>
 /// This exposes the Http.Sys HTTP_REQUEST_INFO extensibility point as opaque data for the caller to interperate.
-/// https://docs.microsoft.com/en-us/windows/win32/api/http/ns-http-http_request_v2
-/// https://docs.microsoft.com/en-us/windows/win32/api/http/ns-http-http_request_info
+/// <see href="https://docs.microsoft.com/en-us/windows/win32/api/http/ns-http-http_request_v2"/>
+/// <see href="https://docs.microsoft.com/en-us/windows/win32/api/http/ns-http-http_request_info"/>
 /// </summary>
 public interface IHttpSysRequestInfoFeature
 {

--- a/src/Servers/IIS/IIS/src/StartupHook.cs
+++ b/src/Servers/IIS/IIS/src/StartupHook.cs
@@ -7,14 +7,14 @@ using Microsoft.Extensions.FileProviders;
 
 /// <summary>
 /// Startup hooks are pieces of code that will run before a users program main executes
-/// See: https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/host-startup-hook.md
+/// See: <see href="https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/host-startup-hook.md"/>
 /// The type must be named StartupHook without any namespace, and should be internal.
 /// </summary>
 internal class StartupHook
 {
     /// <summary>
     /// Startup hooks are pieces of code that will run before a users program main executes
-    /// See: https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/host-startup-hook.md
+    /// See: <see href="https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/host-startup-hook.md"/>
     /// </summary>
     public static void Initialize()
     {

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -51,7 +51,7 @@ public class KestrelServerOptions
     /// <summary>
     /// Gets or sets a value that controls whether dynamic compression of response headers is allowed.
     /// For more information about the security considerations of HPack dynamic header compression, visit
-    /// https://tools.ietf.org/html/rfc7541#section-7.
+    /// <see href="https://tools.ietf.org/html/rfc7541#section-7"/>.
     /// </summary>
     /// <remarks>
     /// Defaults to true.
@@ -72,8 +72,8 @@ public class KestrelServerOptions
     /// If <c>false</c> then the `:scheme` field for HTTP/2 and HTTP/3 requests must exactly match the transport (e.g. https for TLS
     /// connections, http for non-TLS). If <c>true</c> then the `:scheme` field for HTTP/2 and HTTP/3 requests can be set to alternate values
     /// and this will be reflected by `HttpRequest.Scheme`. The Scheme must still be valid according to
-    /// https://datatracker.ietf.org/doc/html/rfc3986/#section-3.1. Only enable this when working with a trusted proxy. This can be used in
-    /// scenarios such as proxies converting from alternate protocols. See https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.3.
+    /// <see href="https://datatracker.ietf.org/doc/html/rfc3986/#section-3.1"/>. Only enable this when working with a trusted proxy. This can be used in
+    /// scenarios such as proxies converting from alternate protocols. See <see href="https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.3"/>.
     /// Applications that enable this should validate an expected scheme is provided before using it.
     /// </para>
     /// </summary>

--- a/src/SignalR/common/Http.Connections/src/WebSocketOptions.cs
+++ b/src/SignalR/common/Http.Connections/src/WebSocketOptions.cs
@@ -20,7 +20,7 @@ public class WebSocketOptions
     /// by the client in the 'Sec-WebSocket-Protocol' request header.
     /// </summary>
     /// <remarks>
-    /// See RFC 6455 section 1.3 for more details on the WebSocket handshake: https://tools.ietf.org/html/rfc6455#section-1.3
+    /// See RFC 6455 section 1.3 for more details on the WebSocket handshake: <see href="https://tools.ietf.org/html/rfc6455#section-1.3"/>
     /// </remarks>
     // WebSocketManager's list of sub protocols is an IList:
     // https://github.com/aspnet/HttpAbstractions/blob/a6bdb9b1ec6ed99978a508e71a7f131be7e4d9fb/src/Microsoft.AspNetCore.Http.Abstractions/WebSocketManager.cs#L23


### PR DESCRIPTION
`<see href="..." />` makes VS turn hrefs into clickable links.

Found by searching across repo with regex: `\/\/\/.+(https:)`

Before:
![image](https://user-images.githubusercontent.com/303201/163909807-af91b9fa-799c-498a-859d-44577d1ec98f.png)

After:
![image](https://user-images.githubusercontent.com/303201/163909877-d8e726fd-89f5-4b28-b233-a302df010b94.png)
