### PR TITLE
Fixed the window update hangs

### DIFF
--- a/src/Grpc/Interop/test/InteropTests/InteropTests.cs
+++ b/src/Grpc/Interop/test/InteropTests/InteropTests.cs
@@ -64,7 +64,6 @@ public class InteropTests
     public Task UnimplementedMethod() => InteropTestCase("unimplemented_method");
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/41248")]
     public Task ClientCompressedUnary() => InteropTestCase("client_compressed_unary");
 
     [Fact]

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
@@ -239,7 +239,8 @@ internal class Http2FrameWriter
                     {
                         // If we queued the connection for a window update or we were unable to schedule the next write
                         // then we're waiting for a window update to resume the scheduling.
-                        if (TryQueueProducerForConnectionWindowUpdate(actual, producer) || !producer.TryScheduleNextWrite())
+                        if (TryQueueProducerForConnectionWindowUpdate(actual, producer) ||
+                            !producer.TryScheduleNextWriteIfStreamWindowHasSpace())
                         {
                             // Include waiting for window updates in timing writes
                             if (_minResponseDataRate != null)

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
@@ -267,8 +267,8 @@ internal class Http2FrameWriter
             // Check the connection window under a lock so that we don't miss window updates
             if (_connectionWindow == 0)
             {
-                // We have no more connection window, put this producer in a queue waiting for it to
-                // a window update to resume the connection.
+                // We have no more connection window, put this producer in a queue waiting for
+                // a window update to resume the producer.
 
                 // In order to make scheduling more fair we want to make sure that streams that have data get a chance to run in a round robin manner.
                 // To do this we will store the producer that consumed the window in a field and put it to the back of the queue.

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
@@ -269,7 +269,7 @@ internal class Http2FrameWriter
         lock (_windowUpdateLock)
         {
             // Check the connection window under a lock so that we don't miss window updates
-            if (_connectionWindow <= 0)
+            if (_connectionWindow == 0)
             {
                 // We have no more connection window, put this producer in a queue waiting for
                 // a window update to resume the producer.

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -157,14 +157,19 @@ internal class Http2OutputProducer : IHttpOutputProducer, IHttpOutputAborter, ID
         }
     }
 
-    // Consumes bytes from the stream's window and returns the remaining bytes and actual bytes consumed
-    internal long ConsumeStreamWindow(long bytes)
+    internal long CheckStreamWindow(long bytes)
     {
         lock (_dataWriterLock)
         {
-            var actual = Math.Min(bytes, _streamWindow);
-            _streamWindow -= actual;
-            return actual;
+            return Math.Min(bytes, _streamWindow);
+        }
+    }
+
+    internal void ConsumeStreamWindow(long bytes)
+    {
+        lock (_dataWriterLock)
+        {
+            _streamWindow -= bytes;
         }
     }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -302,7 +302,7 @@ internal class Http2OutputProducer : IHttpOutputProducer, IHttpOutputAborter, ID
         _frameWriter.Schedule(this);
     }
 
-    public bool TryScheduleNextWrite()
+    public bool TryScheduleNextWriteIfStreamWindowHasSpace()
     {
         lock (_dataWriterLock)
         {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -1971,7 +1971,7 @@ public class Http2ConnectionTests : Http2TestBase
             withStreamId: 1).DefaultTimeout();
 
         // Send more than enough bytes for the window update
-        await SendWindowUpdateAsync(0, (int)Http2PeerSettings.DefaultInitialWindowSize);
+        await SendWindowUpdateAsync(0, 1);
 
         // Expect the last frame
         await ExpectAsync(Http2FrameType.DATA,

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -1937,6 +1937,58 @@ public class Http2ConnectionTests : Http2TestBase
     }
 
     [Fact]
+    public async Task StreamWindow_BiggerThan_ConnectionWindow()
+    {
+        // This only affects the stream windows. The connection-level window is always initialized at 64KiB.
+        _clientSettings.InitialWindowSize = 16384 * 5;
+
+        await InitializeConnectionAsync(async context =>
+        {
+            var data = new byte[16384 * 4];
+            data.AsSpan().Fill(1);
+            await context.Response.Body.WriteAsync(data);
+        });
+
+        await StartStreamAsync(1, _browserRequestHeaders, endStream: true);
+
+        await ExpectAsync(Http2FrameType.HEADERS,
+            withLength: 32,
+            withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS),
+            withStreamId: 1).DefaultTimeout();
+
+        for (int i = 0; i < 3; i++)
+        {
+            await ExpectAsync(Http2FrameType.DATA,
+                withLength: 16384,
+                withFlags: (byte)(Http2DataFrameFlags.NONE),
+                withStreamId: 1).DefaultTimeout();
+        }
+
+        // Now we've consumed the entire connection window, and there's one more frame to write
+        await ExpectAsync(Http2FrameType.DATA,
+            withLength: 16383,
+            withFlags: (byte)(Http2DataFrameFlags.NONE),
+            withStreamId: 1).DefaultTimeout();
+
+        // Send more than enough bytes for the window update
+        await SendWindowUpdateAsync(0, (int)Http2PeerSettings.DefaultInitialWindowSize);
+
+        // Expect the last frame
+        await ExpectAsync(Http2FrameType.DATA,
+            withLength: 1,
+            withFlags: (byte)(Http2DataFrameFlags.NONE),
+            withStreamId: 1).DefaultTimeout();
+
+        // 0 length end of stream frame
+        await ExpectAsync(Http2FrameType.DATA,
+            withLength: 0,
+            withFlags: (byte)Http2DataFrameFlags.END_STREAM,
+            withStreamId: 1);
+
+        await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+    }
+
+    [Fact]
     public async Task HEADERS_Received_Decoded()
     {
         await InitializeConnectionAsync(_readHeadersApplication);


### PR DESCRIPTION
- While computing how many bytes we needed to write, we were returning the remaining number of window bytes (for both the connection and stream windows). Since window updates happen concurrently with the write loop, it was possible to miss and not observe the window update depending on when the update happened in relation to the loop observing this state. We now look at the current state of the connection window and stream window before we decide to queue or wait for a window update under the appropriate locks.


Fixes #41248
