### PR TITLE
Remove some legacy folders and add area-grpc, area-web-frameworks

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1533,8 +1533,7 @@
             "src/Mvc/Mvc.Testing.Tasks/src/",
             "src/Mvc/Mvc.Testing/",
             "src/Mvc/Mvc/",
-            "src/Mvc/perf/",
-            "src/Mvc/"
+            "src/Mvc/perf/"
           ]
         }
       ]

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1478,7 +1478,7 @@
             "src/Razor/",
             "src/Mvc/Mvc.Localization/",
             "src/Mvc/Mvc.DataAnnotations/",
-            "src/Mvcv/Mvc.Razor.RuntimeCompilation/",
+            "src/Mvc/Mvc.Razor.RuntimeCompilation/",
             "src/Mvc/Mvc.Razor/",
             "src/Mvc/Mvc.RazorPages/",
             "src/Mvc/Mvc.TagHelpers/",

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1476,8 +1476,13 @@
           "pathFilter": [
             "src/ProjectTemplates/",
             "src/Razor/",
-            "src/MusicStore/",
-            "src/Mvc/"
+            "src/Mvc/Mvc.Localization/",
+            "src/Mvc/Mvc.DataAnnotations/",
+            "src/Mvcv/Mvc.Razor.RuntimeCompilation/",
+            "src/Mvc/Mvc.Razor/",
+            "src/Mvc/Mvc.RazorPages/",
+            "src/Mvc/Mvc.TagHelpers/",
+            "src/Mvc/Mvc.ViewFeatures/"
           ]
         },
         {
@@ -1508,9 +1513,28 @@
           ]
         },
         {
-          "label": "blazor-wasm",
+          "label": "area-grpc",
           "pathFilter": [
-            "src/ProjectTemplates/BlazorWasm.ProjectTemplates/"
+            "src/Grpc/"
+          ]
+        },
+        {
+          "label": "area-web-frameworks",
+          "pathFilter": [
+            "src/Mvc/Mvc.Abstractions/",
+            "src/Mvc/Mvc.Analyzers/",
+            "src/Mvc/Mvc.Api.Analyzers/",
+            "src/Mvc/Mvc.ApiExplorer/",
+            "src/Mvc/Mvc.Core/",
+            "src/Mvc/Mvc.Cors/",
+            "src/Mvc/Mvc.Formatters.Json/",
+            "src/Mvc/Mvc.Formatters.Xml/",
+            "src/Mvc/Mvc.NewtonsoftJson/",
+            "src/Mvc/Mvc.Testing.Tasks/src/",
+            "src/Mvc/Mvc.Testing/",
+            "src/Mvc/Mvc/",
+            "src/Mvc/perf/",
+            "src/Mvc/"
           ]
         }
       ]


### PR DESCRIPTION
Updated FabricBot mappings to:
1. Remove MusicStore mapping (as the folder doesn't exist any more)
2. Remove Blazor WASM template mapping, as the template has merged with the rest of the templates under ProjectTemplates
3. Adds mappings for area-web-frameworks
4. Adds mapping for area-grpc