### PR TITLE
Dispose httpclient in IIS tests

### DIFF
--- a/src/Hosting/Server.IntegrationTesting/src/Common/DeploymentResult.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/DeploymentResult.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Server.IntegrationTesting;
 /// <summary>
 /// Result of a deployment.
 /// </summary>
-public class DeploymentResult
+public class DeploymentResult : IDisposable
 {
     private readonly ILoggerFactory _loggerFactory;
 
@@ -67,4 +67,6 @@ public class DeploymentResult
             BaseAddress = new Uri(ApplicationBaseUri),
             Timeout = TimeSpan.FromSeconds(200),
         };
+
+    public void Dispose() => HttpClient.Dispose();
 }

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/FunctionalTestsBase.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/FunctionalTestsBase.cs
@@ -33,6 +33,14 @@ public class FunctionalTestsBase : LoggedTest
         return IISApplicationDeployerFactory.Create(parameters, LoggerFactory);
     }
 
+    protected virtual async Task RunTest(IISDeploymentParameters deploymentParameters, Action<IISDeploymentResult> testCode)
+    {
+        using (var deploymentResult = await DeployAsync(deploymentParameters))
+        {
+            testCode(deploymentResult);
+        }
+    }
+
     protected virtual async Task<IISDeploymentResult> DeployAsync(IISDeploymentParameters parameters)
     {
         _deployer = (IISDeployerBase)CreateDeployer(parameters);

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/IISFunctionalTestBase.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/IISFunctionalTestBase.cs
@@ -1,15 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.IO;
 using System.Net;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.Extensions.Logging;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/IISFunctionalTestBase.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/IISFunctionalTestBase.cs
@@ -29,6 +29,9 @@ public class IISFunctionalTestBase : FunctionalTestsBase
         return await DeployAsync(deploymentParameters);
     }
 
+    public Task RunTest(HostingModel hostingModel, Action<IISDeploymentResult> testCode)
+        => RunTest(Fixture.GetBaseDeploymentParameters(hostingModel: hostingModel), testCode);
+
     public void AddAppOffline(string appPath, string content = "The app is offline.")
     {
         File.WriteAllText(Path.Combine(appPath, "app_offline.htm"), content);

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/MaxRequestBodySizeTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/MaxRequestBodySizeTests.cs
@@ -3,12 +3,10 @@
 
 using System.Net;
 using System.Net.Http;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
-using Xunit;
 
 #if !IIS_FUNCTIONALS
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
@@ -59,13 +57,14 @@ public class MaxRequestBodySizeTests : IISFunctionalTestBase
                     .GetOrAdd("requestFiltering")
                     .GetOrAdd("requestLimits", "maxAllowedContentLength", "1");
             });
-        var deploymentResult = await DeployAsync(deploymentParameters);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var result = await deploymentResult.HttpClient.PostAsync("/ReadRequestBody", new StringContent("test"));
 
-        var result = await deploymentResult.HttpClient.PostAsync("/ReadRequestBody", new StringContent("test"));
-
-        // IIS either returns a 404 or a 413 based on versions of IIS.
-        // Check for both as we don't know which specific patch version.
-        Assert.True(result.StatusCode == HttpStatusCode.NotFound || result.StatusCode == HttpStatusCode.RequestEntityTooLarge);
+            // IIS either returns a 404 or a 413 based on versions of IIS.
+            // Check for both as we don't know which specific patch version.
+            Assert.True(result.StatusCode == HttpStatusCode.NotFound || result.StatusCode == HttpStatusCode.RequestEntityTooLarge);
+        });
     }
 
     [ConditionalFact]
@@ -82,11 +81,11 @@ public class MaxRequestBodySizeTests : IISFunctionalTestBase
                     .GetOrAdd("requestFiltering")
                     .GetOrAdd("requestLimits", "maxAllowedContentLength", "100000000");
             });
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        var result = await deploymentResult.HttpClient.PostAsync("/ReadRequestBodyLarger", new StringContent(new string('a', 100000000)));
-
-        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var result = await deploymentResult.HttpClient.PostAsync("/ReadRequestBodyLarger", new StringContent(new string('a', 100000000)));
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        });
     }
 
     [ConditionalFact]
@@ -103,11 +102,11 @@ public class MaxRequestBodySizeTests : IISFunctionalTestBase
                     .GetOrAdd("requestFiltering")
                     .GetOrAdd("requestLimits", "maxAllowedContentLength", "4294967295");
             });
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        var result = await deploymentResult.HttpClient.PostAsync("/ReadRequestBodyLarger", new StringContent(new string('a', 10000)));
-
-        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var result = await deploymentResult.HttpClient.PostAsync("/ReadRequestBodyLarger", new StringContent(new string('a', 10000)));
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        });
     }
 
     [ConditionalFact]
@@ -115,19 +114,20 @@ public class MaxRequestBodySizeTests : IISFunctionalTestBase
     public async Task IISRejectsContentLengthTooLargeByDefault()
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        using (var connection = new TestConnection(deploymentResult.HttpClient.BaseAddress.Port))
+        await RunTest(deploymentParameters, async deploymentResult =>
         {
-            await connection.Send(
-                "POST /HelloWorld HTTP/1.1",
-                $"Content-Length: 30000001",
-                "Host: localhost",
-                "",
-                "A");
-            var requestLine = await connection.ReadLineAsync();
-            Assert.True(requestLine.Contains("404") || requestLine.Contains("413"));
-        }
+            using (var connection = new TestConnection(deploymentResult.HttpClient.BaseAddress.Port))
+            {
+                await connection.Send(
+                    "POST /HelloWorld HTTP/1.1",
+                    $"Content-Length: 30000001",
+                    "Host: localhost",
+                    "",
+                    "A");
+                var requestLine = await connection.ReadLineAsync();
+                Assert.True(requestLine.Contains("404") || requestLine.Contains("413"));
+            }
+        });
     }
 
     [ConditionalFact]
@@ -149,18 +149,19 @@ public class MaxRequestBodySizeTests : IISFunctionalTestBase
                     .GetOrAdd("requestFiltering")
                     .GetOrAdd("requestLimits", "maxAllowedContentLength", "1");
             });
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        var result = await deploymentResult.HttpClient.PostAsync("/IncreaseRequestLimit", new StringContent("1"));
-        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
-
-        StopServer();
-
-        if (deploymentParameters.ServerType == ServerType.IISExpress)
+        await RunTest(deploymentParameters, async deploymentResult =>
         {
-            Assert.Single(TestSink.Writes, w => w.Message.Contains("Increasing the MaxRequestBodySize conflicts with the max value for IIS limit maxAllowedContentLength." +
-                " HTTP requests that have a content length greater than maxAllowedContentLength will still be rejected by IIS." +
-                " You can disable the limit by either removing or setting the maxAllowedContentLength value to a higher limit."));
-        }
+            var result = await deploymentResult.HttpClient.PostAsync("/IncreaseRequestLimit", new StringContent("1"));
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+
+            StopServer();
+
+            if (deploymentParameters.ServerType == ServerType.IISExpress)
+            {
+                Assert.Single(TestSink.Writes, w => w.Message.Contains("Increasing the MaxRequestBodySize conflicts with the max value for IIS limit maxAllowedContentLength." +
+                    " HTTP requests that have a content length greater than maxAllowedContentLength will still be rejected by IIS." +
+                    " You can disable the limit by either removing or setting the maxAllowedContentLength value to a higher limit."));
+            }
+        });
     }
 }

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/LoggingTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/LoggingTests.cs
@@ -1,17 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Diagnostics;
 using System.Globalization;
-using System.IO;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
-using Xunit;
 
 #if !IIS_FUNCTIONALS
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
@@ -65,18 +60,15 @@ public class LoggingTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(variant);
         deploymentParameters.EnableLogging(LogFolderPath);
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        await Helpers.AssertStarts(deploymentResult, path);
-
-        StopServer();
-
-        var contents = Helpers.ReadAllTextFromFile(Helpers.GetExpectedLogName(deploymentResult, LogFolderPath), Logger);
-
-        Assert.Contains("TEST MESSAGE", contents);
-        Assert.DoesNotContain("\r\n\r\n", contents);
-        Assert.Contains("\r\n", contents);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            await Helpers.AssertStarts(deploymentResult, path);
+            StopServer();
+            var contents = Helpers.ReadAllTextFromFile(Helpers.GetExpectedLogName(deploymentResult, LogFolderPath), Logger);
+            Assert.Contains("TEST MESSAGE", contents);
+            Assert.DoesNotContain("\r\n\r\n", contents);
+            Assert.Contains("\r\n", contents);
+        });
     }
 
     // Move to separate file
@@ -85,22 +77,20 @@ public class LoggingTests : IISFunctionalTestBase
     public async Task InvalidFilePathForLogs_ServerStillRuns(TestVariant variant)
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(variant);
-
         deploymentParameters.WebConfigActionList.Add(
             WebConfigHelpers.AddOrModifyAspNetCoreSection("stdoutLogEnabled", "true"));
         deploymentParameters.WebConfigActionList.Add(
             WebConfigHelpers.AddOrModifyAspNetCoreSection("stdoutLogFile", Path.Combine("Q:", "std")));
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        await Helpers.AssertStarts(deploymentResult, "HelloWorld");
-
-        StopServer();
-        if (variant.HostingModel == HostingModel.InProcess)
+        await RunTest(deploymentParameters, async deploymentResult =>
         {
-            // Error is getting logged twice, from shim and handler
-            EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.CouldNotStartStdoutFileRedirection("Q:\\std", deploymentResult), Logger, allowMultiple: true);
-        }
+            await Helpers.AssertStarts(deploymentResult, "HelloWorld");
+            StopServer();
+            if (variant.HostingModel == HostingModel.InProcess)
+            {
+                // Error is getting logged twice, from shim and handler
+                EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.CouldNotStartStdoutFileRedirection("Q:\\std", deploymentResult), Logger, allowMultiple: true);
+            }
+        });
     }
 
     [ConditionalTheory]
@@ -111,12 +101,11 @@ public class LoggingTests : IISFunctionalTestBase
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(variant);
         deploymentParameters.HandlerSettings["debugLevel"] = "file";
         deploymentParameters.HandlerSettings["debugFile"] = "subdirectory\\debug.txt";
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        await deploymentResult.HttpClient.GetAsync("/");
-
-        AssertLogs(Path.Combine(deploymentResult.ContentRoot, "subdirectory", "debug.txt"));
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            await deploymentResult.HttpClient.GetAsync("/");
+            AssertLogs(Path.Combine(deploymentResult.ContentRoot, "subdirectory", "debug.txt"));
+        });
     }
 
     [ConditionalTheory]
@@ -125,12 +114,11 @@ public class LoggingTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(variant);
         deploymentParameters.HandlerSettings["debugLevel"] = "file";
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        await deploymentResult.HttpClient.GetAsync("/");
-
-        AssertLogs(Path.Combine(deploymentResult.ContentRoot, "aspnetcore-debug.log"));
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            await deploymentResult.HttpClient.GetAsync("/");
+            AssertLogs(Path.Combine(deploymentResult.ContentRoot, "aspnetcore-debug.log"));
+        });
     }
 
     [ConditionalTheory]
@@ -142,11 +130,11 @@ public class LoggingTests : IISFunctionalTestBase
         deploymentParameters.EnvironmentVariables["ASPNETCORE_MODULE_DEBUG"] = "file";
         // Add empty debugFile handler setting to prevent IIS deployer from overriding debug settings
         deploymentParameters.HandlerSettings["debugFile"] = "";
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        await deploymentResult.HttpClient.GetAsync("/");
-
-        AssertLogs(Path.Combine(deploymentResult.ContentRoot, "aspnetcore-debug.log"));
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            await deploymentResult.HttpClient.GetAsync("/");
+            AssertLogs(Path.Combine(deploymentResult.ContentRoot, "aspnetcore-debug.log"));
+        });
     }
 
     [ConditionalTheory]
@@ -162,17 +150,17 @@ public class LoggingTests : IISFunctionalTestBase
             var deploymentParameters = Fixture.GetBaseDeploymentParameters(variant);
             deploymentParameters.EnvironmentVariables["ASPNETCORE_MODULE_DEBUG_FILE"] = firstTempFile;
             deploymentParameters.AddDebugLogToWebConfig(secondTempFile);
+            await RunTest(deploymentParameters, async deploymentResult =>
+            {
+                var response = await deploymentResult.HttpClient.GetAsync("/");
 
-            var deploymentResult = await DeployAsync(deploymentParameters);
+                StopServer();
+                var logContents = Helpers.ReadAllTextFromFile(firstTempFile, Logger);
 
-            var response = await deploymentResult.HttpClient.GetAsync("/");
+                Assert.Contains("Switching debug log files to", logContents);
 
-            StopServer();
-            var logContents = Helpers.ReadAllTextFromFile(firstTempFile, Logger);
-
-            Assert.Contains("Switching debug log files to", logContents);
-
-            AssertLogs(secondTempFile);
+                AssertLogs(secondTempFile);
+            });
         }
         finally
         {
@@ -205,17 +193,15 @@ public class LoggingTests : IISFunctionalTestBase
         var logFolderPath = LogFolderPath + "\\彡⾔";
         deploymentParameters.EnableLogging(logFolderPath);
 
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        var response = await deploymentResult.HttpClient.GetAsync(path);
-
-        Assert.False(response.IsSuccessStatusCode);
-
-        StopServer();
-
-        var contents = Helpers.ReadAllTextFromFile(Helpers.GetExpectedLogName(deploymentResult, logFolderPath), Logger);
-        Assert.Contains("彡⾔", contents);
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessThreadExitStdOut(deploymentResult, "12", "(.*)彡⾔(.*)"), Logger);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var response = await deploymentResult.HttpClient.GetAsync(path);
+            Assert.False(response.IsSuccessStatusCode);
+            StopServer();
+            var contents = Helpers.ReadAllTextFromFile(Helpers.GetExpectedLogName(deploymentResult, logFolderPath), Logger);
+            Assert.Contains("彡⾔", contents);
+            EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessThreadExitStdOut(deploymentResult, "12", "(.*)彡⾔(.*)"), Logger);
+        });
     }
 
     [ConditionalTheory]
@@ -223,15 +209,13 @@ public class LoggingTests : IISFunctionalTestBase
     public async Task OnlyOneFileCreatedWithProcessStartTime(TestVariant variant)
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(variant);
-
         deploymentParameters.EnableLogging(LogFolderPath);
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-        await Helpers.AssertStarts(deploymentResult, "ConsoleWrite");
-
-        StopServer();
-
-        Assert.Single(Directory.GetFiles(LogFolderPath), Helpers.GetExpectedLogName(deploymentResult, LogFolderPath));
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            await Helpers.AssertStarts(deploymentResult, "ConsoleWrite");
+            StopServer();
+            Assert.Single(Directory.GetFiles(LogFolderPath), Helpers.GetExpectedLogName(deploymentResult, LogFolderPath));
+        });
     }
 
     [ConditionalFact]
@@ -239,13 +223,12 @@ public class LoggingTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);
         deploymentParameters.TransformArguments((a, _) => $"{a} ConsoleWriteSingle");
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        var response = await deploymentResult.HttpClient.GetAsync("Test");
-
-        StopServer();
-
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, "Wow!"), Logger);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var response = await deploymentResult.HttpClient.GetAsync("Test");
+            StopServer();
+            EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, "Wow!"), Logger);
+        });
     }
 
     [ConditionalFact]
@@ -255,13 +238,12 @@ public class LoggingTests : IISFunctionalTestBase
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);
         deploymentParameters.HandlerSettings["enableOutOfProcessConsoleRedirection"] = "false";
         deploymentParameters.TransformArguments((a, _) => $"{a} ConsoleWriteSingle");
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        var response = await deploymentResult.HttpClient.GetAsync("Test");
-
-        StopServer();
-
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, ""), Logger);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var response = await deploymentResult.HttpClient.GetAsync("Test");
+            StopServer();
+            EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, ""), Logger);
+        });
     }
 
     [ConditionalFact]
@@ -269,13 +251,12 @@ public class LoggingTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);
         deploymentParameters.TransformArguments((a, _) => $"{a} ConsoleWrite30Kb");
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        var response = await deploymentResult.HttpClient.GetAsync("Test");
-
-        StopServer();
-
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, new string('a', 30000)), Logger);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var response = await deploymentResult.HttpClient.GetAsync("Test");
+            StopServer();
+            EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.OutOfProcessFailedToStart(deploymentResult, new string('a', 30000)), Logger);
+        });
     }
 
     [ConditionalTheory]
@@ -284,22 +265,18 @@ public class LoggingTests : IISFunctionalTestBase
     public async Task CheckStdoutLoggingToPipeWithFirstWrite(string path)
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
-
         var firstWriteString = "TEST MESSAGE";
-
         deploymentParameters.TransformArguments((a, _) => $"{a} {path}");
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        await Helpers.AssertStarts(deploymentResult);
-
-        StopServer();
-
-        if (deploymentParameters.ServerType == ServerType.IISExpress)
+        await RunTest(deploymentParameters, async deploymentResult =>
         {
-            // We can't read stdout logs from IIS as they aren't redirected.
-            Assert.Contains(TestSink.Writes, context => context.Message.Contains(firstWriteString));
-        }
+            await Helpers.AssertStarts(deploymentResult);
+            StopServer();
+            if (deploymentParameters.ServerType == ServerType.IISExpress)
+            {
+                // We can't read stdout logs from IIS as they aren't redirected.
+                Assert.Contains(TestSink.Writes, context => context.Message.Contains(firstWriteString));
+            }
+        });
     }
 
     [ConditionalFact]
@@ -307,28 +284,29 @@ public class LoggingTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
 
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        await Helpers.AssertStarts(deploymentResult);
-
-        StopServer();
-
-        var aspnetcorev2Log = TestSink.Writes.First(w => w.Message.Contains("Description: IIS ASP.NET Core Module V2. Commit:"));
-        var aspnetcoreHandlerLog = TestSink.Writes.First(w => w.Message.Contains("Description: IIS ASP.NET Core Module V2 Request Handler. Commit:"));
-
-        var processIdPattern = new Regex("Process Id: (\\d+)\\.", RegexOptions.Singleline);
-        var processIdMatch = processIdPattern.Match(aspnetcorev2Log.Message);
-        Assert.True(processIdMatch.Success, $"'{processIdPattern}' did not match '{aspnetcorev2Log}'");
-        var processId = int.Parse(processIdMatch.Groups[1].Value, CultureInfo.InvariantCulture);
-
-        if (DeployerSelector.HasNewShim)
+        await RunTest(deploymentParameters, async deploymentResult =>
         {
-            AssertTimestampAndPIDPrefix(processId, aspnetcorev2Log.Message);
-        }
-        if (DeployerSelector.HasNewHandler)
-        {
-            AssertTimestampAndPIDPrefix(processId, aspnetcoreHandlerLog.Message);
-        }
+            await Helpers.AssertStarts(deploymentResult);
+
+            StopServer();
+
+            var aspnetcorev2Log = TestSink.Writes.First(w => w.Message.Contains("Description: IIS ASP.NET Core Module V2. Commit:"));
+            var aspnetcoreHandlerLog = TestSink.Writes.First(w => w.Message.Contains("Description: IIS ASP.NET Core Module V2 Request Handler. Commit:"));
+
+            var processIdPattern = new Regex("Process Id: (\\d+)\\.", RegexOptions.Singleline);
+            var processIdMatch = processIdPattern.Match(aspnetcorev2Log.Message);
+            Assert.True(processIdMatch.Success, $"'{processIdPattern}' did not match '{aspnetcorev2Log}'");
+            var processId = int.Parse(processIdMatch.Groups[1].Value, CultureInfo.InvariantCulture);
+
+            if (DeployerSelector.HasNewShim)
+            {
+                AssertTimestampAndPIDPrefix(processId, aspnetcorev2Log.Message);
+            }
+            if (DeployerSelector.HasNewHandler)
+            {
+                AssertTimestampAndPIDPrefix(processId, aspnetcoreHandlerLog.Message);
+            }
+        });
     }
 
     private static string ReadLogs(string logPath)

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/MultiApplicationTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/MultiApplicationTests.cs
@@ -1,16 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
-using Xunit;
 
 #if !IIS_FUNCTIONALS
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
@@ -42,10 +37,12 @@ public class MultiApplicationTests : IISFunctionalTestBase
     {
         var parameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);
         parameters.ServerConfigActionList.Add(DuplicateApplication);
-        var result = await DeployAsync(parameters);
-        var id1 = await result.HttpClient.GetStringAsync("/app1/ProcessId");
-        var id2 = await result.HttpClient.GetStringAsync("/app2/ProcessId");
-        Assert.NotEqual(id2, id1);
+        await RunTest(parameters, async result =>
+        {
+            var id1 = await result.HttpClient.GetStringAsync("/app1/ProcessId");
+            var id2 = await result.HttpClient.GetStringAsync("/app2/ProcessId");
+            Assert.NotEqual(id2, id1);
+        });
     }
 
     [ConditionalFact]
@@ -76,24 +73,25 @@ public class MultiApplicationTests : IISFunctionalTestBase
     {
         var parameters = Fixture.GetBaseDeploymentParameters(firstApp);
         parameters.ServerConfigActionList.Add(DuplicateApplication);
-        var result = await DeployAsync(parameters);
-
-        // Modify hosting model of other app to be the opposite
-        var otherApp = firstApp == HostingModel.InProcess ? HostingModel.OutOfProcess : HostingModel.InProcess;
-        SetHostingModel(_publishedApplication.Path, otherApp);
-
-        var result1 = await result.HttpClient.GetAsync("/app1/HelloWorld");
-        var result2 = await result.HttpClient.GetAsync("/app2/HelloWorld");
-        Assert.Equal(200, (int)result1.StatusCode);
-        Assert.Equal(500, (int)result2.StatusCode);
-        StopServer();
-
-        if (DeployerSelector.HasNewShim)
+        await RunTest(parameters, async result =>
         {
-            Assert.Contains("500.34", await result2.Content.ReadAsStringAsync());
-        }
+            // Modify hosting model of other app to be the opposite
+            var otherApp = firstApp == HostingModel.InProcess ? HostingModel.OutOfProcess : HostingModel.InProcess;
+            SetHostingModel(_publishedApplication.Path, otherApp);
 
-        EventLogHelpers.VerifyEventLogEvent(result, "Mixed hosting model is not supported.", Logger);
+            var result1 = await result.HttpClient.GetAsync("/app1/HelloWorld");
+            var result2 = await result.HttpClient.GetAsync("/app2/HelloWorld");
+            Assert.Equal(200, (int)result1.StatusCode);
+            Assert.Equal(500, (int)result2.StatusCode);
+            StopServer();
+
+            if (DeployerSelector.HasNewShim)
+            {
+                Assert.Contains("500.34", await result2.Content.ReadAsStringAsync());
+            }
+
+            EventLogHelpers.VerifyEventLogEvent(result, "Mixed hosting model is not supported.", Logger);
+        });
     }
 
     private void SetHostingModel(string directory, HostingModel model)

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/WindowsAuthTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/WindowsAuthTests.cs
@@ -1,14 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Net.Http;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
-using Xunit;
 
 #if !IIS_FUNCTIONALS
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
@@ -48,13 +45,14 @@ public class WindowsAuthTests : IISFunctionalTestBase
         deploymentParameters.SetWindowsAuth();
 
         // The default in hosting sets windows auth to true.
-        var deploymentResult = await DeployAsync(deploymentParameters);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var client = deploymentResult.CreateClient(new HttpClientHandler { UseDefaultCredentials = true });
+            var response = await client.GetAsync("/Auth");
+            var responseText = await response.Content.ReadAsStringAsync();
 
-        var client = deploymentResult.CreateClient(new HttpClientHandler { UseDefaultCredentials = true });
-        var response = await client.GetAsync("/Auth");
-        var responseText = await response.Content.ReadAsStringAsync();
-
-        Assert.StartsWith("Windows:", responseText);
-        Assert.Contains(Environment.UserName, responseText);
+            Assert.StartsWith("Windows:", responseText);
+            Assert.Contains(Environment.UserName, responseText);
+        });
     }
 }

--- a/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
@@ -63,23 +63,24 @@ public class StartupTests : IISFunctionalTestBase
         deploymentParameters.WebConfigActionList.Add(WebConfigHelpers.AddOrModifyAspNetCoreSection("processPath", path));
         deploymentParameters.WebConfigActionList.Add(WebConfigHelpers.AddOrModifyAspNetCoreSection("arguments", arguments));
 
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        var response = await deploymentResult.HttpClient.GetAsync("HelloWorld");
-
-        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-
-        StopServer();
-
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.UnableToStart(deploymentResult, subError), Logger);
-        if (DeployerSelector.HasNewShim)
+        await RunTest(deploymentParameters, async deploymentResult =>
         {
-            Assert.Contains("500.0", await response.Content.ReadAsStringAsync());
-        }
-        else
-        {
-            Assert.Contains("500.0", await response.Content.ReadAsStringAsync());
-        }
+            var response = await deploymentResult.HttpClient.GetAsync("HelloWorld");
+
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+
+            StopServer();
+
+            EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.UnableToStart(deploymentResult, subError), Logger);
+            if (DeployerSelector.HasNewShim)
+            {
+                Assert.Contains("500.0", await response.Content.ReadAsStringAsync());
+            }
+            else
+            {
+                Assert.Contains("500.0", await response.Content.ReadAsStringAsync());
+            }
+        });
     }
 
     [ConditionalFact]
@@ -111,16 +112,15 @@ public class StartupTests : IISFunctionalTestBase
     public async Task StartsWithDotnetOnThePath(string path)
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
-
         deploymentParameters.EnvironmentVariables["PATH"] = Path.GetDirectoryName(_dotnetLocation);
         deploymentParameters.WebConfigActionList.Add(WebConfigHelpers.AddOrModifyAspNetCoreSection("processPath", path));
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-        await deploymentResult.AssertStarts();
-
-        StopServer();
-        // Verify that in this scenario where.exe was invoked only once by shim and request handler uses cached value
-        Assert.Equal(1, TestSink.Writes.Count(w => w.Message.Contains("Invoking where.exe to find dotnet.exe")));
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            await deploymentResult.AssertStarts();
+            StopServer();
+            // Verify that in this scenario where.exe was invoked only once by shim and request handler uses cached value
+            Assert.Equal(1, TestSink.Writes.Count(w => w.Message.Contains("Invoking where.exe to find dotnet.exe")));
+        });
     }
 
     [ConditionalFact]
@@ -146,13 +146,15 @@ public class StartupTests : IISFunctionalTestBase
                 "InstallLocation",
                 installDir))
             {
-                var deploymentResult = await DeployAsync(deploymentParameters);
-                await deploymentResult.AssertStarts();
-                StopServer();
-                // Verify that in this scenario dotnet.exe was found using InstallLocation lookup
-                // I would've liked to make a copy of dotnet directory in this test and use it for verification
-                // but dotnet roots are usually very large on dev machines so this test would take disproportionally long time and disk space
-                Assert.Equal(1, TestSink.Writes.Count(w => w.Message.Contains($"Found dotnet.exe in InstallLocation at '{installDir}\\dotnet.exe'")));
+                await RunTest(deploymentParameters, async deploymentResult =>
+                {
+                    await deploymentResult.AssertStarts();
+                    StopServer();
+                    // Verify that in this scenario dotnet.exe was found using InstallLocation lookup
+                    // I would've liked to make a copy of dotnet directory in this test and use it for verification
+                    // but dotnet roots are usually very large on dev machines so this test would take disproportionally long time and disk space
+                    Assert.Equal(1, TestSink.Writes.Count(w => w.Message.Contains($"Found dotnet.exe in InstallLocation at '{installDir}\\dotnet.exe'")));
+                });
             }
         }
     }
@@ -163,24 +165,21 @@ public class StartupTests : IISFunctionalTestBase
     public async Task DoesNotStartIfDisabled()
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
-
         using (new TestRegistryKey(
             Registry.LocalMachine,
             "SOFTWARE\\Microsoft\\IIS Extensions\\IIS AspNetCore Module V2\\Parameters",
             "DisableANCM",
             1))
         {
-            var deploymentResult = await DeployAsync(deploymentParameters);
-            // Disabling ANCM produces no log files
-            deploymentResult.AllowNoLogs();
-
-            var response = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
-
-            Assert.False(response.IsSuccessStatusCode);
-
-            StopServer();
-
-            EventLogHelpers.VerifyEventLogEvent(deploymentResult, "AspNetCore Module is disabled", Logger);
+            await RunTest(deploymentParameters, async deploymentResult =>
+            {
+                // Disabling ANCM produces no log files
+                deploymentResult.AllowNoLogs();
+                var response = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
+                Assert.False(response.IsSuccessStatusCode);
+                StopServer();
+                EventLogHelpers.VerifyEventLogEvent(deploymentResult, "AspNetCore Module is disabled", Logger);
+            });
         }
     }
 
@@ -209,13 +208,13 @@ public class StartupTests : IISFunctionalTestBase
         // We need the right dotnet on the path in IIS
         deploymentParameters.EnvironmentVariables["PATH"] = Path.GetDirectoryName(DotNetCommands.GetDotNetExecutable(deploymentParameters.RuntimeArchitecture));
 
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        Assert.True(File.Exists(Path.Combine(deploymentResult.ContentRoot, "InProcessWebSite.exe")));
-        Assert.False(File.Exists(Path.Combine(deploymentResult.ContentRoot, "hostfxr.dll")));
-        Assert.Contains("InProcessWebSite.exe", Helpers.ReadAllTextFromFile(Path.Combine(deploymentResult.ContentRoot, "web.config"), Logger));
-
-        await deploymentResult.AssertStarts();
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            Assert.True(File.Exists(Path.Combine(deploymentResult.ContentRoot, "InProcessWebSite.exe")));
+            Assert.False(File.Exists(Path.Combine(deploymentResult.ContentRoot, "hostfxr.dll")));
+            Assert.Contains("InProcessWebSite.exe", Helpers.ReadAllTextFromFile(Path.Combine(deploymentResult.ContentRoot, "web.config"), Logger));
+            await deploymentResult.AssertStarts();
+        });
     }
 
     [ConditionalFact]
@@ -223,16 +222,15 @@ public class StartupTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
         deploymentParameters.TransformArguments((a, _) => $"{a} OverriddenServer");
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-        var response = await deploymentResult.HttpClient.GetAsync("/");
-        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-
-        StopServer();
-
-        EventLogHelpers.VerifyEventLogEvents(deploymentResult,
-            EventLogHelpers.InProcessFailedToStart(deploymentResult, "CLR worker thread exited prematurely"),
-            EventLogHelpers.InProcessThreadException(deploymentResult, ".*?Application is running inside IIS process but is not configured to use IIS server"));
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var response = await deploymentResult.HttpClient.GetAsync("/");
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            StopServer();
+            EventLogHelpers.VerifyEventLogEvents(deploymentResult,
+                EventLogHelpers.InProcessFailedToStart(deploymentResult, "CLR worker thread exited prematurely"),
+                EventLogHelpers.InProcessThreadException(deploymentResult, ".*?Application is running inside IIS process but is not configured to use IIS server"));
+        });
     }
 
     [ConditionalFact]
@@ -240,17 +238,15 @@ public class StartupTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
         deploymentParameters.TransformArguments((a, _) => $"{a} Throw");
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        var response = await deploymentResult.HttpClient.GetAsync("/");
-        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-
-        StopServer();
-
-        EventLogHelpers.VerifyEventLogEvents(deploymentResult,
-            EventLogHelpers.InProcessFailedToStart(deploymentResult, "CLR worker thread exited prematurely"),
-            EventLogHelpers.InProcessThreadException(deploymentResult, ", exception code = '0xe0434352'"));
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var response = await deploymentResult.HttpClient.GetAsync("/");
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            StopServer();
+            EventLogHelpers.VerifyEventLogEvents(deploymentResult,
+                EventLogHelpers.InProcessFailedToStart(deploymentResult, "CLR worker thread exited prematurely"),
+                EventLogHelpers.InProcessThreadException(deploymentResult, ", exception code = '0xe0434352'"));
+        });
     }
 
     [ConditionalFact]
@@ -258,16 +254,15 @@ public class StartupTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
         deploymentParameters.TransformArguments((a, _) => $"{a} EarlyReturn");
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        var response = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
-        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-
-        StopServer();
-
-        EventLogHelpers.VerifyEventLogEvents(deploymentResult,
-            EventLogHelpers.InProcessFailedToStart(deploymentResult, "CLR worker thread exited prematurely"),
-            EventLogHelpers.InProcessThreadExit(deploymentResult, "12"));
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var response = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            StopServer();
+            EventLogHelpers.VerifyEventLogEvents(deploymentResult,
+                EventLogHelpers.InProcessFailedToStart(deploymentResult, "CLR worker thread exited prematurely"),
+                EventLogHelpers.InProcessThreadExit(deploymentResult, "12"));
+        });
     }
 
     [ConditionalFact]
@@ -275,30 +270,28 @@ public class StartupTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
         deploymentParameters.ApplicationType = ApplicationType.Standalone;
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        File.Copy(
-            Path.Combine(deploymentResult.ContentRoot, "aspnetcorev2_inprocess.dll"),
-            Path.Combine(deploymentResult.ContentRoot, "hostfxr.dll"),
-            true);
-
-        if (DeployerSelector.HasNewShim)
+        await RunTest(deploymentParameters, async deploymentResult =>
         {
-            await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.32");
-        }
-        else
-        {
-            await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
-        }
-
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessHostfxrInvalid(deploymentResult), Logger);
+            File.Copy(
+                Path.Combine(deploymentResult.ContentRoot, "aspnetcorev2_inprocess.dll"),
+                Path.Combine(deploymentResult.ContentRoot, "hostfxr.dll"),
+                true);
+            if (DeployerSelector.HasNewShim)
+            {
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.32");
+            }
+            else
+            {
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
+            }
+            EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessHostfxrInvalid(deploymentResult), Logger);
+        });
     }
 
     [ConditionalFact]
     public async Task PublishWithWrongBitness()
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
-
         if (deploymentParameters.ServerType == ServerType.IISExpress)
         {
             return;
@@ -311,27 +304,27 @@ public class StartupTests : IISFunctionalTestBase
         });
 
         // Change ANCM dll to 32 bit
-        deploymentParameters.AddServerConfigAction(
-                        element =>
-                        {
-                            var ancmElement = element
-                                .RequiredElement("system.webServer")
-                                .RequiredElement("globalModules")
-                                .Elements("add")
-                                .FirstOrDefault(e => e.Attribute("name").Value == "AspNetCoreModuleV2");
-
-                            ancmElement.SetAttributeValue("image", ancmElement.Attribute("image").Value.Replace("x64", "x86"));
-                        });
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        if (DeployerSelector.HasNewShim)
+        deploymentParameters.AddServerConfigAction(element =>
         {
-            await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.32");
-        }
-        else
+            var ancmElement = element
+                .RequiredElement("system.webServer")
+                .RequiredElement("globalModules")
+                .Elements("add")
+                .FirstOrDefault(e => e.Attribute("name").Value == "AspNetCoreModuleV2");
+
+            ancmElement.SetAttributeValue("image", ancmElement.Attribute("image").Value.Replace("x64", "x86"));
+        });
+        await RunTest(deploymentParameters, async deploymentResult =>
         {
-            await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.0");
-        }
+            if (DeployerSelector.HasNewShim)
+            {
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.32");
+            }
+            else
+            {
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.0");
+            }
+        });
     }
 
     [ConditionalFact]
@@ -340,40 +333,39 @@ public class StartupTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
         deploymentParameters.ApplicationType = ApplicationType.Standalone;
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        // We don't distinguish between load failure types so making dll empty should be enough
-        File.WriteAllText(Path.Combine(deploymentResult.ContentRoot, "hostfxr.dll"), "");
-
-        if (DeployerSelector.HasNewShim)
+        await RunTest(deploymentParameters, async deploymentResult =>
         {
-            await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.32");
-        }
-        else
-        {
-            await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
-        }
-
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessHostfxrUnableToLoad(deploymentResult), Logger);
+            // We don't distinguish between load failure types so making dll empty should be enough
+            File.WriteAllText(Path.Combine(deploymentResult.ContentRoot, "hostfxr.dll"), "");
+            if (DeployerSelector.HasNewShim)
+            {
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.32");
+            }
+            else
+            {
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
+            }
+            EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessHostfxrUnableToLoad(deploymentResult), Logger);
+        });
     }
 
     [ConditionalFact]
     public async Task TargedDifferenceSharedFramework_FailedToFindNativeDependencies()
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        Helpers.ModifyFrameworkVersionInRuntimeConfig(deploymentResult);
-        if (DeployerSelector.HasNewShim)
+        await RunTest(deploymentParameters, async deploymentResult =>
         {
-            await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.31");
-        }
-        else
-        {
-            await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
-        }
-
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindNativeDependencies(deploymentResult), Logger);
+            Helpers.ModifyFrameworkVersionInRuntimeConfig(deploymentResult);
+            if (DeployerSelector.HasNewShim)
+            {
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.31");
+            }
+            else
+            {
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
+            }
+            EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindNativeDependencies(deploymentResult), Logger);
+        });
     }
 
     [ConditionalFact]
@@ -381,17 +373,18 @@ public class StartupTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
         deploymentParameters.ApplicationType = ApplicationType.Standalone;
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        File.Delete(Path.Combine(deploymentResult.ContentRoot, "InProcessWebSite.dll"));
-        if (DeployerSelector.HasNewShim)
+        await RunTest(deploymentParameters, async deploymentResult =>
         {
-            await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.38");
-        }
-        else
-        {
-            await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
-        }
+            File.Delete(Path.Combine(deploymentResult.ContentRoot, "InProcessWebSite.dll"));
+            if (DeployerSelector.HasNewShim)
+            {
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.38");
+            }
+            else
+            {
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
+            }
+        });
     }
 
     [ConditionalFact]
@@ -399,22 +392,23 @@ public class StartupTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
         deploymentParameters.WebConfigBasedEnvironmentVariables["ASPNETCORE_DETAILEDERRORS"] = "TRUE";
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        Helpers.ModifyFrameworkVersionInRuntimeConfig(deploymentResult);
-        if (DeployerSelector.HasNewShim)
+        await RunTest(deploymentParameters, async deploymentResult =>
         {
-            var response = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
+            Helpers.ModifyFrameworkVersionInRuntimeConfig(deploymentResult);
+            if (DeployerSelector.HasNewShim)
+            {
+                var response = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
 
-            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-            var responseContent = await response.Content.ReadAsStringAsync();
-            Assert.Contains("500.31", responseContent);
-            Assert.Contains("Framework: 'Microsoft.NETCore.App', version '2.9.9'", responseContent);
-        }
-        else
-        {
-            await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
-        }
+                Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+                var responseContent = await response.Content.ReadAsStringAsync();
+                Assert.Contains("500.31", responseContent);
+                Assert.Contains("Framework: 'Microsoft.NETCore.App', version '2.9.9'", responseContent);
+            }
+            else
+            {
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
+            }
+        });
     }
 
     [ConditionalFact]
@@ -422,22 +416,20 @@ public class StartupTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
         deploymentParameters.ApplicationType = ApplicationType.Standalone;
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        File.Delete(Path.Combine(deploymentResult.ContentRoot, "aspnetcorev2_inprocess.dll"));
-
-        if (DeployerSelector.HasNewShim)
+        await RunTest(deploymentParameters, async deploymentResult =>
         {
-            await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.33");
-
-            EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindRequestHandler(deploymentResult), Logger);
-        }
-        else
-        {
-            await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
-
-            EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindRequestHandler(deploymentResult), Logger);
-        }
+            File.Delete(Path.Combine(deploymentResult.ContentRoot, "aspnetcorev2_inprocess.dll"));
+            if (DeployerSelector.HasNewShim)
+            {
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult, "500.33");
+                EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindRequestHandler(deploymentResult), Logger);
+            }
+            else
+            {
+                await AssertSiteFailsToStartWithInProcessStaticContent(deploymentResult);
+                EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessFailedToFindRequestHandler(deploymentResult), Logger);
+            }
+        });
     }
 
     [ConditionalFact]
@@ -453,24 +445,24 @@ public class StartupTests : IISFunctionalTestBase
             deploymentParameters.TransformArguments((a, _) => $"{a} Hang");
             deploymentParameters.WebConfigActionList.Add(
                 WebConfigHelpers.AddOrModifyAspNetCoreSection("startupTimeLimit", "1"));
-
-            var deploymentResult = await DeployAsync(deploymentParameters);
-
-            var response = await deploymentResult.HttpClient.GetAsync("/");
-            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-
-            // Startup timeout now recycles process.
-            deploymentResult.AssertWorkerProcessStop();
-
-            EventLogHelpers.VerifyEventLogEvent(deploymentResult,
-                EventLogHelpers.InProcessFailedToStart(deploymentResult, "Managed server didn't initialize after 1000 ms."),
-                Logger);
-
-            if (DeployerSelector.HasNewHandler)
+            await RunTest(deploymentParameters, async deploymentResult =>
             {
-                var responseContent = await response.Content.ReadAsStringAsync();
-                Assert.Contains("500.37", responseContent);
-            }
+                var response = await deploymentResult.HttpClient.GetAsync("/");
+                Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+
+                // Startup timeout now recycles process.
+                deploymentResult.AssertWorkerProcessStop();
+
+                EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+                    EventLogHelpers.InProcessFailedToStart(deploymentResult, "Managed server didn't initialize after 1000 ms."),
+                    Logger);
+
+                if (DeployerSelector.HasNewHandler)
+                {
+                    var responseContent = await response.Content.ReadAsStringAsync();
+                    Assert.Contains("500.37", responseContent);
+                }
+            });
         }
     }
 
@@ -487,22 +479,20 @@ public class StartupTests : IISFunctionalTestBase
             deploymentParameters.WebConfigActionList.Add(
                 WebConfigHelpers.AddOrModifyAspNetCoreSection("startupTimeLimit", "1"));
             deploymentParameters.HandlerSettings["suppressRecycleOnStartupTimeout"] = "true";
-            var deploymentResult = await DeployAsync(deploymentParameters);
-
-            var response = await deploymentResult.HttpClient.GetAsync("/");
-            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-
-            StopServer(gracefulShutdown: false);
-
-            EventLogHelpers.VerifyEventLogEvent(deploymentResult,
-                EventLogHelpers.InProcessFailedToStart(deploymentResult, "Managed server didn't initialize after 1000 ms."),
-                Logger);
-
-            if (DeployerSelector.HasNewHandler)
+            await RunTest(deploymentParameters, async deploymentResult =>
             {
-                var responseContent = await response.Content.ReadAsStringAsync();
-                Assert.Contains("500.37", responseContent);
-            }
+                var response = await deploymentResult.HttpClient.GetAsync("/");
+                Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+                StopServer(gracefulShutdown: false);
+                EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+                    EventLogHelpers.InProcessFailedToStart(deploymentResult, "Managed server didn't initialize after 1000 ms."),
+                    Logger);
+                if (DeployerSelector.HasNewHandler)
+                {
+                    var responseContent = await response.Content.ReadAsStringAsync();
+                    Assert.Contains("500.37", responseContent);
+                }
+            });
         }
     }
 
@@ -511,18 +501,14 @@ public class StartupTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
         deploymentParameters.WebConfigActionList.Add(WebConfigHelpers.AddOrModifyAspNetCoreSection("hostingModel", "bogus"));
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        var response = await deploymentResult.HttpClient.GetAsync("HelloWorld");
-
-        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-
-        StopServer();
-
-        EventLogHelpers.VerifyEventLogEvents(deploymentResult,
-            EventLogHelpers.ConfigurationLoadError(deploymentResult, "Unknown hosting model 'bogus'. Please specify either hostingModel=\"inprocess\" or hostingModel=\"outofprocess\" in the web.config file.")
-            );
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var response = await deploymentResult.HttpClient.GetAsync("HelloWorld");
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            StopServer();
+            EventLogHelpers.VerifyEventLogEvents(deploymentResult,
+                EventLogHelpers.ConfigurationLoadError(deploymentResult, "Unknown hosting model 'bogus'. Please specify either hostingModel=\"inprocess\" or hostingModel=\"outofprocess\" in the web.config file."));
+        });
     }
 
     private static Dictionary<string, (string, Action<XElement>)> InvalidConfigTransformations = InitInvalidConfigTransformations();
@@ -535,18 +521,20 @@ public class StartupTests : IISFunctionalTestBase
         var (expectedError, action) = InvalidConfigTransformations[scenario];
         var iisDeploymentParameters = Fixture.GetBaseDeploymentParameters();
         iisDeploymentParameters.WebConfigActionList.Add((element, _) => action(element));
-        var deploymentResult = await DeployAsync(iisDeploymentParameters);
-        var result = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
-        Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);
+        await RunTest(iisDeploymentParameters, async deploymentResult =>
+        {
+            var result = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
+            Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);
 
-        // Config load errors might not allow us to initialize log file
-        deploymentResult.AllowNoLogs();
+            // Config load errors might not allow us to initialize log file
+            deploymentResult.AllowNoLogs();
 
-        StopServer();
+            StopServer();
 
-        EventLogHelpers.VerifyEventLogEvents(deploymentResult,
-            EventLogHelpers.ConfigurationLoadError(deploymentResult, expectedError)
-        );
+            EventLogHelpers.VerifyEventLogEvents(deploymentResult,
+                EventLogHelpers.ConfigurationLoadError(deploymentResult, expectedError)
+            );
+        });
     }
 
     public static Dictionary<string, (string, Action<XElement>)> InitInvalidConfigTransformations()
@@ -580,8 +568,8 @@ public class StartupTests : IISFunctionalTestBase
         var action = PortableConfigTransformations[scenario];
         var iisDeploymentParameters = Fixture.GetBaseDeploymentParameters();
         var expectedArguments = action(iisDeploymentParameters);
-        var result = await DeployAsync(iisDeploymentParameters);
-        Assert.Equal(expectedArguments, await result.HttpClient.GetStringAsync("/CommandLineArgs"));
+        await RunTest(iisDeploymentParameters, async result =>
+            Assert.Equal(expectedArguments, await result.HttpClient.GetStringAsync("/CommandLineArgs")));
     }
 
     public static Dictionary<string, Func<IISDeploymentParameters, string>> InitPortableWebConfigTransformations()
@@ -651,8 +639,8 @@ public class StartupTests : IISFunctionalTestBase
         var iisDeploymentParameters = Fixture.GetBaseDeploymentParameters();
         iisDeploymentParameters.ApplicationType = ApplicationType.Standalone;
         var expectedArguments = action(iisDeploymentParameters);
-        var result = await DeployAsync(iisDeploymentParameters);
-        Assert.Equal(expectedArguments, await result.HttpClient.GetStringAsync("/CommandLineArgs"));
+        await RunTest(iisDeploymentParameters, async result =>
+            Assert.Equal(expectedArguments, await result.HttpClient.GetStringAsync("/CommandLineArgs")));
     }
 
     public static Dictionary<string, Func<IISDeploymentParameters, string>> InitStandaloneConfigTransformations()
@@ -687,14 +675,14 @@ public class StartupTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
         deploymentParameters.HandlerSettings["SetCurrentDirectory"] = "false";
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        Assert.Equal(deploymentResult.ContentRoot, await deploymentResult.HttpClient.GetStringAsync("/ContentRootPath"));
-        Assert.Equal(deploymentResult.ContentRoot + "\\wwwroot", await deploymentResult.HttpClient.GetStringAsync("/WebRootPath"));
-        Assert.Equal(Path.GetDirectoryName(deploymentResult.HostProcess.MainModule.FileName), await deploymentResult.HttpClient.GetStringAsync("/CurrentDirectory"));
-        Assert.Equal(deploymentResult.ContentRoot + "\\", await deploymentResult.HttpClient.GetStringAsync("/BaseDirectory"));
-        Assert.Equal(deploymentResult.ContentRoot + "\\", await deploymentResult.HttpClient.GetStringAsync("/ASPNETCORE_IIS_PHYSICAL_PATH"));
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            Assert.Equal(deploymentResult.ContentRoot, await deploymentResult.HttpClient.GetStringAsync("/ContentRootPath"));
+            Assert.Equal(deploymentResult.ContentRoot + "\\wwwroot", await deploymentResult.HttpClient.GetStringAsync("/WebRootPath"));
+            Assert.Equal(Path.GetDirectoryName(deploymentResult.HostProcess.MainModule.FileName), await deploymentResult.HttpClient.GetStringAsync("/CurrentDirectory"));
+            Assert.Equal(deploymentResult.ContentRoot + "\\", await deploymentResult.HttpClient.GetStringAsync("/BaseDirectory"));
+            Assert.Equal(deploymentResult.ContentRoot + "\\", await deploymentResult.HttpClient.GetStringAsync("/ASPNETCORE_IIS_PHYSICAL_PATH"));
+        });
     }
 
     [ConditionalFact]
@@ -711,25 +699,26 @@ public class StartupTests : IISFunctionalTestBase
         var startWaitHandle = new EventWaitHandle(false, EventResetMode.ManualReset, eventPrefix + "ANCM_TestEvent");
         var suspendedWaitHandle = new EventWaitHandle(false, EventResetMode.ManualReset, eventPrefix + "ANCM_TestEvent_suspended");
 
-        var deploymentResult = await DeployAsync(deploymentParameters);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var request = deploymentResult.AssertStarts();
 
-        var request = deploymentResult.AssertStarts();
+            Assert.True(suspendedWaitHandle.WaitOne(TimeoutExtensions.DefaultTimeoutValue));
 
-        Assert.True(suspendedWaitHandle.WaitOne(TimeoutExtensions.DefaultTimeoutValue));
+            // didn't figure out a better way to check that ANCM is waiting to start
+            var applicationDll = Path.Combine(deploymentResult.ContentRoot, "InProcessWebSite.dll");
+            var handlerDll = Path.Combine(deploymentResult.ContentRoot, "aspnetcorev2_inprocess.dll");
+            // Make sure application dll is not locked
+            File.WriteAllBytes(applicationDll, File.ReadAllBytes(applicationDll));
+            // Make sure handler dll is not locked
+            File.WriteAllBytes(handlerDll, File.ReadAllBytes(handlerDll));
+            // Make sure request is not completed
+            Assert.False(request.IsCompleted);
 
-        // didn't figure out a better way to check that ANCM is waiting to start
-        var applicationDll = Path.Combine(deploymentResult.ContentRoot, "InProcessWebSite.dll");
-        var handlerDll = Path.Combine(deploymentResult.ContentRoot, "aspnetcorev2_inprocess.dll");
-        // Make sure application dll is not locked
-        File.WriteAllBytes(applicationDll, File.ReadAllBytes(applicationDll));
-        // Make sure handler dll is not locked
-        File.WriteAllBytes(handlerDll, File.ReadAllBytes(handlerDll));
-        // Make sure request is not completed
-        Assert.False(request.IsCompleted);
+            startWaitHandle.Set();
 
-        startWaitHandle.Set();
-
-        await request;
+            await request;
+        });
     }
 
     [ConditionalTheory]
@@ -748,17 +737,19 @@ public class StartupTests : IISFunctionalTestBase
         deploymentParameters.EnvironmentVariables.Remove("ASPNETCORE_DETAILEDERRORS");
         deploymentParameters.EnvironmentVariables[environmentVariable] = value;
 
-        var deploymentResult = await DeployAsync(deploymentParameters);
-        var result = await deploymentResult.HttpClient.GetAsync("/");
-        Assert.False(result.IsSuccessStatusCode);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var result = await deploymentResult.HttpClient.GetAsync("/");
+            Assert.False(result.IsSuccessStatusCode);
 
-        var content = await result.Content.ReadAsStringAsync();
-        Assert.Contains("InvalidOperationException", content);
-        Assert.Contains("TestSite.Program.Main", content);
+            var content = await result.Content.ReadAsStringAsync();
+            Assert.Contains("InvalidOperationException", content);
+            Assert.Contains("TestSite.Program.Main", content);
 
-        StopServer();
+            StopServer();
 
-        VerifyDotnetRuntimeEventLog(deploymentResult);
+            VerifyDotnetRuntimeEventLog(deploymentResult);
+        });
     }
 
     [ConditionalFact]
@@ -767,22 +758,22 @@ public class StartupTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
         deploymentParameters.TransformArguments((a, _) => $"{a} Throw");
-
         // Deployment parameters by default set ASPNETCORE_DETAILEDERRORS to true
         deploymentParameters.EnvironmentVariables.Remove("ASPNETCORE_DETAILEDERRORS");
         deploymentParameters.WebConfigBasedEnvironmentVariables["ASPNETCORE_DETAILEDERRORS"] = "TRUE";
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var result = await deploymentResult.HttpClient.GetAsync("/");
+            Assert.False(result.IsSuccessStatusCode);
 
-        var deploymentResult = await DeployAsync(deploymentParameters);
-        var result = await deploymentResult.HttpClient.GetAsync("/");
-        Assert.False(result.IsSuccessStatusCode);
+            var content = await result.Content.ReadAsStringAsync();
+            Assert.Contains("InvalidOperationException", content);
+            Assert.Contains("TestSite.Program.Main", content);
 
-        var content = await result.Content.ReadAsStringAsync();
-        Assert.Contains("InvalidOperationException", content);
-        Assert.Contains("TestSite.Program.Main", content);
+            StopServer();
 
-        StopServer();
-
-        VerifyDotnetRuntimeEventLog(deploymentResult);
+            VerifyDotnetRuntimeEventLog(deploymentResult);
+        });
     }
 
     [ConditionalTheory]
@@ -794,19 +785,17 @@ public class StartupTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
         deploymentParameters.TransformArguments((a, _) => $"{a} {startupType}");
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-        var result = await deploymentResult.HttpClient.GetAsync("/");
-        Assert.False(result.IsSuccessStatusCode);
-
-        var content = await result.Content.ReadAsStringAsync();
-        Assert.Contains("InvalidOperationException", content);
-        Assert.Contains("TestSite.Program.Main", content);
-        Assert.Contains("From Configure", content);
-
-        StopServer();
-
-        VerifyDotnetRuntimeEventLog(deploymentResult);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var result = await deploymentResult.HttpClient.GetAsync("/");
+            Assert.False(result.IsSuccessStatusCode);
+            var content = await result.Content.ReadAsStringAsync();
+            Assert.Contains("InvalidOperationException", content);
+            Assert.Contains("TestSite.Program.Main", content);
+            Assert.Contains("From Configure", content);
+            StopServer();
+            VerifyDotnetRuntimeEventLog(deploymentResult);
+        });
     }
 
     [ConditionalFact]
@@ -819,17 +808,18 @@ public class StartupTests : IISFunctionalTestBase
         deploymentParameters.EnvironmentVariables["ASPNETCORE_DETAILEDERRORS"] = "";
         deploymentParameters.EnvironmentVariables["ASPNETCORE_ENVIRONMENT"] = "Development";
         deploymentParameters.HandlerSettings["callStartupHook"] = "false";
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var result = await deploymentResult.HttpClient.GetAsync("/");
+            Assert.False(result.IsSuccessStatusCode);
 
-        var deploymentResult = await DeployAsync(deploymentParameters);
-        var result = await deploymentResult.HttpClient.GetAsync("/");
-        Assert.False(result.IsSuccessStatusCode);
+            var content = await result.Content.ReadAsStringAsync();
+            Assert.DoesNotContain("InvalidOperationException", content);
 
-        var content = await result.Content.ReadAsStringAsync();
-        Assert.DoesNotContain("InvalidOperationException", content);
+            StopServer();
 
-        StopServer();
-
-        VerifyDotnetRuntimeEventLog(deploymentResult);
+            VerifyDotnetRuntimeEventLog(deploymentResult);
+        });
     }
 
     [ConditionalFact]
@@ -842,16 +832,18 @@ public class StartupTests : IISFunctionalTestBase
         // Deployment parameters by default set ASPNETCORE_DETAILEDERRORS to true
         deploymentParameters.EnvironmentVariables["ASPNETCORE_DETAILEDERRORS"] = "";
 
-        var deploymentResult = await DeployAsync(deploymentParameters);
-        var result = await deploymentResult.HttpClient.GetAsync("/");
-        Assert.False(result.IsSuccessStatusCode);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var result = await deploymentResult.HttpClient.GetAsync("/");
+            Assert.False(result.IsSuccessStatusCode);
 
-        var content = await result.Content.ReadAsStringAsync();
-        Assert.DoesNotContain("InvalidOperationException", content);
+            var content = await result.Content.ReadAsStringAsync();
+            Assert.DoesNotContain("InvalidOperationException", content);
 
-        StopServer();
+            StopServer();
 
-        VerifyDotnetRuntimeEventLog(deploymentResult);
+            VerifyDotnetRuntimeEventLog(deploymentResult);
+        });
     }
 
     [ConditionalFact]
@@ -862,13 +854,13 @@ public class StartupTests : IISFunctionalTestBase
 
         // Deployment parameters by default set ASPNETCORE_DETAILEDERRORS to true
         deploymentParameters.WebConfigBasedEnvironmentVariables["DOTNET_STARTUP_HOOKS"] = "InProcessWebSite";
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-        var result = await deploymentResult.HttpClient.GetAsync("/StartupHook");
-        var content = await result.Content.ReadAsStringAsync();
-        Assert.Equal("True", content);
-
-        StopServer();
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var result = await deploymentResult.HttpClient.GetAsync("/StartupHook");
+            var content = await result.Content.ReadAsStringAsync();
+            Assert.Equal("True", content);
+            StopServer();
+        });
     }
 
     [ConditionalFact]
@@ -880,13 +872,13 @@ public class StartupTests : IISFunctionalTestBase
         // Deployment parameters by default set ASPNETCORE_DETAILEDERRORS to true
         deploymentParameters.WebConfigBasedEnvironmentVariables["DOTNET_STARTUP_HOOKS"] = "InProcessWebSite";
         deploymentParameters.HandlerSettings["callStartupHook"] = "false";
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-        var result = await deploymentResult.HttpClient.GetAsync("/StartupHook");
-        var content = await result.Content.ReadAsStringAsync();
-        Assert.Equal("True", content);
-
-        StopServer();
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var result = await deploymentResult.HttpClient.GetAsync("/StartupHook");
+            var content = await result.Content.ReadAsStringAsync();
+            Assert.Equal("True", content);
+            StopServer();
+        });
     }
 
     [ConditionalFact]
@@ -894,9 +886,11 @@ public class StartupTests : IISFunctionalTestBase
     public async Task StackOverflowIsAvoidedBySettingLargerStack()
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
-        var deploymentResult = await DeployAsync(deploymentParameters);
-        var result = await deploymentResult.HttpClient.GetAsync("/StackSize");
-        Assert.True(result.IsSuccessStatusCode);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var result = await deploymentResult.HttpClient.GetAsync("/StackSize");
+            Assert.True(result.IsSuccessStatusCode);
+        });
     }
 
     [ConditionalFact]
@@ -905,10 +899,11 @@ public class StartupTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
         deploymentParameters.HandlerSettings["stackSize"] = "10000000";
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-        var result = await deploymentResult.HttpClient.GetAsync("/StackSizeLarge");
-        Assert.True(result.IsSuccessStatusCode);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var result = await deploymentResult.HttpClient.GetAsync("/StackSizeLarge");
+            Assert.True(result.IsSuccessStatusCode);
+        });
     }
 
     [ConditionalTheory]
@@ -920,10 +915,8 @@ public class StartupTests : IISFunctionalTestBase
     public async Task EnvironmentVariableForLauncherPathIsPreferred(HostingModel hostingModel)
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(hostingModel);
-
         deploymentParameters.EnvironmentVariables["ANCM_LAUNCHER_PATH"] = _dotnetLocation;
         deploymentParameters.WebConfigActionList.Add(WebConfigHelpers.AddOrModifyAspNetCoreSection("processPath", "nope"));
-
         await StartAsync(deploymentParameters);
     }
 
@@ -937,10 +930,8 @@ public class StartupTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(hostingModel);
         using var publishedApp = await deploymentParameters.ApplicationPublisher.Publish(deploymentParameters, LoggerFactory.CreateLogger("test"));
-
         deploymentParameters.EnvironmentVariables["ANCM_LAUNCHER_ARGS"] = Path.ChangeExtension(Path.Combine(publishedApp.Path, deploymentParameters.ApplicationPublisher.ApplicationPath), ".dll");
         deploymentParameters.WebConfigActionList.Add(WebConfigHelpers.AddOrModifyAspNetCoreSection("arguments", "nope"));
-
         await StartAsync(deploymentParameters);
     }
 
@@ -949,18 +940,17 @@ public class StartupTests : IISFunctionalTestBase
     public async Task OnCompletedDoesNotFailRequest()
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        var response = await deploymentResult.HttpClient.GetAsync("/OnCompletedThrows");
-        Assert.True(response.IsSuccessStatusCode);
-
-        StopServer();
-
-        if (deploymentParameters.ServerType == ServerType.IISExpress)
+        await RunTest(deploymentParameters, async deploymentResult =>
         {
-            // We can't read stdout logs from IIS as they aren't redirected.
-            Assert.Contains(TestSink.Writes, context => context.Message.Contains("An unhandled exception was thrown by the application."));
-        }
+            var response = await deploymentResult.HttpClient.GetAsync("/OnCompletedThrows");
+            Assert.True(response.IsSuccessStatusCode);
+            StopServer();
+            if (deploymentParameters.ServerType == ServerType.IISExpress)
+            {
+                // We can't read stdout logs from IIS as they aren't redirected.
+                Assert.Contains(TestSink.Writes, context => context.Message.Contains("An unhandled exception was thrown by the application."));
+            }
+        });
     }
 
     [ConditionalTheory]
@@ -972,20 +962,21 @@ public class StartupTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
         deploymentParameters.TransformArguments((a, _) => $"{a} {mode}");
-        var deploymentResult = await DeployAsync(deploymentParameters);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            await AssertFailsToStart(deploymentResult);
 
-        await AssertFailsToStart(deploymentResult);
+            StopServer();
 
-        StopServer();
+            // Logs can be split due to the ANCM logging occuring at the same time as logs from the app, so check for a portion of the
+            // string instead of the entire string. The entire string will still be present in the event log.
+            var expectedLogString = new string('a', 16);
 
-        // Logs can be split due to the ANCM logging occuring at the same time as logs from the app, so check for a portion of the
-        // string instead of the entire string. The entire string will still be present in the event log.
-        var expectedLogString = new string('a', 16);
+            Assert.Contains(TestSink.Writes, context => context.Message.Contains(expectedLogString));
+            var expectedEventLogString = new string('a', 30000);
 
-        Assert.Contains(TestSink.Writes, context => context.Message.Contains(expectedLogString));
-        var expectedEventLogString = new string('a', 30000);
-
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessThreadExitStdOut(deploymentResult, "12", expectedEventLogString), Logger);
+            EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessThreadExitStdOut(deploymentResult, "12", expectedEventLogString), Logger);
+        });
     }
 
     [ConditionalTheory]
@@ -996,22 +987,22 @@ public class StartupTests : IISFunctionalTestBase
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
         deploymentParameters.TransformArguments((a, _) => $"{a} {mode}");
         deploymentParameters.EnableLogging(LogFolderPath);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            await AssertFailsToStart(deploymentResult);
 
-        var deploymentResult = await DeployAsync(deploymentParameters);
+            var contents = GetLogFileContent(deploymentResult);
 
-        await AssertFailsToStart(deploymentResult);
+            // Logs can be split due to the ANCM logging occuring at the same time as logs from the app, so check for a portion of the
+            // string instead of the entire string. The entire string will still be present in the event log.
+            var expectedLogString = new string('a', 16);
 
-        var contents = GetLogFileContent(deploymentResult);
+            Assert.Contains(expectedLogString, contents);
 
-        // Logs can be split due to the ANCM logging occuring at the same time as logs from the app, so check for a portion of the
-        // string instead of the entire string. The entire string will still be present in the event log.
-        var expectedLogString = new string('a', 16);
+            var expectedEventLogString = new string('a', 30000);
 
-        Assert.Contains(expectedLogString, contents);
-
-        var expectedEventLogString = new string('a', 30000);
-
-        EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessThreadExitStdOut(deploymentResult, "12", expectedEventLogString), Logger);
+            EventLogHelpers.VerifyEventLogEvent(deploymentResult, EventLogHelpers.InProcessThreadExitStdOut(deploymentResult, "12", expectedEventLogString), Logger);
+        });
     }
 
     [ConditionalFact]
@@ -1019,12 +1010,11 @@ public class StartupTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
         deploymentParameters.TransformArguments((a, _) => $"{a} CheckConsoleFunctions");
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        await AssertFailsToStart(deploymentResult);
-
-        Assert.Contains(TestSink.Writes, context => context.Message.Contains("Is Console redirection: True"));
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            await AssertFailsToStart(deploymentResult);
+            Assert.Contains(TestSink.Writes, context => context.Message.Contains("Is Console redirection: True"));
+        });
     }
 
     [ConditionalFact]
@@ -1032,15 +1022,14 @@ public class StartupTests : IISFunctionalTestBase
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
         deploymentParameters.TransformArguments((a, _) => $"{a} EarlyReturn");
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        var response = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
-        Assert.False(response.IsSuccessStatusCode);
-        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-
-        var responseText = await response.Content.ReadAsStringAsync();
-        Assert.Contains("500.30", responseText);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var response = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
+            Assert.False(response.IsSuccessStatusCode);
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            var responseText = await response.Content.ReadAsStringAsync();
+            Assert.Contains("500.30", responseText);
+        });
     }
 
     [ConditionalFact]
@@ -1088,19 +1077,20 @@ public class StartupTests : IISFunctionalTestBase
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);
         deploymentParameters.HandlerSettings["handlerVersion"] = "88.93";
         deploymentParameters.EnvironmentVariables["ANCM_ADDITIONAL_ERROR_PAGE_LINK"] = "http://example";
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var response = await deploymentResult.HttpClient.GetAsync("HelloWorld");
 
-        var deploymentResult = await DeployAsync(deploymentParameters);
-        var response = await deploymentResult.HttpClient.GetAsync("HelloWorld");
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
-        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            StopServer();
 
-        StopServer();
+            var responseString = await response.Content.ReadAsStringAsync();
+            Assert.Contains("500.0", responseString);
+            VerifyNoExtraTrailingBytes(responseString);
 
-        var responseString = await response.Content.ReadAsStringAsync();
-        Assert.Contains("500.0", responseString);
-        VerifyNoExtraTrailingBytes(responseString);
-
-        await AssertLink(response);
+            await AssertLink(response);
+        });
     }
 
     [ConditionalFact]
@@ -1111,19 +1101,20 @@ public class StartupTests : IISFunctionalTestBase
         var deploymentParameters = Fixture.GetBaseDeploymentParameters();
         deploymentParameters.TransformArguments((a, _) => $"{a} EarlyReturn");
         deploymentParameters.EnvironmentVariables["ANCM_ADDITIONAL_ERROR_PAGE_LINK"] = "http://example";
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var response = await deploymentResult.HttpClient.GetAsync("HelloWorld");
 
-        var deploymentResult = await DeployAsync(deploymentParameters);
-        var response = await deploymentResult.HttpClient.GetAsync("HelloWorld");
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
 
-        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            StopServer();
 
-        StopServer();
+            var responseString = await response.Content.ReadAsStringAsync();
+            Assert.Contains("500.30", responseString);
+            VerifyNoExtraTrailingBytes(responseString);
 
-        var responseString = await response.Content.ReadAsStringAsync();
-        Assert.Contains("500.30", responseString);
-        VerifyNoExtraTrailingBytes(responseString);
-
-        await AssertLink(response);
+            await AssertLink(response);
+        });
     }
 
     [ConditionalFact]
@@ -1279,7 +1270,6 @@ public class StartupTests : IISFunctionalTestBase
     public async Task ServerAddressesIncludesBaseAddress()
     {
         var appName = "\u041C\u043E\u0451\u041F\u0440\u0438\u043B\u043E\u0436\u0435\u043D\u0438\u0435";
-
         var port = TestPortHelper.GetNextSSLPort();
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.InProcess);
         deploymentParameters.ApplicationBaseUriHint = $"https://localhost:{port}/";
@@ -1291,10 +1281,11 @@ public class StartupTests : IISFunctionalTestBase
                 element.Descendants("site").Single().Element("application").SetAttributeValue("path", "/" + appName);
                 Helpers.CreateEmptyApplication(element, root);
             });
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-        var client = CreateNonValidatingClient(deploymentResult);
-        Assert.Equal(deploymentParameters.ApplicationBaseUriHint + appName, await client.GetStringAsync($"/{appName}/ServerAddresses"));
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var client = CreateNonValidatingClient(deploymentResult);
+            Assert.Equal(deploymentParameters.ApplicationBaseUriHint + appName, await client.GetStringAsync($"/{appName}/ServerAddresses"));
+        });
     }
 
     [ConditionalFact]
@@ -1303,7 +1294,6 @@ public class StartupTests : IISFunctionalTestBase
     public async Task AncmHttpsPortCanBeOverriden()
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);
-
         deploymentParameters.AddServerConfigAction(
             element =>
             {
@@ -1312,14 +1302,13 @@ public class StartupTests : IISFunctionalTestBase
                     .GetOrAdd("binding", "protocol", "https")
                     .SetAttributeValue("bindingInformation", $":{TestPortHelper.GetNextSSLPort()}:localhost");
             });
-
         deploymentParameters.WebConfigBasedEnvironmentVariables["ASPNETCORE_ANCM_HTTPS_PORT"] = "123";
-
-        var deploymentResult = await DeployAsync(deploymentParameters);
-        var client = CreateNonValidatingClient(deploymentResult);
-
-        Assert.Equal("123", await client.GetStringAsync("/ANCM_HTTPS_PORT"));
-        Assert.Equal("NOVALUE", await client.GetStringAsync("/HTTPS_PORT"));
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var client = CreateNonValidatingClient(deploymentResult);
+            Assert.Equal("123", await client.GetStringAsync("/ANCM_HTTPS_PORT"));
+            Assert.Equal("NOVALUE", await client.GetStringAsync("/HTTPS_PORT"));
+        });
     }
 
     [ConditionalFact]
@@ -1330,7 +1319,6 @@ public class StartupTests : IISFunctionalTestBase
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);
         deploymentParameters.WebConfigBasedEnvironmentVariables["ENABLE_HTTPS_REDIRECTION"] = "true";
         deploymentParameters.ApplicationBaseUriHint = $"http://localhost:{TestPortHelper.GetNextPort()}/";
-
         deploymentParameters.AddServerConfigAction(
             element =>
             {
@@ -1343,29 +1331,30 @@ public class StartupTests : IISFunctionalTestBase
                     .Single()
                     .SetAttributeValue("sslFlags", "None");
             });
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var handler = new HttpClientHandler
+            {
+                ServerCertificateCustomValidationCallback = (a, b, c, d) => true,
+                AllowAutoRedirect = false
+            };
+            var client = new HttpClient(handler)
+            {
+                BaseAddress = new Uri(deploymentParameters.ApplicationBaseUriHint),
+                Timeout = TimeSpan.FromSeconds(200),
+            };
 
-        var deploymentResult = await DeployAsync(deploymentParameters);
-        var handler = new HttpClientHandler
-        {
-            ServerCertificateCustomValidationCallback = (a, b, c, d) => true,
-            AllowAutoRedirect = false
-        };
-        var client = new HttpClient(handler)
-        {
-            BaseAddress = new Uri(deploymentParameters.ApplicationBaseUriHint),
-            Timeout = TimeSpan.FromSeconds(200),
-        };
-
-        if (DeployerSelector.HasNewHandler)
-        {
-            var response = await client.GetAsync("/ANCM_HTTPS_PORT");
-            Assert.Equal(307, (int)response.StatusCode);
-        }
-        else
-        {
-            var response = await client.GetAsync("/ANCM_HTTPS_PORT");
-            Assert.Equal(200, (int)response.StatusCode);
-        }
+            if (DeployerSelector.HasNewHandler)
+            {
+                var response = await client.GetAsync("/ANCM_HTTPS_PORT");
+                Assert.Equal(307, (int)response.StatusCode);
+            }
+            else
+            {
+                var response = await client.GetAsync("/ANCM_HTTPS_PORT");
+                Assert.Equal(200, (int)response.StatusCode);
+            }
+        });
     }
 
     [ConditionalFact]
@@ -1392,10 +1381,11 @@ public class StartupTests : IISFunctionalTestBase
                             new XAttribute("bindingInformation", $":{anotherSslPort}:localhost")));
             });
 
-        var deploymentResult = await DeployAsync(deploymentParameters);
-        var client = CreateNonValidatingClient(deploymentResult);
-
-        Assert.Equal("NOVALUE", await client.GetStringAsync("/ANCM_HTTPS_PORT"));
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var client = CreateNonValidatingClient(deploymentResult);
+            Assert.Equal("NOVALUE", await client.GetStringAsync("/ANCM_HTTPS_PORT"));
+        });
     }
 
     [ConditionalFact]
@@ -1406,12 +1396,12 @@ public class StartupTests : IISFunctionalTestBase
         // Only tests OutOfProcess as the Connection header is removed for out of process and not inprocess.
         // This test checks a quirk to allow setting the Connection header.
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(HostingModel.OutOfProcess);
-
         deploymentParameters.HandlerSettings["forwardResponseConnectionHeader"] = "true";
-        var deploymentResult = await DeployAsync(deploymentParameters);
-
-        var response = await deploymentResult.HttpClient.GetAsync("ConnectionClose");
-        Assert.Equal(true, response.Headers.ConnectionClose);
+        await RunTest(deploymentParameters, async deploymentResult =>
+        {
+            var response = await deploymentResult.HttpClient.GetAsync("ConnectionClose");
+            Assert.Equal(true, response.Headers.ConnectionClose);
+        });
     }
 
     public static int GetNextSSLPort(int avoid = 0)

--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ApplicationInitializationTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ApplicationInitializationTests.cs
@@ -1,16 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.IO;
-using System.ServiceProcess;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.AspNetCore.Testing;
-using Xunit;
 
 #if !IIS_FUNCTIONALS
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
@@ -48,11 +42,12 @@ public class ApplicationInitializationTests : IISFunctionalTestBase
                 (args, contentRoot) => $"{args} CreateFile \"{Path.Combine(contentRoot, "Started.txt")}\"");
             EnablePreload(baseDeploymentParameters);
 
-            var result = await DeployAsync(baseDeploymentParameters);
-
-            await Helpers.Retry(async () => await File.ReadAllTextAsync(Path.Combine(result.ContentRoot, "Started.txt")), TimeoutExtensions.DefaultTimeoutValue);
-            StopServer();
-            EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.Started(result), Logger);
+            await RunTest(baseDeploymentParameters, async result =>
+            {
+                await Helpers.Retry(async () => await File.ReadAllTextAsync(Path.Combine(result.ContentRoot, "Started.txt")), TimeoutExtensions.DefaultTimeoutValue);
+                StopServer();
+                EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.Started(result), Logger);
+            });
         }
     }
 
@@ -78,11 +73,12 @@ public class ApplicationInitializationTests : IISFunctionalTestBase
                         .GetOrAdd("add", "initializationPage", "/CreateFile");
                 });
 
-            var result = await DeployAsync(baseDeploymentParameters);
-
-            await Helpers.Retry(async () => await File.ReadAllTextAsync(Path.Combine(result.ContentRoot, "Started.txt")), TimeoutExtensions.DefaultTimeoutValue);
-            StopServer();
-            EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.Started(result), Logger);
+            await RunTest(baseDeploymentParameters, async result =>
+            {
+                await Helpers.Retry(async () => await File.ReadAllTextAsync(Path.Combine(result.ContentRoot, "Started.txt")), TimeoutExtensions.DefaultTimeoutValue);
+                StopServer();
+                EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.Started(result), Logger);
+            });
         }
     }
 

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
@@ -361,19 +361,17 @@ public class IISDeployer : IISDeployerBase
         {
             RetryServerManagerAction(serverManager =>
             {
-                foreach (var site in serverManager.Sites)
+                var site = serverManager.Sites.SingleOrDefault();
+                if (site == null)
                 {
-                    if (site.State != ObjectState.Stopped && site.State != ObjectState.Stopping)
-                    {
-                        var state = site.Stop();
-                        Logger.LogInformation($"Stopping site, state: {state}");
-                    }
+                    throw new InvalidOperationException("Site not found");
                 }
 
-                foreach (var appPool in serverManager.ApplicationPools)
+                if (site.State != ObjectState.Stopped && site.State != ObjectState.Stopping)
                 {
                     var state = site.Stop();
                     Logger.LogInformation($"Stopping site, state: {state}");
+
                     if (appPool.State != ObjectState.Stopped && appPool.State != ObjectState.Stopping)
                     {
                         var state = appPool.Stop();
@@ -381,7 +379,8 @@ public class IISDeployer : IISDeployerBase
                     }
                 }
 
-                foreach (var site in serverManager.Sites)
+                var appPool = serverManager.ApplicationPools.SingleOrDefault();
+                if (appPool == null)
                 {
                     throw new InvalidOperationException("Application pool not found");
                 }
@@ -400,16 +399,14 @@ public class IISDeployer : IISDeployerBase
 
                 try
                 {
-                    foreach (var appPool in serverManager.ApplicationPools)
+                    if (appPool.WorkerProcesses != null &&
+                        appPool.WorkerProcesses.Any(wp =>
+                            wp.State == WorkerProcessState.Running ||
+                            wp.State == WorkerProcessState.Stopping))
                     {
-                        if (appPool.WorkerProcesses != null &&
-                            appPool.WorkerProcesses.Any(wp =>
-                                wp.State == WorkerProcessState.Running ||
-                                wp.State == WorkerProcessState.Stopping))
-                        {
-                            throw new InvalidOperationException("WorkerProcess not stopped yet");
-                        }
+                        throw new InvalidOperationException("WorkerProcess not stopped yet");
                     }
+
                 }
                 // If WAS was stopped for some reason appPool.WorkerProcesses
                 // would throw UnauthorizedAccessException.

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
@@ -371,12 +371,6 @@ public class IISDeployer : IISDeployerBase
                 {
                     var state = site.Stop();
                     Logger.LogInformation($"Stopping site, state: {state}");
-
-                    if (appPool.State != ObjectState.Stopped && appPool.State != ObjectState.Stopping)
-                    {
-                        var state = appPool.Stop();
-                        Logger.LogInformation($"Stopping pool, state: {state}");
-                    }
                 }
 
                 var appPool = serverManager.ApplicationPools.SingleOrDefault();
@@ -391,10 +385,9 @@ public class IISDeployer : IISDeployerBase
                     Logger.LogInformation($"Stopping pool, state: {state}");
                 }
 
-                    if (site.State != ObjectState.Stopped)
-                    {
-                        throw new InvalidOperationException($"Site {site.Name} not stopped yet");
-                    }
+                if (site.State != ObjectState.Stopped)
+                {
+                    throw new InvalidOperationException($"Site {site.Name} not stopped yet");
                 }
 
                 try

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
@@ -361,20 +361,27 @@ public class IISDeployer : IISDeployerBase
         {
             RetryServerManagerAction(serverManager =>
             {
-                var site = serverManager.Sites.SingleOrDefault();
-                if (site == null)
+                foreach (var site in serverManager.Sites)
                 {
-                    throw new InvalidOperationException("Site not found");
+                    if (site.State != ObjectState.Stopped && site.State != ObjectState.Stopping)
+                    {
+                        var state = site.Stop();
+                        Logger.LogInformation($"Stopping site, state: {state}");
+                    }
                 }
 
-                if (site.State != ObjectState.Stopped && site.State != ObjectState.Stopping)
+                foreach (var appPool in serverManager.ApplicationPools)
                 {
                     var state = site.Stop();
                     Logger.LogInformation($"Stopping site, state: {state}");
+                    if (appPool.State != ObjectState.Stopped && appPool.State != ObjectState.Stopping)
+                    {
+                        var state = appPool.Stop();
+                        Logger.LogInformation($"Stopping pool, state: {state}");
+                    }
                 }
 
-                var appPool = serverManager.ApplicationPools.SingleOrDefault();
-                if (appPool == null)
+                foreach (var site in serverManager.Sites)
                 {
                     throw new InvalidOperationException("Application pool not found");
                 }
@@ -385,21 +392,24 @@ public class IISDeployer : IISDeployerBase
                     Logger.LogInformation($"Stopping pool, state: {state}");
                 }
 
-                if (site.State != ObjectState.Stopped)
-                {
-                    throw new InvalidOperationException("Site not stopped yet");
+                    if (site.State != ObjectState.Stopped)
+                    {
+                        throw new InvalidOperationException($"Site {site.Name} not stopped yet");
+                    }
                 }
 
                 try
                 {
-                    if (appPool.WorkerProcesses != null &&
-                        appPool.WorkerProcesses.Any(wp =>
-                            wp.State == WorkerProcessState.Running ||
-                            wp.State == WorkerProcessState.Stopping))
+                    foreach (var appPool in serverManager.ApplicationPools)
                     {
-                        throw new InvalidOperationException("WorkerProcess not stopped yet");
+                        if (appPool.WorkerProcesses != null &&
+                            appPool.WorkerProcesses.Any(wp =>
+                                wp.State == WorkerProcessState.Running ||
+                                wp.State == WorkerProcessState.Stopping))
+                        {
+                            throw new InvalidOperationException("WorkerProcess not stopped yet");
+                        }
                     }
-
                 }
                 // If WAS was stopped for some reason appPool.WorkerProcesses
                 // would throw UnauthorizedAccessException.


### PR DESCRIPTION
For https://github.com/dotnet/aspnetcore/issues/41281

Just did GlobalVersionTests to start, if this pattern looks good I'll update the rest of the tests, roughly takes half as much time for tests that are hitting this

Before
![image](https://user-images.githubusercontent.com/6537861/164282262-14e7c18a-0a13-4350-b0ee-6e758c556cbc.png)

After
![image](https://user-images.githubusercontent.com/6537861/164282300-375891a8-8060-43a8-9eb8-539083b351af.png)

cc @davidfowl in case we want to disable connection pooling instead
