### PR TITLE
Remove quotes from MultipartReader boundary

### DIFF
--- a/src/Http/WebUtilities/src/MultipartReader.cs
+++ b/src/Http/WebUtilities/src/MultipartReader.cs
@@ -52,8 +52,6 @@ public class MultipartReader
             throw new ArgumentNullException(nameof(boundary));
         }
 
-        boundary = HeaderUtilities.RemoveQuotes(new StringSegment(boundary)).ToString();
-
         if (stream == null)
         {
             throw new ArgumentNullException(nameof(stream));
@@ -64,6 +62,7 @@ public class MultipartReader
             throw new ArgumentOutOfRangeException(nameof(bufferSize), bufferSize, "Insufficient buffer space, the buffer must be larger than the boundary: " + boundary);
         }
         _stream = new BufferedReadStream(stream, bufferSize);
+        boundary = HeaderUtilities.RemoveQuotes(new StringSegment(boundary)).ToString();
         _boundary = new MultipartBoundary(boundary, false);
         // This stream will drain any preamble data and remove the first boundary marker.
         // TODO: HeadersLengthLimit can't be modified until after the constructor.

--- a/src/Http/WebUtilities/src/MultipartReader.cs
+++ b/src/Http/WebUtilities/src/MultipartReader.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.WebUtilities;
 
@@ -50,6 +51,8 @@ public class MultipartReader
         {
             throw new ArgumentNullException(nameof(boundary));
         }
+
+        boundary = HeaderUtilities.RemoveQuotes(new StringSegment(boundary)).ToString();
 
         if (stream == null)
         {

--- a/src/Http/WebUtilities/test/MultipartReaderTests.cs
+++ b/src/Http/WebUtilities/test/MultipartReaderTests.cs
@@ -10,6 +10,7 @@ namespace Microsoft.AspNetCore.WebUtilities;
 public class MultipartReaderTests
 {
     private const string Boundary = "9051914041544843365972754266";
+    private const string BoundaryWithQuotes = @"""9051914041544843365972754266""";
     // Note that CRLF (\r\n) is required. You can't use multi-line C# strings here because the line breaks on Linux are just LF.
     private const string OnePartBody =
 "--9051914041544843365972754266\r\n" +
@@ -376,5 +377,16 @@ public class MultipartReaderTests
         Assert.Equal("text default", Encoding.ASCII.GetString(buffer.ToArray()));
 
         Assert.Null(await reader.ReadNextSectionAsync());
+    }
+
+    // MultiPartReader should strip any quotes from the boundary passed in instead of throwing an exception
+    [Fact]
+    public async Task MultipartReader_StripQuotesFromBoundary()
+    {
+        var stream = MakeStream(OnePartBody);
+        var reader = new MultipartReader(BoundaryWithQuotes, stream);
+
+        var section = await reader.ReadNextSectionAsync();
+        Assert.NotNull(section);
     }
 }


### PR DESCRIPTION
# Remove quotes from MultipartReader boundary

## Description

When a request is submitted by HttpClient via MultipartFormDataContent, the boundary value in multipart/formdata request header is enclosed with double quotes. In this case, when using MediaTypeHeaderValue.TryParse to parse the header, the MediaTypeHeaderValue will include those double quotes as boundary when parsing the header. This leads to an exception being thrown. 

The solution for now is to remove quotes from the boundary passed in to the MultipartReader constructor. I also added a unit test that checks to see if a boundary with double quotes works.

Fixes #41237
