### PR TITLE
Zero byte reads support for FileBufferingReadStream #41287

### DIFF
--- a/src/Http/WebUtilities/src/FileBufferingReadStream.cs
+++ b/src/Http/WebUtilities/src/FileBufferingReadStream.cs
@@ -313,7 +313,8 @@ public class FileBufferingReadStream : Stream
         {
             _buffer.Write(buffer.Slice(0, read));
         }
-        else
+        // Allow zero-byte reads
+        else if (buffer.Length > 0)
         {
             _completelyBuffered = true;
         }
@@ -388,7 +389,8 @@ public class FileBufferingReadStream : Stream
         {
             await _buffer.WriteAsync(buffer.Slice(0, read), cancellationToken);
         }
-        else
+        // Allow zero-byte reads
+        else if (buffer.Length > 0)
         {
             _completelyBuffered = true;
         }

--- a/src/Http/WebUtilities/test/FileBufferingReadStreamTests.cs
+++ b/src/Http/WebUtilities/test/FileBufferingReadStreamTests.cs
@@ -37,6 +37,39 @@ public class FileBufferingReadStreamTests
     }
 
     [Fact]
+    public void FileBufferingReadStream_Sync0ByteReadUnderThreshold_DoesntCreateFile()
+    {
+        var inner = MakeStream(1024);
+        using (var stream = new FileBufferingReadStream(inner, 1024 * 2, null, Directory.GetCurrentDirectory()))
+        {
+            var bytes = new byte[1000];
+            var read0 = stream.Read(bytes, 0, 0);
+            Assert.Equal(0, read0);
+            Assert.Equal(read0, stream.Length);
+            Assert.Equal(read0, stream.Position);
+            Assert.True(stream.InMemory);
+            Assert.Null(stream.TempFileName);
+
+            var read1 = stream.Read(bytes, 0, bytes.Length);
+            Assert.Equal(bytes.Length, read1);
+            Assert.Equal(read0 + read1, stream.Length);
+            Assert.Equal(read0 + read1, stream.Position);
+            Assert.True(stream.InMemory);
+            Assert.Null(stream.TempFileName);
+
+            var read2 = stream.Read(bytes, 0, bytes.Length);
+            Assert.Equal(inner.Length - read0 - read1, read2);
+            Assert.Equal(read0 + read1 + read2, stream.Length);
+            Assert.Equal(read0 + read1 + read2, stream.Position);
+            Assert.True(stream.InMemory);
+            Assert.Null(stream.TempFileName);
+
+            var read3 = stream.Read(bytes, 0, bytes.Length);
+            Assert.Equal(0, read3);
+        }
+    }
+
+    [Fact]
     public void FileBufferingReadStream_SyncReadUnderThreshold_DoesntCreateFile()
     {
         var inner = MakeStream(1024 * 2);
@@ -166,6 +199,39 @@ public class FileBufferingReadStreamTests
     ///////////////////
 
     [Fact]
+    public async Task FileBufferingReadStream_Async0ByteReadUnderThreshold_DoesntCreateFile()
+    {
+        var inner = MakeStream(1024);
+        using (var stream = new FileBufferingReadStream(inner, 1024 * 2, null, Directory.GetCurrentDirectory()))
+        {
+            var bytes = new byte[1000];
+            var read0 = await stream.ReadAsync(bytes, 0, 0);
+            Assert.Equal(0, read0);
+            Assert.Equal(read0, stream.Length);
+            Assert.Equal(read0, stream.Position);
+            Assert.True(stream.InMemory);
+            Assert.Null(stream.TempFileName);
+
+            var read1 = await stream.ReadAsync(bytes, 0, bytes.Length);
+            Assert.Equal(bytes.Length, read1);
+            Assert.Equal(read0 + read1, stream.Length);
+            Assert.Equal(read0 + read1, stream.Position);
+            Assert.True(stream.InMemory);
+            Assert.Null(stream.TempFileName);
+
+            var read2 = await stream.ReadAsync(bytes, 0, bytes.Length);
+            Assert.Equal(inner.Length - read0 - read1, read2);
+            Assert.Equal(read0 + read1 + read2, stream.Length);
+            Assert.Equal(read0 + read1 + read2, stream.Position);
+            Assert.True(stream.InMemory);
+            Assert.Null(stream.TempFileName);
+
+            var read3 = await stream.ReadAsync(bytes, 0, bytes.Length);
+            Assert.Equal(0, read3);
+        }
+    }
+
+    [Fact]
     public async Task FileBufferingReadStream_AsyncReadUnderThreshold_DoesntCreateFile()
     {
         var inner = MakeStream(1024 * 2);
@@ -232,6 +298,47 @@ public class FileBufferingReadStreamTests
 
             var read3 = await stream.ReadAsync(bytes, 0, bytes.Length);
             Assert.Equal(0, read3);
+        }
+
+        Assert.False(File.Exists(tempFileName));
+    }
+
+    [Fact]
+    public async Task FileBufferingReadStream_Async0ByteReadAfterBuffering_ReadsFromFile()
+    {
+        var inner = MakeStream(1024 * 2);
+        string tempFileName;
+        using (var stream = new FileBufferingReadStream(inner, 1024, null, GetCurrentDirectory()))
+        {
+            await stream.DrainAsync(default);
+            stream.Position = 0;
+            Assert.Equal(inner.Length, stream.Length);
+            Assert.Equal(0, stream.Position);
+            Assert.False(stream.InMemory);
+            Assert.NotNull(stream.TempFileName);
+            tempFileName = stream.TempFileName!;
+            Assert.True(File.Exists(tempFileName));
+
+            var bytes = new byte[1000];
+            var read0 = await stream.ReadAsync(bytes, 0, 0);
+            Assert.Equal(0, read0);
+            Assert.Equal(read0, stream.Position);
+
+            var read1 = await stream.ReadAsync(bytes, 0, bytes.Length);
+            Assert.Equal(bytes.Length, read1);
+            Assert.Equal(read0 + read1, stream.Position);
+
+            var read2 = await stream.ReadAsync(bytes, 0, bytes.Length);
+            Assert.Equal(bytes.Length, read2);
+            Assert.Equal(read0 + read1 + read2, stream.Position);
+
+            var read3 = await stream.ReadAsync(bytes, 0, bytes.Length);
+            Assert.Equal(inner.Length - read0 - read1 - read2, read3);
+            Assert.Equal(read0 + read1 + read2 + read3, stream.Length);
+            Assert.Equal(read0 + read1 + read2 + read3, stream.Position);
+
+            var read4 = await stream.ReadAsync(bytes, 0, bytes.Length);
+            Assert.Equal(0, read4);
         }
 
         Assert.False(File.Exists(tempFileName));


### PR DESCRIPTION
Contributes to #41287

EnableBuffering/FileBufferingReadStream do not support zero-byte reads from the stream. If the inner stream ever returns 0 then these assume that buffering is complete. Fix: Only assume buffering is complete the buffer passed in was non-zero length.

Servicing candidate to enable YARP scenarios.