### PR TITLE
Support all return types from handler in filters

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -326,6 +326,10 @@ public static partial class RequestDelegateFactory
         {
             return Expression.Call(ExecuteValueTaskWithEmptyResultMethod, methodCall);
         }
+        else if (returnType == typeof(ValueTask<object?>))
+        {
+            return methodCall;
+        }
         else if (returnType.IsGenericType &&
                      returnType.GetGenericTypeDefinition() == typeof(ValueTask<>))
         {

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -348,7 +348,7 @@ public static partial class RequestDelegateFactory
     {
         static async ValueTask<object?> ExecuteAwaited(ValueTask<T> valueTask)
         {
-            return await new ValueTask<object?>(await valueTask);
+            return await valueTask;
         }
 
         if (valueTask.IsCompletedSuccessfully)
@@ -363,7 +363,7 @@ public static partial class RequestDelegateFactory
     {
         static async ValueTask<object?> ExecuteAwaited(Task<T> task)
         {
-            return await new ValueTask<object?>(await task);
+            return await task;
         }
 
         if (task.IsCompletedSuccessfully)
@@ -1794,7 +1794,7 @@ public static partial class RequestDelegateFactory
         static async ValueTask<object?> ExecuteAwaited(Task task)
         {
             await task;
-            return await new ValueTask<object?>(EmptyHttpResult.Instance);
+            return EmptyHttpResult.Instance;
         }
 
         if (task.IsCompletedSuccessfully)
@@ -1811,7 +1811,7 @@ public static partial class RequestDelegateFactory
         static async ValueTask<object?> ExecuteAwaited(ValueTask task)
         {
             await task;
-            return await new ValueTask<object?>(EmptyHttpResult.Instance);
+            return EmptyHttpResult.Instance;
         }
 
         if (valueTask.IsCompletedSuccessfully)

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -323,21 +323,32 @@ public static partial class RequestDelegateFactory
 
     private static ValueTask<object?> ValueTaskOfTToValueTaskOfObject<T>(ValueTask<T> valueTask)
     {
+        static async ValueTask<object?> ExecuteAwait(ValueTask<T> valueTask)
+        {
+            return await new ValueTask<object?>(await valueTask);
+        }
+
         if (valueTask.IsCompletedSuccessfully)
         {
             return new ValueTask<object?>(valueTask.Result);
         }
 
-        return new ValueTask<object?>(valueTask.GetAwaiter().GetResult());
+        return ExecuteAwait(valueTask);
     }
 
     private static ValueTask<object?> TaskOfTToValueTaskOfObject<T>(Task<T> task)
     {
+        static async ValueTask<object?> ExecuteAwait(Task<T> task)
+        {
+            return await new ValueTask<object?>(await task);
+        }
+
         if (task.IsCompletedSuccessfully)
         {
             return new ValueTask<object?>(task.Result);
         }
-        return new ValueTask<object?>(task.GetAwaiter().GetResult());
+
+        return ExecuteAwait(task);
     }
 
     private static void AddTypeProvidedMetadata(MethodInfo methodInfo, List<object> metadata, IServiceProvider? services)

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -323,7 +323,7 @@ public static partial class RequestDelegateFactory
 
     private static ValueTask<object?> ValueTaskOfTToValueTaskOfObject<T>(ValueTask<T> valueTask)
     {
-        static async ValueTask<object?> ExecuteAwait(ValueTask<T> valueTask)
+        static async ValueTask<object?> ExecuteAwaited(ValueTask<T> valueTask)
         {
             return await new ValueTask<object?>(await valueTask);
         }
@@ -333,12 +333,12 @@ public static partial class RequestDelegateFactory
             return new ValueTask<object?>(valueTask.Result);
         }
 
-        return ExecuteAwait(valueTask);
+        return ExecuteAwaited(valueTask);
     }
 
     private static ValueTask<object?> TaskOfTToValueTaskOfObject<T>(Task<T> task)
     {
-        static async ValueTask<object?> ExecuteAwait(Task<T> task)
+        static async ValueTask<object?> ExecuteAwaited(Task<T> task)
         {
             return await new ValueTask<object?>(await task);
         }
@@ -348,7 +348,7 @@ public static partial class RequestDelegateFactory
             return new ValueTask<object?>(task.Result);
         }
 
-        return ExecuteAwait(task);
+        return ExecuteAwaited(task);
     }
 
     private static void AddTypeProvidedMetadata(MethodInfo methodInfo, List<object> metadata, IServiceProvider? services)

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -1785,6 +1785,11 @@ public static partial class RequestDelegateFactory
             await task;
         }
 
+        if (task.IsCompletedSuccessfully)
+        {
+            task.GetAwaiter().GetResult();
+        }
+
         return ExecuteAwaited(task);
     }
 
@@ -1798,7 +1803,6 @@ public static partial class RequestDelegateFactory
 
         if (task.IsCompletedSuccessfully)
         {
-            task.GetAwaiter().GetResult();
             return new ValueTask<object?>(EmptyHttpResult.Instance);
         }
 

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -1785,11 +1785,6 @@ public static partial class RequestDelegateFactory
             await task;
         }
 
-        if (task.IsCompletedSuccessfully)
-        {
-            task.GetAwaiter().GetResult();
-        }
-
         return ExecuteAwaited(task);
     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -4699,6 +4699,175 @@ public class RequestDelegateFactoryTests : LoggedTest
     }
 
     [Fact]
+    public async Task CanInvokeFilter_OnVoidReturningHandler()
+    {
+        // Arrange
+        var invoked = false;
+        void VoidMethod()
+        {
+            invoked = true;
+        }
+        var responseBodyStream = new MemoryStream();
+        var httpContext = CreateHttpContext();
+        httpContext.Response.Body = responseBodyStream;
+
+        // Act
+        var factoryResult = RequestDelegateFactory.Create(VoidMethod, new RequestDelegateFactoryOptions()
+        {
+            RouteHandlerFilterFactories = new List<Func<RouteHandlerContext, RouteHandlerFilterDelegate, RouteHandlerFilterDelegate>>()
+            {
+                (routeHandlerContext, next) => async (context) =>
+                {
+                    return await next(context);
+                }
+            }
+        });
+        var requestDelegate = factoryResult.RequestDelegate;
+        await requestDelegate(httpContext);
+
+        Assert.Equal(200, httpContext.Response.StatusCode);
+        Assert.True(invoked);
+        var decodedResponseBody = Encoding.UTF8.GetString(responseBodyStream.ToArray());
+        Assert.Equal(string.Empty, decodedResponseBody);
+    }
+
+    [Fact]
+    public async Task CanInvokeFilter_OnTaskOfTReturningHandler()
+    {
+        // Arrange
+        var invoked = false;
+        Task<string> TaskOfTMethod()
+        {
+            invoked = true;
+            return Task.FromResult("foo");
+        }
+        var responseBodyStream = new MemoryStream();
+        var httpContext = CreateHttpContext();
+        httpContext.Response.Body = responseBodyStream;
+
+        // Act
+        var factoryResult = RequestDelegateFactory.Create(TaskOfTMethod, new RequestDelegateFactoryOptions()
+        {
+            RouteHandlerFilterFactories = new List<Func<RouteHandlerContext, RouteHandlerFilterDelegate, RouteHandlerFilterDelegate>>()
+            {
+                (routeHandlerContext, next) => async (context) =>
+                {
+                    return await next(context);
+                }
+            }
+        });
+        var requestDelegate = factoryResult.RequestDelegate;
+        await requestDelegate(httpContext);
+
+        Assert.Equal(200, httpContext.Response.StatusCode);
+        Assert.True(invoked);
+        var decodedResponseBody = Encoding.UTF8.GetString(responseBodyStream.ToArray());
+        Assert.Equal("foo", decodedResponseBody);
+    }
+
+    [Fact]
+    public async Task CanInvokeFilter_OnValueTaskOfTReturningHandler()
+    {
+        // Arrange
+        var invoked = false;
+        ValueTask<string> ValueTaskOfTMethod()
+        {
+            invoked = true;
+            return ValueTask.FromResult("foo");
+        }
+        var responseBodyStream = new MemoryStream();
+        var httpContext = CreateHttpContext();
+        httpContext.Response.Body = responseBodyStream;
+
+        // Act
+        var factoryResult = RequestDelegateFactory.Create(ValueTaskOfTMethod, new RequestDelegateFactoryOptions()
+        {
+            RouteHandlerFilterFactories = new List<Func<RouteHandlerContext, RouteHandlerFilterDelegate, RouteHandlerFilterDelegate>>()
+            {
+                (routeHandlerContext, next) => async (context) =>
+                {
+                    return await next(context);
+                }
+            }
+        });
+        var requestDelegate = factoryResult.RequestDelegate;
+        await requestDelegate(httpContext);
+
+        Assert.Equal(200, httpContext.Response.StatusCode);
+        Assert.True(invoked);
+        var decodedResponseBody = Encoding.UTF8.GetString(responseBodyStream.ToArray());
+        Assert.Equal("foo", decodedResponseBody);
+    }
+
+    [Fact]
+    public async Task CanInvokeFilter_OnValueTaskReturningHandler()
+    {
+        // Arrange
+        var invoked = false;
+        ValueTask ValueTaskMethod()
+        {
+            invoked = true;
+            return new ValueTask();
+        }
+        var responseBodyStream = new MemoryStream();
+        var httpContext = CreateHttpContext();
+        httpContext.Response.Body = responseBodyStream;
+
+        // Act
+        var factoryResult = RequestDelegateFactory.Create(ValueTaskMethod, new RequestDelegateFactoryOptions()
+        {
+            RouteHandlerFilterFactories = new List<Func<RouteHandlerContext, RouteHandlerFilterDelegate, RouteHandlerFilterDelegate>>()
+            {
+                (routeHandlerContext, next) => async (context) =>
+                {
+                    return await next(context);
+                }
+            }
+        });
+        var requestDelegate = factoryResult.RequestDelegate;
+        await requestDelegate(httpContext);
+
+        Assert.Equal(200, httpContext.Response.StatusCode);
+        Assert.True(invoked);
+        var decodedResponseBody = Encoding.UTF8.GetString(responseBodyStream.ToArray());
+        Assert.Equal(String.Empty, decodedResponseBody);
+    }
+
+    [Fact]
+    public async Task CanInvokeFilter_OnTaskReturningHandler()
+    {
+        // Arrange
+        var invoked = false;
+        Task TaskMethod()
+        {
+            invoked = true;
+            return Task.CompletedTask;
+        }
+        var responseBodyStream = new MemoryStream();
+        var httpContext = CreateHttpContext();
+        httpContext.Response.Body = responseBodyStream;
+
+        // Act
+        var factoryResult = RequestDelegateFactory.Create(TaskMethod, new RequestDelegateFactoryOptions()
+        {
+            RouteHandlerFilterFactories = new List<Func<RouteHandlerContext, RouteHandlerFilterDelegate, RouteHandlerFilterDelegate>>()
+            {
+                (routeHandlerContext, next) => async (context) =>
+                {
+                    return await next(context);
+                }
+            }
+        });
+        var requestDelegate = factoryResult.RequestDelegate;
+        await requestDelegate(httpContext);
+
+        Assert.Equal(200, httpContext.Response.StatusCode);
+        Assert.True(invoked);
+        var decodedResponseBody = Encoding.UTF8.GetString(responseBodyStream.ToArray());
+        Assert.Equal(string.Empty, decodedResponseBody);
+    }
+
+    [Fact]
     public void Create_AddsDelegateMethodInfo_AsMetadata()
     {
         // Arrange


### PR DESCRIPTION
This PR fixes an issue where users could not apply route handler filters to endpoints that returned void, void-returning `Task`s and `ValueTask`s, and generic `ValueTask` or `Task`.

#### Technical Detail
The current implementation of filters has logic that wraps the user provided handler into a method that complies with the `RouteHandlerFilterDelegateSignature`, namely it must return a `ValueTask<object?>` and take in a `RouteHandlerInvocationContext`. To map the return types correctly, the implementation previously indiscriminately applied `ValueTask.FromResult<object?>()` to whatever the route handler returned. This meant that you could sometimes have invocations like `ValueTask.FromResult(VoidReturningMethod())` or `ValueTask.FromResult(new Task("foo"))`.

To resolve this issue, we are improving the mapping of route handler types to `ValueTask<object?>` to account for three scenarios:

- Void returning methods
- Non-generic `Task` and `ValueTask`
- Generic `Task` and `ValueTask`

Fixes https://github.com/dotnet/aspnetcore/issues/41213

## Customer Impact

Without this fix, customers are not able to apply route handler filters to any endpoint in their application with running into exceptions or strange behavior. This bug fix allows us to achieve the stated goal of filters being applicable on all endpoints.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Change was validated manually and with automated tests. Surface area of change limited to user code that has handlers with the 3 return types outlined above.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
