### PR TITLE
Fix Blazor Wasm benchmarks

### DIFF
--- a/src/Components/benchmarkapps/Wasm.Performance/dockerfile
+++ b/src/Components/benchmarkapps/Wasm.Performance/dockerfile
@@ -28,7 +28,7 @@ RUN .dotnet/dotnet publish -c Release --no-restore -o /app ./src/Components/benc
 RUN chmod +x /app/Wasm.Performance.Driver
 
 WORKDIR /app
-FROM selenium/standalone-chrome:latest as final
+FROM selenium/standalone-chrome:98.0 as final
 COPY --from=build ./app ./
 COPY ./exec.sh ./
 

--- a/src/Components/benchmarkapps/Wasm.Performance/dockerfile
+++ b/src/Components/benchmarkapps/Wasm.Performance/dockerfile
@@ -28,7 +28,7 @@ RUN .dotnet/dotnet publish -c Release --no-restore -o /app ./src/Components/benc
 RUN chmod +x /app/Wasm.Performance.Driver
 
 WORKDIR /app
-FROM selenium/standalone-chrome:98.0 as final
+FROM selenium/standalone-chrome:99.0 as final
 COPY --from=build ./app ./
 COPY ./exec.sh ./
 

--- a/src/Components/benchmarkapps/Wasm.Performance/dockerfile
+++ b/src/Components/benchmarkapps/Wasm.Performance/dockerfile
@@ -28,7 +28,7 @@ RUN .dotnet/dotnet publish -c Release --no-restore -o /app ./src/Components/benc
 RUN chmod +x /app/Wasm.Performance.Driver
 
 WORKDIR /app
-FROM selenium/standalone-chrome:99.0 as final
+FROM selenium/standalone-chrome:98.0 as final
 COPY --from=build ./app ./
 COPY ./exec.sh ./
 


### PR DESCRIPTION
Fixes #41302

Docker floating tag is not appropriate for this benchmarks as new Chrome versions can break it if it's not on par with the repo's selenium driver.

Updating build-ops instructions in a separate PR.