### PR TITLE
[release/2.1] Stick w/ `$(RepositoryCommit)`

### DIFF
--- a/build/Publish.targets
+++ b/build/Publish.targets
@@ -44,7 +44,7 @@
     -->
     <WriteLinesToFile
       File="$(LatestRuntimeVersionFile)"
-      Lines="$(CommitHash);$(PackageVersion)"
+      Lines="$(RepositoryCommit);$(PackageVersion)"
       Overwrite="true" />
 
     <ItemGroup>
@@ -304,8 +304,8 @@
                     UploadTimeoutInMinutes="$(PushToBlobFeed_UploadTimeoutMinutes)"
                     ManifestBranch="$(BuildBranch)"
                     ManifestBuildId="$(Version)"
-                    ManifestBuildData="ProductVersion=$(PackageVersion);UniverseCommitHash=$(CommitHash)"
-                    ManifestCommit="$(CommitHash)"
+                    ManifestBuildData="ProductVersion=$(PackageVersion);UniverseCommitHash=$(RepositoryCommit)"
+                    ManifestCommit="$(RepositoryCommit)"
                     ManifestName="aspnet"
                     MaxClients="$(PushToBlobFeed_MaxClients)"
                     Condition="@(PackageToPublish->Count()) != 0" />
@@ -318,8 +318,8 @@
                     UploadTimeoutInMinutes="$(PushToBlobFeed_UploadTimeoutMinutes)"
                     ManifestBranch="$(BuildBranch)"
                     ManifestBuildId="$(Version)"
-                    ManifestBuildData="ProductVersion=$(PackageVersion);UniverseCommitHash=$(CommitHash)"
-                    ManifestCommit="$(CommitHash)"
+                    ManifestBuildData="ProductVersion=$(PackageVersion);UniverseCommitHash=$(RepositoryCommit)"
+                    ManifestCommit="$(RepositoryCommit)"
                     ManifestName="aspnet"
                     MaxClients="$(PushToBlobFeed_MaxClients)" />
   </Target>

--- a/src/Servers/IIS/build/native.targets
+++ b/src/Servers/IIS/build/native.targets
@@ -11,7 +11,7 @@
       <VersionHeaderContents Include="#define ProductVersion $(AspNetCoreModuleVersionMajor),$(AspNetCoreModuleVersionMinor),$(AssemblyBuild),$(AspNetCoreModuleVersionRevision)" />
       <VersionHeaderContents Include="#define ProductVersionStr &quot;$(AspNetCoreModuleVersionMajor).$(AspNetCoreModuleVersionMinor).$(AssemblyBuild).$(AspNetCoreModuleVersionRevision)\0&quot;" />
       <VersionHeaderContents Include="#define PlatformToolset &quot;$(PlatformToolset)\0&quot;" />
-      <VersionHeaderContents Include="#define CommitHash &quot;$(CommitHash)\0&quot;" />
+      <VersionHeaderContents Include="#define CommitHash &quot;$(RepositoryCommit)\0&quot;" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- don't mix in attempts to use `$(CommitHash)`
- `$(CommitHash)` is not set correctly in CI builds

See also #41290 and aspnet/BuildTools#1010
- will bump the BuildTools version here after aspnet/BuildTools#1010 is in