### PR TITLE
Allow HttpSys zero-byte reads #41305

### DIFF
--- a/src/Servers/HttpSys/src/RequestProcessing/RequestStreamAsyncResult.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestStreamAsyncResult.cs
@@ -13,38 +13,24 @@ internal unsafe class RequestStreamAsyncResult : IAsyncResult, IDisposable
 
     private readonly SafeNativeOverlapped? _overlapped;
     private readonly IntPtr _pinnedBuffer;
+    private readonly int _size;
     private readonly uint _dataAlreadyRead;
     private readonly TaskCompletionSource<int> _tcs;
     private readonly RequestStream _requestStream;
     private readonly AsyncCallback? _callback;
     private readonly CancellationTokenRegistration _cancellationRegistration;
 
-    internal RequestStreamAsyncResult(RequestStream requestStream, object? userState, AsyncCallback? callback)
+    internal RequestStreamAsyncResult(RequestStream requestStream, object? userState, AsyncCallback? callback, byte[] buffer, int offset, int size, uint dataAlreadyRead, CancellationTokenRegistration cancellationRegistration)
     {
         _requestStream = requestStream;
         _tcs = new TaskCompletionSource<int>(userState);
         _callback = callback;
-    }
-
-    internal RequestStreamAsyncResult(RequestStream requestStream, object? userState, AsyncCallback? callback, uint dataAlreadyRead)
-        : this(requestStream, userState, callback)
-    {
-        _dataAlreadyRead = dataAlreadyRead;
-    }
-
-    internal RequestStreamAsyncResult(RequestStream requestStream, object? userState, AsyncCallback? callback, byte[] buffer, int offset, uint dataAlreadyRead)
-        : this(requestStream, userState, callback, buffer, offset, dataAlreadyRead, new CancellationTokenRegistration())
-    {
-    }
-
-    internal RequestStreamAsyncResult(RequestStream requestStream, object? userState, AsyncCallback? callback, byte[] buffer, int offset, uint dataAlreadyRead, CancellationTokenRegistration cancellationRegistration)
-        : this(requestStream, userState, callback)
-    {
         _dataAlreadyRead = dataAlreadyRead;
         var boundHandle = requestStream.RequestContext.Server.RequestQueue.BoundHandle;
         _overlapped = new SafeNativeOverlapped(boundHandle,
             boundHandle.AllocateNativeOverlapped(IOCallback, this, buffer));
         _pinnedBuffer = (Marshal.UnsafeAddrOfPinnedArrayElement(buffer, offset));
+        _size = size;
         _cancellationRegistration = cancellationRegistration;
     }
 
@@ -83,7 +69,13 @@ internal unsafe class RequestStreamAsyncResult : IAsyncResult, IDisposable
     {
         try
         {
-            if (errorCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS && errorCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_HANDLE_EOF)
+            // Zero-byte reads
+            if (errorCode == UnsafeNclNativeMethods.ErrorCodes.ERROR_MORE_DATA && asyncResult._size == 0)
+            {
+                // numBytes returns 1 to let us know there's data available. Don't count it against the request body size yet.
+                asyncResult.Complete(0, errorCode);
+            }
+            else if (errorCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS && errorCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_HANDLE_EOF)
             {
                 asyncResult.Fail(new IOException(string.Empty, new HttpSysException((int)errorCode)));
             }

--- a/src/Servers/HttpSys/test/FunctionalTests/RequestBodyTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/RequestBodyTests.cs
@@ -40,6 +40,28 @@ public class RequestBodyTests
     }
 
     [ConditionalFact]
+    public async Task RequestBody_Read0ByteSync_Success()
+    {
+        string address;
+        using (Utilities.CreateHttpServer(out address, httpContext =>
+        {
+            Assert.True(httpContext.Request.CanHaveBody());
+            byte[] input = new byte[100];
+            httpContext.Features.Get<IHttpBodyControlFeature>().AllowSynchronousIO = true;
+            int read = httpContext.Request.Body.Read(input, 0, 0);
+            Assert.Equal(0, read);
+            read = httpContext.Request.Body.Read(input, 0, input.Length);
+            httpContext.Response.ContentLength = read;
+            httpContext.Response.Body.Write(input, 0, read);
+            return Task.FromResult(0);
+        }))
+        {
+            string response = await SendRequestAsync(address, "Hello World");
+            Assert.Equal("Hello World", response);
+        }
+    }
+
+    [ConditionalFact]
     public async Task RequestBody_ReadAsync_Success()
     {
         string address;
@@ -50,6 +72,29 @@ public class RequestBodyTests
             int read = await httpContext.Request.Body.ReadAsync(input, 0, input.Length);
             httpContext.Response.ContentLength = read;
             await httpContext.Response.Body.WriteAsync(input, 0, read);
+        }))
+        {
+            string response = await SendRequestAsync(address, "Hello World");
+            Assert.Equal("Hello World", response);
+        }
+    }
+
+    [ConditionalFact]
+    public async Task RequestBody_Read0ByteAsync_Success()
+    {
+        string address;
+        using (Utilities.CreateHttpServer(out address, async httpContext =>
+        {
+            Assert.True(httpContext.Request.CanHaveBody());
+            byte[] input = new byte[100];
+            await Task.Delay(1000);
+            int read = await httpContext.Request.Body.ReadAsync(input, 0, 1);
+            Assert.Equal(1, read);
+            read = await httpContext.Request.Body.ReadAsync(input, 0, 0);
+            Assert.Equal(0, read);
+            read = await httpContext.Request.Body.ReadAsync(input, 1, input.Length - 1);
+            httpContext.Response.ContentLength = read + 1;
+            await httpContext.Response.Body.WriteAsync(input, 0, read + 1);
         }))
         {
             string response = await SendRequestAsync(address, "Hello World");
@@ -87,7 +132,6 @@ public class RequestBodyTests
             Assert.Throws<ArgumentOutOfRangeException>("offset", () => httpContext.Request.Body.Read(input, -1, 1));
             Assert.Throws<ArgumentOutOfRangeException>("offset", () => httpContext.Request.Body.Read(input, input.Length + 1, 1));
             Assert.Throws<ArgumentOutOfRangeException>("size", () => httpContext.Request.Body.Read(input, 10, -1));
-            Assert.Throws<ArgumentOutOfRangeException>("size", () => httpContext.Request.Body.Read(input, 0, 0));
             Assert.Throws<ArgumentOutOfRangeException>("size", () => httpContext.Request.Body.Read(input, 1, input.Length));
             Assert.Throws<ArgumentOutOfRangeException>("size", () => httpContext.Request.Body.Read(input, 0, input.Length + 1));
             return Task.FromResult(0);

--- a/src/Servers/HttpSys/test/FunctionalTests/RequestBodyTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/RequestBodyTests.cs
@@ -87,14 +87,11 @@ public class RequestBodyTests
         {
             Assert.True(httpContext.Request.CanHaveBody());
             byte[] input = new byte[100];
-            await Task.Delay(1000);
-            int read = await httpContext.Request.Body.ReadAsync(input, 0, 1);
-            Assert.Equal(1, read);
-            read = await httpContext.Request.Body.ReadAsync(input, 0, 0);
+            int read = await httpContext.Request.Body.ReadAsync(input, 0, 0);
             Assert.Equal(0, read);
-            read = await httpContext.Request.Body.ReadAsync(input, 1, input.Length - 1);
-            httpContext.Response.ContentLength = read + 1;
-            await httpContext.Response.Body.WriteAsync(input, 0, read + 1);
+            read = await httpContext.Request.Body.ReadAsync(input, 0, input.Length);
+            httpContext.Response.ContentLength = read;
+            await httpContext.Response.Body.WriteAsync(input, 0, read);
         }))
         {
             string response = await SendRequestAsync(address, "Hello World");


### PR DESCRIPTION
Contributes to #41305

When passed a zero-byte buffer Http.Sys returns ERROR_MORE_DATA. We need to handle this specially. I also had to change the argument validation.

Perf impact:
- zero-byte reads to Http.Sys always complete async, even when data is available and a normal read could complete sync. This adds latency to the request.
- Setup: Upload a 20mb request body using a 16k read buffer.
  - No zero-byte read: 65ms
  - With zero-byte reads: 105ms.