### PR TITLE
Throw BadHttpRequestException for non-ASCII in absolute-form targets

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
@@ -212,6 +212,15 @@ public class BadHttpRequestTests : LoggedTest
         }
     }
 
+    [Fact]
+    public Task BadRequestForAbsoluteFormTargetWithNonAsciiChars()
+    {
+        return TestBadRequest(
+            $"GET http://localhost/ÿÿÿ HTTP/1.1\r\n",
+            "400 Bad Request",
+            CoreStrings.FormatBadRequest_InvalidRequestTarget_Detail("http://localhost/\\xFF\\xFF\\xFF"));
+    }
+
     private class BadRequestEventListener : IObserver<KeyValuePair<string, object>>, IDisposable
     {
         private IDisposable _subscription;


### PR DESCRIPTION
Fix #41071

This change makes it so that when non-ASCII chars are included with absolute-form targets, we show a meaningful `BadHttpRequestException` instead of an opaque `InvalidOperationException: Operation is not valid due to the current state of the object.`

After this change, `GET http://127.0.0.1:5000/ÿÿÿÿÿÿÿÿÿÿÿ HTTP/1.1` will result in this:

```
      Connection id "0HMH4OCKNS0RO" bad request data: "Invalid request target: 'http://127.0.0.1:5000/\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'"
      Microsoft.AspNetCore.Server.Kestrel.Core.BadHttpRequestException: Invalid request target: 'http://127.0.0.1:5000/\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.Http1Connection.OnAbsoluteFormTarget(TargetOffsetPathLength targetPath, Span`1 target) in C:\code\aspnetcore\src\Servers\Kestrel\Core\src\Internal\Http\Http1Connection.cs:line 527
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.Http1Connection.OnStartLine(HttpVersionAndMethod versionAndMethod, TargetOffsetPathLength targetPath, Span`1 startLine) in C:\code\aspnetcore\src\Servers\Kestrel\Core\src\Internal\Http\Http1Connection.cs:line 286
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.Http1ParsingHandler.OnStartLine(HttpVersionAndMethod versionAndMethod, TargetOffsetPathLength targetPath, Span`1 startLine) in C:\code\aspnetcore\src\Servers\Kestrel\Core\src\Internal\Http\Http1ParsingHandler.cs:line 48
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpParser`1.ParseRequestLine(TRequestHandler handler, ReadOnlySpan`1 requestLine) in C:\code\aspnetcore\src\Servers\Kestrel\Core\src\Internal\Http\HttpParser.cs:line 164
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpParser`1.ParseRequestLine(TRequestHandler handler, SequenceReader`1& reader) in C:\code\aspnetcore\src\Servers\Kestrel\Core\src\Internal\Http\HttpParser.cs:line 68
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.Http1Connection.TakeStartLine(SequenceReader`1& reader) in C:\code\aspnetcore\src\Servers\Kestrel\Core\src\Internal\Http\Http1Connection.cs:line 196
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.Http1Connection.ParseRequest(SequenceReader`1& reader) in C:\code\aspnetcore\src\Servers\Kestrel\Core\src\Internal\Http\Http1Connection.cs:line 164
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.Http1Connection.TryParseRequest(ReadResult result, Boolean& endConnection) in C:\code\aspnetcore\src\Servers\Kestrel\Core\src\Internal\Http\Http1Connection.cs:line 679
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application) in C:\code\aspnetcore\src\Servers\Kestrel\Core\src\Internal\Http\HttpProtocol.cs:line 639
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequestsAsync[TContext](IHttpApplication`1 application) in C:\code\aspnetcore\src\Servers\Kestrel\Core\src\Internal\Http\HttpProtocol.cs:line 564
```