### PR TITLE
Reduce invocation allocations

### DIFF
--- a/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs
+++ b/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs
@@ -174,15 +174,16 @@ public sealed class JsonHubProtocol : IHubProtocol
                                     $"Expected '{StreamIdsPropertyName}' to be of type {SystemTextJsonExtensions.GetTokenString(JsonTokenType.StartArray)}.");
                             }
 
-                            var newStreamIds = new List<string>();
+                            List<string>? newStreamIds = null;
                             reader.Read();
                             while (reader.TokenType != JsonTokenType.EndArray)
                             {
+                                newStreamIds ??= new();
                                 newStreamIds.Add(reader.GetString() ?? throw new InvalidDataException($"Null value for '{StreamIdsPropertyName}' is not valid."));
                                 reader.Read();
                             }
 
-                            streamIds = newStreamIds.ToArray();
+                            streamIds = newStreamIds?.ToArray() ?? Array.Empty<string>();
                         }
                         else if (reader.ValueTextEquals(TargetPropertyNameBytes.EncodedUtf8Bytes))
                         {

--- a/src/SignalR/common/Protocols.NewtonsoftJson/src/Protocol/NewtonsoftJsonHubProtocol.cs
+++ b/src/SignalR/common/Protocols.NewtonsoftJson/src/Protocol/NewtonsoftJsonHubProtocol.cs
@@ -176,15 +176,16 @@ public class NewtonsoftJsonHubProtocol : IHubProtocol
                                         throw new InvalidDataException($"Expected '{StreamIdsPropertyName}' to be of type {JTokenType.Array}.");
                                     }
 
-                                    var newStreamIds = new List<string>();
+                                    List<string>? newStreamIds = null;
                                     reader.Read();
                                     while (reader.TokenType != JsonToken.EndArray)
                                     {
+                                        newStreamIds ??= new();
                                         newStreamIds.Add(reader.Value?.ToString() ?? throw new InvalidDataException($"Null value for '{StreamIdsPropertyName}' is not valid."));
                                         reader.Read();
                                     }
 
-                                    streamIds = newStreamIds.ToArray();
+                                    streamIds = newStreamIds?.ToArray() ?? Array.Empty<string>();
                                     break;
                                 case TargetPropertyName:
                                     target = JsonUtils.ReadAsString(reader, TargetPropertyName);

--- a/src/SignalR/common/SignalR.Common/test/Internal/Protocol/JsonHubProtocolTestsBase.cs
+++ b/src/SignalR/common/SignalR.Common/test/Internal/Protocol/JsonHubProtocolTestsBase.cs
@@ -194,6 +194,18 @@ public abstract class JsonHubProtocolTestsBase
         Assert.Equal(expectedMessage, ex.Message);
     }
 
+    [Fact]
+    public void EmptyStreamIdsDoesNotAllocateNewArray()
+    {
+        var testData = Frame("{\"type\":1,\"target\":\"Target\",\"arguments\":[],\"streamIds\":[]}");
+
+        var binder = new TestBinder(Array.Empty<Type>(), typeof(object));
+        var data = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(testData));
+        JsonHubProtocol.TryParseMessage(ref data, binder, out var message);
+        Assert.IsType<InvocationMessage>(message);
+        Assert.Same(Array.Empty<string>(), (message as InvocationMessage).StreamIds);
+    }
+
     [Theory]
     [MemberData(nameof(OutOfOrderJsonTestDataNames))]
     public void ParseOutOfOrderJson(string outOfOrderJsonTestDataName)


### PR DESCRIPTION
- Today we allocate an empty list of stream ids (both a list an array). This will remove the array allocation for normal invocations.

Contributes to https://github.com/dotnet/aspnetcore/issues/41343