### PR TITLE
release/6.0 port of abort handling

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.IO.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.IO.cs
@@ -162,6 +162,11 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
                     var buffer = result.Buffer;
                     try
                     {
+                        if (_bodyOutput.Aborted)
+                        {
+                            break;
+                        }
+
                         if (!buffer.IsEmpty)
                         {
                             await AsyncIO!.WriteAsync(buffer);

--- a/src/Servers/IIS/IIS/test/IIS.Tests/ResponseAbortTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/ResponseAbortTests.cs
@@ -33,7 +33,6 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests
         }
 
         [ConditionalFact]
-        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/31404")]
         public async Task ClosesAfterDataSent()
         {
             var bodyReceived = CreateTaskCompletionSource();


### PR DESCRIPTION
## Description

This fixes a bug with IIS where Abort would gracefully close a response instead of aborting it.

Backport of https://github.com/dotnet/aspnetcore/pull/41263

## Customer Impact

Clients could see potentially truncated responses instead of being able to tell that the response was aborted abnormally, this is a form of data corruption.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Abort behavior had a test that slowly got to 0% pass rate due to scheduling changes, this change fixes the test

## Verification

- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A