### PR TITLE
Configure Http.sys UrlGroup when CreateOrAttach is specified and the specified UrlPrefixes do not exist

### DIFF
--- a/src/Servers/HttpSys/src/HttpSysListener.cs
+++ b/src/Servers/HttpSys/src/HttpSysListener.cs
@@ -147,10 +147,10 @@ internal partial class HttpSysListener : IDisposable
                     return;
                 }
 
-                // If this instance created the queue then configure it.
-                if (_requestQueue.Created)
+                // Always configure the UrlGroup if the intent was to create, only configure the queue if we actually created it
+                if (Options.RequestQueueMode == RequestQueueMode.Create || Options.RequestQueueMode == RequestQueueMode.CreateOrAttach)
                 {
-                    Options.Apply(UrlGroup, RequestQueue);
+                    Options.Apply(UrlGroup, _requestQueue.Created ? RequestQueue : null);
 
                     _requestQueue.AttachToUrlGroup();
 
@@ -195,7 +195,7 @@ internal partial class HttpSysListener : IDisposable
                 Log.ListenerStopping(Logger);
 
                 // If this instance created the queue then remove the URL prefixes before shutting down.
-                if (_requestQueue.Created)
+                if (Options.RequestQueueMode == RequestQueueMode.Create || Options.RequestQueueMode == RequestQueueMode.CreateOrAttach)
                 {
                     Options.UrlPrefixes.UnregisterAllPrefixes();
                     _requestQueue.DetachFromUrlGroup();

--- a/src/Servers/HttpSys/src/HttpSysListener.cs
+++ b/src/Servers/HttpSys/src/HttpSysListener.cs
@@ -194,7 +194,7 @@ internal partial class HttpSysListener : IDisposable
 
                 Log.ListenerStopping(Logger);
 
-                // If this instance created the queue then remove the URL prefixes before shutting down.
+                // If this instance registered URL prefixes then remove them before shutting down.
                 if (Options.RequestQueueMode == RequestQueueMode.Create || Options.RequestQueueMode == RequestQueueMode.CreateOrAttach)
                 {
                     Options.UrlPrefixes.UnregisterAllPrefixes();

--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -238,7 +238,7 @@ public class HttpSysOptions
     public bool UseLatin1RequestHeaders { get; set; }
 
     // Not called when attaching to an existing queue.
-    internal void Apply(UrlGroup urlGroup, RequestQueue requestQueue)
+    internal void Apply(UrlGroup urlGroup, RequestQueue? requestQueue)
     {
         _urlGroup = urlGroup;
         _requestQueue = requestQueue;
@@ -248,14 +248,17 @@ public class HttpSysOptions
             _urlGroup.SetMaxConnections(_maxConnections.Value);
         }
 
-        if (_requestQueueLength != DefaultRequestQueueLength)
+        if (_requestQueue is not null)
         {
-            _requestQueue.SetLengthLimit(_requestQueueLength);
-        }
+            if (_requestQueueLength != DefaultRequestQueueLength)
+            {
+                _requestQueue.SetLengthLimit(_requestQueueLength);
+            }
 
-        if (_rejectionVebosityLevel != DefaultRejectionVerbosityLevel)
-        {
-            _requestQueue.SetRejectionVerbosity(_rejectionVebosityLevel);
+            if (_rejectionVebosityLevel != DefaultRejectionVerbosityLevel)
+            {
+                _requestQueue.SetRejectionVerbosity(_rejectionVebosityLevel);
+            }
         }
 
         Authentication.SetUrlGroupSecurity(urlGroup);

--- a/src/Servers/HttpSys/src/MessagePump.cs
+++ b/src/Servers/HttpSys/src/MessagePump.cs
@@ -53,7 +53,7 @@ internal partial class MessagePump : IServer
 
         if (HttpApi.SupportsDelegation)
         {
-            var delegationProperty = new ServerDelegationPropertyFeature(Listener.RequestQueue, _logger);
+            var delegationProperty = new ServerDelegationPropertyFeature(Listener.UrlGroup, _logger);
             Features.Set<IServerDelegationFeature>(delegationProperty);
         }
 

--- a/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
@@ -10,26 +10,22 @@ namespace Microsoft.AspNetCore.Server.HttpSys;
 
 internal sealed partial class RequestQueue
 {
-    private static readonly int BindingInfoSize =
-        Marshal.SizeOf<HttpApiTypes.HTTP_BINDING_INFO>();
-
     private readonly RequestQueueMode _mode;
     private readonly ILogger _logger;
     private bool _disposed;
 
     internal RequestQueue(string requestQueueName, ILogger logger)
-        : this(urlGroup: null, requestQueueName, RequestQueueMode.Attach, logger, receiver: true)
+        : this(requestQueueName, RequestQueueMode.Attach, logger, receiver: true)
     {
     }
 
-    internal RequestQueue(UrlGroup urlGroup, string? requestQueueName, RequestQueueMode mode, ILogger logger)
-        : this(urlGroup, requestQueueName, mode, logger, false)
+    internal RequestQueue(string? requestQueueName, RequestQueueMode mode, ILogger logger)
+        : this(requestQueueName, mode, logger, false)
     { }
 
-    private RequestQueue(UrlGroup? urlGroup, string? requestQueueName, RequestQueueMode mode, ILogger logger, bool receiver)
+    private RequestQueue(string? requestQueueName, RequestQueueMode mode, ILogger logger, bool receiver)
     {
         _mode = mode;
-        UrlGroup = urlGroup;
         _logger = logger;
 
         var flags = HttpApiTypes.HTTP_CREATE_REQUEST_QUEUE_FLAG.None;
@@ -105,57 +101,6 @@ internal sealed partial class RequestQueue
 
     internal SafeHandle Handle { get; }
     internal ThreadPoolBoundHandle BoundHandle { get; }
-
-    internal UrlGroup? UrlGroup { get; }
-
-    internal unsafe void AttachToUrlGroup()
-    {
-        if (UrlGroup == null)
-        {
-            throw new NotSupportedException("Can't attach when UrlGroup is null");
-        }
-
-        CheckDisposed();
-        // Set the association between request queue and url group. After this, requests for registered urls will
-        // get delivered to this request queue.
-
-        UrlGroup.Queue = this;
-
-        var info = new HttpApiTypes.HTTP_BINDING_INFO();
-        info.Flags = HttpApiTypes.HTTP_FLAGS.HTTP_PROPERTY_FLAG_PRESENT;
-        info.RequestQueueHandle = Handle.DangerousGetHandle();
-
-        var infoptr = new IntPtr(&info);
-
-        UrlGroup.SetProperty(HttpApiTypes.HTTP_SERVER_PROPERTY.HttpServerBindingProperty,
-            infoptr, (uint)BindingInfoSize);
-    }
-
-    internal unsafe void DetachFromUrlGroup()
-    {
-        if (UrlGroup == null)
-        {
-            throw new NotSupportedException("Can't detach when UrlGroup is null");
-        }
-
-        CheckDisposed();
-        // Break the association between request queue and url group. After this, requests for registered urls
-        // will get 503s.
-        // Note that this method may be called multiple times (Stop() and then Abort()). This
-        // is fine since http.sys allows to set HttpServerBindingProperty multiple times for valid
-        // Url groups.
-
-        UrlGroup.Queue = null;
-
-        var info = new HttpApiTypes.HTTP_BINDING_INFO();
-        info.Flags = HttpApiTypes.HTTP_FLAGS.NONE;
-        info.RequestQueueHandle = IntPtr.Zero;
-
-        var infoptr = new IntPtr(&info);
-
-        UrlGroup.SetProperty(HttpApiTypes.HTTP_SERVER_PROPERTY.HttpServerBindingProperty,
-            infoptr, (uint)BindingInfoSize, throwOnError: false);
-    }
 
     // The listener must be active for this to work.
     internal unsafe void SetLengthLimit(long length)

--- a/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/RequestQueue.cs
@@ -115,10 +115,11 @@ internal sealed partial class RequestQueue
             throw new NotSupportedException("Can't attach when UrlGroup is null");
         }
 
-        Debug.Assert(Created);
         CheckDisposed();
         // Set the association between request queue and url group. After this, requests for registered urls will
         // get delivered to this request queue.
+
+        UrlGroup.Queue = this;
 
         var info = new HttpApiTypes.HTTP_BINDING_INFO();
         info.Flags = HttpApiTypes.HTTP_FLAGS.HTTP_PROPERTY_FLAG_PRESENT;
@@ -137,13 +138,14 @@ internal sealed partial class RequestQueue
             throw new NotSupportedException("Can't detach when UrlGroup is null");
         }
 
-        Debug.Assert(Created);
         CheckDisposed();
         // Break the association between request queue and url group. After this, requests for registered urls
         // will get 503s.
         // Note that this method may be called multiple times (Stop() and then Abort()). This
         // is fine since http.sys allows to set HttpServerBindingProperty multiple times for valid
         // Url groups.
+
+        UrlGroup.Queue = null;
 
         var info = new HttpApiTypes.HTTP_BINDING_INFO();
         info.Flags = HttpApiTypes.HTTP_FLAGS.NONE;

--- a/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
@@ -166,14 +166,12 @@ internal partial class UrlGroup : IDisposable
         }
     }
 
-    internal bool UnregisterPrefix(string uriPrefix)
+    internal void UnregisterPrefix(string uriPrefix)
     {
         Log.UnregisteringPrefix(_logger, uriPrefix);
         CheckDisposed();
 
-        var statusCode = HttpApi.HttpRemoveUrlFromUrlGroup(Id, uriPrefix, 0);
-
-        return statusCode == UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS;
+        HttpApi.HttpRemoveUrlFromUrlGroup(Id, uriPrefix, 0);
     }
 
     public void Dispose()

--- a/src/Servers/HttpSys/src/ServerDelegationPropertyFeature.cs
+++ b/src/Servers/HttpSys/src/ServerDelegationPropertyFeature.cs
@@ -10,9 +10,9 @@ internal class ServerDelegationPropertyFeature : IServerDelegationFeature
     private readonly ILogger _logger;
     private readonly UrlGroup _urlGroup;
 
-    public ServerDelegationPropertyFeature(UrlGroup urlGroup!!, ILogger logger)
+    public ServerDelegationPropertyFeature(UrlGroup urlGroup, ILogger logger)
     {
-        _urlGroup = urlGroup;
+        _urlGroup = urlGroup ?? throw new ArgumentNullException(nameof(urlGroup));
         _logger = logger;
     }
 

--- a/src/Servers/HttpSys/src/ServerDelegationPropertyFeature.cs
+++ b/src/Servers/HttpSys/src/ServerDelegationPropertyFeature.cs
@@ -10,14 +10,9 @@ internal class ServerDelegationPropertyFeature : IServerDelegationFeature
     private readonly ILogger _logger;
     private readonly UrlGroup _urlGroup;
 
-    public ServerDelegationPropertyFeature(RequestQueue queue, ILogger logger)
+    public ServerDelegationPropertyFeature(UrlGroup urlGroup!!, ILogger logger)
     {
-        if (queue.UrlGroup == null)
-        {
-            throw new ArgumentException($"{nameof(queue)}.UrlGroup can't be null");
-        }
-
-        _urlGroup = queue.UrlGroup;
+        _urlGroup = urlGroup;
         _logger = logger;
     }
 

--- a/src/Servers/HttpSys/test/FunctionalTests/DelegateTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/DelegateTests.cs
@@ -227,9 +227,7 @@ public class DelegateTests
         // Stop the receiver
         receiver?.Dispose();
 
-        // Start the receiver again but this time we need to attach to the existing queue.
-        // Due to https://github.com/dotnet/aspnetcore/issues/40359, we have to manually
-        // register URL prefixes and attach the server's queue to them.
+        // Start the receiver again but this time we need to use CreateOrAttach to attach to the existing queue and setup the UrlPrefixes
         using var receiverRestarted = (MessagePump)Utilities.CreateHttpServer(out receiverAddress, async httpContext =>
         {
             await httpContext.Response.WriteAsync(_expectedResponseString);
@@ -237,29 +235,15 @@ public class DelegateTests
         options =>
         {
             options.RequestQueueName = queueName;
-            options.RequestQueueMode = RequestQueueMode.Attach;
+            options.RequestQueueMode = RequestQueueMode.CreateOrAttach;
             options.UrlPrefixes.Clear();
             options.UrlPrefixes.Add(receiverAddress);
         });
-        AttachToUrlGroup(receiverRestarted.Listener.RequestQueue);
-        receiverRestarted.Listener.Options.UrlPrefixes.RegisterAllPrefixes(receiverRestarted.Listener.UrlGroup);
 
         responseString = await SendRequestAsync(delegatorAddress);
         Assert.Equal(_expectedResponseString, responseString);
 
         destination?.Dispose();
-    }
-
-    private unsafe void AttachToUrlGroup(RequestQueue requestQueue)
-    {
-        var info = new HttpApiTypes.HTTP_BINDING_INFO();
-        info.Flags = HttpApiTypes.HTTP_FLAGS.HTTP_PROPERTY_FLAG_PRESENT;
-        info.RequestQueueHandle = requestQueue.Handle.DangerousGetHandle();
-
-        var infoptr = new IntPtr(&info);
-
-        requestQueue.UrlGroup.SetProperty(HttpApiTypes.HTTP_SERVER_PROPERTY.HttpServerBindingProperty,
-            infoptr, (uint)Marshal.SizeOf<HttpApiTypes.HTTP_BINDING_INFO>());
     }
 
     private async Task<string> SendRequestAsync(string uri)

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/AuthenticationOnExistingQueueTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/AuthenticationOnExistingQueueTests.cs
@@ -10,7 +10,37 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Server.HttpSys.Listener;
 
-public class AuthenticationOnExistingQueueTests
+public class AuthenticationOnExistingQueueTests_Attach : AuthenticationOnExistingQueueTests
+{
+    protected override string ConfigureServer(HttpSysOptions options, string baseServerAddress)
+    {
+        options.RequestQueueMode = RequestQueueMode.Attach;
+        return baseServerAddress;
+    }
+}
+
+public class AuthenticationOnExistingQueueTests_CreateOrAttach_UseExistingUrlPrefix : AuthenticationOnExistingQueueTests
+{
+    protected override string ConfigureServer(HttpSysOptions options, string baseServerAddress)
+    {
+        options.RequestQueueMode = RequestQueueMode.CreateOrAttach;
+        return baseServerAddress;
+    }
+}
+
+public class AuthenticationOnExistingQueueTests_CreateOrAttach_UseNewUrlPrefix : AuthenticationOnExistingQueueTests
+{
+    protected override string ConfigureServer(HttpSysOptions options, string baseServerAddress)
+    {
+        options.RequestQueueMode = RequestQueueMode.CreateOrAttach;
+        var basePrefix = UrlPrefix.Create(baseServerAddress);
+        var prefix = UrlPrefix.Create(basePrefix.Scheme, basePrefix.Host, basePrefix.Port, "/server");
+        options.UrlPrefixes.Add(prefix);
+        return prefix.ToString();
+    }
+}
+
+public abstract class AuthenticationOnExistingQueueTests
 {
     private static readonly bool AllowAnoymous = true;
     private static readonly bool DenyAnoymous = false;
@@ -24,8 +54,8 @@ public class AuthenticationOnExistingQueueTests
     [InlineData(AuthenticationSchemes.Negotiate | AuthenticationSchemes.NTLM | /*AuthenticationSchemes.Digest |*/ AuthenticationSchemes.Basic)]
     public async Task AuthTypes_AllowAnonymous_NoChallenge(AuthenticationSchemes authType)
     {
-        using var baseServer = Utilities.CreateHttpAuthServer(authType, AllowAnoymous, out var address);
-        using var server = Utilities.CreateServerOnExistingQueue(authType, AllowAnoymous, baseServer.Options.RequestQueueName);
+        using var baseServer = CreateHttpAuthServer(authType, AllowAnoymous);
+        using var server = CreateServerOnExistingQueue(authType, AllowAnoymous, baseServer, out var address);
 
         Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
@@ -47,8 +77,8 @@ public class AuthenticationOnExistingQueueTests
     [InlineData(AuthenticationSchemes.Basic)]
     public async Task AuthType_RequireAuth_ChallengesAdded(AuthenticationSchemes authType)
     {
-        using var baseServer = Utilities.CreateHttpAuthServer(authType, DenyAnoymous, out var address);
-        using var server = Utilities.CreateServerOnExistingQueue(authType, DenyAnoymous, baseServer.Options.RequestQueueName);
+        using var baseServer = CreateHttpAuthServer(authType, DenyAnoymous);
+        using var server = CreateServerOnExistingQueue(authType, DenyAnoymous, baseServer, out var address);
 
         Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
@@ -65,8 +95,8 @@ public class AuthenticationOnExistingQueueTests
     [InlineData(AuthenticationSchemes.Basic)]
     public async Task AuthType_AllowAnonymousButSpecify401_ChallengesAdded(AuthenticationSchemes authType)
     {
-        using var baseServer = Utilities.CreateHttpAuthServer(authType, AllowAnoymous, out var address);
-        using var server = Utilities.CreateServerOnExistingQueue(authType, AllowAnoymous, baseServer.Options.RequestQueueName);
+        using var baseServer = CreateHttpAuthServer(authType, AllowAnoymous);
+        using var server = CreateServerOnExistingQueue(authType, AllowAnoymous, baseServer, out var address);
 
         Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
@@ -90,8 +120,8 @@ public class AuthenticationOnExistingQueueTests
             | AuthenticationSchemes.NTLM
             /* | AuthenticationSchemes.Digest TODO: Not implemented */
             | AuthenticationSchemes.Basic;
-        using var baseServer = Utilities.CreateHttpAuthServer(authType, AllowAnoymous, out var address);
-        using var server = Utilities.CreateServerOnExistingQueue(authType, AllowAnoymous, baseServer.Options.RequestQueueName);
+        using var baseServer = CreateHttpAuthServer(authType, AllowAnoymous);
+        using var server = CreateServerOnExistingQueue(authType, AllowAnoymous, baseServer, out var address);
 
         Task<HttpResponseMessage> responseTask = SendRequestAsync(address);
 
@@ -115,8 +145,8 @@ public class AuthenticationOnExistingQueueTests
     [InlineData(AuthenticationSchemes.Negotiate | AuthenticationSchemes.NTLM | /*AuthenticationType.Digest |*/ AuthenticationSchemes.Basic)]
     public async Task AuthTypes_AllowAnonymousButSpecify401_Success(AuthenticationSchemes authType)
     {
-        using var baseServer = Utilities.CreateHttpAuthServer(authType, AllowAnoymous, out var address);
-        using var server = Utilities.CreateServerOnExistingQueue(authType, AllowAnoymous, baseServer.Options.RequestQueueName);
+        using var baseServer = CreateHttpAuthServer(authType, AllowAnoymous);
+        using var server = CreateServerOnExistingQueue(authType, AllowAnoymous, baseServer, out var address);
 
         Task<HttpResponseMessage> responseTask = SendRequestAsync(address, useDefaultCredentials: true);
 
@@ -145,8 +175,8 @@ public class AuthenticationOnExistingQueueTests
     [InlineData(AuthenticationSchemes.Negotiate | AuthenticationSchemes.NTLM | /*AuthenticationType.Digest |*/ AuthenticationSchemes.Basic)]
     public async Task AuthTypes_RequireAuth_Success(AuthenticationSchemes authType)
     {
-        using var baseServer = Utilities.CreateHttpAuthServer(authType, DenyAnoymous, out var address);
-        using var server = Utilities.CreateServerOnExistingQueue(authType, DenyAnoymous, baseServer.Options.RequestQueueName);
+        using var baseServer = CreateHttpAuthServer(authType, DenyAnoymous);
+        using var server = CreateServerOnExistingQueue(authType, DenyAnoymous, baseServer, out var address);
 
         Task<HttpResponseMessage> responseTask = SendRequestAsync(address, useDefaultCredentials: true);
 
@@ -158,6 +188,32 @@ public class AuthenticationOnExistingQueueTests
 
         var response = await responseTask;
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    protected abstract string ConfigureServer(HttpSysOptions options, string baseServerAddress);
+
+    private HttpSysListener CreateHttpAuthServer(AuthenticationSchemes authType, bool allowAnonymous)
+    {
+        var server = Utilities.CreateDynamicHttpServer("/baseServer", out var root, out var baseAddress);
+        server.Options.Authentication.Schemes = authType;
+        server.Options.Authentication.AllowAnonymous = allowAnonymous;
+        return server;
+    }
+
+    private HttpSysListener CreateServerOnExistingQueue(AuthenticationSchemes authScheme, bool allowAnonymos, HttpSysListener baseServer, out string address)
+    {
+        string serverAddress = null;
+        var baseServerAddress = baseServer.Options.UrlPrefixes.First().ToString();
+        var server = Utilities.CreateServer(options =>
+        {
+            options.RequestQueueName = baseServer.Options.RequestQueueName;
+            options.Authentication.Schemes = authScheme;
+            options.Authentication.AllowAnonymous = allowAnonymos;
+            serverAddress = ConfigureServer(options, baseServerAddress);
+        });
+
+        address = serverAddress;
+        return server;
     }
 
     private async Task<HttpResponseMessage> SendRequestAsync(string uri, bool useDefaultCredentials = false)

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/ServerOnExistingQueueTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/ServerOnExistingQueueTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.HttpSys.Internal;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
@@ -226,6 +227,88 @@ public class ServerOnExistingQueueTests
         context = await server.AcceptAsync(Utilities.DefaultTimeout).Before(responseTask);
         Assert.Equal(string.Empty, context.Request.PathBase);
         Assert.Equal("/pathbase/", context.Request.Path);
+        context.Dispose();
+
+        response = await responseTask;
+        Assert.Equal(string.Empty, response);
+    }
+
+    [ConditionalFact]
+    public async Task Server_CreateOrAttach_NoUrlPrefix_NewUrlPrefixWorks()
+    {
+        var queueName = Guid.NewGuid().ToString();
+
+        // Create a queue without a UrlGroup or any UrlPrefixes
+        HttpRequestQueueV2Handle requestQueueHandle = null;
+        var statusCode = HttpApi.HttpCreateRequestQueue(
+                HttpApi.Version,
+                queueName,
+                null,
+                0,
+                out requestQueueHandle);
+
+        Assert.True(statusCode == UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS);
+
+        using var server = Utilities.CreateServer(options =>
+        {
+            options.RequestQueueName = queueName;
+            options.RequestQueueMode = RequestQueueMode.CreateOrAttach;
+            options.UrlPrefixes.Add("http://localhost:0");
+        });
+
+        var address = server.Options.UrlPrefixes.First().FullPrefix;
+
+        var responseTask = SendRequestAsync(address);
+
+        var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+        context.Dispose();
+
+        var response = await responseTask;
+        Assert.Equal(string.Empty, response);
+    }
+
+    [ConditionalFact]
+    public async Task Server_CreateOrAttach_UrlPrefixExist_ExistingUrlPrefixWorks()
+    {
+        using var baseServer = Utilities.CreateHttpServer(out var address);
+        using var server = Utilities.CreateServer(options =>
+        {
+            options.RequestQueueName = baseServer.Options.RequestQueueName;
+            options.RequestQueueMode = RequestQueueMode.CreateOrAttach;
+            options.UrlPrefixes.Add(address);
+        });
+
+        var responseTask = SendRequestAsync(address);
+
+        var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+        context.Dispose();
+
+        var response = await responseTask;
+        Assert.Equal(string.Empty, response);
+    }
+
+    [ConditionalFact]
+    public async Task Server_CreateOrAttach_UrlPrefixExist_NewAndExistingUrlPrefixsWork()
+    {
+        using var baseServer = Utilities.CreateHttpServerReturnRoot("/baseServer", out string rootAddress);
+        using var server = Utilities.CreateServer(options =>
+        {
+            options.RequestQueueName = baseServer.Options.RequestQueueName;
+            options.RequestQueueMode = RequestQueueMode.CreateOrAttach;
+            options.UrlPrefixes.Add(rootAddress + "/server");
+        });
+
+        var responseTask = SendRequestAsync(rootAddress + "/baseServer");
+
+        var context = await server.AcceptAsync(Utilities.DefaultTimeout);
+        context.Dispose();
+
+        var response = await responseTask;
+        Assert.Equal(string.Empty, response);
+
+        responseTask = SendRequestAsync(rootAddress + "/server");
+
+        context = await server.AcceptAsync(Utilities.DefaultTimeout);
         context.Dispose();
 
         response = await responseTask;

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/Utilities.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/Utilities.cs
@@ -22,14 +22,6 @@ internal static class Utilities
 
     internal static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(15);
 
-    internal static HttpSysListener CreateHttpAuthServer(AuthenticationSchemes authType, bool allowAnonymous, out string baseAddress)
-    {
-        var listener = CreateHttpServer(out baseAddress);
-        listener.Options.Authentication.Schemes = authType;
-        listener.Options.Authentication.AllowAnonymous = allowAnonymous;
-        return listener;
-    }
-
     internal static HttpSysListener CreateHttpServer(out string baseAddress)
     {
         string root;
@@ -90,21 +82,24 @@ internal static class Utilities
         return listener;
     }
 
-    internal static HttpSysListener CreateServerOnExistingQueue(string requestQueueName)
-    {
-        return CreateServerOnExistingQueue(AuthenticationSchemes.None, true, requestQueueName);
-    }
-
-    internal static HttpSysListener CreateServerOnExistingQueue(AuthenticationSchemes authScheme, bool allowAnonymos, string requestQueueName)
+    internal static HttpSysListener CreateServer(Action<HttpSysOptions> configureOptions)
     {
         var options = new HttpSysOptions();
-        options.RequestQueueMode = RequestQueueMode.Attach;
-        options.RequestQueueName = requestQueueName;
-        options.Authentication.Schemes = authScheme;
-        options.Authentication.AllowAnonymous = allowAnonymos;
+        configureOptions(options);
         var listener = new HttpSysListener(options, new LoggerFactory());
         listener.Start();
         return listener;
+    }
+
+    internal static HttpSysListener CreateServerOnExistingQueue(string requestQueueName)
+    {
+        return CreateServer(options =>
+        {
+            options.RequestQueueName = requestQueueName;
+            options.RequestQueueMode = RequestQueueMode.Attach;
+            options.Authentication.Schemes = AuthenticationSchemes.None;
+            options.Authentication.AllowAnonymous = true;
+        });
     }
 
     /// <summary>

--- a/src/Servers/HttpSys/test/FunctionalTests/Listener/Utilities.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/Listener/Utilities.cs
@@ -97,8 +97,6 @@ internal static class Utilities
         {
             options.RequestQueueName = requestQueueName;
             options.RequestQueueMode = RequestQueueMode.Attach;
-            options.Authentication.Schemes = AuthenticationSchemes.None;
-            options.Authentication.AllowAnonymous = true;
         });
     }
 


### PR DESCRIPTION
This change ensures any specified UrlPrefixes are properly configured when RequestQueueMode.CreateOrAttach is specified and the queue already exists. Before this change, if the queue exists, any specified prefixes are ignored and we assumed the process which created the queue already set up the prefixes. This may not always be the case (e.g. in the queue delegation scenario) so this change always tries to register the specified prefixes but ignores errors if the prefix was already setup for the queue. 

As part of this change, I also reversed the relationship between UrlGroup and RequestQueue. Previously RequestQueue had a reference to UrlGroup. I changed it so that UrlGroup references a RequestQueue. This makes more sense with how http.sys works (multiple UrlGroups can be linked to a RequestQueue but a UrlGroup can only be linked to one RequestQueue). This also made the code with my changes cleaner. 

Fixes #40359 
