### PR TITLE
Remove allocations in ValueTask<object> and Task<object> codepaths

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -1718,53 +1718,46 @@ public static partial class RequestDelegateFactory
         return ExecuteAwaited(task, httpContext);
     }
 
-    private static async Task ExecuteObjectReturn(object obj, HttpContext httpContext)
+    private static Task ExecuteObjectReturn(object obj, HttpContext httpContext)
     {
         if (obj is Task<object> taskObj)
         {
-            await ExecuteTaskOfObject(taskObj, httpContext);
-            return;
+            return ExecuteTaskOfObject(taskObj, httpContext);
         }
         else if (obj is ValueTask<object> valueTaskObj)
         {
-            await ExecuteValueTaskOfObject(valueTaskObj, httpContext);
-            return;
+            return ExecuteValueTaskOfObject(valueTaskObj, httpContext);
         }
         else if (obj is Task<IResult?> task)
         {
-            await ExecuteTaskResult(task, httpContext);
-            return;
+            return ExecuteTaskResult(task, httpContext);
         }
         else if (obj is ValueTask<IResult?> valueTask)
         {
-            await ExecuteValueTaskResult(valueTask, httpContext);
-            return;
+            return ExecuteValueTaskResult(valueTask, httpContext);
         }
         else if (obj is Task<string?> taskString)
         {
-            await ExecuteTaskOfString(taskString, httpContext);
-            return;
-        }
+            return ExecuteTaskOfString(taskString, httpContext);        }
         else if (obj is ValueTask<string?> valueTaskString)
         {
-            await ExecuteValueTaskOfString(valueTaskString, httpContext);
-            return;
+            return ExecuteValueTaskOfString(valueTaskString, httpContext);
         }
         // Terminal built ins
         else if (obj is IResult result)
         {
-            await ExecuteResultWriteResponse(result, httpContext);
+            return ExecuteResultWriteResponse(result, httpContext);
         }
         else if (obj is string stringValue)
         {
             SetPlaintextContentType(httpContext);
-            await httpContext.Response.WriteAsync(stringValue);
+            return httpContext.Response.WriteAsync(stringValue);
         }
         else
         {
             // Otherwise, we JSON serialize when we reach the terminal state
             // Call WriteAsJsonAsync<object?>() to serialize the runtime return type rather than the declared return type.
-            await httpContext.Response.WriteAsJsonAsync<object?>(obj);
+            return httpContext.Response.WriteAsJsonAsync<object?>(obj);
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/41376.

The boxing that was previously occurring in this codepath had a particularly bad effect on the filter pipeline which exclusively used `ValueTask<object>` as the response time. Refactoring the code a bit to remove these allocations.

Validated allocations on the following test app:

```csharp
var builder = WebApplication.CreateBuilder(args);

var app = builder.Build();

if (app.Environment.IsDevelopment())
{
    app.UseDeveloperExceptionPage();
}

string Plaintext() => "Hello, World!";
app.MapGet("/plaintext", Plaintext).AddFilter((c, n) => n(c));

app.Run();
```

With the following invocation:

```ps
1..1000 | % { curl http://localhost:5000/plaintext }
```

**Allocation Profile (With Change)**
[trace-with-fix.zip](https://github.com/dotnet/aspnetcore/files/8567184/trace-with-fix.zip)

|Type|Allocations|Bytes|
|-|-|-|
| - Microsoft.AspNetCore.Http.RequestDelegateFactory.\<ExecuteObjectReturn\>d\_\_98|1,000|168,000|
| - Microsoft.AspNetCore.Http.RouteHandlerInvocationContext|1,000|32,000|

**Allocation Profile (Without Change)**
[trace-without-fix.zip](https://github.com/dotnet/aspnetcore/files/8567191/trace-without-fix.zip)

|Type|Allocations|Bytes|
|-|-|-|
| - Microsoft.AspNetCore.Http.RequestDelegateFactory.\<ExecuteObjectReturn\>d\_\_94|1,000|216,000|
| - System.Threading.Tasks.ValueTask\<System.Object\>|1,000|40,000|
| - Microsoft.AspNetCore.Http.RouteHandlerInvocationContext|1,000|32,000|
