### PR TITLE
Fix MapPath and UsePathBase's use of implicit PathStrings

### DIFF
--- a/src/Http/Http.Abstractions/src/Extensions/MapMiddleware.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/MapMiddleware.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Builder.Extensions
             return _next(context);
         }
 
-        private async Task InvokeCore(HttpContext context, string matchedPath, string remainingPath)
+        private async Task InvokeCore(HttpContext context, PathString matchedPath, PathString remainingPath)
         {
             var path = context.Request.Path;
             var pathBase = context.Request.PathBase;

--- a/src/Http/Http.Abstractions/src/Extensions/UsePathBaseExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/UsePathBaseExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Builder
             }
 
             // Strip trailing slashes
-            pathBase = pathBase.Value?.TrimEnd('/');
+            pathBase = new PathString(pathBase.Value?.TrimEnd('/'));
             if (!pathBase.HasValue)
             {
                 return app;

--- a/src/Http/Http.Abstractions/src/Extensions/UsePathBaseMiddleware.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/UsePathBaseMiddleware.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Builder.Extensions
             return _next(context);
         }
 
-        private async Task InvokeCore(HttpContext context, string matchedPath, string remainingPath)
+        private async Task InvokeCore(HttpContext context, PathString matchedPath, PathString remainingPath)
         {
             var originalPath = context.Request.Path;
             var originalPathBase = context.Request.PathBase;

--- a/src/Http/Http.Abstractions/test/UsePathBaseExtensionsTests.cs
+++ b/src/Http/Http.Abstractions/test/UsePathBaseExtensionsTests.cs
@@ -131,11 +131,23 @@ namespace Microsoft.AspNetCore.Builder.Extensions
             return TestPathBase(registeredPathBase, pathBase, requestPath, expectedPathBase, expectedPath);
         }
 
+        [Theory]
+        [InlineData("/b%42", "", "/b%42/something%42", "/b%42", "/something%42")]
+        [InlineData("/b%42", "", "/B%42/something%42", "/B%42", "/something%42")]
+        [InlineData("/b%42", "", "/b%42/Something%42", "/b%42", "/Something%42")]
+        [InlineData("/b%42", "/oldb%42", "/b%42/something%42", "/oldb%42/b%42", "/something%42")]
+        [InlineData("/b%42", "/oldb%42", "/b%42/Something%42", "/oldb%42/b%42", "/Something%42")]
+        [InlineData("/b%42", "/oldb%42", "/B%42/something%42", "/oldb%42/B%42", "/something%42")]
+        public Task PathBaseCanHavePercentCharacters(string registeredPathBase, string pathBase, string requestPath, string expectedPathBase, string expectedPath)
+        {
+            return TestPathBase(registeredPathBase, pathBase, requestPath, expectedPathBase, expectedPath);
+        }
+
         private static async Task TestPathBase(string registeredPathBase, string pathBase, string requestPath, string expectedPathBase, string expectedPath)
         {
             HttpContext requestContext = CreateRequest(pathBase, requestPath);
             var builder = CreateBuilder()
-                .UsePathBase(registeredPathBase);
+                .UsePathBase(new PathString(registeredPathBase));
             builder.Run(context =>
             {
                 context.Items["test.Path"] = context.Request.Path;


### PR DESCRIPTION
# Fix MapPath and UsePathBase's use of implicit PathStrings

Fixes a regression caused by the use of implicit converters between string and PathString.

## Description

PathString requires that the url path be in it's un-escaped format and defines implicit converters to/from string that will un/escape %XX values. This conversion must only happen once to avoid ambiguity issues like escaped `%` characters.

A regression happened in 6.0 where methods were split up for performance reasons and a helper method accidentally used string parameters instead of PathStrings. The implicit converter made this compile, but the resulting value was in the wrong format (double un-escaped).

Fixes #41168

## Customer Impact

UsePathBase is used by default in some IIS scenarios and the resulting mis-formatted path can cause decoding exceptions and failed requests. This is impacting customers that have upgraded to 6.0. https://github.com/dotnet/aspnetcore/issues/41168#issuecomment-1102369134

## Regression?

- [x] Yes
- [ ] No

From 5.0

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Corner case that's unit testable.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A