### PR TITLE
Fix discovery of endpoint metadata from async route handlers

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -406,13 +406,19 @@ public static partial class RequestDelegateFactory
         }
 
         // Get metadata from return type
-        if (methodInfo.ReturnType is not null && typeof(IEndpointMetadataProvider).IsAssignableFrom(methodInfo.ReturnType))
+        var returnType = methodInfo.ReturnType;
+        if (AwaitableInfo.IsTypeAwaitable(returnType, out var awaitableInfo))
+        {
+            returnType = awaitableInfo.ResultType;
+        }
+
+        if (returnType is not null && typeof(IEndpointMetadataProvider).IsAssignableFrom(returnType))
         {
             // Return type implements IEndpointMetadataProvider
             var context = new EndpointMetadataContext(methodInfo, metadata, services);
             invokeArgs ??= new object[1];
             invokeArgs[0] = context;
-            PopulateMetadataForEndpointMethod.MakeGenericMethod(methodInfo.ReturnType).Invoke(null, invokeArgs);
+            PopulateMetadataForEndpointMethod.MakeGenericMethod(returnType).Invoke(null, invokeArgs);
         }
     }
 


### PR DESCRIPTION
# Fix discovery of endpoint metadata from async route handlers returning types that implement IEndpointMetadataProvider

Simple fix to `RequestDelegateFactory` that ensures the underlying type is retrieved if the method returns an awaitable. This is needed to ensure that the end-to-end scenario of minimal APIs that can describe themselves in OpenAPI/Swagger using the in-box `IResult` types works correctly.

Added tests to cover the scenario.

Fixes #41384
