### PR TITLE
Allow Multiple Wildcard Prefix Server Names of the Same Length in SNI Configuration

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
@@ -225,7 +225,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             public int Compare(string? x, string? y)
             {
                 // Flip x and y to put the longest instead of the shortest string first in the SortedList.
-                return y!.Length.CompareTo(x!.Length);
+                var lengthResult = y!.Length.CompareTo(x!.Length);
+                if (lengthResult != 0)
+                {
+                    return lengthResult;
+                }
+                else
+                {
+                    return string.Compare(x, y, StringComparison.OrdinalIgnoreCase);
+                }
             }
         }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
@@ -225,6 +225,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal
             public int Compare(string? x, string? y)
             {
                 // Flip x and y to put the longest instead of the shortest string first in the SortedList.
+                // SortedList does not support duplicate entries, so fall back to
+                // StringComparison.OrdinalIgnoreCase behavior for equal length strings.
                 var lengthResult = y!.Length.CompareTo(x!.Length);
                 if (lengthResult != 0)
                 {


### PR DESCRIPTION

# Allow Multiple Wildcard Prefix Server Names of the Same Length in SNI Configuration

Fix sorting collision in SNI config

## Description

When trying to load endpoints and certificates for Kestrel from a configuration file it's possible to list several certificates with different host names. Host names are then sorted by length so we can match the longest, most specific first.

There's a bug in the sort comparer that only considers length, and SortedList doesn't allow entries with equal keys. The comparer needs a tie breaker.

Fixes #41216

## Customer Impact

Customers are unable to load configurations with certain combinations of host names. They cannot work around this from config, they need to set up kestrel in code instead.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Easy to test once reported.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
