### PR TITLE
Zero byte reads support for EnableBuffering/FileBufferingReadStream 

### DIFF
--- a/src/Http/WebUtilities/src/FileBufferingReadStream.cs
+++ b/src/Http/WebUtilities/src/FileBufferingReadStream.cs
@@ -317,7 +317,8 @@ namespace Microsoft.AspNetCore.WebUtilities
             {
                 _buffer.Write(buffer.Slice(0, read));
             }
-            else
+            // Allow zero-byte reads
+            else if (buffer.Length > 0)
             {
                 _completelyBuffered = true;
             }
@@ -392,7 +393,8 @@ namespace Microsoft.AspNetCore.WebUtilities
             {
                 await _buffer.WriteAsync(buffer.Slice(0, read), cancellationToken);
             }
-            else
+            // Allow zero-byte reads
+            else if (buffer.Length > 0)
             {
                 _completelyBuffered = true;
             }

--- a/src/Http/WebUtilities/test/FileBufferingReadStreamTests.cs
+++ b/src/Http/WebUtilities/test/FileBufferingReadStreamTests.cs
@@ -36,6 +36,39 @@ namespace Microsoft.AspNetCore.WebUtilities
         }
 
         [Fact]
+        public void FileBufferingReadStream_Sync0ByteReadUnderThreshold_DoesntCreateFile()
+        {
+            var inner = MakeStream(1024);
+            using (var stream = new FileBufferingReadStream(inner, 1024 * 2, null, Directory.GetCurrentDirectory()))
+            {
+                var bytes = new byte[1000];
+                var read0 = stream.Read(bytes, 0, 0);
+                Assert.Equal(0, read0);
+                Assert.Equal(read0, stream.Length);
+                Assert.Equal(read0, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+
+                var read1 = stream.Read(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, read1);
+                Assert.Equal(read0 + read1, stream.Length);
+                Assert.Equal(read0 + read1, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+
+                var read2 = stream.Read(bytes, 0, bytes.Length);
+                Assert.Equal(inner.Length - read0 - read1, read2);
+                Assert.Equal(read0 + read1 + read2, stream.Length);
+                Assert.Equal(read0 + read1 + read2, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+
+                var read3 = stream.Read(bytes, 0, bytes.Length);
+                Assert.Equal(0, read3);
+            }
+        }
+
+        [Fact]
         public void FileBufferingReadStream_SyncReadUnderThreshold_DoesntCreateFile()
         {
             var inner = MakeStream(1024 * 2);
@@ -165,6 +198,39 @@ namespace Microsoft.AspNetCore.WebUtilities
         ///////////////////
 
         [Fact]
+        public async Task FileBufferingReadStream_Async0ByteReadUnderThreshold_DoesntCreateFile()
+        {
+            var inner = MakeStream(1024);
+            using (var stream = new FileBufferingReadStream(inner, 1024 * 2, null, Directory.GetCurrentDirectory()))
+            {
+                var bytes = new byte[1000];
+                var read0 = await stream.ReadAsync(bytes, 0, 0);
+                Assert.Equal(0, read0);
+                Assert.Equal(read0, stream.Length);
+                Assert.Equal(read0, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+
+                var read1 = await stream.ReadAsync(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, read1);
+                Assert.Equal(read0 + read1, stream.Length);
+                Assert.Equal(read0 + read1, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+
+                var read2 = await stream.ReadAsync(bytes, 0, bytes.Length);
+                Assert.Equal(inner.Length - read0 - read1, read2);
+                Assert.Equal(read0 + read1 + read2, stream.Length);
+                Assert.Equal(read0 + read1 + read2, stream.Position);
+                Assert.True(stream.InMemory);
+                Assert.Null(stream.TempFileName);
+
+                var read3 = await stream.ReadAsync(bytes, 0, bytes.Length);
+                Assert.Equal(0, read3);
+            }
+        }
+
+        [Fact]
         public async Task FileBufferingReadStream_AsyncReadUnderThreshold_DoesntCreateFile()
         {
             var inner = MakeStream(1024 * 2);
@@ -231,6 +297,47 @@ namespace Microsoft.AspNetCore.WebUtilities
 
                 var read3 = await stream.ReadAsync(bytes, 0, bytes.Length);
                 Assert.Equal(0, read3);
+            }
+
+            Assert.False(File.Exists(tempFileName));
+        }
+
+        [Fact]
+        public async Task FileBufferingReadStream_Async0ByteReadAfterBuffering_ReadsFromFile()
+        {
+            var inner = MakeStream(1024 * 2);
+            string tempFileName;
+            using (var stream = new FileBufferingReadStream(inner, 1024, null, GetCurrentDirectory()))
+            {
+                await stream.DrainAsync(default);
+                stream.Position = 0;
+                Assert.Equal(inner.Length, stream.Length);
+                Assert.Equal(0, stream.Position);
+                Assert.False(stream.InMemory);
+                Assert.NotNull(stream.TempFileName);
+                tempFileName = stream.TempFileName!;
+                Assert.True(File.Exists(tempFileName));
+
+                var bytes = new byte[1000];
+                var read0 = await stream.ReadAsync(bytes, 0, 0);
+                Assert.Equal(0, read0);
+                Assert.Equal(read0, stream.Position);
+
+                var read1 = await stream.ReadAsync(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, read1);
+                Assert.Equal(read0 + read1, stream.Position);
+
+                var read2 = await stream.ReadAsync(bytes, 0, bytes.Length);
+                Assert.Equal(bytes.Length, read2);
+                Assert.Equal(read0 + read1 + read2, stream.Position);
+
+                var read3 = await stream.ReadAsync(bytes, 0, bytes.Length);
+                Assert.Equal(inner.Length - read0 - read1 - read2, read3);
+                Assert.Equal(read0 + read1 + read2 + read3, stream.Length);
+                Assert.Equal(read0 + read1 + read2 + read3, stream.Position);
+
+                var read4 = await stream.ReadAsync(bytes, 0, bytes.Length);
+                Assert.Equal(0, read4);
             }
 
             Assert.False(File.Exists(tempFileName));


### PR DESCRIPTION
# Zero byte reads support for EnableBuffering/FileBufferingReadStream

Correctly handle read operations that pass a zero-length buffer.

## Description

AspNetCore and YARP have started to take advantage of the zero-byte-read pattern, where zero length buffers are passed to read operations to be notified when data is available. This allows the caller to avoid allocations and pinning on slow/idle streams like gRPC and WebSockets.

EnableBuffering/FileBufferingReadStream do not correctly handle receiving an empty buffer. When the inner stream returns 0 bytes read it assumes the buffering is completed and it stops delegating to the inner stream.

Fixes #41287

## Customer Impact

In YARP projects customers are unable to use the EnableBuffering API which is a common tool used when logging, manipulating, or retrying the request body.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
