### PR TITLE
Revert "Try out 1es images"

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -120,12 +120,7 @@ jobs:
       ${{ if eq(parameters.agentOs, 'Windows') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: NetCore1ESPool-Public
-          ${{ if ne(parameters.isAzDOTestingJob, true) }}:
-            # Visual Studio Build Tools
-            demands: ImageOverride -equals Build.Server.Amd64.VS2019.BT.Open
-          ${{ if eq(parameters.isAzDOTestingJob, true) }}:
-            # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-            demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
+          demands: ImageOverride -equals 1es-windows-2019-open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCore1ESPool-Internal
           # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -120,10 +120,16 @@ jobs:
       ${{ if eq(parameters.agentOs, 'Windows') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: NetCore1ESPool-Public
-          demands: ImageOverride -equals 1es-windows-2019-open
+          ${{ if ne(parameters.isAzDOTestingJob, true) }}:
+            # Visual Studio Build Tools
+            demands: ImageOverride -equals Build.Server.Amd64.VS2019.BT.Open
+          ${{ if eq(parameters.isAzDOTestingJob, true) }}:
+            # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
+            demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals 1es-windows-2019
+          # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
+          demands: ImageOverride -equals Build.Server.Amd64.VS2019
     ${{ if ne(parameters.container, '') }}:
       container: ${{ parameters.container }}
     ${{ if ne(parameters.disableComponentGovernance, '') }}:


### PR DESCRIPTION
This broke our internal builds:

```
##[error]NetCore1ESPool-Internal 5 is missing installed cert(s) or private key(s) required for installed cert(s): 
 
SubjectName                                        Installed CertSubject PrivateKey
-----------                                        --------- ----------- ----------
ea4022a2-6f71-4214-88b6-18d2bbd6b4cc.microsoft.com     False                  False
dec434ad-6bd4-4a20-b400-4bf6db7fc3fb                   False                  False
Microsoft Assurance Designation Root 2011              False                  False
```

CC @MattGal @dotnet/dnceng 