### PR TITLE
Added overloads on Results/TypedResults for Content/Text with status code

### DIFF
--- a/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
@@ -144,6 +144,16 @@ Microsoft.AspNetCore.Http.HttpResults.RedirectToRouteHttpResult.Permanent.get ->
 Microsoft.AspNetCore.Http.HttpResults.RedirectToRouteHttpResult.PreserveMethod.get -> bool
 Microsoft.AspNetCore.Http.HttpResults.RedirectToRouteHttpResult.RouteName.get -> string?
 Microsoft.AspNetCore.Http.HttpResults.RedirectToRouteHttpResult.RouteValues.get -> Microsoft.AspNetCore.Routing.RouteValueDictionary?
+static Microsoft.AspNetCore.Http.Results.Content(string! content, string? contentType = null, System.Text.Encoding? contentEncoding = null, int? statusCode = null) -> Microsoft.AspNetCore.Http.IResult!
+*REMOVED*static Microsoft.AspNetCore.Http.Results.Content(string! content, string? contentType = null, System.Text.Encoding? contentEncoding = null) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.Content(string! content, string? contentType, System.Text.Encoding? contentEncoding) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.Text(string! content, string? contentType = null, System.Text.Encoding? contentEncoding = null, int? statusCode = null) -> Microsoft.AspNetCore.Http.IResult!
+*REMOVED*static Microsoft.AspNetCore.Http.Results.Text(string! content, string? contentType = null, System.Text.Encoding? contentEncoding = null) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.Text(string! content, string? contentType, System.Text.Encoding? contentEncoding) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.TypedResults.Content(string? content, string? contentType = null, System.Text.Encoding? contentEncoding = null, int? statusCode = null) -> Microsoft.AspNetCore.Http.HttpResults.ContentHttpResult!
+static Microsoft.AspNetCore.Http.TypedResults.Content(string? content, string? contentType, System.Text.Encoding? contentEncoding) -> Microsoft.AspNetCore.Http.HttpResults.ContentHttpResult!
+static Microsoft.AspNetCore.Http.TypedResults.Text(string? content, string? contentType = null, System.Text.Encoding? contentEncoding = null, int? statusCode = null) -> Microsoft.AspNetCore.Http.HttpResults.ContentHttpResult!
+static Microsoft.AspNetCore.Http.TypedResults.Text(string? content, string? contentType, System.Text.Encoding? contentEncoding) -> Microsoft.AspNetCore.Http.HttpResults.ContentHttpResult!
 ~Microsoft.AspNetCore.Http.HttpResults.Results<TResult1, TResult2, TResult3, TResult4, TResult5, TResult6>
 ~Microsoft.AspNetCore.Http.HttpResults.Results<TResult1, TResult2, TResult3, TResult4, TResult5, TResult6>.ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext httpContext) -> System.Threading.Tasks.Task
 ~Microsoft.AspNetCore.Http.HttpResults.Results<TResult1, TResult2, TResult3, TResult4, TResult5, TResult6>.Result.get -> Microsoft.AspNetCore.Http.IResult
@@ -213,7 +223,6 @@ static Microsoft.AspNetCore.Http.TypedResults.Challenge(Microsoft.AspNetCore.Aut
 static Microsoft.AspNetCore.Http.TypedResults.Conflict() -> Microsoft.AspNetCore.Http.HttpResults.Conflict!
 static Microsoft.AspNetCore.Http.TypedResults.Conflict<TValue>(TValue? error) -> Microsoft.AspNetCore.Http.HttpResults.Conflict<TValue>!
 static Microsoft.AspNetCore.Http.TypedResults.Content(string? content, Microsoft.Net.Http.Headers.MediaTypeHeaderValue! contentType) -> Microsoft.AspNetCore.Http.HttpResults.ContentHttpResult!
-static Microsoft.AspNetCore.Http.TypedResults.Content(string? content, string? contentType = null, System.Text.Encoding? contentEncoding = null) -> Microsoft.AspNetCore.Http.HttpResults.ContentHttpResult!
 static Microsoft.AspNetCore.Http.TypedResults.Created(System.Uri! uri) -> Microsoft.AspNetCore.Http.HttpResults.Created!
 static Microsoft.AspNetCore.Http.TypedResults.Created(string! uri) -> Microsoft.AspNetCore.Http.HttpResults.Created!
 static Microsoft.AspNetCore.Http.TypedResults.Created<TValue>(System.Uri! uri, TValue? value) -> Microsoft.AspNetCore.Http.HttpResults.Created<TValue>!
@@ -242,7 +251,6 @@ static Microsoft.AspNetCore.Http.TypedResults.StatusCode(int statusCode) -> Micr
 static Microsoft.AspNetCore.Http.TypedResults.Stream(System.Func<System.IO.Stream!, System.Threading.Tasks.Task!>! streamWriterCallback, string? contentType = null, string? fileDownloadName = null, System.DateTimeOffset? lastModified = null, Microsoft.Net.Http.Headers.EntityTagHeaderValue? entityTag = null) -> Microsoft.AspNetCore.Http.HttpResults.PushStreamHttpResult!
 static Microsoft.AspNetCore.Http.TypedResults.Stream(System.IO.Pipelines.PipeReader! pipeReader, string? contentType = null, string? fileDownloadName = null, System.DateTimeOffset? lastModified = null, Microsoft.Net.Http.Headers.EntityTagHeaderValue? entityTag = null, bool enableRangeProcessing = false) -> Microsoft.AspNetCore.Http.HttpResults.FileStreamHttpResult!
 static Microsoft.AspNetCore.Http.TypedResults.Stream(System.IO.Stream! stream, string? contentType = null, string? fileDownloadName = null, System.DateTimeOffset? lastModified = null, Microsoft.Net.Http.Headers.EntityTagHeaderValue? entityTag = null, bool enableRangeProcessing = false) -> Microsoft.AspNetCore.Http.HttpResults.FileStreamHttpResult!
-static Microsoft.AspNetCore.Http.TypedResults.Text(string? content, string? contentType = null, System.Text.Encoding? contentEncoding = null) -> Microsoft.AspNetCore.Http.HttpResults.ContentHttpResult!
 static Microsoft.AspNetCore.Http.TypedResults.Unauthorized() -> Microsoft.AspNetCore.Http.HttpResults.UnauthorizedHttpResult!
 static Microsoft.AspNetCore.Http.TypedResults.UnprocessableEntity() -> Microsoft.AspNetCore.Http.HttpResults.UnprocessableEntity!
 static Microsoft.AspNetCore.Http.TypedResults.UnprocessableEntity<TValue>(TValue? error) -> Microsoft.AspNetCore.Http.HttpResults.UnprocessableEntity<TValue>!

--- a/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
@@ -144,12 +144,13 @@ Microsoft.AspNetCore.Http.HttpResults.RedirectToRouteHttpResult.Permanent.get ->
 Microsoft.AspNetCore.Http.HttpResults.RedirectToRouteHttpResult.PreserveMethod.get -> bool
 Microsoft.AspNetCore.Http.HttpResults.RedirectToRouteHttpResult.RouteName.get -> string?
 Microsoft.AspNetCore.Http.HttpResults.RedirectToRouteHttpResult.RouteValues.get -> Microsoft.AspNetCore.Routing.RouteValueDictionary?
-static Microsoft.AspNetCore.Http.Results.Content(string! content, string? contentType = null, System.Text.Encoding? contentEncoding = null, int? statusCode = null) -> Microsoft.AspNetCore.Http.IResult!
 *REMOVED*static Microsoft.AspNetCore.Http.Results.Content(string! content, string? contentType = null, System.Text.Encoding? contentEncoding = null) -> Microsoft.AspNetCore.Http.IResult!
-static Microsoft.AspNetCore.Http.Results.Content(string! content, string? contentType, System.Text.Encoding? contentEncoding) -> Microsoft.AspNetCore.Http.IResult!
-static Microsoft.AspNetCore.Http.Results.Text(string! content, string? contentType = null, System.Text.Encoding? contentEncoding = null, int? statusCode = null) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.Content(string? content, Microsoft.Net.Http.Headers.MediaTypeHeaderValue! contentType) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.Content(string? content, string? contentType = null, System.Text.Encoding? contentEncoding = null, int? statusCode = null) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.Content(string? content, string? contentType, System.Text.Encoding? contentEncoding) -> Microsoft.AspNetCore.Http.IResult!
 *REMOVED*static Microsoft.AspNetCore.Http.Results.Text(string! content, string? contentType = null, System.Text.Encoding? contentEncoding = null) -> Microsoft.AspNetCore.Http.IResult!
-static Microsoft.AspNetCore.Http.Results.Text(string! content, string? contentType, System.Text.Encoding? contentEncoding) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.Text(string? content, string? contentType = null, System.Text.Encoding? contentEncoding = null, int? statusCode = null) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.Text(string? content, string? contentType, System.Text.Encoding? contentEncoding) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.TypedResults.Content(string? content, string? contentType = null, System.Text.Encoding? contentEncoding = null, int? statusCode = null) -> Microsoft.AspNetCore.Http.HttpResults.ContentHttpResult!
 static Microsoft.AspNetCore.Http.TypedResults.Content(string? content, string? contentType, System.Text.Encoding? contentEncoding) -> Microsoft.AspNetCore.Http.HttpResults.ContentHttpResult!
 static Microsoft.AspNetCore.Http.TypedResults.Text(string? content, string? contentType = null, System.Text.Encoding? contentEncoding = null, int? statusCode = null) -> Microsoft.AspNetCore.Http.HttpResults.ContentHttpResult!

--- a/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
@@ -145,6 +145,7 @@ Microsoft.AspNetCore.Http.HttpResults.RedirectToRouteHttpResult.PreserveMethod.g
 Microsoft.AspNetCore.Http.HttpResults.RedirectToRouteHttpResult.RouteName.get -> string?
 Microsoft.AspNetCore.Http.HttpResults.RedirectToRouteHttpResult.RouteValues.get -> Microsoft.AspNetCore.Routing.RouteValueDictionary?
 *REMOVED*static Microsoft.AspNetCore.Http.Results.Content(string! content, string? contentType = null, System.Text.Encoding? contentEncoding = null) -> Microsoft.AspNetCore.Http.IResult!
+*REMOVED*static Microsoft.AspNetCore.Http.Results.Content(string! content, Microsoft.Net.Http.Headers.MediaTypeHeaderValue! contentType) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.Content(string? content, Microsoft.Net.Http.Headers.MediaTypeHeaderValue! contentType) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.Content(string? content, string? contentType = null, System.Text.Encoding? contentEncoding = null, int? statusCode = null) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.Content(string? content, string? contentType, System.Text.Encoding? contentEncoding) -> Microsoft.AspNetCore.Http.IResult!

--- a/src/Http/Http.Results/src/Results.cs
+++ b/src/Http/Http.Results/src/Results.cs
@@ -78,7 +78,7 @@ public static partial class Results
     /// <summary>
     /// Writes the <paramref name="content"/> string to the HTTP response.
     /// <para>
-    /// This is an alias for <see cref="Text(string, string?, Encoding?)"/>.
+    /// This is an alias for <see cref="Text(string, string?, Encoding?, int?)"/>.
     /// </para>
     /// </summary>
     /// <param name="content">The content to write to the response.</param>
@@ -89,13 +89,31 @@ public static partial class Results
     /// If encoding is provided by both the 'charset' and the <paramref name="contentEncoding"/> parameters, then
     /// the <paramref name="contentEncoding"/> parameter is chosen as the final encoding.
     /// </remarks>
-    public static IResult Content(string content, string? contentType = null, Encoding? contentEncoding = null)
-        => TypedResults.Content(content, contentType, contentEncoding);
+    public static IResult Content(string content, string? contentType, Encoding? contentEncoding)
+        => Content(content, contentType, contentEncoding, null);
 
     /// <summary>
     /// Writes the <paramref name="content"/> string to the HTTP response.
     /// <para>
-    /// This is an alias for <see cref="Content(string, string?, Encoding?)"/>.
+    /// This is an alias for <see cref="Text(string, string?, Encoding?, int?)"/>.
+    /// </para>
+    /// </summary>
+    /// <param name="content">The content to write to the response.</param>
+    /// <param name="contentType">The content type (MIME type).</param>
+    /// <param name="contentEncoding">The content encoding.</param>
+    /// <param name="statusCode">The status code to return.</param>
+    /// <returns>The created <see cref="IResult"/> object for the response.</returns>
+    /// <remarks>
+    /// If encoding is provided by both the 'charset' and the <paramref name="contentEncoding"/> parameters, then
+    /// the <paramref name="contentEncoding"/> parameter is chosen as the final encoding.
+    /// </remarks>
+    public static IResult Content(string content, string? contentType = null, Encoding? contentEncoding = null, int? statusCode = null)
+        => TypedResults.Content(content, contentType, contentEncoding, statusCode);
+
+    /// <summary>
+    /// Writes the <paramref name="content"/> string to the HTTP response.
+    /// <para>
+    /// This is an alias for <see cref="Content(string, string?, Encoding?, int?)"/>.
     /// </para>
     /// </summary>
     /// <param name="content">The content to write to the response.</param>
@@ -106,8 +124,26 @@ public static partial class Results
     /// If encoding is provided by both the 'charset' and the <paramref name="contentEncoding"/> parameters, then
     /// the <paramref name="contentEncoding"/> parameter is chosen as the final encoding.
     /// </remarks>
-    public static IResult Text(string content, string? contentType = null, Encoding? contentEncoding = null)
-        => TypedResults.Text(content, contentType, contentEncoding);
+    public static IResult Text(string content, string? contentType, Encoding? contentEncoding)
+        => Text(content, contentType, contentEncoding, null);
+
+    /// <summary>
+    /// Writes the <paramref name="content"/> string to the HTTP response.
+    /// <para>
+    /// This is an alias for <see cref="Content(string, string?, Encoding?, int?)"/>.
+    /// </para>
+    /// </summary>
+    /// <param name="content">The content to write to the response.</param>
+    /// <param name="contentType">The content type (MIME type).</param>
+    /// <param name="contentEncoding">The content encoding.</param>
+    /// <param name="statusCode">The status code to return.</param>
+    /// <returns>The created <see cref="IResult"/> object for the response.</returns>
+    /// <remarks>
+    /// If encoding is provided by both the 'charset' and the <paramref name="contentEncoding"/> parameters, then
+    /// the <paramref name="contentEncoding"/> parameter is chosen as the final encoding.
+    /// </remarks>
+    public static IResult Text(string content, string? contentType = null, Encoding? contentEncoding = null, int? statusCode = null)
+        => TypedResults.Text(content, contentType, contentEncoding, statusCode);
 
     /// <summary>
     /// Writes the <paramref name="content"/> string to the HTTP response.

--- a/src/Http/Http.Results/src/Results.cs
+++ b/src/Http/Http.Results/src/Results.cs
@@ -78,7 +78,7 @@ public static partial class Results
     /// <summary>
     /// Writes the <paramref name="content"/> string to the HTTP response.
     /// <para>
-    /// This is an alias for <see cref="Text(string, string?, Encoding?, int?)"/>.
+    /// This is equivalent to <see cref="Text(string?, string?, Encoding?)"/>.
     /// </para>
     /// </summary>
     /// <param name="content">The content to write to the response.</param>
@@ -95,7 +95,7 @@ public static partial class Results
     /// <summary>
     /// Writes the <paramref name="content"/> string to the HTTP response.
     /// <para>
-    /// This is an alias for <see cref="Text(string, string?, Encoding?, int?)"/>.
+    /// This is equivalent to <see cref="Text(string?, string?, Encoding?, int?)"/>.
     /// </para>
     /// </summary>
     /// <param name="content">The content to write to the response.</param>
@@ -113,7 +113,7 @@ public static partial class Results
     /// <summary>
     /// Writes the <paramref name="content"/> string to the HTTP response.
     /// <para>
-    /// This is an alias for <see cref="Content(string, string?, Encoding?, int?)"/>.
+    /// This is an alias for <see cref="Content(string?, string?, Encoding?)"/>.
     /// </para>
     /// </summary>
     /// <param name="content">The content to write to the response.</param>
@@ -130,7 +130,7 @@ public static partial class Results
     /// <summary>
     /// Writes the <paramref name="content"/> string to the HTTP response.
     /// <para>
-    /// This is an alias for <see cref="Content(string, string?, Encoding?, int?)"/>.
+    /// This is an alias for <see cref="Content(string?, string?, Encoding?, int?)"/>.
     /// </para>
     /// </summary>
     /// <param name="content">The content to write to the response.</param>

--- a/src/Http/Http.Results/src/Results.cs
+++ b/src/Http/Http.Results/src/Results.cs
@@ -89,7 +89,7 @@ public static partial class Results
     /// If encoding is provided by both the 'charset' and the <paramref name="contentEncoding"/> parameters, then
     /// the <paramref name="contentEncoding"/> parameter is chosen as the final encoding.
     /// </remarks>
-    public static IResult Content(string content, string? contentType, Encoding? contentEncoding)
+    public static IResult Content(string? content, string? contentType, Encoding? contentEncoding)
         => Content(content, contentType, contentEncoding, null);
 
     /// <summary>
@@ -107,7 +107,7 @@ public static partial class Results
     /// If encoding is provided by both the 'charset' and the <paramref name="contentEncoding"/> parameters, then
     /// the <paramref name="contentEncoding"/> parameter is chosen as the final encoding.
     /// </remarks>
-    public static IResult Content(string content, string? contentType = null, Encoding? contentEncoding = null, int? statusCode = null)
+    public static IResult Content(string? content, string? contentType = null, Encoding? contentEncoding = null, int? statusCode = null)
         => TypedResults.Content(content, contentType, contentEncoding, statusCode);
 
     /// <summary>
@@ -124,7 +124,7 @@ public static partial class Results
     /// If encoding is provided by both the 'charset' and the <paramref name="contentEncoding"/> parameters, then
     /// the <paramref name="contentEncoding"/> parameter is chosen as the final encoding.
     /// </remarks>
-    public static IResult Text(string content, string? contentType, Encoding? contentEncoding)
+    public static IResult Text(string? content, string? contentType, Encoding? contentEncoding)
         => Text(content, contentType, contentEncoding, null);
 
     /// <summary>
@@ -142,7 +142,7 @@ public static partial class Results
     /// If encoding is provided by both the 'charset' and the <paramref name="contentEncoding"/> parameters, then
     /// the <paramref name="contentEncoding"/> parameter is chosen as the final encoding.
     /// </remarks>
-    public static IResult Text(string content, string? contentType = null, Encoding? contentEncoding = null, int? statusCode = null)
+    public static IResult Text(string? content, string? contentType = null, Encoding? contentEncoding = null, int? statusCode = null)
         => TypedResults.Text(content, contentType, contentEncoding, statusCode);
 
     /// <summary>
@@ -151,7 +151,7 @@ public static partial class Results
     /// <param name="content">The content to write to the response.</param>
     /// <param name="contentType">The content type (MIME type).</param>
     /// <returns>The created <see cref="IResult"/> object for the response.</returns>
-    public static IResult Content(string content, MediaTypeHeaderValue contentType)
+    public static IResult Content(string? content, MediaTypeHeaderValue contentType)
         => TypedResults.Content(content, contentType);
 
     /// <summary>

--- a/src/Http/Http.Results/src/TypedResults.cs
+++ b/src/Http/Http.Results/src/TypedResults.cs
@@ -82,7 +82,7 @@ public static class TypedResults
     /// <summary>
     /// Writes the <paramref name="content"/> string to the HTTP response.
     /// <para>
-    /// This is an alias for <see cref="Text(string, string?, Encoding?)"/>.
+    /// This is equivalent to <see cref="Text(string?, string?, Encoding?)"/>.
     /// </para>
     /// </summary>
     /// <remarks>
@@ -99,7 +99,7 @@ public static class TypedResults
     /// <summary>
     /// Writes the <paramref name="content"/> string to the HTTP response.
     /// <para>
-    /// This is an alias for <see cref="Text(string, string?, Encoding?, int?)"/>.
+    /// This is equivalent to <see cref="Text(string?, string?, Encoding?, int?)"/>.
     /// </para>
     /// </summary>
     /// <remarks>
@@ -117,7 +117,7 @@ public static class TypedResults
     /// <summary>
     /// Writes the <paramref name="content"/> string to the HTTP response.
     /// <para>
-    /// This is an alias for <see cref="Content(string, string?, Encoding?)"/>.
+    /// This is an alias for <see cref="Content(string?, string?, Encoding?)"/>.
     /// </para>
     /// </summary>
     /// <remarks>
@@ -134,7 +134,7 @@ public static class TypedResults
     /// <summary>
     /// Writes the <paramref name="content"/> string to the HTTP response.
     /// <para>
-    /// This is an alias for <see cref="Content(string, string?, Encoding?, int?)"/>.
+    /// This is an alias for <see cref="Content(string?, string?, Encoding?, int?)"/>.
     /// </para>
     /// </summary>
     /// <remarks>

--- a/src/Http/Http.Results/src/TypedResults.cs
+++ b/src/Http/Http.Results/src/TypedResults.cs
@@ -93,8 +93,26 @@ public static class TypedResults
     /// <param name="contentType">The content type (MIME type).</param>
     /// <param name="contentEncoding">The content encoding.</param>
     /// <returns>The created <see cref="ContentHttpResult"/> object for the response.</returns>
-    public static ContentHttpResult Content(string? content, string? contentType = null, Encoding? contentEncoding = null)
-        => Text(content, contentType, contentEncoding);
+    public static ContentHttpResult Content(string? content, string? contentType, Encoding? contentEncoding)
+        => Content(content, contentType, contentEncoding, null);
+
+    /// <summary>
+    /// Writes the <paramref name="content"/> string to the HTTP response.
+    /// <para>
+    /// This is an alias for <see cref="Text(string, string?, Encoding?, int?)"/>.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// If encoding is provided by both the 'charset' and the <paramref name="contentEncoding"/> parameters, then
+    /// the <paramref name="contentEncoding"/> parameter is chosen as the final encoding.
+    /// </remarks>
+    /// <param name="content">The content to write to the response.</param>
+    /// <param name="contentType">The content type (MIME type).</param>
+    /// <param name="contentEncoding">The content encoding.</param>
+    /// <param name="statusCode">The status code to return.</param>
+    /// <returns>The created <see cref="ContentHttpResult"/> object for the response.</returns>
+    public static ContentHttpResult Content(string? content, string? contentType = null, Encoding? contentEncoding = null, int? statusCode = null)
+        => Text(content, contentType, contentEncoding, statusCode);
 
     /// <summary>
     /// Writes the <paramref name="content"/> string to the HTTP response.
@@ -110,7 +128,25 @@ public static class TypedResults
     /// <param name="contentType">The content type (MIME type).</param>
     /// <param name="contentEncoding">The content encoding.</param>
     /// <returns>The created <see cref="ContentHttpResult"/> object for the response.</returns>
-    public static ContentHttpResult Text(string? content, string? contentType = null, Encoding? contentEncoding = null)
+    public static ContentHttpResult Text(string? content, string? contentType, Encoding? contentEncoding)
+        => Text(content, contentType, contentEncoding, null);
+
+    /// <summary>
+    /// Writes the <paramref name="content"/> string to the HTTP response.
+    /// <para>
+    /// This is an alias for <see cref="Content(string, string?, Encoding?, int?)"/>.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// If encoding is provided by both the 'charset' and the <paramref name="contentEncoding"/> parameters, then
+    /// the <paramref name="contentEncoding"/> parameter is chosen as the final encoding.
+    /// </remarks>
+    /// <param name="content">The content to write to the response.</param>
+    /// <param name="contentType">The content type (MIME type).</param>
+    /// <param name="contentEncoding">The content encoding.</param>
+    /// <param name="statusCode">The status code to return.</param>
+    /// <returns>The created <see cref="ContentHttpResult"/> object for the response.</returns>
+    public static ContentHttpResult Text(string? content, string? contentType = null, Encoding? contentEncoding = null, int? statusCode = null)
     {
         MediaTypeHeaderValue? mediaTypeHeaderValue = null;
         if (contentType is not null)
@@ -119,7 +155,7 @@ public static class TypedResults
             mediaTypeHeaderValue.Encoding = contentEncoding ?? mediaTypeHeaderValue.Encoding;
         }
 
-        return new(content, mediaTypeHeaderValue?.ToString());
+        return new(content, mediaTypeHeaderValue?.ToString(), statusCode);
     }
 
     /// <summary>

--- a/src/Http/Http.Results/test/ResultsTests.cs
+++ b/src/Http/Http.Results/test/ResultsTests.cs
@@ -360,12 +360,30 @@ public class ResultsTests
         var encoding = Encoding.UTF8;
 
         // Act
-        var result = Results.Content(content, contentType, null) as ContentHttpResult;
+        var result = Results.Content(content, contentType, encoding) as ContentHttpResult;
 
         // Assert
         Assert.Null(result.StatusCode);
         Assert.Equal(content, result.ResponseContent);
-        Assert.Equal(contentType, result.ContentType);
+        Assert.Equal("text/plain; charset=utf-8", result.ContentType);
+    }
+
+    [Fact]
+    public void Content_WithContentAndContentTypeAndEncodingAndStatusCode_ResultHasCorrectValues()
+    {
+        // Arrange
+        var content = "test content";
+        var contentType = "text/plain";
+        var encoding = Encoding.UTF8;
+        var statusCode = 201;
+
+        // Act
+        var result = Results.Content(content, contentType, encoding, statusCode) as ContentHttpResult;
+
+        // Assert
+        Assert.Equal(statusCode, result.StatusCode);
+        Assert.Equal(content, result.ResponseContent);
+        Assert.Equal("text/plain; charset=utf-8", result.ContentType);
     }
 
     [Fact]
@@ -926,6 +944,22 @@ public class ResultsTests
     }
 
     [Fact]
+    public void Text_WithContentAndContentType_ResultHasCorrectValues()
+    {
+        // Arrange
+        var content = "test content";
+        var contentType = "text/plain";
+
+        // Act
+        var result = Results.Text(content, contentType) as ContentHttpResult;
+
+        // Assert
+        Assert.Null(result.StatusCode);
+        Assert.Equal(content, result.ResponseContent);
+        Assert.Equal(contentType, result.ContentType);
+    }
+
+    [Fact]
     public void Text_WithContentAndContentTypeAndEncoding_ResultHasCorrectValues()
     {
         // Arrange
@@ -938,6 +972,26 @@ public class ResultsTests
 
         // Assert
         Assert.Null(result.StatusCode);
+        Assert.Equal(content, result.ResponseContent);
+        var expectedMediaType = MediaTypeHeaderValue.Parse(contentType);
+        expectedMediaType.Encoding = encoding;
+        Assert.Equal(expectedMediaType.ToString(), result.ContentType);
+    }
+
+    [Fact]
+    public void Text_WithContentAndContentTypeAndEncodingAndStatusCode_ResultHasCorrectValues()
+    {
+        // Arrange
+        var content = "test content";
+        var contentType = "text/plain";
+        var encoding = Encoding.ASCII;
+        var statusCode = 201;
+
+        // Act
+        var result = Results.Text(content, contentType, encoding, statusCode) as ContentHttpResult;
+
+        // Assert
+        Assert.Equal(statusCode, result.StatusCode);
         Assert.Equal(content, result.ResponseContent);
         var expectedMediaType = MediaTypeHeaderValue.Parse(contentType);
         expectedMediaType.Encoding = encoding;
@@ -1007,6 +1061,7 @@ public class ResultsTests
         (() => Results.Conflict(null), typeof(Conflict)),
         (() => Results.Conflict(new()), typeof(Conflict<object>)),
         (() => Results.Content("content", null, null), typeof(ContentHttpResult)),
+        (() => Results.Content("content", null, null, null), typeof(ContentHttpResult)),
         (() => Results.Created("/path", null), typeof(Created)),
         (() => Results.Created("/path", new()), typeof(Created<object>)),
         (() => Results.CreatedAtRoute("routeName", null, null), typeof(CreatedAtRoute)),
@@ -1027,6 +1082,7 @@ public class ResultsTests
         (() => Results.Stream(new MemoryStream(), null, null, null, null, false), typeof(FileStreamHttpResult)),
         (() => Results.Stream(s => Task.CompletedTask, null, null, null, null), typeof(PushStreamHttpResult)),
         (() => Results.Text("content", null, null), typeof(ContentHttpResult)),
+        (() => Results.Text("content", null, null, null), typeof(ContentHttpResult)),
         (() => Results.Redirect("/path", false, false), typeof(RedirectHttpResult)),
         (() => Results.LocalRedirect("/path", false, false), typeof(RedirectHttpResult)),
         (() => Results.RedirectToRoute("routeName", null, false, false, null), typeof(RedirectToRouteHttpResult)),

--- a/src/Http/Http.Results/test/TypedResultsTests.cs
+++ b/src/Http/Http.Results/test/TypedResultsTests.cs
@@ -475,12 +475,30 @@ public class TypedResultsTests
         var encoding = Encoding.UTF8;
 
         // Act
-        var result = TypedResults.Content(content, contentType, null);
+        var result = TypedResults.Content(content, contentType, encoding);
 
         // Assert
         Assert.Null(result.StatusCode);
         Assert.Equal(content, result.ResponseContent);
-        Assert.Equal(contentType, result.ContentType);
+        Assert.Equal("text/plain; charset=utf-8", result.ContentType);
+    }
+
+    [Fact]
+    public void Content_WithContentAndContentTypeAndEncodingAndStatusCode_ResultHasCorrectValues()
+    {
+        // Arrange
+        var content = "test content";
+        var contentType = "text/plain";
+        var encoding = Encoding.UTF8;
+        var statusCode = 201;
+
+        // Act
+        var result = TypedResults.Content(content, contentType, encoding, statusCode);
+
+        // Assert
+        Assert.Equal(statusCode, result.StatusCode);
+        Assert.Equal(content, result.ResponseContent);
+        Assert.Equal("text/plain; charset=utf-8", result.ContentType);
     }
 
     [Fact]
@@ -1039,6 +1057,22 @@ public class TypedResultsTests
     }
 
     [Fact]
+    public void Text_WithContentAndContentType_ResultHasCorrectValues()
+    {
+        // Arrange
+        var content = "test content";
+        var contentType = "text/plain";
+
+        // Act
+        var result = TypedResults.Text(content, contentType);
+
+        // Assert
+        Assert.Null(result.StatusCode);
+        Assert.Equal(content, result.ResponseContent);
+        Assert.Equal(contentType, result.ContentType);
+    }
+
+    [Fact]
     public void Text_WithContentAndContentTypeAndEncoding_ResultHasCorrectValues()
     {
         // Arrange
@@ -1051,6 +1085,26 @@ public class TypedResultsTests
 
         // Assert
         Assert.Null(result.StatusCode);
+        Assert.Equal(content, result.ResponseContent);
+        var expectedMediaType = MediaTypeHeaderValue.Parse(contentType);
+        expectedMediaType.Encoding = encoding;
+        Assert.Equal(expectedMediaType.ToString(), result.ContentType);
+    }
+
+    [Fact]
+    public void Text_WithContentAndContentTypeAndEncodingAndStatusCode_ResultHasCorrectValues()
+    {
+        // Arrange
+        var content = "test content";
+        var contentType = "text/plain";
+        var encoding = Encoding.ASCII;
+        var statusCode = 201;
+
+        // Act
+        var result = TypedResults.Text(content, contentType, encoding, statusCode);
+
+        // Assert
+        Assert.Equal(statusCode, result.StatusCode);
         Assert.Equal(content, result.ResponseContent);
         var expectedMediaType = MediaTypeHeaderValue.Parse(contentType);
         expectedMediaType.Encoding = encoding;


### PR DESCRIPTION
# Add method to Results/TypedResults to allow creating a ContentHttpResult with a custom status code

Added methods to `Results` and `TypedResults` to allow creating `ContentHttpResult` results with a custom status code.

## Description

The `ContentHttpResult` type already supported custom status codes but the factory creation methods did not and the types only have internal constructors so it was not possible to create an in-box `IResult` with a custom status code and text-based message body.

To ensure backwards compatibility the existing methods with optional parameters had the optionality removed and a new overload was added with the original and new optional parameters.

Fixes #41444
