### PR TITLE
Give `$(DotnetEfVersion)` readable casing

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -284,7 +284,7 @@
     <MicrosoftDataSqlClientVersion>4.0.1</MicrosoftDataSqlClientVersion>
     <MicrosoftAspNetCoreAppVersion>6.0.0-preview.3.21167.1</MicrosoftAspNetCoreAppVersion>
     <MicrosoftOpenApiVersion>1.2.3</MicrosoftOpenApiVersion>
-    <!-- dotnet tool versions (see also auto-updated dotnetefVersion property). -->
+    <!-- dotnet tool versions (see also auto-updated DotnetEfVersion property). -->
     <DotnetDumpVersion>6.0.322601</DotnetDumpVersion>
     <DotnetServeVersion>1.10.93</DotnetServeVersion>
     <MicrosoftPlaywrightCLIVersion>1.2.3</MicrosoftPlaywrightCLIVersion>

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -52,7 +52,7 @@
 
     <!-- Grab the tool packages for what HelixTestRunner installs. -->
     <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-dump\$(DotnetDumpVersion)\dotnet-dump.$(DotnetDumpVersion).nupkg" />
-    <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-ef\$(dotnetefVersion)\dotnet-ef.$(dotnetefVersion).nupkg" />
+    <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-ef\$(DotnetEfVersion)\dotnet-ef.$(DotnetEfVersion).nupkg" />
     <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-serve\$(DotnetServeVersion)\dotnet-serve.$(DotnetServeVersion).nupkg" />
 
     <!-- Grab published `HelixTestRunner` project output. -->

--- a/eng/scripts/CodeCheck.ps1
+++ b/eng/scripts/CodeCheck.ps1
@@ -99,7 +99,6 @@ try {
         $expectedVersion = $dep.Version
 
         if ($dep.Name -in $globalJson.'msbuild-sdks'.PSObject.Properties.Name) {
-
             $actualVersion = $globalJson.'msbuild-sdks'.($dep.Name)
 
             if ($expectedVersion -ne $actualVersion) {

--- a/eng/tools/GenerateFiles/GenerateFiles.csproj
+++ b/eng/tools/GenerateFiles/GenerateFiles.csproj
@@ -18,7 +18,7 @@
         AspNetCorePatchVersion=$(AspNetCorePatchVersion);
         DefaultNetCoreTargetFramework=$(DefaultNetCoreTargetFramework);
         DotnetDumpVersion=$(DotnetDumpVersion);
-        dotnetefVersion=$(dotnetefVersion);
+        DotnetEfVersion=$(DotnetEfVersion);
         DotnetServeVersion=$(DotnetServeVersion);
         MicrosoftAspNetCoreAppRefVersion=$(TargetingPackVersion);
         MicrosoftAspNetCoreAppRuntimeVersion=$(SharedFxVersion);

--- a/eng/tools/GenerateFiles/dotnet-tools.json.in
+++ b/eng/tools/GenerateFiles/dotnet-tools.json.in
@@ -9,7 +9,7 @@
       ]
     },
     "dotnet-ef": {
-      "version": "${dotnetefVersion}",
+      "version": "${DotnetEfVersion}",
       "commands": [
         "dotnet-ef"
       ]


### PR DESCRIPTION
- `msbuild` property names are case-insensitive anyway
- leave property setting alone; `darc` writes `<dotnetefVersion />` regardless of current case
  - i.e. changing the setting would be very short-lived