### PR TITLE
Only load bcrypt.dll on Windows

### DIFF
--- a/src/DataProtection/Cryptography.Internal/src/Cng/OSVersionUtil.cs
+++ b/src/DataProtection/Cryptography.Internal/src/Cng/OSVersionUtil.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Cryptography.SafeHandles;
 
 namespace Microsoft.AspNetCore.Cryptography.Cng;
@@ -11,34 +13,29 @@ internal static class OSVersionUtil
 
     private static OSVersion GetOSVersion()
     {
-        const string BCRYPT_LIB = "bcrypt.dll";
-        SafeLibraryHandle? bcryptLibHandle = null;
-        try
+        if (Environment.OSVersion.Platform is not PlatformID.Win32NT)
         {
-            bcryptLibHandle = SafeLibraryHandle.Open(BCRYPT_LIB);
-        }
-        catch
-        {
-            // we'll handle the exceptional case later
+            // Not running on Win7+.
+            return OSVersion.NotWindows;
         }
 
-        if (bcryptLibHandle != null)
+        try
         {
-            using (bcryptLibHandle)
+            // REVIEW: Should we just use the lazy handle instead of disposing?
+            using var bcryptLibHandle = SafeLibraryHandle.Open(UnsafeNativeMethods.BCRYPT_LIB);
+
+            if (bcryptLibHandle.DoesProcExist("BCryptKeyDerivation"))
             {
-                if (bcryptLibHandle.DoesProcExist("BCryptKeyDerivation"))
-                {
-                    // We're running on Win8+.
-                    return OSVersion.Win8OrLater;
-                }
-                else
-                {
-                    // We're running on Win7+.
-                    return OSVersion.Win7OrLater;
-                }
+                // We're running on Win8+.
+                return OSVersion.Win8OrLater;
+            }
+            else
+            {
+                // We're running on Win7+.
+                return OSVersion.Win7OrLater;
             }
         }
-        else
+        catch
         {
             // Not running on Win7+.
             return OSVersion.NotWindows;

--- a/src/DataProtection/Cryptography.Internal/src/Cng/OSVersionUtil.cs
+++ b/src/DataProtection/Cryptography.Internal/src/Cng/OSVersionUtil.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Cryptography.SafeHandles;
 
 namespace Microsoft.AspNetCore.Cryptography.Cng;

--- a/src/DataProtection/Cryptography.Internal/src/UnsafeNativeMethods.cs
+++ b/src/DataProtection/Cryptography.Internal/src/UnsafeNativeMethods.cs
@@ -18,19 +18,13 @@ namespace Microsoft.AspNetCore.Cryptography;
 internal static unsafe class UnsafeNativeMethods
 {
     private const string BCRYPT_LIB = "bcrypt.dll";
-    private static readonly Lazy<SafeLibraryHandle> _lazyBCryptLibHandle = GetLazyLibraryHandle(BCRYPT_LIB);
+    private static SafeLibraryHandle? _lazyBCryptLibHandle;
 
     private const string CRYPT32_LIB = "crypt32.dll";
-    private static readonly Lazy<SafeLibraryHandle> _lazyCrypt32LibHandle = GetLazyLibraryHandle(CRYPT32_LIB);
+    private static SafeLibraryHandle? _lazyCrypt32LibHandle;
 
     private const string NCRYPT_LIB = "ncrypt.dll";
-    private static readonly Lazy<SafeLibraryHandle> _lazyNCryptLibHandle = GetLazyLibraryHandle(NCRYPT_LIB);
-
-    private static Lazy<SafeLibraryHandle> GetLazyLibraryHandle(string libraryName)
-    {
-        // We don't need to worry about race conditions: SafeLibraryHandle will clean up after itself
-        return new Lazy<SafeLibraryHandle>(() => SafeLibraryHandle.Open(libraryName), LazyThreadSafetyMode.PublicationOnly);
-    }
+    private static SafeLibraryHandle? _lazyNCryptLibHandle;
 
     /*
      * BCRYPT.DLL
@@ -304,6 +298,24 @@ internal static unsafe class UnsafeNativeMethods
     /*
      * HELPER FUNCTIONS
      */
+    private static SafeLibraryHandle InitializeLazySafeLibraryHandle(string libraryName, ref SafeLibraryHandle? safeLibraryHandle)
+    {
+        if (safeLibraryHandle is null)
+        {
+            var newHandle = SafeLibraryHandle.Open(libraryName);
+            if (Interlocked.CompareExchange(ref safeLibraryHandle, newHandle, null) is not null)
+            {
+                newHandle.Dispose();
+            }
+        }
+
+        return safeLibraryHandle;
+    }
+
+    // We use methods instead of properties to access lazy handles in order to prevent debuggers from automatically attempting to load libraries on unsupported platforms.
+    private static SafeLibraryHandle GetBCryptLibHandle() => InitializeLazySafeLibraryHandle(BCRYPT_LIB, ref _lazyBCryptLibHandle);
+    private static SafeLibraryHandle GetCrypt32LibHandle() => InitializeLazySafeLibraryHandle(CRYPT32_LIB, ref _lazyCrypt32LibHandle);
+    private static SafeLibraryHandle GetNCryptLibHandle() => InitializeLazySafeLibraryHandle(NCRYPT_LIB, ref _lazyNCryptLibHandle);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void ThrowExceptionForBCryptStatus(int ntstatus)
@@ -318,7 +330,7 @@ internal static unsafe class UnsafeNativeMethods
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowExceptionForBCryptStatusImpl(int ntstatus)
     {
-        var message = _lazyBCryptLibHandle.Value.FormatMessage(ntstatus);
+        var message = GetBCryptLibHandle().FormatMessage(ntstatus);
         throw new CryptographicException(message);
     }
 
@@ -327,7 +339,7 @@ internal static unsafe class UnsafeNativeMethods
         var lastError = Marshal.GetLastWin32Error();
         Debug.Assert(lastError != 0, "This method should only be called if there was an error.");
 
-        var message = _lazyCrypt32LibHandle.Value.FormatMessage(lastError);
+        var message = GetCrypt32LibHandle().FormatMessage(lastError);
         throw new CryptographicException(message);
     }
 
@@ -344,7 +356,7 @@ internal static unsafe class UnsafeNativeMethods
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowExceptionForNCryptStatusImpl(int ntstatus)
     {
-        var message = _lazyNCryptLibHandle.Value.FormatMessage(ntstatus);
+        var message = GetNCryptLibHandle().FormatMessage(ntstatus);
         throw new CryptographicException(message);
     }
 }

--- a/src/DataProtection/Cryptography.Internal/src/UnsafeNativeMethods.cs
+++ b/src/DataProtection/Cryptography.Internal/src/UnsafeNativeMethods.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Cryptography;
 [SuppressUnmanagedCodeSecurity]
 internal static unsafe class UnsafeNativeMethods
 {
-    private const string BCRYPT_LIB = "bcrypt.dll";
+    internal const string BCRYPT_LIB = "bcrypt.dll";
     private static SafeLibraryHandle? _lazyBCryptLibHandle;
 
     private const string CRYPT32_LIB = "crypt32.dll";

--- a/src/DataProtection/Cryptography.Internal/src/UnsafeNativeMethods.cs
+++ b/src/DataProtection/Cryptography.Internal/src/UnsafeNativeMethods.cs
@@ -298,7 +298,7 @@ internal static unsafe class UnsafeNativeMethods
     /*
      * HELPER FUNCTIONS
      */
-    private static SafeLibraryHandle InitializeLazySafeLibraryHandle(string libraryName, ref SafeLibraryHandle? safeLibraryHandle)
+    private static SafeLibraryHandle GetLibHandle(string libraryName, ref SafeLibraryHandle? safeLibraryHandle)
     {
         if (safeLibraryHandle is null)
         {
@@ -313,9 +313,9 @@ internal static unsafe class UnsafeNativeMethods
     }
 
     // We use methods instead of properties to access lazy handles in order to prevent debuggers from automatically attempting to load libraries on unsupported platforms.
-    private static SafeLibraryHandle GetBCryptLibHandle() => InitializeLazySafeLibraryHandle(BCRYPT_LIB, ref _lazyBCryptLibHandle);
-    private static SafeLibraryHandle GetCrypt32LibHandle() => InitializeLazySafeLibraryHandle(CRYPT32_LIB, ref _lazyCrypt32LibHandle);
-    private static SafeLibraryHandle GetNCryptLibHandle() => InitializeLazySafeLibraryHandle(NCRYPT_LIB, ref _lazyNCryptLibHandle);
+    private static SafeLibraryHandle GetBCryptLibHandle() => GetLibHandle(BCRYPT_LIB, ref _lazyBCryptLibHandle);
+    private static SafeLibraryHandle GetCrypt32LibHandle() => GetLibHandle(CRYPT32_LIB, ref _lazyCrypt32LibHandle);
+    private static SafeLibraryHandle GetNCryptLibHandle() => GetLibHandle(NCRYPT_LIB, ref _lazyNCryptLibHandle);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void ThrowExceptionForBCryptStatus(int ntstatus)


### PR DESCRIPTION
This PR fixes two potential causes of seeing a `DllNotFoundException`s loading bcrypt.dll on non-Windows platforms. Before this change, `Microsoft.AspNetCore.Cryptography.Cng.OSVersionUtil.IsWindows()` itself tried to load `bcrypt.dll` on other platforms as part of `AddDataProtection()`.

<img width="1027" alt="image" src="https://user-images.githubusercontent.com/54385/166390582-19bb5701-cf75-4e0d-8494-4243b410a312.png">

<details>
  <summary>Stack Trace</summary>

```
Microsoft.AspNetCore.Cryptography.Internal.dll!Microsoft.AspNetCore.Cryptography.SafeHandles.SafeLibraryHandle.Open(string filename) (Unknown Source:0)
Microsoft.AspNetCore.Cryptography.Internal.dll!Microsoft.AspNetCore.Cryptography.Cng.OSVersionUtil.GetOSVersion() (Unknown Source:0)
Microsoft.AspNetCore.Cryptography.Internal.dll!Microsoft.AspNetCore.Cryptography.Cng.OSVersionUtil.OSVersionUtil() (Unknown Source:0)
[Native to Managed Transition] (Unknown Source:0)
[Managed to Native Transition] (Unknown Source:0)
Microsoft.AspNetCore.Cryptography.Internal.dll!Microsoft.AspNetCore.Cryptography.Cng.OSVersionUtil.IsWindows() (Unknown Source:0)
Microsoft.AspNetCore.DataProtection.dll!Microsoft.Extensions.DependencyInjection.DataProtectionServiceCollectionExtensions.AddDataProtectionServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services) (Unknown Source:0)
Microsoft.AspNetCore.DataProtection.dll!Microsoft.Extensions.DependencyInjection.DataProtectionServiceCollectionExtensions.AddDataProtection(Microsoft.Extensions.DependencyInjection.IServiceCollection services) (Unknown Source:0)
Microsoft.AspNetCore.Mvc.ViewFeatures.dll!Microsoft.Extensions.DependencyInjection.MvcViewFeaturesMvcCoreBuilderExtensions.AddViewServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services) (Unknown Source:0)
Microsoft.AspNetCore.Mvc.ViewFeatures.dll!Microsoft.Extensions.DependencyInjection.MvcViewFeaturesMvcCoreBuilderExtensions.AddViews(Microsoft.Extensions.DependencyInjection.IMvcCoreBuilder builder) (Unknown Source:0)
Microsoft.AspNetCore.Mvc.Razor.dll!Microsoft.Extensions.DependencyInjection.MvcRazorMvcCoreBuilderExtensions.AddRazorViewEngine(Microsoft.Extensions.DependencyInjection.IMvcCoreBuilder builder) (Unknown Source:0)
Microsoft.AspNetCore.Mvc.RazorPages.dll!Microsoft.Extensions.DependencyInjection.MvcRazorPagesMvcCoreBuilderExtensions.AddRazorPages(Microsoft.Extensions.DependencyInjection.IMvcCoreBuilder builder) (Unknown Source:0)
Microsoft.AspNetCore.Mvc.dll!Microsoft.Extensions.DependencyInjection.MvcServiceCollectionExtensions.AddRazorPagesCore(Microsoft.Extensions.DependencyInjection.IServiceCollection services) (Unknown Source:0)
Microsoft.AspNetCore.Mvc.dll!Microsoft.Extensions.DependencyInjection.MvcServiceCollectionExtensions.AddRazorPages(Microsoft.Extensions.DependencyInjection.IServiceCollection services) (Unknown Source:0)
Web.Api.dll!Program.<Main>$(string[] args) Line 104 (\home\halter73\dev\khteh\AspNetCoreApiStarter\src\Web.Api\Program.cs:104)
[Native to Managed Transition] (Unknown Source:0)
```
</details>

You could also get this error if you tried to evaluate `Microsoft.AspNetCore.Cryptography.UnsafeNativeMethods._lazyBCryptLibHandle.Value` in the debugger for some reason.

<img width="512" alt="image" src="https://user-images.githubusercontent.com/54385/166390607-3f50dbd3-89ab-45d2-b7dc-55cc93bc0126.png">

Fixes #41417
