### PR TITLE
Support minimal APIs & program/main together in Web API template

### DIFF
--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -142,7 +142,7 @@ public class Project : IDisposable
         }
     }
 
-    internal async Task<ProcessResult> RunDotNetPublishAsync(IDictionary<string, string> packageOptions = null, string additionalArgs = null, bool noRestore = true)
+    internal async Task<ProcessResult> RunDotNetPublishAsync(IDictionary<string, string> packageOptions = null, string additionalArgs = null, bool noRestore = true, bool errorOnBuildWarning = true)
     {
         Output.WriteLine("Publishing ASP.NET Core application...");
 
@@ -151,23 +151,41 @@ public class Project : IDisposable
 
         var restoreArgs = noRestore ? "--no-restore" : null;
 
-        using var result = ProcessEx.Run(Output, TemplateOutputDir, DotNetMuxer.MuxerPathOrDefault(), $"publish {restoreArgs} -c Release /bl {additionalArgs}", packageOptions);
-        await result.Exited;
-        CaptureBinLogOnFailure(result);
-        return new ProcessResult(result);
+        using var execution = ProcessEx.Run(Output, TemplateOutputDir, DotNetMuxer.MuxerPathOrDefault(), $"publish {restoreArgs} -c Release /bl {additionalArgs}", packageOptions);
+        await execution.Exited;
+
+        var result = new ProcessResult(execution);
+
+        // Fail if there were build warnings
+        if (errorOnBuildWarning && (execution.Output.Contains(": warning") || execution.Error.Contains(": warning")))
+        {
+            result.ExitCode = -1;
+        }
+
+        CaptureBinLogOnFailure(execution);
+        return result;
     }
 
-    internal async Task<ProcessResult> RunDotNetBuildAsync(IDictionary<string, string> packageOptions = null, string additionalArgs = null)
+    internal async Task<ProcessResult> RunDotNetBuildAsync(IDictionary<string, string> packageOptions = null, string additionalArgs = null, bool errorOnBuildWarning = true)
     {
         Output.WriteLine("Building ASP.NET Core application...");
 
         // Avoid restoring as part of build or publish. These projects should have already restored as part of running dotnet new. Explicitly disabling restore
         // should avoid any global contention and we can execute a build or publish in a lock-free way
 
-        using var result = ProcessEx.Run(Output, TemplateOutputDir, DotNetMuxer.MuxerPathOrDefault(), $"build --no-restore -c Debug /bl {additionalArgs}", packageOptions);
-        await result.Exited;
-        CaptureBinLogOnFailure(result);
-        return new ProcessResult(result);
+        using var execution = ProcessEx.Run(Output, TemplateOutputDir, DotNetMuxer.MuxerPathOrDefault(), $"build --no-restore -c Debug /bl {additionalArgs}", packageOptions);
+        await execution.Exited;
+
+        var result = new ProcessResult(execution);
+
+        // Fail if there were build warnings
+        if (errorOnBuildWarning && (execution.Output.Contains(": warning") || execution.Error.Contains(": warning")))
+        {
+            result.ExitCode = -1;
+        }
+
+        CaptureBinLogOnFailure(execution);
+        return result;
     }
 
     internal AspNetProcess StartBuiltProjectAsync(bool hasListeningUri = true, ILogger logger = null)

--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -142,7 +142,7 @@ public class Project : IDisposable
         }
     }
 
-    internal async Task<ProcessResult> RunDotNetPublishAsync(IDictionary<string, string> packageOptions = null, string additionalArgs = null, bool noRestore = true, bool errorOnBuildWarning = true)
+    internal async Task<ProcessResult> RunDotNetPublishAsync(IDictionary<string, string> packageOptions = null, string additionalArgs = null, bool noRestore = true)
     {
         Output.WriteLine("Publishing ASP.NET Core application...");
 
@@ -157,7 +157,7 @@ public class Project : IDisposable
         var result = new ProcessResult(execution);
 
         // Fail if there were build warnings
-        if (errorOnBuildWarning && (execution.Output.Contains(": warning") || execution.Error.Contains(": warning")))
+        if (execution.Output.Contains(": warning") || execution.Error.Contains(": warning"))
         {
             result.ExitCode = -1;
         }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
@@ -40,8 +40,7 @@
         {
           "condition": "(!UseProgramMain)",
           "exclude": [
-            "Program.Main.cs",
-            "WeatherForecast.cs"
+            "Program.Main.cs"
           ]
         },
         {
@@ -59,6 +58,12 @@
           "condition": "(UseMinimalAPIs)",
           "exclude": [
             "Controllers/WeatherForecastController.cs"
+          ]
+        },
+        {
+          "condition": "(UseMinimalAPIs && !UseProgramMain)",
+          "exclude": [
+            "WeatherForecast.cs"
           ]
         },
         {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
@@ -40,13 +40,16 @@
         {
           "condition": "(!UseProgramMain)",
           "exclude": [
-            "Program.Main.cs"
+            "Program.Main.cs",
+            "WeatherForecast.cs"
           ]
         },
         {
-          "condition": "(UseProgramMain && !UseMinimalAPIs)",
+          "condition": "(UseProgramMain)",
           "exclude": [
-            "Program.cs"
+            "Program.cs",
+            "Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs",
+            "Program.MinimalAPIs.WindowsOrNoAuth.cs"
           ],
           "rename": {
             "Program.Main.cs": "Program.cs"
@@ -55,13 +58,11 @@
         {
           "condition": "(UseMinimalAPIs)",
           "exclude": [
-            "Controllers/WeatherForecastController.cs",
-            "Program.cs",
-            "WeatherForecast.cs"
+            "Controllers/WeatherForecastController.cs"
           ]
         },
         {
-          "condition": "(UseMinimalAPIs && (NoAuth || WindowsAuth))",
+          "condition": "(!UseProgramMain && UseMinimalAPIs && (NoAuth || WindowsAuth))",
           "rename": {
             "Program.MinimalAPIs.WindowsOrNoAuth.cs": "Program.cs"
           },
@@ -70,7 +71,7 @@
           ]
         },
         {
-          "condition": "(UseMinimalAPIs && (IndividualAuth || OrganizationalAuth))",
+          "condition": "(!UseProgramMain && UseMinimalAPIs && (IndividualAuth || OrganizationalAuth))",
           "rename": {
             "Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs": "Program.cs"
           },

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.Main.cs
@@ -13,6 +13,7 @@ using Graph = Microsoft.Graph;
 #endif
 #if (OrganizationalAuth || IndividualB2CAuth)
 using Microsoft.Identity.Web;
+using Microsoft.Identity.Web.Resource;
 #endif
 #if (OrganizationalAuth || IndividualB2CAuth || GenerateGraph || WindowsAuth || EnableOpenAPI)
 
@@ -98,7 +99,7 @@ public class Program
 
         #if (UseMinimalAPIs)
         #if (OrganizationalAuth || IndividualB2CAuth)
-        var scopeRequiredByApi = app.Configuration["AzureAd:Scopes"];
+        var scopeRequiredByApi = app.Configuration["AzureAd:Scopes"] ?? "";
         #endif
         var summaries = new[]
         {
@@ -106,7 +107,7 @@ public class Program
         };
 
         #if (GenerateApi)
-        app.MapGet("/weatherforecast", (HttpContext httpContext, IDownstreamWebApi downstreamWebApi) =>
+        app.MapGet("/weatherforecast", async (HttpContext httpContext, IDownstreamWebApi downstreamWebApi) =>
         {
             httpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
 
@@ -132,9 +133,8 @@ public class Program
                 .ToArray();
 
             return forecast;
-        })
         #elif (GenerateGraph)
-        app.MapGet("/weatherforecast", (HttpContext httpContext, GraphServiceClient graphServiceClient) =>
+        app.MapGet("/weatherforecast", async (HttpContext httpContext, GraphServiceClient graphServiceClient) =>
         {
             httpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
 
@@ -150,7 +150,6 @@ public class Program
                 .ToArray();
 
             return forecast;
-        })
         #else
         app.MapGet("/weatherforecast", (HttpContext httpContext) =>
         {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.Main.cs
@@ -5,13 +5,16 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 #if (WindowsAuth)
 using Microsoft.AspNetCore.Authentication.Negotiate;
 #endif
+#if (EnableOpenAPI)
+using Microsoft.AspNetCore.OpenApi;
+#endif
 #if (GenerateGraph)
 using Graph = Microsoft.Graph;
 #endif
 #if (OrganizationalAuth || IndividualB2CAuth)
 using Microsoft.Identity.Web;
 #endif
-#if (OrganizationalAuth || IndividualB2CAuth || GenerateGraph || WindowsAuth)
+#if (OrganizationalAuth || IndividualB2CAuth || GenerateGraph || WindowsAuth || EnableOpenAPI)
 
 #endif
 namespace Company.WebApplication1;
@@ -20,76 +23,172 @@ public class Program
 {
     public static void Main(string[] args)
     {
-    var builder = WebApplication.CreateBuilder(args);
+        var builder = WebApplication.CreateBuilder(args);
 
-    // Add services to the container.
-    #if (OrganizationalAuth)
-    builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-    #if (GenerateApiOrGraph)
-        .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"))
-            .EnableTokenAcquisitionToCallDownstreamApi()
-    #if (GenerateApi)
-                .AddDownstreamWebApi("DownstreamApi", builder.Configuration.GetSection("DownstreamApi"))
-    #endif
-    #if (GenerateGraph)
-                .AddMicrosoftGraph(builder.Configuration.GetSection("DownstreamApi"))
-    #endif
-                .AddInMemoryTokenCaches();
-    #else
-        .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"));
-    #endif
-    #elif (IndividualB2CAuth)
-    builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-    #if (GenerateApi)
-        .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAdB2C"))
-            .EnableTokenAcquisitionToCallDownstreamApi()
-                .AddDownstreamWebApi("DownstreamApi", builder.Configuration.GetSection("DownstreamApi"))
-                .AddInMemoryTokenCaches();
-    #else
-        .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAdB2C"));
-    #endif
-    #endif
+        // Add services to the container.
+        #if (OrganizationalAuth)
+        builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+        #if (GenerateApiOrGraph)
+            .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"))
+                .EnableTokenAcquisitionToCallDownstreamApi()
+        #if (GenerateApi)
+                    .AddDownstreamWebApi("DownstreamApi", builder.Configuration.GetSection("DownstreamApi"))
+        #endif
+        #if (GenerateGraph)
+                    .AddMicrosoftGraph(builder.Configuration.GetSection("DownstreamApi"))
+        #endif
+                    .AddInMemoryTokenCaches();
+        #else
+            .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"));
+        #endif
+        #elif (IndividualB2CAuth)
+        builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+        #if (GenerateApi)
+            .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAdB2C"))
+                .EnableTokenAcquisitionToCallDownstreamApi()
+                    .AddDownstreamWebApi("DownstreamApi", builder.Configuration.GetSection("DownstreamApi"))
+                    .AddInMemoryTokenCaches();
+        #else
+            .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAdB2C"));
+        #endif
+        #endif
+        #if (UseMinimalAPIs)
+        builder.Services.AddAuthorization();
+        #endif
 
-    builder.Services.AddControllers();
-    #if (EnableOpenAPI)
-    // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-    builder.Services.AddEndpointsApiExplorer();
-    builder.Services.AddSwaggerGen();
-    #endif
-    #if (WindowsAuth)
+        #if (UseControllers)
+        builder.Services.AddControllers();
+        #endif
+        #if (EnableOpenAPI)
+        // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+        builder.Services.AddEndpointsApiExplorer();
+        builder.Services.AddSwaggerGen();
+        #endif
+        #if (WindowsAuth)
 
-    builder.Services.AddAuthentication(NegotiateDefaults.AuthenticationScheme)
-    .AddNegotiate();
+        builder.Services.AddAuthentication(NegotiateDefaults.AuthenticationScheme)
+            .AddNegotiate();
 
-    builder.Services.AddAuthorization(options =>
-    {
-        // By default, all incoming requests will be authorized according to the default policy.
-        options.FallbackPolicy = options.DefaultPolicy;
-    });
-    #endif
+        builder.Services.AddAuthorization(options =>
+        {
+            // By default, all incoming requests will be authorized according to the default policy.
+            options.FallbackPolicy = options.DefaultPolicy;
+        });
+        #endif
 
-    var app = builder.Build();
+        var app = builder.Build();
 
-    // Configure the HTTP request pipeline.
-    #if (EnableOpenAPI)
-    if (app.Environment.IsDevelopment())
-    {
-        app.UseSwagger();
-        app.UseSwaggerUI();
-    }
-    #endif
-    #if (RequiresHttps)
+        // Configure the HTTP request pipeline.
+        #if (EnableOpenAPI)
+        if (app.Environment.IsDevelopment())
+        {
+            app.UseSwagger();
+            app.UseSwaggerUI();
+        }
+        #endif
+        #if (RequiresHttps)
 
-    app.UseHttpsRedirection();
-    #endif
+        app.UseHttpsRedirection();
+        #endif
 
-    #if (OrganizationalAuth || IndividualAuth || WindowsAuth)
-    app.UseAuthentication();
-    #endif
-    app.UseAuthorization();
+        #if (OrganizationalAuth || IndividualAuth || WindowsAuth)
+        app.UseAuthentication();
+        #endif
+        app.UseAuthorization();
 
-    app.MapControllers();
+        #if (UseMinimalAPIs)
+        #if (OrganizationalAuth || IndividualB2CAuth)
+        var scopeRequiredByApi = app.Configuration["AzureAd:Scopes"];
+        #endif
+        var summaries = new[]
+        {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
 
-    app.Run();
+        #if (GenerateApi)
+        app.MapGet("/weatherforecast", (HttpContext httpContext, IDownstreamWebApi downstreamWebApi) =>
+        {
+            httpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
+
+            using var response = await downstreamWebApi.CallWebApiForUserAsync("DownstreamApi").ConfigureAwait(false);
+            if (response.StatusCode == System.Net.HttpStatusCode.OK)
+            {
+                var apiResult = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                // Do something
+            }
+            else
+            {
+                var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                throw new HttpRequestException($"Invalid status code in the HttpResponseMessage: {response.StatusCode}: {error}");
+            }
+
+            var forecast =  Enumerable.Range(1, 5).Select(index =>
+                new WeatherForecast
+                {
+                    Date = DateTime.Now.AddDays(index),
+                    TemperatureC = Random.Shared.Next(-20, 55),
+                    Summary = summaries[Random.Shared.Next(summaries.Length)]
+                })
+                .ToArray();
+
+            return forecast;
+        })
+        #elif (GenerateGraph)
+        app.MapGet("/weatherforecast", (HttpContext httpContext, GraphServiceClient graphServiceClient) =>
+        {
+            httpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
+
+            var user = await _graphServiceClient.Me.Request().GetAsync();
+
+            var forecast =  Enumerable.Range(1, 5).Select(index =>
+                new WeatherForecast
+                {
+                    Date = DateTime.Now.AddDays(index),
+                    TemperatureC = Random.Shared.Next(-20, 55),
+                    Summary = summaries[Random.Shared.Next(summaries.Length)]
+                })
+                .ToArray();
+
+            return forecast;
+        })
+        #else
+        app.MapGet("/weatherforecast", (HttpContext httpContext) =>
+        {
+            #if (OrganizationalAuth || IndividualB2CAuth)
+            httpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
+
+            #endif
+            var forecast =  Enumerable.Range(1, 5).Select(index =>
+                new WeatherForecast
+                {
+                    Date = DateTime.Now.AddDays(index),
+                    TemperatureC = Random.Shared.Next(-20, 55),
+                    Summary = summaries[Random.Shared.Next(summaries.Length)]
+                })
+                .ToArray();
+            return forecast;
+        #endif
+        #if (EnableOpenAPI && !NoAuth)
+        })
+        .WithName("GetWeatherForecast")
+        .WithOpenApi()
+        .RequireAuthorization();
+        #elif (EnableOpenAPI && NoAuth)
+        })
+        .WithName("GetWeatherForecast")
+        .WithOpenApi();
+        #elif (!EnableOpenAPI && !NoAuth)
+        })
+        .RequireAuthorization();
+        #else
+        });
+        #endif
+        #endif
+        #if (UseControllers)
+
+        app.MapControllers();
+        #endif
+
+        app.Run();
     }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.Main.cs
@@ -134,11 +134,11 @@ public class Program
 
             return forecast;
         #elif (GenerateGraph)
-        app.MapGet("/weatherforecast", async (HttpContext httpContext, GraphServiceClient graphServiceClient) =>
+        app.MapGet("/weatherforecast", async (HttpContext httpContext, Graph.GraphServiceClient graphServiceClient) =>
         {
             httpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
 
-            var user = await _graphServiceClient.Me.Request().GetAsync();
+            var user = await graphServiceClient.Me.Request().GetAsync();
 
             var forecast =  Enumerable.Range(1, 5).Select(index =>
                 new WeatherForecast

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs
@@ -101,8 +101,8 @@ app.MapGet("/weatherforecast", (HttpContext httpContext, IDownstreamWebApi downs
 
     return forecast;
 })
-#elseif (GenerateGraph)
-app.MapGet("/weahterforecast", (HttpContext httpContext, GraphServiceClient graphServiceClient) =>
+#elif (GenerateGraph)
+app.MapGet("/weatherforecast", (HttpContext httpContext, GraphServiceClient graphServiceClient) =>
 {
     httpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs
@@ -101,11 +101,11 @@ app.MapGet("/weatherforecast", async (HttpContext httpContext, IDownstreamWebApi
 
     return forecast;
 #elif (GenerateGraph)
-app.MapGet("/weatherforecast", async (HttpContext httpContext, GraphServiceClient graphServiceClient) =>
+app.MapGet("/weatherforecast", async (HttpContext httpContext, Graph.GraphServiceClient graphServiceClient) =>
 {
     httpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
 
-    var user = await _graphServiceClient.Me.Request().GetAsync();
+    var user = await graphServiceClient.Me.Request().GetAsync();
 
     var forecast =  Enumerable.Range(1, 5).Select(index =>
         new WeatherForecast

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs
@@ -100,7 +100,6 @@ app.MapGet("/weatherforecast", (HttpContext httpContext, IDownstreamWebApi downs
         .ToArray();
 
     return forecast;
-})
 #elif (GenerateGraph)
 app.MapGet("/weatherforecast", (HttpContext httpContext, GraphServiceClient graphServiceClient) =>
 {
@@ -118,7 +117,6 @@ app.MapGet("/weatherforecast", (HttpContext httpContext, GraphServiceClient grap
         .ToArray();
 
     return forecast;
-})
 #else
 app.MapGet("/weatherforecast", (HttpContext httpContext) =>
 {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs
@@ -67,14 +67,14 @@ app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
 
-var scopeRequiredByApi = app.Configuration["AzureAd:Scopes"];
+var scopeRequiredByApi = app.Configuration["AzureAd:Scopes"] ?? "";
 var summaries = new[]
 {
     "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
 };
 
 #if (GenerateApi)
-app.MapGet("/weatherforecast", (HttpContext httpContext, IDownstreamWebApi downstreamWebApi) =>
+app.MapGet("/weatherforecast", async (HttpContext httpContext, IDownstreamWebApi downstreamWebApi) =>
 {
     httpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
 
@@ -101,7 +101,7 @@ app.MapGet("/weatherforecast", (HttpContext httpContext, IDownstreamWebApi downs
 
     return forecast;
 #elif (GenerateGraph)
-app.MapGet("/weatherforecast", (HttpContext httpContext, GraphServiceClient graphServiceClient) =>
+app.MapGet("/weatherforecast", async (HttpContext httpContext, GraphServiceClient graphServiceClient) =>
 {
     httpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.WindowsOrNoAuth.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.WindowsOrNoAuth.cs
@@ -41,6 +41,7 @@ app.UseHttpsRedirection();
 #endif
 #if (WindowsAuth)
 app.UseAuthentication();
+app.UseAuthorization();
 #endif
 
 var summaries = new[]

--- a/src/ProjectTemplates/scripts/Run-WebApiProgamMainMinimal-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-WebApiProgamMainMinimal-Locally.ps1
@@ -1,0 +1,12 @@
+#!/usr/bin/env pwsh
+#requires -version 4
+
+[CmdletBinding(PositionalBinding = $false)]
+param()
+
+Set-StrictMode -Version 2
+$ErrorActionPreference = 'Stop'
+
+. $PSScriptRoot\Test-Template.ps1
+
+Test-Template "webapi" "webapi --use-program-main --use-minimal-apis" "Microsoft.DotNet.Web.ProjectTemplates.7.0.7.0.0-dev.nupkg" $false

--- a/src/ProjectTemplates/test/ArgConstants.cs
+++ b/src/ProjectTemplates/test/ArgConstants.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Templates.Test;
+
+internal static class ArgConstants
+{
+    public const string UseProgramMain = "--use-program-main";
+    public const string UseMinimalApis = "--use-minimal-apis";
+    public const string Hosted = "--hosted";
+    public const string Pwa = "--pwa";
+    public const string CallsGraph = "--calls-graph";
+    public const string CalledApiUrl = "--called-api-url";
+    public const string CalledApiUrlGraphMicrosoftCom = "--called-api-url \"https://graph.microsoft.com\"";
+    public const string CalledApiScopes = "--called-api-scopes";
+    public const string CalledApiScopesUserReadWrite = $"{CalledApiScopes} user.readwrite";
+    public const string NoOpenApi = "--no-openapi";
+    public const string Auth = "-au";
+    public const string ClientId = "--client-id";
+    public const string Domain = "--domain";
+    public const string DefaultScope = "--default-scope";
+    public const string AppIdUri = "--app-id-uri";
+    public const string AppIdClientId = "--api-client-id";
+    public const string TenantId = "--tenant-id";
+    public const string AadB2cInstance = "--aad-b2c-instance";
+}

--- a/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
+++ b/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
@@ -27,27 +27,27 @@ public class BlazorServerTemplateTest : BlazorTemplateTest
     public Task BlazorServerTemplateWorks_NoAuth() => CreateBuildPublishAsync("blazorservernoauth");
 
     [Fact]
-    public Task BlazorServerTemplateWorks_ProgamMainNoAuth() => CreateBuildPublishAsync("blazorservernoauth", args: new [] { "--use-program-main" });
+    public Task BlazorServerTemplateWorks_ProgamMainNoAuth() => CreateBuildPublishAsync("blazorservernoauth", args: new[] { ArgConstants.UseProgramMain });
 
     [Theory]
     [InlineData(true, null)]
-    [InlineData(true, new string[] { "--use-program-main" })]
+    [InlineData(true, new string[] { ArgConstants.UseProgramMain })]
     [InlineData(false, null)]
-    [InlineData(false, new string[] { "--use-program-main" })]
+    [InlineData(false, new string[] { ArgConstants.UseProgramMain })]
     [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/30825", Queues = "All.OSX")]
     public Task BlazorServerTemplateWorks_IndividualAuth(bool useLocalDB, string[] args) => CreateBuildPublishAsync("blazorserverindividual" + (useLocalDB ? "uld" : "", args: args));
 
     [Theory]
     [InlineData("IndividualB2C", null)]
-    [InlineData("IndividualB2C", new [] { "--use-program-main" })]
-    [InlineData("IndividualB2C", new [] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("IndividualB2C", new [] { "--use-program-main", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("IndividualB2C", new[] { ArgConstants.UseProgramMain })]
+    [InlineData("IndividualB2C", new[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+    [InlineData("IndividualB2C", new[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
     [InlineData("SingleOrg", null)]
-    [InlineData("SingleOrg", new [] { "--use-program-main" })]
-    [InlineData("SingleOrg", new [] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("SingleOrg", new [] { "--use-program-main", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("SingleOrg", new [] { "--calls-graph" })]
-    [InlineData("SingleOrg", new [] { "--use-program-main", "--calls-graph" })]
+    [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain })]
+    [InlineData("SingleOrg", new[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+    [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+    [InlineData("SingleOrg", new[] { ArgConstants.CallsGraph })]
+    [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CallsGraph })]
     public Task BlazorServerTemplate_IdentityWeb_BuildAndPublish(string auth, string[] args)
         => CreateBuildPublishAsync("blazorserveridweb" + Guid.NewGuid().ToString().Substring(0, 10).ToLowerInvariant(), auth, args);
 

--- a/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
+++ b/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
@@ -39,13 +39,15 @@ public class BlazorServerTemplateTest : BlazorTemplateTest
 
     [Theory]
     [InlineData("IndividualB2C", null)]
-    [InlineData("IndividualB2C", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("IndividualB2C", new string[] { "--use-program-main", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("IndividualB2C", new [] { "--use-program-main" })]
+    [InlineData("IndividualB2C", new [] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("IndividualB2C", new [] { "--use-program-main", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
     [InlineData("SingleOrg", null)]
-    [InlineData("SingleOrg", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("SingleOrg", new string[] { "--use-program-main --called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("SingleOrg", new string[] { "--calls-graph" })]
-    [InlineData("SingleOrg", new string[] { "--use-program-main --calls-graph" })]
+    [InlineData("SingleOrg", new [] { "--use-program-main" })]
+    [InlineData("SingleOrg", new [] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("SingleOrg", new [] { "--use-program-main", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("SingleOrg", new [] { "--calls-graph" })]
+    [InlineData("SingleOrg", new [] { "--use-program-main", "--calls-graph" })]
     public Task BlazorServerTemplate_IdentityWeb_BuildAndPublish(string auth, string[] args)
         => CreateBuildPublishAsync("blazorserveridweb" + Guid.NewGuid().ToString().Substring(0, 10).ToLowerInvariant(), auth, args);
 

--- a/src/ProjectTemplates/test/BlazorWasmTemplateTest.cs
+++ b/src/ProjectTemplates/test/BlazorWasmTemplateTest.cs
@@ -81,20 +81,32 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
     // LocalDB doesn't work on non Windows platforms
     [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
     public Task BlazorWasmHostedTemplate_IndividualAuth_Works_WithLocalDB()
-        => BlazorWasmHostedTemplate_IndividualAuth_Works(true);
+        => BlazorWasmHostedTemplate_IndividualAuth_Works(true, false);
 
     [ConditionalFact]
     [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/34554", Queues = "Windows.10.Arm64v8.Open")]
     public Task BlazorWasmHostedTemplate_IndividualAuth_Works_WithOutLocalDB()
-        => BlazorWasmHostedTemplate_IndividualAuth_Works(false);
+        => BlazorWasmHostedTemplate_IndividualAuth_Works(false, false);
 
-    private async Task<Project> CreateBuildPublishIndividualAuthProject(bool useLocalDb)
+    [ConditionalFact]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/34554", Queues = "Windows.10.Arm64v8.Open")]
+    // LocalDB doesn't work on non Windows platforms
+    [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
+    public Task BlazorWasmHostedTemplate_IndividualAuth_Works_WithLocalDB_ProgramMain()
+        => BlazorWasmHostedTemplate_IndividualAuth_Works(true, true);
+
+    [ConditionalFact]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/34554", Queues = "Windows.10.Arm64v8.Open")]
+    public Task BlazorWasmHostedTemplate_IndividualAuth_Works_WithOutLocalDB_ProgramMain()
+        => BlazorWasmHostedTemplate_IndividualAuth_Works(false, true);
+
+    private async Task<Project> CreateBuildPublishIndividualAuthProject(bool useLocalDb, bool useProgramMain = false)
     {
         // Additional arguments are needed. See: https://github.com/dotnet/aspnetcore/issues/24278
         Environment.SetEnvironmentVariable("EnableDefaultScopedCssItems", "true");
 
         var project = await CreateBuildPublishAsync("blazorhostedindividual" + (useLocalDb ? "uld" : ""),
-            args: new[] { "--hosted", "-au", "Individual", useLocalDb ? "-uld" : "" });
+            args: new[] { "--hosted", "-au", "Individual", useLocalDb ? "-uld" : "", useProgramMain ? "--use-program-main" : "" });
 
         var serverProject = GetSubProject(project, "Server", $"{project.ProjectName}.Server");
 
@@ -128,9 +140,9 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
         return project;
     }
 
-    private async Task BlazorWasmHostedTemplate_IndividualAuth_Works(bool useLocalDb)
+    private async Task BlazorWasmHostedTemplate_IndividualAuth_Works(bool useLocalDb, bool useProgramMain)
     {
-        var project = await CreateBuildPublishIndividualAuthProject(useLocalDb: useLocalDb);
+        var project = await CreateBuildPublishIndividualAuthProject(useLocalDb: useLocalDb, useProgramMain: useProgramMain);
 
         var serverProject = GetSubProject(project, "Server", $"{project.ProjectName}.Server");
     }
@@ -161,6 +173,17 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
                 "--app-id-uri", "ApiUri",
                 "--api-client-id", "1234123413241324"),
             new TemplateInstance(
+                "blazorwasmhostedaadb2c_program_main", "-ho",
+                "-au", "IndividualB2C",
+                "--aad-b2c-instance", "example.b2clogin.com",
+                "-ssp", "b2c_1_siupin",
+                "--client-id", "clientId",
+                "--domain", "my-domain",
+                "--default-scope", "full",
+                "--app-id-uri", "ApiUri",
+                "--api-client-id", "1234123413241324",
+                "--use-program-main"),
+            new TemplateInstance(
                 "blazorwasmhostedaad", "-ho",
                 "-au", "SingleOrg",
                 "--domain", "my-domain",
@@ -169,6 +192,16 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
                 "--default-scope", "full",
                 "--app-id-uri", "ApiUri",
                 "--api-client-id", "1234123413241324"),
+            new TemplateInstance(
+                "blazorwasmhostedaad_program_main", "-ho",
+                "-au", "SingleOrg",
+                "--domain", "my-domain",
+                "--tenant-id", "tenantId",
+                "--client-id", "clientId",
+                "--default-scope", "full",
+                "--app-id-uri", "ApiUri",
+                "--api-client-id", "1234123413241324",
+                "--use-program-main"),
             new TemplateInstance(
                 "blazorwasmhostedaadgraph", "-ho",
                 "-au", "SingleOrg",
@@ -179,6 +212,17 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
                 "--default-scope", "full",
                 "--app-id-uri", "ApiUri",
                 "--api-client-id", "1234123413241324"),
+            new TemplateInstance(
+                "blazorwasmhostedaadgraph_program_main", "-ho",
+                "-au", "SingleOrg",
+                "--calls-graph",
+                "--domain", "my-domain",
+                "--tenant-id", "tenantId",
+                "--client-id", "clientId",
+                "--default-scope", "full",
+                "--app-id-uri", "ApiUri",
+                "--api-client-id", "1234123413241324",
+                "--use-program-main"),
             new TemplateInstance(
                 "blazorwasmhostedaadapi", "-ho",
                 "-au", "SingleOrg",
@@ -191,6 +235,18 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
                 "--app-id-uri", "ApiUri",
                 "--api-client-id", "1234123413241324"),
             new TemplateInstance(
+                "blazorwasmhostedaadapi_program_main", "-ho",
+                "-au", "SingleOrg",
+                "--called-api-url", "\"https://graph.microsoft.com\"",
+                "--called-api-scopes", "user.readwrite",
+                "--domain", "my-domain",
+                "--tenant-id", "tenantId",
+                "--client-id", "clientId",
+                "--default-scope", "full",
+                "--app-id-uri", "ApiUri",
+                "--api-client-id", "1234123413241324",
+                "--use-program-main"),
+            new TemplateInstance(
                 "blazorwasmstandaloneaadb2c",
                 "-au", "IndividualB2C",
                 "--aad-b2c-instance", "example.b2clogin.com",
@@ -198,11 +254,26 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
                 "--client-id", "clientId",
                 "--domain", "my-domain"),
             new TemplateInstance(
+                "blazorwasmstandaloneaadb2c_program_main",
+                "-au", "IndividualB2C",
+                "--aad-b2c-instance", "example.b2clogin.com",
+                "-ssp", "b2c_1_siupin",
+                "--client-id", "clientId",
+                "--domain", "my-domain",
+                "--use-program-main"),
+            new TemplateInstance(
                 "blazorwasmstandaloneaad",
                 "-au", "SingleOrg",
                 "--domain", "my-domain",
                 "--tenant-id", "tenantId",
                 "--client-id", "clientId"),
+            new TemplateInstance(
+                "blazorwasmstandaloneaad_program_main",
+                "-au", "SingleOrg",
+                "--domain", "my-domain",
+                "--tenant-id", "tenantId",
+                "--client-id", "clientId",
+                "--use-program-main"),
         };
 
     public class TemplateInstance

--- a/src/ProjectTemplates/test/BlazorWasmTemplateTest.cs
+++ b/src/ProjectTemplates/test/BlazorWasmTemplateTest.cs
@@ -35,18 +35,18 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
     }
 
     [Fact]
-    public Task BlazorWasmHostedTemplateCanCreateBuildPublish() => CreateBuildPublishAsync("blazorhosted", args: new[] { "--hosted" }, serverProject: true);
+    public Task BlazorWasmHostedTemplateCanCreateBuildPublish() => CreateBuildPublishAsync("blazorhosted", args: new[] { ArgConstants.Hosted }, serverProject: true);
 
     [Fact]
-    public Task BlazorWasmHostedTemplateWithProgamMainCanCreateBuildPublish() => CreateBuildPublishAsync("blazorhosted", args: new[] { "--use-program-main", "--hosted" }, serverProject: true);
+    public Task BlazorWasmHostedTemplateWithProgamMainCanCreateBuildPublish() => CreateBuildPublishAsync("blazorhosted", args: new[] { ArgConstants.UseProgramMain, ArgConstants.Hosted }, serverProject: true);
 
     [Fact]
-    public Task BlazorWasmStandalonePwaTemplateCanCreateBuildPublish() => CreateBuildPublishAsync("blazorstandalonepwa", args: new[] { "--pwa" });
+    public Task BlazorWasmStandalonePwaTemplateCanCreateBuildPublish() => CreateBuildPublishAsync("blazorstandalonepwa", args: new[] { ArgConstants.Pwa });
 
     [Fact]
     public async Task BlazorWasmHostedPwaTemplateCanCreateBuildPublish()
     {
-        var project = await CreateBuildPublishAsync("blazorhostedpwa", args: new[] { "--hosted", "--pwa" }, serverProject: true);
+        var project = await CreateBuildPublishAsync("blazorhostedpwa", args: new[] { ArgConstants.Hosted, ArgConstants.Pwa }, serverProject: true);
 
         var serverProject = GetSubProject(project, "Server", $"{project.ProjectName}.Server");
 
@@ -106,7 +106,7 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
         Environment.SetEnvironmentVariable("EnableDefaultScopedCssItems", "true");
 
         var project = await CreateBuildPublishAsync("blazorhostedindividual" + (useLocalDb ? "uld" : ""),
-            args: new[] { "--hosted", "-au", "Individual", useLocalDb ? "-uld" : "", useProgramMain ? "--use-program-main" : "" });
+            args: new[] { ArgConstants.Hosted, ArgConstants.Auth, "Individual", useLocalDb ? "-uld" : "", useProgramMain ? ArgConstants.UseProgramMain : "" });
 
         var serverProject = GetSubProject(project, "Server", $"{project.ProjectName}.Server");
 
@@ -151,11 +151,11 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
     public async Task BlazorWasmStandaloneTemplate_IndividualAuth_CreateBuildPublish()
     {
         var project = await CreateBuildPublishAsync("blazorstandaloneindividual", args: new[] {
-                "-au",
+                ArgConstants.Auth,
                 "Individual",
                 "--authority",
                 "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration",
-                "--client-id",
+                ArgConstants.ClientId,
                 "sample-client-id"
             });
     }
@@ -164,116 +164,116 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
         {
             new TemplateInstance(
                 "blazorwasmhostedaadb2c", "-ho",
-                "-au", "IndividualB2C",
-                "--aad-b2c-instance", "example.b2clogin.com",
+                ArgConstants.Auth, "IndividualB2C",
+                ArgConstants.AadB2cInstance, "example.b2clogin.com",
                 "-ssp", "b2c_1_siupin",
-                "--client-id", "clientId",
-                "--domain", "my-domain",
-                "--default-scope", "full",
-                "--app-id-uri", "ApiUri",
-                "--api-client-id", "1234123413241324"),
+                ArgConstants.ClientId, "clientId",
+                ArgConstants.Domain, "my-domain",
+                ArgConstants.DefaultScope, "full",
+                ArgConstants.AppIdUri, "ApiUri",
+                ArgConstants.AppIdClientId, "1234123413241324"),
             new TemplateInstance(
                 "blazorwasmhostedaadb2c_program_main", "-ho",
-                "-au", "IndividualB2C",
-                "--aad-b2c-instance", "example.b2clogin.com",
+                ArgConstants.Auth, "IndividualB2C",
+                ArgConstants.AadB2cInstance, "example.b2clogin.com",
                 "-ssp", "b2c_1_siupin",
-                "--client-id", "clientId",
-                "--domain", "my-domain",
-                "--default-scope", "full",
-                "--app-id-uri", "ApiUri",
-                "--api-client-id", "1234123413241324",
-                "--use-program-main"),
+                ArgConstants.ClientId, "clientId",
+                ArgConstants.Domain, "my-domain",
+                ArgConstants.DefaultScope, "full",
+                ArgConstants.AppIdUri, "ApiUri",
+                ArgConstants.AppIdClientId, "1234123413241324",
+                ArgConstants.UseProgramMain),
             new TemplateInstance(
                 "blazorwasmhostedaad", "-ho",
-                "-au", "SingleOrg",
-                "--domain", "my-domain",
-                "--tenant-id", "tenantId",
-                "--client-id", "clientId",
-                "--default-scope", "full",
-                "--app-id-uri", "ApiUri",
-                "--api-client-id", "1234123413241324"),
+                ArgConstants.Auth, "SingleOrg",
+                ArgConstants.Domain, "my-domain",
+                ArgConstants.TenantId, "tenantId",
+                ArgConstants.ClientId, "clientId",
+                ArgConstants.DefaultScope, "full",
+                ArgConstants.AppIdUri, "ApiUri",
+                ArgConstants.AppIdClientId, "1234123413241324"),
             new TemplateInstance(
                 "blazorwasmhostedaad_program_main", "-ho",
-                "-au", "SingleOrg",
-                "--domain", "my-domain",
-                "--tenant-id", "tenantId",
-                "--client-id", "clientId",
-                "--default-scope", "full",
-                "--app-id-uri", "ApiUri",
-                "--api-client-id", "1234123413241324",
-                "--use-program-main"),
+                ArgConstants.Auth, "SingleOrg",
+                ArgConstants.Domain, "my-domain",
+                ArgConstants.TenantId, "tenantId",
+                ArgConstants.ClientId, "clientId",
+                ArgConstants.DefaultScope, "full",
+                ArgConstants.AppIdUri, "ApiUri",
+                ArgConstants.AppIdClientId, "1234123413241324",
+                ArgConstants.UseProgramMain),
             new TemplateInstance(
                 "blazorwasmhostedaadgraph", "-ho",
-                "-au", "SingleOrg",
-                "--calls-graph",
-                "--domain", "my-domain",
-                "--tenant-id", "tenantId",
-                "--client-id", "clientId",
-                "--default-scope", "full",
-                "--app-id-uri", "ApiUri",
-                "--api-client-id", "1234123413241324"),
+                ArgConstants.Auth, "SingleOrg",
+                ArgConstants.CallsGraph,
+                ArgConstants.Domain, "my-domain",
+                ArgConstants.TenantId, "tenantId",
+                ArgConstants.ClientId, "clientId",
+                ArgConstants.DefaultScope, "full",
+                ArgConstants.AppIdUri, "ApiUri",
+                ArgConstants.AppIdClientId, "1234123413241324"),
             new TemplateInstance(
                 "blazorwasmhostedaadgraph_program_main", "-ho",
-                "-au", "SingleOrg",
-                "--calls-graph",
-                "--domain", "my-domain",
-                "--tenant-id", "tenantId",
-                "--client-id", "clientId",
-                "--default-scope", "full",
-                "--app-id-uri", "ApiUri",
-                "--api-client-id", "1234123413241324",
-                "--use-program-main"),
+                ArgConstants.Auth, "SingleOrg",
+                ArgConstants.CallsGraph,
+                ArgConstants.Domain, "my-domain",
+                ArgConstants.TenantId, "tenantId",
+                ArgConstants.ClientId, "clientId",
+                ArgConstants.DefaultScope, "full",
+                ArgConstants.AppIdUri, "ApiUri",
+                ArgConstants.AppIdClientId, "1234123413241324",
+                ArgConstants.UseProgramMain),
             new TemplateInstance(
                 "blazorwasmhostedaadapi", "-ho",
-                "-au", "SingleOrg",
-                "--called-api-url", "\"https://graph.microsoft.com\"",
-                "--called-api-scopes", "user.readwrite",
-                "--domain", "my-domain",
-                "--tenant-id", "tenantId",
-                "--client-id", "clientId",
-                "--default-scope", "full",
-                "--app-id-uri", "ApiUri",
-                "--api-client-id", "1234123413241324"),
+                ArgConstants.Auth, "SingleOrg",
+                ArgConstants.CalledApiUrl, "\"https://graph.microsoft.com\"",
+                ArgConstants.CalledApiScopes, "user.readwrite",
+                ArgConstants.Domain, "my-domain",
+                ArgConstants.TenantId, "tenantId",
+                ArgConstants.ClientId, "clientId",
+                ArgConstants.DefaultScope, "full",
+                ArgConstants.AppIdUri, "ApiUri",
+                ArgConstants.AppIdClientId, "1234123413241324"),
             new TemplateInstance(
                 "blazorwasmhostedaadapi_program_main", "-ho",
-                "-au", "SingleOrg",
-                "--called-api-url", "\"https://graph.microsoft.com\"",
-                "--called-api-scopes", "user.readwrite",
-                "--domain", "my-domain",
-                "--tenant-id", "tenantId",
-                "--client-id", "clientId",
-                "--default-scope", "full",
-                "--app-id-uri", "ApiUri",
-                "--api-client-id", "1234123413241324",
-                "--use-program-main"),
+                ArgConstants.Auth, "SingleOrg",
+                ArgConstants.CalledApiUrl, "\"https://graph.microsoft.com\"",
+                ArgConstants.CalledApiScopes, "user.readwrite",
+                ArgConstants.Domain, "my-domain",
+                ArgConstants.TenantId, "tenantId",
+                ArgConstants.ClientId, "clientId",
+                ArgConstants.DefaultScope, "full",
+                ArgConstants.AppIdUri, "ApiUri",
+                ArgConstants.AppIdClientId, "1234123413241324",
+                ArgConstants.UseProgramMain),
             new TemplateInstance(
                 "blazorwasmstandaloneaadb2c",
-                "-au", "IndividualB2C",
-                "--aad-b2c-instance", "example.b2clogin.com",
+                ArgConstants.Auth, "IndividualB2C",
+                ArgConstants.AadB2cInstance, "example.b2clogin.com",
                 "-ssp", "b2c_1_siupin",
-                "--client-id", "clientId",
-                "--domain", "my-domain"),
+                ArgConstants.ClientId, "clientId",
+                ArgConstants.Domain, "my-domain"),
             new TemplateInstance(
                 "blazorwasmstandaloneaadb2c_program_main",
-                "-au", "IndividualB2C",
-                "--aad-b2c-instance", "example.b2clogin.com",
+                ArgConstants.Auth, "IndividualB2C",
+                ArgConstants.AadB2cInstance, "example.b2clogin.com",
                 "-ssp", "b2c_1_siupin",
-                "--client-id", "clientId",
-                "--domain", "my-domain",
-                "--use-program-main"),
+                ArgConstants.ClientId, "clientId",
+                ArgConstants.Domain, "my-domain",
+                ArgConstants.UseProgramMain),
             new TemplateInstance(
                 "blazorwasmstandaloneaad",
-                "-au", "SingleOrg",
-                "--domain", "my-domain",
-                "--tenant-id", "tenantId",
-                "--client-id", "clientId"),
+                ArgConstants.Auth, "SingleOrg",
+                ArgConstants.Domain, "my-domain",
+                ArgConstants.TenantId, "tenantId",
+                ArgConstants.ClientId, "clientId"),
             new TemplateInstance(
                 "blazorwasmstandaloneaad_program_main",
-                "-au", "SingleOrg",
-                "--domain", "my-domain",
-                "--tenant-id", "tenantId",
-                "--client-id", "clientId",
-                "--use-program-main"),
+                ArgConstants.Auth, "SingleOrg",
+                ArgConstants.Domain, "my-domain",
+                ArgConstants.TenantId, "tenantId",
+                ArgConstants.ClientId, "clientId",
+                ArgConstants.UseProgramMain),
         };
 
     public class TemplateInstance

--- a/src/ProjectTemplates/test/EmptyWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/EmptyWebTemplateTest.cs
@@ -42,7 +42,7 @@ public class EmptyWebTemplateTest : LoggedTest
     [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
     public async Task EmptyWebTemplateProgramMainCSharp()
     {
-        await EmtpyTemplateCore(languageOverride: null, args: new [] { "--use-program-main" });
+        await EmtpyTemplateCore(languageOverride: null, args: new[] { ArgConstants.UseProgramMain });
     }
 
     [Fact]

--- a/src/ProjectTemplates/test/GrpcTemplateTest.cs
+++ b/src/ProjectTemplates/test/GrpcTemplateTest.cs
@@ -43,7 +43,7 @@ public class GrpcTemplateTest : LoggedTest
     {
         var project = await ProjectFactory.GetOrCreateProject("grpc", Output);
 
-        var args = useProgramMain ? new [] { "--use-program-main" } : null;
+        var args = useProgramMain ? new[] { ArgConstants.UseProgramMain } : null;
         var createResult = await project.RunDotNetNewAsync("grpc", args: args);
         Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
 

--- a/src/ProjectTemplates/test/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/MvcTemplateTest.cs
@@ -38,7 +38,7 @@ public class MvcTemplateTest : LoggedTest
 
     [ConditionalFact]
     [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64 + HelixConstants.DebianAmd64)]
-    public async Task MvcTemplate_ProgramMainNoAuthCSharp() => await MvcTemplateCore(languageOverride: null, new [] { "--use-program-main" });
+    public async Task MvcTemplate_ProgramMainNoAuthCSharp() => await MvcTemplateCore(languageOverride: null, new[] { ArgConstants.UseProgramMain });
 
     private async Task MvcTemplateCore(string languageOverride, string[] args = null)
     {
@@ -122,7 +122,7 @@ public class MvcTemplateTest : LoggedTest
     {
         var project = await ProjectFactory.GetOrCreateProject("mvcindividual" + (useLocalDB ? "uld" : ""), Output);
 
-        var args = useProgramMain ? new [] { "--use-program-main" } : null;
+        var args = useProgramMain ? new[] { ArgConstants.UseProgramMain } : null;
         var createResult = await project.RunDotNetNewAsync("mvc", auth: "Individual", useLocalDB: useLocalDB, args: args);
         Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
 
@@ -254,7 +254,7 @@ public class MvcTemplateTest : LoggedTest
         var menuLinks = new[]
         {
             PageUrls.HomeUrl,
-            PageUrls.HomeUrl,            
+            PageUrls.HomeUrl,
             PageUrls.PrivacyFullUrl
         };
 
@@ -285,15 +285,15 @@ public class MvcTemplateTest : LoggedTest
     [ConditionalTheory]
     [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
     [InlineData("IndividualB2C", null)]
-    [InlineData("IndividualB2C", new[] { "--use-program-main" })]
-    [InlineData("IndividualB2C", new [] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("IndividualB2C", new [] { "--use-program-main", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("IndividualB2C", new[] { ArgConstants.UseProgramMain })]
+    [InlineData("IndividualB2C", new[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+    [InlineData("IndividualB2C", new[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
     [InlineData("SingleOrg", null)]
-    [InlineData("SingleOrg", new[] { "--use-program-main" })]
-    [InlineData("SingleOrg", new [] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("SingleOrg", new [] { "--use-program-main", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("SingleOrg", new [] { "--calls-graph" })]
-    [InlineData("SingleOrg", new [] { "--use-program-main", "--calls-graph" })]
+    [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain })]
+    [InlineData("SingleOrg", new[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+    [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+    [InlineData("SingleOrg", new[] { ArgConstants.CallsGraph })]
+    [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CallsGraph })]
     public Task MvcTemplate_IdentityWeb_BuildsAndPublishes(string auth, string[] args) => MvcTemplateBuildsAndPublishes(auth: auth, args: args);
 
     private async Task<Project> MvcTemplateBuildsAndPublishes(string auth, string[] args)

--- a/src/ProjectTemplates/test/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/MvcTemplateTest.cs
@@ -285,10 +285,15 @@ public class MvcTemplateTest : LoggedTest
     [ConditionalTheory]
     [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
     [InlineData("IndividualB2C", null)]
-    [InlineData("IndividualB2C", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("IndividualB2C", new[] { "--use-program-main" })]
+    [InlineData("IndividualB2C", new [] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("IndividualB2C", new [] { "--use-program-main", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
     [InlineData("SingleOrg", null)]
-    [InlineData("SingleOrg", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("SingleOrg", new string[] { "--calls-graph" })]
+    [InlineData("SingleOrg", new[] { "--use-program-main" })]
+    [InlineData("SingleOrg", new [] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("SingleOrg", new [] { "--use-program-main", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("SingleOrg", new [] { "--calls-graph" })]
+    [InlineData("SingleOrg", new [] { "--use-program-main", "--calls-graph" })]
     public Task MvcTemplate_IdentityWeb_BuildsAndPublishes(string auth, string[] args) => MvcTemplateBuildsAndPublishes(auth: auth, args: args);
 
     private async Task<Project> MvcTemplateBuildsAndPublishes(string auth, string[] args)

--- a/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
+++ b/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
@@ -231,16 +231,18 @@ public class RazorPagesTemplateTest : LoggedTest
     [ConditionalTheory]
     [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
     [InlineData("IndividualB2C", null)]
-    [InlineData("IndividualB2C", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("IndividualB2C", new string[] { "--use-program-main --called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("IndividualB2C", new [] { "--use-program-main" })]
+    [InlineData("IndividualB2C", new [] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("IndividualB2C", new [] { "--use-program-main", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
     [InlineData("SingleOrg", null)]
-    [InlineData("SingleOrg", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("SingleOrg", new string[] { "--use-program-main --called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("SingleOrg", new [] { "--use-program-main" })]
+    [InlineData("SingleOrg", new [] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("SingleOrg", new [] { "--use-program-main", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
     public Task RazorPagesTemplate_IdentityWeb_BuildsAndPublishes(string auth, string[] args) => BuildAndPublishRazorPagesTemplate(auth: auth, args: args);
 
     [ConditionalTheory]
-    [InlineData("SingleOrg", new string[] { "--calls-graph" })]
-    [InlineData("SingleOrg", new string[] { "--use-program-main --calls-graph" })]
+    [InlineData("SingleOrg", new [] { "--calls-graph" })]
+    [InlineData("SingleOrg", new [] { "--use-program-main", "--calls-graph" })]
     public Task RazorPagesTemplate_IdentityWeb_BuildsAndPublishes_WithSingleOrg(string auth, string[] args) => BuildAndPublishRazorPagesTemplate(auth: auth, args: args);
 
     private async Task<Project> BuildAndPublishRazorPagesTemplate(string auth, string[] args)

--- a/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
+++ b/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
@@ -42,7 +42,7 @@ public class RazorPagesTemplateTest : LoggedTest
     {
         var project = await ProjectFactory.GetOrCreateProject("razorpagesnoauth", Output);
 
-        var args = useProgramMain ? new [] { "--use-program-main" } : null;
+        var args = useProgramMain ? new[] { ArgConstants.UseProgramMain } : null;
         var createResult = await project.RunDotNetNewAsync("razor", args: args);
         Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("razor", project, createResult));
 
@@ -116,7 +116,7 @@ public class RazorPagesTemplateTest : LoggedTest
     {
         var project = await ProjectFactory.GetOrCreateProject("razorpagesindividual" + (useLocalDB ? "uld" : ""), Output);
 
-        var args = useProgramMain ? new [] { "--use-program-main" } : null;
+        var args = useProgramMain ? new[] { ArgConstants.UseProgramMain } : null;
         var createResult = await project.RunDotNetNewAsync("razor", auth: "Individual", useLocalDB: useLocalDB, args: args);
         Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
 
@@ -231,18 +231,18 @@ public class RazorPagesTemplateTest : LoggedTest
     [ConditionalTheory]
     [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
     [InlineData("IndividualB2C", null)]
-    [InlineData("IndividualB2C", new [] { "--use-program-main" })]
-    [InlineData("IndividualB2C", new [] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("IndividualB2C", new [] { "--use-program-main", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("IndividualB2C", new[] { ArgConstants.UseProgramMain })]
+    [InlineData("IndividualB2C", new[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+    [InlineData("IndividualB2C", new[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
     [InlineData("SingleOrg", null)]
-    [InlineData("SingleOrg", new [] { "--use-program-main" })]
-    [InlineData("SingleOrg", new [] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("SingleOrg", new [] { "--use-program-main", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain })]
+    [InlineData("SingleOrg", new[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+    [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
     public Task RazorPagesTemplate_IdentityWeb_BuildsAndPublishes(string auth, string[] args) => BuildAndPublishRazorPagesTemplate(auth: auth, args: args);
 
     [ConditionalTheory]
-    [InlineData("SingleOrg", new [] { "--calls-graph" })]
-    [InlineData("SingleOrg", new [] { "--use-program-main", "--calls-graph" })]
+    [InlineData("SingleOrg", new[] { ArgConstants.CallsGraph })]
+    [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CallsGraph })]
     public Task RazorPagesTemplate_IdentityWeb_BuildsAndPublishes_WithSingleOrg(string auth, string[] args) => BuildAndPublishRazorPagesTemplate(auth: auth, args: args);
 
     private async Task<Project> BuildAndPublishRazorPagesTemplate(string auth, string[] args)

--- a/src/ProjectTemplates/test/WebApiTemplateTest.cs
+++ b/src/ProjectTemplates/test/WebApiTemplateTest.cs
@@ -73,7 +73,7 @@ public class WebApiTemplateTest : LoggedTest
 
     [ConditionalFact]
     [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
-    public Task WebApiTemplateProgramMainMinimalApisCSharp() => WebApiTemplateCore(languageOverride: null, args: new[] { "ArgConstants.UseProgramMain ArgConstants.UseMinimalApis" });
+    public Task WebApiTemplateProgramMainMinimalApisCSharp() => WebApiTemplateCore(languageOverride: null, args: new[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis });
 
     [ConditionalTheory]
     [InlineData(false, false)]

--- a/src/ProjectTemplates/test/WebApiTemplateTest.cs
+++ b/src/ProjectTemplates/test/WebApiTemplateTest.cs
@@ -35,25 +35,25 @@ public class WebApiTemplateTest : LoggedTest
     [ConditionalTheory]
     [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
     [InlineData("IndividualB2C", null)]
-    [InlineData("IndividualB2C", new string[] { "--use-program-main" })]
-    [InlineData("IndividualB2C", new string[] { "--use-minimal-apis" })]
-    [InlineData("IndividualB2C", new string[] { "--use-program-main", "--use-minimal-apis" })]
-    [InlineData("IndividualB2C", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("IndividualB2C", new string[] { "--use-minimal-apis", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("IndividualB2C", new string[] { "--use-program-main", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("IndividualB2C", new string[] { "--use-program-main", "--use-minimal-apis", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("IndividualB2C", new string[] { ArgConstants.UseProgramMain })]
+    [InlineData("IndividualB2C", new string[] { ArgConstants.UseMinimalApis })]
+    [InlineData("IndividualB2C", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis })]
+    [InlineData("IndividualB2C", new string[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+    [InlineData("IndividualB2C", new string[] { ArgConstants.UseMinimalApis, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+    [InlineData("IndividualB2C", new string[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+    [InlineData("IndividualB2C", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
     [InlineData("SingleOrg", null)]
-    [InlineData("SingleOrg", new string[] { "--use-program-main" })]
-    [InlineData("SingleOrg", new string[] { "--use-minimal-apis" })]
-    [InlineData("SingleOrg", new string[] { "--use-program-main", "--use-minimal-apis" })]
-    [InlineData("SingleOrg", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("SingleOrg", new string[] { "--use-minimal-apis", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("SingleOrg", new string[] { "--use-program-main", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("SingleOrg", new string[] { "--use-program-main", "--use-minimal-apis", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("SingleOrg", new string[] { "--calls-graph" })]
-    [InlineData("SingleOrg", new string[] { "--use-program-main", "--calls-graph" })]
-    [InlineData("SingleOrg", new string[] { "--use-minimal-apis", "--calls-graph" })]
-    [InlineData("SingleOrg", new string[] { "--use-program-main", "--use-minimal-apis", "--calls-graph" })]
+    [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain })]
+    [InlineData("SingleOrg", new string[] { ArgConstants.UseMinimalApis })]
+    [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis })]
+    [InlineData("SingleOrg", new string[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+    [InlineData("SingleOrg", new string[] { ArgConstants.UseMinimalApis, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+    [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+    [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+    [InlineData("SingleOrg", new string[] { ArgConstants.CallsGraph })]
+    [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain, ArgConstants.CallsGraph })]
+    [InlineData("SingleOrg", new string[] { ArgConstants.UseMinimalApis, ArgConstants.CallsGraph })]
+    [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis, ArgConstants.CallsGraph })]
     public Task WebApiTemplateCSharp_IdentityWeb_BuildsAndPublishes(string auth, string[] args) => PublishAndBuildWebApiTemplate(languageOverride: null, auth: auth, args: args);
 
     [Fact]
@@ -65,15 +65,15 @@ public class WebApiTemplateTest : LoggedTest
 
     [ConditionalFact]
     [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
-    public Task WebApiTemplateProgramMainCSharp() => WebApiTemplateCore(languageOverride: null, args: new [] { "--use-program-main" });
+    public Task WebApiTemplateProgramMainCSharp() => WebApiTemplateCore(languageOverride: null, args: new[] { ArgConstants.UseProgramMain });
 
     [ConditionalFact]
     [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
-    public Task WebApiTemplateMinimalApisCSharp() => WebApiTemplateCore(languageOverride: null, args: new [] { "--use-minimal-apis" });
+    public Task WebApiTemplateMinimalApisCSharp() => WebApiTemplateCore(languageOverride: null, args: new[] { ArgConstants.UseMinimalApis });
 
     [ConditionalFact]
     [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
-    public Task WebApiTemplateProgramMainMinimalApisCSharp() => WebApiTemplateCore(languageOverride: null, args: new [] { "--use-program-main --use-minimal-apis" });
+    public Task WebApiTemplateProgramMainMinimalApisCSharp() => WebApiTemplateCore(languageOverride: null, args: new[] { "ArgConstants.UseProgramMain ArgConstants.UseMinimalApis" });
 
     [ConditionalTheory]
     [InlineData(false, false)]
@@ -87,11 +87,11 @@ public class WebApiTemplateTest : LoggedTest
 
         var args = useProgramMain
             ? useMinimalApis
-                ? new[] { "--use-program-main", "--use-minimal-apis", "--no-openapi" }
-                : new[] { "--use-program-main", "--no-openapi" }
+                ? new[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis, ArgConstants.NoOpenApi }
+                : new[] { ArgConstants.UseProgramMain, ArgConstants.NoOpenApi }
             : useMinimalApis
-                ? new[] { "--use-minimal-apis", "--no-openapi" }
-                : new[] { "--no-openapi" };
+                ? new[] { ArgConstants.UseMinimalApis, ArgConstants.NoOpenApi }
+                : new[] { ArgConstants.NoOpenApi };
         var createResult = await project.RunDotNetNewAsync("webapi", args: args);
         Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
 

--- a/src/ProjectTemplates/test/WebApiTemplateTest.cs
+++ b/src/ProjectTemplates/test/WebApiTemplateTest.cs
@@ -36,14 +36,24 @@ public class WebApiTemplateTest : LoggedTest
     [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
     [InlineData("IndividualB2C", null)]
     [InlineData("IndividualB2C", new string[] { "--use-program-main" })]
+    [InlineData("IndividualB2C", new string[] { "--use-minimal-apis" })]
+    [InlineData("IndividualB2C", new string[] { "--use-program-main", "--use-minimal-apis" })]
     [InlineData("IndividualB2C", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("IndividualB2C", new string[] { "--use-program-main --called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("IndividualB2C", new string[] { "--use-minimal-apis", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("IndividualB2C", new string[] { "--use-program-main", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("IndividualB2C", new string[] { "--use-program-main", "--use-minimal-apis", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
     [InlineData("SingleOrg", null)]
     [InlineData("SingleOrg", new string[] { "--use-program-main" })]
+    [InlineData("SingleOrg", new string[] { "--use-minimal-apis" })]
+    [InlineData("SingleOrg", new string[] { "--use-program-main", "--use-minimal-apis" })]
     [InlineData("SingleOrg", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-    [InlineData("SingleOrg", new string[] { "--use-program-main --called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("SingleOrg", new string[] { "--use-minimal-apis", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("SingleOrg", new string[] { "--use-program-main", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+    [InlineData("SingleOrg", new string[] { "--use-program-main", "--use-minimal-apis", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
     [InlineData("SingleOrg", new string[] { "--calls-graph" })]
-    [InlineData("SingleOrg", new string[] { "--use-program-main --calls-graph" })]
+    [InlineData("SingleOrg", new string[] { "--use-program-main", "--calls-graph" })]
+    [InlineData("SingleOrg", new string[] { "--use-minimal-apis", "--calls-graph" })]
+    [InlineData("SingleOrg", new string[] { "--use-program-main", "--use-minimal-apis", "--calls-graph" })]
     public Task WebApiTemplateCSharp_IdentityWeb_BuildsAndPublishes(string auth, string[] args) => PublishAndBuildWebApiTemplate(languageOverride: null, auth: auth, args: args);
 
     [Fact]
@@ -57,15 +67,31 @@ public class WebApiTemplateTest : LoggedTest
     [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
     public Task WebApiTemplateProgramMainCSharp() => WebApiTemplateCore(languageOverride: null, args: new [] { "--use-program-main" });
 
-    [ConditionalTheory]
-    [InlineData(false)]
-    [InlineData(true)]
+    [ConditionalFact]
     [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
-    public async Task WebApiTemplateCSharp_WithoutOpenAPI(bool useProgramMain)
+    public Task WebApiTemplateMinimalApisCSharp() => WebApiTemplateCore(languageOverride: null, args: new [] { "--use-minimal-apis" });
+
+    [ConditionalFact]
+    [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
+    public Task WebApiTemplateProgramMainMinimalApisCSharp() => WebApiTemplateCore(languageOverride: null, args: new [] { "--use-program-main --use-minimal-apis" });
+
+    [ConditionalTheory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
+    public async Task WebApiTemplateCSharp_WithoutOpenAPI(bool useProgramMain, bool useMinimalApis)
     {
         var project = await FactoryFixture.GetOrCreateProject("webapinoopenapi", Output);
 
-        var args = useProgramMain ? new[] { "--use-program-main --no-openapi" } : new[] { "--no-openapi" };
+        var args = useProgramMain
+            ? useMinimalApis
+                ? new[] { "--use-program-main", "--use-minimal-apis", "--no-openapi" }
+                : new[] { "--use-program-main", "--no-openapi" }
+            : useMinimalApis
+                ? new[] { "--use-minimal-apis", "--no-openapi" }
+                : new[] { "--no-openapi" };
         var createResult = await project.RunDotNetNewAsync("webapi", args: args);
         Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
 

--- a/src/ProjectTemplates/test/WorkerTemplateTest.cs
+++ b/src/ProjectTemplates/test/WorkerTemplateTest.cs
@@ -33,13 +33,13 @@ public class WorkerTemplateTest : LoggedTest
     [ConditionalTheory]
     [OSSkipCondition(OperatingSystems.Linux, SkipReason = "https://github.com/dotnet/sdk/issues/12831")]
     [InlineData("C#", null)]
-    [InlineData("C#", new string[] { "--use-program-main" })]
+    [InlineData("C#", new string[] { ArgConstants.UseProgramMain })]
     [InlineData("F#", null)]
     [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/25404")]
     public async Task WorkerTemplateAsync(string language, string[] args)
     {
         var project = await ProjectFactory.GetOrCreateProject(
-            $"worker-{ language.ToLowerInvariant()[0] }sharp",
+            $"worker-{language.ToLowerInvariant()[0]}sharp",
             Output);
 
         var createResult = await project.RunDotNetNewAsync("worker", language: language, args: args);


### PR DESCRIPTION
# Fix issue when using minimal APIs & `Program.Main` together in Web API template

- Updated test cases to cover more options combinations
- Fixed route pattern typo in minimal APIs case
- Added missing UseAuthorization call in minimal APIs + Windows Auth case
- Fixed numerous issues with the Web API template when using any auth combined with minimal APIs (seems like it was pretty broken before this 😞)
- Fail template tests if a compiler warning is output on build or publish

Fixes #41491
