### PR TITLE
Allow HttpSys zero-byte reads 

### DIFF
--- a/src/Servers/HttpSys/src/RequestProcessing/RequestStream.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestStream.cs
@@ -102,11 +102,11 @@ namespace Microsoft.AspNetCore.Server.HttpSys
             {
                 throw new ArgumentNullException(nameof(buffer));
             }
-            if (offset < 0 || offset > buffer.Length)
+            if ((uint)offset > (uint)buffer.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(offset), offset, string.Empty);
             }
-            if (size <= 0 || size > buffer.Length - offset)
+            if ((uint)size > (uint)(buffer.Length - offset))
             {
                 throw new ArgumentOutOfRangeException(nameof(size), size, string.Empty);
             }
@@ -163,7 +163,14 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
                     dataRead += extraDataRead;
                 }
-                if (statusCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS && statusCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_HANDLE_EOF)
+
+                // Zero-byte reads
+                if (statusCode == UnsafeNclNativeMethods.ErrorCodes.ERROR_MORE_DATA && size == 0)
+                {
+                    // extraDataRead returns 1 to let us know there's data available. Don't count it against the request body size yet.
+                    dataRead = 0;
+                }
+                else if (statusCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS && statusCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_HANDLE_EOF)
                 {
                     Exception exception = new IOException(string.Empty, new HttpSysException((int)statusCode));
                     Log.ErrorWhileRead(Logger, exception);
@@ -183,7 +190,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         internal void UpdateAfterRead(uint statusCode, uint dataRead)
         {
-            if (statusCode == UnsafeNclNativeMethods.ErrorCodes.ERROR_HANDLE_EOF || dataRead == 0)
+            if (statusCode == UnsafeNclNativeMethods.ErrorCodes.ERROR_HANDLE_EOF
+                || statusCode != UnsafeNclNativeMethods.ErrorCodes.ERROR_MORE_DATA && dataRead == 0)
             {
                 Dispose();
             }
@@ -244,7 +252,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 cancellationRegistration = RequestContext.RegisterForCancellation(cancellationToken);
             }
 
-            asyncResult = new RequestStreamAsyncResult(this, null, null, buffer, offset, dataRead, cancellationRegistration);
+            asyncResult = new RequestStreamAsyncResult(this, null, null, buffer, offset, size, dataRead, cancellationRegistration);
             uint bytesReturned;
 
             try


### PR DESCRIPTION
# Allow HttpSys zero-byte reads

Allow zero length reads from the Http.Sys request body stream

## Description

AspNetCore and YARP have started to take advantage of the zero-byte-read pattern, where zero length buffers are passed to read operations to be notified when data is available. This allows the caller to avoid allocations and pinning on slow/idle streams like gRPC and WebSockets.

The Http.Sys server request body stream does not currently allow this. First, it performs argument checks that disallow a zero length buffer. Also, when the native read completes it returns ERROR_MORE_DATA rather than SUCCESS. This needs to be handled by the stream or it will throw an IOException.

Fixes #41305

## Customer Impact

Since YARP 1.1 adopted the zero-byte-read pattern for performance reasons customers can no longer use it with our Http.Sys server.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
