### PR TITLE
Set Content-Type more accurately in SignalR TS client

### DIFF
--- a/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/HubConnectionTests.ts
@@ -1019,29 +1019,6 @@ describe("hubConnection", () => {
         }
     });
 
-    it("populates the Content-Type header when sending XMLHttpRequest", async () => {
-        // Skip test on Node as this header isn't set (it was added for React-Native)
-        if (typeof window === "undefined") {
-            return;
-        }
-        const hubConnection = getConnectionBuilder(HttpTransportType.LongPolling, TESTHUB_NOWEBSOCKETS_ENDPOINT_URL)
-            .withHubProtocol(new JsonHubProtocol())
-            .build();
-
-        try {
-            await hubConnection.start();
-
-            // Check what transport was used by asking the server to tell us.
-            expect(await hubConnection.invoke("GetActiveTransportName")).toEqual("LongPolling");
-            // Check to see that the Content-Type header is set the expected value
-            expect(await hubConnection.invoke("GetContentTypeHeader")).toEqual("text/plain;charset=UTF-8");
-
-            await hubConnection.stop();
-        } catch (e) {
-            fail(e);
-        }
-    });
-
     eachTransport((t) => {
         it("sets the user agent header", async () => {
             const hubConnection = getConnectionBuilder(t, TESTHUBENDPOINT_URL)

--- a/src/SignalR/clients/ts/signalr/tests/FetchHttpClient.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/FetchHttpClient.test.ts
@@ -17,4 +17,52 @@ describe("FetchHttpClient", () => {
             expect(e).toEqual(new Error("error from test"));
         }
     });
+
+    it("sets Content-type header for plaintext", async () => {
+        (global.fetch as any) = (_: string, request: RequestInit) => {
+            expect((request.headers as any)!["Content-Type"]).toEqual("text/plain;charset=UTF-8")
+            throw new Error("error from test");
+        };
+        const httpClient = new FetchHttpClient(NullLogger.instance);
+
+        try {
+            await httpClient.post("/", { content: "content" });
+        } catch (e) {
+            expect(e).toEqual(new Error("error from test"));
+        }
+    });
+
+    it("sets Content-Type header for binary", async () => {
+        (global.fetch as any) = (_: string, request: RequestInit) => {
+            expect((request.headers as any)!["Content-Type"]).toEqual("application/octet-stream")
+            throw new Error("error from test");
+        };
+        const httpClient = new FetchHttpClient(NullLogger.instance);
+
+        try {
+            await httpClient.post("/", { content: new ArrayBuffer(1) });
+        } catch (e) {
+            expect(e).toEqual(new Error("error from test"));
+        }
+    });
+
+    it("does not set Content-Type header for empty content", async () => {
+        (global.fetch as any) = (_: string, request: RequestInit) => {
+            expect((request.headers as any)!["Content-Type"]).toBeUndefined()
+            throw new Error("error from test");
+        };
+        const httpClient = new FetchHttpClient(NullLogger.instance);
+
+        try {
+            await httpClient.post("/", { content: "" });
+        } catch (e) {
+            expect(e).toEqual(new Error("error from test"));
+        }
+
+        try {
+            await httpClient.post("/");
+        } catch (e) {
+            expect(e).toEqual(new Error("error from test"));
+        }
+    });
 });


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/41378 and https://github.com/dotnet/aspnetcore/issues/34537

| | Before | After |
| - | - | - |
| no content | "text/plain;charset=UTF-8" | `<none>` |
| binary content | "text/plain;charset=UTF-8" | "application/octet-stream" |
| text content | "text/plain;charset=UTF-8" | "text/plain;charset=UTF-8" |

Tested against react-native android which is where we previously had issues with content-type, this change works with that environment.