### PR TITLE
Add CancellationToken overloads for reading multipart form sections

### DIFF
--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -25,10 +25,7 @@ public class FormFeature : IFormFeature
     /// <param name="form">The <see cref="IFormCollection"/> to use as the backing store.</param>
     public FormFeature(IFormCollection form)
     {
-        if (form == null)
-        {
-            throw new ArgumentNullException(nameof(form));
-        }
+        ArgumentNullException.ThrowIfNull(form);
 
         Form = form;
         _request = default!;
@@ -51,14 +48,8 @@ public class FormFeature : IFormFeature
     /// <param name="options">The <see cref="FormOptions"/>.</param>
     public FormFeature(HttpRequest request, FormOptions options)
     {
-        if (request == null)
-        {
-            throw new ArgumentNullException(nameof(request));
-        }
-        if (options == null)
-        {
-            throw new ArgumentNullException(nameof(options));
-        }
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(options);
 
         _request = request;
         _options = options;
@@ -68,7 +59,7 @@ public class FormFeature : IFormFeature
     {
         get
         {
-            MediaTypeHeaderValue.TryParse(_request.ContentType, out var mt);
+            _ = MediaTypeHeaderValue.TryParse(_request.ContentType, out var mt);
             return mt;
         }
     }

--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -245,7 +245,7 @@ public class FormFeature : IFormFeature
 
                         // Do not limit the key name length here because the multipart headers length limit is already in effect.
                         var key = formDataSection.Name;
-                        var value = await formDataSection.GetValueAsync();
+                        var value = await formDataSection.GetValueAsync(cancellationToken);
 
                         formAccumulator.Append(key, value);
                         if (formAccumulator.ValueCount > _options.ValueCountLimit)

--- a/src/Http/WebUtilities/src/FormMultipartSection.cs
+++ b/src/Http/WebUtilities/src/FormMultipartSection.cs
@@ -53,8 +53,15 @@ public class FormMultipartSection
     /// Gets the form value
     /// </summary>
     /// <returns>The form value</returns>
-    public Task<string> GetValueAsync()
+    public Task<string> GetValueAsync() => GetValueAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Gets the form value
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The form value</returns>
+    public Task<string> GetValueAsync(CancellationToken cancellationToken)
     {
-        return Section.ReadAsStringAsync();
+        return Section.ReadAsStringAsync(cancellationToken);
     }
 }

--- a/src/Http/WebUtilities/src/FormMultipartSection.cs
+++ b/src/Http/WebUtilities/src/FormMultipartSection.cs
@@ -53,15 +53,13 @@ public class FormMultipartSection
     /// Gets the form value
     /// </summary>
     /// <returns>The form value</returns>
-    public Task<string> GetValueAsync() => GetValueAsync(CancellationToken.None);
+    public Task<string> GetValueAsync() => Section.ReadAsStringAsync();
 
     /// <summary>
     /// Gets the form value
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The form value</returns>
-    public Task<string> GetValueAsync(CancellationToken cancellationToken)
-    {
-        return Section.ReadAsStringAsync(cancellationToken);
-    }
+    public ValueTask<string> GetValueAsync(CancellationToken cancellationToken)
+        => Section.ReadAsStringAsync(cancellationToken);
 }

--- a/src/Http/WebUtilities/src/MultipartSectionStreamExtensions.cs
+++ b/src/Http/WebUtilities/src/MultipartSectionStreamExtensions.cs
@@ -16,8 +16,8 @@ public static class MultipartSectionStreamExtensions
     /// </summary>
     /// <param name="section">The section to read from</param>
     /// <returns>The body steam as string</returns>
-    public static async Task<string> ReadAsStringAsync(this MultipartSection section)
-        => await section.ReadAsStringAsync(CancellationToken.None);
+    public static Task<string> ReadAsStringAsync(this MultipartSection section)
+        => section.ReadAsStringAsync(CancellationToken.None).AsTask();
 
     /// <summary>
     /// Reads the body of the section as a string
@@ -25,7 +25,7 @@ public static class MultipartSectionStreamExtensions
     /// <param name="section">The section to read from</param>
     /// <param name="cancellationToken">The cancellationt token.</param>
     /// <returns>The body steam as string</returns>
-    public static async Task<string> ReadAsStringAsync(this MultipartSection section, CancellationToken cancellationToken)
+    public static async ValueTask<string> ReadAsStringAsync(this MultipartSection section, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(section);
 

--- a/src/Http/WebUtilities/src/PublicAPI.Unshipped.txt
+++ b/src/Http/WebUtilities/src/PublicAPI.Unshipped.txt
@@ -1,7 +1,9 @@
 #nullable enable
+Microsoft.AspNetCore.WebUtilities.FormMultipartSection.GetValueAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!
 override Microsoft.AspNetCore.WebUtilities.BufferedReadStream.WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
 override Microsoft.AspNetCore.WebUtilities.FileBufferingReadStream.WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
 override Microsoft.AspNetCore.WebUtilities.FileBufferingWriteStream.ReadAsync(System.Memory<byte> buffer, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<int>
 override Microsoft.AspNetCore.WebUtilities.HttpResponseStreamWriter.WriteLineAsync(char value) -> System.Threading.Tasks.Task!
 override Microsoft.AspNetCore.WebUtilities.HttpResponseStreamWriter.WriteLineAsync(char[]! values, int index, int count) -> System.Threading.Tasks.Task!
 override Microsoft.AspNetCore.WebUtilities.HttpResponseStreamWriter.WriteLineAsync(string? value) -> System.Threading.Tasks.Task!
+static Microsoft.AspNetCore.WebUtilities.MultipartSectionStreamExtensions.ReadAsStringAsync(this Microsoft.AspNetCore.WebUtilities.MultipartSection! section, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!

--- a/src/Http/WebUtilities/src/PublicAPI.Unshipped.txt
+++ b/src/Http/WebUtilities/src/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 #nullable enable
-Microsoft.AspNetCore.WebUtilities.FormMultipartSection.GetValueAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!
+Microsoft.AspNetCore.WebUtilities.FormMultipartSection.GetValueAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<string!>
 override Microsoft.AspNetCore.WebUtilities.BufferedReadStream.WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
 override Microsoft.AspNetCore.WebUtilities.FileBufferingReadStream.WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
 override Microsoft.AspNetCore.WebUtilities.FileBufferingWriteStream.ReadAsync(System.Memory<byte> buffer, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<int>
 override Microsoft.AspNetCore.WebUtilities.HttpResponseStreamWriter.WriteLineAsync(char value) -> System.Threading.Tasks.Task!
 override Microsoft.AspNetCore.WebUtilities.HttpResponseStreamWriter.WriteLineAsync(char[]! values, int index, int count) -> System.Threading.Tasks.Task!
 override Microsoft.AspNetCore.WebUtilities.HttpResponseStreamWriter.WriteLineAsync(string? value) -> System.Threading.Tasks.Task!
-static Microsoft.AspNetCore.WebUtilities.MultipartSectionStreamExtensions.ReadAsStringAsync(this Microsoft.AspNetCore.WebUtilities.MultipartSection! section, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!
+static Microsoft.AspNetCore.WebUtilities.MultipartSectionStreamExtensions.ReadAsStringAsync(this Microsoft.AspNetCore.WebUtilities.MultipartSection! section, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<string!>


### PR DESCRIPTION
# Add CancellationToken overloads for reading multipart form sections

Support passing through a CancellationToken when reading multipart forms.

## Description

- Add `CancellationToken` overloads to methods for reading multipart form sections and use in `FormFeature`.
- Update `MultipartSectionStreamExtensions` to apply IDE refactoring suggestions.

Fixes #41532.
