### PR TITLE
Fix failing test on machine using en-GB

### DIFF
--- a/src/Security/samples/CustomPolicyProvider/Controllers/AccountController.cs
+++ b/src/Security/samples/CustomPolicyProvider/Controllers/AccountController.cs
@@ -1,10 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
+using System.Globalization;
 using System.Security.Claims;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;
 
@@ -20,7 +18,7 @@ public class AccountController : Controller
     }
 
     [HttpPost]
-    public async Task<IActionResult> Signin(string userName, DateTime? birthDate, string returnUrl = null)
+    public async Task<IActionResult> Signin(string userName, string birthDate = null, string returnUrl = null)
     {
         if (string.IsNullOrEmpty(userName))
         {
@@ -31,9 +29,9 @@ public class AccountController : Controller
         var claims = new List<Claim>();
         // Add a Name claim and, if birth date was provided, a DateOfBirth claim
         claims.Add(new Claim(ClaimTypes.Name, userName));
-        if (birthDate.HasValue)
+        if (DateTime.TryParse(birthDate, CultureInfo.InvariantCulture, out _))
         {
-            claims.Add(new Claim(ClaimTypes.DateOfBirth, birthDate.Value.ToShortDateString()));
+            claims.Add(new Claim(ClaimTypes.DateOfBirth, birthDate));
         }
 
         // Create user's identity and sign them in


### PR DESCRIPTION
# Fix failing test on machine using en-GB

Fixes a test that fails when run on a machine configured to use en-GB.

## Description

Fix the `MinimumAge50WorksIfOldEnough` test failing on a machine configured to use the `en-GB` locale on dates that end up being after the 12th day of any given month.

The model binder for form values uses the current culture, which created a mismatch with the invariant date formatting in the test.

https://github.com/dotnet/aspnetcore/blob/c85baf8db0c72ae8e68643029d514b2e737c9fae/src/Mvc/Mvc.Core/src/ModelBinding/FormValueProviderFactory.cs#L57-L60

This meant today's date would produce a birth date of `"05/19/1967"` that fails to bind for the `dd/MM/yyyy` pattern used in the UK, so the `birthDate` value would come through as `null`.

Fixed by manually parsing the string in the sample's sign-in controller, rather than trying to reconfigure the site/model binders.

Output of the test on my machine today without this fix:

```
 AuthSamples.FunctionalTests.CustomPolicyProviderTests.MinimumAge50WorksIfOldEnough
Assert.Contains() Failure\r\nNot found: Welcome, Dude\r\nIn value:      \r\n<!-- Simple view used when a user doesn't have authorization to access a resource -->\r\n<h2>Access Denied: Dude is not authorized to view this page.</h2>\r\n\r\n<!-- Show the current user's date of birth (if such a claim exists) for debugging purposes -->\r\n<h3>Date of birth: &lt;Undefined&gt;</h3>\r\n\r\n<ul>\r\n    <li><a href=\"/\">Home</a></li>\r\n    <li><a href=\"/Account/Signout\">Sign Out</a></li>\r\n</ul>
   at AuthSamples.FunctionalTests.CustomPolicyProviderTests.MinimumAge50WorksIfOldEnough() in C:\Coding\dotnet\aspnetcore\src\Security\test\AuthSamples.FunctionalTests\CustomPolicyProviderTests.cs:line 90
--- End of stack trace from previous location ---
```