### PR TITLE
Fix templates sourceName & port of template fixes from main

### DIFF
--- a/eng/helix/content/RunTests/ProcessUtil.cs
+++ b/eng/helix/content/RunTests/ProcessUtil.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -80,7 +81,7 @@ namespace RunTests
             Action<int>? onStart = null,
             CancellationToken cancellationToken = default)
         {
-            Console.WriteLine($"Running '{filename} {arguments}'");
+            PrintMessage($"Running '{filename} {arguments}'");
             using var process = new Process()
             {
                 StartInfo =
@@ -153,7 +154,7 @@ namespace RunTests
 
             process.Exited += (_, e) =>
             {
-                Console.WriteLine($"'{process.StartInfo.FileName} {process.StartInfo.Arguments}' completed with exit code '{process.ExitCode}'");
+                PrintMessage($"'{process.StartInfo.FileName} {process.StartInfo.Arguments}' completed with exit code '{process.ExitCode}'");
                 if (throwOnError && process.ExitCode != 0)
                 {
                     processLifetimeTask.TrySetException(new InvalidOperationException($"Command {filename} {arguments} returned exit code {process.ExitCode} output: {outputBuilder.ToString()}"));
@@ -208,5 +209,8 @@ namespace RunTests
 
             return await processLifetimeTask.Task;
         }
+
+        public static void PrintMessage(string message) => Console.WriteLine($"{DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)} {message}");
+        public static void PrintErrorMessage(string message) => Console.Error.WriteLine($"{DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)} {message}");
     }
 }

--- a/eng/helix/content/RunTests/Program.cs
+++ b/eng/helix/content/RunTests/Program.cs
@@ -25,7 +25,7 @@ namespace RunTests
                     keepGoing = await runner.InstallPlaywrightAsync();
                 }
 #else
-                Console.WriteLine("Playwright install skipped.");
+                ProcessUtil.PrintMessage("Playwright install skipped.");
 #endif
 
                 runner.DisplayContents();
@@ -34,23 +34,23 @@ namespace RunTests
                 {
                     if (!await runner.CheckTestDiscoveryAsync())
                     {
-                        Console.WriteLine("RunTest stopping due to test discovery failure.");
+                        ProcessUtil.PrintMessage("RunTest stopping due to test discovery failure.");
                         Environment.Exit(1);
                         return;
                     }
 
                     var exitCode = await runner.RunTestsAsync();
                     runner.UploadResults();
-                    Console.WriteLine($"Completed Helix job with exit code '{exitCode}'");
+                    ProcessUtil.PrintMessage($"Completed Helix job with exit code '{exitCode}'");
                     Environment.Exit(exitCode);
                 }
 
-                Console.WriteLine("Tests were not run due to previous failures. Exit code=1");
+                ProcessUtil.PrintMessage("Tests were not run due to previous failures. Exit code=1");
                 Environment.Exit(1);
             }
             catch (Exception e)
             {
-                Console.WriteLine($"RunTests uncaught exception: {e.ToString()}");
+                ProcessUtil.PrintMessage($"RunTests uncaught exception: {e.ToString()}");
                 Environment.Exit(1);
             }
         }

--- a/eng/helix/content/RunTests/TestRunner.cs
+++ b/eng/helix/content/RunTests/TestRunner.cs
@@ -215,7 +215,7 @@ namespace RunTests
                 // Timeout test run 5 minutes before the Helix job would timeout
                 var cts = new CancellationTokenSource(Options.Timeout.Subtract(TimeSpan.FromMinutes(5)));
                 var diagLog = Path.Combine(Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT"), "vstest.log");
-                var commonTestArgs = $"test {Options.Target} --diag:{diagLog} --logger:xunit --logger:\"console;verbosity=normal\" --blame \"CollectHangDump;TestTimeout=60m\"";
+                var commonTestArgs = $"test {Options.Target} --diag:{diagLog} --logger:xunit --logger:\"console;verbosity=normal\" --blame \"CollectHangDump;CollectDump;TestTimeout=60m\"";
                 if (Options.Quarantined)
                 {
                     Console.WriteLine("Running quarantined tests.");

--- a/eng/helix/content/RunTests/TestRunner.cs
+++ b/eng/helix/content/RunTests/TestRunner.cs
@@ -33,36 +33,36 @@ namespace RunTests
                 EnvironmentVariables.Add("PATH", Options.Path);
                 EnvironmentVariables.Add("helix", Options.HelixQueue);
 
-                Console.WriteLine($"Current Directory: {Options.HELIX_WORKITEM_ROOT}");
+                ProcessUtil.PrintMessage($"Current Directory: {Options.HELIX_WORKITEM_ROOT}");
                 var helixDir = Options.HELIX_WORKITEM_ROOT;
-                Console.WriteLine($"Setting HELIX_DIR: {helixDir}");
+                ProcessUtil.PrintMessage($"Setting HELIX_DIR: {helixDir}");
                 EnvironmentVariables.Add("HELIX_DIR", helixDir);
                 EnvironmentVariables.Add("NUGET_FALLBACK_PACKAGES", helixDir);
                 var nugetRestore = Path.Combine(helixDir, "nugetRestore");
                 EnvironmentVariables.Add("NUGET_RESTORE", nugetRestore);
                 var dotnetEFFullPath = Path.Combine(nugetRestore, helixDir, "dotnet-ef.exe");
-                Console.WriteLine($"Set DotNetEfFullPath: {dotnetEFFullPath}");
+                ProcessUtil.PrintMessage($"Set DotNetEfFullPath: {dotnetEFFullPath}");
                 EnvironmentVariables.Add("DotNetEfFullPath", dotnetEFFullPath);
                 var appRuntimePath = $"{Options.DotnetRoot}/shared/Microsoft.AspNetCore.App/{Options.RuntimeVersion}";
-                Console.WriteLine($"Set ASPNET_RUNTIME_PATH: {appRuntimePath}");
+                ProcessUtil.PrintMessage($"Set ASPNET_RUNTIME_PATH: {appRuntimePath}");
                 EnvironmentVariables.Add("ASPNET_RUNTIME_PATH", appRuntimePath);
                 var dumpPath = Environment.GetEnvironmentVariable("HELIX_DUMP_FOLDER");
-                Console.WriteLine($"Set VSTEST_DUMP_PATH: {dumpPath}");
+                ProcessUtil.PrintMessage($"Set VSTEST_DUMP_PATH: {dumpPath}");
                 EnvironmentVariables.Add("VSTEST_DUMP_PATH", dumpPath);
 
 #if INSTALLPLAYWRIGHT
                 // Playwright will download and look for browsers to this directory
                 var playwrightBrowsers = Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH");
-                Console.WriteLine($"Setting PLAYWRIGHT_BROWSERS_PATH: {playwrightBrowsers}");
+                ProcessUtil.PrintMessage($"Setting PLAYWRIGHT_BROWSERS_PATH: {playwrightBrowsers}");
                 EnvironmentVariables.Add("PLAYWRIGHT_BROWSERS_PATH", playwrightBrowsers);
                 var playrightDriver = Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_PATH");
-                Console.WriteLine($"Setting PLAYWRIGHT_DRIVER_PATH: {playrightDriver}");
+                ProcessUtil.PrintMessage($"Setting PLAYWRIGHT_DRIVER_PATH: {playrightDriver}");
                 EnvironmentVariables.Add("PLAYWRIGHT_DRIVER_PATH", playrightDriver);
 #else
-                Console.WriteLine($"Skipping setting PLAYWRIGHT_BROWSERS_PATH");
+                ProcessUtil.PrintMessage($"Skipping setting PLAYWRIGHT_BROWSERS_PATH");
 #endif
 
-                Console.WriteLine($"Creating nuget restore directory: {nugetRestore}");
+                ProcessUtil.PrintMessage($"Creating nuget restore directory: {nugetRestore}");
                 Directory.CreateDirectory(nugetRestore);
 
                 // Rename default.runner.json to xunit.runner.json if there is not a custom one from the project
@@ -80,7 +80,7 @@ namespace RunTests
             }
             catch (Exception e)
             {
-                Console.WriteLine($"Exception in SetupEnvironment: {e.ToString()}");
+                ProcessUtil.PrintMessage($"Exception in SetupEnvironment: {e.ToString()}");
                 return false;
             }
         }
@@ -90,20 +90,20 @@ namespace RunTests
             try
             {
                 Console.WriteLine();
-                Console.WriteLine($"Displaying directory contents for {path}:");
+                ProcessUtil.PrintMessage($"Displaying directory contents for {path}:");
                 foreach (var file in Directory.EnumerateFiles(path))
                 {
-                    Console.WriteLine(Path.GetFileName(file));
+                    ProcessUtil.PrintMessage(Path.GetFileName(file));
                 }
                 foreach (var file in Directory.EnumerateDirectories(path))
                 {
-                    Console.WriteLine(Path.GetFileName(file));
+                    ProcessUtil.PrintMessage(Path.GetFileName(file));
                 }
                 Console.WriteLine();
             }
             catch (Exception e)
             {
-                Console.WriteLine($"Exception in DisplayContents: {e.ToString()}");
+                ProcessUtil.PrintMessage($"Exception in DisplayContents: {e.ToString()}");
             }
         }
 
@@ -112,14 +112,14 @@ namespace RunTests
         {
             try
             {
-                Console.WriteLine($"Installing Playwright to Browsers: {Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH")} Driver: {Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_PATH")}");
+                ProcessUtil.PrintMessage($"Installing Playwright to Browsers: {Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH")} Driver: {Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_PATH")}");
                 await Playwright.InstallAsync(Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH"), Environment.GetEnvironmentVariable("PLAYWRIGHT_DRIVER_PATH"));
                 DisplayContents(Environment.GetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH"));
                 return true;
             }
             catch (Exception e)
             {
-                Console.WriteLine($"Exception installing playwright: {e.ToString()}");
+                ProcessUtil.PrintMessage($"Exception installing playwright: {e.ToString()}");
                 return false;
             }
         }
@@ -133,18 +133,18 @@ namespace RunTests
                 await ProcessUtil.RunAsync($"{Options.DotnetRoot}/dotnet",
                     $"tool install dotnet-dump --tool-path {Options.HELIX_WORKITEM_ROOT} --version 5.0.0-*",
                     environmentVariables: EnvironmentVariables,
-                    outputDataReceived: Console.WriteLine,
-                    errorDataReceived: Console.Error.WriteLine,
+                    outputDataReceived: ProcessUtil.PrintMessage,
+                    errorDataReceived: ProcessUtil.PrintErrorMessage,
                     throwOnError: false,
                     cancellationToken: new CancellationTokenSource(TimeSpan.FromMinutes(2)).Token);
 
-                Console.WriteLine($"Adding current directory to nuget sources: {Options.HELIX_WORKITEM_ROOT}");
+                ProcessUtil.PrintMessage($"Adding current directory to nuget sources: {Options.HELIX_WORKITEM_ROOT}");
 
                 await ProcessUtil.RunAsync($"{Options.DotnetRoot}/dotnet",
                     $"nuget add source {Options.HELIX_WORKITEM_ROOT} --configfile NuGet.config",
                     environmentVariables: EnvironmentVariables,
-                    outputDataReceived: Console.WriteLine,
-                    errorDataReceived: Console.Error.WriteLine,
+                    outputDataReceived: ProcessUtil.PrintMessage,
+                    errorDataReceived: ProcessUtil.PrintErrorMessage,
                     throwOnError: false,
                     cancellationToken: new CancellationTokenSource(TimeSpan.FromMinutes(2)).Token);
 
@@ -152,24 +152,24 @@ namespace RunTests
                 await ProcessUtil.RunAsync($"{Options.DotnetRoot}/dotnet",
                     "nuget list source",
                     environmentVariables: EnvironmentVariables,
-                    outputDataReceived: Console.WriteLine,
-                    errorDataReceived: Console.Error.WriteLine,
+                    outputDataReceived: ProcessUtil.PrintMessage,
+                    errorDataReceived: ProcessUtil.PrintErrorMessage,
                     throwOnError: false,
                     cancellationToken: new CancellationTokenSource(TimeSpan.FromMinutes(2)).Token);
 
                 await ProcessUtil.RunAsync($"{Options.DotnetRoot}/dotnet",
                     $"tool install dotnet-ef --version {Options.EfVersion} --tool-path {Options.HELIX_WORKITEM_ROOT}",
                     environmentVariables: EnvironmentVariables,
-                    outputDataReceived: Console.WriteLine,
-                    errorDataReceived: Console.Error.WriteLine,
+                    outputDataReceived: ProcessUtil.PrintMessage,
+                    errorDataReceived: ProcessUtil.PrintErrorMessage,
                     throwOnError: false,
                     cancellationToken: new CancellationTokenSource(TimeSpan.FromMinutes(2)).Token);
 
                 await ProcessUtil.RunAsync($"{Options.DotnetRoot}/dotnet",
                     $"tool install dotnet-serve --tool-path {Options.HELIX_WORKITEM_ROOT}",
                     environmentVariables: EnvironmentVariables,
-                    outputDataReceived: Console.WriteLine,
-                    errorDataReceived: Console.Error.WriteLine,
+                    outputDataReceived: ProcessUtil.PrintMessage,
+                    errorDataReceived: ProcessUtil.PrintErrorMessage,
                     throwOnError: false,
                     cancellationToken: new CancellationTokenSource(TimeSpan.FromMinutes(2)).Token);
 
@@ -177,7 +177,7 @@ namespace RunTests
             }
             catch (Exception e)
             {
-                Console.WriteLine($"Exception in InstallDotnetTools: {e}");
+                ProcessUtil.PrintMessage($"Exception in InstallDotnetTools: {e}");
                 return false;
             }
         }
@@ -194,15 +194,15 @@ namespace RunTests
 
                 if (discoveryResult.StandardOutput.Contains("Exception thrown"))
                 {
-                    Console.WriteLine("Exception thrown during test discovery.");
-                    Console.WriteLine(discoveryResult.StandardOutput);
+                    ProcessUtil.PrintMessage("Exception thrown during test discovery.");
+                    ProcessUtil.PrintMessage(discoveryResult.StandardOutput);
                     return false;
                 }
                 return true;
             }
             catch (Exception e)
             {
-                Console.WriteLine($"Exception in CheckTestDiscovery: {e.ToString()}");
+                ProcessUtil.PrintMessage($"Exception in CheckTestDiscovery: {e.ToString()}");
                 return false;
             }
         }
@@ -219,14 +219,14 @@ namespace RunTests
                 var commonTestArgs = $"test {Options.Target} --diag:{diagLog} --logger:xunit --logger:\"console;verbosity=normal\" --blame \"CollectHangDump;CollectDump;TestTimeout=15m\"";
                 if (Options.Quarantined)
                 {
-                    Console.WriteLine("Running quarantined tests.");
+                    ProcessUtil.PrintMessage("Running quarantined tests.");
 
                     // Filter syntax: https://github.com/Microsoft/vstest-docs/blob/master/docs/filter.md
                     var result = await ProcessUtil.RunAsync($"{Options.DotnetRoot}/dotnet",
                         commonTestArgs + " --TestCaseFilter:\"Quarantined=true\"",
                         environmentVariables: EnvironmentVariables,
-                        outputDataReceived: Console.WriteLine,
-                        errorDataReceived: Console.Error.WriteLine,
+                        outputDataReceived: ProcessUtil.PrintMessage,
+                        errorDataReceived: ProcessUtil.PrintErrorMessage,
                         throwOnError: false,
                         cancellationToken: cts.Token);
 
@@ -234,21 +234,21 @@ namespace RunTests
                     {
                         if (cts.Token.IsCancellationRequested)
                         {
-                            Console.WriteLine($"Quarantined tests exceeded configured timeout: {testProcessTimeout.TotalMinutes}m.");
+                            ProcessUtil.PrintMessage($"Quarantined tests exceeded configured timeout: {testProcessTimeout.TotalMinutes}m.");
                         }
-                        Console.WriteLine($"Failure in quarantined tests. Exit code: {result.ExitCode}.");
+                        ProcessUtil.PrintMessage($"Failure in quarantined tests. Exit code: {result.ExitCode}.");
                     }
                 }
                 else
                 {
-                    Console.WriteLine("Running non-quarantined tests.");
+                    ProcessUtil.PrintMessage("Running non-quarantined tests.");
 
                     // Filter syntax: https://github.com/Microsoft/vstest-docs/blob/master/docs/filter.md
                     var result = await ProcessUtil.RunAsync($"{Options.DotnetRoot}/dotnet",
                         commonTestArgs + " --TestCaseFilter:\"Quarantined!=true|Quarantined=false\"",
                         environmentVariables: EnvironmentVariables,
-                        outputDataReceived: Console.WriteLine,
-                        errorDataReceived: Console.Error.WriteLine,
+                        outputDataReceived: ProcessUtil.PrintMessage,
+                        errorDataReceived: ProcessUtil.PrintErrorMessage,
                         throwOnError: false,
                         cancellationToken: cts.Token);
 
@@ -256,17 +256,17 @@ namespace RunTests
                     {
                         if (cts.Token.IsCancellationRequested)
                         {
-                            Console.WriteLine($"Non-quarantined tests exceeded configured timeout: {testProcessTimeout.TotalMinutes}m.");
+                            ProcessUtil.PrintMessage($"Non-quarantined tests exceeded configured timeout: {testProcessTimeout.TotalMinutes}m.");
                         }
 
-                        Console.WriteLine($"Failure in non-quarantined tests. Exit code: {result.ExitCode}.");
+                        ProcessUtil.PrintMessage($"Failure in non-quarantined tests. Exit code: {result.ExitCode}.");
                         exitCode = result.ExitCode;
                     }
                 }
             }
             catch (Exception e)
             {
-                Console.WriteLine($"Exception in RunTests: {e.ToString()}");
+                ProcessUtil.PrintMessage($"Exception in RunTests: {e.ToString()}");
                 exitCode = 1;
             }
             return exitCode;
@@ -275,51 +275,51 @@ namespace RunTests
         public void UploadResults()
         {
             // 'testResults.xml' is the file Helix looks for when processing test results
-            Console.WriteLine("Trying to upload results...");
+            ProcessUtil.PrintMessage("Trying to upload results...");
             if (File.Exists("TestResults/TestResults.xml"))
             {
-                Console.WriteLine("Copying TestResults/TestResults.xml to ./testResults.xml");
+                ProcessUtil.PrintMessage("Copying TestResults/TestResults.xml to ./testResults.xml");
                 File.Copy("TestResults/TestResults.xml", "testResults.xml");
             }
             else
             {
-                Console.WriteLine("No test results found.");
+                ProcessUtil.PrintMessage("No test results found.");
             }
 
             var HELIX_WORKITEM_UPLOAD_ROOT = Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT");
             if (string.IsNullOrEmpty(HELIX_WORKITEM_UPLOAD_ROOT))
             {
-                Console.WriteLine("No HELIX_WORKITEM_UPLOAD_ROOT specified, skipping log copy");
+                ProcessUtil.PrintMessage("No HELIX_WORKITEM_UPLOAD_ROOT specified, skipping log copy");
                 return;
             }
-            Console.WriteLine($"Copying artifacts/log/ to {HELIX_WORKITEM_UPLOAD_ROOT}/");
+            ProcessUtil.PrintMessage($"Copying artifacts/log/ to {HELIX_WORKITEM_UPLOAD_ROOT}/");
             if (Directory.Exists("artifacts/log"))
             {
                 foreach (var file in Directory.EnumerateFiles("artifacts/log", "*.log", SearchOption.AllDirectories))
                 {
                     // Combine the directory name + log name for the copied log file name to avoid overwriting duplicate test names in different test projects
                     var logName = $"{Path.GetFileName(Path.GetDirectoryName(file))}_{Path.GetFileName(file)}";
-                    Console.WriteLine($"Copying: {file} to {Path.Combine(HELIX_WORKITEM_UPLOAD_ROOT, logName)}");
+                    ProcessUtil.PrintMessage($"Copying: {file} to {Path.Combine(HELIX_WORKITEM_UPLOAD_ROOT, logName)}");
                     File.Copy(file, Path.Combine(HELIX_WORKITEM_UPLOAD_ROOT, logName));
                 }
             }
             else
             {
-                Console.WriteLine("No logs found in artifacts/log");
+                ProcessUtil.PrintMessage("No logs found in artifacts/log");
             }
-            Console.WriteLine($"Copying TestResults/**/Sequence*.xml to {HELIX_WORKITEM_UPLOAD_ROOT}/");
+            ProcessUtil.PrintMessage($"Copying TestResults/**/Sequence*.xml to {HELIX_WORKITEM_UPLOAD_ROOT}/");
             if (Directory.Exists("TestResults"))
             {
                 foreach (var file in Directory.EnumerateFiles("TestResults", "Sequence*.xml", SearchOption.AllDirectories))
                 {
                     var fileName = Path.GetFileName(file);
-                    Console.WriteLine($"Copying: {file} to {Path.Combine(HELIX_WORKITEM_UPLOAD_ROOT, fileName)}");
+                    ProcessUtil.PrintMessage($"Copying: {file} to {Path.Combine(HELIX_WORKITEM_UPLOAD_ROOT, fileName)}");
                     File.Copy(file, Path.Combine(HELIX_WORKITEM_UPLOAD_ROOT, fileName));
                 }
             }
             else
             {
-                Console.WriteLine("No TestResults directory found.");
+                ProcessUtil.PrintMessage("No TestResults directory found.");
             }
         }
     }

--- a/eng/helix/content/RunTests/TestRunner.cs
+++ b/eng/helix/content/RunTests/TestRunner.cs
@@ -215,7 +215,7 @@ namespace RunTests
                 // Timeout test run 5 minutes before the Helix job would timeout
                 var cts = new CancellationTokenSource(Options.Timeout.Subtract(TimeSpan.FromMinutes(5)));
                 var diagLog = Path.Combine(Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT"), "vstest.log");
-                var commonTestArgs = $"test {Options.Target} --diag:{diagLog} --logger:xunit --logger:\"console;verbosity=normal\" --blame \"CollectHangDump;TestTimeout=15m\"";
+                var commonTestArgs = $"test {Options.Target} --diag:{diagLog} --logger:xunit --logger:\"console;verbosity=normal\" --blame \"CollectHangDump;TestTimeout=60m\"";
                 if (Options.Quarantined)
                 {
                     Console.WriteLine("Running quarantined tests.");

--- a/eng/targets/Helix.props
+++ b/eng/targets/Helix.props
@@ -11,8 +11,7 @@
 
   <PropertyGroup>
     <CreateHelixPayload>true</CreateHelixPayload>
-    <HelixTimeout>00:30:00</HelixTimeout>
-    <HelixTimeout Condition="$(HelixTargetQueue.StartsWith('Windows.10.Amd64'))">00:40:00</HelixTimeout>
+    <HelixTimeout>00:45:00</HelixTimeout>
     <RunQuarantinedTests>false</RunQuarantinedTests>
     <HelixTestName>$(MSBuildProjectName)--$(TargetFramework)</HelixTestName>
     <LoggingTestingDisableFileLogging Condition="'$(IsHelixJob)' == 'true'">false</LoggingTestingDisableFileLogging>

--- a/src/Hosting/Hosting/src/Internal/WebHost.cs
+++ b/src/Hosting/Hosting/src/Internal/WebHost.cs
@@ -81,12 +81,12 @@ namespace Microsoft.AspNetCore.Hosting
             // There's no way to to register multiple service types per definition. See https://github.com/aspnet/DependencyInjection/issues/360
 #pragma warning disable CS8634 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'class' constraint.
             _applicationServiceCollection.AddSingleton(services
-                => services.GetService<ApplicationLifetime>() as IHostApplicationLifetime);
+                => services.GetService<ApplicationLifetime>()! as IHostApplicationLifetime);
 #pragma warning disable CS0618 // Type or member is obsolete
             _applicationServiceCollection.AddSingleton(services
-                => services.GetService<ApplicationLifetime>() as AspNetCore.Hosting.IApplicationLifetime);
+                => services.GetService<ApplicationLifetime>()! as AspNetCore.Hosting.IApplicationLifetime);
             _applicationServiceCollection.AddSingleton(services
-                => services.GetService<ApplicationLifetime>() as Extensions.Hosting.IApplicationLifetime);
+                => services.GetService<ApplicationLifetime>()! as Extensions.Hosting.IApplicationLifetime);
 #pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CS8634 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'class' constraint.
             _applicationServiceCollection.AddSingleton<HostedServiceExecutor>();

--- a/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplateTest.cs
+++ b/src/ProjectTemplates/BlazorTemplates.Tests/BlazorTemplateTest.cs
@@ -29,7 +29,7 @@ namespace Templates.Test
             // Additional arguments are needed. See: https://github.com/dotnet/aspnetcore/issues/24278
             Environment.SetEnvironmentVariable("EnableDefaultScopedCssItems", "true");
 
-            var project = await ProjectFactory.GetOrCreateProject(projectName, Output);
+            var project = await ProjectFactory.CreateProject(Output);
             if (targetFramework != null)
             {
                 project.TargetFramework = targetFramework;

--- a/src/ProjectTemplates/Shared/ProcessResult.cs
+++ b/src/ProjectTemplates/Shared/ProcessResult.cs
@@ -17,7 +17,7 @@ namespace Templates.Test.Helpers
 
         public string Process { get; }
 
-        public int ExitCode { get; }
+        public int ExitCode { get; set; }
 
         public string Error { get; }
 

--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -144,11 +144,12 @@ namespace Templates.Test.Helpers
 
             var result = new ProcessResult(execution);
 
+            // Comment out to see if it impacts test failures
             // Fail if there were build warnings
-            if (execution.Output.Contains(": warning") || execution.Error.Contains(": warning"))
-            {
-                result.ExitCode = -1;
-            }
+            //if (execution.Output.Contains(": warning") || execution.Error.Contains(": warning"))
+            //{
+            //    result.ExitCode = -1;
+            //}
 
             CaptureBinLogOnFailure(execution);
             return result;

--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -96,38 +96,24 @@ namespace Templates.Test.Helpers
 
             argString += $" -o {TemplateOutputDir}";
 
-            // Only run one instance of 'dotnet new' at once, as a workaround for
-            // https://github.com/aspnet/templating/issues/63
-
-            await DotNetNewLock.WaitAsync();
-            try
+            if (Directory.Exists(TemplateOutputDir))
             {
-                Output.WriteLine("Acquired DotNetNewLock");
-
-                if (Directory.Exists(TemplateOutputDir))
-                {
-                    Output.WriteLine($"Template directory already exists, deleting contents of {TemplateOutputDir}");
-                    Directory.Delete(TemplateOutputDir, recursive: true);
-                }
-
-                using var execution = ProcessEx.Run(Output, AppContext.BaseDirectory, DotNetMuxer.MuxerPathOrDefault(), argString, environmentVariables);
-                await execution.Exited;
-
-                var result = new ProcessResult(execution);
-
-                // Because dotnet new automatically restores but silently ignores restore errors, need to handle restore errors explicitly
-                if (errorOnRestoreError && (execution.Output.Contains("Restore failed.") || execution.Error.Contains("Restore failed.")))
-                {
-                    result.ExitCode = -1;
-                }
-
-                return result;
+                Output.WriteLine($"Template directory already exists, deleting contents of {TemplateOutputDir}");
+                Directory.Delete(TemplateOutputDir, recursive: true);
             }
-            finally
+
+            using var execution = ProcessEx.Run(Output, AppContext.BaseDirectory, DotNetMuxer.MuxerPathOrDefault(), argString, environmentVariables);
+            await execution.Exited;
+
+            var result = new ProcessResult(execution);
+
+            // Because dotnet new automatically restores but silently ignores restore errors, need to handle restore errors explicitly
+            if (errorOnRestoreError && (execution.Output.Contains("Restore failed.") || execution.Error.Contains("Restore failed.")))
             {
-                DotNetNewLock.Release();
-                Output.WriteLine("Released DotNetNewLock");
+                result.ExitCode = -1;
             }
+
+            return result;
         }
 
         internal async Task<ProcessResult> RunDotNetPublishAsync(IDictionary<string, string> packageOptions = null, string additionalArgs = null, bool noRestore = true)
@@ -144,12 +130,11 @@ namespace Templates.Test.Helpers
 
             var result = new ProcessResult(execution);
 
-            // Comment out to see if it impacts test failures
             // Fail if there were build warnings
-            //if (execution.Output.Contains(": warning") || execution.Error.Contains(": warning"))
-            //{
-            //    result.ExitCode = -1;
-            //}
+            if (execution.Output.Contains(": warning") || execution.Error.Contains(": warning"))
+            {
+               result.ExitCode = -1;
+            }
 
             CaptureBinLogOnFailure(execution);
             return result;
@@ -212,31 +197,19 @@ namespace Templates.Test.Helpers
         {
             var args = $"--verbose --no-build migrations add {migrationName}";
 
-            // Only run one instance of 'dotnet new' at once, as a workaround for
-            // https://github.com/aspnet/templating/issues/63
-            await DotNetNewLock.WaitAsync();
-            try
+            var command = DotNetMuxer.MuxerPathOrDefault();
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DotNetEfFullPath")))
             {
-                Output.WriteLine("Acquired DotNetNewLock");
-                var command = DotNetMuxer.MuxerPathOrDefault();
-                if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DotNetEfFullPath")))
-                {
-                    args = $"\"{DotNetEfFullPath}\" " + args;
-                }
-                else
-                {
-                    command = "dotnet-ef";
-                }
+                args = $"\"{DotNetEfFullPath}\" " + args;
+            }
+            else
+            {
+                command = "dotnet-ef";
+            }
 
-                using var result = ProcessEx.Run(Output, TemplateOutputDir, command, args);
-                await result.Exited;
-                return new ProcessResult(result);
-            }
-            finally
-            {
-                DotNetNewLock.Release();
-                Output.WriteLine("Released DotNetNewLock");
-            }
+            using var result = ProcessEx.Run(Output, TemplateOutputDir, command, args);
+            await result.Exited;
+            return new ProcessResult(result);
         }
 
         internal async Task<ProcessResult> RunDotNetEfUpdateDatabaseAsync()
@@ -245,31 +218,19 @@ namespace Templates.Test.Helpers
 
             var args = "--verbose --no-build database update";
 
-            // Only run one instance of 'dotnet new' at once, as a workaround for
-            // https://github.com/aspnet/templating/issues/63
-            await DotNetNewLock.WaitAsync();
-            try
+            var command = DotNetMuxer.MuxerPathOrDefault();
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DotNetEfFullPath")))
             {
-                Output.WriteLine("Acquired DotNetNewLock");
-                var command = DotNetMuxer.MuxerPathOrDefault();
-                if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DotNetEfFullPath")))
-                {
-                    args = $"\"{DotNetEfFullPath}\" " + args;
-                }
-                else
-                {
-                    command = "dotnet-ef";
-                }
+                args = $"\"{DotNetEfFullPath}\" " + args;
+            }
+            else
+            {
+                command = "dotnet-ef";
+            }
 
-                using var result = ProcessEx.Run(Output, TemplateOutputDir, command, args);
-                await result.Exited;
-                return new ProcessResult(result);
-            }
-            finally
-            {
-                DotNetNewLock.Release();
-                Output.WriteLine("Released DotNetNewLock");
-            }
+            using var result = ProcessEx.Run(Output, TemplateOutputDir, command, args);
+            await result.Exited;
+            return new ProcessResult(result);
         }
 
         // If this fails, you should generate new migrations via migrations/updateMigrations.cmd
@@ -323,25 +284,15 @@ namespace Templates.Test.Helpers
 
         internal async Task<ProcessEx> RunDotNetNewRawAsync(string arguments)
         {
-            await DotNetNewLock.WaitAsync();
-            try
-            {
-                Output.WriteLine("Acquired DotNetNewLock");
-                var result = ProcessEx.Run(
-                    Output,
-                    AppContext.BaseDirectory,
-                    DotNetMuxer.MuxerPathOrDefault(),
-                    arguments +
-                        $" --debug:disable-sdk-templates --debug:custom-hive \"{TemplatePackageInstaller.CustomHivePath}\"" +
-                        $" -o {TemplateOutputDir}");
-                await result.Exited;
-                return result;
-            }
-            finally
-            {
-                DotNetNewLock.Release();
-                Output.WriteLine("Released DotNetNewLock");
-            }
+            var result = ProcessEx.Run(
+                Output,
+                AppContext.BaseDirectory,
+                DotNetMuxer.MuxerPathOrDefault(),
+                arguments +
+                    $" --debug:disable-sdk-templates --debug:custom-hive \"{TemplatePackageInstaller.CustomHivePath}\"" +
+                    $" -o {TemplateOutputDir}");
+            await result.Exited;
+            return result;
         }
 
         public void Dispose()

--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -104,10 +104,7 @@ namespace Templates.Test.Helpers
 
             using var execution = ProcessEx.Run(Output, AppContext.BaseDirectory, DotNetMuxer.MuxerPathOrDefault(), argString, environmentVariables);
             await execution.Exited;
-
-            var result = new ProcessResult(execution);
-
-            return result;
+            return new ProcessResult(execution);
         }
 
         internal async Task<ProcessResult> RunDotNetPublishAsync(IDictionary<string, string> packageOptions = null, string additionalArgs = null, bool noRestore = true)
@@ -132,7 +129,7 @@ namespace Templates.Test.Helpers
             // Avoid restoring as part of build or publish. These projects should have already restored as part of running dotnet new. Explicitly disabling restore
             // should avoid any global contention and we can execute a build or publish in a lock-free way
 
-            using var result = ProcessEx.Run(Output, TemplateOutputDir, DotNetMuxer.MuxerPathOrDefault(), $"publish {restoreArgs} -c Release /bl {additionalArgs}", packageOptions);
+            using var result = ProcessEx.Run(Output, TemplateOutputDir, DotNetMuxer.MuxerPathOrDefault(), $"build --no-restore -c Debug /bl {additionalArgs}", packageOptions);
             await result.Exited;
             CaptureBinLogOnFailure(result);
             return new ProcessResult(result);

--- a/src/ProjectTemplates/Shared/ProjectFactoryFixture.cs
+++ b/src/ProjectTemplates/Shared/ProjectFactoryFixture.cs
@@ -64,6 +64,7 @@ namespace Templates.Test.Helpers
                 // declarations (i.e. make it more stable for testing)
                 ProjectGuid = GetRandomLetter() + Path.GetRandomFileName().Replace(".", string.Empty)
             };
+            project.ProjectName = $"AspNetCore.{project.ProjectGuid}";
 
             var assemblyPath = GetType().Assembly;
             var basePath = GetTemplateFolderBasePath(assemblyPath);

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Program.Main.cs
@@ -37,7 +37,7 @@ using BlazorServerWeb_CSharp.Areas.Identity;
 #endif
 using BlazorServerWeb_CSharp.Data;
 
-namespace Company.WebApplication1;
+namespace BlazorServerWeb_CSharp;
 
 public class Program
 {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Program.Main.cs
@@ -9,7 +9,11 @@ using ComponentsWebAssembly_CSharp.Client;
 using ComponentsWebAssembly_CSharp;
 #endif
 
-namespace Company.WebApplication1;
+#if (Hosted)
+namespace ComponentsWebAssembly_CSharp.Client;
+#else
+namespace ComponentsWebAssembly_CSharp;
+#endif
 
 public class Program
 {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Program.Main.cs
@@ -19,7 +19,7 @@ using ComponentsWebAssembly_CSharp.Server.Data;
 using ComponentsWebAssembly_CSharp.Server.Models;
 #endif
 
-namespace Company.WebApplication1;
+namespace ComponentsWebAssembly_CSharp;
 
 public class Program
 {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Program.Main.cs
@@ -1,6 +1,6 @@
 using GrpcService_CSharp.Services;
 
-namespace Company.WebApplication1;
+namespace GrpcService_CSharp;
 
 public class Program
 {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
@@ -44,9 +44,11 @@
           ]
         },
         {
-          "condition": "(UseProgramMain && !UseMinimalAPIs)",
+          "condition": "(UseProgramMain)",
           "exclude": [
-            "Program.cs"
+            "Program.cs",
+            "Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs",
+            "Program.MinimalAPIs.WindowsOrNoAuth.cs"
           ],
           "rename": {
             "Program.Main.cs": "Program.cs"
@@ -55,13 +57,17 @@
         {
           "condition": "(UseMinimalAPIs)",
           "exclude": [
-            "Controllers/WeatherForecastController.cs",
-            "Program.cs",
+            "Controllers/WeatherForecastController.cs"
+          ]
+        },
+        {
+          "condition": "(UseMinimalAPIs && !UseProgramMain)",
+          "exclude": [
             "WeatherForecast.cs"
           ]
         },
         {
-          "condition": "(UseMinimalAPIs && (NoAuth || WindowsAuth))",
+          "condition": "(!UseProgramMain && UseMinimalAPIs && (NoAuth || WindowsAuth))",
           "rename": {
             "Program.MinimalAPIs.WindowsOrNoAuth.cs": "Program.cs"
           },
@@ -70,7 +76,7 @@
           ]
         },
         {
-          "condition": "(UseMinimalAPIs && (IndividualAuth || OrganizationalAuth))",
+          "condition": "(!UseProgramMain && UseMinimalAPIs && (IndividualAuth || OrganizationalAuth))",
           "rename": {
             "Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs": "Program.cs"
           },

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.Main.cs
@@ -5,13 +5,17 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 #if (WindowsAuth)
 using Microsoft.AspNetCore.Authentication.Negotiate;
 #endif
+#if (EnableOpenAPI)
+using Microsoft.AspNetCore.OpenApi;
+#endif
 #if (GenerateGraph)
 using Graph = Microsoft.Graph;
 #endif
 #if (OrganizationalAuth || IndividualB2CAuth)
 using Microsoft.Identity.Web;
+using Microsoft.Identity.Web.Resource;
 #endif
-#if (OrganizationalAuth || IndividualB2CAuth || GenerateGraph || WindowsAuth)
+#if (OrganizationalAuth || IndividualB2CAuth || GenerateGraph || WindowsAuth || EnableOpenAPI)
 
 #endif
 namespace Company.WebApplication1;
@@ -20,76 +24,170 @@ public class Program
 {
     public static void Main(string[] args)
     {
-    var builder = WebApplication.CreateBuilder(args);
+        var builder = WebApplication.CreateBuilder(args);
 
-    // Add services to the container.
-    #if (OrganizationalAuth)
-    builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-    #if (GenerateApiOrGraph)
-        .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"))
-            .EnableTokenAcquisitionToCallDownstreamApi()
-    #if (GenerateApi)
-                .AddDownstreamWebApi("DownstreamApi", builder.Configuration.GetSection("DownstreamApi"))
-    #endif
-    #if (GenerateGraph)
-                .AddMicrosoftGraph(builder.Configuration.GetSection("DownstreamApi"))
-    #endif
-                .AddInMemoryTokenCaches();
-    #else
-        .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"));
-    #endif
-    #elif (IndividualB2CAuth)
-    builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-    #if (GenerateApi)
-        .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAdB2C"))
-            .EnableTokenAcquisitionToCallDownstreamApi()
-                .AddDownstreamWebApi("DownstreamApi", builder.Configuration.GetSection("DownstreamApi"))
-                .AddInMemoryTokenCaches();
-    #else
-        .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAdB2C"));
-    #endif
-    #endif
+        // Add services to the container.
+        #if (OrganizationalAuth)
+        builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+        #if (GenerateApiOrGraph)
+            .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"))
+                .EnableTokenAcquisitionToCallDownstreamApi()
+        #if (GenerateApi)
+                    .AddDownstreamWebApi("DownstreamApi", builder.Configuration.GetSection("DownstreamApi"))
+        #endif
+        #if (GenerateGraph)
+                    .AddMicrosoftGraph(builder.Configuration.GetSection("DownstreamApi"))
+        #endif
+                    .AddInMemoryTokenCaches();
+        #else
+            .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"));
+        #endif
+        #elif (IndividualB2CAuth)
+        builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+        #if (GenerateApi)
+            .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAdB2C"))
+                .EnableTokenAcquisitionToCallDownstreamApi()
+                    .AddDownstreamWebApi("DownstreamApi", builder.Configuration.GetSection("DownstreamApi"))
+                    .AddInMemoryTokenCaches();
+        #else
+            .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAdB2C"));
+        #endif
+        #endif
+        #if (UseMinimalAPIs)
+        builder.Services.AddAuthorization();
+        #endif
 
-    builder.Services.AddControllers();
-    #if (EnableOpenAPI)
-    // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-    builder.Services.AddEndpointsApiExplorer();
-    builder.Services.AddSwaggerGen();
-    #endif
-    #if (WindowsAuth)
+        #if (UseControllers)
+        builder.Services.AddControllers();
+        #endif
+        #if (EnableOpenAPI)
+        // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+        builder.Services.AddEndpointsApiExplorer();
+        builder.Services.AddSwaggerGen();
+        #endif
+        #if (WindowsAuth)
 
-    builder.Services.AddAuthentication(NegotiateDefaults.AuthenticationScheme)
-    .AddNegotiate();
+        builder.Services.AddAuthentication(NegotiateDefaults.AuthenticationScheme)
+            .AddNegotiate();
 
-    builder.Services.AddAuthorization(options =>
-    {
-        // By default, all incoming requests will be authorized according to the default policy.
-        options.FallbackPolicy = options.DefaultPolicy;
-    });
-    #endif
+        builder.Services.AddAuthorization(options =>
+        {
+            // By default, all incoming requests will be authorized according to the default policy.
+            options.FallbackPolicy = options.DefaultPolicy;
+        });
+        #endif
 
-    var app = builder.Build();
+        var app = builder.Build();
 
-    // Configure the HTTP request pipeline.
-    #if (EnableOpenAPI)
-    if (app.Environment.IsDevelopment())
-    {
-        app.UseSwagger();
-        app.UseSwaggerUI();
-    }
-    #endif
-    #if (RequiresHttps)
+        // Configure the HTTP request pipeline.
+        #if (EnableOpenAPI)
+        if (app.Environment.IsDevelopment())
+        {
+            app.UseSwagger();
+            app.UseSwaggerUI();
+        }
+        #endif
+        #if (RequiresHttps)
 
-    app.UseHttpsRedirection();
-    #endif
+        app.UseHttpsRedirection();
+        #endif
 
-    #if (OrganizationalAuth || IndividualAuth || WindowsAuth)
-    app.UseAuthentication();
-    #endif
-    app.UseAuthorization();
+        #if (OrganizationalAuth || IndividualAuth || WindowsAuth)
+        app.UseAuthentication();
+        #endif
+        app.UseAuthorization();
 
-    app.MapControllers();
+        #if (UseMinimalAPIs)
+        #if (OrganizationalAuth || IndividualB2CAuth)
+        var scopeRequiredByApi = app.Configuration["AzureAd:Scopes"] ?? "";
+        #endif
+        var summaries = new[]
+        {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
 
-    app.Run();
+        #if (GenerateApi)
+        app.MapGet("/weatherforecast", async (HttpContext httpContext, IDownstreamWebApi downstreamWebApi) =>
+        {
+            httpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
+
+            using var response = await downstreamWebApi.CallWebApiForUserAsync("DownstreamApi").ConfigureAwait(false);
+            if (response.StatusCode == System.Net.HttpStatusCode.OK)
+            {
+                var apiResult = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                // Do something
+            }
+            else
+            {
+                var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                throw new HttpRequestException($"Invalid status code in the HttpResponseMessage: {response.StatusCode}: {error}");
+            }
+
+            var forecast =  Enumerable.Range(1, 5).Select(index =>
+                new WeatherForecast
+                {
+                    Date = DateTime.Now.AddDays(index),
+                    TemperatureC = Random.Shared.Next(-20, 55),
+                    Summary = summaries[Random.Shared.Next(summaries.Length)]
+                })
+                .ToArray();
+
+            return forecast;
+        #elif (GenerateGraph)
+        app.MapGet("/weatherforecast", async (HttpContext httpContext, Graph.GraphServiceClient graphServiceClient) =>
+        {
+            httpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
+
+            var user = await graphServiceClient.Me.Request().GetAsync();
+
+            var forecast =  Enumerable.Range(1, 5).Select(index =>
+                new WeatherForecast
+                {
+                    Date = DateTime.Now.AddDays(index),
+                    TemperatureC = Random.Shared.Next(-20, 55),
+                    Summary = summaries[Random.Shared.Next(summaries.Length)]
+                })
+                .ToArray();
+
+            return forecast;
+        #else
+        app.MapGet("/weatherforecast", (HttpContext httpContext) =>
+        {
+            #if (OrganizationalAuth || IndividualB2CAuth)
+            httpContext.VerifyUserHasAnyAcceptedScope(scopeRequiredByApi);
+
+            #endif
+            var forecast =  Enumerable.Range(1, 5).Select(index =>
+                new WeatherForecast
+                {
+                    Date = DateTime.Now.AddDays(index),
+                    TemperatureC = Random.Shared.Next(-20, 55),
+                    Summary = summaries[Random.Shared.Next(summaries.Length)]
+                })
+                .ToArray();
+            return forecast;
+        #endif
+        #if (EnableOpenAPI && !NoAuth)
+        })
+        .WithName("GetWeatherForecast")
+        .WithOpenApi()
+        .RequireAuthorization();
+        #elif (EnableOpenAPI && NoAuth)
+        })
+        .WithName("GetWeatherForecast")
+        .WithOpenApi();
+        #elif (!EnableOpenAPI && !NoAuth)
+        })
+        .RequireAuthorization();
+        #else
+        });
+        #endif
+        #endif
+        #if (UseControllers)
+
+        app.MapControllers();
+        #endif
+
+        app.Run();
     }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.Main.cs
@@ -5,9 +5,6 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 #if (WindowsAuth)
 using Microsoft.AspNetCore.Authentication.Negotiate;
 #endif
-#if (EnableOpenAPI)
-using Microsoft.AspNetCore.OpenApi;
-#endif
 #if (GenerateGraph)
 using Graph = Microsoft.Graph;
 #endif
@@ -15,7 +12,7 @@ using Graph = Microsoft.Graph;
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.Resource;
 #endif
-#if (OrganizationalAuth || IndividualB2CAuth || GenerateGraph || WindowsAuth || EnableOpenAPI)
+#if (OrganizationalAuth || IndividualB2CAuth || GenerateGraph || WindowsAuth)
 
 #endif
 namespace Company.WebApplication1;
@@ -170,12 +167,10 @@ public class Program
         #if (EnableOpenAPI && !NoAuth)
         })
         .WithName("GetWeatherForecast")
-        .WithOpenApi()
         .RequireAuthorization();
         #elif (EnableOpenAPI && NoAuth)
         })
-        .WithName("GetWeatherForecast")
-        .WithOpenApi();
+        .WithName("GetWeatherForecast");
         #elif (!EnableOpenAPI && !NoAuth)
         })
         .RequireAuthorization();

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.WindowsOrNoAuth.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/Program.MinimalAPIs.WindowsOrNoAuth.cs
@@ -37,6 +37,7 @@ app.UseHttpsRedirection();
 #endif
 #if (WindowsAuth)
 app.UseAuthentication();
+app.UseAuthorization();
 #endif
 
 var summaries = new[]

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.Main.cs
@@ -1,6 +1,4 @@
-using Company.Application1;
-
-namespace Company.WebApplication1;
+namespace Company.Application1;
 
 public class Program
 {

--- a/src/ProjectTemplates/scripts/Run-Angular-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-Angular-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "angular" "angular" "Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "angular" "angular" "Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-AngularProgramMain-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-AngularProgramMain-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "angular" "angular --use-program-main" "Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "angular" "angular --use-program-main" "Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-Blazor-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-Blazor-Locally.ps1
@@ -10,4 +10,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "blazorserver" "blazorserver" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "blazorserver" "blazorserver" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-BlazorProgramMain-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-BlazorProgramMain-Locally.ps1
@@ -10,4 +10,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "blazorserver" "blazorserver --use-program-main" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "blazorserver" "blazorserver --use-program-main" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-BlazorWasm-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-BlazorWasm-Locally.ps1
@@ -10,4 +10,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "blazorwasm" "blazorwasm --hosted --auth Individual" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.0-dev.nupkg" $true
+Test-Template "blazorwasm" "blazorwasm --hosted --auth Individual" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.6.nupkg" $true

--- a/src/ProjectTemplates/scripts/Run-BlazorWasmProgramMain-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-BlazorWasmProgramMain-Locally.ps1
@@ -10,4 +10,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "blazorwasm" "blazorwasm --use-program-main --hosted --auth Individual" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.0-dev.nupkg" $true
+Test-Template "blazorwasm" "blazorwasm --use-program-main --hosted --auth Individual" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.6.nupkg" $true

--- a/src/ProjectTemplates/scripts/Run-EmptyWeb-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-EmptyWeb-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "web" "web" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "web" "web" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-EmptyWebProgramMain-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-EmptyWebProgramMain-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "web" "web --use-program-main" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "web" "web --use-program-main" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-Razor-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-Razor-Locally.ps1
@@ -6,4 +6,4 @@ param()
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "webapp" "webapp -au Individual" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "webapp" "webapp -au Individual" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-RazorProgramMain-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-RazorProgramMain-Locally.ps1
@@ -6,4 +6,4 @@ param()
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "webapp" "webapp -au Individual --use-program-main" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "webapp" "webapp -au Individual --use-program-main" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-React-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-React-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "react" "react" "Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "react" "react" "Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-ReactProgramMain-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-ReactProgramMain-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "react" "react --use-program-main" "Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "react" "react --use-program-main" "Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-ReactRedux-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-ReactRedux-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "reactredux" "reactredux" "Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "reactredux" "reactredux" "Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-Starterweb-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-Starterweb-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "mvc" "mvc -au Individual" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "mvc" "mvc -au Individual" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-StarterwebProgramMain-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-StarterwebProgramMain-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "mvc" "mvc -au Individual --use-program-main" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "mvc" "mvc -au Individual --use-program-main" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-WebApi-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-WebApi-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "webapi" "webapi" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "webapi" "webapi" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-WebApiMinimal-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-WebApiMinimal-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "webapimin" "webapi -minimal" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "webapimin" "webapi -minimal" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-WebApiProgamMain-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-WebApiProgamMain-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "webapi" "webapi --use-program-main" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "webapi" "webapi --use-program-main" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-WebApiProgamMainMinimal-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-WebApiProgamMainMinimal-Locally.ps1
@@ -1,0 +1,12 @@
+#!/usr/bin/env pwsh
+#requires -version 4
+
+[CmdletBinding(PositionalBinding = $false)]
+param()
+
+Set-StrictMode -Version 2
+$ErrorActionPreference = 'Stop'
+
+. $PSScriptRoot\Test-Template.ps1
+
+Test-Template "webapi" "webapi --use-program-main --use-minimal-apis" "Microsoft.DotNet.Web.ProjectTemplates.7.0.7.0.0-dev.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-WebApiProgamMainMinimal-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-WebApiProgamMainMinimal-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "webapi" "webapi --use-program-main --use-minimal-apis" "Microsoft.DotNet.Web.ProjectTemplates.7.0.7.0.0-dev.nupkg" $false
+Test-Template "webapi" "webapi --use-program-main --use-minimal-apis" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-Worker-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-Worker-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "worker" "worker" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "worker" "worker" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-WorkerProgramMain-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-WorkerProgramMain-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "worker" "worker --use-program-main" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "worker" "worker --use-program-main" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/scripts/Run-gRPC-Locally.ps1
+++ b/src/ProjectTemplates/scripts/Run-gRPC-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Test-Template.ps1
 
-Test-Template "grpc" "grpc" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.0-dev.nupkg" $false
+Test-Template "grpc" "grpc" "Microsoft.DotNet.Web.ProjectTemplates.6.0.6.0.6.nupkg" $false

--- a/src/ProjectTemplates/test/ArgConstants.cs
+++ b/src/ProjectTemplates/test/ArgConstants.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Templates.Test;
+
+internal static class ArgConstants
+{
+    public const string UseProgramMain = "--use-program-main";
+    public const string UseMinimalApis = "--use-minimal-apis";
+    public const string Hosted = "--hosted";
+    public const string Pwa = "--pwa";
+    public const string CallsGraph = "--calls-graph";
+    public const string CalledApiUrl = "--called-api-url";
+    public const string CalledApiUrlGraphMicrosoftCom = "--called-api-url \"https://graph.microsoft.com\"";
+    public const string CalledApiScopes = "--called-api-scopes";
+    public const string CalledApiScopesUserReadWrite = $"{CalledApiScopes} user.readwrite";
+    public const string NoOpenApi = "--no-openapi";
+    public const string Auth = "-au";
+    public const string ClientId = "--client-id";
+    public const string Domain = "--domain";
+    public const string DefaultScope = "--default-scope";
+    public const string AppIdUri = "--app-id-uri";
+    public const string AppIdClientId = "--api-client-id";
+    public const string TenantId = "--tenant-id";
+    public const string AadB2cInstance = "--aad-b2c-instance";
+}

--- a/src/ProjectTemplates/test/ArgConstants.cs
+++ b/src/ProjectTemplates/test/ArgConstants.cs
@@ -23,4 +23,5 @@ internal static class ArgConstants
     public const string AppIdClientId = "--api-client-id";
     public const string TenantId = "--tenant-id";
     public const string AadB2cInstance = "--aad-b2c-instance";
+    public const string UseLocalDb = "-uld";
 }

--- a/src/ProjectTemplates/test/AssemblyInfo.AssemblyFixtures.cs
+++ b/src/ProjectTemplates/test/AssemblyInfo.AssemblyFixtures.cs
@@ -3,5 +3,7 @@
 
 using Microsoft.AspNetCore.Testing;
 using Templates.Test.Helpers;
+using Xunit;
 
 [assembly: AssemblyFixture(typeof(ProjectFactoryFixture))]
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/ProjectTemplates/test/BaselineTest.cs
+++ b/src/ProjectTemplates/test/BaselineTest.cs
@@ -67,6 +67,7 @@ namespace Templates.Test
         }
 
         // This test should generally not be quarantined as it only is checking that the expected files are on disk
+        // and that the namespace declarations in the generated .cs files start with the project name
         [Theory]
         [MemberData(nameof(TemplateBaselines))]
         public async Task Template_Produces_The_Right_Set_Of_FilesAsync(string arguments, string[] expectedFiles)

--- a/src/ProjectTemplates/test/BaselineTest.cs
+++ b/src/ProjectTemplates/test/BaselineTest.cs
@@ -105,7 +105,7 @@ namespace Templates.Test
                 if (relativePath.EndsWith(".cs", StringComparison.Ordinal))
                 {
                     var namespaceDeclarationPrefix = "namespace ";
-                    var namespaceDeclaration = File.ReadLines(Path.Combine(Project.TemplateOutputDir, relativePath))
+                    var namespaceDeclaration = File.ReadLines(file)
                         .SingleOrDefault(line => line.StartsWith(namespaceDeclarationPrefix, StringComparison.Ordinal))
                         ?.Substring(namespaceDeclarationPrefix.Length);
 

--- a/src/ProjectTemplates/test/BaselineTest.cs
+++ b/src/ProjectTemplates/test/BaselineTest.cs
@@ -100,6 +100,20 @@ namespace Templates.Test
                     continue;
                 }
                 Assert.Contains(relativePath, expectedFiles);
+
+                if (relativePath.EndsWith(".cs", StringComparison.Ordinal))
+                {
+                    var namespaceDeclarationPrefix = "namespace ";
+                    var namespaceDeclaration = File.ReadLines(Path.Combine(Project.TemplateOutputDir, relativePath))
+                        .SingleOrDefault(line => line.StartsWith(namespaceDeclarationPrefix, StringComparison.Ordinal))
+                        ?.Substring(namespaceDeclarationPrefix.Length);
+
+                    // nullable because Program.cs with top-level statements doesn't have a namespace declaration
+                    if (namespaceDeclaration is not null)
+                    {
+                        Assert.StartsWith(Project.ProjectName, namespaceDeclaration, StringComparison.Ordinal);
+                    }
+                }
             }
         }
 

--- a/src/ProjectTemplates/test/BaselineTest.cs
+++ b/src/ProjectTemplates/test/BaselineTest.cs
@@ -102,19 +102,20 @@ namespace Templates.Test
                 }
                 Assert.Contains(relativePath, expectedFiles);
 
-                if (relativePath.EndsWith(".cs", StringComparison.Ordinal))
-                {
-                    var namespaceDeclarationPrefix = "namespace ";
-                    var namespaceDeclaration = File.ReadLines(file)
-                        .SingleOrDefault(line => line.StartsWith(namespaceDeclarationPrefix, StringComparison.Ordinal))
-                        ?.Substring(namespaceDeclarationPrefix.Length);
+                // Commented out to see if it impacts the Helix test failures
+                // if (relativePath.EndsWith(".cs", StringComparison.Ordinal))
+                // {
+                //     var namespaceDeclarationPrefix = "namespace ";
+                //     var namespaceDeclaration = File.ReadLines(file)
+                //         .SingleOrDefault(line => line.StartsWith(namespaceDeclarationPrefix, StringComparison.Ordinal))
+                //         ?.Substring(namespaceDeclarationPrefix.Length);
 
-                    // nullable because Program.cs with top-level statements doesn't have a namespace declaration
-                    if (namespaceDeclaration is not null)
-                    {
-                        Assert.StartsWith(Project.ProjectName, namespaceDeclaration, StringComparison.Ordinal);
-                    }
-                }
+                //     // nullable because Program.cs with top-level statements doesn't have a namespace declaration
+                //     if (namespaceDeclaration is not null)
+                //     {
+                //         Assert.StartsWith(Project.ProjectName, namespaceDeclaration, StringComparison.Ordinal);
+                //     }
+                // }
             }
         }
 

--- a/src/ProjectTemplates/test/BaselineTest.cs
+++ b/src/ProjectTemplates/test/BaselineTest.cs
@@ -72,7 +72,7 @@ namespace Templates.Test
         [MemberData(nameof(TemplateBaselines))]
         public async Task Template_Produces_The_Right_Set_Of_FilesAsync(string arguments, string[] expectedFiles)
         {
-            Project = await ProjectFactory.GetOrCreateProject(CreateProjectKey(arguments), Output);
+            Project = await ProjectFactory.CreateProject(Output);
             var createResult = await Project.RunDotNetNewRawAsync(arguments);
             Assert.True(createResult.ExitCode == 0, createResult.GetFormattedOutput());
 
@@ -103,79 +103,20 @@ namespace Templates.Test
                 Assert.Contains(relativePath, expectedFiles);
 
                 // Commented out to see if it impacts the Helix test failures
-                // if (relativePath.EndsWith(".cs", StringComparison.Ordinal))
-                // {
-                //     var namespaceDeclarationPrefix = "namespace ";
-                //     var namespaceDeclaration = File.ReadLines(file)
-                //         .SingleOrDefault(line => line.StartsWith(namespaceDeclarationPrefix, StringComparison.Ordinal))
-                //         ?.Substring(namespaceDeclarationPrefix.Length);
-
-                //     // nullable because Program.cs with top-level statements doesn't have a namespace declaration
-                //     if (namespaceDeclaration is not null)
-                //     {
-                //         Assert.StartsWith(Project.ProjectName, namespaceDeclaration, StringComparison.Ordinal);
-                //     }
-                // }
-            }
-        }
-
-        private static ConcurrentDictionary<string, object> _projectKeys = new();
-
-        private string CreateProjectKey(string arguments)
-        {
-            var text = "baseline";
-
-            // Turn string like "new templatename -minimal -au SingleOrg --another-option OptionValue"
-            // into array like [ "new templatename", "minimal", "au SingleOrg", "another-option OptionValue" ]
-            var argumentsArray = arguments
-                .Split(new[] { " --", " -" }, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
-                .ToArray();
-
-            // Add template name, value has form of "new name"
-            text += argumentsArray[0].Substring("new ".Length);
-
-            // Sort arguments to ensure definitions that differ only by arguments order are caught
-            Array.Sort(argumentsArray, StringComparer.Ordinal);
-
-            foreach (var argValue in argumentsArray)
-            {
-                var argSegments = argValue.Split(' ', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-
-                if (argSegments.Length == 0)
+                if (relativePath.EndsWith(".cs", StringComparison.Ordinal))
                 {
-                    continue;
-                }
-                else if (argSegments.Length == 1)
-                {
-                    text += argSegments[0] switch
+                    var namespaceDeclarationPrefix = "namespace ";
+                    var namespaceDeclaration = File.ReadLines(file)
+                        .SingleOrDefault(line => line.StartsWith(namespaceDeclarationPrefix, StringComparison.Ordinal))
+                        ?.Substring(namespaceDeclarationPrefix.Length);
+
+                    // nullable because Program.cs with top-level statements doesn't have a namespace declaration
+                    if (namespaceDeclaration is not null)
                     {
-                        "ho" => "hosted",
-                        "p" => "pwa",
-                        _ => argSegments[0].Replace("-","")
-                    };
-                }
-                else
-                {
-                    text += argSegments[0] switch
-                    {
-                        "au" => argSegments[1],
-                        "uld" => "uld",
-                        "language" => argSegments[1].Replace("#", "Sharp"),
-                        "support-pages-and-views" when argSegments[1] == "true" => "supportpagesandviewstrue",
-                        _ => ""
-                    };
+                        Assert.StartsWith(Project.ProjectName, namespaceDeclaration, StringComparison.Ordinal);
+                    }
                 }
             }
-
-            if (!_projectKeys.TryAdd(text, null))
-            {
-                throw new InvalidOperationException(
-                    $"Project key for template with args '{arguments}' already exists. " +
-                    $"Check that the metadata specified in {BaselineDefinitionFileResourceName} is correct and that " +
-                    $"the {nameof(CreateProjectKey)} method is considering enough template arguments to ensure uniqueness.");
-            }
-
-            return text;
         }
 
         private void AssertFileExists(string basePath, string path, bool shouldExist)

--- a/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
+++ b/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
@@ -27,25 +27,27 @@ namespace Templates.Test
         public Task BlazorServerTemplateWorks_NoAuth() => CreateBuildPublishAsync("blazorservernoauth");
 
         [Fact]
-        public Task BlazorServerTemplateWorks_ProgamMainNoAuth() => CreateBuildPublishAsync("blazorservernoauth", args: new [] { "--use-program-main" });
+        public Task BlazorServerTemplateWorks_ProgamMainNoAuth() => CreateBuildPublishAsync("blazorservernoauth", args: new [] { ArgConstants.UseProgramMain });
 
         [Theory]
         [InlineData(true, null)]
-        [InlineData(true, new string[] { "--use-program-main" })]
+        [InlineData(true, new string[] { ArgConstants.UseProgramMain })]
         [InlineData(false, null)]
-        [InlineData(false, new string[] { "--use-program-main" })]
+        [InlineData(false, new string[] { ArgConstants.UseProgramMain })]
         [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/30825", Queues = "All.OSX")]
         public Task BlazorServerTemplateWorks_IndividualAuth(bool useLocalDB, string[] args) => CreateBuildPublishAsync("blazorserverindividual" + (useLocalDB ? "uld" : "", args: args));
 
         [Theory]
         [InlineData("IndividualB2C", null)]
-        [InlineData("IndividualB2C", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-        [InlineData("IndividualB2C", new string[] { "--use-program-main", "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+        [InlineData("IndividualB2C", new[] { ArgConstants.UseProgramMain })]
+        [InlineData("IndividualB2C", new[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        [InlineData("IndividualB2C", new[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
         [InlineData("SingleOrg", null)]
-        [InlineData("SingleOrg", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-        [InlineData("SingleOrg", new string[] { "--use-program-main --called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-        [InlineData("SingleOrg", new string[] { "--calls-graph" })]
-        [InlineData("SingleOrg", new string[] { "--use-program-main --calls-graph" })]
+        [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain })]
+        [InlineData("SingleOrg", new[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        [InlineData("SingleOrg", new[] { ArgConstants.CallsGraph })]
+        [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CallsGraph })]
         public Task BlazorServerTemplate_IdentityWeb_BuildAndPublish(string auth, string[] args)
             => CreateBuildPublishAsync("blazorserveridweb" + Guid.NewGuid().ToString().Substring(0, 10).ToLowerInvariant(), auth, args);
 

--- a/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
+++ b/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
@@ -24,18 +24,18 @@ namespace Templates.Test
         public override string ProjectType { get; } = "blazorserver";
 
         [Fact]
-        public Task BlazorServerTemplateWorks_NoAuth() => CreateBuildPublishAsync("blazorservernoauth");
+        public Task BlazorServerTemplateWorks_NoAuth() => CreateBuildPublishAsync();
 
         [Fact]
-        public Task BlazorServerTemplateWorks_ProgamMainNoAuth() => CreateBuildPublishAsync("blazorservernoauth", args: new [] { ArgConstants.UseProgramMain });
+        public Task BlazorServerTemplateWorks_ProgamMainNoAuth() => CreateBuildPublishAsync(args: new [] { ArgConstants.UseProgramMain });
 
         [Theory]
-        [InlineData(true, null)]
-        [InlineData(true, new string[] { ArgConstants.UseProgramMain })]
-        [InlineData(false, null)]
-        [InlineData(false, new string[] { ArgConstants.UseProgramMain })]
+        [InlineData("Individual", null)]
+        [InlineData("Individual", new string[] { ArgConstants.UseLocalDb })]
+        [InlineData("Individual", new string[] { ArgConstants.UseProgramMain })]
+        [InlineData("Individual", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseLocalDb })]
         [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/30825", Queues = "All.OSX")]
-        public Task BlazorServerTemplateWorks_IndividualAuth(bool useLocalDB, string[] args) => CreateBuildPublishAsync("blazorserverindividual" + (useLocalDB ? "uld" : "", args: args));
+        public Task BlazorServerTemplateWorks_IndividualAuth(string auth, string[] args) => CreateBuildPublishAsync(auth, args: args);
 
         [Theory]
         [InlineData("IndividualB2C", null)]
@@ -49,7 +49,6 @@ namespace Templates.Test
         [InlineData("SingleOrg", new[] { ArgConstants.CallsGraph })]
         [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CallsGraph })]
         public Task BlazorServerTemplate_IdentityWeb_BuildAndPublish(string auth, string[] args)
-            => CreateBuildPublishAsync("blazorserveridweb" + Guid.NewGuid().ToString().Substring(0, 10).ToLowerInvariant(), auth, args);
-
+            => CreateBuildPublishAsync(auth, args);
     }
 }

--- a/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
+++ b/src/ProjectTemplates/test/BlazorServerTemplateTest.cs
@@ -29,26 +29,32 @@ namespace Templates.Test
         [Fact]
         public Task BlazorServerTemplateWorks_ProgamMainNoAuth() => CreateBuildPublishAsync(args: new [] { ArgConstants.UseProgramMain });
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("Individual", null)]
-        [InlineData("Individual", new string[] { ArgConstants.UseLocalDb })]
         [InlineData("Individual", new string[] { ArgConstants.UseProgramMain })]
-        [InlineData("Individual", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseLocalDb })]
         [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/30825", Queues = "All.OSX")]
         public Task BlazorServerTemplateWorks_IndividualAuth(string auth, string[] args) => CreateBuildPublishAsync(auth, args: args);
+
+        [ConditionalTheory]
+        [InlineData("Individual", new string[] { ArgConstants.UseLocalDb })]
+        [InlineData("Individual", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseLocalDb })]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX, SkipReason = "No LocalDb on non-Windows")]
+        public Task BlazorServerTemplateWorks_IndividualAuth_LocalDb(string auth, string[] args) => CreateBuildPublishAsync(auth, args: args);
 
         [Theory]
         [InlineData("IndividualB2C", null)]
         [InlineData("IndividualB2C", new[] { ArgConstants.UseProgramMain })]
         [InlineData("IndividualB2C", new[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
         [InlineData("IndividualB2C", new[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        public Task BlazorServerTemplate_IdentityWeb_BuildAndPublish_IndividualB2C(string auth, string[] args) => CreateBuildPublishAsync(auth, args);
+
+        [Theory]
         [InlineData("SingleOrg", null)]
         [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain })]
         [InlineData("SingleOrg", new[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
         [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
         [InlineData("SingleOrg", new[] { ArgConstants.CallsGraph })]
         [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CallsGraph })]
-        public Task BlazorServerTemplate_IdentityWeb_BuildAndPublish(string auth, string[] args)
-            => CreateBuildPublishAsync(auth, args);
+        public Task BlazorServerTemplate_IdentityWeb_BuildAndPublish_SingleOrg(string auth, string[] args) => CreateBuildPublishAsync(auth, args);
     }
 }

--- a/src/ProjectTemplates/test/BlazorTemplateTest.cs
+++ b/src/ProjectTemplates/test/BlazorTemplateTest.cs
@@ -41,12 +41,12 @@ namespace Templates.Test
 
         public abstract string ProjectType { get; }
 
-        protected async Task<Project> CreateBuildPublishAsync(string projectName, string auth = null, string[] args = null, string targetFramework = null, bool serverProject = false, bool onlyCreate = false)
+        protected async Task<Project> CreateBuildPublishAsync(string auth = null, string[] args = null, string targetFramework = null, bool serverProject = false, bool onlyCreate = false)
         {
             // Additional arguments are needed. See: https://github.com/dotnet/aspnetcore/issues/24278
             Environment.SetEnvironmentVariable("EnableDefaultScopedCssItems", "true");
 
-            var project = await ProjectFactory.GetOrCreateProject(projectName, Output);
+            var project = await ProjectFactory.CreateProject(Output);
             if (targetFramework != null)
             {
                 project.TargetFramework = targetFramework;

--- a/src/ProjectTemplates/test/BlazorWasmTemplateTest.cs
+++ b/src/ProjectTemplates/test/BlazorWasmTemplateTest.cs
@@ -27,7 +27,7 @@ namespace Templates.Test
         [Fact]
         public async Task BlazorWasmStandaloneTemplateCanCreateBuildPublish()
         {
-            var project = await CreateBuildPublishAsync("blazorstandalone");
+            var project = await CreateBuildPublishAsync();
 
             // The service worker assets manifest isn't generated for non-PWA projects
             var publishDir = Path.Combine(project.TemplatePublishDir, "wwwroot");
@@ -35,18 +35,18 @@ namespace Templates.Test
         }
 
         [Fact]
-        public Task BlazorWasmHostedTemplateCanCreateBuildPublish() => CreateBuildPublishAsync("blazorhosted", args: new[] { ArgConstants.Hosted }, serverProject: true);
+        public Task BlazorWasmHostedTemplateCanCreateBuildPublish() => CreateBuildPublishAsync(args: new[] { ArgConstants.Hosted }, serverProject: true);
 
         [Fact]
-        public Task BlazorWasmHostedTemplateWithProgamMainCanCreateBuildPublish() => CreateBuildPublishAsync("blazorhosted", args: new[] { ArgConstants.UseProgramMain, ArgConstants.Hosted }, serverProject: true);
+        public Task BlazorWasmHostedTemplateWithProgamMainCanCreateBuildPublish() => CreateBuildPublishAsync(args: new[] { ArgConstants.UseProgramMain, ArgConstants.Hosted }, serverProject: true);
 
         [Fact]
-        public Task BlazorWasmStandalonePwaTemplateCanCreateBuildPublish() => CreateBuildPublishAsync("blazorstandalonepwa", args: new[] { ArgConstants.Pwa });
+        public Task BlazorWasmStandalonePwaTemplateCanCreateBuildPublish() => CreateBuildPublishAsync(args: new[] { ArgConstants.Pwa });
 
         [Fact]
         public async Task BlazorWasmHostedPwaTemplateCanCreateBuildPublish()
         {
-            var project = await CreateBuildPublishAsync("blazorhostedpwa", args: new[] { ArgConstants.Hosted, ArgConstants.Pwa }, serverProject: true);
+            var project = await CreateBuildPublishAsync(args: new[] { ArgConstants.Hosted, ArgConstants.Pwa }, serverProject: true);
 
             var serverProject = GetSubProject(project, "Server", $"{project.ProjectName}.Server");
 
@@ -105,8 +105,8 @@ namespace Templates.Test
             // Additional arguments are needed. See: https://github.com/dotnet/aspnetcore/issues/24278
             Environment.SetEnvironmentVariable("EnableDefaultScopedCssItems", "true");
 
-            var project = await CreateBuildPublishAsync("blazorhostedindividual" + (useLocalDb ? "uld" : ""),
-                args: new[] { ArgConstants.Hosted, ArgConstants.Auth, "Individual", useLocalDb ? "-uld" : "", useProgramMain ? ArgConstants.UseProgramMain : "" });
+            var project = await CreateBuildPublishAsync("Individual",
+                args: new[] { ArgConstants.Hosted, useLocalDb ? ArgConstants.UseLocalDb : "", useProgramMain ? ArgConstants.UseProgramMain : "" });
 
             var serverProject = GetSubProject(project, "Server", $"{project.ProjectName}.Server");
 
@@ -150,9 +150,7 @@ namespace Templates.Test
         [Fact]
         public async Task BlazorWasmStandaloneTemplate_IndividualAuth_CreateBuildPublish()
         {
-            var project = await CreateBuildPublishAsync("blazorstandaloneindividual", args: new[] {
-                ArgConstants.Auth,
-                "Individual",
+            var project = await CreateBuildPublishAsync("Individual", args: new[] {
                 "--authority",
                 "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration",
                 ArgConstants.ClientId,
@@ -291,7 +289,7 @@ namespace Templates.Test
         [Theory]
         [MemberData(nameof(TemplateData))]
         public Task BlazorWasmHostedTemplate_AzureActiveDirectoryTemplate_Works(TemplateInstance instance)
-            => CreateBuildPublishAsync(instance.Name, args: instance.Arguments, targetFramework: "netstandard2.1");
+            => CreateBuildPublishAsync(args: instance.Arguments, targetFramework: "netstandard2.1");
 
         private string ReadFile(string basePath, string path)
         {

--- a/src/ProjectTemplates/test/BlazorWasmTemplateTest.cs
+++ b/src/ProjectTemplates/test/BlazorWasmTemplateTest.cs
@@ -158,7 +158,7 @@ namespace Templates.Test
             });
         }
 
-        public static TheoryData<TemplateInstance> TemplateData => new TheoryData<TemplateInstance>
+        public static TheoryData<TemplateInstance> TemplateDataIndividualB2C => new TheoryData<TemplateInstance>
         {
             new TemplateInstance(
                 "blazorwasmhostedaadb2c", "-ho",
@@ -182,69 +182,6 @@ namespace Templates.Test
                 ArgConstants.AppIdClientId, "1234123413241324",
                 ArgConstants.UseProgramMain),
             new TemplateInstance(
-                "blazorwasmhostedaad", "-ho",
-                ArgConstants.Auth, "SingleOrg",
-                ArgConstants.Domain, "my-domain",
-                ArgConstants.TenantId, "tenantId",
-                ArgConstants.ClientId, "clientId",
-                ArgConstants.DefaultScope, "full",
-                ArgConstants.AppIdUri, "ApiUri",
-                ArgConstants.AppIdClientId, "1234123413241324"),
-            new TemplateInstance(
-                "blazorwasmhostedaad_program_main", "-ho",
-                ArgConstants.Auth, "SingleOrg",
-                ArgConstants.Domain, "my-domain",
-                ArgConstants.TenantId, "tenantId",
-                ArgConstants.ClientId, "clientId",
-                ArgConstants.DefaultScope, "full",
-                ArgConstants.AppIdUri, "ApiUri",
-                ArgConstants.AppIdClientId, "1234123413241324",
-                ArgConstants.UseProgramMain),
-            new TemplateInstance(
-                "blazorwasmhostedaadgraph", "-ho",
-                ArgConstants.Auth, "SingleOrg",
-                ArgConstants.CallsGraph,
-                ArgConstants.Domain, "my-domain",
-                ArgConstants.TenantId, "tenantId",
-                ArgConstants.ClientId, "clientId",
-                ArgConstants.DefaultScope, "full",
-                ArgConstants.AppIdUri, "ApiUri",
-                ArgConstants.AppIdClientId, "1234123413241324"),
-            new TemplateInstance(
-                "blazorwasmhostedaadgraph_program_main", "-ho",
-                ArgConstants.Auth, "SingleOrg",
-                ArgConstants.CallsGraph,
-                ArgConstants.Domain, "my-domain",
-                ArgConstants.TenantId, "tenantId",
-                ArgConstants.ClientId, "clientId",
-                ArgConstants.DefaultScope, "full",
-                ArgConstants.AppIdUri, "ApiUri",
-                ArgConstants.AppIdClientId, "1234123413241324",
-                ArgConstants.UseProgramMain),
-            new TemplateInstance(
-                "blazorwasmhostedaadapi", "-ho",
-                ArgConstants.Auth, "SingleOrg",
-                ArgConstants.CalledApiUrl, "\"https://graph.microsoft.com\"",
-                ArgConstants.CalledApiScopes, "user.readwrite",
-                ArgConstants.Domain, "my-domain",
-                ArgConstants.TenantId, "tenantId",
-                ArgConstants.ClientId, "clientId",
-                ArgConstants.DefaultScope, "full",
-                ArgConstants.AppIdUri, "ApiUri",
-                ArgConstants.AppIdClientId, "1234123413241324"),
-            new TemplateInstance(
-                "blazorwasmhostedaadapi_program_main", "-ho",
-                ArgConstants.Auth, "SingleOrg",
-                ArgConstants.CalledApiUrl, "\"https://graph.microsoft.com\"",
-                ArgConstants.CalledApiScopes, "user.readwrite",
-                ArgConstants.Domain, "my-domain",
-                ArgConstants.TenantId, "tenantId",
-                ArgConstants.ClientId, "clientId",
-                ArgConstants.DefaultScope, "full",
-                ArgConstants.AppIdUri, "ApiUri",
-                ArgConstants.AppIdClientId, "1234123413241324",
-                ArgConstants.UseProgramMain),
-            new TemplateInstance(
                 "blazorwasmstandaloneaadb2c",
                 ArgConstants.Auth, "IndividualB2C",
                 ArgConstants.AadB2cInstance, "example.b2clogin.com",
@@ -259,12 +196,83 @@ namespace Templates.Test
                 ArgConstants.ClientId, "clientId",
                 ArgConstants.Domain, "my-domain",
                 ArgConstants.UseProgramMain),
+        };
+
+        public static TheoryData<TemplateInstance> TemplateDataSingleOrg => new TheoryData<TemplateInstance>
+        {
+            new TemplateInstance(
+                "blazorwasmhostedaad", "-ho",
+                ArgConstants.Auth, "SingleOrg",
+                ArgConstants.Domain, "my-domain",
+                ArgConstants.TenantId, "tenantId",
+                ArgConstants.ClientId, "clientId",
+                ArgConstants.DefaultScope, "full",
+                ArgConstants.AppIdUri, "ApiUri",
+                ArgConstants.AppIdClientId, "1234123413241324"),
+            new TemplateInstance(
+                "blazorwasmhostedaadgraph", "-ho",
+                ArgConstants.Auth, "SingleOrg",
+                ArgConstants.CallsGraph,
+                ArgConstants.Domain, "my-domain",
+                ArgConstants.TenantId, "tenantId",
+                ArgConstants.ClientId, "clientId",
+                ArgConstants.DefaultScope, "full",
+                ArgConstants.AppIdUri, "ApiUri",
+                ArgConstants.AppIdClientId, "1234123413241324"),
+            new TemplateInstance(
+                "blazorwasmhostedaadapi", "-ho",
+                ArgConstants.Auth, "SingleOrg",
+                ArgConstants.CalledApiUrl, "\"https://graph.microsoft.com\"",
+                ArgConstants.CalledApiScopes, "user.readwrite",
+                ArgConstants.Domain, "my-domain",
+                ArgConstants.TenantId, "tenantId",
+                ArgConstants.ClientId, "clientId",
+                ArgConstants.DefaultScope, "full",
+                ArgConstants.AppIdUri, "ApiUri",
+                ArgConstants.AppIdClientId, "1234123413241324"),
             new TemplateInstance(
                 "blazorwasmstandaloneaad",
                 ArgConstants.Auth, "SingleOrg",
                 ArgConstants.Domain, "my-domain",
                 ArgConstants.TenantId, "tenantId",
                 ArgConstants.ClientId, "clientId"),
+        };
+
+        public static TheoryData<TemplateInstance> TemplateDataSingleOrgProgramMain => new TheoryData<TemplateInstance>
+        {
+            new TemplateInstance(
+                "blazorwasmhostedaad_program_main", "-ho",
+                ArgConstants.Auth, "SingleOrg",
+                ArgConstants.Domain, "my-domain",
+                ArgConstants.TenantId, "tenantId",
+                ArgConstants.ClientId, "clientId",
+                ArgConstants.DefaultScope, "full",
+                ArgConstants.AppIdUri, "ApiUri",
+                ArgConstants.AppIdClientId, "1234123413241324",
+                ArgConstants.UseProgramMain),
+            new TemplateInstance(
+                "blazorwasmhostedaadgraph_program_main", "-ho",
+                ArgConstants.Auth, "SingleOrg",
+                ArgConstants.CallsGraph,
+                ArgConstants.Domain, "my-domain",
+                ArgConstants.TenantId, "tenantId",
+                ArgConstants.ClientId, "clientId",
+                ArgConstants.DefaultScope, "full",
+                ArgConstants.AppIdUri, "ApiUri",
+                ArgConstants.AppIdClientId, "1234123413241324",
+                ArgConstants.UseProgramMain),
+            new TemplateInstance(
+                "blazorwasmhostedaadapi_program_main", "-ho",
+                ArgConstants.Auth, "SingleOrg",
+                ArgConstants.CalledApiUrl, "\"https://graph.microsoft.com\"",
+                ArgConstants.CalledApiScopes, "user.readwrite",
+                ArgConstants.Domain, "my-domain",
+                ArgConstants.TenantId, "tenantId",
+                ArgConstants.ClientId, "clientId",
+                ArgConstants.DefaultScope, "full",
+                ArgConstants.AppIdUri, "ApiUri",
+                ArgConstants.AppIdClientId, "1234123413241324",
+                ArgConstants.UseProgramMain),
             new TemplateInstance(
                 "blazorwasmstandaloneaad_program_main",
                 ArgConstants.Auth, "SingleOrg",
@@ -287,8 +295,18 @@ namespace Templates.Test
         }
 
         [Theory]
-        [MemberData(nameof(TemplateData))]
-        public Task BlazorWasmHostedTemplate_AzureActiveDirectoryTemplate_Works(TemplateInstance instance)
+        [MemberData(nameof(TemplateDataIndividualB2C))]
+        public Task BlazorWasmHostedTemplate_AzureActiveDirectoryTemplate_IndividualB2C_Works(TemplateInstance instance)
+            => CreateBuildPublishAsync(args: instance.Arguments, targetFramework: "netstandard2.1");
+
+        [Theory]
+        [MemberData(nameof(TemplateDataSingleOrg))]
+        public Task BlazorWasmHostedTemplate_AzureActiveDirectoryTemplate_SingleOrg_Works(TemplateInstance instance)
+            => CreateBuildPublishAsync(args: instance.Arguments, targetFramework: "netstandard2.1");
+
+        [Theory]
+        [MemberData(nameof(TemplateDataSingleOrgProgramMain))]
+        public Task BlazorWasmHostedTemplate_AzureActiveDirectoryTemplate_SingleOrg_ProgramMain_Works(TemplateInstance instance)
             => CreateBuildPublishAsync(args: instance.Arguments, targetFramework: "netstandard2.1");
 
         private string ReadFile(string basePath, string path)

--- a/src/ProjectTemplates/test/EmptyWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/EmptyWebTemplateTest.cs
@@ -42,7 +42,7 @@ namespace Templates.Test
         [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
         public async Task EmptyWebTemplateProgramMainCSharp()
         {
-            await EmtpyTemplateCore(languageOverride: null, args: new [] { "--use-program-main" });
+            await EmtpyTemplateCore(languageOverride: null, args: new[] { ArgConstants.UseProgramMain });
         }
 
         [Fact]

--- a/src/ProjectTemplates/test/EmptyWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/EmptyWebTemplateTest.cs
@@ -53,7 +53,7 @@ namespace Templates.Test
 
         private async Task EmtpyTemplateCore(string languageOverride, string[] args = null)
         {
-            var project = await ProjectFactory.GetOrCreateProject("empty" + (languageOverride == "F#" ? "fsharp" : "csharp"), Output);
+            var project = await ProjectFactory.CreateProject(Output);
 
             var createResult = await project.RunDotNetNewAsync("web", args: args, language: languageOverride);
             Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));

--- a/src/ProjectTemplates/test/GrpcTemplateTest.cs
+++ b/src/ProjectTemplates/test/GrpcTemplateTest.cs
@@ -43,7 +43,7 @@ namespace Templates.Test
         {
             var project = await ProjectFactory.GetOrCreateProject("grpc", Output);
 
-            var args = useProgramMain ? new [] { "--use-program-main" } : null;
+            var args = useProgramMain ? new [] { ArgConstants.UseProgramMain } : null;
             var createResult = await project.RunDotNetNewAsync("grpc", args: args);
             Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
 

--- a/src/ProjectTemplates/test/GrpcTemplateTest.cs
+++ b/src/ProjectTemplates/test/GrpcTemplateTest.cs
@@ -41,7 +41,7 @@ namespace Templates.Test
         [InlineData(false)]
         public async Task GrpcTemplate(bool useProgramMain)
         {
-            var project = await ProjectFactory.GetOrCreateProject("grpc", Output);
+            var project = await ProjectFactory.CreateProject(Output);
 
             var args = useProgramMain ? new [] { ArgConstants.UseProgramMain } : null;
             var createResult = await project.RunDotNetNewAsync("grpc", args: args);

--- a/src/ProjectTemplates/test/IdentityUIPackageTest.cs
+++ b/src/ProjectTemplates/test/IdentityUIPackageTest.cs
@@ -102,7 +102,7 @@ namespace Templates.Test
         public async Task IdentityUIPackage_WorksWithDifferentOptions()
         {
             var packageOptions = new Dictionary<string, string>();
-            var project = await ProjectFactory.GetOrCreateProject("identityuipackage" + string.Concat(packageOptions.Values), Output);
+            var project = await ProjectFactory.CreateProject(Output);
             var useLocalDB = false;
 
             var createResult = await project.RunDotNetNewAsync("razor", auth: "Individual", useLocalDB: useLocalDB, environmentVariables: packageOptions);

--- a/src/ProjectTemplates/test/ItemTemplateTests/BlazorServerTests.cs
+++ b/src/ProjectTemplates/test/ItemTemplateTests/BlazorServerTests.cs
@@ -25,7 +25,7 @@ namespace Templates.Items.Test
         [Fact]
         public async Task BlazorServerItemTemplate()
         {
-            Project = await ProjectFactory.GetOrCreateProject("razorcomponentitem", Output);
+            Project = await ProjectFactory.CreateProject(Output);
 
             var createResult = await Project.RunDotNetNewAsync("razorcomponent --name Different");
             Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create", Project, createResult));

--- a/src/ProjectTemplates/test/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/MvcTemplateTest.cs
@@ -255,7 +255,7 @@ namespace Templates.Test
             var createResult = await project.RunDotNetNewAsync("mvc");
             Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
 
-            var publishResult = await project.RunDotNetPublishAsync(additionalArgs: $"/p:PublishSingleFile=true -r {runtimeIdentifer}", noRestore: false);
+            var publishResult = await project.RunDotNetPublishAsync(additionalArgs: $"/p:PublishSingleFile=true -r {runtimeIdentifer} --self-contained", noRestore: false);
             Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
 
             var menuLinks = new[]

--- a/src/ProjectTemplates/test/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/MvcTemplateTest.cs
@@ -45,7 +45,7 @@ namespace Templates.Test
 
         [ConditionalFact]
         [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
-        public async Task MvcTemplate_ProgramMainNoAuthCSharp() => await MvcTemplateCore(languageOverride: null, new [] { "--use-program-main" });
+        public async Task MvcTemplate_ProgramMainNoAuthCSharp() => await MvcTemplateCore(languageOverride: null, new [] { ArgConstants.UseProgramMain });
 
         private async Task MvcTemplateCore(string languageOverride, string[] args = null)
         {
@@ -129,7 +129,7 @@ namespace Templates.Test
         {
             var project = await ProjectFactory.GetOrCreateProject("mvcindividual" + (useLocalDB ? "uld" : ""), Output);
 
-            var args = useProgramMain ? new [] { "--use-program-main" } : null;
+            var args = useProgramMain ? new [] { ArgConstants.UseProgramMain } : null;
             var createResult = await project.RunDotNetNewAsync("mvc", auth: "Individual", useLocalDB: useLocalDB, args: args);
             Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
 
@@ -292,10 +292,15 @@ namespace Templates.Test
         [ConditionalTheory]
         [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
         [InlineData("IndividualB2C", null)]
-        [InlineData("IndividualB2C", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+        [InlineData("IndividualB2C", new[] { ArgConstants.UseProgramMain })]
+        [InlineData("IndividualB2C", new[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        [InlineData("IndividualB2C", new[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
         [InlineData("SingleOrg", null)]
-        [InlineData("SingleOrg", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-        [InlineData("SingleOrg", new string[] { "--calls-graph" })]
+        [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain })]
+        [InlineData("SingleOrg", new[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        [InlineData("SingleOrg", new[] { ArgConstants.CallsGraph })]
+        [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CallsGraph })]
         public Task MvcTemplate_IdentityWeb_BuildsAndPublishes(string auth, string[] args) => MvcTemplateBuildsAndPublishes(auth: auth, args: args);
 
         private async Task<Project> MvcTemplateBuildsAndPublishes(string auth, string[] args)

--- a/src/ProjectTemplates/test/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/MvcTemplateTest.cs
@@ -49,7 +49,7 @@ namespace Templates.Test
 
         private async Task MvcTemplateCore(string languageOverride, string[] args = null)
         {
-            var project = await ProjectFactory.GetOrCreateProject("mvcnoauth" + (languageOverride == "F#" ? "fsharp" : "csharp"), Output);
+            var project = await ProjectFactory.CreateProject(Output);
 
             var createResult = await project.RunDotNetNewAsync("mvc", language: languageOverride, args: args);
             Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
@@ -127,7 +127,7 @@ namespace Templates.Test
         [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
         public async Task MvcTemplate_IndividualAuth(bool useLocalDB, bool useProgramMain)
         {
-            var project = await ProjectFactory.GetOrCreateProject("mvcindividual" + (useLocalDB ? "uld" : ""), Output);
+            var project = await ProjectFactory.CreateProject(Output);
 
             var args = useProgramMain ? new [] { ArgConstants.UseProgramMain } : null;
             var createResult = await project.RunDotNetNewAsync("mvc", auth: "Individual", useLocalDB: useLocalDB, args: args);
@@ -249,7 +249,7 @@ namespace Templates.Test
             // This test verifies publishing an MVC app as a single file exe works. We'll limit testing
             // this to a few operating systems to make our lives easier.
             var runtimeIdentifer = "win-x64";
-            var project = await ProjectFactory.GetOrCreateProject("mvcsinglefileexe", Output);
+            var project = await ProjectFactory.CreateProject(Output);
             project.RuntimeIdentifier = runtimeIdentifer;
 
             var createResult = await project.RunDotNetNewAsync("mvc");
@@ -305,7 +305,7 @@ namespace Templates.Test
 
         private async Task<Project> MvcTemplateBuildsAndPublishes(string auth, string[] args)
         {
-            var project = await ProjectFactory.GetOrCreateProject("mvc" + Guid.NewGuid().ToString().Substring(0, 10).ToLowerInvariant(), Output);
+            var project = await ProjectFactory.CreateProject(Output);
 
             var createResult = await project.RunDotNetNewAsync("mvc", auth: auth, args: args);
             Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));

--- a/src/ProjectTemplates/test/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/MvcTemplateTest.cs
@@ -120,12 +120,19 @@ namespace Templates.Test
         }
 
         [ConditionalTheory]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
+        [InlineData(false)]
+        [InlineData(true)]
         [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
-        public async Task MvcTemplate_IndividualAuth(bool useLocalDB, bool useProgramMain)
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX, SkipReason = "No LocalDb on non-Windows")]
+        public Task MvcTemplate_IndividualAuth_LocalDb(bool useProgramMain) => MvcTemplate_IndividualAuth_Core(useLocalDB: true, useProgramMain);
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64 + HelixConstants.DebianAmd64)]
+        public Task MvcTemplate_IndividualAuth(bool useProgramMain) => MvcTemplate_IndividualAuth_Core(useLocalDB: false, useProgramMain);
+
+        private async Task MvcTemplate_IndividualAuth_Core(bool useLocalDB, bool useProgramMain)
         {
             var project = await ProjectFactory.CreateProject(Output);
 
@@ -295,13 +302,17 @@ namespace Templates.Test
         [InlineData("IndividualB2C", new[] { ArgConstants.UseProgramMain })]
         [InlineData("IndividualB2C", new[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
         [InlineData("IndividualB2C", new[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        public Task MvcTemplate_IdentityWeb_IndividualB2C_BuildsAndPublishes(string auth, string[] args) => MvcTemplateBuildsAndPublishes(auth: auth, args: args);
+        
+        [ConditionalTheory]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
         [InlineData("SingleOrg", null)]
         [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain })]
         [InlineData("SingleOrg", new[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
         [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
         [InlineData("SingleOrg", new[] { ArgConstants.CallsGraph })]
         [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CallsGraph })]
-        public Task MvcTemplate_IdentityWeb_BuildsAndPublishes(string auth, string[] args) => MvcTemplateBuildsAndPublishes(auth: auth, args: args);
+        public Task MvcTemplate_IdentityWeb_SingleOrg_BuildsAndPublishes(string auth, string[] args) => MvcTemplateBuildsAndPublishes(auth: auth, args: args);
 
         private async Task<Project> MvcTemplateBuildsAndPublishes(string auth, string[] args)
         {

--- a/src/ProjectTemplates/test/ProjectTemplates.Tests.csproj
+++ b/src/ProjectTemplates/test/ProjectTemplates.Tests.csproj
@@ -19,6 +19,9 @@
     <TestTemplateCreationFolder>TestTemplates\</TestTemplateCreationFolder>
     <TestPackageRestorePath>$([MSBuild]::EnsureTrailingSlash('$(RepoRoot)'))obj\template-restore\</TestPackageRestorePath>
     <TestDependsOnAspNetRuntime>true</TestDependsOnAspNetRuntime>
+    <SkipHelixQueues>
+      $(HelixQueueArmDebian11);
+    </SkipHelixQueues>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ProjectTemplates/test/RazorClassLibraryTemplateTest.cs
+++ b/src/ProjectTemplates/test/RazorClassLibraryTemplateTest.cs
@@ -33,7 +33,7 @@ namespace Templates.Test
         [Fact]
         public async Task RazorClassLibraryTemplate_WithViews_Async()
         {
-            var project = await ProjectFactory.GetOrCreateProject("razorclasslibwithviews", Output);
+            var project = await ProjectFactory.CreateProject(Output);
 
             var createResult = await project.RunDotNetNewAsync("razorclasslib", args: new[] { "--support-pages-and-views", "true" });
             Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
@@ -53,7 +53,7 @@ namespace Templates.Test
         [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
         public async Task RazorClassLibraryTemplateAsync()
         {
-            var project = await ProjectFactory.GetOrCreateProject("razorclasslib", Output);
+            var project = await ProjectFactory.CreateProject(Output);
 
             var createResult = await project.RunDotNetNewAsync("razorclasslib");
             Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));

--- a/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
+++ b/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
@@ -42,7 +42,7 @@ namespace Templates.Test
         {
             var project = await ProjectFactory.GetOrCreateProject("razorpagesnoauth", Output);
 
-            var args = useProgramMain ? new [] { "--use-program-main" } : null;
+            var args = useProgramMain ? new [] { ArgConstants.UseProgramMain } : null;
             var createResult = await project.RunDotNetNewAsync("razor", args: args);
             Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("razor", project, createResult));
 
@@ -116,7 +116,7 @@ namespace Templates.Test
         {
             var project = await ProjectFactory.GetOrCreateProject("razorpagesindividual" + (useLocalDB ? "uld" : ""), Output);
 
-            var args = useProgramMain ? new [] { "--use-program-main" } : null;
+            var args = useProgramMain ? new [] { ArgConstants.UseProgramMain } : null;
             var createResult = await project.RunDotNetNewAsync("razor", auth: "Individual", useLocalDB: useLocalDB, args: args);
             Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
 
@@ -231,16 +231,18 @@ namespace Templates.Test
         [ConditionalTheory]
         [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
         [InlineData("IndividualB2C", null)]
-        [InlineData("IndividualB2C", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-        [InlineData("IndividualB2C", new string[] { "--use-program-main --called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+        [InlineData("IndividualB2C", new[] { ArgConstants.UseProgramMain })]
+        [InlineData("IndividualB2C", new[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        [InlineData("IndividualB2C", new[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
         [InlineData("SingleOrg", null)]
-        [InlineData("SingleOrg", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-        [InlineData("SingleOrg", new string[] { "--use-program-main --called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+        [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain })]
+        [InlineData("SingleOrg", new[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
         public Task RazorPagesTemplate_IdentityWeb_BuildsAndPublishes(string auth, string[] args) => BuildAndPublishRazorPagesTemplate(auth: auth, args: args);
 
         [ConditionalTheory]
-        [InlineData("SingleOrg", new string[] { "--calls-graph" })]
-        [InlineData("SingleOrg", new string[] { "--use-program-main --calls-graph" })]
+        [InlineData("SingleOrg", new[] { ArgConstants.CallsGraph })]
+        [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CallsGraph })]
         public Task RazorPagesTemplate_IdentityWeb_BuildsAndPublishes_WithSingleOrg(string auth, string[] args) => BuildAndPublishRazorPagesTemplate(auth: auth, args: args);
 
         private async Task<Project> BuildAndPublishRazorPagesTemplate(string auth, string[] args)

--- a/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
+++ b/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
@@ -107,12 +107,19 @@ namespace Templates.Test
         }
 
         [ConditionalTheory]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
-        public async Task RazorPagesTemplate_IndividualAuth(bool useLocalDB, bool useProgramMain)
+        [InlineData(false)]
+        [InlineData(true)]
+        [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64 + HelixConstants.DebianAmd64)]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX, SkipReason = "No LocalDb on non-Windows")]
+        public Task RazorPagesTemplate_IndividualAuth_LocalDb(bool useProgramMain) => RazorPagesTemplate_IndividualAuth_Core(useLocalDB: true, useProgramMain);
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        [InlineData(true)]
+        [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64 + HelixConstants.DebianAmd64)]
+        public Task RazorPagesTemplate_IndividualAuth(bool useProgramMain) => RazorPagesTemplate_IndividualAuth_Core(useLocalDB: false, useProgramMain);
+
+        private async Task RazorPagesTemplate_IndividualAuth_Core(bool useLocalDB, bool useProgramMain)
         {
             var project = await ProjectFactory.CreateProject(Output);
 
@@ -234,16 +241,20 @@ namespace Templates.Test
         [InlineData("IndividualB2C", new[] { ArgConstants.UseProgramMain })]
         [InlineData("IndividualB2C", new[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
         [InlineData("IndividualB2C", new[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        public Task RazorPagesTemplate_IdentityWeb_IndividualB2C_BuildsAndPublishes(string auth, string[] args) => BuildAndPublishRazorPagesTemplate(auth: auth, args: args);
+
+        [ConditionalTheory]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
         [InlineData("SingleOrg", null)]
         [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain })]
         [InlineData("SingleOrg", new[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
         [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
-        public Task RazorPagesTemplate_IdentityWeb_BuildsAndPublishes(string auth, string[] args) => BuildAndPublishRazorPagesTemplate(auth: auth, args: args);
+        public Task RazorPagesTemplate_IdentityWeb_SingleOrg_BuildsAndPublishes(string auth, string[] args) => BuildAndPublishRazorPagesTemplate(auth: auth, args: args);
 
         [ConditionalTheory]
         [InlineData("SingleOrg", new[] { ArgConstants.CallsGraph })]
         [InlineData("SingleOrg", new[] { ArgConstants.UseProgramMain, ArgConstants.CallsGraph })]
-        public Task RazorPagesTemplate_IdentityWeb_BuildsAndPublishes_WithSingleOrg(string auth, string[] args) => BuildAndPublishRazorPagesTemplate(auth: auth, args: args);
+        public Task RazorPagesTemplate_IdentityWeb_SingleOrg_CallsGraph_BuildsAndPublishes(string auth, string[] args) => BuildAndPublishRazorPagesTemplate(auth: auth, args: args);
 
         private async Task<Project> BuildAndPublishRazorPagesTemplate(string auth, string[] args)
         {

--- a/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
+++ b/src/ProjectTemplates/test/RazorPagesTemplateTest.cs
@@ -40,7 +40,7 @@ namespace Templates.Test
         [InlineData(false)]
         public async Task RazorPagesTemplate_NoAuth(bool useProgramMain)
         {
-            var project = await ProjectFactory.GetOrCreateProject("razorpagesnoauth", Output);
+            var project = await ProjectFactory.CreateProject(Output);
 
             var args = useProgramMain ? new [] { ArgConstants.UseProgramMain } : null;
             var createResult = await project.RunDotNetNewAsync("razor", args: args);
@@ -114,7 +114,7 @@ namespace Templates.Test
         [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
         public async Task RazorPagesTemplate_IndividualAuth(bool useLocalDB, bool useProgramMain)
         {
-            var project = await ProjectFactory.GetOrCreateProject("razorpagesindividual" + (useLocalDB ? "uld" : ""), Output);
+            var project = await ProjectFactory.CreateProject(Output);
 
             var args = useProgramMain ? new [] { ArgConstants.UseProgramMain } : null;
             var createResult = await project.RunDotNetNewAsync("razor", auth: "Individual", useLocalDB: useLocalDB, args: args);
@@ -247,7 +247,7 @@ namespace Templates.Test
 
         private async Task<Project> BuildAndPublishRazorPagesTemplate(string auth, string[] args)
         {
-            var project = await ProjectFactory.GetOrCreateProject("razorpages" + Guid.NewGuid().ToString().Substring(0, 10).ToLowerInvariant(), Output);
+            var project = await ProjectFactory.CreateProject(Output);
 
             var createResult = await project.RunDotNetNewAsync("razor", auth: auth, args: args);
             Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));

--- a/src/ProjectTemplates/test/SpaTemplatesTest.cs
+++ b/src/ProjectTemplates/test/SpaTemplatesTest.cs
@@ -35,13 +35,13 @@ namespace Templates.Test
         }
 
         [Theory]
-        [InlineData("angularind", "angular", "Individual")]
-        [InlineData("reactind", "react", "Individual")]
-        [InlineData("angularnoauth", "angular", null)]
-        [InlineData("reactnoauth", "react", null)]
-        public async Task SpaTemplates_BuildAndPublish(string projectKey, string template, string auth)
+        [InlineData("angular", "Individual")]
+        [InlineData("react", "Individual")]
+        [InlineData("angular", null)]
+        [InlineData("react", null)]
+        public async Task SpaTemplates_BuildAndPublish(string template, string auth)
         {
-            var project = await ProjectFactory.GetOrCreateProject(projectKey, Output);
+            var project = await ProjectFactory.CreateProject(Output);
             var args = new[] { "--NoSpaFrontEnd", "true" };
             var createResult = await project.RunDotNetNewAsync(template, auth: auth, args: args);
             Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage(template, project, createResult));

--- a/src/ProjectTemplates/test/WebApiTemplateTest.cs
+++ b/src/ProjectTemplates/test/WebApiTemplateTest.cs
@@ -35,15 +35,25 @@ namespace Templates.Test
         [ConditionalTheory]
         [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
         [InlineData("IndividualB2C", null)]
-        [InlineData("IndividualB2C", new string[] { "--use-program-main" })]
-        [InlineData("IndividualB2C", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-        [InlineData("IndividualB2C", new string[] { "--use-program-main --called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
+        [InlineData("IndividualB2C", new string[] { ArgConstants.UseProgramMain })]
+        [InlineData("IndividualB2C", new string[] { ArgConstants.UseMinimalApis })]
+        [InlineData("IndividualB2C", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis })]
+        [InlineData("IndividualB2C", new string[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        [InlineData("IndividualB2C", new string[] { ArgConstants.UseMinimalApis, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        [InlineData("IndividualB2C", new string[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        [InlineData("IndividualB2C", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
         [InlineData("SingleOrg", null)]
-        [InlineData("SingleOrg", new string[] { "--use-program-main" })]
-        [InlineData("SingleOrg", new string[] { "--called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-        [InlineData("SingleOrg", new string[] { "--use-program-main --called-api-url \"https://graph.microsoft.com\"", "--called-api-scopes user.readwrite" })]
-        [InlineData("SingleOrg", new string[] { "--calls-graph" })]
-        [InlineData("SingleOrg", new string[] { "--use-program-main --calls-graph" })]
+        [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain })]
+        [InlineData("SingleOrg", new string[] { ArgConstants.UseMinimalApis })]
+        [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis })]
+        [InlineData("SingleOrg", new string[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        [InlineData("SingleOrg", new string[] { ArgConstants.UseMinimalApis, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        [InlineData("SingleOrg", new string[] { ArgConstants.CallsGraph })]
+        [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain, ArgConstants.CallsGraph })]
+        [InlineData("SingleOrg", new string[] { ArgConstants.UseMinimalApis, ArgConstants.CallsGraph })]
+        [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis, ArgConstants.CallsGraph })]
         public Task WebApiTemplateCSharp_IdentityWeb_BuildsAndPublishes(string auth, string[] args) => PublishAndBuildWebApiTemplate(languageOverride: null, auth: auth, args: args);
 
         [Fact]
@@ -55,17 +65,33 @@ namespace Templates.Test
 
         [ConditionalFact]
         [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
-        public Task WebApiTemplateProgramMainCSharp() => WebApiTemplateCore(languageOverride: null, args: new [] { "--use-program-main" });
+        public Task WebApiTemplateProgramMainCSharp() => WebApiTemplateCore(languageOverride: null, args: new [] { ArgConstants.UseProgramMain });
+
+        [ConditionalFact]
+        [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
+        public Task WebApiTemplateMinimalApisCSharp() => WebApiTemplateCore(languageOverride: null, args: new[] { ArgConstants.UseMinimalApis });
+
+        [ConditionalFact]
+        [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
+        public Task WebApiTemplateProgramMainMinimalApisCSharp() => WebApiTemplateCore(languageOverride: null, args: new[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis });
 
         [ConditionalTheory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
         [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
-        public async Task WebApiTemplateCSharp_WithoutOpenAPI(bool useProgramMain)
+        public async Task WebApiTemplateCSharp_WithoutOpenAPI(bool useProgramMain, bool useMinimalApis)
         {
             var project = await FactoryFixture.GetOrCreateProject("webapinoopenapi", Output);
 
-            var args = useProgramMain ? new[] { "--use-program-main --no-openapi" } : new[] { "--no-openapi" };
+            var args = useProgramMain
+            ? useMinimalApis
+                ? new[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis, ArgConstants.NoOpenApi }
+                : new[] { ArgConstants.UseProgramMain, ArgConstants.NoOpenApi }
+            : useMinimalApis
+                ? new[] { ArgConstants.UseMinimalApis, ArgConstants.NoOpenApi }
+                : new[] { ArgConstants.NoOpenApi };
             var createResult = await project.RunDotNetNewAsync("webapi", args: args);
             Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
 

--- a/src/ProjectTemplates/test/WebApiTemplateTest.cs
+++ b/src/ProjectTemplates/test/WebApiTemplateTest.cs
@@ -83,7 +83,7 @@ namespace Templates.Test
         [SkipOnHelix("Cert failure, https://github.com/dotnet/aspnetcore/issues/28090", Queues = "All.OSX;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
         public async Task WebApiTemplateCSharp_WithoutOpenAPI(bool useProgramMain, bool useMinimalApis)
         {
-            var project = await FactoryFixture.GetOrCreateProject("webapinoopenapi", Output);
+            var project = await FactoryFixture.CreateProject(Output);
 
             var args = useProgramMain
             ? useMinimalApis

--- a/src/ProjectTemplates/test/WebApiTemplateTest.cs
+++ b/src/ProjectTemplates/test/WebApiTemplateTest.cs
@@ -35,26 +35,40 @@ namespace Templates.Test
         [ConditionalTheory]
         [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
         [InlineData("IndividualB2C", null)]
-        [InlineData("IndividualB2C", new string[] { ArgConstants.UseProgramMain })]
         [InlineData("IndividualB2C", new string[] { ArgConstants.UseMinimalApis })]
-        [InlineData("IndividualB2C", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis })]
         [InlineData("IndividualB2C", new string[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
         [InlineData("IndividualB2C", new string[] { ArgConstants.UseMinimalApis, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        public Task WebApiTemplateCSharp_IdentityWeb_IndividualB2C_BuildsAndPublishes(string auth, string[] args) => PublishAndBuildWebApiTemplate(languageOverride: null, auth: auth, args: args);
+
+        [ConditionalTheory]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
+        [InlineData("IndividualB2C", null)]
+        [InlineData("IndividualB2C", new string[] { ArgConstants.UseProgramMain })]
+        [InlineData("IndividualB2C", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis })]
         [InlineData("IndividualB2C", new string[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
         [InlineData("IndividualB2C", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        public Task WebApiTemplateCSharp_IdentityWeb_IndividualB2C_ProgramMain_BuildsAndPublishes(string auth, string[] args) => PublishAndBuildWebApiTemplate(languageOverride: null, auth: auth, args: args);
+
+        [ConditionalTheory]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
         [InlineData("SingleOrg", null)]
-        [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain })]
         [InlineData("SingleOrg", new string[] { ArgConstants.UseMinimalApis })]
-        [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis })]
         [InlineData("SingleOrg", new string[] { ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
         [InlineData("SingleOrg", new string[] { ArgConstants.UseMinimalApis, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
+        [InlineData("SingleOrg", new string[] { ArgConstants.CallsGraph })]
+        [InlineData("SingleOrg", new string[] { ArgConstants.UseMinimalApis, ArgConstants.CallsGraph })]
+        public Task WebApiTemplateCSharp_IdentityWeb_SingleOrg_BuildsAndPublishes(string auth, string[] args) => PublishAndBuildWebApiTemplate(languageOverride: null, auth: auth, args: args);
+
+        [ConditionalTheory]
+        [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/28090", Queues = HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
+        [InlineData("SingleOrg", null)]
+        [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain })]
+        [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis })]
         [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
         [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis, ArgConstants.CalledApiUrlGraphMicrosoftCom, ArgConstants.CalledApiScopesUserReadWrite })]
-        [InlineData("SingleOrg", new string[] { ArgConstants.CallsGraph })]
         [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain, ArgConstants.CallsGraph })]
-        [InlineData("SingleOrg", new string[] { ArgConstants.UseMinimalApis, ArgConstants.CallsGraph })]
         [InlineData("SingleOrg", new string[] { ArgConstants.UseProgramMain, ArgConstants.UseMinimalApis, ArgConstants.CallsGraph })]
-        public Task WebApiTemplateCSharp_IdentityWeb_BuildsAndPublishes(string auth, string[] args) => PublishAndBuildWebApiTemplate(languageOverride: null, auth: auth, args: args);
+        public Task WebApiTemplateCSharp_IdentityWeb_SingleOrg_ProgramMain_BuildsAndPublishes(string auth, string[] args) => PublishAndBuildWebApiTemplate(languageOverride: null, auth: auth, args: args);
 
         [Fact]
         public Task WebApiTemplateFSharp() => WebApiTemplateCore(languageOverride: "F#");

--- a/src/ProjectTemplates/test/WorkerTemplateTest.cs
+++ b/src/ProjectTemplates/test/WorkerTemplateTest.cs
@@ -33,13 +33,13 @@ namespace Templates.Test
         [ConditionalTheory]
         [OSSkipCondition(OperatingSystems.Linux, SkipReason = "https://github.com/dotnet/sdk/issues/12831")]
         [InlineData("C#", null)]
-        [InlineData("C#", new string[] { "--use-program-main" })]
+        [InlineData("C#", new string[] { ArgConstants.UseProgramMain })]
         [InlineData("F#", null)]
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/25404")]
         public async Task WorkerTemplateAsync(string language, string[] args)
         {
             var project = await ProjectFactory.GetOrCreateProject(
-                $"worker-{ language.ToLowerInvariant()[0] }sharp",
+                $"worker-{language.ToLowerInvariant()[0]}sharp",
                 Output);
 
             var createResult = await project.RunDotNetNewAsync("worker", language: language, args: args);

--- a/src/ProjectTemplates/test/WorkerTemplateTest.cs
+++ b/src/ProjectTemplates/test/WorkerTemplateTest.cs
@@ -38,9 +38,7 @@ namespace Templates.Test
         [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/25404")]
         public async Task WorkerTemplateAsync(string language, string[] args)
         {
-            var project = await ProjectFactory.GetOrCreateProject(
-                $"worker-{language.ToLowerInvariant()[0]}sharp",
-                Output);
+            var project = await ProjectFactory.CreateProject(Output);
 
             var createResult = await project.RunDotNetNewAsync("worker", language: language, args: args);
             Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));

--- a/src/ProjectTemplates/test/template-baselines.json
+++ b/src/ProjectTemplates/test/template-baselines.json
@@ -541,9 +541,35 @@
       ],
       "AuthOption": "IndividualB2C"
     },
+    "IndividualB2CProgramMain": {
+      "Template": "webapi",
+      "Arguments": "new webapi -au IndividualB2C --use-program-main --aad-b2c-instance https://login.microsoftonline.com/tfp/ --domain fake-b2c-domain.onmicrosoft.com --client-id 64f31f76-2750-49e4-aab9-f5de105b5172 -ssp B2C_1_SiUpIn",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "WeatherForecast.cs",
+        "Controllers/WeatherForecastController.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "IndividualB2C"
+    },
     "SingleOrg": {
       "Template": "webapi",
       "Arguments": "new webapi -au SingleOrg --aad-instance https://login.microsoftonline.com/ --domain fake-aad-domain.onmicrosoft.com --client-id db33c356-12cc-4953-9167-00ad56c2e8b2 --tenant-id 7e511586-66ec-4108-bc9c-a68dee0dc2aa",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "WeatherForecast.cs",
+        "Controllers/WeatherForecastController.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "SingleOrg"
+    },
+    "SingleOrgProgramMain": {
+      "Template": "webapi",
+      "Arguments": "new webapi -au SingleOrg --use-program-main --aad-instance https://login.microsoftonline.com/ --domain fake-aad-domain.onmicrosoft.com --client-id db33c356-12cc-4953-9167-00ad56c2e8b2 --tenant-id 7e511586-66ec-4108-bc9c-a68dee0dc2aa",
       "Files": [
         "appsettings.Development.json",
         "appsettings.json",
@@ -567,6 +593,19 @@
       ],
       "AuthOption": "None"
     },
+    "NoneProgramMain": {
+      "Template": "webapi",
+      "Arguments": "new webapi -au None --use-program-main",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "WeatherForecast.cs",
+        "Controllers/WeatherForecastController.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "None"
+    },
     "MinimalIndividualB2C": {
       "Template": "webapi",
       "Arguments": "new webapi -minimal -au IndividualB2C --aad-b2c-instance https://login.microsoftonline.com/tfp/ --domain fake-b2c-domain.onmicrosoft.com --client-id 64f31f76-2750-49e4-aab9-f5de105b5172 -ssp B2C_1_SiUpIn",
@@ -574,6 +613,18 @@
         "appsettings.Development.json",
         "appsettings.json",
         "Program.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "IndividualB2C"
+    },
+    "MinimalIndividualB2CProgramMain": {
+      "Template": "webapi",
+      "Arguments": "new webapi -minimal --use-program-main -au IndividualB2C --aad-b2c-instance https://login.microsoftonline.com/tfp/ --domain fake-b2c-domain.onmicrosoft.com --client-id 64f31f76-2750-49e4-aab9-f5de105b5172 -ssp B2C_1_SiUpIn",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "WeatherForecast.cs",
         "Properties/launchSettings.json"
       ],
       "AuthOption": "IndividualB2C"
@@ -589,6 +640,18 @@
       ],
       "AuthOption": "SingleOrg"
     },
+    "MinimalSingleOrgProgramMain": {
+      "Template": "webapi",
+      "Arguments": "new webapi -minimal --use-program-main -au SingleOrg --aad-instance https://login.microsoftonline.com/ --domain fake-aad-domain.onmicrosoft.com --client-id db33c356-12cc-4953-9167-00ad56c2e8b2 --tenant-id 7e511586-66ec-4108-bc9c-a68dee0dc2aa",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "WeatherForecast.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "SingleOrg"
+    },
     "Minimal": {
       "Template": "webapi",
       "Arguments": "new webapi -minimal -au None",
@@ -596,6 +659,18 @@
         "appsettings.Development.json",
         "appsettings.json",
         "Program.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "None"
+    },
+    "MinimalProgramMain": {
+      "Template": "webapi",
+      "Arguments": "new webapi -minimal --use-program-main -au None",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "WeatherForecast.cs",
         "Properties/launchSettings.json"
       ],
       "AuthOption": "None"
@@ -613,9 +688,33 @@
       ],
       "AuthOption": "Windows"
     },
+    "WindowsProgramMain": {
+      "Template": "webapi",
+      "Arguments": "new webapi -au Windows --use-program-main",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "WeatherForecast.cs",
+        "Controllers/WeatherForecastController.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "Windows"
+    },
     "MinimalWindows": {
       "Template": "webapi",
       "Arguments": "new webapi -minimal -au Windows",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "Windows"
+    },
+    "MinimalWindowsProgramMain": {
+      "Template": "webapi",
+      "Arguments": "new webapi -minimal -au Windows --use-program-main",
       "Files": [
         "appsettings.Development.json",
         "appsettings.json",

--- a/src/ProjectTemplates/test/template-baselines.json
+++ b/src/ProjectTemplates/test/template-baselines.json
@@ -714,11 +714,12 @@
     },
     "MinimalWindowsProgramMain": {
       "Template": "webapi",
-      "Arguments": "new webapi -minimal -au Windows --use-program-main",
+      "Arguments": "new webapi -minimal --use-program-main -au Windows",
       "Files": [
         "appsettings.Development.json",
         "appsettings.json",
         "Program.cs",
+        "WeatherForecast.cs",
         "Properties/launchSettings.json"
       ],
       "AuthOption": "Windows"

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -493,11 +493,11 @@ namespace Microsoft.AspNetCore.Certificates.Generation
                                 // Export the key first to an encrypted PEM to avoid issues with System.Security.Cryptography.Cng indicating that the operation is not supported.
                                 // This is likely by design to avoid exporting the key by mistake.
                                 // To bypass it, we export the certificate to pem temporarily and then we import it and export it as unprotected PEM.
-                                keyBytes = key.ExportEncryptedPkcs8PrivateKey("", new PbeParameters(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 1));
+                                keyBytes = key.ExportEncryptedPkcs8PrivateKey((ReadOnlySpan<char>)"", new PbeParameters(PbeEncryptionAlgorithm.Aes256Cbc, HashAlgorithmName.SHA256, 1));
                                 pem = PemEncoding.Write("ENCRYPTED PRIVATE KEY", keyBytes);
                                 key.Dispose();
                                 key = RSA.Create();
-                                key.ImportFromEncryptedPem(pem, "");
+                                key.ImportFromEncryptedPem(pem, (ReadOnlySpan<char>)"");
                                 Array.Clear(keyBytes, 0, keyBytes.Length);
                                 Array.Clear(pem, 0, pem.Length);
                                 keyBytes = key.ExportPkcs8PrivateKey();

--- a/src/Testing/src/xunit/HelixConstants.cs
+++ b/src/Testing/src/xunit/HelixConstants.cs
@@ -6,6 +6,7 @@ namespace Microsoft.AspNetCore.Testing
     public static class HelixConstants
     {
         public const string Windows10Arm64 = "Windows.10.Arm64v8.Open;";
+        public const string DebianAmd64 = "Debian.11.Amd64.Open;";
         public const string DebianArm64 = "Debian.11.Arm64.Open;";
         public const string RedhatAmd64 = "Redhat.7.Amd64.Open;";
     }


### PR DESCRIPTION
This PR fixes two template issues that were introduced by the recent addition of the `--use-program-main` option, as well as another issue discovered during implementation of the fixes:

1. #41529
    ## Description
    In the Blazor WebAssembly, Blazor Server, and gRPC project templates, if the `--use-program-main` option is specified, the created `Program.cs` file contains a namespace declaration that does not match the project name, but instead is always `Company.WebApplication1`. 

    ## Customer Impact
    This doesn't result in any compiler warning or other build issues on its own, but the name is obviously wrong.

   ## Cause
    This is due to the namespaces not being updated for each specific project template when it was copy/pasted on authoring, as each project template uses a different placeholder namespace that is then replaced with the project name after creation.

    ## Discovered
    This issue was found internally during verification of 6.0.300. The fix has already been [merged to main](https://github.com/dotnet/aspnetcore/pull/41499).

    ## Testing
    Automated tests have been updated to verify that the declared namespaces in the generated *.cs files start with the specified project name. The changes were also verified with manual testing.

    ## Regression
    This is not a regression as it's an issue in the implementation of a newly added feature.

1. #41491
    ## Description
    In the Web API project template, if both the `--use-program-main` and `--use-minimal-apis` options are specified, the project ends up with two different entry points: one in `Program.cs` and another in `Program.Main.cs`.

    ## Customer Impact
    This results in a compiler warning when trying to build the created project:
    ```
    >dotnet build
    Microsoft (R) Build Engine version 17.2.0+41abc5629 for .NET
    Copyright (C) Microsoft Corporation. All rights reserved.
    
      Determining projects to restore...
      All projects are up-to-date for restore.
    C:\Users\<user>\Solutions\Projects02\WebApi02\Program.Main.cs(5,24): warning CS7022: The entry point of the program is
    global code; ignoring 'Program.Main(string[])' entry point. [C:\Users\<user>\Solutions\Projects02\WebApi02\WebApi02.csp
    roj]
      WebApi02 -> C:\Users\<user>\Solutions\Projects02\WebApi02\bin\Debug\net6.0\WebApi02.dll
    
    Build succeeded.
    
    C:\Users\<user>\Solutions\Projects02\WebApi02\Program.Main.cs(5,24): warning CS7022: The entry point of the program is
    global code; ignoring 'Program.Main(string[])' entry point. [C:\Users\<user>\Solutions\Projects02\WebApi02\WebApi02.csp
    roj]
        1 Warning(s)
        0 Error(s)
    
    Time Elapsed 00:00:05.16
    ```
    ## Cause
    This is due to an authoring bug in the template config that doesn't correctly handle the case when both options are specified.

    ## Discovered
    This issue was found internally during verification of 6.0.300. The fix has already been [merged to main](https://github.com/dotnet/aspnetcore/pull/41499).

    ## Testing
    Automated tests have been updated to verify that only the expected files are generated for all template option combinations, along with verifying that no compiler warnings are emitted when building newly created projects. The changes were also verified with manual testing.

    ## Regression
    This is not a regression as it's an issue in the implementation of a newly added feature.

1. **Web API template produces unbuildable project when `--use-minimal-apis` and any authentication (`-au`) option is supplied.**
    ## Description
    In the Web API project template, if both the `--use-minimal-apis` and any cloud authentication (`-au`) option is supplied, the resultant project contains numerous code errors that result in build failures. This issue only manifests when using the templates from the command line (`dotnet new`) as Visual Studio uses its own mechanism for configuring authentication in new projects.

    ## Customer Impact
    New minimal API projects with cloud authentication options created from the command line cannot be built.

   ## Cause
    This is due to authoring mistakes in the template itself.

    ## Discovered
    These issues were discovered as part of reviewing the templates when implementing the fixes for the issues described above. Despite these mistakes being in the templates since the `--use-minimal-apis` option was added during 6.0.0, there were no customer reports. The fix has already been [merged to main](https://github.com/dotnet/aspnetcore/pull/41499).

    ## Testing
    Automated tests have been updated to verify that the declared namespaces in the generated *.cs files start with the specified project name. The changes were also verified with manual testing.

    ## Regression
    This is not a regression as it's an issue in the implementation since the feature was added.

Addresses #41529 in 6.0.xxx
Fixes #41519