### PR TITLE
Implemented test to monitor issue 4754

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseHeaderTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseHeaderTests.cs
@@ -105,17 +105,15 @@ public class ResponseHeaderTests : TestApplicationErrorLoggerLoggedTest
     [Fact]
     public async Task ResponseHeaders_NullEntriesAreIgnored()
     {
-        string tag = "tag";
+        var tag = "Warning";
 
         await using var server = new TestServer(context =>
         {
             Assert.Empty(context.Response.Headers[tag]);
-            var beforeLength = context.Response.Headers.ContentLength;
 
             context.Response.Headers.Add(tag, new StringValues((string)null));
 
             Assert.Empty(context.Response.Headers[tag]);
-            Assert.Equal(beforeLength, context.Response.Headers.ContentLength);
 
             // this should not throw
             context.Response.Headers.Add(tag, new StringValues("Hello"));

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseHeaderTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseHeaderTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.Primitives;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests;
@@ -99,5 +100,43 @@ public class ResponseHeaderTests : TestApplicationErrorLoggerLoggedTest
             "");
 
         await connection.ReceiveEnd();
+    }
+
+    [Fact]
+    public async Task ResponseHeaders_NullEntriesAreIgnored()
+    {
+        string tag = "tag";
+
+        await using var server = new TestServer(context =>
+        {
+            Assert.Empty(context.Response.Headers[tag]);
+            var beforeLength = context.Response.Headers.ContentLength;
+
+            context.Response.Headers.Add(tag, new StringValues((string)null));
+
+            Assert.Empty(context.Response.Headers[tag]);
+            Assert.Equal(beforeLength, context.Response.Headers.ContentLength);
+
+            // this should not throw
+            context.Response.Headers.Add(tag, new StringValues("Hello"));
+
+            context.Response.ContentLength = 11;
+            return context.Response.WriteAsync("Hello World");
+        }, new TestServiceContext(LoggerFactory));
+
+        using var connection = server.CreateConnection();
+        await connection.Send(
+            "GET / HTTP/1.1",
+            "Host:",
+            "",
+            "");
+
+        await connection.Receive(
+            $"HTTP/1.1 200 OK",
+            "Content-Length: 11",
+            $"Date: {server.Context.DateHeaderValue}",
+            $"{tag}: Hello",
+            "",
+            "Hello World");
     }
 }


### PR DESCRIPTION
Implemented unit test to close issue #4754. 

## Description

Added a new InMemory unit test to Kestrel to avoid regressing issue #4754. Currently the test passes.

Fixes #4754