### PR TITLE
Port template test fixes from release/6.0

### DIFF
--- a/src/ProjectTemplates/Shared/ProjectFactoryFixture.cs
+++ b/src/ProjectTemplates/Shared/ProjectFactoryFixture.cs
@@ -14,6 +14,7 @@ namespace Templates.Test.Helpers;
 
 public class ProjectFactoryFixture : IDisposable
 {
+    private const string LetterChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
     private readonly ConcurrentDictionary<string, Project> _projects = new ConcurrentDictionary<string, Project>();
 
     public IMessageSink DiagnosticsMessageSink { get; }
@@ -42,7 +43,16 @@ public class ProjectFactoryFixture : IDisposable
                     DiagnosticsMessageSink = DiagnosticsMessageSink,
                     ProjectGuid = Path.GetRandomFileName().Replace(".", string.Empty)
                 };
-                project.ProjectName = $"AspNet.{project.ProjectGuid}";
+                // Replace first character with a random letter if it's a digit to avoid random insertions of '_'
+                // into template namespace declarations (i.e. make it more stable for testing)
+                var projectNameSuffix = !char.IsLetter(project.ProjectGuid[0])
+                    ? string.Create(project.ProjectGuid.Length, project.ProjectGuid, (suffix, guid) =>
+                    {
+                        guid.AsSpan(1).CopyTo(suffix[1..]);
+                        suffix[0] = GetRandomLetter();
+                    })
+                    : project.ProjectGuid;
+                project.ProjectName = $"AspNet.{projectNameSuffix}";
 
                 var assemblyPath = GetType().Assembly;
                 var basePath = GetTemplateFolderBasePath(assemblyPath);
@@ -51,6 +61,8 @@ public class ProjectFactoryFixture : IDisposable
             },
             output);
     }
+
+    private static char GetRandomLetter() => LetterChars[Random.Shared.Next(LetterChars.Length - 1)];
 
     private static string GetTemplateFolderBasePath(Assembly assembly) =>
         (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("HELIX_DIR")))

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/Program.Main.cs
@@ -37,7 +37,7 @@ using BlazorServerWeb_CSharp.Areas.Identity;
 #endif
 using BlazorServerWeb_CSharp.Data;
 
-namespace Company.WebApplication1;
+namespace BlazorServerWeb_CSharp;
 
 public class Program
 {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Program.Main.cs
@@ -9,7 +9,11 @@ using ComponentsWebAssembly_CSharp.Client;
 using ComponentsWebAssembly_CSharp;
 #endif
 
-namespace Company.WebApplication1;
+#if (Hosted)
+namespace ComponentsWebAssembly_CSharp.Client;
+#else
+namespace ComponentsWebAssembly_CSharp;
+#endif
 
 public class Program
 {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Server/Program.Main.cs
@@ -19,7 +19,7 @@ using ComponentsWebAssembly_CSharp.Server.Data;
 using ComponentsWebAssembly_CSharp.Server.Models;
 #endif
 
-namespace Company.WebApplication1;
+namespace ComponentsWebAssembly_CSharp;
 
 public class Program
 {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/Program.Main.cs
@@ -1,6 +1,6 @@
 using GrpcService_CSharp.Services;
 
-namespace Company.WebApplication1;
+namespace GrpcService_CSharp;
 
 public class Program
 {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.Main.cs
@@ -1,6 +1,4 @@
-using Company.Application1;
-
-namespace Company.WebApplication1;
+namespace Company.Application1;
 
 public class Program
 {

--- a/src/ProjectTemplates/test/BaselineTest.cs
+++ b/src/ProjectTemplates/test/BaselineTest.cs
@@ -100,6 +100,20 @@ public class BaselineTest : LoggedTest
                 continue;
             }
             Assert.Contains(relativePath, expectedFiles);
+
+            if (relativePath.EndsWith(".cs", StringComparison.Ordinal))
+            {
+                var namespaceDeclarationPrefix = "namespace ";
+                var namespaceDeclaration = File.ReadLines(Path.Combine(Project.TemplateOutputDir, relativePath))
+                    .SingleOrDefault(line => line.StartsWith(namespaceDeclarationPrefix, StringComparison.Ordinal))
+                    ?.Substring(namespaceDeclarationPrefix.Length);
+
+                // nullable because Program.cs with top-level statements doesn't have a namespace declaration
+                if (namespaceDeclaration is not null)
+                {
+                    Assert.StartsWith(Project.ProjectName, namespaceDeclaration, StringComparison.Ordinal);
+                }
+            }
         }
     }
 

--- a/src/ProjectTemplates/test/BaselineTest.cs
+++ b/src/ProjectTemplates/test/BaselineTest.cs
@@ -67,6 +67,7 @@ public class BaselineTest : LoggedTest
     }
 
     // This test should generally not be quarantined as it only is checking that the expected files are on disk
+    // and that the namespace declarations in the generated .cs files start with the project name
     [Theory]
     [MemberData(nameof(TemplateBaselines))]
     public async Task Template_Produces_The_Right_Set_Of_FilesAsync(string arguments, string[] expectedFiles)

--- a/src/ProjectTemplates/test/template-baselines.json
+++ b/src/ProjectTemplates/test/template-baselines.json
@@ -541,9 +541,35 @@
       ],
       "AuthOption": "IndividualB2C"
     },
+    "IndividualB2CProgramMain": {
+      "Template": "webapi",
+      "Arguments": "new webapi -au IndividualB2C --use-program-main --aad-b2c-instance https://login.microsoftonline.com/tfp/ --domain fake-b2c-domain.onmicrosoft.com --client-id 64f31f76-2750-49e4-aab9-f5de105b5172 -ssp B2C_1_SiUpIn",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "WeatherForecast.cs",
+        "Controllers/WeatherForecastController.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "IndividualB2C"
+    },
     "SingleOrg": {
       "Template": "webapi",
       "Arguments": "new webapi -au SingleOrg --aad-instance https://login.microsoftonline.com/ --domain fake-aad-domain.onmicrosoft.com --client-id db33c356-12cc-4953-9167-00ad56c2e8b2 --tenant-id 7e511586-66ec-4108-bc9c-a68dee0dc2aa",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "WeatherForecast.cs",
+        "Controllers/WeatherForecastController.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "SingleOrg"
+    },
+    "SingleOrgProgramMain": {
+      "Template": "webapi",
+      "Arguments": "new webapi -au SingleOrg --use-program-main --aad-instance https://login.microsoftonline.com/ --domain fake-aad-domain.onmicrosoft.com --client-id db33c356-12cc-4953-9167-00ad56c2e8b2 --tenant-id 7e511586-66ec-4108-bc9c-a68dee0dc2aa",
       "Files": [
         "appsettings.Development.json",
         "appsettings.json",
@@ -567,6 +593,19 @@
       ],
       "AuthOption": "None"
     },
+    "NoneProgramMain": {
+      "Template": "webapi",
+      "Arguments": "new webapi -au None --use-program-main",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "WeatherForecast.cs",
+        "Controllers/WeatherForecastController.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "None"
+    },
     "MinimalIndividualB2C": {
       "Template": "webapi",
       "Arguments": "new webapi -minimal -au IndividualB2C --aad-b2c-instance https://login.microsoftonline.com/tfp/ --domain fake-b2c-domain.onmicrosoft.com --client-id 64f31f76-2750-49e4-aab9-f5de105b5172 -ssp B2C_1_SiUpIn",
@@ -574,6 +613,18 @@
         "appsettings.Development.json",
         "appsettings.json",
         "Program.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "IndividualB2C"
+    },
+    "MinimalIndividualB2CProgramMain": {
+      "Template": "webapi",
+      "Arguments": "new webapi -minimal --use-program-main -au IndividualB2C --aad-b2c-instance https://login.microsoftonline.com/tfp/ --domain fake-b2c-domain.onmicrosoft.com --client-id 64f31f76-2750-49e4-aab9-f5de105b5172 -ssp B2C_1_SiUpIn",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "WeatherForecast.cs",
         "Properties/launchSettings.json"
       ],
       "AuthOption": "IndividualB2C"
@@ -589,6 +640,18 @@
       ],
       "AuthOption": "SingleOrg"
     },
+    "MinimalSingleOrgProgramMain": {
+      "Template": "webapi",
+      "Arguments": "new webapi -minimal --use-program-main -au SingleOrg --aad-instance https://login.microsoftonline.com/ --domain fake-aad-domain.onmicrosoft.com --client-id db33c356-12cc-4953-9167-00ad56c2e8b2 --tenant-id 7e511586-66ec-4108-bc9c-a68dee0dc2aa",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "WeatherForecast.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "SingleOrg"
+    },
     "Minimal": {
       "Template": "webapi",
       "Arguments": "new webapi -minimal -au None",
@@ -596,6 +659,18 @@
         "appsettings.Development.json",
         "appsettings.json",
         "Program.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "None"
+    },
+    "MinimalProgramMain": {
+      "Template": "webapi",
+      "Arguments": "new webapi -minimal --use-program-main -au None",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "WeatherForecast.cs",
         "Properties/launchSettings.json"
       ],
       "AuthOption": "None"
@@ -613,6 +688,19 @@
       ],
       "AuthOption": "Windows"
     },
+    "WindowsProgramMain": {
+      "Template": "webapi",
+      "Arguments": "new webapi -au Windows --use-program-main",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "WeatherForecast.cs",
+        "Controllers/WeatherForecastController.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "Windows"
+    },
     "MinimalWindows": {
       "Template": "webapi",
       "Arguments": "new webapi -minimal -au Windows",
@@ -620,6 +708,18 @@
         "appsettings.Development.json",
         "appsettings.json",
         "Program.cs",
+        "Properties/launchSettings.json"
+      ],
+      "AuthOption": "Windows"
+    },
+    "MinimalWindowsProgramMain": {
+      "Template": "webapi",
+      "Arguments": "new webapi -minimal --use-program-main -au Windows",
+      "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
+        "Program.cs",
+        "WeatherForecast.cs",
         "Properties/launchSettings.json"
       ],
       "AuthOption": "Windows"


### PR DESCRIPTION
This PR ports a number of project templates fixes from [release/6.0](https://github.com/dotnet/aspnetcore/pull/41536) to main.
([Note the fixes are not actually merged in release/6.0 yet](https://github.com/dotnet/aspnetcore/pull/41536))

This includes the fix for #41529 along with improvements to the project templates tests from release/6.0 to cover the cases which caused these issues.
