### PR TITLE
Initialize Activity with parent ID

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -323,7 +323,7 @@ internal sealed class HostingApplicationDiagnostics
             out var requestId,
             out var traceState);
 
-        Activity? activity = _activitySource.CreateActivity(
+        var activity = _activitySource.CreateActivity(
             ActivityName,
             ActivityKind.Server,
             string.IsNullOrEmpty(requestId) ? null! : requestId
@@ -331,9 +331,15 @@ internal sealed class HostingApplicationDiagnostics
 
         if (activity is null)
         {
+            // CreateActivity didn't create an Activity (this is an optimization for the
+            // case when there are no listeners). Let's create it here if needed.
             if (loggingEnabled || diagnosticListenerActivityCreationEnabled)
             {
                 activity = new Activity(ActivityName);
+                if (!string.IsNullOrEmpty(requestId))
+                {
+                    activity.SetParentId(requestId);
+                }
             }
             else
             {

--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -307,17 +307,6 @@ internal sealed class HostingApplicationDiagnostics
         HostingEventSource.Log.RequestStart(httpContext.Request.Method, httpContext.Request.Path);
     }
 
-    private static bool TryParseActivityContext(string? traceParent, string? traceState, out ActivityContext context)
-    {
-        if (ActivityContext.TryParse(traceParent, traceState, out context))
-        {
-            context = new ActivityContext(context.TraceId, context.SpanId, context.TraceFlags, context.TraceState, isRemote: true);
-            return true;
-        }
-
-        return false;
-    }
-
     [MethodImpl(MethodImplOptions.NoInlining)]
     private Activity? StartActivity(HttpContext httpContext, bool loggingEnabled, bool diagnosticListenerActivityCreationEnabled, out bool hasDiagnosticListener)
     {
@@ -337,7 +326,7 @@ internal sealed class HostingApplicationDiagnostics
         Activity? activity = null;
         if (_activitySource.HasListeners())
         {
-            if (TryParseActivityContext(requestId, traceState, out ActivityContext context))
+            if (ActivityContext.TryParse(requestId, traceState, true, out ActivityContext context))
             {
                 // The requestId used W3C ID format. Unfortunately the ActivitySource.CreateActivity overload that
                 // takes a string ID sets ActivityContext.IsRemote = false when it parses the string internally.

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -459,6 +459,50 @@ public class HostingApplicationDiagnosticsTests
     }
 
     [Fact]
+    public void SamplersReceiveCorrectParentAndTraceIds()
+    {
+        var testSource = new ActivitySource(Path.GetRandomFileName());
+        var hostingApplication = CreateApplication(out var features, activitySource: testSource);
+        var parentId = "";
+        var parentSpanId = "";
+        var traceId = "";
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = activitySource => ReferenceEquals(activitySource, testSource),
+            Sample = (ref ActivityCreationOptions<ActivityContext> options) => ComputeActivitySamplingResult(ref options),
+            ActivityStarted = activity =>
+            {
+                parentId = activity.ParentId;
+                parentSpanId = activity.ParentSpanId.ToHexString();
+                traceId = activity.TraceId.ToHexString();
+            }
+        };
+
+        ActivitySource.AddActivityListener(listener);
+
+        features.Set<IHttpRequestFeature>(new HttpRequestFeature()
+        {
+            Headers = new HeaderDictionary()
+                {
+                    {"traceparent", "00-35aae61e3e99044eb5ea5007f2cd159b-40a8bd87c078cb4c-00"},
+                }
+        });
+
+        hostingApplication.CreateContext(features);
+        Assert.Equal("00-35aae61e3e99044eb5ea5007f2cd159b-40a8bd87c078cb4c-00", parentId);
+        Assert.Equal("40a8bd87c078cb4c", parentSpanId);
+        Assert.Equal("35aae61e3e99044eb5ea5007f2cd159b", traceId);
+
+        static ActivitySamplingResult ComputeActivitySamplingResult(ref ActivityCreationOptions<ActivityContext> options)
+        {
+            Assert.Equal("35aae61e3e99044eb5ea5007f2cd159b", options.TraceId.ToHexString());
+            Assert.Equal("40a8bd87c078cb4c", options.Parent.SpanId.ToHexString());
+
+            return ActivitySamplingResult.AllDataAndRecorded;
+        }
+    }
+
+    [Fact]
     public void ActivityOnImportHookIsCalled()
     {
         var diagnosticListener = new DiagnosticListener("DummySource");


### PR DESCRIPTION
Fix #37471

@noahfalk Please take a look. This seems to work but it's weird from an API perspective that calling `CreateActivity` with the parent ID specified behaves differently than specifying the parent ID using `SetParentId` between creating and starting the Activity. The difference doesn't seem to be mentioned in the API docs either unless I missed something.