### PR TITLE
Merge HTTP/2 and HTTP/3 request cookies on Kestrel

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -7926,7 +7926,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void MergeCookies()
         {
             if (HasCookie && _headers._Cookie.Count > 1)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -7925,10 +7925,10 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
         public void MergeCookies()
         {
-            if (_headers._Cookie.Count > 1)
+            if ((_bits & 0x20000L) != 0 && _headers._Cookie.Count > 1)
             {
                 _headers._Cookie = string.Join("; ", _headers._Cookie.ToArray());
             }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -383,6 +383,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         private HeaderReferences _headers;
 
         public bool HasConnection => (_bits & 0x2L) != 0;
+        public bool HasCookie => (_bits & 0x20000L) != 0;
         public bool HasTransferEncoding => (_bits & 0x20000000000L) != 0;
 
         public int HostCount => _headers._Host.Count;
@@ -7928,7 +7929,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
         public void MergeCookies()
         {
-            if ((_bits & 0x20000L) != 0 && _headers._Cookie.Count > 1)
+            if (HasCookie && _headers._Cookie.Count > 1)
             {
                 _headers._Cookie = string.Join("; ", _headers._Cookie.ToArray());
             }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -7926,6 +7926,15 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         }
 
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        public void MergeCookies()
+        {
+            if (_headers._Cookie.Count > 1)
+            {
+                _headers._Cookie = string.Join("; ", _headers._Cookie.ToArray()); // TODO string.Join is less than ideal
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public unsafe bool TryQPackAppend(int index, ReadOnlySpan<byte> value, bool checkForNewlineChars)
         {
             ref StringValues values = ref Unsafe.AsRef<StringValues>(null);

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -7930,7 +7930,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             if (_headers._Cookie.Count > 1)
             {
-                _headers._Cookie = string.Join("; ", _headers._Cookie.ToArray()); // TODO string.Join is less than ideal
+                _headers._Cookie = string.Join("; ", _headers._Cookie.ToArray());
             }
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -7926,15 +7926,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void MergeCookies()
-        {
-            if (HasCookie && _headers._Cookie.Count > 1)
-            {
-                _headers._Cookie = string.Join("; ", _headers._Cookie.ToArray());
-            }
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public unsafe bool TryQPackAppend(int index, ReadOnlySpan<byte> value, bool checkForNewlineChars)
         {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
@@ -53,9 +53,7 @@ internal sealed partial class HttpRequestHeaders : HttpHeaders
     {
         if (HasCookie && _headers._Cookie.Count > 1)
         {
-            {
-                _headers._Cookie = string.Join("; ", _headers._Cookie.ToArray());
-            }
+            _headers._Cookie = string.Join("; ", _headers._Cookie.ToArray());
         }
     }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
@@ -132,7 +132,7 @@ internal sealed partial class HttpRequestHeaders : HttpHeaders
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private bool AddValueUnknown(string key, StringValues value)
-    { 
+    {
         Unknown.Add(GetInternedHeaderName(key), value);
         // Return true, above will throw and exit for false
         return true;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
@@ -132,7 +132,7 @@ internal sealed partial class HttpRequestHeaders : HttpHeaders
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private bool AddValueUnknown(string key, StringValues value)
-    {
+    { 
         Unknown.Add(GetInternedHeaderName(key), value);
         // Return true, above will throw and exit for false
         return true;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpRequestHeaders.cs
@@ -48,6 +48,17 @@ internal sealed partial class HttpRequestHeaders : HttpHeaders
         Clear(headersToClear);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void MergeCookies()
+    {
+        if (HasCookie && _headers._Cookie.Count > 1)
+        {
+            {
+                _headers._Cookie = string.Join("; ", _headers._Cookie.ToArray());
+            }
+        }
+    }
+
     protected override void ClearFast()
     {
         if (!ReuseHeaderValues)

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -11,6 +11,8 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2.FlowControl;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Primitives;
+using ASCIIEncoding = System.Text.ASCIIEncoding;
+using HeaderNames = Microsoft.Net.Http.Headers.HeaderNames;
 using HttpCharacters = Microsoft.AspNetCore.Http.HttpCharacters;
 using HttpMethods = Microsoft.AspNetCore.Http.HttpMethods;
 
@@ -200,6 +202,17 @@ internal abstract partial class Http2Stream : HttpProtocol, IThreadPoolWorkItem,
 
         // Suppress pseudo headers from the public headers collection.
         HttpRequestHeaders.ClearPseudoRequestHeaders();
+
+        // Cookies should be merged into a single string separated by "; "
+        StringValues cookies;
+        var containsCookies = HttpRequestHeaders.Remove(HeaderNames.Cookie, out cookies);
+        if (containsCookies)
+        {
+            var mergeCookies = string.Join("; ", cookies.ToArray());
+            var cookiesMergedValueSpan = new ReadOnlySpan<byte>(ASCIIEncoding.ASCII.GetBytes(mergeCookies));
+            var cookiesHeaderValueSpan = new ReadOnlySpan<byte>(ASCIIEncoding.ASCII.GetBytes(HeaderNames.Cookie));
+            HttpRequestHeaders.Append(cookiesHeaderValueSpan, cookiesMergedValueSpan, false);
+        }
 
         return true;
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -202,11 +202,11 @@ internal abstract partial class Http2Stream : HttpProtocol, IThreadPoolWorkItem,
         HttpRequestHeaders.ClearPseudoRequestHeaders();
 
         // Cookies should be merged into a single string separated by "; "
+        // https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.5
         var headers = (AspNetCore.Http.IHeaderDictionary)HttpRequestHeaders;
         if (headers.Cookie.Count > 1)
         {
-            var mergedCookies = string.Join("; ", headers.Cookie.ToArray());
-            headers.Cookie = new StringValues(mergedCookies);
+            headers.Cookie = string.Join("; ", headers.Cookie.ToArray());
         }
 
         return true;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -203,11 +203,7 @@ internal abstract partial class Http2Stream : HttpProtocol, IThreadPoolWorkItem,
 
         // Cookies should be merged into a single string separated by "; "
         // https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.5
-        var headers = (AspNetCore.Http.IHeaderDictionary)HttpRequestHeaders;
-        if (headers.Cookie.Count > 1)
-        {
-            headers.Cookie = string.Join("; ", headers.Cookie.ToArray());
-        }
+        HttpRequestHeaders.MergeCookies();
 
         return true;
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -18,8 +18,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
-using ASCIIEncoding = System.Text.ASCIIEncoding;
-using HeaderNames = Microsoft.Net.Http.Headers.HeaderNames;
 using HttpCharacters = Microsoft.AspNetCore.Http.HttpCharacters;
 using HttpMethod = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod;
 using HttpMethods = Microsoft.AspNetCore.Http.HttpMethods;
@@ -910,14 +908,11 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
         HttpRequestHeaders.ClearPseudoRequestHeaders();
 
         // Cookies should be merged into a single string separated by "; "
-        StringValues cookies;
-        var containsCookies = HttpRequestHeaders.Remove(HeaderNames.Cookie, out cookies);
-        if (containsCookies)
+        var headers = (AspNetCore.Http.IHeaderDictionary)HttpRequestHeaders;
+        if (headers.Cookie.Count > 1)
         {
-            var mergeCookies = string.Join("; ", cookies.ToArray());
-            var cookiesMergedValueSpan = new ReadOnlySpan<byte>(ASCIIEncoding.ASCII.GetBytes(mergeCookies));
-            var cookiesHeaderValueSpan = new ReadOnlySpan<byte>(ASCIIEncoding.ASCII.GetBytes(HeaderNames.Cookie));
-            HttpRequestHeaders.Append(cookiesHeaderValueSpan, cookiesMergedValueSpan, false);
+            var mergedCookies = string.Join("; ", headers.Cookie.ToArray());
+            headers.Cookie = new StringValues(mergedCookies);
         }
 
         return true;

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -909,11 +909,7 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
 
         // Cookies should be merged into a single string separated by "; "
         // https://datatracker.ietf.org/doc/html/draft-ietf-quic-http-34#section-4.1.1.2
-        var headers = (AspNetCore.Http.IHeaderDictionary)HttpRequestHeaders;
-        if (headers.Cookie.Count > 1)
-        {
-            headers.Cookie = string.Join("; ", headers.Cookie.ToArray());
-        }
+        HttpRequestHeaders.MergeCookies();
 
         return true;
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -908,11 +908,11 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
         HttpRequestHeaders.ClearPseudoRequestHeaders();
 
         // Cookies should be merged into a single string separated by "; "
+        // https://datatracker.ietf.org/doc/html/draft-ietf-quic-http-34#section-4.1.1.2
         var headers = (AspNetCore.Http.IHeaderDictionary)HttpRequestHeaders;
         if (headers.Cookie.Count > 1)
         {
-            var mergedCookies = string.Join("; ", headers.Cookie.ToArray());
-            headers.Cookie = new StringValues(mergedCookies);
+            headers.Cookie = string.Join("; ", headers.Cookie.ToArray());
         }
 
         return true;

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
@@ -58,7 +58,7 @@ public abstract class Http2ConnectionBenchmarkBase
             var cookies = new StringValues("0=1");
             for (var index = 1; index < NumCookies; index++)
             {
-                cookies = (StringValues)cookies.Append($"{index}={index + 1}");
+                cookies = cookies.Append($"{index}={index + 1}").ToArray();
             }
             _httpRequestHeaders[HeaderNames.Cookie] = cookies;
         }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
@@ -58,7 +58,7 @@ public abstract class Http2ConnectionBenchmarkBase
             var cookies = new StringValues("0=1");
             for (var index = 1; index < NumCookies; index++)
             {
-                _ = cookies.Append($"{index}={index + 1}");
+                cookies = cookies.Append($"{index}={index + 1}");
             }
             _httpRequestHeaders[HeaderNames.Cookie] = cookies;
         }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
@@ -58,7 +58,7 @@ public abstract class Http2ConnectionBenchmarkBase
             var cookies = new StringValues("0=1");
             for (var index = 1; index < NumCookies; index++)
             {
-                cookies = cookies.Append($"{index}={index + 1}");
+                cookies = (StringValues)cookies.Append($"{index}={index + 1}");
             }
             _httpRequestHeaders[HeaderNames.Cookie] = cookies;
         }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
@@ -55,10 +55,10 @@ public abstract class Http2ConnectionBenchmarkBase
 
         if (NumCookies > 0)
         {
-            var cookies = new StringValues("0=1");
+            var cookies = new string[NumCookies];
             for (var index = 1; index < NumCookies; index++)
             {
-                cookies = cookies.Append($"{index}={index + 1}").ToArray();
+                cookies[index] = $"{index}={index + 1}";
             }
             _httpRequestHeaders[HeaderNames.Cookie] = cookies;
         }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
@@ -36,15 +36,17 @@ public abstract class Http2ConnectionBenchmarkBase
     private int _currentStreamId;
     private byte[] _headersBuffer;
     private DuplexPipe.DuplexPipePair _connectionPair;
-    private Http2Frame _httpFrame;
     private int _dataWritten;
+    private Task _requestProcessingTask;
+
+    private Http2Frame _receiveHttpFrame = new();
+    private Http2Frame _sendHttpFrame = new();
 
     protected abstract Task ProcessRequest(HttpContext httpContext);
 
     public virtual void GlobalSetup()
     {
         _memoryPool = PinnedBlockMemoryPoolFactory.Create();
-        _httpFrame = new Http2Frame();
 
         var options = new PipeOptions(_memoryPool, readerScheduler: PipeScheduler.Inline, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false);
 
@@ -79,7 +81,7 @@ public abstract class Http2ConnectionBenchmarkBase
 
         _currentStreamId = 1;
 
-        _ = _connection.ProcessRequestsAsync(new DummyApplication(ProcessRequest, new MockHttpContextFactory()));
+        _requestProcessingTask = _connection.ProcessRequestsAsync(new DummyApplication(ProcessRequest, new MockHttpContextFactory()));
 
         _connectionPair.Application.Output.Write(Http2Connection.ClientPreface);
         _connectionPair.Application.Output.WriteSettings(new Http2PeerSettings
@@ -89,12 +91,12 @@ public abstract class Http2ConnectionBenchmarkBase
         _connectionPair.Application.Output.FlushAsync().GetAwaiter().GetResult();
 
         // Read past connection setup frames
-        ReceiveFrameAsync(_connectionPair.Application.Input, _httpFrame).GetAwaiter().GetResult();
-        Debug.Assert(_httpFrame.Type == Http2FrameType.SETTINGS);
-        ReceiveFrameAsync(_connectionPair.Application.Input, _httpFrame).GetAwaiter().GetResult();
-        Debug.Assert(_httpFrame.Type == Http2FrameType.WINDOW_UPDATE);
-        ReceiveFrameAsync(_connectionPair.Application.Input, _httpFrame).GetAwaiter().GetResult();
-        Debug.Assert(_httpFrame.Type == Http2FrameType.SETTINGS);
+        ReceiveFrameAsync(_connectionPair.Application.Input).GetAwaiter().GetResult();
+        Debug.Assert(_receiveHttpFrame.Type == Http2FrameType.SETTINGS);
+        ReceiveFrameAsync(_connectionPair.Application.Input).GetAwaiter().GetResult();
+        Debug.Assert(_receiveHttpFrame.Type == Http2FrameType.WINDOW_UPDATE);
+        ReceiveFrameAsync(_connectionPair.Application.Input).GetAwaiter().GetResult();
+        Debug.Assert(_receiveHttpFrame.Type == Http2FrameType.SETTINGS);
     }
 
     [Benchmark]
@@ -102,32 +104,32 @@ public abstract class Http2ConnectionBenchmarkBase
     {
         _requestHeadersEnumerator.Initialize(_httpRequestHeaders);
         _requestHeadersEnumerator.MoveNext();
-        _connectionPair.Application.Output.WriteStartStream(streamId: _currentStreamId, _hpackEncoder, _requestHeadersEnumerator, _headersBuffer, endStream: true, frame: _httpFrame);
+        _connectionPair.Application.Output.WriteStartStream(streamId: _currentStreamId, _hpackEncoder, _requestHeadersEnumerator, _headersBuffer, endStream: true, frame: _sendHttpFrame);
         await _connectionPair.Application.Output.FlushAsync();
 
         while (true)
         {
-            await ReceiveFrameAsync(_connectionPair.Application.Input, _httpFrame);
+            await ReceiveFrameAsync(_connectionPair.Application.Input);
 
-            if (_httpFrame.StreamId != _currentStreamId && _httpFrame.StreamId != 0)
+            if (_receiveHttpFrame.StreamId != _currentStreamId && _receiveHttpFrame.StreamId != 0)
             {
-                throw new Exception($"Unexpected stream ID: {_httpFrame.StreamId}");
+                throw new Exception($"Unexpected stream ID: {_receiveHttpFrame.StreamId}");
             }
 
-            if (_httpFrame.Type == Http2FrameType.DATA)
+            if (_receiveHttpFrame.Type == Http2FrameType.DATA)
             {
-                _dataWritten += _httpFrame.DataPayloadLength;
+                _dataWritten += _receiveHttpFrame.DataPayloadLength;
             }
 
             if (_dataWritten > 1024 * 32)
             {
-                _connectionPair.Application.Output.WriteWindowUpdateAsync(streamId: 0, _dataWritten, _httpFrame);
+                _connectionPair.Application.Output.WriteWindowUpdateAsync(streamId: 0, _dataWritten, _sendHttpFrame);
                 await _connectionPair.Application.Output.FlushAsync();
 
                 _dataWritten = 0;
             }
 
-            if ((_httpFrame.HeadersFlags & Http2HeadersFrameFlags.END_STREAM) == Http2HeadersFrameFlags.END_STREAM)
+            if ((_receiveHttpFrame.HeadersFlags & Http2HeadersFrameFlags.END_STREAM) == Http2HeadersFrameFlags.END_STREAM)
             {
                 break;
             }
@@ -136,7 +138,7 @@ public abstract class Http2ConnectionBenchmarkBase
         _currentStreamId += 2;
     }
 
-    internal async ValueTask ReceiveFrameAsync(PipeReader pipeReader, Http2Frame frame, uint maxFrameSize = Http2PeerSettings.DefaultMaxFrameSize)
+    internal async ValueTask ReceiveFrameAsync(PipeReader pipeReader, uint maxFrameSize = Http2PeerSettings.DefaultMaxFrameSize)
     {
         while (true)
         {
@@ -147,7 +149,7 @@ public abstract class Http2ConnectionBenchmarkBase
 
             try
             {
-                if (Http2FrameReader.TryReadFrame(ref buffer, frame, maxFrameSize, out var framePayload))
+                if (Http2FrameReader.TryReadFrame(ref buffer, _receiveHttpFrame, maxFrameSize, out var framePayload))
                 {
                     consumed = examined = framePayload.End;
                     return;
@@ -170,9 +172,10 @@ public abstract class Http2ConnectionBenchmarkBase
     }
 
     [GlobalCleanup]
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         _connectionPair.Application.Output.Complete();
+        await _requestProcessingTask;
         _memoryPool?.Dispose();
     }
 }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
@@ -56,7 +56,7 @@ public abstract class Http2ConnectionBenchmarkBase
         if (NumCookies > 0)
         {
             var cookies = new string[NumCookies];
-            for (var index = 1; index < NumCookies; index++)
+            for (var index = 0; index < NumCookies; index++)
             {
                 cookies[index] = $"{index}={index + 1}";
             }

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
@@ -44,6 +44,9 @@ public abstract class Http2ConnectionBenchmarkBase
 
     protected abstract Task ProcessRequest(HttpContext httpContext);
 
+    [Params(0, 1, 3)]
+    public int numCookies { get; set; }
+
     public virtual void GlobalSetup()
     {
         _memoryPool = PinnedBlockMemoryPoolFactory.Create();
@@ -58,6 +61,15 @@ public abstract class Http2ConnectionBenchmarkBase
         _httpRequestHeaders[HeaderNames.Scheme] = new StringValues("http");
         _httpRequestHeaders[HeaderNames.Authority] = new StringValues("localhost:80");
 
+        if (numCookies > 0) {
+            var cookies = new StringValues("0=1");
+            for (int i = 1; i < numCookies; i++)
+            {
+                cookies.Append($"{i}={i + 1}");
+            }
+            _httpRequestHeaders[HeaderNames.Cookie] = cookies;
+        }
+        
         _headersBuffer = new byte[1024 * 16];
         _hpackEncoder = new DynamicHPackEncoder();
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionBenchmarkBase.cs
@@ -1,25 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Buffers;
-using System.Buffers.Binary;
 using System.Diagnostics;
-using System.IO;
 using System.IO.Pipelines;
-using System.Linq;
 using System.Net.Http.HPack;
-using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Testing;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using Http2HeadersEnumerator = Microsoft.AspNetCore.Server.Kestrel.Core.Tests.Http2HeadersEnumerator;
@@ -39,13 +31,13 @@ public abstract class Http2ConnectionBenchmarkBase
     private int _dataWritten;
     private Task _requestProcessingTask;
 
-    private Http2Frame _receiveHttpFrame = new();
-    private Http2Frame _sendHttpFrame = new();
+    private readonly Http2Frame _receiveHttpFrame = new();
+    private readonly Http2Frame _sendHttpFrame = new();
 
     protected abstract Task ProcessRequest(HttpContext httpContext);
 
     [Params(0, 1, 3)]
-    public int numCookies { get; set; }
+    public int NumCookies { get; set; }
 
     public virtual void GlobalSetup()
     {
@@ -61,15 +53,16 @@ public abstract class Http2ConnectionBenchmarkBase
         _httpRequestHeaders[HeaderNames.Scheme] = new StringValues("http");
         _httpRequestHeaders[HeaderNames.Authority] = new StringValues("localhost:80");
 
-        if (numCookies > 0) {
+        if (NumCookies > 0)
+        {
             var cookies = new StringValues("0=1");
-            for (int i = 1; i < numCookies; i++)
+            for (var index = 1; index < NumCookies; index++)
             {
-                cookies.Append($"{i}={i + 1}");
+                _ = cookies.Append($"{index}={index + 1}");
             }
             _httpRequestHeaders[HeaderNames.Cookie] = cookies;
         }
-        
+
         _headersBuffer = new byte[1024 * 16];
         _hpackEncoder = new DynamicHPackEncoder();
 

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionEmptyBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http2/Http2ConnectionEmptyBenchmark.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Microbenchmarks;
 
 public class Http2ConnectionBenchmark : Http2ConnectionBenchmarkBase
 {
-    [Params(0, 128, 1024)]
+    [Params(0)]
     public int ResponseDataLength { get; set; }
 
     private string _responseData;

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -1329,15 +1329,6 @@ $@"        private void Clear(long bitsToClear)
             }}
         }}
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void MergeCookies()
-        {{
-            if (HasCookie && _headers._Cookie.Count > 1)
-            {{
-                _headers._Cookie = string.Join(""; "", _headers._Cookie.ToArray());
-            }}
-        }}
-
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public unsafe bool TryQPackAppend(int index, ReadOnlySpan<byte> value, bool checkForNewlineChars)
         {{

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -1328,10 +1328,10 @@ $@"        private void Clear(long bitsToClear)
             }}
         }}
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
         public void MergeCookies()
         {{
-            if (_headers._Cookie.Count > 1)
+            if ((_bits & 0x20000L) != 0 && _headers._Cookie.Count > 1)
             {{
                 _headers._Cookie = string.Join(""; "", _headers._Cookie.ToArray());
             }}

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -1329,7 +1329,7 @@ $@"        private void Clear(long bitsToClear)
             }}
         }}
 
-        [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void MergeCookies()
         {{
             if (HasCookie && _headers._Cookie.Count > 1)

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -101,6 +101,7 @@ public class KnownHeaders
         };
         var requestHeadersExistence = new[]
         {
+            HeaderNames.Cookie,
             HeaderNames.Connection,
             HeaderNames.TransferEncoding,
         };
@@ -1331,7 +1332,7 @@ $@"        private void Clear(long bitsToClear)
         [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.AggressiveInlining)]
         public void MergeCookies()
         {{
-            if ((_bits & 0x20000L) != 0 && _headers._Cookie.Count > 1)
+            if (HasCookie && _headers._Cookie.Count > 1)
             {{
                 _headers._Cookie = string.Join(""; "", _headers._Cookie.ToArray());
             }}

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -1329,6 +1329,15 @@ $@"        private void Clear(long bitsToClear)
         }}
 
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        public void MergeCookies()
+        {{
+            if (_headers._Cookie.Count > 1)
+            {{
+                _headers._Cookie = string.Join(""; "", _headers._Cookie.ToArray()); // TODO string.Join is less than ideal
+            }}
+        }}
+
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public unsafe bool TryQPackAppend(int index, ReadOnlySpan<byte> value, bool checkForNewlineChars)
         {{
             ref StringValues values = ref Unsafe.AsRef<StringValues>(null);

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -1333,7 +1333,7 @@ $@"        private void Clear(long bitsToClear)
         {{
             if (_headers._Cookie.Count > 1)
             {{
-                _headers._Cookie = string.Join(""; "", _headers._Cookie.ToArray()); // TODO string.Join is less than ideal
+                _headers._Cookie = string.Join(""; "", _headers._Cookie.ToArray());
             }}
         }}
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -5431,7 +5431,7 @@ public class Http2ConnectionTests : Http2TestBase
         await StopConnectionAsync(expectedLastStreamId: 0, ignoreNonGoAwayFrames: false);
     }
 
-public static TheoryData<byte[]> UpperCaseHeaderNameData
+    public static TheoryData<byte[]> UpperCaseHeaderNameData
     {
         get
         {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -2862,7 +2862,7 @@ public class Http2ConnectionTests : Http2TestBase
             withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
             withStreamId: 1);
 
-        Assert.Equal("a=0; b=1; c=2", _receivedHeaders["Cookie"]);
+        Assert.Equal("a=0; b=1; c=2", _receivedHeaders[HeaderNames.Cookie]);
 
         await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
     }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
@@ -133,7 +133,7 @@ public class Http3ConnectionTests : Http3TestBase
     [Fact]
     public async Task HEADERS_CookiesMergedIntoOne()
     {
-        var headers = new[]
+        var requestHeaders = new[]
         {
                 new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
                 new KeyValuePair<string, string>(HeaderNames.Path, "/"),
@@ -143,10 +143,15 @@ public class Http3ConnectionTests : Http3TestBase
                 new KeyValuePair<string, string>(HeaderNames.Cookie, "c=2"),
             };
 
+        var receivedHeaders = "";
+
         await Http3Api.InitializeConnectionAsync(async context =>
         {
             var buffer = new byte[16 * 1024];
             var received = 0;
+
+            // verify that the cookies are all merged into a single string
+            receivedHeaders = context.Request.Headers[HeaderNames.Cookie];
 
             while ((received = await context.Request.Body.ReadAsync(buffer, 0, buffer.Length)) > 0)
             {
@@ -156,18 +161,16 @@ public class Http3ConnectionTests : Http3TestBase
 
         await Http3Api.CreateControlStream();
         await Http3Api.GetInboundControlStream();
-
         var requestStream = await Http3Api.CreateRequestStream();
 
-        await requestStream.SendHeadersAsync(headers);
-        var frame = await requestStream.ReceiveFrameAsync();
 
-        await requestStream.SendDataAsync(Encoding.ASCII.GetBytes("Hello world"), endStream: false);
-        var receivedHeaders = await requestStream.ExpectHeadersAsync();
+        await requestStream.SendHeadersAsync(requestHeaders, endStream: true);
+        var responseHeaders = await requestStream.ExpectHeadersAsync();
 
-        Assert.Equal("a=0; b=1; c=2", receivedHeaders[HeaderNames.Cookie]);
-
+        await requestStream.ExpectReceiveEndOfStream();
         await requestStream.OnDisposedTask.DefaultTimeout();
+
+        Assert.Equal("a=0; b=1; c=2", receivedHeaders);
     }
 
     [Theory]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3ConnectionTests.cs
@@ -163,7 +163,6 @@ public class Http3ConnectionTests : Http3TestBase
         await Http3Api.GetInboundControlStream();
         var requestStream = await Http3Api.CreateRequestStream();
 
-
         await requestStream.SendHeadersAsync(requestHeaders, endStream: true);
         var responseHeaders = await requestStream.ExpectHeadersAsync();
 


### PR DESCRIPTION
Merge HTTP/2 and HTTP/3 request cookies on Kestrel

## Description
Added a check to squash request cookies into a single cookie string delimited by `; ` as per the HTTP/2 and HTTP/3 specs. I also added unit tests to make sure we don't regress this in the future.

Fixes: #26461 