### PR TITLE
Add trimming annotations to DotNetObjectReference

### DIFF
--- a/src/Components/Web/src/Microsoft.AspNetCore.Components.Web.WarningSuppressions.xml
+++ b/src/Components/Web/src/Microsoft.AspNetCore.Components.Web.WarningSuppressions.xml
@@ -1,18 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <linker>
-  <assembly fullname="Microsoft.AspNetCore.Components.Web, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2026</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Components.Web.Infrastructure.JSComponentInterop.SetRootComponentParameters(System.Int32,System.Int32,System.Text.Json.JsonElement,System.Text.Json.JsonSerializerOptions)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2026</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Components.Web.WebEventData.ParseEventArgsJson(Microsoft.AspNetCore.Components.RenderTree.Renderer,System.Text.Json.JsonSerializerOptions,System.UInt64,System.String,System.Text.Json.JsonElement)</property>
-    </attribute>
+  <assembly fullname="Microsoft.AspNetCore.Components.Web, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
       <argument>IL2062</argument>

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Microsoft.AspNetCore.Components.WebAssembly.Authentication.WarningSuppressions.xml
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Microsoft.AspNetCore.Components.WebAssembly.Authentication.WarningSuppressions.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <linker>
   <assembly fullname="Microsoft.AspNetCore.Components.WebAssembly.Authentication, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60">
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
@@ -6,12 +6,6 @@
       <argument>IL2091</argument>
       <property name="Scope">member</property>
       <property name="Target">F:Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.&lt;&gt;c__1`1.&lt;&gt;9__1_0</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2091</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.&lt;&gt;c__1`1.&lt;AddAuthenticationStateProvider&gt;b__1_0(System.IServiceProvider)</property>
     </attribute>
   </assembly>
 </linker>

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReference.cs
@@ -13,7 +13,7 @@ public static class DotNetObjectReference
     /// </summary>
     /// <param name="value">The reference type to track.</param>
     /// <returns>An instance of <see cref="DotNetObjectReference{TValue}" />.</returns>
-    public static DotNetObjectReference<TValue> Create<TValue>(TValue value) where TValue : class
+    public static DotNetObjectReference<TValue> Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TValue>(TValue value) where TValue : class
     {
         if (value is null)
         {

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReference.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.JSInterop;
 
@@ -15,7 +16,7 @@ public static class DotNetObjectReference
     /// </summary>
     /// <param name="value">The reference type to track.</param>
     /// <returns>An instance of <see cref="DotNetObjectReference{TValue}" />.</returns>
-    public static DotNetObjectReference<TValue> Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TValue>(TValue value) where TValue : class
+    public static DotNetObjectReference<TValue> Create<[DynamicallyAccessedMembers(JSInvokable)] TValue>(TValue value) where TValue : class
     {
         if (value is null)
         {

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReference.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.JSInterop;
 
 /// <summary>

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReferenceOfT.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReferenceOfT.cs
@@ -73,6 +73,8 @@ public sealed class DotNetObjectReference<[DynamicallyAccessedMembers(Dynamicall
     }
 
     object IDotNetObjectReference.Value => Value;
+
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
     Type IDotNetObjectReference.Type => typeof(TValue);
 
     internal bool Disposed { get; private set; }

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReferenceOfT.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReferenceOfT.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.JSInterop.Infrastructure;
 

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReferenceOfT.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReferenceOfT.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.JSInterop.Infrastructure;
 
 namespace Microsoft.JSInterop;
@@ -13,7 +13,8 @@ namespace Microsoft.JSInterop;
 /// To avoid leaking memory, the reference must later be disposed by JS code or by .NET code.
 /// </summary>
 /// <typeparam name="TValue">The type of the value to wrap.</typeparam>
-public sealed class DotNetObjectReference<TValue> : IDotNetObjectReference, IDisposable where TValue : class
+public sealed class DotNetObjectReference<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TValue> :
+    IDotNetObjectReference, IDisposable where TValue : class
 {
     private readonly TValue _value;
     private long _objectId;
@@ -71,6 +72,7 @@ public sealed class DotNetObjectReference<TValue> : IDotNetObjectReference, IDis
     }
 
     object IDotNetObjectReference.Value => Value;
+    Type IDotNetObjectReference.Type => typeof(TValue);
 
     internal bool Disposed { get; private set; }
 

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReferenceOfT.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReferenceOfT.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.JSInterop.Infrastructure;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.JSInterop;
 
@@ -14,7 +15,7 @@ namespace Microsoft.JSInterop;
 /// To avoid leaking memory, the reference must later be disposed by JS code or by .NET code.
 /// </summary>
 /// <typeparam name="TValue">The type of the value to wrap.</typeparam>
-public sealed class DotNetObjectReference<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TValue> :
+public sealed class DotNetObjectReference<[DynamicallyAccessedMembers(JSInvokable)] TValue> :
     IDotNetObjectReference, IDisposable where TValue : class
 {
     private readonly TValue _value;
@@ -74,7 +75,7 @@ public sealed class DotNetObjectReference<[DynamicallyAccessedMembers(Dynamicall
 
     object IDotNetObjectReference.Value => Value;
 
-    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+    [DynamicallyAccessedMembers(JSInvokable)]
     Type IDotNetObjectReference.Type => typeof(TValue);
 
     internal bool Disposed { get; private set; }

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReferenceOfT.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReferenceOfT.cs
@@ -75,9 +75,6 @@ public sealed class DotNetObjectReference<[DynamicallyAccessedMembers(JSInvokabl
 
     object IDotNetObjectReference.Value => Value;
 
-    [DynamicallyAccessedMembers(JSInvokable)]
-    Type IDotNetObjectReference.Type => typeof(TValue);
-
     internal bool Disposed { get; private set; }
 
     /// <summary>

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -381,11 +381,9 @@ public static class DotNetDispatcher
 
     private static Task CreateValueTaskConverter<[DynamicallyAccessedMembers(LinkerFlags.JsonSerialized)] T>(object result) => ((ValueTask<T>)result).AsTask();
 
-    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2111:ReflectionToDynamicallyAccessedMembers",
-        Justification = "The Type being passed into GetOrAdd is annotated, but the trimmer warns anyway. See https://github.com/dotnet/linker/issues/2790")]
     private static (MethodInfo methodInfo, Type[] parameterTypes) GetCachedMethodInfo(IDotNetObjectReference objectReference, string methodIdentifier)
     {
-        var type = objectReference.Type;
+        var type = objectReference.Value.GetType();
         var assemblyMethods = _cachedMethodsByType.GetOrAdd(type, ScanTypeForCallableMethods);
         if (assemblyMethods.TryGetValue(methodIdentifier, out var result))
         {

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -383,7 +383,7 @@ public static class DotNetDispatcher
 
     private static (MethodInfo methodInfo, Type[] parameterTypes) GetCachedMethodInfo(IDotNetObjectReference objectReference, string methodIdentifier)
     {
-        var type = objectReference.Value.GetType();
+        var type = objectReference.Type;
         var assemblyMethods = _cachedMethodsByType.GetOrAdd(type, ScanTypeForCallableMethods);
         if (assemblyMethods.TryGetValue(methodIdentifier, out var result))
         {
@@ -394,7 +394,7 @@ public static class DotNetDispatcher
             throw new ArgumentException($"The type '{type.Name}' does not contain a public invokable method with [{nameof(JSInvokableAttribute)}(\"{methodIdentifier}\")].");
         }
 
-        static Dictionary<string, (MethodInfo, Type[])> ScanTypeForCallableMethods(Type type)
+        static Dictionary<string, (MethodInfo, Type[])> ScanTypeForCallableMethods([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type)
         {
             var result = new Dictionary<string, (MethodInfo, Type[])>(StringComparer.Ordinal);
 

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetDispatcher.cs
@@ -11,6 +11,7 @@ using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Internal;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 [assembly: MetadataUpdateHandler(typeof(Microsoft.JSInterop.Infrastructure.DotNetDispatcher.MetadataUpdateHandler))]
 
@@ -19,7 +20,6 @@ namespace Microsoft.JSInterop.Infrastructure;
 /// <summary>
 /// Provides methods that receive incoming calls from JS to .NET.
 /// </summary>
-[UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070", Justification = "Linker does not propogate annotations to generated state machine. https://github.com/mono/linker/issues/1403")]
 public static class DotNetDispatcher
 {
     private const string DisposeDotNetObjectReferenceMethodName = "__Dispose";
@@ -396,7 +396,7 @@ public static class DotNetDispatcher
             throw new ArgumentException($"The type '{type.Name}' does not contain a public invokable method with [{nameof(JSInvokableAttribute)}(\"{methodIdentifier}\")].");
         }
 
-        static Dictionary<string, (MethodInfo, Type[])> ScanTypeForCallableMethods([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type)
+        static Dictionary<string, (MethodInfo, Type[])> ScanTypeForCallableMethods([DynamicallyAccessedMembers(JSInvokable)] Type type)
         {
             var result = new Dictionary<string, (MethodInfo, Type[])>(StringComparer.Ordinal);
 

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetObjectReferenceJsonConverter.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetObjectReferenceJsonConverter.cs
@@ -1,12 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.JSInterop.Infrastructure;
 
-internal sealed class DotNetObjectReferenceJsonConverter<TValue> : JsonConverter<DotNetObjectReference<TValue>> where TValue : class
+internal sealed class DotNetObjectReferenceJsonConverter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TValue> : JsonConverter<DotNetObjectReference<TValue>> where TValue : class
 {
     public DotNetObjectReferenceJsonConverter(JSRuntime jsRuntime)
     {

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetObjectReferenceJsonConverter.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/DotNetObjectReferenceJsonConverter.cs
@@ -4,10 +4,11 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.JSInterop.Infrastructure;
 
-internal sealed class DotNetObjectReferenceJsonConverter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TValue> : JsonConverter<DotNetObjectReference<TValue>> where TValue : class
+internal sealed class DotNetObjectReferenceJsonConverter<[DynamicallyAccessedMembers(JSInvokable)] TValue> : JsonConverter<DotNetObjectReference<TValue>> where TValue : class
 {
     public DotNetObjectReferenceJsonConverter(JSRuntime jsRuntime)
     {

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/IDotNetObjectReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/IDotNetObjectReference.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.JSInterop.Infrastructure;
 
@@ -9,6 +10,6 @@ internal interface IDotNetObjectReference : IDisposable
 {
     object Value { get; }
 
-    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+    [DynamicallyAccessedMembers(JSInvokable)]
     Type Type { get; }
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/IDotNetObjectReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/IDotNetObjectReference.cs
@@ -1,15 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-using static Microsoft.AspNetCore.Internal.LinkerFlags;
-
 namespace Microsoft.JSInterop.Infrastructure;
 
 internal interface IDotNetObjectReference : IDisposable
 {
     object Value { get; }
-
-    [DynamicallyAccessedMembers(JSInvokable)]
-    Type Type { get; }
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/IDotNetObjectReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/IDotNetObjectReference.cs
@@ -6,4 +6,7 @@ namespace Microsoft.JSInterop.Infrastructure;
 internal interface IDotNetObjectReference : IDisposable
 {
     object Value { get; }
+
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+    Type Type { get; }
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/IDotNetObjectReference.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/IDotNetObjectReference.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.JSInterop.Infrastructure;
 
 internal interface IDotNetObjectReference : IDisposable

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
@@ -290,7 +290,7 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
         return streamId;
     }
 
-    internal long TrackObjectReference<TValue>(DotNetObjectReference<TValue> dotNetObjectReference) where TValue : class
+    internal long TrackObjectReference<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TValue>(DotNetObjectReference<TValue> dotNetObjectReference) where TValue : class
     {
         if (dotNetObjectReference == null)
         {

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
@@ -290,7 +290,7 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
         return streamId;
     }
 
-    internal long TrackObjectReference<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TValue>(DotNetObjectReference<TValue> dotNetObjectReference) where TValue : class
+    internal long TrackObjectReference<[DynamicallyAccessedMembers(JSInvokable)] TValue>(DotNetObjectReference<TValue> dotNetObjectReference) where TValue : class
     {
         if (dotNetObjectReference == null)
         {

--- a/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.WarningSuppressions.xml
+++ b/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.WarningSuppressions.xml
@@ -67,5 +67,11 @@
       <property name="Scope">member</property>
       <property name="Target">M:Microsoft.JSInterop.JSRuntimeExtensions.&lt;InvokeAsync&gt;d__4`1.MoveNext</property>
     </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2111</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:Microsoft.JSInterop.Infrastructure.DotNetDispatcher.GetCachedMethodInfo(Microsoft.JSInterop.Infrastructure.IDotNetObjectReference,System.String)</property>
+    </attribute>
   </assembly>
 </linker>

--- a/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.WarningSuppressions.xml
+++ b/src/JSInterop/Microsoft.JSInterop/src/Microsoft.JSInterop.WarningSuppressions.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <linker>
-  <assembly fullname="Microsoft.JSInterop, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
+  <assembly fullname="Microsoft.JSInterop, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60">
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
       <argument>IL2026</argument>
@@ -39,9 +39,9 @@
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>
-      <argument>IL2060</argument>
+      <argument>IL2055</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.JSInterop.Infrastructure.DotNetDispatcher.&lt;&gt;c.&lt;GetTaskByType&gt;b__14_0(System.Type,System.Reflection.MethodInfo)</property>
+      <property name="Target">M:Microsoft.JSInterop.Infrastructure.DotNetObjectReferenceJsonConverterFactory.CreateConverter(System.Type,System.Text.Json.JsonSerializerOptions)</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
       <argument>ILLink</argument>

--- a/src/Shared/LinkerFlags.cs
+++ b/src/Shared/LinkerFlags.cs
@@ -16,4 +16,9 @@ internal static class LinkerFlags
     /// Flags for a component
     /// </summary>
     public const DynamicallyAccessedMemberTypes Component = DynamicallyAccessedMemberTypes.All;
+
+    /// <summary>
+    /// Flags for a JSInvokable type.
+    /// </summary>
+    public const DynamicallyAccessedMemberTypes JSInvokable = DynamicallyAccessedMemberTypes.PublicMethods;
 }


### PR DESCRIPTION
DotNetDispatcher has some unbounded reflection against DotNetObjectReference Types that the trimmer can't understand. Adding trimming annotations to tell the trimmer to preserve the public methods on the TValue of DotNetObjectReference instances, so the JSInvokable methods won't be trimmed.

See https://github.com/dotnet/maui/issues/6965

cc @vitek-karas 