### PR TITLE
Count forms with invalid content-disposition in FormFeature

### DIFF
--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -253,10 +253,7 @@ public class FormFeature : IFormFeature
                     }
                     else
                     {
-                        if (sectionCount > _options.ValueCountLimit)
-                        {
-                            // Ignore form sections with invalid content disposition
-                        }
+                        // Ignore form sections with invalid content disposition
                     }
 
                     section = await multipartReader.ReadNextSectionAsync(cancellationToken);

--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -255,7 +255,7 @@ public class FormFeature : IFormFeature
                     }
                     else
                     {
-                        System.Diagnostics.Debug.Assert(false, "Unrecognized content-disposition for this section: " + section.ContentDisposition);
+                        throw new InvalidDataException($"Unrecognized content-disposition for this section:  {section.ContentDisposition}");
                     }
 
                     section = await multipartReader.ReadNextSectionAsync(cancellationToken);


### PR DESCRIPTION
Forward-port of https://github.com/dotnet/aspnetcore/pull/41611/commits/108c22182e1ada7052e969add7d2d128f786c37b. Previously, forms with invalid content-disposition weren't being counted, so someone could send a form with infinitely many such segments & we'd buffer indefinitely. Also, stop counting forms, files, and invalid segments separately. Previously, you could have up to `ValueCountLimit` of each - now we count them all together and compare that against `ValueCountLimit`.