### PR TITLE
Make Mvc Individual auth test fail when useLocalDb is true

### DIFF
--- a/src/ProjectTemplates/test/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/MvcTemplateTest.cs
@@ -232,6 +232,8 @@ public class MvcTemplateTest : LoggedTest
 
             await aspNetProcess.AssertPagesOk(pages);
         }
+        
+        Assert.False(useLocalDB);
     }
 
     [ConditionalFact]


### PR DESCRIPTION
Investigating why localdb is passing on non windows queues