### PR TITLE
Avoid repeatedly encoding method name strings in protocol

### DIFF
--- a/src/SignalR/server/Core/src/Internal/Utf8HashLookup.cs
+++ b/src/SignalR/server/Core/src/Internal/Utf8HashLookup.cs
@@ -61,7 +61,7 @@ internal sealed class Utf8HashLookup
 
         for (var i = _caseSensitiveBuckets[caseSensitiveHashCode % _caseSensitiveBuckets.Length] - 1; i >= 0; i = _slots[i].caseSensitiveNext)
         {
-            if (_slots[i].caseSensitiveHashCode == caseSensitiveHashCode && encodedValue.SequenceEqual(_slots[i].encodedValue.Span))
+            if (_slots[i].caseSensitiveHashCode == caseSensitiveHashCode && encodedValue.SequenceEqual(_slots[i].encodedValue.AsSpan()))
             {
                 value = _slots[i].value;
                 return true;
@@ -152,7 +152,7 @@ internal sealed class Utf8HashLookup
         internal int caseSensitiveHashCode;
 
         internal string value;
-        internal Memory<byte> encodedValue;
+        internal byte[] encodedValue;
 
         internal int next;
         internal int caseSensitiveNext;

--- a/src/SignalR/server/Core/src/Internal/Utf8HashLookup.cs
+++ b/src/SignalR/server/Core/src/Internal/Utf8HashLookup.cs
@@ -48,7 +48,6 @@ internal sealed class Utf8HashLookup
         _slots[slotIndex].value = value;
         _slots[slotIndex].encodedValue = encodedValue;
 
-
         _slots[slotIndex].next = _buckets[bucketIndex] - 1;
         _slots[slotIndex].caseSensitiveNext = _caseSensitiveBuckets[caseSensitiveBucketIndex] - 1;
 

--- a/src/SignalR/server/Core/src/Internal/Utf8HashLookup.cs
+++ b/src/SignalR/server/Core/src/Internal/Utf8HashLookup.cs
@@ -38,7 +38,6 @@ internal sealed class Utf8HashLookup
 
         int bucket = hashCode % buckets.Length;
         slots[index].hashCode = hashCode;
-        slots[index].key = value;
         slots[index].value = value;
         slots[index].next = buckets[bucket] - 1;
         buckets[bucket] = index + 1;
@@ -70,7 +69,7 @@ internal sealed class Utf8HashLookup
 
         for (var i = buckets[hashCode % buckets.Length] - 1; i >= 0; i = slots[i].next)
         {
-            if (slots[i].hashCode == hashCode && key.Equals(slots[i].key, StringComparison.OrdinalIgnoreCase))
+            if (slots[i].hashCode == hashCode && key.Equals(slots[i].value, StringComparison.OrdinalIgnoreCase))
             {
                 value = slots[i].value;
                 return true;
@@ -106,7 +105,6 @@ internal sealed class Utf8HashLookup
     {
         internal int hashCode;
         internal int next;
-        internal string key;
         internal string value;
     }
 }


### PR DESCRIPTION
This is a follow up to https://github.com/dotnet/aspnetcore/pull/41465 and specifically https://github.com/dotnet/aspnetcore/pull/41465#discussion_r869991091.

I reran the `StringLookup` and `Uf8Lookup` (sic) scenarios from the original PR's `StringLookupBenchmark` after updating the `Payload` to match the expected casing. This yields a perf improvement over repeatedly allocating the string and looking it up in a dictionary instead of a perf regression like before:

### Before

|       Method |      Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------- |----------:|---------:|---------:|-------:|----------:|
| StringLookup |  92.02 ns | 1.824 ns | 1.523 ns | 0.0030 |      32 B |
|    Uf8Lookup | 104.24 ns | 0.286 ns | 0.239 ns |      - |         - |

### After

|       Method |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------- |---------:|---------:|---------:|-------:|----------:|
| StringLookup | 90.15 ns | 0.505 ns | 0.473 ns | 0.0030 |      32 B |
|   Uf8Lookup | 77.74 ns | 0.457 ns | 0.428 ns |      - |         - |

It also avoids any allocations in the common case where the casing matches. I expect mismatched casing between the server and client is really uncommon now that we don't generate automatic client proxies with different casing. The targets are just strings on the client and the server, so it doesn't make sense to mix up the casing. And even if the casing doesn't match, everything still works as before.
