### PR TITLE
Fall back to using old command when GetServer isn't supported

### DIFF
--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -292,13 +292,22 @@ public class RedisCache : IDistributedCache, IDisposable
     {
         _ = _connection ?? throw new InvalidOperationException($"{nameof(_connection)} cannot be null.");
 
-        foreach (var endPoint in _connection.GetEndPoints())
+        try
         {
-            if (_connection.GetServer(endPoint).Version < ServerVersionWithExtendedSetCommand)
+            foreach (var endPoint in _connection.GetEndPoints())
             {
-                _setScript = SetScriptPreExtendedSetCommand;
-                return;
+                if (_connection.GetServer(endPoint).Version < ServerVersionWithExtendedSetCommand)
+                {
+                    _setScript = SetScriptPreExtendedSetCommand;
+                    return;
+                }
             }
+        }
+        catch (NotSupportedException)
+        {
+            // The GetServer call may not be supported with some configurations, in which
+            // case let's also fall back to using the older command.
+            _setScript = SetScriptPreExtendedSetCommand;
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/41320

Commit https://github.com/dotnet/aspnetcore/commit/85a090053585a76203eb6ffcdcd6d95d55fba847 added logic to check the server version and decide whether or not to use a deprecated API. It turns out that the `GetServer` call that's being used when determining the version doesn't work in some cases (such as when using Redis behind a proxy).

This change makes it so that we treat a `NotSupportedException` from `GetServer` the same as we'd treat an old version (i.e. by falling back to the deprecated command).