### PR TITLE
Refactor DataProtection trimming

### DIFF
--- a/src/DataProtection/Abstractions/src/DataProtectionCommonExtensions.cs
+++ b/src/DataProtection/Abstractions/src/DataProtectionCommonExtensions.cs
@@ -183,7 +183,6 @@ public static class DataProtectionCommonExtensions
     /// <param name="protector">The data protector to use for this operation.</param>
     /// <param name="plaintext">The plaintext data to protect.</param>
     /// <returns>The protected form of the plaintext data.</returns>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     public static string Protect(this IDataProtector protector, string plaintext)
     {
         if (protector == null)
@@ -218,7 +217,6 @@ public static class DataProtectionCommonExtensions
     /// <exception cref="System.Security.Cryptography.CryptographicException">
     /// Thrown if <paramref name="protectedData"/> is invalid or malformed.
     /// </exception>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     public static string Unprotect(this IDataProtector protector, string protectedData)
     {
         if (protector == null)

--- a/src/DataProtection/Abstractions/src/IDataProtector.cs
+++ b/src/DataProtection/Abstractions/src/IDataProtector.cs
@@ -15,7 +15,6 @@ public interface IDataProtector : IDataProtectionProvider
     /// </summary>
     /// <param name="plaintext">The plaintext data to protect.</param>
     /// <returns>The protected form of the plaintext data.</returns>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     byte[] Protect(byte[] plaintext);
 
     /// <summary>
@@ -26,6 +25,5 @@ public interface IDataProtector : IDataProtectionProvider
     /// <exception cref="System.Security.Cryptography.CryptographicException">
     /// Thrown if the protected data is invalid or malformed.
     /// </exception>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     byte[] Unprotect(byte[] protectedData);
 }

--- a/src/DataProtection/DataProtection/src/ActivatorExtensions.cs
+++ b/src/DataProtection/DataProtection/src/ActivatorExtensions.cs
@@ -18,8 +18,7 @@ internal static class ActivatorExtensions
     /// Creates an instance of <paramref name="implementationTypeName"/> and ensures
     /// that it is assignable to <typeparamref name="T"/>.
     /// </summary>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
-    public static T CreateInstance<T>(this IActivator activator, string implementationTypeName)
+    public static T CreateInstance<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IActivator activator, string implementationTypeName)
         where T : class
     {
         if (implementationTypeName == null)

--- a/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/AuthenticatedEncryptorDescriptorDeserializer.cs
+++ b/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/AuthenticatedEncryptorDescriptorDeserializer.cs
@@ -17,7 +17,6 @@ public sealed class AuthenticatedEncryptorDescriptorDeserializer : IAuthenticate
     /// <summary>
     /// Imports the <see cref="AuthenticatedEncryptorDescriptor"/> from serialized XML.
     /// </summary>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     public IAuthenticatedEncryptorDescriptor ImportFromXml(XElement element)
     {
         if (element == null)

--- a/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/CngCbcAuthenticatedEncryptorDescriptorDeserializer.cs
+++ b/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/CngCbcAuthenticatedEncryptorDescriptorDeserializer.cs
@@ -18,7 +18,6 @@ public sealed class CngCbcAuthenticatedEncryptorDescriptorDeserializer : IAuthen
     /// <summary>
     /// Imports the <see cref="CngCbcAuthenticatedEncryptorDescriptor"/> from serialized XML.
     /// </summary>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     public IAuthenticatedEncryptorDescriptor ImportFromXml(XElement element)
     {
         if (element == null)

--- a/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/CngGcmAuthenticatedEncryptorDescriptorDeserializer.cs
+++ b/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/CngGcmAuthenticatedEncryptorDescriptorDeserializer.cs
@@ -18,7 +18,6 @@ public sealed class CngGcmAuthenticatedEncryptorDescriptorDeserializer : IAuthen
     /// <summary>
     /// Imports the <see cref="CngCbcAuthenticatedEncryptorDescriptor"/> from serialized XML.
     /// </summary>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     public IAuthenticatedEncryptorDescriptor ImportFromXml(XElement element)
     {
         if (element == null)

--- a/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/IAuthenticatedEncryptorDescriptorDeserializer.cs
+++ b/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/IAuthenticatedEncryptorDescriptorDeserializer.cs
@@ -16,6 +16,5 @@ public interface IAuthenticatedEncryptorDescriptorDeserializer
     /// </summary>
     /// <param name="element">The element to deserialize.</param>
     /// <returns>The <see cref="IAuthenticatedEncryptorDescriptor"/> represented by <paramref name="element"/>.</returns>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     IAuthenticatedEncryptorDescriptor ImportFromXml(XElement element);
 }

--- a/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/ManagedAuthenticatedEncryptorDescriptorDeserializer.cs
+++ b/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/ManagedAuthenticatedEncryptorDescriptorDeserializer.cs
@@ -17,7 +17,6 @@ public sealed class ManagedAuthenticatedEncryptorDescriptorDeserializer : IAuthe
     /// <summary>
     /// Imports the <see cref="ManagedAuthenticatedEncryptorDescriptor"/> from serialized XML.
     /// </summary>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     public IAuthenticatedEncryptorDescriptor ImportFromXml(XElement element)
     {
         if (element == null)
@@ -48,7 +47,6 @@ public sealed class ManagedAuthenticatedEncryptorDescriptorDeserializer : IAuthe
 
     // Any changes to this method should also be be reflected
     // in ManagedAuthenticatedEncryptorDescriptor.TypeToFriendlyName.
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     private static Type FriendlyNameToType(string typeName)
     {
         if (typeName == nameof(Aes))
@@ -73,7 +71,7 @@ public sealed class ManagedAuthenticatedEncryptorDescriptorDeserializer : IAuthe
         }
         else
         {
-            return Type.GetType(typeName, throwOnError: true)!;
+            return TypeExtensions.GetTypeWithTrimFriendlyErrorMessage(typeName);
         }
     }
 }

--- a/src/DataProtection/DataProtection/src/EphemeralDataProtectionProvider.cs
+++ b/src/DataProtection/DataProtection/src/EphemeralDataProtectionProvider.cs
@@ -95,7 +95,6 @@ public sealed class EphemeralDataProtectionProvider : IDataProtectionProvider
             return (keyId == default(Guid)) ? DefaultAuthenticatedEncryptor : null;
         }
 
-        [RequiresUnreferencedCode(TrimmerWarning.Message)]
         public IKeyRing GetCurrentKeyRing()
         {
             return this;

--- a/src/DataProtection/DataProtection/src/IPersistedDataProtector.cs
+++ b/src/DataProtection/DataProtection/src/IPersistedDataProtector.cs
@@ -31,6 +31,5 @@ public interface IPersistedDataProtector : IDataProtector
     /// Implementations should throw CryptographicException if the protected data is
     /// invalid or malformed.
     /// </remarks>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     byte[] DangerousUnprotect(byte[] protectedData, bool ignoreRevocationErrors, out bool requiresMigration, out bool wasRevoked);
 }

--- a/src/DataProtection/DataProtection/src/IRegistryPolicyResolver.cs
+++ b/src/DataProtection/DataProtection/src/IRegistryPolicyResolver.cs
@@ -10,6 +10,5 @@ namespace Microsoft.AspNetCore.DataProtection;
 // even if it was not registered causing problems crossplat
 internal interface IRegistryPolicyResolver
 {
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     RegistryPolicy? ResolvePolicy();
 }

--- a/src/DataProtection/DataProtection/src/Internal/IActivator.cs
+++ b/src/DataProtection/DataProtection/src/Internal/IActivator.cs
@@ -16,6 +16,5 @@ public interface IActivator
     /// Creates an instance of <paramref name="implementationTypeName"/> and ensures
     /// that it is assignable to <paramref name="expectedBaseType"/>.
     /// </summary>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
-    object CreateInstance(Type expectedBaseType, string implementationTypeName);
+    object CreateInstance([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type expectedBaseType, string implementationTypeName);
 }

--- a/src/DataProtection/DataProtection/src/KeyManagement/DeferredKey.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/DeferredKey.cs
@@ -18,7 +18,6 @@ namespace Microsoft.AspNetCore.DataProtection.KeyManagement;
 /// </summary>
 internal sealed class DeferredKey : KeyBase
 {
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     public DeferredKey(
         Guid keyId,
         DateTimeOffset creationDate,
@@ -36,7 +35,6 @@ internal sealed class DeferredKey : KeyBase
     {
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     private static Func<IAuthenticatedEncryptorDescriptor> GetLazyDescriptorDelegate(IInternalXmlKeyManager keyManager, XElement keyElement)
     {
         // The <key> element will be held around in memory for a potentially lengthy period
@@ -54,7 +52,6 @@ internal sealed class DeferredKey : KeyBase
             keyElement = null!;
         }
 
-        [RequiresUnreferencedCode(TrimmerWarning.Message)]
         IAuthenticatedEncryptorDescriptor GetLazyDescriptorDelegate()
         {
             return keyManager.DeserializeDescriptorFromKeyElement(encryptedKeyElement.ToXElement());

--- a/src/DataProtection/DataProtection/src/KeyManagement/IKeyManager.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/IKeyManager.cs
@@ -29,7 +29,6 @@ public interface IKeyManager
     /// Fetches all keys from the underlying repository.
     /// </summary>
     /// <returns>The collection of all keys.</returns>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     IReadOnlyCollection<IKey> GetAllKeys();
 
     /// <summary>

--- a/src/DataProtection/DataProtection/src/KeyManagement/Internal/ICacheableKeyRingProvider.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/Internal/ICacheableKeyRingProvider.cs
@@ -16,6 +16,5 @@ public interface ICacheableKeyRingProvider
     /// This API supports infrastructure and is not intended to be used
     /// directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     CacheableKeyRing GetCacheableKeyRing(DateTimeOffset now);
 }

--- a/src/DataProtection/DataProtection/src/KeyManagement/Internal/IInternalXmlKeyManager.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/Internal/IInternalXmlKeyManager.cs
@@ -24,7 +24,6 @@ public interface IInternalXmlKeyManager
     /// This API supports infrastructure and is not intended to be used
     /// directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     IAuthenticatedEncryptorDescriptor DeserializeDescriptorFromKeyElement(XElement keyElement);
 
     /// <summary>

--- a/src/DataProtection/DataProtection/src/KeyManagement/Internal/IKeyRingProvider.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/Internal/IKeyRingProvider.cs
@@ -15,6 +15,5 @@ public interface IKeyRingProvider
     /// This API supports infrastructure and is not intended to be used
     /// directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     IKeyRing GetCurrentKeyRing();
 }

--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedDataProtector.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingBasedDataProtector.cs
@@ -76,7 +76,6 @@ internal sealed unsafe class KeyRingBasedDataProtector : IDataProtector, IPersis
     }
 
     // allows decrypting payloads whose keys have been revoked
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     public byte[] DangerousUnprotect(byte[] protectedData, bool ignoreRevocationErrors, out bool requiresMigration, out bool wasRevoked)
     {
         // argument & state checking
@@ -92,7 +91,6 @@ internal sealed unsafe class KeyRingBasedDataProtector : IDataProtector, IPersis
         return retVal;
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     public byte[] Protect(byte[] plaintext)
     {
         if (plaintext == null)
@@ -182,7 +180,6 @@ internal sealed unsafe class KeyRingBasedDataProtector : IDataProtector, IPersis
         }
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     public byte[] Unprotect(byte[] protectedData)
     {
         if (protectedData == null)
@@ -197,7 +194,6 @@ internal sealed unsafe class KeyRingBasedDataProtector : IDataProtector, IPersis
             wasRevoked: out _);
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     private byte[] UnprotectCore(byte[] protectedData, bool allowOperationsOnRevokedKeys, out UnprotectStatus status)
     {
         Debug.Assert(protectedData != null);

--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
@@ -58,7 +58,6 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
 
     internal bool InAutoRefreshWindow() => DateTime.UtcNow < AutoRefreshWindowEnd;
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     private CacheableKeyRing CreateCacheableKeyRingCore(DateTimeOffset now, IKey? keyJustAdded)
     {
         // Refresh the list of all keys
@@ -146,19 +145,16 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
             allKeys: allKeys);
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     public IKeyRing GetCurrentKeyRing()
     {
         return GetCurrentKeyRingCore(DateTime.UtcNow);
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     internal IKeyRing RefreshCurrentKeyRing()
     {
         return GetCurrentKeyRingCore(DateTime.UtcNow, forceRefresh: true);
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     internal IKeyRing GetCurrentKeyRingCore(DateTime utcNow, bool forceRefresh = false)
     {
         Debug.Assert(utcNow.Kind == DateTimeKind.Utc);
@@ -277,7 +273,6 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
         return (a < b) ? a : b;
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     CacheableKeyRing ICacheableKeyRingProvider.GetCacheableKeyRing(DateTimeOffset now)
     {
         // the entry point allows one recursive call

--- a/src/DataProtection/DataProtection/src/KeyManagement/XmlKeyManager.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/XmlKeyManager.cs
@@ -477,11 +477,11 @@ public sealed class XmlKeyManager : IKeyManager, IInternalXmlKeyManager
         {
             return _activator.CreateInstance<AuthenticatedEncryptorDescriptorDeserializer>(descriptorDeserializerTypeName);
         }
-        else if (type == typeof(CngCbcAuthenticatedEncryptorDescriptorDeserializer))
+        else if (type == typeof(CngCbcAuthenticatedEncryptorDescriptorDeserializer) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             return _activator.CreateInstance<CngCbcAuthenticatedEncryptorDescriptorDeserializer>(descriptorDeserializerTypeName);
         }
-        else if (type == typeof(CngGcmAuthenticatedEncryptorDescriptorDeserializer))
+        else if (type == typeof(CngGcmAuthenticatedEncryptorDescriptorDeserializer) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             return _activator.CreateInstance<CngGcmAuthenticatedEncryptorDescriptorDeserializer>(descriptorDeserializerTypeName);
         }

--- a/src/DataProtection/DataProtection/src/KeyManagement/XmlKeyManager.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/XmlKeyManager.cs
@@ -28,14 +28,6 @@ using Microsoft.Win32;
 
 namespace Microsoft.AspNetCore.DataProtection.KeyManagement;
 
-//internal sealed class KnownTypeActivator : IActivator
-//{
-//    public object CreateInstance(Type expectedBaseType, string implementationTypeName)
-//    {
-//        throw new NotImplementedException();
-//    }
-//}
-
 /// <summary>
 /// A key manager backed by an <see cref="IXmlRepository"/>.
 /// </summary>

--- a/src/DataProtection/DataProtection/src/RegistryPolicyResolver.cs
+++ b/src/DataProtection/DataProtection/src/RegistryPolicyResolver.cs
@@ -37,7 +37,6 @@ internal sealed class RegistryPolicyResolver : IRegistryPolicyResolver
         _activator = activator;
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     private static List<string> ReadKeyEscrowSinks(RegistryKey key)
     {
         var sinks = new List<string>();
@@ -52,7 +51,7 @@ internal sealed class RegistryPolicyResolver : IRegistryPolicyResolver
                 var candidate = sinkFromRegistry.Trim();
                 if (!string.IsNullOrEmpty(candidate))
                 {
-                    typeof(IKeyEscrowSink).AssertIsAssignableFrom(Type.GetType(candidate, throwOnError: true)!);
+                    typeof(IKeyEscrowSink).AssertIsAssignableFrom(TypeExtensions.GetTypeWithTrimFriendlyErrorMessage(candidate));
                     sinks.Add(candidate);
                 }
             }
@@ -61,7 +60,6 @@ internal sealed class RegistryPolicyResolver : IRegistryPolicyResolver
         return sinks;
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     public RegistryPolicy? ResolvePolicy()
     {
         using (var registryKey = _getPolicyRegKey())
@@ -70,7 +68,6 @@ internal sealed class RegistryPolicyResolver : IRegistryPolicyResolver
         }
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     private RegistryPolicy? ResolvePolicyCore(RegistryKey? policyRegKey)
     {
         if (policyRegKey == null)
@@ -174,14 +171,13 @@ internal sealed class RegistryPolicyResolver : IRegistryPolicyResolver
         return options;
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     private static ManagedAuthenticatedEncryptorConfiguration GetManagedAuthenticatedEncryptorConfiguration(RegistryKey key)
     {
         var options = new ManagedAuthenticatedEncryptorConfiguration();
         var valueFromRegistry = key.GetValue(nameof(ManagedAuthenticatedEncryptorConfiguration.EncryptionAlgorithmType));
         if (valueFromRegistry != null)
         {
-            options.EncryptionAlgorithmType = Type.GetType(Convert.ToString(valueFromRegistry, CultureInfo.InvariantCulture)!, throwOnError: true)!;
+            options.EncryptionAlgorithmType = TypeExtensions.GetTypeWithTrimFriendlyErrorMessage(Convert.ToString(valueFromRegistry, CultureInfo.InvariantCulture)!);
         }
 
         valueFromRegistry = key.GetValue(nameof(ManagedAuthenticatedEncryptorConfiguration.EncryptionAlgorithmKeySize));
@@ -193,7 +189,7 @@ internal sealed class RegistryPolicyResolver : IRegistryPolicyResolver
         valueFromRegistry = key.GetValue(nameof(ManagedAuthenticatedEncryptorConfiguration.ValidationAlgorithmType));
         if (valueFromRegistry != null)
         {
-            options.ValidationAlgorithmType = Type.GetType(Convert.ToString(valueFromRegistry, CultureInfo.InvariantCulture)!, throwOnError: true)!;
+            options.ValidationAlgorithmType = TypeExtensions.GetTypeWithTrimFriendlyErrorMessage(Convert.ToString(valueFromRegistry, CultureInfo.InvariantCulture)!);
         }
 
         return options;

--- a/src/DataProtection/DataProtection/src/SimpleActivator.cs
+++ b/src/DataProtection/DataProtection/src/SimpleActivator.cs
@@ -27,11 +27,12 @@ internal class SimpleActivator : IActivator
         _services = services;
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
-    public virtual object CreateInstance(Type expectedBaseType, string implementationTypeName)
+    [UnconditionalSuppressMessage("Trimmer", "IL2072", Justification = "Unknown type names are rarely used by apps. Handle trimmed types by providing a useful error message.")]
+    [UnconditionalSuppressMessage("Trimmer", "IL2075", Justification = "Unknown type names are rarely used by apps. Handle trimmed types by providing a useful error message.")]
+    public virtual object CreateInstance([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type expectedBaseType, string implementationTypeName)
     {
         // Would the assignment even work?
-        var implementationType = Type.GetType(implementationTypeName, throwOnError: true)!;
+        var implementationType = TypeExtensions.GetTypeWithTrimFriendlyErrorMessage(implementationTypeName);
         expectedBaseType.AssertIsAssignableFrom(implementationType);
 
         // If no IServiceProvider was specified, prefer .ctor() [if it exists]

--- a/src/DataProtection/DataProtection/src/TypeExtensions.cs
+++ b/src/DataProtection/DataProtection/src/TypeExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.DataProtection;
 
@@ -23,6 +24,19 @@ internal static class TypeExtensions
             // for this pattern when the caller knows ahead of time the operation will fail.
             throw new InvalidCastException(Resources.FormatTypeExtensions_BadCast(
                 expectedBaseType.AssemblyQualifiedName, implementationType.AssemblyQualifiedName));
+        }
+    }
+
+    [UnconditionalSuppressMessage("Trimmer", "IL2057", Justification = "Unknown type names are rarely used by apps. Handle trimmed types by providing a useful error message.")]
+    public static Type GetTypeWithTrimFriendlyErrorMessage(string typeName)
+    {
+        try
+        {
+            return Type.GetType(typeName, throwOnError: true)!;
+        }
+        catch (TypeLoadException ex)
+        {
+            throw new InvalidOperationException($"Unable to load type '{typeName}'. If the app is published with trimming then ensure the type's assembly is excluded from trimming.", ex);
         }
     }
 }

--- a/src/DataProtection/DataProtection/src/TypeExtensions.cs
+++ b/src/DataProtection/DataProtection/src/TypeExtensions.cs
@@ -36,7 +36,7 @@ internal static class TypeExtensions
         }
         catch (TypeLoadException ex)
         {
-            throw new InvalidOperationException($"Unable to load type '{typeName}'. If the app is published with trimming then ensure the type's assembly is excluded from trimming.", ex);
+            throw new InvalidOperationException($"Unable to load type '{typeName}'. If the app is published with trimming then this type may have been trimmed. Ensure the type's assembly is excluded from trimming.", ex);
         }
     }
 }

--- a/src/DataProtection/DataProtection/src/TypeForwardingActivator.cs
+++ b/src/DataProtection/DataProtection/src/TypeForwardingActivator.cs
@@ -27,29 +27,14 @@ internal class TypeForwardingActivator : SimpleActivator
         _logger = loggerFactory.CreateLogger(typeof(TypeForwardingActivator));
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
-    public override object CreateInstance(Type expectedBaseType, string originalTypeName)
+    public override object CreateInstance([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type expectedBaseType, string originalTypeName)
         => CreateInstance(expectedBaseType, originalTypeName, out var _);
 
     // for testing
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
-    internal object CreateInstance(Type expectedBaseType, string originalTypeName, out bool forwarded)
+    [UnconditionalSuppressMessage("Trimmer", "IL2057", Justification = "Type.GetType is only used with forwarded types that are referenced by DataProtection assembly.")]
+    internal object CreateInstance([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type expectedBaseType, string originalTypeName, out bool forwarded)
     {
-        var forwardedTypeName = originalTypeName;
-        var candidate = false;
-        if (originalTypeName.Contains(OldNamespace))
-        {
-            candidate = true;
-            forwardedTypeName = originalTypeName.Replace(OldNamespace, CurrentNamespace);
-        }
-
-        if (candidate || forwardedTypeName.StartsWith(CurrentNamespace + ".", StringComparison.Ordinal))
-        {
-            candidate = true;
-            forwardedTypeName = RemoveVersionFromAssemblyName(forwardedTypeName);
-        }
-
-        if (candidate)
+        if (TryForwardTypeName(originalTypeName, out var forwardedTypeName))
         {
             var type = Type.GetType(forwardedTypeName, false);
             if (type != null)
@@ -64,6 +49,26 @@ internal class TypeForwardingActivator : SimpleActivator
 
         forwarded = false;
         return base.CreateInstance(expectedBaseType, originalTypeName);
+    }
+
+    internal static bool TryForwardTypeName(string originalTypeName, out string forwardedTypeName)
+    {
+        forwardedTypeName = originalTypeName;
+
+        var candidate = false;
+        if (originalTypeName.Contains(OldNamespace))
+        {
+            candidate = true;
+            forwardedTypeName = originalTypeName.Replace(OldNamespace, CurrentNamespace);
+        }
+
+        if (candidate || forwardedTypeName.StartsWith(CurrentNamespace + ".", StringComparison.Ordinal))
+        {
+            candidate = true;
+            forwardedTypeName = RemoveVersionFromAssemblyName(forwardedTypeName);
+        }
+
+        return candidate;
     }
 
     protected static string RemoveVersionFromAssemblyName(string forwardedTypeName)

--- a/src/DataProtection/DataProtection/test/RegistryPolicyResolverTests.cs
+++ b/src/DataProtection/DataProtection/test/RegistryPolicyResolverTests.cs
@@ -51,6 +51,24 @@ public class RegistryPolicyResolverTests
 
     [ConditionalFact]
     [ConditionalRunTestOnlyIfHkcuRegistryAvailable]
+    public void ResolvePolicy_MissingKeyEscrowSinks()
+    {
+        // Arrange
+        var typeName = typeof(MyKeyEscrowSink1).AssemblyQualifiedName.Replace("MyKeyEscrowSink1", "MyKeyEscrowSinkDontExist");
+        var registryEntries = new Dictionary<string, object>()
+        {
+            ["KeyEscrowSinks"] = typeName
+        };
+
+        // Act
+        var ex = ExceptionAssert.Throws<InvalidOperationException>(() => RunTestWithRegValues(registryEntries));
+
+        // Assert
+        Assert.Equal($"Unable to load type '{typeName}'. If the app is published with trimming then this type may have been trimmed. Ensure the type's assembly is excluded from trimming.", ex.Message);
+    }
+
+    [ConditionalFact]
+    [ConditionalRunTestOnlyIfHkcuRegistryAvailable]
     public void ResolvePolicy_DefaultKeyLifetime()
     {
         // Arrange

--- a/src/DataProtection/Extensions/src/DataProtectionAdvancedExtensions.cs
+++ b/src/DataProtection/Extensions/src/DataProtectionAdvancedExtensions.cs
@@ -19,7 +19,6 @@ public static class DataProtectionAdvancedExtensions
     /// <param name="plaintext">The plaintext data to protect.</param>
     /// <param name="lifetime">The amount of time after which the payload should no longer be unprotectable.</param>
     /// <returns>The protected form of the plaintext data.</returns>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     public static byte[] Protect(this ITimeLimitedDataProtector protector, byte[] plaintext, TimeSpan lifetime)
     {
         if (protector == null)
@@ -43,7 +42,6 @@ public static class DataProtectionAdvancedExtensions
     /// <param name="plaintext">The plaintext data to protect.</param>
     /// <param name="expiration">The time when this payload should expire.</param>
     /// <returns>The protected form of the plaintext data.</returns>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     public static string Protect(this ITimeLimitedDataProtector protector, string plaintext, DateTimeOffset expiration)
     {
         if (protector == null)
@@ -68,7 +66,6 @@ public static class DataProtectionAdvancedExtensions
     /// <param name="plaintext">The plaintext data to protect.</param>
     /// <param name="lifetime">The amount of time after which the payload should no longer be unprotectable.</param>
     /// <returns>The protected form of the plaintext data.</returns>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     public static string Protect(this ITimeLimitedDataProtector protector, string plaintext, TimeSpan lifetime)
     {
         if (protector == null)
@@ -111,7 +108,6 @@ public static class DataProtectionAdvancedExtensions
     /// <exception cref="System.Security.Cryptography.CryptographicException">
     /// Thrown if <paramref name="protectedData"/> is invalid, malformed, or expired.
     /// </exception>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     public static string Unprotect(this ITimeLimitedDataProtector protector, string protectedData, out DateTimeOffset expiration)
     {
         if (protector == null)
@@ -150,7 +146,6 @@ public static class DataProtectionAdvancedExtensions
             throw new NotImplementedException();
         }
 
-        [RequiresUnreferencedCode(TrimmerWarning.Message)]
         public byte[] Protect(byte[] plaintext)
         {
             if (plaintext == null)
@@ -161,7 +156,6 @@ public static class DataProtectionAdvancedExtensions
             return _innerProtector.Protect(plaintext, Expiration);
         }
 
-        [RequiresUnreferencedCode(TrimmerWarning.Message)]
         public byte[] Unprotect(byte[] protectedData)
         {
             if (protectedData == null)

--- a/src/DataProtection/Extensions/src/ITimeLimitedDataProtector.cs
+++ b/src/DataProtection/Extensions/src/ITimeLimitedDataProtector.cs
@@ -39,7 +39,6 @@ public interface ITimeLimitedDataProtector : IDataProtector
     /// <param name="plaintext">The plaintext data to protect.</param>
     /// <param name="expiration">The time when this payload should expire.</param>
     /// <returns>The protected form of the plaintext data.</returns>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     byte[] Protect(byte[] plaintext, DateTimeOffset expiration);
 
     /// <summary>
@@ -52,6 +51,5 @@ public interface ITimeLimitedDataProtector : IDataProtector
     /// <exception cref="System.Security.Cryptography.CryptographicException">
     /// Thrown if <paramref name="protectedData"/> is invalid, malformed, or expired.
     /// </exception>
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     byte[] Unprotect(byte[] protectedData, out DateTimeOffset expiration);
 }

--- a/src/DataProtection/Extensions/src/TimeLimitedDataProtector.cs
+++ b/src/DataProtection/Extensions/src/TimeLimitedDataProtector.cs
@@ -47,7 +47,6 @@ internal sealed class TimeLimitedDataProtector : ITimeLimitedDataProtector
         return retVal;
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     public byte[] Protect(byte[] plaintext, DateTimeOffset expiration)
     {
         if (plaintext == null)
@@ -63,7 +62,6 @@ internal sealed class TimeLimitedDataProtector : ITimeLimitedDataProtector
         return GetInnerProtectorWithTimeLimitedPurpose().Protect(plaintextWithHeader);
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     public byte[] Unprotect(byte[] protectedData, out DateTimeOffset expiration)
     {
         if (protectedData == null)
@@ -74,7 +72,6 @@ internal sealed class TimeLimitedDataProtector : ITimeLimitedDataProtector
         return UnprotectCore(protectedData, DateTimeOffset.UtcNow, out expiration);
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     internal byte[] UnprotectCore(byte[] protectedData, DateTimeOffset now, out DateTimeOffset expiration)
     {
         if (protectedData == null)
@@ -128,7 +125,6 @@ internal sealed class TimeLimitedDataProtector : ITimeLimitedDataProtector
         return CreateProtector(purpose);
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     byte[] IDataProtector.Protect(byte[] plaintext)
     {
         if (plaintext == null)
@@ -140,7 +136,6 @@ internal sealed class TimeLimitedDataProtector : ITimeLimitedDataProtector
         return Protect(plaintext, DateTimeOffset.MaxValue);
     }
 
-    [RequiresUnreferencedCode(TrimmerWarning.Message)]
     byte[] IDataProtector.Unprotect(byte[] protectedData)
     {
         if (protectedData == null)

--- a/src/DataProtection/shared/src/TrimmerWarning.cs
+++ b/src/DataProtection/shared/src/TrimmerWarning.cs
@@ -1,9 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-namespace Microsoft.AspNetCore.DataProtection;
-
-internal static class TrimmerWarning
-{
-    public const string Message = "Data Protection may attempt to load types in a way that cannot be statically analyzed. Ensure all required types are preserved.";
-}


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/41411
Fixes https://github.com/dotnet/aspnetcore/issues/24705

Result of the discussion with Levi and Hao about how DataProtection is used:
- Custom type names are rare
- Registry policy is also rare. Mostly used by administrators who want to override crypto settings machine-wide. Adding a config setting to opt into registry policy isn't ideal for this situation because now the machine admin also needs to know that all apps have the setting enabled.

Since custom type names are rare, this PR removes build warnings. It's possible to get runtime errors, but this change tries to make them useful.

This PR:
- Removes trimming warnings from public APIs
- Suppresses warnings at a lower level
- Provides friendly error message if a custom type name is used and trimmed
- Statically references any built-in types, e.g. deserializers, encryptors