### PR TITLE
Changed the Rate Limiter API to action-based

### DIFF
--- a/src/Middleware/RateLimiting/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/RateLimiting/src/PublicAPI.Unshipped.txt
@@ -8,4 +8,4 @@ Microsoft.AspNetCore.RateLimiting.RateLimiterOptions.OnRejected.set -> void
 Microsoft.AspNetCore.RateLimiting.RateLimiterOptions.RateLimiterOptions() -> void
 Microsoft.AspNetCore.RateLimiting.RateLimitingApplicationBuilderExtensions
 static Microsoft.AspNetCore.RateLimiting.RateLimitingApplicationBuilderExtensions.UseRateLimiter(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
-static Microsoft.AspNetCore.RateLimiting.RateLimitingApplicationBuilderExtensions.UseRateLimiter(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, System.Action<Microsoft.AspNetCore.RateLimiting.RateLimiterOptions!> options) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
+static Microsoft.AspNetCore.RateLimiting.RateLimitingApplicationBuilderExtensions.UseRateLimiter(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, System.Action<Microsoft.AspNetCore.RateLimiting.RateLimiterOptions!>! options) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!

--- a/src/Middleware/RateLimiting/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/RateLimiting/src/PublicAPI.Unshipped.txt
@@ -8,4 +8,4 @@ Microsoft.AspNetCore.RateLimiting.RateLimiterOptions.OnRejected.set -> void
 Microsoft.AspNetCore.RateLimiting.RateLimiterOptions.RateLimiterOptions() -> void
 Microsoft.AspNetCore.RateLimiting.RateLimitingApplicationBuilderExtensions
 static Microsoft.AspNetCore.RateLimiting.RateLimitingApplicationBuilderExtensions.UseRateLimiter(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
-static Microsoft.AspNetCore.RateLimiting.RateLimitingApplicationBuilderExtensions.UseRateLimiter(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, Microsoft.AspNetCore.RateLimiting.RateLimiterOptions! options) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
+static Microsoft.AspNetCore.RateLimiting.RateLimitingApplicationBuilderExtensions.UseRateLimiter(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, System.Action<Microsoft.AspNetCore.RateLimiting.RateLimiterOptions!> options) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!

--- a/src/Middleware/RateLimiting/src/RateLimitingApplicationBuilderExtensions.cs
+++ b/src/Middleware/RateLimiting/src/RateLimitingApplicationBuilderExtensions.cs
@@ -29,11 +29,14 @@ public static class RateLimitingApplicationBuilderExtensions
     /// <param name="app"></param>
     /// <param name="options"></param>
     /// <returns></returns>
-    public static IApplicationBuilder UseRateLimiter(this IApplicationBuilder app, RateLimiterOptions options)
+    public static IApplicationBuilder UseRateLimiter(this IApplicationBuilder app, Action<RateLimiterOptions> options)
     {
         ArgumentNullException.ThrowIfNull(app, nameof(app));
         ArgumentNullException.ThrowIfNull(options, nameof(options));
 
-        return app.UseMiddleware<RateLimitingMiddleware>(Options.Create(options));
+        var rateLimiterOptions = new RateLimiterOptions();
+        options?.Invoke(rateLimiterOptions);
+
+        return app.UseMiddleware<RateLimitingMiddleware>(Options.Create(rateLimiterOptions));
     }
 }

--- a/src/Middleware/RateLimiting/src/RateLimitingApplicationBuilderExtensions.cs
+++ b/src/Middleware/RateLimiting/src/RateLimitingApplicationBuilderExtensions.cs
@@ -35,7 +35,7 @@ public static class RateLimitingApplicationBuilderExtensions
         ArgumentNullException.ThrowIfNull(options, nameof(options));
 
         var rateLimiterOptions = new RateLimiterOptions();
-        options?.Invoke(rateLimiterOptions);
+        options.Invoke(rateLimiterOptions);
 
         return app.UseMiddleware<RateLimitingMiddleware>(Options.Create(rateLimiterOptions));
     }

--- a/src/Middleware/RateLimiting/test/RateLimitingApplicationBuilderExtensionsTests.cs
+++ b/src/Middleware/RateLimiting/test/RateLimitingApplicationBuilderExtensionsTests.cs
@@ -28,9 +28,11 @@ public class RateLimitingApplicationBuilderExtensionsTests : LoggedTest
     public void UseRateLimiter_RespectsOptions()
     {
         // These are the options that should get used
-        var options = new RateLimiterOptions();
-        options.DefaultRejectionStatusCode = 429;
-        options.Limiter = new TestPartitionedRateLimiter<HttpContext>(new TestRateLimiter(false));
+        var configureOptions = new Action<RateLimiterOptions>(opt =>
+        {
+            opt.DefaultRejectionStatusCode = 429;
+            opt.Limiter = new TestPartitionedRateLimiter<HttpContext>(new TestRateLimiter(false));
+        });
 
         // These should not get used
         var services = new ServiceCollection();
@@ -44,7 +46,7 @@ public class RateLimitingApplicationBuilderExtensionsTests : LoggedTest
         var appBuilder = new ApplicationBuilder(serviceProvider);
 
         // Act
-        appBuilder.UseRateLimiter(options);
+        appBuilder.UseRateLimiter(configureOptions);
         var app = appBuilder.Build();
         var context = new DefaultHttpContext();
         app.Invoke(context);


### PR DESCRIPTION
# Changed the Rate Limiter API to action-based

## Description

The most common approach when it comes to configuring options/settings in AddXXX, UseXXX and MapXXX methods during project setup is to use the Action-based approach.
`UseRateLimiter` doesn't follow that approach. This PR addresses that by allowing people to do: 
```c#
app.UseRateLimiter(options =>
{
    options.DefaultRejectionStatusCode = 429;
});
```

Fixes #41655
