### PR TITLE
Remove temporary allocations in Session and Identity

### DIFF
--- a/src/Identity/Extensions.Core/src/Base32.cs
+++ b/src/Identity/Extensions.Core/src/Base32.cs
@@ -43,20 +43,20 @@ internal static class Base32
         {
             throw new ArgumentNullException(nameof(input));
         }
-        input = input.TrimEnd('=').ToUpperInvariant();
-        if (input.Length == 0)
+        var trimmedInput = input.AsSpan().TrimEnd('=');
+        if (trimmedInput.Length == 0)
         {
             return Array.Empty<byte>();
         }
 
-        var output = new byte[input.Length * 5 / 8];
+        var output = new byte[trimmedInput.Length * 5 / 8];
         var bitIndex = 0;
         var inputIndex = 0;
         var outputBits = 0;
         var outputIndex = 0;
         while (outputIndex < output.Length)
         {
-            var byteIndex = _base32Chars.IndexOf(input[inputIndex]);
+            var byteIndex = _base32Chars.IndexOf(char.ToUpperInvariant(trimmedInput[inputIndex]));
             if (byteIndex < 0)
             {
                 throw new FormatException();

--- a/src/Middleware/Session/src/SessionMiddleware.cs
+++ b/src/Middleware/Session/src/SessionMiddleware.cs
@@ -85,9 +85,15 @@ public class SessionMiddleware
         if (string.IsNullOrWhiteSpace(sessionKey) || sessionKey.Length != SessionKeyLength)
         {
             // No valid cookie, new session.
-            var guidBytes = new byte[16];
-            RandomNumberGenerator.Fill(guidBytes);
-            sessionKey = new Guid(guidBytes).ToString();
+            sessionKey = GetSessionKey();
+
+            static string GetSessionKey()
+            {
+                Span<byte> guidBytes = stackalloc byte[16];
+                RandomNumberGenerator.Fill(guidBytes);
+                return new Guid(guidBytes).ToString();
+            }
+
             cookieValue = CookieProtection.Protect(_dataProtector, sessionKey);
             var establisher = new SessionEstablisher(context, cookieValue, _options);
             tryEstablishSession = establisher.TryEstablishSession;


### PR DESCRIPTION
Remove some unnecessary allocations by using Spans