### PR TITLE
Handle multiple response annotations for the same status code in OpenApi

### DIFF
--- a/src/OpenApi/src/OpenApiGenerator.cs
+++ b/src/OpenApi/src/OpenApiGenerator.cs
@@ -142,7 +142,7 @@ internal sealed class OpenApiGenerator
             if (discoveredTypeAnnotation is not null)
             {
                 GenerateDefaultContent(discoveredContentTypeAnnotation, discoveredTypeAnnotation);
-                eligibileAnnotations.Add(statusCode, (discoveredTypeAnnotation, discoveredContentTypeAnnotation));
+                eligibileAnnotations[statusCode] = (discoveredTypeAnnotation, discoveredContentTypeAnnotation);
             }
         }
 
@@ -182,7 +182,7 @@ internal sealed class OpenApiGenerator
                 : discoveredTypeAnnotation;
 
             GenerateDefaultContent(discoveredContentTypeAnnotation, discoveredTypeAnnotation);
-            eligibileAnnotations.Add(statusCode, (discoveredTypeAnnotation, discoveredContentTypeAnnotation));
+            eligibileAnnotations[statusCode] = (discoveredTypeAnnotation, discoveredContentTypeAnnotation);
         }
 
         if (eligibileAnnotations.Count == 0)


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/41622