### PR TITLE
Add AppOfflineDroppedWhileSiteIsDown_SiteReturns503_InProcess to test retry list

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -4,6 +4,7 @@
   "localRerunCount" : 3,
   "retryOnRules": [
     {"testName": {"contains": "AppOfflineDroppedWhileSiteStarting_SiteShutsDown_InProcess"}},
+    {"testName": {"contains": "AppOfflineDroppedWhileSiteIsDown_SiteReturns503_InProcess"}},
     {"testName": {"contains": "CheckFrebDisconnect"}},
     {"testName": {"contains": "CheckStdoutWithLargeWrites"}},
     {"testName": {"contains": "ServerShutsDownWhenMainExitsStress" }},

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
@@ -264,7 +264,7 @@ public class IISDeployer : IISDeployerBase
             var workerProcess = appPool.WorkerProcesses.SingleOrDefault();
             if (workerProcess == null)
             {
-                throw new InvalidOperationException("Site is started but no worked process found");
+                throw new InvalidOperationException("Site is started but no worker process found");
             }
 
             HostProcess = Process.GetProcessById(workerProcess.ProcessId);
@@ -413,7 +413,7 @@ public class IISDeployer : IISDeployerBase
                     }
                 }
 
-                if (!HostProcess.HasExited)
+                if (HostProcess is not null && !HostProcess.HasExited)
                 {
                     throw new InvalidOperationException("Site is stopped but host process is not");
                 }


### PR DESCRIPTION
Test failure looks like an IIS failure so adding to our retry list instead of quarantining.
Failing test at https://dev.azure.com/dnceng/public/_build/results?buildId=1774510&view=ms.vss-test-web.build-test-results-tab&runId=47634902&resultId=122473&paneView=dotnet-dnceng.dnceng-build-release-tasks.helix-test-information-tab

Kept outputting the following for 60 seconds.

> "Site is started but no worker process found"