### PR TITLE
Remove support for some Tasks and ValueTasks declared as objects in RDF

### DIFF
--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -2845,14 +2845,6 @@ public class RequestDelegateFactoryTests : LoggedTest
 
             // Object return type where the object is IResult
             static object StaticResultAsObject() => new CustomResult("Still not enough tests!");
-            static object StaticResultAsTaskObject() => Task.FromResult<object>(new CustomResult("Still not enough tests!"));
-            static object StaticResultAsValueTaskObject() => ValueTask.FromResult<object>(new CustomResult("Still not enough tests!"));
-
-            // Object return type where the object is Task<IResult>
-            static object StaticResultAsTaskIResult() => Task.FromResult<IResult>(new CustomResult("Still not enough tests!"));
-
-            // Object return type where the object is ValueTask<IResult>
-            static object StaticResultAsValueTaskIResult() => ValueTask.FromResult<IResult>(new CustomResult("Still not enough tests!"));
 
             // Task<object> return type
             static Task<object> StaticTaskOfIResultAsObject() => Task.FromResult<object>(new CustomResult("Still not enough tests!"));
@@ -2872,11 +2864,6 @@ public class RequestDelegateFactoryTests : LoggedTest
                     new object[] { (Func<ValueTask<CustomResult>>)StaticValueTaskTestAction},
 
                     new object[] { (Func<object>)StaticResultAsObject},
-                    new object[] { (Func<object>)StaticResultAsTaskObject},
-                    new object[] { (Func<object>)StaticResultAsValueTaskObject},
-
-                    new object[] { (Func<object>)StaticResultAsTaskIResult},
-                    new object[] { (Func<object>)StaticResultAsValueTaskIResult},
 
                     new object[] { (Func<Task<object>>)StaticTaskOfIResultAsObject},
                     new object[] { (Func<ValueTask<object>>)StaticValueTaskOfIResultAsObject},
@@ -2922,8 +2909,6 @@ public class RequestDelegateFactoryTests : LoggedTest
 
             // Dynamic via object
             static object StaticStringAsObjectTestAction() => "String Test";
-            static object StaticTaskStringAsObjectTestAction() => Task.FromResult("String Test");
-            static object StaticValueTaskStringAsObjectTestAction() => ValueTask.FromResult("String Test");
 
             // Dynamic via Task<object>
             static Task<object> StaticStringAsTaskObjectTestAction() => Task.FromResult<object>("String Test");
@@ -2941,8 +2926,6 @@ public class RequestDelegateFactoryTests : LoggedTest
                     new object[] { (Func<ValueTask<string>>)StaticValueTaskTestAction },
 
                     new object[] { (Func<object>)StaticStringAsObjectTestAction },
-                    new object[] { (Func<object>)StaticTaskStringAsObjectTestAction },
-                    new object[] { (Func<object>)StaticValueTaskStringAsObjectTestAction },
 
                     new object[] { (Func<Task<object>>)StaticStringAsTaskObjectTestAction },
                     new object[] { (Func<ValueTask<object>>)StaticStringAsValueTaskObjectTestAction },


### PR DESCRIPTION
The deleted tests verified that we would await Tasks and ValueTasks *declared as object in the method signature* if and only if they happened to be exactly `Task<object>`, `Task<IResult>` or `Task<string>` (or their `ValueTask<TResult>` equivalent). This completely broke as soon as the runtime type was `Task<CustomType>`, `Task<Ok<string>>` or literally anything other than those six types. It's not worth even calling out as a breaking change. This is just a simplification of `RequestDelegateFactory`.
