### PR TITLE
Allow explicit manual runs of mirror pipeline

### DIFF
--- a/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
+++ b/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
@@ -21,6 +21,7 @@ jobs:
   parameters:
     enableTelemetry: true
     helixRepo: dotnet/arcade
+    manualRun: ${{ parameters.manualRun }}
     jobs:
     - job: Merge_Azure_DevOps_Branches
       enableSBOM: false

--- a/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
+++ b/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
@@ -17,7 +17,7 @@ variables:
 
 # Merges code from one AzDO branch into another
 jobs:
-- ${{ if or(and(contains(variables['Build.SourceBranch'], 'internal'), eq(variables['Build.Reason'], 'BatchedCI')), eq(parameters.manualRun, 'true')) }}:
+- ${{ if and(contains(variables['Build.SourceBranch'], 'internal'), or(eq(variables['Build.Reason'], 'BatchedCI'), eq(parameters.manualRun, 'true'))) }}:
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableTelemetry: true

--- a/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
+++ b/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
@@ -4,6 +4,13 @@ trigger:
   branches:
     include:
     - internal/release/6.0
+    
+parameters:
+# Run the pipeline manually (usually disallowed)
+- name: manualRun
+  default: false
+  displayName: Are you sure you want to run this pipeline manually?
+  type: boolean
 
 variables:
   - group: Mirror-Credentials
@@ -17,7 +24,7 @@ jobs:
     jobs:
     - job: Merge_Azure_DevOps_Branches
       enableSBOM: false
-      condition: and(contains(variables['Build.SourceBranch'], 'internal'), eq(variables['Build.Reason'], 'BatchedCI'))
+      condition: or((and(contains(variables['Build.SourceBranch'], 'internal'), eq(variables['Build.Reason'], 'BatchedCI'))), (eq(parameters.manualRun, 'true')))
       pool:
         name: NetCore1ESPool-Internal
         demands: ImageOverride -equals Build.Server.Amd64.VS2019

--- a/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
+++ b/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
@@ -22,7 +22,6 @@ jobs:
     parameters:
       enableTelemetry: true
       helixRepo: dotnet/aspnetcore
-      manualRun: ${{ parameters.manualRun }}
       jobs:
       - job: Merge_Azure_DevOps_Branches
         enableSBOM: false

--- a/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
+++ b/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
@@ -24,7 +24,7 @@ jobs:
     jobs:
     - job: Merge_Azure_DevOps_Branches
       enableSBOM: false
-      condition: or((and(contains(variables['Build.SourceBranch'], 'internal'), eq(variables['Build.Reason'], 'BatchedCI'))), (eq(parameters.manualRun, 'true')))
+      condition: or(and(contains(variables['Build.SourceBranch'], 'internal'), eq(variables['Build.Reason'], 'BatchedCI')), eq(parameters.manualRun, 'true'))
       pool:
         name: NetCore1ESPool-Internal
         demands: ImageOverride -equals Build.Server.Amd64.VS2019

--- a/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
+++ b/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
@@ -17,53 +17,53 @@ variables:
 
 # Merges code from one AzDO branch into another
 jobs:
-- template: /eng/common/templates/jobs/jobs.yml
-  parameters:
-    enableTelemetry: true
-    helixRepo: dotnet/arcade
-    manualRun: ${{ parameters.manualRun }}
-    jobs:
-    - job: Merge_Azure_DevOps_Branches
-      enableSBOM: false
-      condition: or(and(contains(variables['Build.SourceBranch'], 'internal'), eq(variables['Build.Reason'], 'BatchedCI')), eq(parameters.manualRun, 'true'))
-      pool:
-        name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals Build.Server.Amd64.VS2019
-      variables:
-      - name: WorkingDirectoryName
-        value: repo-dir
-      - name: AzdoRepo
-        value: dotnet-aspnetcore
-      - name: TargetBranchName
-        value: $(Build.SourceBranch)-nonstable
-      - name: BranchToMirror
-        value: $(Build.SourceBranch)
-      steps:
-      - script: |
-          git clone https://dn-bot:$(dn-bot-dnceng-build-rw-code-rw)@dev.azure.com/dnceng/internal/_git/$(AzdoRepo) $(WorkingDirectoryName) --recursive --no-tags --branch $(TargetBranchName)
-        displayName: Clone AzDO repo
-      - script: |
-          git -c user.email="dotnet-bot@microsoft.com" -c user.name="dotnet-bot" merge origin/$(BranchToMirror) -m "Merge in '$(BranchToMirror)' changes" 
-        displayName: Merge head branch to target branch
-        workingDirectory: $(WorkingDirectoryName)
-      - script: |
-          git push origin $(TargetBranchName)
-        displayName: Push changes to Azure DevOps repo
-        workingDirectory: $(WorkingDirectoryName)
-
-      - task: PowerShell@1
-        displayName: Broadcast target, branch, commit in metadata
-        continueOnError: true
-        condition: always()
-        inputs:
-          scriptType: inlineScript
-          arguments: '$(BranchToMirror)'
+- ${{ if or(and(contains(variables['Build.SourceBranch'], 'internal'), eq(variables['Build.Reason'], 'BatchedCI')), eq(parameters.manualRun, 'true')) }}:
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableTelemetry: true
+      helixRepo: dotnet/aspnetcore
+      manualRun: ${{ parameters.manualRun }}
+      jobs:
+      - job: Merge_Azure_DevOps_Branches
+        enableSBOM: false
+        pool:
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        variables:
+        - name: WorkingDirectoryName
+          value: repo-dir
+        - name: AzdoRepo
+          value: dotnet-aspnetcore
+        - name: TargetBranchName
+          value: $(Build.SourceBranch)-nonstable
+        - name: BranchToMirror
+          value: $(Build.SourceBranch)
+        steps:
+        - script: |
+            git clone https://dn-bot:$(dn-bot-dnceng-build-rw-code-rw)@dev.azure.com/dnceng/internal/_git/$(AzdoRepo) $(WorkingDirectoryName) --recursive --no-tags --branch $(TargetBranchName)
+          displayName: Clone AzDO repo
+        - script: |
+            git -c user.email="dotnet-bot@microsoft.com" -c user.name="dotnet-bot" merge origin/$(BranchToMirror) -m "Merge in '$(BranchToMirror)' changes"
+          displayName: Merge head branch to target branch
           workingDirectory: $(WorkingDirectoryName)
-          inlineScript: |
-            param([string]$branch)
+        - script: |
+            git push origin $(TargetBranchName)
+          displayName: Push changes to Azure DevOps repo
+          workingDirectory: $(WorkingDirectoryName)
 
-            $commit = (git rev-parse HEAD).Substring(0, 7)
-            $target = "$branch".Replace('/', ' ')
+        - task: PowerShell@1
+          displayName: Broadcast target, branch, commit in metadata
+          continueOnError: true
+          condition: always()
+          inputs:
+            scriptType: inlineScript
+            arguments: '$(BranchToMirror)'
+            workingDirectory: $(WorkingDirectoryName)
+            inlineScript: |
+              param([string]$branch)
 
-            Write-Host "##vso[build.updatebuildnumber]$target $commit"
-            Write-Host "##vso[build.addbuildtag]$target"
+              $commit = (git rev-parse HEAD).Substring(0, 7)
+              $target = "$branch".Replace('/', ' ')
+
+              Write-Host "##vso[build.updatebuildnumber]$target $commit"
+              Write-Host "##vso[build.addbuildtag]$target"


### PR DESCRIPTION
In case we ever need to trigger this manually, surface a checkbox to the user. Test build worked (though couldn't actually do any mirroring, since the variable group we use is only available on branches named `main`)