### PR TITLE
Fix the RedirectHandler (in Mvc.Testing) for relative URIs

### DIFF
--- a/src/Mvc/Mvc.Testing/src/Handlers/RedirectHandler.cs
+++ b/src/Mvc/Mvc.Testing/src/Handlers/RedirectHandler.cs
@@ -144,9 +144,7 @@ public class RedirectHandler : DelegatingHandler
         {
             if (!location.IsAbsoluteUri && response.RequestMessage.RequestUri is Uri requestUri)
             {
-                location = new Uri(
-                    new Uri(requestUri.GetLeftPart(UriPartial.Authority)),
-                    location);
+                location = new Uri(requestUri, location);
             }
 
             redirect.RequestUri = location;

--- a/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/TestingInfrastructureTests.cs
@@ -110,6 +110,19 @@ public class TestingInfrastructureTests : IClassFixture<WebApplicationFactory<Ba
     }
 
     [Fact]
+    public async Task TestingInfrastructure_RedirectHandlerHandlesRelativeLocation()
+    {
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, "Testing/RedirectHandler/Relative/");
+        var client = Factory.CreateDefaultClient(
+            new RedirectHandler());
+        var response = await client.SendAsync(request);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
     public async Task TestingInfrastructure_RedirectHandlerFollowsStatusCode303()
     {
         // Act

--- a/src/Mvc/test/WebSites/BasicWebSite/Controllers/TestingController.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/Controllers/TestingController.cs
@@ -77,10 +77,19 @@ public class TestingController : Controller
         }
     }
 
+    [HttpGet("Testing/RedirectHandler/Relative/")]
+    public IActionResult RedirectHandlerRelative()
+    {
+        return Redirect("Ok");
+    }
+
+    [HttpGet("Testing/RedirectHandler/Relative/Ok")]
+    public IActionResult RedirectHandlerRelativeOk() => Ok();
+
     [HttpGet("Testing/RedirectHandler/Redirect303")]
     public IActionResult RedirectHandlerStatusCode303()
     {
-        return new RedirectUsingStatusCode("Testing/Builder", HttpStatusCode.SeeOther);
+        return new RedirectUsingStatusCode("/Testing/Builder", HttpStatusCode.SeeOther);
     }
 
     public class RedirectUsingStatusCode : ActionResult

--- a/src/Mvc/test/WebSites/GenericHostWebSite/Controllers/TestingController.cs
+++ b/src/Mvc/test/WebSites/GenericHostWebSite/Controllers/TestingController.cs
@@ -63,10 +63,19 @@ public class TestingController : Controller
         }
     }
 
+    [HttpGet("Testing/RedirectHandler/Relative/")]
+    public IActionResult RedirectHandlerRelative()
+    {
+        return Redirect("Ok");
+    }
+
+    [HttpGet("Testing/RedirectHandler/Relative/Ok")]
+    public IActionResult RedirectHandlerRelativeOk() => Ok();
+
     [HttpGet("Testing/RedirectHandler/Redirect303")]
     public IActionResult RedirectHandlerStatusCode303()
     {
-        return new RedirectUsingStatusCode("Testing/Builder", HttpStatusCode.SeeOther);
+        return new RedirectUsingStatusCode("/Testing/Builder", HttpStatusCode.SeeOther);
     }
 
     public class RedirectUsingStatusCode : ActionResult


### PR DESCRIPTION
# Fix the RedirectHandler (in Mvc.Testing) for relative URIs

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

This was a case of double bugs cancelling each other. The `Testing/RedirectHandler/Redirect303` route was redirecting to `Testing/Builder` instead of `/Testing/Builder`, hiding the fact that the relative URL in the RedirectHandler was not handled properly.

A new test covering relative URLs has been added.