### PR TITLE
Make RedirectRule honor specified scheme

### DIFF
--- a/src/Middleware/Rewrite/src/RedirectRule.cs
+++ b/src/Middleware/Rewrite/src/RedirectRule.cs
@@ -65,8 +65,10 @@ internal sealed class RedirectRule : IRule
             {
                 var host = default(HostString);
                 var schemeSplit = newPath.IndexOf(Uri.SchemeDelimiter, StringComparison.Ordinal);
+                string? scheme = null;
                 if (schemeSplit >= 0)
                 {
+                    scheme = newPath.Substring(0, schemeSplit);
                     schemeSplit += Uri.SchemeDelimiter.Length;
                     var pathSplit = newPath.IndexOf('/', schemeSplit);
 
@@ -97,7 +99,7 @@ internal sealed class RedirectRule : IRule
                 }
 
                 encodedPath = host.HasValue
-                    ? UriHelper.BuildAbsolute(request.Scheme, host, pathBase, resolvedPath, resolvedQuery, default)
+                    ? UriHelper.BuildAbsolute(scheme ?? request.Scheme, host, pathBase, resolvedPath, resolvedQuery, default)
                     : UriHelper.BuildRelative(pathBase, resolvedPath, resolvedQuery, default);
             }
 

--- a/src/Middleware/Rewrite/src/RedirectRule.cs
+++ b/src/Middleware/Rewrite/src/RedirectRule.cs
@@ -65,7 +65,7 @@ internal sealed class RedirectRule : IRule
             {
                 var host = default(HostString);
                 var schemeSplit = newPath.IndexOf(Uri.SchemeDelimiter, StringComparison.Ordinal);
-                string? scheme = null;
+                string scheme = request.Scheme;
                 if (schemeSplit >= 0)
                 {
                     scheme = newPath.Substring(0, schemeSplit);
@@ -99,7 +99,7 @@ internal sealed class RedirectRule : IRule
                 }
 
                 encodedPath = host.HasValue
-                    ? UriHelper.BuildAbsolute(scheme ?? request.Scheme, host, pathBase, resolvedPath, resolvedQuery, default)
+                    ? UriHelper.BuildAbsolute(scheme, host, pathBase, resolvedPath, resolvedQuery, default)
                     : UriHelper.BuildRelative(pathBase, resolvedPath, resolvedQuery, default);
             }
 

--- a/src/Middleware/Rewrite/test/MiddlewareTests.cs
+++ b/src/Middleware/Rewrite/test/MiddlewareTests.cs
@@ -329,6 +329,36 @@ public class MiddlewareTests
         Assert.Equal("https://" + expectedHostPathAndQuery, response.Headers.Location.OriginalString);
     }
 
+    [Theory]
+    [InlineData("http://example.com/test", "http://www.example.com/")]
+    [InlineData("http://example.com/test", "https://www.example.com/")]
+    [InlineData("https://example.com/test", "http://www.example.com/")]
+    [InlineData("https://example.com/test", "https://www.example.com/")]
+    public async Task CheckRedirectUsesConfiguredScheme(string hostSchemePathAndQuery, string redirectReplacement)
+    {
+        var options = new RewriteOptions().AddRedirect("test", redirectReplacement);
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                .UseTestServer()
+                .Configure(app =>
+                {
+                    app.UseRewriter(options);
+                });
+            }).Build();
+
+        await host.StartAsync();
+
+        var server = host.GetTestServer();
+        server.BaseAddress = new Uri("http://example.com");
+        var response = await server.CreateClient().GetAsync(new Uri(hostSchemePathAndQuery));
+
+        // Regardless of whether we GET with http or https, the redirect should honor
+        // the scheme specified in the configuration.
+        Assert.Equal(redirectReplacement, response.Headers.Location.OriginalString);
+    }
+
     [Fact]
     public async Task CheckPermanentRedirectToHttps()
     {


### PR DESCRIPTION
Fix #41707

https://github.com/dotnet/aspnetcore/pull/28903 introduced a behavioral change in `RedirectRule` where the scheme used in a redirected request overrides the one specified in the redirect configuration.

This fixes that so we now honor the scheme specified in the redirect if there is one.