### PR TITLE
Add support for logging additional request headers

### DIFF
--- a/src/Middleware/HttpLogging/samples/Logging.W3C.Sample/Startup.cs
+++ b/src/Middleware/HttpLogging/samples/Logging.W3C.Sample/Startup.cs
@@ -15,6 +15,10 @@ public class Startup
         {
             // Log all W3C fields
             logging.LoggingFields = W3CLoggingFields.All;
+            logging.AdditionalRequestHeaders = new[] {
+                "x-forwarded-for",
+                "x-client-ssl-protocol",
+            };
         });
     }
 

--- a/src/Middleware/HttpLogging/samples/Logging.W3C.Sample/Startup.cs
+++ b/src/Middleware/HttpLogging/samples/Logging.W3C.Sample/Startup.cs
@@ -18,7 +18,7 @@ public class Startup
             logging.AdditionalRequestHeaders = new[] {
                 "x-forwarded-for",
                 "x-client-ssl-protocol",
-            };
+            }.ToHashSet();
         });
     }
 

--- a/src/Middleware/HttpLogging/samples/Logging.W3C.Sample/Startup.cs
+++ b/src/Middleware/HttpLogging/samples/Logging.W3C.Sample/Startup.cs
@@ -15,10 +15,9 @@ public class Startup
         {
             // Log all W3C fields
             logging.LoggingFields = W3CLoggingFields.All;
-            logging.AdditionalRequestHeaders = new[] {
-                "x-forwarded-for",
-                "x-client-ssl-protocol",
-            }.ToHashSet();
+            logging.AdditionalRequestHeaders.Clear();
+            logging.AdditionalRequestHeaders.Add("x-forwarded-for");
+            logging.AdditionalRequestHeaders.Add("x-client-ssl-protocol");
         });
     }
 

--- a/src/Middleware/HttpLogging/src/FileLoggerProcessor.cs
+++ b/src/Middleware/HttpLogging/src/FileLoggerProcessor.cs
@@ -61,6 +61,7 @@ internal partial class FileLoggerProcessor : IAsyncDisposable
         _maxRetainedFiles = loggerOptions.RetainedFileCountLimit;
         _flushInterval = loggerOptions.FlushInterval;
         _fields = loggerOptions.LoggingFields;
+
         _options.OnChange(options =>
         {
             lock (_pathLock)

--- a/src/Middleware/HttpLogging/src/FileLoggerProcessor.cs
+++ b/src/Middleware/HttpLogging/src/FileLoggerProcessor.cs
@@ -35,6 +35,7 @@ internal partial class FileLoggerProcessor : IAsyncDisposable
     internal ISystemDateTime SystemDateTime { get; set; } = new SystemDateTime();
 
     private readonly object _pathLock = new object();
+    private ISet<string> _additionalHeaders;
 
     public FileLoggerProcessor(IOptionsMonitor<W3CLoggerOptions> options, IHostEnvironment environment, ILoggerFactory factory)
     {
@@ -61,6 +62,7 @@ internal partial class FileLoggerProcessor : IAsyncDisposable
         _maxRetainedFiles = loggerOptions.RetainedFileCountLimit;
         _flushInterval = loggerOptions.FlushInterval;
         _fields = loggerOptions.LoggingFields;
+        _additionalHeaders = W3CLoggerOptions.FilterRequestHeaders(loggerOptions);
 
         _options.OnChange(options =>
         {
@@ -70,7 +72,7 @@ internal partial class FileLoggerProcessor : IAsyncDisposable
                 loggerOptions = options;
 
                 // Move to a new file if the fields have changed
-                if (_fields != loggerOptions.LoggingFields)
+                if (_fields != loggerOptions.LoggingFields || !_additionalHeaders.SetEquals(loggerOptions.AdditionalRequestHeaders))
                 {
                     _fileNumber++;
                     if (_fileNumber >= W3CLoggerOptions.MaxFileCount)
@@ -79,6 +81,7 @@ internal partial class FileLoggerProcessor : IAsyncDisposable
                         Log.MaxFilesReached(_logger);
                     }
                     _fields = loggerOptions.LoggingFields;
+                    _additionalHeaders = W3CLoggerOptions.FilterRequestHeaders(loggerOptions);
                 }
 
                 if (!string.IsNullOrEmpty(loggerOptions.LogDirectory))

--- a/src/Middleware/HttpLogging/src/HttpLoggingOptions.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingOptions.cs
@@ -20,6 +20,11 @@ public sealed class HttpLoggingOptions
     /// <p>
     /// If a request header is not present in the <see cref="RequestHeaders"/>,
     /// the header name will be logged with a redacted value.
+    /// Request headers can contain authentication tokens,
+    /// or private information which may have regulatory concerns
+    /// under GDPR and other laws. Arbitrary request headers
+    /// should not be logged unless logs are secure and
+    /// access controlled and the privacy impact assessed.
     /// </p>
     /// </summary>
     public ISet<string> RequestHeaders => _internalRequestHeaders;

--- a/src/Middleware/HttpLogging/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/HttpLogging/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.HttpLogging.W3CLoggerOptions.AdditionalRequestHeaders.get -> System.Collections.Generic.IReadOnlyList<string!>?
+Microsoft.AspNetCore.HttpLogging.W3CLoggerOptions.AdditionalRequestHeaders.set -> void

--- a/src/Middleware/HttpLogging/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/HttpLogging/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 #nullable enable
-Microsoft.AspNetCore.HttpLogging.W3CLoggerOptions.AdditionalRequestHeaders.get -> System.Collections.Generic.IReadOnlyList<string!>?
+Microsoft.AspNetCore.HttpLogging.W3CLoggerOptions.AdditionalRequestHeaders.get -> System.Collections.Generic.ISet<string!>?
 Microsoft.AspNetCore.HttpLogging.W3CLoggerOptions.AdditionalRequestHeaders.set -> void

--- a/src/Middleware/HttpLogging/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/HttpLogging/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,2 @@
 #nullable enable
-Microsoft.AspNetCore.HttpLogging.W3CLoggerOptions.AdditionalRequestHeaders.get -> System.Collections.Generic.ISet<string!>?
-Microsoft.AspNetCore.HttpLogging.W3CLoggerOptions.AdditionalRequestHeaders.set -> void
+Microsoft.AspNetCore.HttpLogging.W3CLoggerOptions.AdditionalRequestHeaders.get -> System.Collections.Generic.ISet<string!>!

--- a/src/Middleware/HttpLogging/src/W3CLogger.cs
+++ b/src/Middleware/HttpLogging/src/W3CLogger.cs
@@ -47,7 +47,8 @@ internal class W3CLogger : IAsyncDisposable
         var firstElement = true;
         for (var i = 0; i < elements.Length; i++)
         {
-            if (_loggingFields.HasFlag((W3CLoggingFields)(1 << i)))
+            // Custom headers start at index 17
+            if (_loggingFields.HasFlag((W3CLoggingFields)(1 << i)) || i >= 17)
             {
                 if (!firstElement)
                 {

--- a/src/Middleware/HttpLogging/src/W3CLogger.cs
+++ b/src/Middleware/HttpLogging/src/W3CLogger.cs
@@ -35,20 +35,19 @@ internal class W3CLogger : IAsyncDisposable
 
     public ValueTask DisposeAsync() => _messageQueue.DisposeAsync();
 
-    public void Log(string[] elements)
+    public void Log(string[] elements, string[] additionalHeaders)
     {
-        _messageQueue.EnqueueMessage(Format(elements));
+        _messageQueue.EnqueueMessage(Format(elements, additionalHeaders));
     }
 
-    private string Format(string[] elements)
+    private string Format(string[] elements, string[] additionalHeaders)
     {
         // 200 is around the length of an average cookie-less entry
         var sb = new ValueStringBuilder(200);
         var firstElement = true;
         for (var i = 0; i < elements.Length; i++)
         {
-            // Custom headers start at index 17
-            if (_loggingFields.HasFlag((W3CLoggingFields)(1 << i)) || i >= 17)
+            if (_loggingFields.HasFlag((W3CLoggingFields)(1 << i)))
             {
                 if (!firstElement)
                 {
@@ -67,6 +66,27 @@ internal class W3CLogger : IAsyncDisposable
                 {
                     sb.Append(elements[i]);
                 }
+            }
+        }
+
+        for (var i = 0; i < additionalHeaders.Length; i++)
+        {
+            if (!firstElement)
+            {
+                sb.Append(' ');
+            }
+            else
+            {
+                firstElement = false;
+            }
+            // If the element was not logged, or was the empty string, we log it as a dash
+            if (string.IsNullOrEmpty(additionalHeaders[i]))
+            {
+                sb.Append('-');
+            }
+            else
+            {
+                sb.Append(additionalHeaders[i]);
             }
         }
         return sb.ToString();

--- a/src/Middleware/HttpLogging/src/W3CLoggerOptions.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggerOptions.cs
@@ -107,6 +107,16 @@ public sealed class W3CLoggerOptions
     }
 
     /// <summary>
+    /// List of additional request header values to log.
+    /// The cookie header can contain authentication tokens,
+    /// or private information which may have regulatory concerns
+    /// under GDPR and other laws. Cookies should not be logged
+    /// unless logs are secure and access controlled
+    /// and the privacy impact assessed.
+    /// </summary>
+    public IReadOnlyList<string>? AdditionalRequestHeaders { get; set; }
+
+    /// <summary>
     /// Fields to log. Defaults to logging request and response properties and headers,
     /// plus date/time info and server name.
     /// </summary>

--- a/src/Middleware/HttpLogging/src/W3CLoggerOptions.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggerOptions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Net.Http.Headers;
+
 namespace Microsoft.AspNetCore.HttpLogging;
 
 /// <summary>
@@ -116,7 +118,7 @@ public sealed class W3CLoggerOptions
     /// access controlled and the privacy impact assessed.
     /// </p>
     /// </summary>
-    public ISet<string> AdditionalRequestHeaders { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    public ISet<string> AdditionalRequestHeaders { get; } = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Fields to log. Defaults to logging request and response properties and headers,
@@ -127,4 +129,26 @@ public sealed class W3CLoggerOptions
         W3CLoggingFields.ProtocolStatus | W3CLoggingFields.TimeTaken | W3CLoggingFields.ProtocolVersion |
         W3CLoggingFields.Host | W3CLoggingFields.UserAgent | W3CLoggingFields.Referer | W3CLoggingFields.ConnectionInfoFields;
 
+    internal static ISet<string> FilterRequestHeaders(W3CLoggerOptions options)
+    {
+        var clonedSet = new SortedSet<string>(options.AdditionalRequestHeaders, StringComparer.InvariantCultureIgnoreCase);
+
+        if (options.LoggingFields.HasFlag(W3CLoggingFields.Host))
+        {
+            clonedSet.Remove(HeaderNames.Host);
+        }
+        if (options.LoggingFields.HasFlag(W3CLoggingFields.Referer))
+        {
+            clonedSet.Remove(HeaderNames.Referer);
+        }
+        if (options.LoggingFields.HasFlag(W3CLoggingFields.UserAgent))
+        {
+            clonedSet.Remove(HeaderNames.UserAgent);
+        }
+        if (options.LoggingFields.HasFlag(W3CLoggingFields.Cookie))
+        {
+            clonedSet.Remove(HeaderNames.Cookie);
+        }
+        return clonedSet;
+    }
 }

--- a/src/Middleware/HttpLogging/src/W3CLoggerOptions.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggerOptions.cs
@@ -116,7 +116,7 @@ public sealed class W3CLoggerOptions
     /// access controlled and the privacy impact assessed.
     /// </p>
     /// </summary>
-    public ISet<string>? AdditionalRequestHeaders { get; set; }
+    public ISet<string> AdditionalRequestHeaders { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Fields to log. Defaults to logging request and response properties and headers,

--- a/src/Middleware/HttpLogging/src/W3CLoggerOptions.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggerOptions.cs
@@ -108,11 +108,13 @@ public sealed class W3CLoggerOptions
 
     /// <summary>
     /// List of additional request header values to log.
-    /// The cookie header can contain authentication tokens,
+    /// <p>
+    /// Request headers can contain authentication tokens,
     /// or private information which may have regulatory concerns
-    /// under GDPR and other laws. Cookies should not be logged
-    /// unless logs are secure and access controlled
-    /// and the privacy impact assessed.
+    /// under GDPR and other laws. Arbitrary request headers
+    /// should not be logged unless logs are secure and
+    /// access controlled and the privacy impact assessed.
+    /// </p>
     /// </summary>
     public ISet<string>? AdditionalRequestHeaders { get; set; }
 

--- a/src/Middleware/HttpLogging/src/W3CLoggerOptions.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggerOptions.cs
@@ -114,7 +114,7 @@ public sealed class W3CLoggerOptions
     /// unless logs are secure and access controlled
     /// and the privacy impact assessed.
     /// </summary>
-    public IReadOnlyList<string>? AdditionalRequestHeaders { get; set; }
+    public ISet<string>? AdditionalRequestHeaders { get; set; }
 
     /// <summary>
     /// Fields to log. Defaults to logging request and response properties and headers,

--- a/src/Middleware/HttpLogging/src/W3CLoggerProcessor.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggerProcessor.cs
@@ -14,10 +14,12 @@ internal class W3CLoggerProcessor : FileLoggerProcessor
 #pragma warning restore CA1852 // Seal internal types
 {
     private readonly W3CLoggingFields _loggingFields;
+    private readonly IReadOnlyList<string>? _additionalRequestHeaders;
 
     public W3CLoggerProcessor(IOptionsMonitor<W3CLoggerOptions> options, IHostEnvironment environment, ILoggerFactory factory) : base(options, environment, factory)
     {
         _loggingFields = options.CurrentValue.LoggingFields;
+        _additionalRequestHeaders = options.CurrentValue.AdditionalRequestHeaders;
     }
 
     public override async Task OnFirstWrite(StreamWriter streamWriter, CancellationToken cancellationToken)
@@ -101,6 +103,14 @@ internal class W3CLoggerProcessor : FileLoggerProcessor
         if (_loggingFields.HasFlag(W3CLoggingFields.Referer))
         {
             sb.Append(" cs(Referer)");
+        }
+
+        if (_additionalRequestHeaders != null)
+        {
+            foreach (var header in _additionalRequestHeaders)
+            {
+                sb.Append($" cs({header})");
+            }
         }
 
         return sb.ToString();

--- a/src/Middleware/HttpLogging/src/W3CLoggerProcessor.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggerProcessor.cs
@@ -14,7 +14,7 @@ internal class W3CLoggerProcessor : FileLoggerProcessor
 #pragma warning restore CA1852 // Seal internal types
 {
     private readonly W3CLoggingFields _loggingFields;
-    private readonly IReadOnlyList<string>? _additionalRequestHeaders;
+    private readonly ISet<string>? _additionalRequestHeaders;
 
     public W3CLoggerProcessor(IOptionsMonitor<W3CLoggerOptions> options, IHostEnvironment environment, ILoggerFactory factory) : base(options, environment, factory)
     {

--- a/src/Middleware/HttpLogging/src/W3CLoggerProcessor.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggerProcessor.cs
@@ -19,7 +19,7 @@ internal class W3CLoggerProcessor : FileLoggerProcessor
     public W3CLoggerProcessor(IOptionsMonitor<W3CLoggerOptions> options, IHostEnvironment environment, ILoggerFactory factory) : base(options, environment, factory)
     {
         _loggingFields = options.CurrentValue.LoggingFields;
-        _additionalRequestHeaders = options.CurrentValue.AdditionalRequestHeaders;
+        _additionalRequestHeaders = W3CLoggerOptions.FilterRequestHeaders(options.CurrentValue);
     }
 
     public override async Task OnFirstWrite(StreamWriter streamWriter, CancellationToken cancellationToken)

--- a/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
@@ -79,7 +79,9 @@ internal sealed class W3CLoggingMiddleware
     {
         var options = _options.CurrentValue;
 
-        var elements = new string[_fieldsLength];
+        var additionalHeadersLength = _options.CurrentValue.AdditionalRequestHeaders?.Count ?? 0;
+
+        var elements = new string[_fieldsLength + additionalHeadersLength];
 
         // Whether any of the requested fields actually had content
         bool shouldLog = false;
@@ -179,6 +181,17 @@ internal sealed class W3CLoggingMiddleware
                     if (headers.TryGetValue(HeaderNames.Cookie, out var cookie))
                     {
                         shouldLog |= AddToList(elements, _cookieIndex, cookie.ToString());
+                    }
+                }
+
+                if (_options.CurrentValue.AdditionalRequestHeaders != null)
+                {
+                    for (var i = 0; i < additionalHeadersLength; i++)
+                    {
+                        if (headers.TryGetValue(_options.CurrentValue.AdditionalRequestHeaders[i], out var headerValue))
+                        {
+                            shouldLog |= AddToList(elements, i + _fieldsLength, headerValue.ToString());
+                        }
                     }
                 }
             }

--- a/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Linq;
 using System.Numerics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Internal;
@@ -186,9 +187,11 @@ internal sealed class W3CLoggingMiddleware
 
                 if (_options.CurrentValue.AdditionalRequestHeaders != null)
                 {
+                    var additionalRequestHeaders = _options.CurrentValue.AdditionalRequestHeaders.ToList();
+
                     for (var i = 0; i < additionalHeadersLength; i++)
                     {
-                        if (headers.TryGetValue(_options.CurrentValue.AdditionalRequestHeaders[i], out var headerValue))
+                        if (headers.TryGetValue(additionalRequestHeaders[i], out var headerValue))
                         {
                             shouldLog |= AddToList(elements, i + _fieldsLength, headerValue.ToString());
                         }

--- a/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
@@ -39,6 +39,7 @@ internal sealed class W3CLoggingMiddleware
     internal static readonly int _userAgentIndex = BitOperations.Log2((int)W3CLoggingFields.UserAgent);
     internal static readonly int _cookieIndex = BitOperations.Log2((int)W3CLoggingFields.Cookie);
     internal static readonly int _refererIndex = BitOperations.Log2((int)W3CLoggingFields.Referer);
+    private readonly ISet<string> _additionalRequestHeaders;
 
     // Number of fields in W3CLoggingFields - equal to the number of _*Index variables above
     internal const int _fieldsLength = 17;
@@ -69,6 +70,7 @@ internal sealed class W3CLoggingMiddleware
         _next = next;
         _options = options;
         _w3cLogger = w3cLogger;
+        _additionalRequestHeaders = W3CLoggerOptions.FilterRequestHeaders(options.CurrentValue);
     }
 
     /// <summary>
@@ -80,7 +82,7 @@ internal sealed class W3CLoggingMiddleware
     {
         var options = _options.CurrentValue;
 
-        var additionalHeadersLength = _options.CurrentValue.AdditionalRequestHeaders?.Count ?? 0;
+        var additionalHeadersLength = _additionalRequestHeaders.Count;
 
         var elements = new string[_fieldsLength + additionalHeadersLength];
 
@@ -185,9 +187,9 @@ internal sealed class W3CLoggingMiddleware
                     }
                 }
 
-                if (_options.CurrentValue.AdditionalRequestHeaders != null)
+                if (_additionalRequestHeaders.Count != 0)
                 {
-                    var additionalRequestHeaders = _options.CurrentValue.AdditionalRequestHeaders.ToList();
+                    var additionalRequestHeaders = _additionalRequestHeaders.ToList();
 
                     for (var i = 0; i < additionalHeadersLength; i++)
                     {

--- a/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
@@ -84,7 +84,8 @@ internal sealed class W3CLoggingMiddleware
 
         var additionalHeadersLength = _additionalRequestHeaders.Count;
 
-        var elements = new string[_fieldsLength + additionalHeadersLength];
+        var elements = new string[_fieldsLength];
+        var additionalHeaderElements = new string[additionalHeadersLength];
 
         // Whether any of the requested fields actually had content
         bool shouldLog = false;
@@ -195,7 +196,7 @@ internal sealed class W3CLoggingMiddleware
                     {
                         if (headers.TryGetValue(additionalRequestHeaders[i], out var headerValue))
                         {
-                            shouldLog |= AddToList(elements, i + _fieldsLength, headerValue.ToString());
+                            shouldLog |= AddToList(additionalHeaderElements, i, headerValue.ToString());
                         }
                     }
                 }
@@ -213,7 +214,7 @@ internal sealed class W3CLoggingMiddleware
             // Write the log
             if (shouldLog)
             {
-                _w3cLogger.Log(elements);
+                _w3cLogger.Log(elements, additionalHeaderElements);
             }
             throw;
         }
@@ -236,7 +237,7 @@ internal sealed class W3CLoggingMiddleware
         // Write the log
         if (shouldLog)
         {
-            _w3cLogger.Log(elements);
+            _w3cLogger.Log(elements, additionalHeaderElements);
         }
     }
 

--- a/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
@@ -27,10 +27,11 @@ public class W3CLoggerTests
             await using (var logger = new TestW3CLogger(new OptionsWrapperMonitor<W3CLoggerOptions>(options), new HostingEnvironment(), NullLoggerFactory.Instance))
             {
                 var elements = new string[W3CLoggingMiddleware._fieldsLength];
+                var additionalHeaders = new string[0];
                 AddToList(elements, W3CLoggingMiddleware._dateIndex, _timestampOne.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
                 AddToList(elements, W3CLoggingMiddleware._timeIndex, _timestampOne.ToString("HH:mm:ss", CultureInfo.InvariantCulture));
 
-                logger.Log(elements);
+                logger.Log(elements, additionalHeaders);
                 await logger.Processor.WaitForWrites(4).DefaultTimeout();
 
                 var lines = logger.Processor.Lines;
@@ -69,11 +70,12 @@ public class W3CLoggerTests
             await using (var logger = new TestW3CLogger(new OptionsWrapperMonitor<W3CLoggerOptions>(options), new HostingEnvironment(), NullLoggerFactory.Instance))
             {
                 var elements = new string[W3CLoggingMiddleware._fieldsLength];
+                var additionalHeaders = new string[0];
                 AddToList(elements, W3CLoggingMiddleware._uriQueryIndex, null);
                 AddToList(elements, W3CLoggingMiddleware._hostIndex, null);
                 AddToList(elements, W3CLoggingMiddleware._protocolStatusIndex, null);
 
-                logger.Log(elements);
+                logger.Log(elements, additionalHeaders);
                 await logger.Processor.WaitForWrites(4).DefaultTimeout();
 
                 var lines = logger.Processor.Lines;

--- a/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
@@ -107,7 +107,7 @@ public class W3CLoggingMiddlewareTests
     public async Task LogsAdditionalRequestHeaders()
     {
         var options = CreateOptionsAccessor();
-        options.CurrentValue.AdditionalRequestHeaders = new[] { "x-forwarded-for", "x-client-ssl-protocol" };
+        options.CurrentValue.AdditionalRequestHeaders = new[] { "x-forwarded-for", "x-client-ssl-protocol" }.ToHashSet();
 
         var logger = new TestW3CLogger(options, new HostingEnvironment(), NullLoggerFactory.Instance);
 

--- a/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
@@ -153,10 +153,11 @@ public class W3CLoggingMiddlewareTests
     public async Task OmitsDuplicateAdditionalRequestHeaders()
     {
         var options = CreateOptionsAccessor();
-        options.CurrentValue.LoggingFields = options.CurrentValue.LoggingFields & W3CLoggingFields.Host &
-                                             W3CLoggingFields.Referer & W3CLoggingFields.UserAgent &
+        options.CurrentValue.LoggingFields = options.CurrentValue.LoggingFields | W3CLoggingFields.Host |
+                                             W3CLoggingFields.Referer | W3CLoggingFields.UserAgent |
                                              W3CLoggingFields.Cookie;
 
+        options.CurrentValue.AdditionalRequestHeaders.Add(":invalid");
         options.CurrentValue.AdditionalRequestHeaders.Add("x-forwarded-for");
         options.CurrentValue.AdditionalRequestHeaders.Add("Host");
         options.CurrentValue.AdditionalRequestHeaders.Add("Referer");
@@ -197,8 +198,9 @@ public class W3CLoggingMiddlewareTests
         var delta = startDate.Subtract(now).TotalSeconds;
         Assert.InRange(delta, -1, 10);
 
-        Assert.Equal("#Fields: date time c-ip s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status time-taken cs-version cs-host cs(User-Agent) cs(Referer) cs(:invalid) cs(x-client-ssl-protocol) cs(x-forwarded-for)", lines[2]);
-        Assert.DoesNotContain("Snickerdoodle", lines[3]);
+        Assert.Equal("#Fields: date time c-ip s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status time-taken cs-version cs-host cs(User-Agent) cs(Cookie) cs(Referer) cs(:invalid) cs(x-client-ssl-protocol) cs(x-forwarded-for)", lines[2]);
+        Assert.Equal(19, lines[3].Split(' ').Length);
+        Assert.Contains("Snickerdoodle", lines[3]);
         Assert.Contains("- - 1.3.3.7,+2001:db8:85a3:8d3:1319:8a2e:370:7348", lines[3]);
     }
 

--- a/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
@@ -107,7 +107,9 @@ public class W3CLoggingMiddlewareTests
     public async Task LogsAdditionalRequestHeaders()
     {
         var options = CreateOptionsAccessor();
-        options.CurrentValue.AdditionalRequestHeaders = new[] { "x-forwarded-for", "x-client-ssl-protocol", ":invalid" }.ToHashSet();
+        options.CurrentValue.AdditionalRequestHeaders.Add("x-forwarded-for");
+        options.CurrentValue.AdditionalRequestHeaders.Add("x-client-ssl-protocol");
+        options.CurrentValue.AdditionalRequestHeaders.Add(":invalid");
 
         var logger = new TestW3CLogger(options, new HostingEnvironment(), NullLoggerFactory.Instance);
 

--- a/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
@@ -122,6 +122,59 @@ public class W3CLoggingMiddlewareTests
             options,
             logger);
 
+        options.CurrentValue.AdditionalRequestHeaders.Add("ignored-header-added-after-clone");
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Protocol = "HTTP/1.0";
+        httpContext.Request.Headers["Cookie"] = "Snickerdoodle";
+        httpContext.Request.Headers["x-forwarded-for"] = "1.3.3.7, 2001:db8:85a3:8d3:1319:8a2e:370:7348";
+        httpContext.Response.StatusCode = 200;
+
+        var now = DateTime.UtcNow;
+        await middleware.Invoke(httpContext);
+        await logger.Processor.WaitForWrites(4).DefaultTimeout();
+
+        var lines = logger.Processor.Lines;
+        Assert.Equal("#Version: 1.0", lines[0]);
+
+        Assert.StartsWith("#Start-Date: ", lines[1]);
+        var startDate = DateTime.Parse(lines[1].Substring(13), CultureInfo.InvariantCulture);
+        // Assert that the log was written in the last 10 seconds
+        // W3CLogger writes start-time to second precision, so delta could be as low as -0.999...
+        var delta = startDate.Subtract(now).TotalSeconds;
+        Assert.InRange(delta, -1, 10);
+
+        Assert.Equal("#Fields: date time c-ip s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status time-taken cs-version cs-host cs(User-Agent) cs(Referer) cs(:invalid) cs(x-client-ssl-protocol) cs(x-forwarded-for)", lines[2]);
+        Assert.DoesNotContain("Snickerdoodle", lines[3]);
+        Assert.EndsWith("- - 1.3.3.7,+2001:db8:85a3:8d3:1319:8a2e:370:7348", lines[3]);
+    }
+
+    [Fact]
+    public async Task OmitsDuplicateAdditionalRequestHeaders()
+    {
+        var options = CreateOptionsAccessor();
+        options.CurrentValue.LoggingFields = W3CLoggingFields.All;
+
+        options.CurrentValue.AdditionalRequestHeaders.Add("x-forwarded-for");
+        options.CurrentValue.AdditionalRequestHeaders.Add("Host");
+        options.CurrentValue.AdditionalRequestHeaders.Add("Referer");
+        options.CurrentValue.AdditionalRequestHeaders.Add("User-Agent");
+        options.CurrentValue.AdditionalRequestHeaders.Add("Cookie");
+        options.CurrentValue.AdditionalRequestHeaders.Add("x-client-ssl-protocol");
+
+        var logger = new TestW3CLogger(options, new HostingEnvironment(), NullLoggerFactory.Instance);
+
+        var middleware = new W3CLoggingMiddleware(
+            c =>
+            {
+                c.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            },
+            options,
+            logger);
+
+        options.CurrentValue.AdditionalRequestHeaders.Add("ignored-header-added-after-clone");
+
         var httpContext = new DefaultHttpContext();
         httpContext.Request.Protocol = "HTTP/1.0";
         httpContext.Request.Headers["Cookie"] = "Snickerdoodle";

--- a/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
@@ -153,7 +153,9 @@ public class W3CLoggingMiddlewareTests
     public async Task OmitsDuplicateAdditionalRequestHeaders()
     {
         var options = CreateOptionsAccessor();
-        options.CurrentValue.LoggingFields = W3CLoggingFields.All;
+        options.CurrentValue.LoggingFields = options.CurrentValue.LoggingFields & W3CLoggingFields.Host &
+                                             W3CLoggingFields.Referer & W3CLoggingFields.UserAgent &
+                                             W3CLoggingFields.Cookie;
 
         options.CurrentValue.AdditionalRequestHeaders.Add("x-forwarded-for");
         options.CurrentValue.AdditionalRequestHeaders.Add("Host");
@@ -195,9 +197,9 @@ public class W3CLoggingMiddlewareTests
         var delta = startDate.Subtract(now).TotalSeconds;
         Assert.InRange(delta, -1, 10);
 
-        Assert.Equal("#Fields: date time c-ip s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status time-taken cs-version cs-host cs(User-Agent) cs(Referer) cs(x-forwarded-for) cs(x-client-ssl-protocol) cs(:invalid)", lines[2]);
+        Assert.Equal("#Fields: date time c-ip s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status time-taken cs-version cs-host cs(User-Agent) cs(Referer) cs(:invalid) cs(x-client-ssl-protocol) cs(x-forwarded-for)", lines[2]);
         Assert.DoesNotContain("Snickerdoodle", lines[3]);
-        Assert.Contains("1.3.3.7,+2001:db8:85a3:8d3:1319:8a2e:370:7348 - -", lines[3]);
+        Assert.Contains("- - 1.3.3.7,+2001:db8:85a3:8d3:1319:8a2e:370:7348", lines[3]);
     }
 
     [Fact]

--- a/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
@@ -107,7 +107,7 @@ public class W3CLoggingMiddlewareTests
     public async Task LogsAdditionalRequestHeaders()
     {
         var options = CreateOptionsAccessor();
-        options.CurrentValue.AdditionalRequestHeaders = new[] { "x-forwarded-for", "x-client-ssl-protocol" }.ToHashSet();
+        options.CurrentValue.AdditionalRequestHeaders = new[] { "x-forwarded-for", "x-client-ssl-protocol", ":invalid" }.ToHashSet();
 
         var logger = new TestW3CLogger(options, new HostingEnvironment(), NullLoggerFactory.Instance);
 
@@ -140,9 +140,9 @@ public class W3CLoggingMiddlewareTests
         var delta = startDate.Subtract(now).TotalSeconds;
         Assert.InRange(delta, -1, 10);
 
-        Assert.Equal("#Fields: date time c-ip s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status time-taken cs-version cs-host cs(User-Agent) cs(Referer) cs(x-forwarded-for) cs(x-client-ssl-protocol)", lines[2]);
+        Assert.Equal("#Fields: date time c-ip s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status time-taken cs-version cs-host cs(User-Agent) cs(Referer) cs(x-forwarded-for) cs(x-client-ssl-protocol) cs(:invalid)", lines[2]);
         Assert.DoesNotContain("Snickerdoodle", lines[3]);
-        Assert.Contains("1.3.3.7,+2001:db8:85a3:8d3:1319:8a2e:370:7348 -", lines[3]);
+        Assert.Contains("1.3.3.7,+2001:db8:85a3:8d3:1319:8a2e:370:7348 - -", lines[3]);
     }
 
     [Fact]


### PR DESCRIPTION
# Add support for logging additional request headers

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Adds an _optional_ AdditionalRequestHeaders field to W3CLoggerOptions, which accepts a string list of request headers to be logged.

I'm unsure what docs need to be updated, but happy to submit a patch for those too. 

Fixes #41698
