### PR TITLE
Fix Integer Overflow in Header Processing

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -636,7 +636,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
         _requestTimedOut = false;
         _requestTargetForm = HttpRequestTarget.Unknown;
         _absoluteRequestTarget = null;
-        _remainingRequestHeadersBytesAllowed = ServerOptions.Limits.MaxRequestHeadersTotalSize + 2;
+        _remainingRequestHeadersBytesAllowed = (long)ServerOptions.Limits.MaxRequestHeadersTotalSize + 2;
 
         MinResponseDataRate = ServerOptions.Limits.MinResponseDataRate;
 

--- a/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
@@ -56,6 +56,17 @@ public class Http1ConnectionTests : Http1ConnectionTestsBase
     }
 
     [Fact]
+    public async Task MaxRequestHeadersTotalSizeDoesNotThrowForMaxValue()
+    {
+        const string headerLine = "Header: value\r\n";
+        _serviceContext.ServerOptions.Limits.MaxRequestHeadersTotalSize = int.MaxValue;
+        _http1Connection.Reset();
+
+        await _application.Output.WriteAsync(Encoding.ASCII.GetBytes($"{headerLine}\r\n"));
+        var readableBuffer = (await _transport.Input.ReadAsync()).Buffer;
+    }
+
+    [Fact]
     public async Task TakeMessageHeadersThrowsWhenHeadersExceedTotalSizeLimit()
     {
         const string headerLine = "Header: value\r\n";


### PR DESCRIPTION
# Fix Integer Overflow in Header Processing

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

When `MaxRequestHeadersTotalSize` is set to `int.MaxValue`, an integer overflow occurs inside `Http1Connection` forcing connections to fail.

## Description

A basic cast from `int` to `long` prior to the addition will solve this. I have attempted to include a Unit test, however I am unable to run unit tests to verify if this does in fact work as expected.

Fixes #41756
