### PR TITLE
Fix client results with Hub<T> IHubContext

### DIFF
--- a/src/SignalR/server/Core/src/Internal/HubClients`T.cs
+++ b/src/SignalR/server/Core/src/Internal/HubClients`T.cs
@@ -15,6 +15,11 @@ internal sealed class HubClients<THub, T> : IHubClients<T> where THub : Hub
 
     public T All { get; }
 
+    public T Single(string connectionId)
+    {
+        return TypedClientBuilder<T>.Build(new SingleClientProxyWithInvoke<THub>(_lifetimeManager, connectionId));
+    }
+
     public T AllExcept(IReadOnlyList<string> excludedConnectionIds)
     {
         return TypedClientBuilder<T>.Build(new AllClientsExceptProxy<THub>(_lifetimeManager, excludedConnectionIds));

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -530,6 +530,8 @@ public interface Test
 {
     Task Send(string message);
     Task Broadcast(string message);
+
+    Task<int> GetClientResult(int value);
 }
 
 public class OnConnectedThrowsHub : Hub


### PR DESCRIPTION
David found this while writing an app.

`IHubContext<Hub<T>, T>` didn't have `Single(string connectionId)` implemented and fell back to the DIM which throws `NotImplementedException`.