### PR TITLE
Add logging to M.E.Caching.StackExchangeRedis

### DIFF
--- a/src/Caching/StackExchangeRedis/src/Microsoft.Extensions.Caching.StackExchangeRedis.csproj
+++ b/src/Caching/StackExchangeRedis/src/Microsoft.Extensions.Caching.StackExchangeRedis.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.Extensions.Caching.Abstractions" />
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.Options" />
     <Reference Include="StackExchange.Redis" />
   </ItemGroup>

--- a/src/Caching/StackExchangeRedis/src/PublicAPI.Unshipped.txt
+++ b/src/Caching/StackExchangeRedis/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.Extensions.Caching.StackExchangeRedis.RedisCache.RedisCache(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions!>! optionsAccessor, Microsoft.Extensions.Logging.ILogger<Microsoft.Extensions.Caching.StackExchangeRedis.RedisCache!>! logger) -> void

--- a/src/Caching/StackExchangeRedis/src/PublicAPI.Unshipped.txt
+++ b/src/Caching/StackExchangeRedis/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 #nullable enable
-Microsoft.Extensions.Caching.StackExchangeRedis.RedisCache.RedisCache(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions!>! optionsAccessor, Microsoft.Extensions.Logging.ILogger<Microsoft.Extensions.Caching.StackExchangeRedis.RedisCache!>! logger) -> void

--- a/src/Caching/StackExchangeRedis/src/RedisCache.Log.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.Log.cs
@@ -10,7 +10,7 @@ public partial class RedisCache
 {
     private static partial class Log
     {
-        [LoggerMessage(1, LogLevel.Warning, "Could not determine the Redis server version as the GetServer() operation is not supported.", EventName = "GetServerNotSupported")]
-        public static partial void GetServerNotSupported(ILogger logger, Exception exception);
+        [LoggerMessage(1, LogLevel.Warning, "Could not determine the Redis server version. Falling back to use HMSET command instead of HSET.", EventName = "CouldNotDetermineServerVersion")]
+        public static partial void CouldNotDetermineServerVersion(ILogger logger, Exception exception);
     }
 }

--- a/src/Caching/StackExchangeRedis/src/RedisCache.Log.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.Log.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Extensions.Caching.StackExchangeRedis;
+
+public partial class RedisCache
+{
+    private static partial class Log
+    {
+        [LoggerMessage(1, LogLevel.Warning, "Could not determine the Redis server version as the GetServer() operation is not supported.", EventName = "GetServerNotSupported")]
+        public static partial void GetServerNotSupported(ILogger logger, Exception exception);
+    }
+}

--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;
@@ -60,7 +59,7 @@ public partial class RedisCache : IDistributedCache, IDisposable
 
     private readonly RedisCacheOptions _options;
     private readonly string _instance;
-    private readonly ILogger<RedisCache> _logger;
+    private readonly ILogger _logger;
 
     private readonly SemaphoreSlim _connectionLock = new SemaphoreSlim(initialCount: 1, maxCount: 1);
 
@@ -78,8 +77,7 @@ public partial class RedisCache : IDistributedCache, IDisposable
     /// </summary>
     /// <param name="optionsAccessor">The configuration options.</param>
     /// <param name="logger">The logger.</param>
-    [ActivatorUtilitiesConstructor]
-    public RedisCache(IOptions<RedisCacheOptions> optionsAccessor, ILogger<RedisCache> logger)
+    internal RedisCache(IOptions<RedisCacheOptions> optionsAccessor, ILogger logger)
     {
         if (optionsAccessor == null)
         {

--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -323,7 +323,7 @@ public partial class RedisCache : IDistributedCache, IDisposable
         }
         catch (NotSupportedException ex)
         {
-            Log.GetServerNotSupported(_logger, ex);
+            Log.CouldNotDetermineServerVersion(_logger, ex);
 
             // The GetServer call may not be supported with some configurations, in which
             // case let's also fall back to using the older command.

--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -7,6 +7,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 
@@ -16,7 +18,7 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis;
 /// Distributed cache implementation using Redis.
 /// <para>Uses <c>StackExchange.Redis</c> as the Redis client.</para>
 /// </summary>
-public class RedisCache : IDistributedCache, IDisposable
+public partial class RedisCache : IDistributedCache, IDisposable
 {
     // -- Explanation of why two kinds of SetScript are used --
     // * Redis 2.0 had HSET key field value for setting individual hash fields,
@@ -58,6 +60,7 @@ public class RedisCache : IDistributedCache, IDisposable
 
     private readonly RedisCacheOptions _options;
     private readonly string _instance;
+    private readonly ILogger<RedisCache> _logger;
 
     private readonly SemaphoreSlim _connectionLock = new SemaphoreSlim(initialCount: 1, maxCount: 1);
 
@@ -66,13 +69,30 @@ public class RedisCache : IDistributedCache, IDisposable
     /// </summary>
     /// <param name="optionsAccessor">The configuration options.</param>
     public RedisCache(IOptions<RedisCacheOptions> optionsAccessor)
+        : this(optionsAccessor, Logging.Abstractions.NullLoggerFactory.Instance.CreateLogger<RedisCache>())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="RedisCache"/>.
+    /// </summary>
+    /// <param name="optionsAccessor">The configuration options.</param>
+    /// <param name="logger">The logger.</param>
+    [ActivatorUtilitiesConstructor]
+    public RedisCache(IOptions<RedisCacheOptions> optionsAccessor, ILogger<RedisCache> logger)
     {
         if (optionsAccessor == null)
         {
             throw new ArgumentNullException(nameof(optionsAccessor));
         }
 
+        if (logger == null)
+        {
+            throw new ArgumentNullException(nameof(logger));
+        }
+
         _options = optionsAccessor.Value;
+        _logger = logger;
 
         // This allows partitioning a single backend cache for use with multiple apps/services.
         _instance = _options.InstanceName ?? string.Empty;
@@ -303,8 +323,10 @@ public class RedisCache : IDistributedCache, IDisposable
                 }
             }
         }
-        catch (NotSupportedException)
+        catch (NotSupportedException ex)
         {
+            Log.GetServerNotSupported(_logger, ex);
+
             // The GetServer call may not be supported with some configurations, in which
             // case let's also fall back to using the older command.
             _setScript = SetScriptPreExtendedSetCommand;

--- a/src/Caching/StackExchangeRedis/src/RedisCacheImpl.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCacheImpl.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.Caching.StackExchangeRedis;
+
+internal sealed class RedisCacheImpl : RedisCache
+{
+    public RedisCacheImpl(IOptions<RedisCacheOptions> optionsAccessor, ILogger<RedisCacheImpl> logger)
+        : base(optionsAccessor, logger)
+    {
+    }
+}

--- a/src/Caching/StackExchangeRedis/src/RedisCacheImpl.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCacheImpl.cs
@@ -8,8 +8,13 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis;
 
 internal sealed class RedisCacheImpl : RedisCache
 {
-    public RedisCacheImpl(IOptions<RedisCacheOptions> optionsAccessor, ILogger<RedisCacheImpl> logger)
+    public RedisCacheImpl(IOptions<RedisCacheOptions> optionsAccessor, ILogger<RedisCache> logger)
         : base(optionsAccessor, logger)
+    {
+    }
+
+    public RedisCacheImpl(IOptions<RedisCacheOptions> optionsAccessor)
+        : base(optionsAccessor)
     {
     }
 }

--- a/src/Caching/StackExchangeRedis/src/StackExchangeRedisCacheServiceCollectionExtensions.cs
+++ b/src/Caching/StackExchangeRedis/src/StackExchangeRedisCacheServiceCollectionExtensions.cs
@@ -43,7 +43,7 @@ public static class StackExchangeRedisCacheServiceCollectionExtensions
 #endif
 
         services.Configure(setupAction);
-        services.Add(ServiceDescriptor.Singleton<IDistributedCache, RedisCache>());
+        services.Add(ServiceDescriptor.Singleton<IDistributedCache, RedisCacheImpl>());
 
         return services;
     }

--- a/src/Caching/StackExchangeRedis/src/StackExchangeRedisCacheServiceCollectionExtensions.cs
+++ b/src/Caching/StackExchangeRedis/src/StackExchangeRedisCacheServiceCollectionExtensions.cs
@@ -4,8 +4,6 @@
 using System;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.StackExchangeRedis;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -34,13 +32,6 @@ public static class StackExchangeRedisCacheServiceCollectionExtensions
         }
 
         services.AddOptions();
-
-#if NET7_0_OR_GREATER
-        services.AddLogging();
-#else
-        services.TryAddSingleton<ILoggerFactory>(Logging.Abstractions.NullLoggerFactory.Instance);
-        services.TryAdd(ServiceDescriptor.Singleton(typeof(ILogger<>), typeof(Logger<>)));
-#endif
 
         services.Configure(setupAction);
         services.Add(ServiceDescriptor.Singleton<IDistributedCache, RedisCacheImpl>());

--- a/src/Caching/StackExchangeRedis/src/StackExchangeRedisCacheServiceCollectionExtensions.cs
+++ b/src/Caching/StackExchangeRedis/src/StackExchangeRedisCacheServiceCollectionExtensions.cs
@@ -4,6 +4,8 @@
 using System;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.StackExchangeRedis;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -32,6 +34,14 @@ public static class StackExchangeRedisCacheServiceCollectionExtensions
         }
 
         services.AddOptions();
+
+#if NET7_0_OR_GREATER
+        services.AddLogging();
+#else
+        services.TryAddSingleton<ILoggerFactory>(Logging.Abstractions.NullLoggerFactory.Instance);
+        services.TryAdd(ServiceDescriptor.Singleton(typeof(ILogger<>), typeof(Logger<>)));
+#endif
+
         services.Configure(setupAction);
         services.Add(ServiceDescriptor.Singleton<IDistributedCache, RedisCache>());
 

--- a/src/Caching/StackExchangeRedis/test/CacheServiceExtensionsTests.cs
+++ b/src/Caching/StackExchangeRedis/test/CacheServiceExtensionsTests.cs
@@ -58,6 +58,39 @@ public class CacheServiceExtensionsTests
     }
 
     [Fact]
+    public void AddStackExchangeRedisCache_IDistributedCacheWithoutLoggingCanBeResolved()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddStackExchangeRedisCache(options => { });
+
+        // Assert
+        using var serviceProvider = services.BuildServiceProvider();
+        var distributedCache = serviceProvider.GetRequiredService<IDistributedCache>();
+
+        Assert.NotNull(distributedCache);
+    }
+
+    [Fact]
+    public void AddStackExchangeRedisCache_IDistributedCacheWithLoggingCanBeResolved()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddStackExchangeRedisCache(options => { });
+        services.AddLogging();
+
+        // Assert
+        using var serviceProvider = services.BuildServiceProvider();
+        var distributedCache = serviceProvider.GetRequiredService<IDistributedCache>();
+
+        Assert.NotNull(distributedCache);
+    }
+
+    [Fact]
     public void AddStackExchangeRedisCache_UsesLoggerFactoryAlreadyRegisteredWithServiceCollection()
     {
         // Arrange
@@ -74,6 +107,7 @@ public class CacheServiceExtensionsTests
         services.AddScoped(typeof(ILoggerFactory), _ => loggerFactory.Object);
 
         // Act
+        services.AddLogging();
         services.AddStackExchangeRedisCache(options => { });
 
         // Assert

--- a/src/Caching/StackExchangeRedis/test/CacheServiceExtensionsTests.cs
+++ b/src/Caching/StackExchangeRedis/test/CacheServiceExtensionsTests.cs
@@ -4,6 +4,8 @@
 using System.Linq;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -44,7 +46,7 @@ public class CacheServiceExtensionsTests
 
         Assert.NotNull(distributedCache);
         Assert.Equal(ServiceLifetime.Scoped, distributedCache.Lifetime);
-        Assert.IsType<RedisCache>(serviceProvider.GetRequiredService<IDistributedCache>());
+        Assert.IsAssignableFrom<RedisCache>(serviceProvider.GetRequiredService<IDistributedCache>());
     }
 
     [Fact]
@@ -53,5 +55,36 @@ public class CacheServiceExtensionsTests
         var services = new ServiceCollection();
 
         Assert.Same(services, services.AddStackExchangeRedisCache(_ => { }));
+    }
+
+    [Fact]
+    public void AddStackExchangeRedisCache_UsesLoggerFactoryAlreadyRegisteredWithServiceCollection()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddScoped(typeof(IDistributedCache), sp => Mock.Of<IDistributedCache>());
+
+        var loggerFactory = new Mock<ILoggerFactory>();
+
+        loggerFactory
+            .Setup(lf => lf.CreateLogger(It.IsAny<string>()))
+            .Returns((string name) => NullLoggerFactory.Instance.CreateLogger(name))
+            .Verifiable();
+
+        services.AddScoped(typeof(ILoggerFactory), _ => loggerFactory.Object);
+
+        // Act
+        services.AddStackExchangeRedisCache(options => { });
+
+        // Assert
+        var serviceProvider = services.BuildServiceProvider();
+
+        var distributedCache = services.FirstOrDefault(desc => desc.ServiceType == typeof(IDistributedCache));
+
+        Assert.NotNull(distributedCache);
+        Assert.Equal(ServiceLifetime.Scoped, distributedCache.Lifetime);
+        Assert.IsAssignableFrom<RedisCache>(serviceProvider.GetRequiredService<IDistributedCache>());
+
+        loggerFactory.Verify();
     }
 }


### PR DESCRIPTION
# Add logging to M.E.Caching.StackExchangeRedis

Support logging in the `RedisCache` class.

## Description

- Add logging to M.E.Caching.StackExchangeRedis.
- Log warning if Redis server version cannot be detected.

Fixes #41723
