### PR TITLE
Fix line endings for SPA proxy script on MacOS

### DIFF
--- a/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
+++ b/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
@@ -251,7 +251,7 @@ catch
     {
         var fileName = Guid.NewGuid().ToString("N") + ".sh";
         var scriptPath = Path.Combine(AppContext.BaseDirectory, fileName);
-        var stopScript = @$"function list_child_processes(){{
+        var stopScript = @$"function list_child_processes () {{
     local ppid=$1;
     local current_children=$(pgrep -P $ppid);
     local local_child;
@@ -282,7 +282,7 @@ do
 done;
 rm {scriptPath};
 ";
-        File.WriteAllText(scriptPath, stopScript);
+        File.WriteAllText(scriptPath, stopScript.ReplaceLineEndings());
 
         var stopScriptInfo = new ProcessStartInfo("/bin/bash", scriptPath)
         {


### PR DESCRIPTION
## Fix line endings for SPA proxy script on MacOS

The bash script generated in SpaProxyLaunchManager was using CRLF line endings, which caused the script to fail on MacOS. This PR fixes the issue by replacing the script's line endings with those used by the current platform.

Fixes #39261