### PR TITLE
[release/6.0] Fix line endings for SPA proxy script on MacOS

### DIFF
--- a/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
+++ b/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
@@ -282,7 +282,7 @@ do
 done;
 rm {scriptPath};
 ";
-            File.WriteAllText(scriptPath, stopScript);
+            File.WriteAllText(scriptPath, stopScript.ReplaceLineEndings());
 
             var stopScriptInfo = new ProcessStartInfo("/bin/bash", scriptPath)
             {

--- a/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
+++ b/src/Middleware/Spa/SpaProxy/src/SpaProxyLaunchManager.cs
@@ -251,7 +251,7 @@ catch
         {
             var fileName = Guid.NewGuid().ToString("N") + ".sh";
             var scriptPath = Path.Combine(AppContext.BaseDirectory, fileName);
-            var stopScript = @$"function list_child_processes(){{
+            var stopScript = @$"function list_child_processes () {{
     local ppid=$1;
     local current_children=$(pgrep -P $ppid);
     local local_child;


### PR DESCRIPTION
# Fix line endings for SPA proxy script on MacOS

Fixes an issue where the SPA proxy stop script would fail on MacOS.

## Description

The generated script that kills old SPA proxy child processes was failing on MacOS due to the script having CRLF line endings. This PR solves the problem by applying line endings for the current platform.

Fixes #39261

## Customer Impact

If child processes are not killed properly, running the project multiple times may fail, forcing the customer to manually kill orphaned processes.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The change is small, and it uses `string.ReplaceLineEndings()`, which is a reliable method for replacing the line endings of a string with those appropriate for the current platform.

## Verification

- [X] Manual (required)
- [ ] Automated

Before:
![image](https://user-images.githubusercontent.com/10456961/170131767-7b610829-06ef-48b2-9c0a-3bb1013c7aef.png)

After:
![image](https://user-images.githubusercontent.com/10456961/170131834-fe3dc1e0-13ab-4c42-b7d1-f7dce3152ae8.png)

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A