### PR TITLE
DataProtection use 6.0 app discriminator trailing slash format

### DIFF
--- a/src/DataProtection/DataProtection/src/Internal/HostingApplicationDiscriminator.cs
+++ b/src/DataProtection/DataProtection/src/Internal/HostingApplicationDiscriminator.cs
@@ -36,7 +36,7 @@ internal sealed class HostingApplicationDiscriminator : IApplicationDiscriminato
             {
                 return contentRoot;
             }
-            return contentRoot.Trim() + DirectorySeparator;
+            return contentRoot + DirectorySeparator;
         }
     }
 }

--- a/src/DataProtection/DataProtection/src/Internal/HostingApplicationDiscriminator.cs
+++ b/src/DataProtection/DataProtection/src/Internal/HostingApplicationDiscriminator.cs
@@ -12,7 +12,6 @@ internal sealed class HostingApplicationDiscriminator : IApplicationDiscriminato
 {
     private readonly IHostEnvironment? _hosting;
     private readonly string DirectorySeparator = Path.DirectorySeparatorChar.ToString();
-    private readonly string AltDirectorySeparator = Path.AltDirectorySeparatorChar.ToString();
 
     // the optional constructor for when IHostingEnvironment is not available from DI
     public HostingApplicationDiscriminator()
@@ -31,10 +30,9 @@ internal sealed class HostingApplicationDiscriminator : IApplicationDiscriminato
     {
         get
         {
-            var contentRoot = _hosting?.ContentRootPath;
-            if (string.IsNullOrWhiteSpace(contentRoot) ||
-                contentRoot.EndsWith(DirectorySeparator, StringComparison.OrdinalIgnoreCase) ||
-                contentRoot.EndsWith(AltDirectorySeparator, StringComparison.OrdinalIgnoreCase))
+            var contentRoot = _hosting?.ContentRootPath?.Trim();
+            if (string.IsNullOrEmpty(contentRoot) ||
+                contentRoot.EndsWith(DirectorySeparator, StringComparison.OrdinalIgnoreCase))
             {
                 return contentRoot;
             }

--- a/src/DataProtection/DataProtection/src/Internal/HostingApplicationDiscriminator.cs
+++ b/src/DataProtection/DataProtection/src/Internal/HostingApplicationDiscriminator.cs
@@ -12,6 +12,7 @@ internal sealed class HostingApplicationDiscriminator : IApplicationDiscriminato
 {
     private readonly IHostEnvironment? _hosting;
     private readonly string DirectorySeparator = Path.DirectorySeparatorChar.ToString();
+    private readonly string AltDirectorySeparator = Path.AltDirectorySeparatorChar.ToString();
 
     // the optional constructor for when IHostingEnvironment is not available from DI
     public HostingApplicationDiscriminator()
@@ -32,7 +33,8 @@ internal sealed class HostingApplicationDiscriminator : IApplicationDiscriminato
         {
             var contentRoot = _hosting?.ContentRootPath?.Trim();
             if (string.IsNullOrEmpty(contentRoot) ||
-                contentRoot.EndsWith(DirectorySeparator, StringComparison.OrdinalIgnoreCase))
+                contentRoot.EndsWith(DirectorySeparator, StringComparison.OrdinalIgnoreCase) ||
+                contentRoot.EndsWith(AltDirectorySeparator, StringComparison.OrdinalIgnoreCase))
             {
                 return contentRoot;
             }

--- a/src/DataProtection/DataProtection/test/DataProtectionUtilityExtensionsTests.cs
+++ b/src/DataProtection/DataProtection/test/DataProtectionUtilityExtensionsTests.cs
@@ -11,8 +11,12 @@ namespace Microsoft.AspNetCore.DataProtection;
 public class DataProtectionUtilityExtensionsTests
 {
     [Theory]
-    [InlineData("app-path", "app-path")]
-    [InlineData("app-path ", "app-path")] // normalized trim
+    [InlineData("app-path", "app-path\\")]
+    [InlineData("app-path ", "app-path\\")] // normalized trim
+    [InlineData("app-path\\", "app-path\\")]
+    [InlineData("app-path/", "app-path/")]
+    [InlineData(" /", "/")]
+    [InlineData(" \\ ", "\\")]
     [InlineData("  ", null)] // normalized whitespace -> null
     [InlineData(null, null)] // nothing provided at all
     public void GetApplicationUniqueIdentifierFromHosting(string contentRootPath, string expected)

--- a/src/DataProtection/DataProtection/test/DataProtectionUtilityExtensionsTests.cs
+++ b/src/DataProtection/DataProtection/test/DataProtectionUtilityExtensionsTests.cs
@@ -46,9 +46,9 @@ public class DataProtectionUtilityExtensionsTests
     [ConditionalTheory]
     [InlineData("app-path", "app-path/")]
     [InlineData("app-path ", "app-path/")] // normalized trim
-    [InlineData("app-path\\", "app-path\\")]
-    [InlineData("app-path \\", "app-path \\")]
-    [InlineData("app-path/", "app-path")]
+    [InlineData("app-path\\", "app-path/")]
+    [InlineData("app-path \\", "app-path /")]
+    [InlineData("app-path/", "app-path/")]
     [InlineData("app-path /", "app-path /")]
     [InlineData(" /", "/")]
     [InlineData(" \\ ", "\\/")]

--- a/src/DataProtection/DataProtection/test/DataProtectionUtilityExtensionsTests.cs
+++ b/src/DataProtection/DataProtection/test/DataProtectionUtilityExtensionsTests.cs
@@ -46,8 +46,8 @@ public class DataProtectionUtilityExtensionsTests
     [ConditionalTheory]
     [InlineData("app-path", "app-path/")]
     [InlineData("app-path ", "app-path/")] // normalized trim
-    [InlineData("app-path\\", "app-path/")]
-    [InlineData("app-path \\", "app-path /")]
+    [InlineData("app-path\\", "app-path\\/")]
+    [InlineData("app-path \\", "app-path \\/")]
     [InlineData("app-path/", "app-path/")]
     [InlineData("app-path /", "app-path /")]
     [InlineData(" /", "/")]

--- a/src/DataProtection/DataProtection/test/DataProtectionUtilityExtensionsTests.cs
+++ b/src/DataProtection/DataProtection/test/DataProtectionUtilityExtensionsTests.cs
@@ -16,9 +16,9 @@ public class DataProtectionUtilityExtensionsTests
     [InlineData("app-path ", "app-path\\")] // normalized trim
     [InlineData("app-path\\", "app-path\\")]
     [InlineData("app-path \\", "app-path \\")]
-    [InlineData("app-path/", "app-path/\\")]
-    [InlineData("app-path /", "app-path /\\")]
-    [InlineData(" /", "/\\")]
+    [InlineData("app-path/", "app-path/")]
+    [InlineData("app-path /", "app-path /")]
+    [InlineData(" /", "/")]
     [InlineData(" \\ ", "\\")]
     [InlineData("  ", null)] // normalized whitespace -> null
     [InlineData(null, null)] // nothing provided at all
@@ -46,9 +46,9 @@ public class DataProtectionUtilityExtensionsTests
     [ConditionalTheory]
     [InlineData("app-path", "app-path/")]
     [InlineData("app-path ", "app-path/")] // normalized trim
-    [InlineData("app-path\\", "app-path\\/")]
-    [InlineData("app-path \\", "app-path \\/")]
-    [InlineData("app-path/", "app-path/")]
+    [InlineData("app-path\\", "app-path\\")]
+    [InlineData("app-path \\", "app-path \\")]
+    [InlineData("app-path/", "app-path")]
     [InlineData("app-path /", "app-path /")]
     [InlineData(" /", "/")]
     [InlineData(" \\ ", "\\/")]

--- a/src/DataProtection/DataProtection/test/HostingTests.cs
+++ b/src/DataProtection/DataProtection/test/HostingTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.DataProtection.Infrastructure;
 using Microsoft.AspNetCore.DataProtection.KeyManagement.Internal;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
@@ -17,28 +16,6 @@ namespace Microsoft.AspNetCore.DataProtection.Test;
 
 public class HostingTests
 {
-    [Fact]
-    public void DefaultApplicationDiscriminatorTrimsTrailingSlash()
-    {
-        var builder = new WebHostBuilder()
-            .UseStartup<TestStartup>()
-            .ConfigureServices(s => s.AddDataProtection());
-
-        using (var host = builder.Build())
-        {
-            var contentRootPath = host.Services.GetRequiredService<IWebHostEnvironment>().ContentRootPath;
-            Assert.True(contentRootPath.EndsWith(Path.DirectorySeparatorChar), "expected contentRootPath to end with a slash");
-
-            var appDisc = host.Services.GetRequiredService<IApplicationDiscriminator>().Discriminator;
-            Assert.False(appDisc.EndsWith(Path.DirectorySeparatorChar), "expected appDiscriminator to have slash trimmed");
-            Assert.False(appDisc.EndsWith(Path.AltDirectorySeparatorChar), "expected appDiscriminator to have slash trimmed");
-
-            var appId = host.Services.GetApplicationUniqueIdentifier();
-            Assert.False(appId.EndsWith(Path.DirectorySeparatorChar), "expected appId to have slash trimmed");
-            Assert.False(appId.EndsWith(Path.AltDirectorySeparatorChar), "expected appId to have slash trimmed");
-        }
-    }
-
     [Fact]
     public async Task WebhostLoadsKeyRingBeforeServerStarts()
     {


### PR DESCRIPTION
We can't normalize to non trailing slash for the HostingDiscriminator if we want to be able to read 6.0 cookies, so we must normalize by adding a trailing slash instead.

Fixes https://github.com/aspnet/AspNetCore-ManualTests/issues/1257