### PR TITLE
Use GetFolderPath(UserProfile) to obtain HOME dir

### DIFF
--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -493,10 +493,9 @@ public class KestrelConfigurationLoader
 
     private bool TryGetCertificatePath([NotNullWhen(true)] out string? path)
     {
-        // This will go away when we implement
-        // https://github.com/aspnet/Hosting/issues/1294
+        // See https://github.com/aspnet/Hosting/issues/1294
         var appData = Environment.GetEnvironmentVariable("APPDATA");
-        var home = Environment.GetEnvironmentVariable("HOME");
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         var basePath = appData != null ? Path.Combine(appData, "ASP.NET", "https") : null;
         basePath = basePath ?? (home != null ? Path.Combine(home, ".aspnet", "https") : null);
         path = basePath != null ? Path.Combine(basePath, $"{HostEnvironment.ApplicationName}.pfx") : null;

--- a/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation;
 internal sealed class MacOSCertificateManager : CertificateManager
 {
     private const string CertificateSubjectRegex = "CN=(.*[^,]+).*";
-    private static readonly string MacOSUserKeyChain = Environment.GetEnvironmentVariable("HOME") + "/Library/Keychains/login.keychain-db";
+    private static readonly string MacOSUserKeyChain = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) + "/Library/Keychains/login.keychain-db";
     private const string MacOSSystemKeyChain = "/Library/Keychains/System.keychain";
     private const string MacOSFindCertificateCommandLine = "security";
     private const string MacOSFindCertificateCommandLineArgumentsFormat = "find-certificate -c {0} -a -Z -p " + MacOSSystemKeyChain;
@@ -91,7 +91,7 @@ internal sealed class MacOSCertificateManager : CertificateManager
 
     internal override CheckCertificateStateResult CheckCertificateState(X509Certificate2 candidate, bool interactive)
     {
-        var sentinelPath = Path.Combine(Environment.GetEnvironmentVariable("HOME")!, ".dotnet", $"certificates.{candidate.GetCertHashString(HashAlgorithmName.SHA256)}.sentinel");
+        var sentinelPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dotnet", $"certificates.{candidate.GetCertHashString(HashAlgorithmName.SHA256)}.sentinel");
         if (!interactive && !File.Exists(sentinelPath))
         {
             return new CheckCertificateStateResult(false, KeyNotAccessibleWithoutUserInteraction);


### PR DESCRIPTION
The BCL API `Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)` provides fallback in case environment variable, corresponding to platform-specific home directory, is not set. e.g. on Unix it fallback to `getpwuid_r` call and similarly on Windows it uses a Win32 API as fallback.