### PR TITLE
Error retrieving the current token in a Blazor application after successful authentication with Oidc client

### DIFF
--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/AuthenticationService.ts
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/AuthenticationService.ts
@@ -111,7 +111,9 @@ class OidcAuthorizeService implements AuthorizeService {
                 const parameters = request && request.scopes ?
                     { scope: request.scopes.join(' ') } : undefined;
 
-                const newUser = await this._userManager.signinSilent(parameters);
+                const newUser = await this._userManager.signinSilent(Object.assign({}, {
+                    response_type: 'id_token token'
+                }, parameters));
 
                 return {
                     status: AccessTokenResultStatus.Success,


### PR DESCRIPTION
# Change `response_type` in `signinSilent` when getting the **access_token**

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

{Detail}

Fixes #39311
