### PR TITLE
Windows.11.Amd64.ClientPre.Open is leaving in June, switch to non-preview

### DIFF
--- a/eng/scripts/RunHelix.ps1
+++ b/eng/scripts/RunHelix.ps1
@@ -16,7 +16,7 @@
     OSX.1015.Amd64.Open
     OSX.1100.Amd64.Open
     Windows.10.Amd64.Server20H2.Open
-    Windows.11.Amd64.ClientPre.Open
+    Windows.11.Amd64.Client.Open
     Windows.Amd64.Server2022.Open
 .PARAMETER RunQuarantinedTests
     By default quarantined tests are not run. Set this to $true to run only the quarantined tests.

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -29,7 +29,7 @@
       <ItemGroup>
         <HelixAvailableTargetQueue Include="Ubuntu.1804.Amd64.Open" Platform="Linux" />
         <HelixAvailableTargetQueue Include="OSX.1100.Amd64.Open" Platform="OSX" />
-        <HelixAvailableTargetQueue Include="Windows.11.Amd64.ClientPre.Open" Platform="Windows" />
+        <HelixAvailableTargetQueue Include="Windows.11.Amd64.Client.Open" Platform="Windows" />
       </ItemGroup>
     </When>
     <Otherwise>


### PR DESCRIPTION
Windows.11.Amd64.ClientPre.Open is leaving in June, switch to non-preview

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Helix queue Windows.11.Amd64.ClientPre.Open is slated for removal mid-June, replaces with new more permanent (life cycle of Windows 11 client) image. 