### PR TITLE
adds kiota to dotnet openapi tool

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -264,7 +264,7 @@
     <NewtonsoftJsonBsonVersion>1.0.2</NewtonsoftJsonBsonVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <NSwagApiDescriptionClientVersion>13.0.4</NSwagApiDescriptionClientVersion>
-    <KiotaApiDescriptionClientVersion>0.5.0-preview</KiotaApiDescriptionClientVersion>
+    <KiotaApiDescriptionClientVersion>0.5.0-preview2</KiotaApiDescriptionClientVersion>
     <PhotinoNETVersion>1.1.6</PhotinoNETVersion>
     <MicrosoftPlaywrightVersion>1.17.3</MicrosoftPlaywrightVersion>
     <PollyExtensionsHttpVersion>3.0.0</PollyExtensionsHttpVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -264,6 +264,7 @@
     <NewtonsoftJsonBsonVersion>1.0.2</NewtonsoftJsonBsonVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <NSwagApiDescriptionClientVersion>13.0.4</NSwagApiDescriptionClientVersion>
+    <KiotaApiDescriptionClientVersion>0.5.0-preview</KiotaApiDescriptionClientVersion>
     <PhotinoNETVersion>1.1.6</PhotinoNETVersion>
     <MicrosoftPlaywrightVersion>1.17.3</MicrosoftPlaywrightVersion>
     <PollyExtensionsHttpVersion>3.0.0</PollyExtensionsHttpVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -265,6 +265,11 @@
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <NSwagApiDescriptionClientVersion>13.0.4</NSwagApiDescriptionClientVersion>
     <KiotaApiDescriptionClientVersion>0.5.0-preview2</KiotaApiDescriptionClientVersion>
+    <KiotaDotnetAbstractionsVersion>1.0.0-preview8</KiotaDotnetAbstractionsVersion>
+    <KiotaDotnetSerializationJsonVersion>1.0.0-preview6</KiotaDotnetSerializationJsonVersion>
+    <KiotaDotnetSerializationTextVersion>1.0.0-preview3</KiotaDotnetSerializationTextVersion>
+    <KiotaDotnetAuthenticationAzureVersion>1.0.0-preview3</KiotaDotnetAuthenticationAzureVersion>
+    <KiotaDotnetHttpVersion>1.0.0-preview8</KiotaDotnetHttpVersion>
     <PhotinoNETVersion>1.1.6</PhotinoNETVersion>
     <MicrosoftPlaywrightVersion>1.17.3</MicrosoftPlaywrightVersion>
     <PollyExtensionsHttpVersion>3.0.0</PollyExtensionsHttpVersion>

--- a/src/Tools/Microsoft.dotnet-openapi/src/CodeGenerator.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/src/CodeGenerator.cs
@@ -6,5 +6,7 @@ namespace Microsoft.DotNet.OpenApi;
 public enum CodeGenerator
 {
     NSwagCSharp,
-    NSwagTypeScript
+    NSwagTypeScript,
+    KiotaCSharp,
+    KiotaTypeScript,
 }

--- a/src/Tools/Microsoft.dotnet-openapi/src/Microsoft.dotnet-openapi.csproj
+++ b/src/Tools/Microsoft.dotnet-openapi/src/Microsoft.dotnet-openapi.csproj
@@ -31,5 +31,10 @@
       <_Parameter2>$(NewtonsoftJsonVersion)</_Parameter2>
       <_Parameter3>NSwagCSharp;NSwagTypeScript</_Parameter3>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="Microsoft.DotNet.Openapi.Tools.Internal.OpenApiDependencyAttribute">
+      <_Parameter1>Microsoft.OpenApi.Kiota.ApiDescription.Client</_Parameter1>
+      <_Parameter2>$(KiotaApiDescriptionClientVersion)</_Parameter2>
+      <_Parameter3>KiotaCSharp;KiotaTypeScript</_Parameter3>
+    </AssemblyAttribute>
   </ItemGroup>
 </Project>

--- a/src/Tools/Microsoft.dotnet-openapi/src/Microsoft.dotnet-openapi.csproj
+++ b/src/Tools/Microsoft.dotnet-openapi/src/Microsoft.dotnet-openapi.csproj
@@ -36,5 +36,30 @@
       <_Parameter2>$(KiotaApiDescriptionClientVersion)</_Parameter2>
       <_Parameter3>KiotaCSharp;KiotaTypeScript</_Parameter3>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="Microsoft.DotNet.Openapi.Tools.Internal.OpenApiDependencyAttribute">
+      <_Parameter1>Microsoft.Kiota.Abstractions</_Parameter1>
+      <_Parameter2>$(KiotaDotnetAbstractionsVersion)</_Parameter2>
+      <_Parameter3>KiotaCSharp</_Parameter3>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="Microsoft.DotNet.Openapi.Tools.Internal.OpenApiDependencyAttribute">
+      <_Parameter1>Microsoft.Kiota.Serialization.Json</_Parameter1>
+      <_Parameter2>$(KiotaDotnetSerializationJsonVersion)</_Parameter2>
+      <_Parameter3>KiotaCSharp</_Parameter3>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="Microsoft.DotNet.Openapi.Tools.Internal.OpenApiDependencyAttribute">
+      <_Parameter1>Microsoft.Kiota.Serialization.Text</_Parameter1>
+      <_Parameter2>$(KiotaDotnetSerializationTextVersion)</_Parameter2>
+      <_Parameter3>KiotaCSharp</_Parameter3>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="Microsoft.DotNet.Openapi.Tools.Internal.OpenApiDependencyAttribute">
+      <_Parameter1>Microsoft.Kiota.Authentication.Azure</_Parameter1>
+      <_Parameter2>$(KiotaDotnetAuthenticationAzureVersion)</_Parameter2>
+      <_Parameter3>KiotaCSharp</_Parameter3>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="Microsoft.DotNet.Openapi.Tools.Internal.OpenApiDependencyAttribute">
+      <_Parameter1>Microsoft.Kiota.Http.HttpClientLibrary</_Parameter1>
+      <_Parameter2>$(KiotaDotnetHttpVersion)</_Parameter2>
+      <_Parameter3>KiotaCSharp</_Parameter3>
+    </AssemblyAttribute>
   </ItemGroup>
 </Project>

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddFileTests.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddFileTests.cs
@@ -159,6 +159,11 @@ public class OpenApiAddFileTests : OpenApiTestBase
         using var reader = new StreamReader(csprojStream);
         var content = await reader.ReadToEndAsync();
         Assert.Contains("<PackageReference Include=\"Microsoft.OpenApi.Kiota.ApiDescription.Client\" Version=\"", content);
+        Assert.Contains("<PackageReference Include=\"Microsoft.Kiota.Abstractions\" Version=\"", content);
+        Assert.Contains("<PackageReference Include=\"Microsoft.Kiota.Serialization.Json\" Version=\"", content);
+        Assert.Contains("<PackageReference Include=\"Microsoft.Kiota.Serialization.Text\" Version=\"", content);
+        Assert.Contains("<PackageReference Include=\"Microsoft.Kiota.Authentication.Azure\" Version=\"", content);
+        Assert.Contains("<PackageReference Include=\"Microsoft.Kiota.Http.HttpClientLibrary\" Version=\"", content);
         Assert.Contains($"<OpenApiReference Include=\"{nswagJsonFile}\" CodeGenerator=\"KiotaCSharp\" />", content);
     }
 

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddFileTests.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddFileTests.cs
@@ -143,6 +143,46 @@ public class OpenApiAddFileTests : OpenApiTestBase
     }
 
     [Fact]
+    public async Task OpenApi_Add_KiotaCSharp()
+    {
+        var project = CreateBasicProject(withOpenApi: true);
+        var nswagJsonFile = project.NSwagJsonFile;
+
+        var app = GetApplication();
+        var run = app.Execute(new[] { "add", "file", nswagJsonFile, "--code-generator", "KiotaCSharp" });
+
+        AssertNoErrors(run);
+
+        // csproj contents
+        var csproj = new FileInfo(project.Project.Path);
+        using var csprojStream = csproj.OpenRead();
+        using var reader = new StreamReader(csprojStream);
+        var content = await reader.ReadToEndAsync();
+        Assert.Contains("<PackageReference Include=\"Microsoft.OpenApi.Kiota.ApiDescription.Client\" Version=\"", content);
+        Assert.Contains($"<OpenApiReference Include=\"{nswagJsonFile}\" CodeGenerator=\"KiotaCSharp\" />", content);
+    }
+
+    [Fact]
+    public async Task OpenApi_Add_KiotaTypeScript()
+    {
+        var project = CreateBasicProject(withOpenApi: true);
+        var nswagJsonFile = project.NSwagJsonFile;
+
+        var app = GetApplication();
+        var run = app.Execute(new[] { "add", "file", nswagJsonFile, "--code-generator", "KiotaTypeScript" });
+
+        AssertNoErrors(run);
+
+        // csproj contents
+        var csproj = new FileInfo(project.Project.Path);
+        using var csprojStream = csproj.OpenRead();
+        using var reader = new StreamReader(csprojStream);
+        var content = await reader.ReadToEndAsync();
+        Assert.Contains("<PackageReference Include=\"Microsoft.OpenApi.Kiota.ApiDescription.Client\" Version=\"", content);
+        Assert.Contains($"<OpenApiReference Include=\"{nswagJsonFile}\" CodeGenerator=\"KiotaTypeScript\" />", content);
+    }
+
+    [Fact]
     public async Task OpenApi_Add_FromJson()
     {
         var project = CreateBasicProject(withOpenApi: true);

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddURLTests.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddURLTests.cs
@@ -299,6 +299,70 @@ $@"<OpenApiReference Include=""{expectedJsonName}"" SourceUrl=""{FakeOpenApiUrl}
     }
 
     [Fact]
+    public async Task OpenApi_Add_Url_KiotaCSharp()
+    {
+        var project = CreateBasicProject(withOpenApi: false);
+
+        var app = GetApplication();
+        var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl, "--code-generator", "KiotaCSharp" });
+
+        AssertNoErrors(run);
+
+        var expectedJsonName = "filename.json";
+
+        // csproj contents
+        using (var csprojStream = new FileInfo(project.Project.Path).OpenRead())
+        using (var reader = new StreamReader(csprojStream))
+        {
+            var content = await reader.ReadToEndAsync();
+            Assert.Contains("<PackageReference Include=\"Microsoft.OpenApi.Kiota.ApiDescription.Client\" Version=\"", content);
+            Assert.Contains(
+$@"<OpenApiReference Include=""{expectedJsonName}"" SourceUrl=""{FakeOpenApiUrl}"" CodeGenerator=""KiotaCSharp"" />", content);
+        }
+
+        var resultFile = Path.Combine(_tempDir.Root, expectedJsonName);
+        Assert.True(File.Exists(resultFile));
+        using (var jsonStream = new FileInfo(resultFile).OpenRead())
+        using (var reader = new StreamReader(jsonStream))
+        {
+            var content = await reader.ReadToEndAsync();
+            Assert.Equal(Content, content);
+        }
+    }
+
+    [Fact]
+    public async Task OpenApi_Add_Url_KiotaTypeScript()
+    {
+        var project = CreateBasicProject(withOpenApi: false);
+
+        var app = GetApplication();
+        var run = app.Execute(new[] { "add", "url", FakeOpenApiUrl, "--code-generator", "KiotaTypeScript" });
+
+        AssertNoErrors(run);
+
+        var expectedJsonName = "filename.json";
+
+        // csproj contents
+        using (var csprojStream = new FileInfo(project.Project.Path).OpenRead())
+        using (var reader = new StreamReader(csprojStream))
+        {
+            var content = await reader.ReadToEndAsync();
+            Assert.Contains("<PackageReference Include=\"Microsoft.OpenApi.Kiota.ApiDescription.Client\" Version=\"", content);
+            Assert.Contains(
+$@"<OpenApiReference Include=""{expectedJsonName}"" SourceUrl=""{FakeOpenApiUrl}"" CodeGenerator=""KiotaTypeScript"" />", content);
+        }
+
+        var resultFile = Path.Combine(_tempDir.Root, expectedJsonName);
+        Assert.True(File.Exists(resultFile));
+        using (var jsonStream = new FileInfo(resultFile).OpenRead())
+        using (var reader = new StreamReader(jsonStream))
+        {
+            var content = await reader.ReadToEndAsync();
+            Assert.Equal(Content, content);
+        }
+    }
+
+    [Fact]
     public async Task OpenApi_Add_Url_OutputFile()
     {
         var project = CreateBasicProject(withOpenApi: false);

--- a/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddURLTests.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/test/OpenApiAddURLTests.cs
@@ -311,23 +311,24 @@ $@"<OpenApiReference Include=""{expectedJsonName}"" SourceUrl=""{FakeOpenApiUrl}
         var expectedJsonName = "filename.json";
 
         // csproj contents
-        using (var csprojStream = new FileInfo(project.Project.Path).OpenRead())
-        using (var reader = new StreamReader(csprojStream))
-        {
-            var content = await reader.ReadToEndAsync();
-            Assert.Contains("<PackageReference Include=\"Microsoft.OpenApi.Kiota.ApiDescription.Client\" Version=\"", content);
-            Assert.Contains(
+        using var csprojStream = new FileInfo(project.Project.Path).OpenRead();
+        using var reader = new StreamReader(csprojStream);
+        var content = await reader.ReadToEndAsync();
+        Assert.Contains("<PackageReference Include=\"Microsoft.OpenApi.Kiota.ApiDescription.Client\" Version=\"", content);
+        Assert.Contains("<PackageReference Include=\"Microsoft.Kiota.Abstractions\" Version=\"", content);
+        Assert.Contains("<PackageReference Include=\"Microsoft.Kiota.Serialization.Json\" Version=\"", content);
+        Assert.Contains("<PackageReference Include=\"Microsoft.Kiota.Serialization.Text\" Version=\"", content);
+        Assert.Contains("<PackageReference Include=\"Microsoft.Kiota.Authentication.Azure\" Version=\"", content);
+        Assert.Contains("<PackageReference Include=\"Microsoft.Kiota.Http.HttpClientLibrary\" Version=\"", content);
+        Assert.Contains(
 $@"<OpenApiReference Include=""{expectedJsonName}"" SourceUrl=""{FakeOpenApiUrl}"" CodeGenerator=""KiotaCSharp"" />", content);
-        }
 
         var resultFile = Path.Combine(_tempDir.Root, expectedJsonName);
         Assert.True(File.Exists(resultFile));
-        using (var jsonStream = new FileInfo(resultFile).OpenRead())
-        using (var reader = new StreamReader(jsonStream))
-        {
-            var content = await reader.ReadToEndAsync();
-            Assert.Equal(Content, content);
-        }
+        var jsonStream = new FileInfo(resultFile).OpenRead();
+        var jsonReader = new StreamReader(jsonStream);
+        var jsonContent = await jsonReader.ReadToEndAsync();
+        Assert.Equal(Content, jsonContent);
     }
 
     [Fact]


### PR DESCRIPTION
follow up of https://github.com/baywet/aspnetcore/pull/1 CC @dougbu

## Questions left:

- Should the dependencies be added by the api definition package or by this process (through the same mechanism that adds the ApiDescription package)?
- How are the TypeScript dependencies supposed to be added since we're talking about a different package manager?
- Would it be possible to add target namespace, target folder, and api client class name parameters to the tool?
- Why is the Option for CodeGenerator not using a generic type to pass the enum and leave the parsing to system.command line?

## Resulting CSProj (for now):

```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net7.0</TargetFramework>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
  </PropertyGroup>
  <ItemGroup>
    <PackageReference Include="Microsoft.OpenApi.Kiota.ApiDescription.Client" Version="0.5.0-preview" />
  </ItemGroup>
  <ItemGroup>
    <OpenApiReference Include="Mail.yml" SourceUrl="https://raw.githubusercontent.com/microsoftgraph/msgraph-sdk-powershell/dev/openApiDocs/v1.0/Mail.yml" CodeGenerator="KiotaCSharp" />
  </ItemGroup>
</Project>
``` 

## Testing steps

### Create a local testing project with a nuget.config

```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
	<packageSources>
		<add key="localnuget" value="file:///workspaces/localnuget" />
	</packageSources>
</configuration>
```

### Add Kiota and Kiota ApiDescription to the local source

dotnet pack for kiota and kiota api ddescription, copy in the previous local source folder

### Pack the tool and run it

```shell
cd src/Tools/Microsoft.dotnet-openapi/src
dotnet pack
dotnet tool install --local Microsoft.dotnet-openapi --add-source /workspaces/aspnetcore/artifacts/packages/Debug/Shipping/ --version 7.0.0-dev
dotnet tool run dotnet-openapi -- add url https://raw.githubusercontent.com/microsoftgraph/msgraph-sdk-powershell/dev/openApiDocs/v1.0/Mail.yml -c KiotaCSharp -p /workspaces/dummy/dummy.csproj
dotnet tool uninstall --local Microsoft.dotnet-openapi
```