### PR TITLE
Allow returns from all single client proxies

### DIFF
--- a/src/SignalR/server/Core/src/IHubClients`T.cs
+++ b/src/SignalR/server/Core/src/IHubClients`T.cs
@@ -14,7 +14,7 @@ public interface IHubClients<T>
     /// </summary>
     /// <param name="connectionId">The connection ID.</param>
     /// <returns>A client caller.</returns>
-    T Single(string connectionId) => throw new NotImplementedException();
+    T Single(string connectionId) => Client(connectionId);
 
     /// <summary>
     /// Gets a <typeparamref name="T" /> that can be used to invoke methods on all clients connected to the hub.

--- a/src/SignalR/server/Core/src/Internal/HubClients.cs
+++ b/src/SignalR/server/Core/src/Internal/HubClients.cs
@@ -15,7 +15,7 @@ internal sealed class HubClients<THub> : IHubClients where THub : Hub
 
     public ISingleClientProxy Single(string connectionId)
     {
-        return new SingleClientProxyWithInvoke<THub>(_lifetimeManager, connectionId);
+        return new SingleClientProxy<THub>(_lifetimeManager, connectionId);
     }
 
     public IClientProxy All { get; }

--- a/src/SignalR/server/Core/src/Internal/HubClients`T.cs
+++ b/src/SignalR/server/Core/src/Internal/HubClients`T.cs
@@ -17,7 +17,7 @@ internal sealed class HubClients<THub, T> : IHubClients<T> where THub : Hub
 
     public T Single(string connectionId)
     {
-        return TypedClientBuilder<T>.Build(new SingleClientProxyWithInvoke<THub>(_lifetimeManager, connectionId));
+        return TypedClientBuilder<T>.Build(new SingleClientProxy<THub>(_lifetimeManager, connectionId));
     }
 
     public T AllExcept(IReadOnlyList<string> excludedConnectionIds)

--- a/src/SignalR/server/Core/src/Internal/HubClients`T.cs
+++ b/src/SignalR/server/Core/src/Internal/HubClients`T.cs
@@ -15,11 +15,6 @@ internal sealed class HubClients<THub, T> : IHubClients<T> where THub : Hub
 
     public T All { get; }
 
-    public T Single(string connectionId)
-    {
-        return TypedClientBuilder<T>.Build(new SingleClientProxy<THub>(_lifetimeManager, connectionId));
-    }
-
     public T AllExcept(IReadOnlyList<string> excludedConnectionIds)
     {
         return TypedClientBuilder<T>.Build(new AllClientsExceptProxy<THub>(_lifetimeManager, excludedConnectionIds));

--- a/src/SignalR/server/Core/src/Internal/Proxies.cs
+++ b/src/SignalR/server/Core/src/Internal/Proxies.cs
@@ -122,23 +122,6 @@ internal sealed class AllClientsExceptProxy<THub> : IClientProxy where THub : Hu
     }
 }
 
-internal sealed class SingleClientProxy<THub> : IClientProxy where THub : Hub
-{
-    private readonly string _connectionId;
-    private readonly HubLifetimeManager<THub> _lifetimeManager;
-
-    public SingleClientProxy(HubLifetimeManager<THub> lifetimeManager, string connectionId)
-    {
-        _lifetimeManager = lifetimeManager;
-        _connectionId = connectionId;
-    }
-
-    public Task SendCoreAsync(string method, object?[] args, CancellationToken cancellationToken = default)
-    {
-        return _lifetimeManager.SendConnectionAsync(_connectionId, method, args, cancellationToken);
-    }
-}
-
 internal sealed class MultipleClientProxy<THub> : IClientProxy where THub : Hub
 {
     private readonly HubLifetimeManager<THub> _lifetimeManager;
@@ -156,12 +139,12 @@ internal sealed class MultipleClientProxy<THub> : IClientProxy where THub : Hub
     }
 }
 
-internal sealed class SingleClientProxyWithInvoke<THub> : ISingleClientProxy where THub : Hub
+internal sealed class SingleClientProxy<THub> : ISingleClientProxy where THub : Hub
 {
     private readonly string _connectionId;
     private readonly HubLifetimeManager<THub> _lifetimeManager;
 
-    public SingleClientProxyWithInvoke(HubLifetimeManager<THub> lifetimeManager, string connectionId)
+    public SingleClientProxy(HubLifetimeManager<THub> lifetimeManager, string connectionId)
     {
         _lifetimeManager = lifetimeManager;
         _connectionId = connectionId;

--- a/src/SignalR/server/Core/src/Internal/TypedHubClients.cs
+++ b/src/SignalR/server/Core/src/Internal/TypedHubClients.cs
@@ -12,7 +12,7 @@ internal sealed class TypedHubClients<T> : IHubCallerClients<T>
         _hubClients = dynamicContext;
     }
 
-    public T Single(string connectionId) => TypedClientBuilder<T>.Build(_hubClients.Single(connectionId));
+    public T Client(string connectionId) => TypedClientBuilder<T>.Build(_hubClients.Single(connectionId));
 
     public T All => TypedClientBuilder<T>.Build(_hubClients.All);
 
@@ -21,11 +21,6 @@ internal sealed class TypedHubClients<T> : IHubCallerClients<T>
     public T Others => TypedClientBuilder<T>.Build(_hubClients.Others);
 
     public T AllExcept(IReadOnlyList<string> excludedConnectionIds) => TypedClientBuilder<T>.Build(_hubClients.AllExcept(excludedConnectionIds));
-
-    public T Client(string connectionId)
-    {
-        return TypedClientBuilder<T>.Build(_hubClients.Client(connectionId));
-    }
 
     public T Group(string groupName)
     {

--- a/src/SignalR/server/SignalR/test/ClientProxyTests.cs
+++ b/src/SignalR/server/SignalR/test/ClientProxyTests.cs
@@ -212,7 +212,7 @@ public class ClientHubProxyTests
     {
         var hubLifetimeManager = new EmptyHubLifetimeManager<FakeHub>();
 
-        var proxy = new SingleClientProxyWithInvoke<FakeHub>(hubLifetimeManager, "");
+        var proxy = new SingleClientProxy<FakeHub>(hubLifetimeManager, "");
         var ex = await Assert.ThrowsAsync<NotImplementedException>(async () => await proxy.InvokeAsync<int>("method")).DefaultTimeout();
         Assert.Equal("EmptyHubLifetimeManager`1 does not support client return values.", ex.Message);
     }

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -440,7 +440,7 @@ public class DynamicTestHub : DynamicHub
     }
 }
 
-public class HubT : Hub<Test>
+public class HubT : Hub<ITest>
 {
     public override Task OnConnectedAsync()
     {
@@ -526,7 +526,7 @@ public class HubT : Hub<Test>
     }
 }
 
-public interface Test
+public interface ITest
 {
     Task Send(string message);
     Task Broadcast(string message);

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -524,6 +524,12 @@ public class HubT : Hub<ITest>
     {
         return Clients.Caller.Send(message);
     }
+
+    public async Task<ClientResults> GetClientResultThreeWays(int singleValue, int clientValue, int callerValue) =>
+        new ClientResults(
+            await Clients.Single(Context.ConnectionId).GetClientResult(singleValue),
+            await Clients.Client(Context.ConnectionId).GetClientResult(clientValue),
+            await Clients.Caller.GetClientResult(callerValue));
 }
 
 public interface ITest
@@ -533,6 +539,8 @@ public interface ITest
 
     Task<int> GetClientResult(int value);
 }
+
+public record ClientResults(int SingleResult, int ClientResult, int CallerResult);
 
 public class OnConnectedThrowsHub : Hub
 {


### PR DESCRIPTION
> We should delete `SingleClientProxy<THub>` in favor of `SingleClientProxyWithInvoke<THub>` for simplicity if nothing else.  We should also switch to `T Single(string connectionId) => Client(connectionId);` because that now works in our case. We wouldn't even have to implement it.
>
> I see the inconsistent experience with strongly-typed vs. non-strongly-typed hubs as a complete non-issue. It's FAR better to be "inconsistent" here! We're already being inconsistent by returning the exact same type from both `Single()` and `Client()` in the strongly-typed case instead of two different types (namely `ISingleClientProxy` and `IClientProxy`) in the default case.
>
> I understand that we can't change `IHubClients : IHubClients<IClientProxy>` to `IHubClients : IHubClients<ISingleClientProxy>` in the default case without breaking apps. It's unfortunate, but if we could do that, we wouldn't have had to introduced `Single()` in the first place.
> 
> However, that doesn't mean we should nerf strongly-typed hubs! So what if they are more flexible with their `Client` property? `Single()` and `Client()` return the exact same type for strong typed hubs. It's already different.

Follow up to https://github.com/dotnet/aspnetcore/pull/41763#issuecomment-1133477185. Hopefully the change and the tests make it clear what I'm trying to fix.