### PR TITLE
Add a rule to mention the `aspnet-build` team on infrastructure issues

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -2516,6 +2516,12 @@
           "parameters": {
             "label": "community-contribution"
           }
+        },
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Thanks for your PR, @${issueAuthor}. Someone from the team will get assigned to your PR shortly and we'll get it reviewed."
+          }
         }
       ]
     }
@@ -3279,6 +3285,58 @@
           "name": "addReply",
           "parameters": {
             "comment": "Hi @${issueAuthor}. If this is not a tell-mode PR, please make sure to follow the instructions laid out in the [servicing process](https://aka.ms/aspnet/servicing) document.\nOtherwise, please add `tell-mode` label."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "labelAdded",
+            "parameters": {
+              "label": "area-infrastructure"
+            }
+          },
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "labeled"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Internal: Debug"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Ping the build team on infrastructure issues",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Hey @aspnet-build, looks like this PR is something you want to take a look at."
+          }
+        },
+        {
+          "name": "assignToUser",
+          "parameters": {
+            "user": "aspnet-build"
           }
         }
       ]

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -3330,7 +3330,7 @@
         {
           "name": "addReply",
           "parameters": {
-            "comment": "Hey @aspnet-build, looks like this PR is something you want to take a look at."
+            "comment": "Hey @dotnet/aspnet-build, looks like this PR is something you want to take a look at."
           }
         },
         {


### PR DESCRIPTION
Also drop a comment on community contributions suggesting that someone will get assigned to the PR soon and get it reviewed.

**Note ⚠️**: Because we don't rely on FabricBot UI any more, I am using the `Internal: Debug` label to validate my new rule. After validation, I'll update this file one more time to remove the condition.