### PR TITLE
RequestDelegateFactory context classes ApplicationServices property

### DIFF
--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -13,10 +13,10 @@ Microsoft.AspNetCore.Http.IRouteHandlerFilter.InvokeAsync(Microsoft.AspNetCore.H
 Microsoft.AspNetCore.Http.Metadata.IFromFormMetadata
 Microsoft.AspNetCore.Http.Metadata.IFromFormMetadata.Name.get -> string?
 Microsoft.AspNetCore.Http.RouteHandlerContext
-Microsoft.AspNetCore.Http.RouteHandlerContext.ApplicationServices.get -> System.IServiceProvider?
+Microsoft.AspNetCore.Http.RouteHandlerContext.ApplicationServices.get -> System.IServiceProvider!
 Microsoft.AspNetCore.Http.RouteHandlerContext.EndpointMetadata.get -> Microsoft.AspNetCore.Http.EndpointMetadataCollection!
 Microsoft.AspNetCore.Http.RouteHandlerContext.MethodInfo.get -> System.Reflection.MethodInfo!
-Microsoft.AspNetCore.Http.RouteHandlerContext.RouteHandlerContext(System.Reflection.MethodInfo! methodInfo, Microsoft.AspNetCore.Http.EndpointMetadataCollection! endpointMetadata, System.IServiceProvider? applicationServices) -> void
+Microsoft.AspNetCore.Http.RouteHandlerContext.RouteHandlerContext(System.Reflection.MethodInfo! methodInfo, Microsoft.AspNetCore.Http.EndpointMetadataCollection! endpointMetadata, System.IServiceProvider! applicationServices) -> void
 Microsoft.AspNetCore.Http.RouteHandlerFilterDelegate
 Microsoft.AspNetCore.Http.RouteHandlerInvocationContext
 Microsoft.AspNetCore.Http.RouteHandlerInvocationContext.RouteHandlerInvocationContext() -> void

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -13,10 +13,10 @@ Microsoft.AspNetCore.Http.IRouteHandlerFilter.InvokeAsync(Microsoft.AspNetCore.H
 Microsoft.AspNetCore.Http.Metadata.IFromFormMetadata
 Microsoft.AspNetCore.Http.Metadata.IFromFormMetadata.Name.get -> string?
 Microsoft.AspNetCore.Http.RouteHandlerContext
+Microsoft.AspNetCore.Http.RouteHandlerContext.ApplicationServices.get -> System.IServiceProvider?
 Microsoft.AspNetCore.Http.RouteHandlerContext.EndpointMetadata.get -> Microsoft.AspNetCore.Http.EndpointMetadataCollection!
 Microsoft.AspNetCore.Http.RouteHandlerContext.MethodInfo.get -> System.Reflection.MethodInfo!
-Microsoft.AspNetCore.Http.RouteHandlerContext.RouteHandlerContext(System.Reflection.MethodInfo! methodInfo, Microsoft.AspNetCore.Http.EndpointMetadataCollection! endpointMetadata, System.IServiceProvider? services) -> void
-Microsoft.AspNetCore.Http.RouteHandlerContext.Services.get -> System.IServiceProvider?
+Microsoft.AspNetCore.Http.RouteHandlerContext.RouteHandlerContext(System.Reflection.MethodInfo! methodInfo, Microsoft.AspNetCore.Http.EndpointMetadataCollection! endpointMetadata, System.IServiceProvider? applicationServices) -> void
 Microsoft.AspNetCore.Http.RouteHandlerFilterDelegate
 Microsoft.AspNetCore.Http.RouteHandlerInvocationContext
 Microsoft.AspNetCore.Http.RouteHandlerInvocationContext.RouteHandlerInvocationContext() -> void

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -15,7 +15,8 @@ Microsoft.AspNetCore.Http.Metadata.IFromFormMetadata.Name.get -> string?
 Microsoft.AspNetCore.Http.RouteHandlerContext
 Microsoft.AspNetCore.Http.RouteHandlerContext.EndpointMetadata.get -> Microsoft.AspNetCore.Http.EndpointMetadataCollection!
 Microsoft.AspNetCore.Http.RouteHandlerContext.MethodInfo.get -> System.Reflection.MethodInfo!
-Microsoft.AspNetCore.Http.RouteHandlerContext.RouteHandlerContext(System.Reflection.MethodInfo! methodInfo, Microsoft.AspNetCore.Http.EndpointMetadataCollection! endpointMetadata) -> void
+Microsoft.AspNetCore.Http.RouteHandlerContext.RouteHandlerContext(System.Reflection.MethodInfo! methodInfo, Microsoft.AspNetCore.Http.EndpointMetadataCollection! endpointMetadata, System.IServiceProvider? services) -> void
+Microsoft.AspNetCore.Http.RouteHandlerContext.Services.get -> System.IServiceProvider?
 Microsoft.AspNetCore.Http.RouteHandlerFilterDelegate
 Microsoft.AspNetCore.Http.RouteHandlerInvocationContext
 Microsoft.AspNetCore.Http.RouteHandlerInvocationContext.RouteHandlerInvocationContext() -> void

--- a/src/Http/Http.Abstractions/src/RouteHandlerContext.cs
+++ b/src/Http/Http.Abstractions/src/RouteHandlerContext.cs
@@ -17,8 +17,12 @@ public sealed class RouteHandlerContext
     /// <param name="methodInfo">The <see cref="MethodInfo"/> associated with the route handler of the current request.</param>
     /// <param name="endpointMetadata">The <see cref="EndpointMetadataCollection"/> associated with the endpoint the filter is targeting.</param>
     /// <param name="applicationServices">The <see cref="IServiceProvider"/> instance used to access the application services.</param>
-    public RouteHandlerContext(MethodInfo methodInfo, EndpointMetadataCollection endpointMetadata, IServiceProvider? applicationServices)
+    public RouteHandlerContext(MethodInfo methodInfo, EndpointMetadataCollection endpointMetadata, IServiceProvider applicationServices)
     {
+        ArgumentNullException.ThrowIfNull(methodInfo, nameof(methodInfo));
+        ArgumentNullException.ThrowIfNull(endpointMetadata, nameof(endpointMetadata));
+        ArgumentNullException.ThrowIfNull(applicationServices, nameof(applicationServices));
+
         MethodInfo = methodInfo;
         EndpointMetadata = endpointMetadata;
         ApplicationServices = applicationServices;
@@ -37,5 +41,5 @@ public sealed class RouteHandlerContext
     /// <summary>
     /// Gets the <see cref="IServiceProvider"/> instance used to access application services.
     /// </summary>
-    public IServiceProvider? ApplicationServices { get; }
+    public IServiceProvider ApplicationServices { get; }
 }

--- a/src/Http/Http.Abstractions/src/RouteHandlerContext.cs
+++ b/src/Http/Http.Abstractions/src/RouteHandlerContext.cs
@@ -19,9 +19,9 @@ public sealed class RouteHandlerContext
     /// <param name="applicationServices">The <see cref="IServiceProvider"/> instance used to access the application services.</param>
     public RouteHandlerContext(MethodInfo methodInfo, EndpointMetadataCollection endpointMetadata, IServiceProvider applicationServices)
     {
-        ArgumentNullException.ThrowIfNull(methodInfo, nameof(methodInfo));
-        ArgumentNullException.ThrowIfNull(endpointMetadata, nameof(endpointMetadata));
-        ArgumentNullException.ThrowIfNull(applicationServices, nameof(applicationServices));
+        ArgumentNullException.ThrowIfNull(methodInfo);
+        ArgumentNullException.ThrowIfNull(endpointMetadata);
+        ArgumentNullException.ThrowIfNull(applicationServices);
 
         MethodInfo = methodInfo;
         EndpointMetadata = endpointMetadata;

--- a/src/Http/Http.Abstractions/src/RouteHandlerContext.cs
+++ b/src/Http/Http.Abstractions/src/RouteHandlerContext.cs
@@ -16,10 +16,12 @@ public sealed class RouteHandlerContext
     /// </summary>
     /// <param name="methodInfo">The <see cref="MethodInfo"/> associated with the route handler of the current request.</param>
     /// <param name="endpointMetadata">The <see cref="EndpointMetadataCollection"/> associated with the endpoint the filter is targeting.</param>
-    public RouteHandlerContext(MethodInfo methodInfo, EndpointMetadataCollection endpointMetadata)
+    /// <param name="services">The <see cref="IServiceProvider"/> instance used to access the application services.</param>
+    public RouteHandlerContext(MethodInfo methodInfo, EndpointMetadataCollection endpointMetadata, IServiceProvider? services)
     {
         MethodInfo = methodInfo;
         EndpointMetadata = endpointMetadata;
+        Services = services;
     }
 
     /// <summary>
@@ -31,4 +33,9 @@ public sealed class RouteHandlerContext
     /// The <see cref="EndpointMetadataCollection"/> associated with the current endpoint.
     /// </summary>
     public EndpointMetadataCollection EndpointMetadata { get; }
+
+    /// <summary>
+    /// Gets the <see cref="IServiceProvider"/> instance used to access application services.
+    /// </summary>
+    public IServiceProvider? Services { get; }
 }

--- a/src/Http/Http.Abstractions/src/RouteHandlerContext.cs
+++ b/src/Http/Http.Abstractions/src/RouteHandlerContext.cs
@@ -16,12 +16,12 @@ public sealed class RouteHandlerContext
     /// </summary>
     /// <param name="methodInfo">The <see cref="MethodInfo"/> associated with the route handler of the current request.</param>
     /// <param name="endpointMetadata">The <see cref="EndpointMetadataCollection"/> associated with the endpoint the filter is targeting.</param>
-    /// <param name="services">The <see cref="IServiceProvider"/> instance used to access the application services.</param>
-    public RouteHandlerContext(MethodInfo methodInfo, EndpointMetadataCollection endpointMetadata, IServiceProvider? services)
+    /// <param name="applicationServices">The <see cref="IServiceProvider"/> instance used to access the application services.</param>
+    public RouteHandlerContext(MethodInfo methodInfo, EndpointMetadataCollection endpointMetadata, IServiceProvider? applicationServices)
     {
         MethodInfo = methodInfo;
         EndpointMetadata = endpointMetadata;
-        Services = services;
+        ApplicationServices = applicationServices;
     }
 
     /// <summary>
@@ -37,5 +37,5 @@ public sealed class RouteHandlerContext
     /// <summary>
     /// Gets the <see cref="IServiceProvider"/> instance used to access application services.
     /// </summary>
-    public IServiceProvider? Services { get; }
+    public IServiceProvider? ApplicationServices { get; }
 }

--- a/src/Http/Http.Extensions/src/EndpointMetadataContext.cs
+++ b/src/Http/Http.Extensions/src/EndpointMetadataContext.cs
@@ -16,10 +16,11 @@ public sealed class EndpointMetadataContext
     /// <param name="method">The <see cref="MethodInfo"/> of the route handler delegate of the endpoint being created.</param>
     /// <param name="endpointMetadata">The list of objects that will be added to the metadata of the endpoint.</param>
     /// <param name="applicationServices">The <see cref="IServiceProvider"/> instance used to access application services.</param>
-    public EndpointMetadataContext(MethodInfo method, IList<object> endpointMetadata, IServiceProvider? applicationServices)
+    public EndpointMetadataContext(MethodInfo method, IList<object> endpointMetadata, IServiceProvider applicationServices)
     {
         ArgumentNullException.ThrowIfNull(method, nameof(method));
         ArgumentNullException.ThrowIfNull(endpointMetadata, nameof(endpointMetadata));
+        ArgumentNullException.ThrowIfNull(applicationServices, nameof(applicationServices));
 
         Method = method;
         EndpointMetadata = endpointMetadata;
@@ -39,5 +40,5 @@ public sealed class EndpointMetadataContext
     /// <summary>
     /// Gets the <see cref="IServiceProvider"/> instance used to access application services.
     /// </summary>
-    public IServiceProvider? ApplicationServices { get; }
+    public IServiceProvider ApplicationServices { get; }
 }

--- a/src/Http/Http.Extensions/src/EndpointMetadataContext.cs
+++ b/src/Http/Http.Extensions/src/EndpointMetadataContext.cs
@@ -15,15 +15,15 @@ public sealed class EndpointMetadataContext
     /// </summary>
     /// <param name="method">The <see cref="MethodInfo"/> of the route handler delegate of the endpoint being created.</param>
     /// <param name="endpointMetadata">The list of objects that will be added to the metadata of the endpoint.</param>
-    /// <param name="services">The <see cref="IServiceProvider"/> instance used to access application services.</param>
-    public EndpointMetadataContext(MethodInfo method, IList<object> endpointMetadata, IServiceProvider? services)
+    /// <param name="applicationServices">The <see cref="IServiceProvider"/> instance used to access application services.</param>
+    public EndpointMetadataContext(MethodInfo method, IList<object> endpointMetadata, IServiceProvider? applicationServices)
     {
         ArgumentNullException.ThrowIfNull(method, nameof(method));
         ArgumentNullException.ThrowIfNull(endpointMetadata, nameof(endpointMetadata));
 
         Method = method;
         EndpointMetadata = endpointMetadata;
-        Services = services;
+        ApplicationServices = applicationServices;
     }
 
     /// <summary>
@@ -39,5 +39,5 @@ public sealed class EndpointMetadataContext
     /// <summary>
     /// Gets the <see cref="IServiceProvider"/> instance used to access application services.
     /// </summary>
-    public IServiceProvider? Services { get; }
+    public IServiceProvider? ApplicationServices { get; }
 }

--- a/src/Http/Http.Extensions/src/EndpointMetadataContext.cs
+++ b/src/Http/Http.Extensions/src/EndpointMetadataContext.cs
@@ -18,9 +18,9 @@ public sealed class EndpointMetadataContext
     /// <param name="applicationServices">The <see cref="IServiceProvider"/> instance used to access application services.</param>
     public EndpointMetadataContext(MethodInfo method, IList<object> endpointMetadata, IServiceProvider applicationServices)
     {
-        ArgumentNullException.ThrowIfNull(method, nameof(method));
-        ArgumentNullException.ThrowIfNull(endpointMetadata, nameof(endpointMetadata));
-        ArgumentNullException.ThrowIfNull(applicationServices, nameof(applicationServices));
+        ArgumentNullException.ThrowIfNull(method);
+        ArgumentNullException.ThrowIfNull(endpointMetadata);
+        ArgumentNullException.ThrowIfNull(applicationServices);
 
         Method = method;
         EndpointMetadata = endpointMetadata;

--- a/src/Http/Http.Extensions/src/EndpointParameterMetadataContext.cs
+++ b/src/Http/Http.Extensions/src/EndpointParameterMetadataContext.cs
@@ -18,9 +18,9 @@ public sealed class EndpointParameterMetadataContext
     /// <param name="applicationServices">The <see cref="IServiceProvider"/> instance used to access application services.</param>
     public EndpointParameterMetadataContext(ParameterInfo parameter, IList<object> endpointMetadata, IServiceProvider applicationServices)
     {
-        ArgumentNullException.ThrowIfNull(parameter, nameof(parameter));
-        ArgumentNullException.ThrowIfNull(endpointMetadata, nameof(endpointMetadata));
-        ArgumentNullException.ThrowIfNull(applicationServices, nameof(applicationServices));
+        ArgumentNullException.ThrowIfNull(parameter);
+        ArgumentNullException.ThrowIfNull(endpointMetadata);
+        ArgumentNullException.ThrowIfNull(applicationServices);
 
         Parameter = parameter;
         EndpointMetadata = endpointMetadata;

--- a/src/Http/Http.Extensions/src/EndpointParameterMetadataContext.cs
+++ b/src/Http/Http.Extensions/src/EndpointParameterMetadataContext.cs
@@ -16,10 +16,11 @@ public sealed class EndpointParameterMetadataContext
     /// <param name="parameter">The parameter of the route handler delegate of the endpoint being created.</param>
     /// <param name="endpointMetadata">The list of objects that will be added to the metadata of the endpoint.</param>
     /// <param name="applicationServices">The <see cref="IServiceProvider"/> instance used to access application services.</param>
-    public EndpointParameterMetadataContext(ParameterInfo parameter, IList<object> endpointMetadata, IServiceProvider? applicationServices)
+    public EndpointParameterMetadataContext(ParameterInfo parameter, IList<object> endpointMetadata, IServiceProvider applicationServices)
     {
         ArgumentNullException.ThrowIfNull(parameter, nameof(parameter));
         ArgumentNullException.ThrowIfNull(endpointMetadata, nameof(endpointMetadata));
+        ArgumentNullException.ThrowIfNull(applicationServices, nameof(applicationServices));
 
         Parameter = parameter;
         EndpointMetadata = endpointMetadata;
@@ -39,5 +40,5 @@ public sealed class EndpointParameterMetadataContext
     /// <summary>
     /// Gets the <see cref="IServiceProvider"/> instance used to access application services.
     /// </summary>
-    public IServiceProvider? ApplicationServices { get; }
+    public IServiceProvider ApplicationServices { get; }
 }

--- a/src/Http/Http.Extensions/src/EndpointParameterMetadataContext.cs
+++ b/src/Http/Http.Extensions/src/EndpointParameterMetadataContext.cs
@@ -15,15 +15,15 @@ public sealed class EndpointParameterMetadataContext
     /// </summary>
     /// <param name="parameter">The parameter of the route handler delegate of the endpoint being created.</param>
     /// <param name="endpointMetadata">The list of objects that will be added to the metadata of the endpoint.</param>
-    /// <param name="services">The <see cref="IServiceProvider"/> instance used to access application services.</param>
-    public EndpointParameterMetadataContext(ParameterInfo parameter, IList<object> endpointMetadata, IServiceProvider? services)
+    /// <param name="applicationServices">The <see cref="IServiceProvider"/> instance used to access application services.</param>
+    public EndpointParameterMetadataContext(ParameterInfo parameter, IList<object> endpointMetadata, IServiceProvider? applicationServices)
     {
         ArgumentNullException.ThrowIfNull(parameter, nameof(parameter));
         ArgumentNullException.ThrowIfNull(endpointMetadata, nameof(endpointMetadata));
 
         Parameter = parameter;
         EndpointMetadata = endpointMetadata;
-        Services = services;
+        ApplicationServices = applicationServices;
     }
 
     /// <summary>
@@ -39,5 +39,5 @@ public sealed class EndpointParameterMetadataContext
     /// <summary>
     /// Gets the <see cref="IServiceProvider"/> instance used to access application services.
     /// </summary>
-    public IServiceProvider? Services { get; }
+    public IServiceProvider? ApplicationServices { get; }
 }

--- a/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
@@ -1,14 +1,14 @@
 #nullable enable
 Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext
-Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.EndpointMetadataContext(System.Reflection.MethodInfo! method, System.Collections.Generic.IList<object!>! endpointMetadata, System.IServiceProvider? services) -> void
+Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.ApplicationServices.get -> System.IServiceProvider?
+Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.EndpointMetadataContext(System.Reflection.MethodInfo! method, System.Collections.Generic.IList<object!>! endpointMetadata, System.IServiceProvider? applicationServices) -> void
 Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.EndpointMetadata.get -> System.Collections.Generic.IList<object!>!
 Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.Method.get -> System.Reflection.MethodInfo!
-Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.Services.get -> System.IServiceProvider?
 Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext
-Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.EndpointParameterMetadataContext(System.Reflection.ParameterInfo! parameter, System.Collections.Generic.IList<object!>! endpointMetadata, System.IServiceProvider? services) -> void
+Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.ApplicationServices.get -> System.IServiceProvider?
+Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.EndpointParameterMetadataContext(System.Reflection.ParameterInfo! parameter, System.Collections.Generic.IList<object!>! endpointMetadata, System.IServiceProvider? applicationServices) -> void
 Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.EndpointMetadata.get -> System.Collections.Generic.IList<object!>!
 Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.Parameter.get -> System.Reflection.ParameterInfo!
-Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.Services.get -> System.IServiceProvider?
 Microsoft.AspNetCore.Http.Metadata.IEndpointMetadataProvider
 Microsoft.AspNetCore.Http.Metadata.IEndpointMetadataProvider.PopulateMetadata(Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext! context) -> void
 Microsoft.AspNetCore.Http.Metadata.IEndpointParameterMetadataProvider

--- a/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
@@ -1,12 +1,12 @@
 #nullable enable
 Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext
-Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.ApplicationServices.get -> System.IServiceProvider?
-Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.EndpointMetadataContext(System.Reflection.MethodInfo! method, System.Collections.Generic.IList<object!>! endpointMetadata, System.IServiceProvider? applicationServices) -> void
+Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.ApplicationServices.get -> System.IServiceProvider!
+Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.EndpointMetadataContext(System.Reflection.MethodInfo! method, System.Collections.Generic.IList<object!>! endpointMetadata, System.IServiceProvider! applicationServices) -> void
 Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.EndpointMetadata.get -> System.Collections.Generic.IList<object!>!
 Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext.Method.get -> System.Reflection.MethodInfo!
 Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext
-Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.ApplicationServices.get -> System.IServiceProvider?
-Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.EndpointParameterMetadataContext(System.Reflection.ParameterInfo! parameter, System.Collections.Generic.IList<object!>! endpointMetadata, System.IServiceProvider? applicationServices) -> void
+Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.ApplicationServices.get -> System.IServiceProvider!
+Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.EndpointParameterMetadataContext(System.Reflection.ParameterInfo! parameter, System.Collections.Generic.IList<object!>! endpointMetadata, System.IServiceProvider! applicationServices) -> void
 Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.EndpointMetadata.get -> System.Collections.Generic.IList<object!>!
 Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext.Parameter.get -> System.Reflection.ParameterInfo!
 Microsoft.AspNetCore.Http.Metadata.IEndpointMetadataProvider

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -106,7 +106,6 @@ public static partial class RequestDelegateFactory
 
     private static readonly string[] DefaultAcceptsContentType = new[] { "application/json" };
     private static readonly string[] FormFileContentType = new[] { "multipart/form-data" };
-    private static readonly IServiceProvider EmptyServiceProvider = new ServiceCollection().BuildServiceProvider();
 
     /// <summary>
     /// Creates a <see cref="RequestDelegate"/> implementation for <paramref name="handler"/>.
@@ -307,7 +306,7 @@ public static partial class RequestDelegateFactory
         var routeHandlerContext = new RouteHandlerContext(
             methodInfo,
             new EndpointMetadataCollection(factoryContext.Metadata),
-            factoryContext.ServiceProvider ?? EmptyServiceProvider);
+            factoryContext.ServiceProvider ?? EmptyServiceProvider.Instance);
 
         for (var i = factoryContext.Filters.Count - 1; i >= 0; i--)
         {
@@ -444,7 +443,7 @@ public static partial class RequestDelegateFactory
             if (typeof(IEndpointParameterMetadataProvider).IsAssignableFrom(parameter.ParameterType))
             {
                 // Parameter type implements IEndpointParameterMetadataProvider
-                var parameterContext = new EndpointParameterMetadataContext(parameter, metadata, services ?? EmptyServiceProvider);
+                var parameterContext = new EndpointParameterMetadataContext(parameter, metadata, services ?? EmptyServiceProvider.Instance);
                 invokeArgs ??= new object[1];
                 invokeArgs[0] = parameterContext;
                 PopulateMetadataForParameterMethod.MakeGenericMethod(parameter.ParameterType).Invoke(null, invokeArgs);
@@ -453,7 +452,7 @@ public static partial class RequestDelegateFactory
             if (typeof(IEndpointMetadataProvider).IsAssignableFrom(parameter.ParameterType))
             {
                 // Parameter type implements IEndpointMetadataProvider
-                var context = new EndpointMetadataContext(methodInfo, metadata, services ?? EmptyServiceProvider);
+                var context = new EndpointMetadataContext(methodInfo, metadata, services ?? EmptyServiceProvider.Instance);
                 invokeArgs ??= new object[1];
                 invokeArgs[0] = context;
                 PopulateMetadataForEndpointMethod.MakeGenericMethod(parameter.ParameterType).Invoke(null, invokeArgs);
@@ -470,7 +469,7 @@ public static partial class RequestDelegateFactory
         if (returnType is not null && typeof(IEndpointMetadataProvider).IsAssignableFrom(returnType))
         {
             // Return type implements IEndpointMetadataProvider
-            var context = new EndpointMetadataContext(methodInfo, metadata, services ?? EmptyServiceProvider);
+            var context = new EndpointMetadataContext(methodInfo, metadata, services ?? EmptyServiceProvider.Instance);
             invokeArgs ??= new object[1];
             invokeArgs[0] = context;
             PopulateMetadataForEndpointMethod.MakeGenericMethod(returnType).Invoke(null, invokeArgs);
@@ -2351,5 +2350,12 @@ public static partial class RequestDelegateFactory
         {
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class EmptyServiceProvider : IServiceProvider
+    {
+        public static IServiceProvider Instance { get; } = new EmptyServiceProvider();
+
+        public object? GetService(Type serviceType) => null;
     }
 }

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -106,6 +106,7 @@ public static partial class RequestDelegateFactory
 
     private static readonly string[] DefaultAcceptsContentType = new[] { "application/json" };
     private static readonly string[] FormFileContentType = new[] { "multipart/form-data" };
+    private static readonly IServiceProvider EmptyServiceProvider = new ServiceCollection().BuildServiceProvider();
 
     /// <summary>
     /// Creates a <see cref="RequestDelegate"/> implementation for <paramref name="handler"/>.
@@ -306,7 +307,7 @@ public static partial class RequestDelegateFactory
         var routeHandlerContext = new RouteHandlerContext(
             methodInfo,
             new EndpointMetadataCollection(factoryContext.Metadata),
-            factoryContext.ServiceProvider);
+            factoryContext.ServiceProvider ?? EmptyServiceProvider);
 
         for (var i = factoryContext.Filters.Count - 1; i >= 0; i--)
         {
@@ -443,7 +444,7 @@ public static partial class RequestDelegateFactory
             if (typeof(IEndpointParameterMetadataProvider).IsAssignableFrom(parameter.ParameterType))
             {
                 // Parameter type implements IEndpointParameterMetadataProvider
-                var parameterContext = new EndpointParameterMetadataContext(parameter, metadata, services);
+                var parameterContext = new EndpointParameterMetadataContext(parameter, metadata, services ?? EmptyServiceProvider);
                 invokeArgs ??= new object[1];
                 invokeArgs[0] = parameterContext;
                 PopulateMetadataForParameterMethod.MakeGenericMethod(parameter.ParameterType).Invoke(null, invokeArgs);
@@ -452,7 +453,7 @@ public static partial class RequestDelegateFactory
             if (typeof(IEndpointMetadataProvider).IsAssignableFrom(parameter.ParameterType))
             {
                 // Parameter type implements IEndpointMetadataProvider
-                var context = new EndpointMetadataContext(methodInfo, metadata, services);
+                var context = new EndpointMetadataContext(methodInfo, metadata, services ?? EmptyServiceProvider);
                 invokeArgs ??= new object[1];
                 invokeArgs[0] = context;
                 PopulateMetadataForEndpointMethod.MakeGenericMethod(parameter.ParameterType).Invoke(null, invokeArgs);
@@ -469,7 +470,7 @@ public static partial class RequestDelegateFactory
         if (returnType is not null && typeof(IEndpointMetadataProvider).IsAssignableFrom(returnType))
         {
             // Return type implements IEndpointMetadataProvider
-            var context = new EndpointMetadataContext(methodInfo, metadata, services);
+            var context = new EndpointMetadataContext(methodInfo, metadata, services ?? EmptyServiceProvider);
             invokeArgs ??= new object[1];
             invokeArgs[0] = context;
             PopulateMetadataForEndpointMethod.MakeGenericMethod(returnType).Invoke(null, invokeArgs);

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -305,7 +305,8 @@ public static partial class RequestDelegateFactory
             FilterContextExpr).Compile();
         var routeHandlerContext = new RouteHandlerContext(
             methodInfo,
-            new EndpointMetadataCollection(factoryContext.Metadata));
+            new EndpointMetadataCollection(factoryContext.Metadata),
+            factoryContext.ServiceProvider);
 
         for (var i = factoryContext.Filters.Count - 1; i >= 0; i--)
         {

--- a/src/Http/Http.Extensions/test/EndpointMetadataContextTests.cs
+++ b/src/Http/Http.Extensions/test/EndpointMetadataContextTests.cs
@@ -16,7 +16,7 @@ public class EndpointMetadataContextTests
     [Fact]
     public void EndpointMetadataContext_Ctor_ThrowsArgumentNullException_WhenMethodInfoIsNull()
     {
-        Assert.Throws<ArgumentNullException>(() => new EndpointMetadataContext(null, new List<object>(), null));
+        Assert.Throws<ArgumentNullException>("method", () => new EndpointMetadataContext(null, new List<object>(), null));
     }
 
     [Fact]
@@ -25,13 +25,22 @@ public class EndpointMetadataContextTests
         Delegate handler = (int id) => { };
         var method = handler.GetMethodInfo();
 
-        Assert.Throws<ArgumentNullException>(() => new EndpointMetadataContext(method, null, null));
+        Assert.Throws<ArgumentNullException>("endpointMetadata", () => new EndpointMetadataContext(method, null, null));
+    }
+
+    [Fact]
+    public void EndpointMetadataContext_Ctor_ThrowsArgumentNullException_WhenApplicationServicesAreNull()
+    {
+        Delegate handler = (int id) => { };
+        var method = handler.GetMethodInfo();
+
+        Assert.Throws<ArgumentNullException>("applicationServices", () => new EndpointMetadataContext(method, new List<object>(), null));
     }
 
     [Fact]
     public void EndpointParameterMetadataContext_Ctor_ThrowsArgumentNullException_WhenParameterInfoIsNull()
     {
-        Assert.Throws<ArgumentNullException>(() => new EndpointParameterMetadataContext(null, new List<object>(), null));
+        Assert.Throws<ArgumentNullException>("parameter", () => new EndpointParameterMetadataContext(null, new List<object>(), null));
     }
 
     [Fact]
@@ -40,6 +49,15 @@ public class EndpointMetadataContextTests
         Delegate handler = (int id) => { };
         var parameter = handler.GetMethodInfo().GetParameters()[0];
 
-        Assert.Throws<ArgumentNullException>(() => new EndpointParameterMetadataContext(parameter, null, null));
+        Assert.Throws<ArgumentNullException>("endpointMetadata", () => new EndpointParameterMetadataContext(parameter, null, null));
+    }
+
+    [Fact]
+    public void EndpointParameterMetadataContext_Ctor_ThrowsArgumentNullException_WhenApplicationServicesAreNull()
+    {
+        Delegate handler = (int id) => { };
+        var parameter = handler.GetMethodInfo().GetParameters()[0];
+
+        Assert.Throws<ArgumentNullException>("applicationServices", () => new EndpointParameterMetadataContext(parameter, new List<object>(), null));
     }
 }

--- a/src/Http/Http.Results/test/AcceptedAtRouteOfTResultTests.cs
+++ b/src/Http/Http.Results/test/AcceptedAtRouteOfTResultTests.cs
@@ -122,7 +122,7 @@ public class AcceptedAtRouteOfTResultTests
         // Arrange
         AcceptedAtRoute<Todo> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<AcceptedAtRoute<Todo>>(context);

--- a/src/Http/Http.Results/test/AcceptedAtRouteResultTests.cs
+++ b/src/Http/Http.Results/test/AcceptedAtRouteResultTests.cs
@@ -75,7 +75,7 @@ public class AcceptedAtRouteResultTests
         // Arrange
         AcceptedAtRoute MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<AcceptedAtRoute>(context);

--- a/src/Http/Http.Results/test/AcceptedOfTResultTests.cs
+++ b/src/Http/Http.Results/test/AcceptedOfTResultTests.cs
@@ -62,7 +62,7 @@ public class AcceptedOfTResultTests
         // Arrange
         Accepted<Todo> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<Accepted<Todo>>(context);

--- a/src/Http/Http.Results/test/AcceptedResultTests.cs
+++ b/src/Http/Http.Results/test/AcceptedResultTests.cs
@@ -32,7 +32,7 @@ public class AcceptedResultTests
         // Arrange
         Accepted MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<Accepted>(context);

--- a/src/Http/Http.Results/test/BadRequestOfTResultTests.cs
+++ b/src/Http/Http.Results/test/BadRequestOfTResultTests.cs
@@ -104,7 +104,7 @@ public class BadRequestOfTResultTests
         // Arrange
         BadRequest<Todo> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<BadRequest<Todo>>(context);

--- a/src/Http/Http.Results/test/BadRequestResultTests.cs
+++ b/src/Http/Http.Results/test/BadRequestResultTests.cs
@@ -45,7 +45,7 @@ public class BadRequestResultTests
         // Arrange
         BadRequest MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<BadRequest>(context);

--- a/src/Http/Http.Results/test/ConflictOfTResultTests.cs
+++ b/src/Http/Http.Results/test/ConflictOfTResultTests.cs
@@ -83,7 +83,7 @@ public class ConflictOfTResultTests
         // Arrange
         Conflict<Todo> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<Conflict<Todo>>(context);

--- a/src/Http/Http.Results/test/ConflictResultTests.cs
+++ b/src/Http/Http.Results/test/ConflictResultTests.cs
@@ -46,7 +46,7 @@ public class ConflictResultTests
         // Arrange
         Conflict MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<Conflict>(context);

--- a/src/Http/Http.Results/test/CreatedAtRouteOfTResultTests.cs
+++ b/src/Http/Http.Results/test/CreatedAtRouteOfTResultTests.cs
@@ -89,7 +89,7 @@ public partial class CreatedAtRouteOfTResultTests
         // Arrange
         CreatedAtRoute<Todo> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<CreatedAtRoute<Todo>>(context);

--- a/src/Http/Http.Results/test/CreatedAtRouteResultTests.cs
+++ b/src/Http/Http.Results/test/CreatedAtRouteResultTests.cs
@@ -71,7 +71,7 @@ public partial class CreatedAtRouteResultTests
         // Arrange
         CreatedAtRoute MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<CreatedAtRoute>(context);

--- a/src/Http/Http.Results/test/CreatedOfTResultTests.cs
+++ b/src/Http/Http.Results/test/CreatedOfTResultTests.cs
@@ -97,7 +97,7 @@ public class CreatedOfTResultTests
         // Arrange
         Created<Todo> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<Created<Todo>>(context);

--- a/src/Http/Http.Results/test/CreatedResultTests.cs
+++ b/src/Http/Http.Results/test/CreatedResultTests.cs
@@ -63,7 +63,7 @@ public class CreatedResultTests
         // Arrange
         Created MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<Created>(context);

--- a/src/Http/Http.Results/test/EmptyServiceProvider.cs
+++ b/src/Http/Http.Results/test/EmptyServiceProvider.cs
@@ -7,5 +7,5 @@ internal sealed class EmptyServiceProvider : IServiceProvider
 {
     public static IServiceProvider Instance { get; } = new EmptyServiceProvider();
 
-    public object? GetService(Type serviceType) => null;
+    public object GetService(Type serviceType) => null;
 }

--- a/src/Http/Http.Results/test/EmptyServiceProvider.cs
+++ b/src/Http/Http.Results/test/EmptyServiceProvider.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Http.HttpResults;
+
+internal sealed class EmptyServiceProvider : IServiceProvider
+{
+    public static IServiceProvider Instance { get; } = new EmptyServiceProvider();
+
+    public object? GetService(Type serviceType) => null;
+}

--- a/src/Http/Http.Results/test/NoContentResultTests.cs
+++ b/src/Http/Http.Results/test/NoContentResultTests.cs
@@ -42,7 +42,7 @@ public class NoContentResultTests
         // Arrange
         NoContent MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<NoContent>(context);

--- a/src/Http/Http.Results/test/NotFoundOfTResultTests.cs
+++ b/src/Http/Http.Results/test/NotFoundOfTResultTests.cs
@@ -65,7 +65,7 @@ public class NotFoundOfTResultTests
         // Arrange
         NotFound<Todo> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<NotFound<Todo>>(context);

--- a/src/Http/Http.Results/test/NotFoundResultTests.cs
+++ b/src/Http/Http.Results/test/NotFoundResultTests.cs
@@ -41,7 +41,7 @@ public class NotFoundResultTests
         // Arrange
         NotFound MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<NotFound>(context);

--- a/src/Http/Http.Results/test/OkOfTResultTests.cs
+++ b/src/Http/Http.Results/test/OkOfTResultTests.cs
@@ -82,7 +82,7 @@ public class OkOfTResultTests
         // Arrange
         Ok<Todo> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<Ok<Todo>>(context);

--- a/src/Http/Http.Results/test/OkResultTests.cs
+++ b/src/Http/Http.Results/test/OkResultTests.cs
@@ -45,7 +45,7 @@ public class OkResultTests
         // Arrange
         Ok MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<Ok>(context);

--- a/src/Http/Http.Results/test/ResultsOfTTests.Generated.cs
+++ b/src/Http/Http.Results/test/ResultsOfTTests.Generated.cs
@@ -208,7 +208,7 @@ public partial class ResultsOfTTests
         // Arrange
         Results<ProvidesMetadataResult1, ProvidesMetadataResult2> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<Results<ProvidesMetadataResult1, ProvidesMetadataResult2>>(context);
@@ -487,7 +487,7 @@ public partial class ResultsOfTTests
         // Arrange
         Results<ProvidesMetadataResult1, ProvidesMetadataResult2, ProvidesMetadataResult3> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<Results<ProvidesMetadataResult1, ProvidesMetadataResult2, ProvidesMetadataResult3>>(context);
@@ -843,7 +843,7 @@ public partial class ResultsOfTTests
         // Arrange
         Results<ProvidesMetadataResult1, ProvidesMetadataResult2, ProvidesMetadataResult3, ProvidesMetadataResult4> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<Results<ProvidesMetadataResult1, ProvidesMetadataResult2, ProvidesMetadataResult3, ProvidesMetadataResult4>>(context);
@@ -1284,7 +1284,7 @@ public partial class ResultsOfTTests
         // Arrange
         Results<ProvidesMetadataResult1, ProvidesMetadataResult2, ProvidesMetadataResult3, ProvidesMetadataResult4, ProvidesMetadataResult5> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<Results<ProvidesMetadataResult1, ProvidesMetadataResult2, ProvidesMetadataResult3, ProvidesMetadataResult4, ProvidesMetadataResult5>>(context);
@@ -1818,7 +1818,7 @@ public partial class ResultsOfTTests
         // Arrange
         Results<ProvidesMetadataResult1, ProvidesMetadataResult2, ProvidesMetadataResult3, ProvidesMetadataResult4, ProvidesMetadataResult5, ProvidesMetadataResult6> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<Results<ProvidesMetadataResult1, ProvidesMetadataResult2, ProvidesMetadataResult3, ProvidesMetadataResult4, ProvidesMetadataResult5, ProvidesMetadataResult6>>(context);

--- a/src/Http/Http.Results/test/ResultsOfTTests.cs
+++ b/src/Http/Http.Results/test/ResultsOfTTests.cs
@@ -94,4 +94,11 @@ public partial class ResultsOfTTests
     {
         public string SourceTypeName { get; init; }
     }
+
+    private class EmptyServiceProvider : IServiceProvider
+    {
+        public static IServiceProvider Instance { get; } = new EmptyServiceProvider();
+
+        public object GetService(Type serviceType) => null;
+    }
 }

--- a/src/Http/Http.Results/test/UnprocessableEntityOfTResultTests.cs
+++ b/src/Http/Http.Results/test/UnprocessableEntityOfTResultTests.cs
@@ -82,7 +82,7 @@ public class UnprocessableEntityOfTResultTests
         // Arrange
         UnprocessableEntity<Todo> MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<UnprocessableEntity<Todo>>(context);

--- a/src/Http/Http.Results/test/UnprocessableEntityResultTests.cs
+++ b/src/Http/Http.Results/test/UnprocessableEntityResultTests.cs
@@ -45,7 +45,7 @@ public class UnprocessableEntityResultTests
         // Arrange
         UnprocessableEntity MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<UnprocessableEntity>(context);

--- a/src/Http/Http.Results/test/ValidationProblemResultTests.cs
+++ b/src/Http/Http.Results/test/ValidationProblemResultTests.cs
@@ -62,7 +62,7 @@ public class ValidationProblemResultTests
         // Arrange
         ValidationProblem MyApi() { throw new NotImplementedException(); }
         var metadata = new List<object>();
-        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         // Act
         PopulateMetadata<ValidationProblem>(context);

--- a/src/Http/Http.Results/tools/ResultsOfTGenerator/Program.cs
+++ b/src/Http/Http.Results/tools/ResultsOfTGenerator/Program.cs
@@ -814,7 +814,7 @@ public class Program
         //    // Arrange
         //    Results<ProvidesMetadataResult1, ProvidesMetadataResult2> MyApi() { throw new NotImplementedException(); }
         //    var metadata = new List<object>();
-        //    var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);
+        //    var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);
 
         //    // Act
         //    PopulateMetadata<Results<ProvidesMetadataResult1, ProvidesMetadataResult2>>(context);
@@ -850,7 +850,7 @@ public class Program
         }
         writer.WriteLine("> MyApi() { throw new NotImplementedException(); }");
         writer.WriteIndentedLine(2, "var metadata = new List<object>();");
-        writer.WriteIndentedLine(2, "var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, null);");
+        writer.WriteIndentedLine(2, "var context = new EndpointMetadataContext(((Delegate)MyApi).GetMethodInfo(), metadata, EmptyServiceProvider.Instance);");
         writer.WriteLine();
 
         // Act

--- a/src/Http/Routing/test/UnitTests/Builder/RouteHandlerEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/RouteHandlerEndpointRouteBuilderExtensionsTest.cs
@@ -980,6 +980,7 @@ public class RouteHandlerEndpointRouteBuilderExtensionsTest : LoggedTest
         var appService = new MyService();
         appServiceCollection.AddSingleton(appService);
         var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(appServiceCollection.BuildServiceProvider()));
+        var filterFactoryRan = false;
 
         string? PrintLogger(HttpContext context) => $"loggerErrorIsEnabled: {context.Items["loggerErrorIsEnabled"]}, parentName: {context.Items["parentName"]}";
         var routeHandlerBuilder = builder.Map("/", PrintLogger);
@@ -988,12 +989,14 @@ public class RouteHandlerEndpointRouteBuilderExtensionsTest : LoggedTest
             Assert.NotNull(rhc.ApplicationServices);
             var myService = rhc.ApplicationServices.GetRequiredService<MyService>();
             Assert.Equal(appService, myService);
+            filterFactoryRan = true;
             return next;
         });
 
         var dataSource = GetBuilderEndpointDataSource(builder);
         // Trigger Endpoint build by calling getter.
-        var endpoint = Assert.Single(dataSource.Endpoints);
+        Assert.Single(dataSource.Endpoints);
+        Assert.True(filterFactoryRan);
     }
 
     [Fact]

--- a/src/Http/Routing/test/UnitTests/Builder/RouteHandlerEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/RouteHandlerEndpointRouteBuilderExtensionsTest.cs
@@ -986,7 +986,7 @@ public class RouteHandlerEndpointRouteBuilderExtensionsTest : LoggedTest
         routeHandlerBuilder.AddFilter((rhc, next) =>
         {
             Assert.NotNull(rhc.ApplicationServices);
-            var myService = rhc.ApplicationServices?.GetRequiredService<MyService>();
+            var myService = rhc.ApplicationServices.GetRequiredService<MyService>();
             Assert.Equal(appService, myService);
             return next;
         });
@@ -994,6 +994,26 @@ public class RouteHandlerEndpointRouteBuilderExtensionsTest : LoggedTest
         var dataSource = GetBuilderEndpointDataSource(builder);
         // Trigger Endpoint build by calling getter.
         var endpoint = Assert.Single(dataSource.Endpoints);
+    }
+
+    [Fact]
+    public void RouteHandlerContext_ThrowsArgumentNullException_ForMethodInfo()
+    {
+        Assert.Throws<ArgumentNullException>("methodInfo", () => new RouteHandlerContext(null!, new(), new ServiceCollection().BuildServiceProvider()));
+    }
+
+    [Fact]
+    public void RouteHandlerContext_ThrowsArgumentNullException_ForEndpointMetadata()
+    {
+        var handler = () => { };
+        Assert.Throws<ArgumentNullException>("endpointMetadata", () => new RouteHandlerContext(handler.Method, null!, new ServiceCollection().BuildServiceProvider()));
+    }
+
+    [Fact]
+    public void RouteHandlerContext_ThrowsArgumentNullException_ForApplicationServices()
+    {
+        var handler = () => { };
+        Assert.Throws<ArgumentNullException>("applicationServices", () => new RouteHandlerContext(handler.Method, new(), null!));
     }
 
     class MyService { }

--- a/src/Http/Routing/test/UnitTests/Builder/RouteHandlerEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/RouteHandlerEndpointRouteBuilderExtensionsTest.cs
@@ -901,7 +901,7 @@ public class RouteHandlerEndpointRouteBuilderExtensionsTest : LoggedTest
                 {
                     Assert.NotNull(routeHandlerContext.MethodInfo);
                     Assert.NotNull(routeHandlerContext.MethodInfo.DeclaringType);
-                    Assert.NotNull(routeHandlerContext.Services);
+                    Assert.NotNull(routeHandlerContext.ApplicationServices);
                     Assert.Equal("RouteHandlerEndpointRouteBuilderExtensionsTest", routeHandlerContext.MethodInfo.DeclaringType?.Name);
                     context.Arguments[0] = context.GetArgument<int>(0) + 1;
                     return await next(context);
@@ -985,8 +985,8 @@ public class RouteHandlerEndpointRouteBuilderExtensionsTest : LoggedTest
         var routeHandlerBuilder = builder.Map("/", PrintLogger);
         routeHandlerBuilder.AddFilter((rhc, next) =>
         {
-            Assert.NotNull(rhc.Services);
-            var myService = rhc.Services?.GetRequiredService<MyService>();
+            Assert.NotNull(rhc.ApplicationServices);
+            var myService = rhc.ApplicationServices?.GetRequiredService<MyService>();
             Assert.Equal(appService, myService);
             return next;
         });


### PR DESCRIPTION
- Added `public IServiceProvider? Services { get; }` property to `RouteHandlerContext`
- Enables route handler filter factories to access app services
- Added a unit test & updated another to ensure app's service provider is passed through correctly by `RequestDelegateFactory`
- Renamed `EndpointMetadataContext.Services` and `EndpointParameterMetadataContext.Services` to `ApplicationServices` and made non-nullable
- Added unit tests to ensure context `ApplicationServices` property is set correctly

Fixes #41900