### PR TITLE
Remove unused and incorrect P/Invoke

### DIFF
--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.cs
@@ -180,16 +180,6 @@ public partial class Startup
             });
     }
 
-    [LibraryImport("kernel32.dll")]
-    private static partial uint GetDllDirectory(uint nBufferLength, [Out, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2)] char[] lpBuffer);
-
-    private async Task DllDirectory(HttpContext context)
-    {
-        var buffer = new char[1024];
-        GetDllDirectory(1024, buffer);
-        await context.Response.WriteAsync(buffer.ToString());
-    }
-
     private async Task GetEnvironmentVariable(HttpContext ctx)
     {
         await ctx.Response.WriteAsync(Environment.GetEnvironmentVariable(ctx.Request.Query["name"].ToString()));


### PR DESCRIPTION
The work to move all P/Invokes to `LibraryImport` incorrectly converted one - see https://github.com/dotnet/aspnetcore/pull/41573#discussion_r886225399. Along with confirming this was incorrectly converted, it was also discovered the code path was dead. This explained why the testing didn't find it - no test hole.

The P/Invoke is now being removed.

/cc @adityamandaleeka 