### PR TITLE
Fix dependabot.yml formatting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,15 +13,15 @@ updates:
       include: scope
     labels:
       - area-infrastructure
-   - package-ecosystem: "github-actions"
-     directory: "/"
-     schedule:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
       # Weekly interval opens PRs on Monday.
       interval: "weekly"
-     commit-message:
-       prefix: "[main] "
-       include: scope
-     labels:
+    commit-message:
+      prefix: "[main] "
+      include: scope
+    labels:
       - area-infrastructure
 
   # Keep submodules up to date in 'release/*' branches. (Unfortunately Dependabot security PRs can't target these.)


### PR DESCRIPTION
Failing with error:
> (<unknown>): did not find expected '-' indicator while parsing a block collection at line 4 column 3

But an online linter showed the issue on line 17, so let's see what this build says.