### PR TITLE
[release/6.0] Backport Blazor boot config fix

### DIFF
--- a/src/Components/Web.JS/src/Platform/BootConfig.ts
+++ b/src/Components/Web.JS/src/Platform/BootConfig.ts
@@ -12,9 +12,15 @@ export class BootConfigResult {
       loadBootResource('manifest', 'blazor.boot.json', '_framework/blazor.boot.json', '') :
       defaultLoadBlazorBootJson('_framework/blazor.boot.json');
 
-    const bootConfigResponse = loaderResponse instanceof Promise ?
-      await loaderResponse :
-      await defaultLoadBlazorBootJson(loaderResponse ?? '_framework/blazor.boot.json');
+    let bootConfigResponse: Response;
+
+    if (!loaderResponse) {
+      bootConfigResponse = await defaultLoadBlazorBootJson('_framework/blazor.boot.json');
+    } else if (typeof loaderResponse === 'string') {
+      bootConfigResponse = await defaultLoadBlazorBootJson(loaderResponse);
+    } else {
+      bootConfigResponse = await loaderResponse;
+    }
 
     // While we can expect an ASP.NET Core hosted application to include the environment, other
     // hosts may not. Assume 'Production' in the absence of any specified value.


### PR DESCRIPTION
# Backport Blazor boot config fix

Fixed a bug preventing Blazor from starting in some cases when used within an Angular or React application.

Backport of #41976

## Description

There was an `instanceof Promise` check in `BootConfig.ts` that failed when the default `Promise` type got overridden (as it does in libraries like `zone.js`). This PR fixes the issue by rearranging the logic to avoid performing this check.

The filed issue used Blazor within in an Angular app, where Blazor was manually started using `Blazor.start()` rather than letting the script auto-start. I've reproduced original bug and verified the fix locally.

Fixes #40245

## Customer Impact

In order to maximize the adoption of Blazor, we want to minimize the effort required for customers to start being productive. If a customer is already developing an application written in a JavaScript-based SPA framework, they would be hesitant to adopt Blazor if it meant re-writing their entire application. Therefore, it has been a goal of ours to ensure customers can reuse their existing code while adding new features using Blazor.

A viable approach to achieve this in .NET 5 was to load an entire Blazor app within an existing non-Blazor app. While this scenario has been improved in .NET 6 to support adding and removing individual Blazor components anywhere on the page, some customers still use the older approach.

A bug introduced in .NET 6 prevents the older approach from working if Blazor initialization is manually deferred. This fix would re-enable that scenario.

## Regression?

- [X] Yes
- [ ] No

Version the behavior has regressed from: .NET 5

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The change is small, and we have ample test coverage for already-working scenarios.

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A
