### PR TITLE
Backport 39275 to release/6.0

### DIFF
--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
@@ -30,7 +30,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         private readonly ObjectPoolProvider _objectPoolProvider;
         private readonly MvcOptions _options;
         private readonly MvcNewtonsoftJsonOptions _jsonOptions;
-        private readonly bool _skipHandledErrorEnabled;
 
         private ObjectPool<JsonSerializer>? _jsonSerializerPool;
 
@@ -82,7 +81,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             _options = options;
             _jsonOptions = jsonOptions;
 
-            _skipHandledErrorEnabled = AppContext.TryGetSwitch(EnableSkipHandledError, out var enabled) && enabled;
+            SkipHandledErrorEnabled = AppContext.TryGetSwitch(EnableSkipHandledError, out var enabled) && enabled;
 
             SupportedEncodings.Add(UTF8EncodingWithoutBOM);
             SupportedEncodings.Add(UTF16EncodingLittleEndian);
@@ -113,6 +112,9 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         /// <see cref="NewtonsoftJsonInputFormatter"/> has been used will have no effect.
         /// </remarks>
         protected JsonSerializerSettings SerializerSettings { get; }
+
+        // internal for testing
+        internal bool SkipHandledErrorEnabled { get; set; }
 
         /// <inheritdoc />
         public override async Task<InputFormatterResult> ReadRequestBodyAsync(
@@ -239,7 +241,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             {
                 // Skipping error, if it's already marked as handled
                 // This allows user code to implement its own error handling
-                if (eventArgs.ErrorContext.Handled && _skipHandledErrorEnabled)
+                if (eventArgs.ErrorContext.Handled && SkipHandledErrorEnabled)
                 {
                     return;
                 }

--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
@@ -30,6 +30,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         private readonly ObjectPoolProvider _objectPoolProvider;
         private readonly MvcOptions _options;
         private readonly MvcNewtonsoftJsonOptions _jsonOptions;
+        private readonly bool _skipHandledErrorEnabled;
 
         private ObjectPool<JsonSerializer>? _jsonSerializerPool;
 
@@ -80,6 +81,8 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             _objectPoolProvider = objectPoolProvider;
             _options = options;
             _jsonOptions = jsonOptions;
+
+            _skipHandledErrorEnabled = AppContext.TryGetSwitch(EnableSkipHandledError, out var enabled) && enabled;
 
             SupportedEncodings.Add(UTF8EncodingWithoutBOM);
             SupportedEncodings.Add(UTF16EncodingLittleEndian);
@@ -236,8 +239,7 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             {
                 // Skipping error, if it's already marked as handled
                 // This allows user code to implement its own error handling
-                if (eventArgs.ErrorContext.Handled &&
-                    AppContext.TryGetSwitch(EnableSkipHandledError, out var enabled) && enabled)
+                if (eventArgs.ErrorContext.Handled && _skipHandledErrorEnabled)
                 {
                     return;
                 }

--- a/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonInputFormatterTest.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonInputFormatterTest.cs
@@ -490,8 +490,6 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
         [Fact]
         public async Task ReadAsync_AllowUserCodeToHandleDeserializationErrors()
         {
-            AppContext.SetSwitch(NewtonsoftJsonInputFormatter.EnableSkipHandledError, isEnabled: true);
-
             // Arrange
             var serializerSettings = new JsonSerializerSettings
             {
@@ -506,7 +504,10 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
                 ArrayPool<char>.Shared,
                 _objectPoolProvider,
                 new MvcOptions(),
-                new MvcNewtonsoftJsonOptions());
+                new MvcNewtonsoftJsonOptions())
+            {
+                SkipHandledErrorEnabled = true
+            };
 
             var content = $"{{'id': 'should be integer', 'name': 'test location'}}";
             var contentBytes = Encoding.UTF8.GetBytes(content);

--- a/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonInputFormatterTest.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/test/NewtonsoftJsonInputFormatterTest.cs
@@ -487,6 +487,46 @@ namespace Microsoft.AspNetCore.Mvc.Formatters
             }
         }
 
+        [Fact]
+        public async Task ReadAsync_AllowUserCodeToHandleDeserializationErrors()
+        {
+            AppContext.SetSwitch(NewtonsoftJsonInputFormatter.EnableSkipHandledError, isEnabled: true);
+
+            // Arrange
+            var serializerSettings = new JsonSerializerSettings
+            {
+                Error = (sender, eventArgs) =>
+                {
+                    eventArgs.ErrorContext.Handled = true;
+                }
+            };
+            var formatter = new NewtonsoftJsonInputFormatter(
+                GetLogger(),
+                serializerSettings,
+                ArrayPool<char>.Shared,
+                _objectPoolProvider,
+                new MvcOptions(),
+                new MvcNewtonsoftJsonOptions());
+
+            var content = $"{{'id': 'should be integer', 'name': 'test location'}}";
+            var contentBytes = Encoding.UTF8.GetBytes(content);
+            var httpContext = new DefaultHttpContext();
+            httpContext.Features.Set<IHttpResponseFeature>(new TestResponseFeature());
+            httpContext.Request.Body = new NonSeekableReadStream(contentBytes, allowSyncReads: false);
+            httpContext.Request.ContentType = "application/json";
+
+            var formatterContext = CreateInputFormatterContext(typeof(Location), httpContext);
+
+            // Act
+            var result = await formatter.ReadAsync(formatterContext);
+
+            // Assert
+            Assert.False(result.HasError);
+            var location = (Location)result.Model;
+            Assert.Equal(0, location?.Id);
+            Assert.Equal("test location", location?.Name);
+        }
+
         private class TestableJsonInputFormatter : NewtonsoftJsonInputFormatter
         {
             public TestableJsonInputFormatter(JsonSerializerSettings settings, ObjectPoolProvider objectPoolProvider)


### PR DESCRIPTION
# NewtonsoftJsonInputFormatter checks for ErrorContext.Handled flag

Added check for `eventArgs.ErrorContext.Handled` flag before reporting error.

## Description

`Newtonsoft.Json` supports error handling serialization/deserialization that lets you catch an error and choose whether to handle it and continue with serialization or let the error bubble up and be thrown in your application. `ASP.NET Core` allows you to do this configuration through the `MvcNewtonsoftJsonOptions.JsonSerializerSettings`. 

```c#
services
    .AddControllers()
    .AddNewtonsoftJson(options =>
    {
        options.SerializerSettings.Error = (s, args) => { args.ErrorContext.Handled = true;  }
    });
```

However, the built-in `input formatter` is not checking if the `ErrorContext` is already `Handled` causing the exception to be reported to the `ModelState`.  This fix is adding a check for `eventArgs.ErrorContext.Handled` flag before reporting error.

Also, probably users are not using since it is not working, however, the new behavior must be opted-in using the compat flag `Microsoft.AspNetCore.Mvc.NewtonsoftJson.EnableSkipHandledError`.

Fixes #37323

## Customer Impact

Since ASP.NET (.NET Framework) does not report the error, this been reported as a block issue during the migration to ASP.NET Core (.NET 6) (Eg.: https://github.com/dotnet/aspnetcore/issues/41883)

## Regression?

- [ ] Yes
- [X] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [X] Low

We are introducing a compat flag `Microsoft.AspNetCore.Mvc.NewtonsoftJson.EnableSkipHandledError` that users need to opt-in.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A
