### PR TITLE
fix: user options not bound when published

### DIFF
--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Options/RemoteAuthenticationApplicationPathsOptions.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Options/RemoteAuthenticationApplicationPathsOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 /// <summary>
 /// Represents the options for the paths used by the application for authentication operations. These paths are relative to the base.
 /// </summary>
-[DynamicallyAccessedMembers(JsonSerialized)] // fix #41998 Can be initialized by configuration binding
+[DynamicallyAccessedMembers(JsonSerialized)]
 public class RemoteAuthenticationApplicationPathsOptions
 {
     /// <summary>

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Options/RemoteAuthenticationApplicationPathsOptions.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Options/RemoteAuthenticationApplicationPathsOptions.cs
@@ -1,11 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using System.Diagnostics.CodeAnalysis;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 
 /// <summary>
 /// Represents the options for the paths used by the application for authentication operations. These paths are relative to the base.
 /// </summary>
+[DynamicallyAccessedMembers(JsonSerialized)] // Can be initialized by configuration binding
 public class RemoteAuthenticationApplicationPathsOptions
 {
     /// <summary>

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Options/RemoteAuthenticationApplicationPathsOptions.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Options/RemoteAuthenticationApplicationPathsOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 /// <summary>
 /// Represents the options for the paths used by the application for authentication operations. These paths are relative to the base.
 /// </summary>
-[DynamicallyAccessedMembers(JsonSerialized)] // Can be initialized by configuration binding
+[DynamicallyAccessedMembers(JsonSerialized)] // fix #41998 Can be initialized by configuration binding
 public class RemoteAuthenticationApplicationPathsOptions
 {
     /// <summary>

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Options/RemoteAuthenticationUserOptions.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Options/RemoteAuthenticationUserOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 /// <summary>
 /// Represents options to use when configuring the <see cref="System.Security.Claims.ClaimsPrincipal"/> for a user.
 /// </summary>
-[DynamicallyAccessedMembers(JsonSerialized)] // fix #41998 Can be initialized by configuration binding
+[DynamicallyAccessedMembers(JsonSerialized)] 
 public class RemoteAuthenticationUserOptions
 {
     /// <summary>

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Options/RemoteAuthenticationUserOptions.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Options/RemoteAuthenticationUserOptions.cs
@@ -1,11 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using System.Diagnostics.CodeAnalysis;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 
 /// <summary>
 /// Represents options to use when configuring the <see cref="System.Security.Claims.ClaimsPrincipal"/> for a user.
 /// </summary>
+[DynamicallyAccessedMembers(JsonSerialized)] // Can be initialized by configuration binding
 public class RemoteAuthenticationUserOptions
 {
     /// <summary>

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Options/RemoteAuthenticationUserOptions.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Options/RemoteAuthenticationUserOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 /// <summary>
 /// Represents options to use when configuring the <see cref="System.Security.Claims.ClaimsPrincipal"/> for a user.
 /// </summary>
-[DynamicallyAccessedMembers(JsonSerialized)] // Can be initialized by configuration binding
+[DynamicallyAccessedMembers(JsonSerialized)] // fix #41998 Can be initialized by configuration binding
 public class RemoteAuthenticationUserOptions
 {
     /// <summary>


### PR DESCRIPTION
# fix: user options not bound when published

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

{Detail}

Fixes #41998 (in this specific format)
