### PR TITLE
Did the first task of issue #42016: removing the default address (https://localhost:5001) for https

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -423,9 +423,6 @@
   <data name="ServerCertificateRequired" xml:space="preserve">
     <value>The server certificate parameter is required.</value>
   </data>
-  <data name="BindingToDefaultAddresses" xml:space="preserve">
-    <value>No listening endpoints were configured. Binding to {address0} and {address1} by default.</value>
-  </data>
   <data name="CertNotFoundInStore" xml:space="preserve">
     <value>The requested certificate {subject} could not be found in {storeLocation}/{storeName} with AllowInvalid setting: {allowInvalid}.</value>
   </data>

--- a/src/Servers/Kestrel/Core/src/Internal/AddressBinder.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/AddressBinder.cs
@@ -151,7 +151,6 @@ internal sealed class AddressBinder
             context.ServerOptions.ApplyEndpointDefaults(httpDefault);
             await httpDefault.BindAsync(context, cancellationToken).ConfigureAwait(false);
 
-            // No default cert is available, do not bind to the https endpoint.
             context.Logger.LogDebug(CoreStrings.BindingToDefaultAddress, Constants.DefaultServerAddress);
         }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/AddressBinder.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/AddressBinder.cs
@@ -151,21 +151,8 @@ internal sealed class AddressBinder
             context.ServerOptions.ApplyEndpointDefaults(httpDefault);
             await httpDefault.BindAsync(context, cancellationToken).ConfigureAwait(false);
 
-            // Conditional https default, only if a cert is available
-            var httpsDefault = ParseAddress(Constants.DefaultServerHttpsAddress, out _);
-            context.ServerOptions.ApplyEndpointDefaults(httpsDefault);
-
-            if (httpsDefault.IsTls || httpsDefault.TryUseHttps())
-            {
-                await httpsDefault.BindAsync(context, cancellationToken).ConfigureAwait(false);
-                context.Logger.LogDebug(CoreStrings.BindingToDefaultAddresses,
-                    Constants.DefaultServerAddress, Constants.DefaultServerHttpsAddress);
-            }
-            else
-            {
-                // No default cert is available, do not bind to the https endpoint.
-                context.Logger.LogDebug(CoreStrings.BindingToDefaultAddress, Constants.DefaultServerAddress);
-            }
+            // No default cert is available, do not bind to the https endpoint.
+            context.Logger.LogDebug(CoreStrings.BindingToDefaultAddress, Constants.DefaultServerAddress);
         }
     }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/Constants.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/Constants.cs
@@ -13,11 +13,6 @@ internal static class Constants
     public const string DefaultServerAddress = "http://localhost:5000";
 
     /// <summary>
-    /// The endpoint Kestrel will bind to if nothing else is specified and a default certificate is available.
-    /// </summary>
-    public const string DefaultServerHttpsAddress = "https://localhost:5001";
-
-    /// <summary>
     /// Prefix of host name used to specify Unix sockets in the configuration.
     /// </summary>
     public const string UnixPipeHostPrefix = "unix:/";

--- a/src/Servers/Kestrel/Core/test/AddressBinderTests.cs
+++ b/src/Servers/Kestrel/Core/test/AddressBinderTests.cs
@@ -248,27 +248,16 @@ public class AddressBinderTests
     }
 
     [Fact]
-    public async Task DefaultAddressBinderWithoutDevCertButHttpsConfiguredBindsToHttpsPorts()
+    public async Task DefaultAddressBinderBindsToHttpPort5000()
     {
-        var x509Certificate2 = TestResources.GetTestCertificate();
         var logger = new MockLogger();
         var addresses = new ServerAddressesFeature();
         var services = new ServiceCollection();
         services.AddLogging();
         var options = new KestrelServerOptions()
         {
-            // This stops the dev cert from being loaded
-            IsDevCertLoaded = true,
             ApplicationServices = services.BuildServiceProvider()
         };
-
-        options.ConfigureEndpointDefaults(e =>
-        {
-            if (e.IPEndPoint.Port == 5001)
-            {
-                e.UseHttps(new HttpsConnectionAdapterOptions { ServerCertificate = x509Certificate2 });
-            }
-        });
 
         var endpoints = new List<ListenOptions>();
 
@@ -285,6 +274,5 @@ public class AddressBinderTests
         await AddressBinder.BindAsync(options.ListenOptions, addressBindContext, CancellationToken.None);
 
         Assert.Contains(endpoints, e => e.IPEndPoint.Port == 5000 && !e.IsTls);
-        Assert.Contains(endpoints, e => e.IPEndPoint.Port == 5001 && e.IsTls);
     }
 }

--- a/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
+++ b/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
@@ -520,7 +520,7 @@ public class AddressRegistrationTests : TestApplicationErrorLoggerLoggedTest
             Assert.Equal(5000, host.GetPort());
 
             Assert.Single(LogMessages, log => log.LogLevel == LogLevel.Debug &&
-                (string.Equals(CoreStrings.FormatBindingToDefaultAddresses(Constants.DefaultServerAddress, "https://localhost:0"), log.Message, StringComparison.Ordinal)
+                (string.Equals(CoreStrings.FormatBindingToDefaultAddress(Constants.DefaultServerAddress), log.Message, StringComparison.Ordinal)
                     || string.Equals(CoreStrings.FormatBindingToDefaultAddress(Constants.DefaultServerAddress), log.Message, StringComparison.Ordinal)));
 
             foreach (var address in addresses)

--- a/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
+++ b/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
@@ -130,12 +130,11 @@ public class AddressRegistrationTests : TestApplicationErrorLoggerLoggedTest
     }
 
     [ConditionalTheory]
-    [MemberData(nameof(AddressRegistrationDataIPv6Port5000And5001Default))]
+    [MemberData(nameof(AddressRegistrationDataIPv6Port5000Default))]
     [IPv6SupportedCondition]
-    public async Task RegisterAddresses_IPv6Port5000And5001Default_Success(string addressInput, string[] testUrls)
+    public async Task RegisterAddresses_IPv6Port5000Default_Success(string addressInput, string[] testUrls)
     {
-        if ((!CanBindToEndpoint(IPAddress.Loopback, 5000) || !CanBindToEndpoint(IPAddress.IPv6Loopback, 5000)) &&
-            (!CanBindToEndpoint(IPAddress.Loopback, 5001) || !CanBindToEndpoint(IPAddress.IPv6Loopback, 5001)))
+        if (!CanBindToEndpoint(IPAddress.Loopback, 5000) || !CanBindToEndpoint(IPAddress.IPv6Loopback, 5000))
         {
             return;
         }
@@ -471,32 +470,30 @@ public class AddressRegistrationTests : TestApplicationErrorLoggerLoggedTest
 
     [ConditionalFact]
     [SkipOnCI]
-    public Task DefaultsServerAddress_BindsToIPv4WithHttps()
+    public Task DefaultsServerAddress_BindsToIPv4WithHttp()
     {
-        if (!CanBindToEndpoint(IPAddress.Loopback, 5000) || !CanBindToEndpoint(IPAddress.Loopback, 5001))
+        if (!CanBindToEndpoint(IPAddress.Loopback, 5000))
         {
             return Task.CompletedTask;
         }
 
         return RegisterDefaultServerAddresses_Success(
-            new[] { "http://127.0.0.1:5000", "https://127.0.0.1:5001" }, mockHttps: true);
+            new[] { "http://127.0.0.1:5000" }, mockHttps: false);
     }
 
     [ConditionalFact]
     [IPv6SupportedCondition]
     [SkipOnCI]
-    public Task DefaultsServerAddress_BindsToIPv6WithHttps()
+    public Task DefaultsServerAddress_BindsToIPv6WithHttp()
     {
-        if (!CanBindToEndpoint(IPAddress.Loopback, 5000) || !CanBindToEndpoint(IPAddress.IPv6Loopback, 5000)
-            || !CanBindToEndpoint(IPAddress.Loopback, 5001) || !CanBindToEndpoint(IPAddress.IPv6Loopback, 5001))
+        if (!CanBindToEndpoint(IPAddress.Loopback, 5000) || !CanBindToEndpoint(IPAddress.IPv6Loopback, 5000))
         {
             return Task.CompletedTask;
         }
 
-        return RegisterDefaultServerAddresses_Success(new[] {
-                "http://127.0.0.1:5000", "http://[::1]:5000",
-                "https://127.0.0.1:5001", "https://[::1]:5001"},
-            mockHttps: true);
+        return RegisterDefaultServerAddresses_Success(
+            new[] { "http://127.0.0.1:5000", "http://[::1]:5000" },
+            mockHttps: false);
     }
 
     private async Task RegisterDefaultServerAddresses_Success(IEnumerable<string> addresses, bool mockHttps = false)
@@ -522,13 +519,8 @@ public class AddressRegistrationTests : TestApplicationErrorLoggerLoggedTest
 
             Assert.Equal(5000, host.GetPort());
 
-            if (mockHttps)
-            {
-                Assert.Contains(5001, host.GetPorts());
-            }
-
             Assert.Single(LogMessages, log => log.LogLevel == LogLevel.Debug &&
-                (string.Equals(CoreStrings.FormatBindingToDefaultAddresses(Constants.DefaultServerAddress, Constants.DefaultServerHttpsAddress), log.Message, StringComparison.Ordinal)
+                (string.Equals(CoreStrings.FormatBindingToDefaultAddresses(Constants.DefaultServerAddress, "https://localhost:0"), log.Message, StringComparison.Ordinal)
                     || string.Equals(CoreStrings.FormatBindingToDefaultAddress(Constants.DefaultServerAddress), log.Message, StringComparison.Ordinal)));
 
             foreach (var address in addresses)
@@ -1144,11 +1136,11 @@ public class AddressRegistrationTests : TestApplicationErrorLoggerLoggedTest
         }
     }
 
-    public static TheoryData<string, string[]> AddressRegistrationDataIPv6Port5000And5001Default =>
+    public static TheoryData<string, string[]> AddressRegistrationDataIPv6Port5000Default =>
         new TheoryData<string, string[]>
         {
-                { null, new[] { "http://127.0.0.1:5000/", "http://[::1]:5000/", "https://127.0.0.1:5001/", "https://[::1]:5001/" } },
-                { string.Empty, new[] { "http://127.0.0.1:5000/", "http://[::1]:5000/", "https://127.0.0.1:5001/", "https://[::1]:5001/" } }
+                { null, new[] { "http://127.0.0.1:5000/", "http://[::1]:5000/" } },
+                { string.Empty, new[] { "http://127.0.0.1:5000/", "http://[::1]:5000/" } }
         };
 
     public static TheoryData<string, string[]> AddressRegistrationDataIPv6Port80 =>


### PR DESCRIPTION
This PR removes the default fallback address for HTTPS connections. This is part of step 1 of Damian's issue #42016. 

I also modified the tests that broke to remove the references to https. As they specifically tested for defaults, I decided not to replace the https parts. I am not sure though if this has put holes in the test coverage. I don't believe they did but it is probably worth keeping in mind for those reviewing the PR.

Contributes to: #42016