### PR TITLE
[release/6.0] Define `$(HelixTestConfigurationFilePath)`

### DIFF
--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -47,6 +47,13 @@
 
     <!-- Similar to ProjectLayout.props in the Arcade SDK. The Helix SDK contains nothing similar. -->
     <OutputPath Condition=" '$(OutputPath)' == '' ">$(RepoRoot)artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+
+    <!--
+      Define $(HelixTestConfigurationFilePath) so the Helix SDK automatically includes our test config file in the
+      correlation payload. The Helix SDK has a fallback value that doesn't work w/o including the Arcade SDK and
+      we intentionally do not do that in this project.
+    -->
+    <HelixTestConfigurationFilePath>$(RepoRoot)eng/test-configuration.json</HelixTestConfigurationFilePath>
   </PropertyGroup>
 
   <!-- Specify the runtime we need which will be included as a correlation payload -->


### PR DESCRIPTION
- manual backport of #42029
- avoid problems caused by an undocumented dependency in the Helix SDK on the Arcade SDK
- symptoms were a complete lack of retries in our Helix work items