### PR TITLE
Clean up test retry list

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -3,13 +3,10 @@
   "defaultOnFailure": "fail",
   "localRerunCount" : 3,
   "retryOnRules": [
-    {"testName": {"contains": "AppOfflineDroppedWhileSiteStarting_SiteShutsDown_InProcess"}},
-    {"testName": {"contains": "AppOfflineDroppedWhileSiteIsDown_SiteReturns503_InProcess"}},
     {"testName": {"contains": "MaxRequestBufferSizeTests.LargeUpload" }},
     {"testName": {"contains": "ReaderThrowsResetExceptionOnInvalidBody" }},
-    {"testName": {"contains": "ShadowCopyTests" }},
-    {"testAssembly": {"wildcard": "IIS*Tests*"}},
-    {"testAssembly": {"wildcard": "IIS.ShadowCopy.Tests*"}},
+    {"testAssembly": {"contains": "IIS*"}},
+    {"testAssembly": {"contains": "ShadowCopy"}},
     {"failureMessage": {"contains":"(Site is started but no worker process found) (Site is started but no worker process found)"}},
     {"failureMessage": {"contains": "network disconnected"}}
   ],

--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -3,6 +3,7 @@
   "defaultOnFailure": "fail",
   "localRerunCount" : 3,
   "retryOnRules": [
+    {"testName": {"contains": "FlakyTestToEnsureRetryWorks" }},
     {"testName": {"contains": "MaxRequestBufferSizeTests.LargeUpload" }},
     {"testName": {"contains": "ReaderThrowsResetExceptionOnInvalidBody" }},
     {"testAssembly": {"contains": "IIS*"}},

--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -7,7 +7,6 @@
     {"testName": {"contains": "MaxRequestBufferSizeTests.LargeUpload" }},
     {"testName": {"contains": "ReaderThrowsResetExceptionOnInvalidBody" }},
     {"testAssembly": {"contains": "IIS"}},
-    {"testAssembly": {"contains": "ShadowCopy"}},
     {"failureMessage": {"contains":"(Site is started but no worker process found) (Site is started but no worker process found)"}},
     {"failureMessage": {"contains": "network disconnected"}}
   ],

--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -6,7 +6,7 @@
     {"testName": {"contains": "FlakyTestToEnsureRetryWorks" }},
     {"testName": {"contains": "MaxRequestBufferSizeTests.LargeUpload" }},
     {"testName": {"contains": "ReaderThrowsResetExceptionOnInvalidBody" }},
-    {"testAssembly": {"contains": "IIS*"}},
+    {"testAssembly": {"contains": "IIS"}},
     {"testAssembly": {"contains": "ShadowCopy"}},
     {"failureMessage": {"contains":"(Site is started but no worker process found) (Site is started but no worker process found)"}},
     {"failureMessage": {"contains": "network disconnected"}}

--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -7,9 +7,10 @@
     {"testName": {"contains": "AppOfflineDroppedWhileSiteIsDown_SiteReturns503_InProcess"}},
     {"testName": {"contains": "MaxRequestBufferSizeTests.LargeUpload" }},
     {"testName": {"contains": "ReaderThrowsResetExceptionOnInvalidBody" }},
+    {"testName": {"contains": "ShadowCopyTests" }},
     {"testAssembly": {"wildcard": "IIS*Tests*"}},
     {"testAssembly": {"wildcard": "IIS.ShadowCopy.Tests*"}},
-    {"failureMessage": {"contains":"System.AggregateException : One or more errors occurred. (Operation did not succeed after 15 retries (Site is started but no worker process found) (Site is started but no worker process found)"}},
+    {"failureMessage": {"contains":"(Site is started but no worker process found) (Site is started but no worker process found)"}},
     {"failureMessage": {"contains": "network disconnected"}}
   ],
   "failOnRules": [

--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -5,12 +5,10 @@
   "retryOnRules": [
     {"testName": {"contains": "AppOfflineDroppedWhileSiteStarting_SiteShutsDown_InProcess"}},
     {"testName": {"contains": "AppOfflineDroppedWhileSiteIsDown_SiteReturns503_InProcess"}},
-    {"testName": {"contains": "CheckFrebDisconnect"}},
-    {"testName": {"contains": "CheckStdoutWithLargeWrites"}},
-    {"testName": {"contains": "ServerShutsDownWhenMainExitsStress" }},
-    {"testName": {"contains": "AddressRegistrationTests" }},
     {"testName": {"contains": "MaxRequestBufferSizeTests.LargeUpload" }},
     {"testName": {"contains": "ReaderThrowsResetExceptionOnInvalidBody" }},
+    {"testAssembly": {"wildcard": "IIS*Tests*"}},
+    {"testAssembly": {"wildcard": "IIS.ShadowCopy.Tests*"}},
     {"failureMessage": {"contains":"System.AggregateException : One or more errors occurred. (Operation did not succeed after 15 retries (Site is started but no worker process found) (Site is started but no worker process found)"}},
     {"failureMessage": {"contains": "network disconnected"}}
   ],

--- a/src/Servers/IIS/IIS/test/IIS.ShadowCopy.Tests/ShadowCopyTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.ShadowCopy.Tests/ShadowCopyTests.cs
@@ -41,6 +41,9 @@ public class ShadowCopyTests : IISFunctionalTestBase
         {
             dirInfo.Delete(recursive: true);
         }
+        
+        // Force a failure REMOVE
+        Assert.False(response.IsSuccessStatusCode);
     }
 
     [ConditionalFact]

--- a/src/Servers/IIS/IIS/test/IIS.ShadowCopy.Tests/ShadowCopyTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.ShadowCopy.Tests/ShadowCopyTests.cs
@@ -41,9 +41,6 @@ public class ShadowCopyTests : IISFunctionalTestBase
         {
             dirInfo.Delete(recursive: true);
         }
-        
-        // Force a failure REMOVE
-        Assert.False(response.IsSuccessStatusCode);
     }
 
     [ConditionalFact]

--- a/src/Testing/test/QuarantinedTestAttributeTest.cs
+++ b/src/Testing/test/QuarantinedTestAttributeTest.cs
@@ -18,4 +18,13 @@ public class QuarantinedTestAttributeTest
             throw new Exception("Flaky!");
         }
     }
+
+    [Fact]
+    [QuarantinedTest("No issue, used to verify retry is working")]
+    public void FlakyTestToEnsureRetryWorks()
+    {
+        // Fail 20% of the time
+        Assert.True(new Random().Next(100) <= 80);
+    }
+
 }

--- a/src/Testing/test/QuarantinedTestAttributeTest.cs
+++ b/src/Testing/test/QuarantinedTestAttributeTest.cs
@@ -26,5 +26,4 @@ public class QuarantinedTestAttributeTest
         // Fail 20% of the time
         Assert.True(new Random().Next(100) <= 80);
     }
-
 }


### PR DESCRIPTION
- Clean up old retry list
- Use retries for all IIS/ShadowCopy tests for now (until I find the root cause of the (Operation did not succeed after 15 retries (Site is started but no worker process found) (Site is started but no worker process found) errors)
- Add a 20% flaky test that's always in quarantine which can be used as a canary to infer if retry is working by looking at the quarantined PR analytics