### PR TITLE
Identity UI: Input forms' `form-floating` broken styles fixed.

### DIFF
--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ExternalLogin.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ExternalLogin.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+@page
 @model ExternalLoginModel
 @{
     ViewData["Title"] = "Register";
@@ -18,8 +18,8 @@
     <div class="col-md-4">
         <form asp-page-handler="Confirmation" asp-route-returnUrl="@Model.ReturnUrl" method="post">
             <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
-            <div class="form-floating">
-                <input asp-for="Input.Email" class="form-control" autocomplete="email" />
+            <div class="form-floating mb-3">
+                <input asp-for="Input.Email" class="form-control" autocomplete="email" placeholder="Please enter your email."/>
                 <label asp-for="Input.Email" class="form-label"></label>
                 <span asp-validation-for="Input.Email" class="text-danger"></span>
             </div>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Login.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Login.cshtml
@@ -18,18 +18,16 @@
                     <label asp-for="Input.Email" class="form-label">Email</label>
                     <span asp-validation-for="Input.Email" class="text-danger"></span>
                 </div>
-                <div class="form-floating">
+                <div class="form-floating mb-3">
                     <input asp-for="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" placeholder="password" />
                     <label asp-for="Input.Password" class="form-label">Password</label>
                     <span asp-validation-for="Input.Password" class="text-danger"></span>
                 </div>
-                <div>
-                    <div class="checkbox">
-                        <label asp-for="Input.RememberMe" class="form-label">
-                            <input class="form-check-input" asp-for="Input.RememberMe" />
-                            @Html.DisplayNameFor(m => m.Input.RememberMe)
-                        </label>
-                    </div>
+                <div class="checkbox mb-3">
+                    <label asp-for="Input.RememberMe" class="form-label">
+                        <input class="form-check-input" asp-for="Input.RememberMe" />
+                        @Html.DisplayNameFor(m => m.Input.RememberMe)
+                    </label>
                 </div>
                 <div>
                     <button id="login-submit" type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/LoginWith2fa.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/LoginWith2fa.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+@page
 @model LoginWith2faModel
 @{
     ViewData["Title"] = "Two-factor authentication";
@@ -12,18 +12,16 @@
         <form method="post" asp-route-returnUrl="@Model.ReturnUrl">
             <input asp-for="RememberMe" type="hidden" />
             <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
-            <div class="form-floating">
+            <div class="form-floating mb-3">
                 <input asp-for="Input.TwoFactorCode" class="form-control" autocomplete="off" />
                 <label asp-for="Input.TwoFactorCode" class="form-label"></label>
                 <span asp-validation-for="Input.TwoFactorCode" class="text-danger"></span>
             </div>
-            <div>
-                <div class="checkbox">
-                    <label asp-for="Input.RememberMachine" class="form-label">
-                        <input asp-for="Input.RememberMachine" />
-                        @Html.DisplayNameFor(m => m.Input.RememberMachine)
-                    </label>
-                </div>
+            <div class="checkbox mb-3">
+                <label asp-for="Input.RememberMachine" class="form-label">
+                    <input asp-for="Input.RememberMachine" />
+                    @Html.DisplayNameFor(m => m.Input.RememberMachine)
+                </label>
             </div>
             <div>
                 <button type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/LoginWithRecoveryCode.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/LoginWithRecoveryCode.cshtml
@@ -14,8 +14,8 @@
     <div class="col-md-4">
         <form method="post">
             <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
-            <div class="form-floating">
-                <input asp-for="Input.RecoveryCode" class="form-control" autocomplete="off" />
+            <div class="form-floating mb-3">
+                <input asp-for="Input.RecoveryCode" class="form-control" autocomplete="off" placeholder="RecoveryCode" />
                 <label asp-for="Input.RecoveryCode" class="form-label"></label>
                 <span asp-validation-for="Input.RecoveryCode" class="text-danger"></span>
             </div>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/ChangePassword.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/ChangePassword.cshtml
@@ -11,18 +11,18 @@
     <div class="col-md-6">
         <form id="change-password-form" method="post">
             <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
-            <div class="form-floating">
-                <input asp-for="Input.OldPassword" class="form-control" autocomplete="current-password" aria-required="true" />
+            <div class="form-floating mb-3">
+                <input asp-for="Input.OldPassword" class="form-control" autocomplete="current-password" aria-required="true" placeholder="Please enter your old password." />
                 <label asp-for="Input.OldPassword" class="form-label"></label>
                 <span asp-validation-for="Input.OldPassword" class="text-danger"></span>
             </div>
-            <div class="form-floating">
-                <input asp-for="Input.NewPassword" class="form-control" autocomplete="new-password" aria-required="true" />
+            <div class="form-floating mb-3">
+                <input asp-for="Input.NewPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="Please enter your new password." />
                 <label asp-for="Input.NewPassword" class="form-label"></label>
                 <span asp-validation-for="Input.NewPassword" class="text-danger"></span>
             </div>
-            <div class="form-floating">
-                <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" />
+            <div class="form-floating mb-3">
+                <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="Please confirm your new password."/>
                 <label asp-for="Input.ConfirmPassword" class="form-label"></label>
                 <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
             </div>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/DeletePersonalData.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/DeletePersonalData.cshtml
@@ -18,8 +18,8 @@
         <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
         @if (Model.RequirePassword)
         {
-            <div class="form-floating">
-                <input asp-for="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" />
+            <div class="form-floating mb-3">
+                <input asp-for="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" placeholder="Please enter your password." />
                 <label asp-for="Input.Password" class="form-label"></label>
                 <span asp-validation-for="Input.Password" class="text-danger"></span>
             </div>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/Email.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/Email.cshtml
@@ -13,8 +13,8 @@
             <div asp-validation-summary="All" class="text-danger" role="alert"></div>
             @if (Model.IsEmailConfirmed)
             {
-                <div class="form-floating input-group">
-                    <input asp-for="Email" class="form-control" disabled />
+                <div class="form-floating mb-3 input-group">
+                    <input asp-for="Email" class="form-control" placeholder="Please enter your email." disabled />
                         <div class="input-group-append">
                             <span class="h-100 input-group-text text-success font-weight-bold">✓</span>
                         </div>
@@ -23,14 +23,14 @@
             }
             else
             {
-                <div class="form-floating">
-                    <input asp-for="Email" class="form-control" disabled />
+                <div class="form-floating mb-3">
+                    <input asp-for="Email" class="form-control" placeholder="Please enter your email." disabled />
                     <label asp-for="Email" class="form-label"></label>
                     <button id="email-verification" type="submit" asp-page-handler="SendVerificationEmail" class="btn btn-link">Send verification email</button>
                 </div>
             }
-            <div class="form-floating">
-                <input asp-for="Input.NewEmail" class="form-control" autocomplete="email" aria-required="true" />
+            <div class="form-floating mb-3">
+                <input asp-for="Input.NewEmail" class="form-control" autocomplete="email" aria-required="true" placeholder="Please enter new email." />
                 <label asp-for="Input.NewEmail" class="form-label"></label>
                 <span asp-validation-for="Input.NewEmail" class="text-danger"></span>
             </div>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/EnableAuthenticator.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/EnableAuthenticator.cshtml
@@ -34,8 +34,8 @@
             <div class="row">
                 <div class="col-md-6">
                     <form id="send-code" method="post">
-                        <div class="form-floating">
-                            <input asp-for="Input.Code" class="form-control" autocomplete="off" />
+                        <div class="form-floating mb-3">
+                            <input asp-for="Input.Code" class="form-control" autocomplete="off" placeholder="Please enter the code."/>
                             <label asp-for="Input.Code" class="control-label form-label">Verification Code</label>
                             <span asp-validation-for="Input.Code" class="text-danger"></span>
                         </div>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/Index.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/Index.cshtml
@@ -11,12 +11,12 @@
     <div class="col-md-6">
         <form id="profile-form" method="post">
             <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
-            <div class="form-floating">
-                <input asp-for="Username" class="form-control" disabled />
+            <div class="form-floating mb-3">
+                <input asp-for="Username" class="form-control" placeholder="Please choose your username." disabled />
                 <label asp-for="Username" class="form-label"></label>
             </div>
-            <div class="form-floating">
-                <input asp-for="Input.PhoneNumber" class="form-control" />
+            <div class="form-floating mb-3">
+                <input asp-for="Input.PhoneNumber" class="form-control" placeholder="Please enter your phone number."/>
                 <label asp-for="Input.PhoneNumber" class="form-label"></label>
                 <span asp-validation-for="Input.PhoneNumber" class="text-danger"></span>
             </div>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/SetPassword.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Manage/SetPassword.cshtml
@@ -15,13 +15,13 @@
     <div class="col-md-6">
         <form id="set-password-form" method="post">
             <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
-            <div class="form-floating">
-                <input asp-for="Input.NewPassword" class="form-control" autocomplete="new-password" />
+            <div class="form-floating mb-3">
+                <input asp-for="Input.NewPassword" class="form-control" autocomplete="new-password" placeholder="Please enter your new password."/>
                 <label asp-for="Input.NewPassword" class="form-label"></label>
                 <span asp-validation-for="Input.NewPassword" class="text-danger"></span>
             </div>
-            <div class="form-floating">
-                <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" />
+            <div class="form-floating mb-3">
+                <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" placeholder="Please confirm your new password."/>
                 <label asp-for="Input.ConfirmPassword" class="form-label"></label>
                 <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
             </div>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ResetPassword.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ResetPassword.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+@page
 @model ResetPasswordModel
 @{
     ViewData["Title"] = "Reset password";
@@ -17,13 +17,13 @@
                 <label asp-for="Input.Email" class="form-label"></label>
                 <span asp-validation-for="Input.Email" class="text-danger"></span>
             </div>
-            <div class="form-floating">
-                <input asp-for="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" />
+            <div class="form-floating mb-3">
+                <input asp-for="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" placeholder="Please enter your password." />
                 <label asp-for="Input.Password" class="form-label"></label>
                 <span asp-validation-for="Input.Password" class="text-danger"></span>
             </div>
-            <div class="form-floating">
-                <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" />
+            <div class="form-floating mb-3">
+                <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="Please confirm your password." />
                 <label asp-for="Input.ConfirmPassword" class="form-label"></label>
                 <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
             </div>


### PR DESCRIPTION
All the broken `form-floating` thought the Identity UI forms have been fixed.

Fixes #40887
