### PR TITLE
Add debugging of repeated config issues

### DIFF
--- a/eng/helix/content/runtests.cmd
+++ b/eng/helix/content/runtests.cmd
@@ -18,6 +18,9 @@ set InstallPlaywright=%$installPlaywright%
 set PLAYWRIGHT_BROWSERS_PATH=%CD%\ms-playwright
 set PLAYWRIGHT_DRIVER_PATH=%CD%\.playwright\win-x64\native\playwright.cmd
 
+REM Avoid https://github.com/dotnet/aspnetcore/issues/41937 in current session.
+set ASPNETCORE_ENVIRONMENT=
+
 set "PATH=%HELIX_WORKITEM_ROOT%;%PATH%;%HELIX_WORKITEM_ROOT%\node\bin"
 echo Set path to: "%PATH%"
 echo.

--- a/src/Mvc/test/Mvc.FunctionalTests/SimpleWithWebApplicationBuilderTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/SimpleWithWebApplicationBuilderTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests
 {
@@ -18,13 +19,16 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
     {
         private readonly MvcTestFixture<SimpleWebSiteWithWebApplicationBuilder.FakeStartup> _fixture;
 
-        public SimpleWithWebApplicationBuilderTests(MvcTestFixture<SimpleWebSiteWithWebApplicationBuilder.FakeStartup> fixture)
+        public SimpleWithWebApplicationBuilderTests(MvcTestFixture<SimpleWebSiteWithWebApplicationBuilder.FakeStartup> fixture,
+            ITestOutputHelper helper)
         {
             _fixture = fixture;
             Client = _fixture.CreateDefaultClient();
+            Helper = helper;
         }
 
         public HttpClient Client { get; }
+        public ITestOutputHelper Helper { get; }
 
         [Fact]
         public async Task HelloWorld()
@@ -131,7 +135,7 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             Assert.Equal("Hello human", content);
         }
 
-        [Fact(Skip = "Failing on Windows environments: https://github.com/dotnet/aspnetcore/issues/41937")]
+        [Fact]
         public async Task DefaultEnvironment_Is_Development()
         {
             // Arrange
@@ -142,6 +146,14 @@ namespace Microsoft.AspNetCore.Mvc.FunctionalTests
             var content = await client.GetStringAsync("http://localhost/environment");
 
             // Assert
+            if (!string.Equals(expected, content))
+            {
+                // Get more information when this test is going to fail.
+                var configContent = await client.GetStringAsync("http://localhost/config");
+
+                Helper.WriteLine($"Configuration debug view: '{configContent}'");
+            }
+
             Assert.Equal(expected, content);
         }
 

--- a/src/Mvc/test/WebSites/SimpleWebSiteWithWebApplicationBuilder/Program.cs
+++ b/src/Mvc/test/WebSites/SimpleWebSiteWithWebApplicationBuilder/Program.cs
@@ -34,6 +34,10 @@ app.MapGet("/many-results", (int id) =>
 app.MapGet("/problem", () => Results.Problem("Some problem"));
 
 app.MapGet("/environment", (IHostEnvironment environment) => environment.EnvironmentName);
+app.MapGet("/config", (IConfiguration config, HttpContext context) => {
+    return context.Response.WriteAsync(((IConfigurationRoot)config).GetDebugView());
+});
+
 app.MapGet("/webroot", (IWebHostEnvironment environment) => environment.WebRootPath);
 
 app.MapGet("/greeting", (IConfiguration config) => config["Greeting"]);


### PR DESCRIPTION
- see #41937
- do not skip `SimpleWebSiteWithWebApplicationBuilder.DefaultEnvironment_Is_Development()`
- get debug view of server's configuration when that test is going to fail