### PR TITLE
Reset Upgraded state for re-used streams

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -358,6 +358,7 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
         _httpProtocol = null;
         _statusCode = StatusCodes.Status200OK;
         _reasonPhrase = null;
+        IsUpgraded = false;
 
         var remoteEndPoint = RemoteEndPoint;
         RemoteIpAddress = remoteEndPoint?.Address;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -1211,9 +1211,9 @@ public class Http2TestBase : TestApplicationErrorLoggerLoggedTest, IDisposable, 
         var frame = await ReceiveFrameAsync((uint)withLength);
 
         Assert.Equal(type, frame.Type);
-        Assert.Equal(withLength, frame.PayloadLength);
-        Assert.Equal(withFlags, frame.Flags);
         Assert.Equal(withStreamId, frame.StreamId);
+        Assert.Equal(withFlags, frame.Flags);
+        Assert.Equal(withLength, frame.PayloadLength);
 
         return frame;
     }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2WebSocketTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2WebSocketTests.cs
@@ -21,12 +21,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
 public class Http2WebSocketTests : Http2TestBase
 {
     [Fact]
-    public async Task HEADERS_Received_ExtendedCONNECTMethod_Accepted()
+    public async Task HEADERS_Received_ExtendedCONNECTMethod_Received()
     {
         await InitializeConnectionAsync(async context =>
         {
+            var connectFeature = context.Features.Get<IHttpExtendedConnectFeature>();
+            Assert.True(connectFeature.IsExtendedConnect);
             Assert.Equal(HttpMethods.Connect, context.Request.Method);
-            Assert.Equal("websocket", context.Features.Get<IHttpExtendedConnectFeature>().Protocol);
+            Assert.Equal("websocket", connectFeature.Protocol);
             Assert.False(context.Request.Headers.TryGetValue(":protocol", out var _));
             Assert.Equal("http", context.Request.Scheme);
             Assert.Equal("/chat", context.Request.Path.Value);
@@ -77,6 +79,194 @@ public class Http2WebSocketTests : Http2TestBase
         Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
         Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
         Assert.Equal("0", _decodedHeaders["content-length"]);
+    }
+
+    [Fact]
+    public async Task HEADERS_Received_ExtendedCONNECTMethod_Accepted()
+    {
+        await InitializeConnectionAsync(async context =>
+        {
+            var connectFeature = context.Features.Get<IHttpExtendedConnectFeature>();
+            Assert.True(connectFeature.IsExtendedConnect);
+            Assert.Equal(HttpMethods.Connect, context.Request.Method);
+            Assert.Equal("websocket", connectFeature.Protocol);
+            Assert.False(context.Request.Headers.TryGetValue(":protocol", out var _));
+            Assert.Equal("http", context.Request.Scheme);
+            Assert.Equal("/chat", context.Request.Path.Value);
+            Assert.Equal("server.example.com", context.Request.Host.Value);
+            Assert.Equal("chat, superchat", context.Request.Headers.WebSocketSubProtocols);
+            Assert.Equal("permessage-deflate", context.Request.Headers.SecWebSocketExtensions);
+            Assert.Equal("13", context.Request.Headers.SecWebSocketVersion);
+            Assert.Equal("http://www.example.com", context.Request.Headers.Origin);
+
+            Assert.Equal(0, await context.Request.Body.ReadAsync(new byte[1]));
+
+            var stream = await connectFeature.AcceptAsync();
+            Assert.Equal(0, await stream.ReadAsync(new byte[1]));
+            await stream.WriteAsync(new byte[] { 0x01 });
+        });
+
+        // HEADERS + END_HEADERS
+        // :method = CONNECT
+        // :protocol = websocket
+        // :scheme = https
+        // :path = /chat
+        // :authority = server.example.com
+        // sec-websocket-protocol = chat, superchat
+        // sec-websocket-extensions = permessage-deflate
+        // sec-websocket-version = 13
+        // origin = http://www.example.com
+        var headers = new[]
+        {
+            new KeyValuePair<string, string>(HeaderNames.Method, "CONNECT"),
+            new KeyValuePair<string, string>(HeaderNames.Protocol, "websocket"),
+            new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            new KeyValuePair<string, string>(HeaderNames.Path, "/chat"),
+            new KeyValuePair<string, string>(HeaderNames.Authority, "server.example.com"),
+            new KeyValuePair<string, string>(HeaderNames.WebSocketSubProtocols, "chat, superchat"),
+            new KeyValuePair<string, string>(HeaderNames.SecWebSocketExtensions, "permessage-deflate"),
+            new KeyValuePair<string, string>(HeaderNames.SecWebSocketVersion, "13"),
+            new KeyValuePair<string, string>(HeaderNames.Origin, "http://www.example.com"),
+        };
+        await SendHeadersAsync(1, Http2HeadersFrameFlags.END_HEADERS, headers);
+        await SendDataAsync(1, Array.Empty<byte>(), endStream: true);
+
+        var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+            withLength: 32,
+            withFlags: (byte)Http2HeadersFrameFlags.END_HEADERS,
+            withStreamId: 1);
+
+        _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+        Assert.Equal(2, _decodedHeaders.Count);
+        Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+
+        var dataFrame = await ExpectAsync(Http2FrameType.DATA,
+            withLength: 1,
+            withFlags: (byte)Http2DataFrameFlags.NONE,
+            withStreamId: 1);
+        Assert.Equal(0x01, dataFrame.Payload.Span[0]);
+
+        dataFrame = await ExpectAsync(Http2FrameType.DATA,
+            withLength: 0,
+            withFlags: (byte)Http2DataFrameFlags.END_STREAM,
+            withStreamId: 1);
+
+        await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+    }
+
+    [Fact]
+    public async Task HEADERS_Received_SecondRequest_Accepted()
+    {
+        // Add stream to Http2Connection._completedStreams inline with SetResult().
+        var appDelegateTcs = new TaskCompletionSource();
+        await InitializeConnectionAsync(async context =>
+        {
+            var connectFeature = context.Features.Get<IHttpExtendedConnectFeature>();
+            Assert.True(connectFeature.IsExtendedConnect);
+            Assert.Equal(HttpMethods.Connect, context.Request.Method);
+            Assert.Equal("websocket", connectFeature.Protocol);
+            Assert.False(context.Request.Headers.TryGetValue(":protocol", out var _));
+            Assert.Equal("http", context.Request.Scheme);
+            Assert.Equal("/chat", context.Request.Path.Value);
+            Assert.Equal("server.example.com", context.Request.Host.Value);
+            Assert.Equal("chat, superchat", context.Request.Headers.WebSocketSubProtocols);
+            Assert.Equal("permessage-deflate", context.Request.Headers.SecWebSocketExtensions);
+            Assert.Equal("13", context.Request.Headers.SecWebSocketVersion);
+            Assert.Equal("http://www.example.com", context.Request.Headers.Origin);
+
+            Assert.Equal(0, await context.Request.Body.ReadAsync(new byte[1]));
+
+            var stream = await connectFeature.AcceptAsync();
+            Assert.Equal(0, await stream.ReadAsync(new byte[1]));
+            await stream.WriteAsync(new byte[] { 0x01 });
+            await appDelegateTcs.Task;
+        });
+
+        // HEADERS + END_HEADERS
+        // :method = CONNECT
+        // :protocol = websocket
+        // :scheme = https
+        // :path = /chat
+        // :authority = server.example.com
+        // sec-websocket-protocol = chat, superchat
+        // sec-websocket-extensions = permessage-deflate
+        // sec-websocket-version = 13
+        // origin = http://www.example.com
+        var headers = new[]
+        {
+            new KeyValuePair<string, string>(HeaderNames.Method, "CONNECT"),
+            new KeyValuePair<string, string>(HeaderNames.Protocol, "websocket"),
+            new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            new KeyValuePair<string, string>(HeaderNames.Path, "/chat"),
+            new KeyValuePair<string, string>(HeaderNames.Authority, "server.example.com"),
+            new KeyValuePair<string, string>(HeaderNames.WebSocketSubProtocols, "chat, superchat"),
+            new KeyValuePair<string, string>(HeaderNames.SecWebSocketExtensions, "permessage-deflate"),
+            new KeyValuePair<string, string>(HeaderNames.SecWebSocketVersion, "13"),
+            new KeyValuePair<string, string>(HeaderNames.Origin, "http://www.example.com"),
+        };
+        await SendHeadersAsync(1, Http2HeadersFrameFlags.END_HEADERS, headers);
+        await SendDataAsync(1, Array.Empty<byte>(), endStream: true);
+
+        var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+            withLength: 32,
+            withFlags: (byte)Http2HeadersFrameFlags.END_HEADERS,
+            withStreamId: 1);
+
+        _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+        Assert.Equal(2, _decodedHeaders.Count);
+        Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+
+        var dataFrame = await ExpectAsync(Http2FrameType.DATA,
+            withLength: 1,
+            withFlags: (byte)Http2DataFrameFlags.NONE,
+            withStreamId: 1);
+        Assert.Equal(0x01, dataFrame.Payload.Span[0]);
+
+        appDelegateTcs.TrySetResult();
+
+        dataFrame = await ExpectAsync(Http2FrameType.DATA,
+            withLength: 0,
+            withFlags: (byte)Http2DataFrameFlags.END_STREAM,
+            withStreamId: 1);
+
+        // TriggerTick will trigger the stream to be returned to the pool so we can assert it
+        TriggerTick();
+
+        // Stream has been returned to the pool
+        Assert.Equal(1, _connection.StreamPool.Count);
+        Assert.True(_connection.StreamPool.TryPeek(out var pooledStream));
+
+        await SendHeadersAsync(3, Http2HeadersFrameFlags.END_HEADERS, headers);
+        await SendDataAsync(3, Array.Empty<byte>(), endStream: true);
+
+        headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+            withLength: 2,
+            withFlags: (byte)Http2HeadersFrameFlags.END_HEADERS,
+            withStreamId: 3);
+
+        _decodedHeaders.Clear();
+        _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+        Assert.Equal(2, _decodedHeaders.Count);
+        Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal("200", _decodedHeaders[HeaderNames.Status]);
+
+        dataFrame = await ExpectAsync(Http2FrameType.DATA,
+            withLength: 1,
+            withFlags: (byte)Http2DataFrameFlags.NONE,
+            withStreamId: 3);
+        Assert.Equal(0x01, dataFrame.Payload.Span[0]);
+
+        dataFrame = await ExpectAsync(Http2FrameType.DATA,
+            withLength: 0,
+            withFlags: (byte)Http2DataFrameFlags.END_STREAM,
+            withStreamId: 3);
+
+        await StopConnectionAsync(expectedLastStreamId: 3, ignoreNonGoAwayFrames: false);
     }
 
     [Theory]


### PR DESCRIPTION
Follow up to #41558

Some Signalr tests were flaky with the following exception:
```
Failed connection handshake.
      System.InvalidOperationException: IHttpExtendedConnectFeature.AcceptAsync was already called and can only be called once per request.
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.Microsoft.AspNetCore.Http.Features.IHttpExtendedConnectFeature.AcceptAsync() in /_/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs:line 300
         at Microsoft.AspNetCore.WebSockets.WebSocketMiddleware.WebSocketHandshake.AcceptAsync(WebSocketAcceptContext acceptContext) in /_/src/Middleware/WebSockets/src/WebSocketMiddleware.cs:line 217
         at Microsoft.AspNetCore.Http.Connections.Internal.Transports.WebSocketsServerTransport.ProcessRequestAsync(HttpContext context, CancellationToken token) in /_/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs:line 64
         at System.IO.Pipelines.Pipe.GetReadResult(ReadResult& result)
         at System.IO.Pipelines.Pipe.GetReadAsyncResult()
         at Microsoft.AspNetCore.SignalR.HubConnectionContext.HandshakeAsync(TimeSpan timeout, IReadOnlyList`1 supportedProtocols, IHubProtocolResolver protocolResolver, IUserIdProvider userIdProvider, Boolean enableDetailedErrors) in /_/src/SignalR/server/Core/src/HubConnectionContext.cs:line 597
```

The problem is that the Upgraded flag wasn't reset when a cached H2Stream was re-used.