### PR TITLE
Expose cookie extensions, consolidate cookie handling 

### DIFF
--- a/src/Http/Headers/src/CacheControlHeaderValue.cs
+++ b/src/Http/Headers/src/CacheControlHeaderValue.cs
@@ -502,7 +502,7 @@ public class CacheControlHeaderValue
     /// </summary>
     /// <param name="input">The value to parse.</param>
     /// <param name="parsedValue">The parsed value.</param>
-    /// <returns><see langword="true"/> if input is a valid <see cref="SetCookieHeaderValue"/>, otherwise <see langword="false"/>.</returns>
+    /// <returns><see langword="true"/> if input is a valid <see cref="CacheControlHeaderValue"/>, otherwise <see langword="false"/>.</returns>
     public static bool TryParse(StringSegment input, [NotNullWhen(true)] out CacheControlHeaderValue? parsedValue)
     {
         var index = 0;

--- a/src/Http/Headers/src/SetCookieHeaderValue.cs
+++ b/src/Http/Headers/src/SetCookieHeaderValue.cs
@@ -41,6 +41,7 @@ public class SetCookieHeaderValue
 
     private StringSegment _name;
     private StringSegment _value;
+    private List<StringSegment>? _extensions;
 
     private SetCookieHeaderValue()
     {
@@ -177,7 +178,10 @@ public class SetCookieHeaderValue
     /// <summary>
     /// Gets a collection of additional values to append to the cookie.
     /// </summary>
-    public IList<StringSegment> Extensions { get; } = new List<StringSegment>();
+    public IList<StringSegment> Extensions
+    {
+        get => _extensions ??= new List<StringSegment>();
+    }
 
     // name="value"; expires=Sun, 06 Nov 1994 08:49:37 GMT; max-age=86400; domain=domain1; path=path1; secure; samesite={strict|lax|none}; httponly
     /// <inheritdoc />
@@ -236,9 +240,12 @@ public class SetCookieHeaderValue
             length += SeparatorToken.Length + HttpOnlyToken.Length;
         }
 
-        foreach (var extension in Extensions)
+        if (_extensions?.Count > 0)
         {
-            length += SeparatorToken.Length + extension.Length;
+            foreach (var extension in _extensions)
+            {
+                length += SeparatorToken.Length + extension.Length;
+            }
         }
 
         return string.Create(length, (this, maxAge, sameSite), (span, tuple) =>
@@ -291,9 +298,12 @@ public class SetCookieHeaderValue
                 AppendSegment(ref span, HttpOnlyToken, null);
             }
 
-            foreach (var extension in Extensions)
+            if (_extensions?.Count > 0)
             {
-                AppendSegment(ref span, extension, null);
+                foreach (var extension in _extensions)
+                {
+                    AppendSegment(ref span, extension, null);
+                }
             }
         });
     }
@@ -373,9 +383,12 @@ public class SetCookieHeaderValue
             AppendSegment(builder, HttpOnlyToken, null);
         }
 
-        foreach (var extension in Extensions)
+        if (_extensions?.Count > 0)
         {
-            AppendSegment(builder, extension, null);
+            foreach (var extension in _extensions)
+            {
+                AppendSegment(builder, extension, null);
+            }
         }
     }
 
@@ -701,7 +714,7 @@ public class SetCookieHeaderValue
             && Secure == other.Secure
             && SameSite == other.SameSite
             && HttpOnly == other.HttpOnly
-            && HeaderUtilities.AreEqualCollections(Extensions, other.Extensions, StringSegmentComparer.OrdinalIgnoreCase);
+            && HeaderUtilities.AreEqualCollections(_extensions, other._extensions, StringSegmentComparer.OrdinalIgnoreCase);
     }
 
     /// <inheritdoc />
@@ -717,9 +730,12 @@ public class SetCookieHeaderValue
             ^ SameSite.GetHashCode()
             ^ HttpOnly.GetHashCode();
 
-        foreach (var extension in Extensions)
+        if (_extensions?.Count > 0)
         {
-            hash ^= extension.GetHashCode();
+            foreach (var extension in _extensions)
+            {
+                hash ^= extension.GetHashCode();
+            }
         }
 
         return hash;

--- a/src/Http/Http.Abstractions/src/CookieBuilder.cs
+++ b/src/Http/Http.Abstractions/src/CookieBuilder.cs
@@ -11,6 +11,7 @@ namespace Microsoft.AspNetCore.Http;
 public class CookieBuilder
 {
     private string? _name;
+    private List<string>? _extensions;
 
     /// <summary>
     /// The name of the cookie.
@@ -80,7 +81,10 @@ public class CookieBuilder
     /// <summary>
     /// Gets a collection of additional values to append to the cookie.
     /// </summary>
-    public IList<string> Extensions { get; } = new List<string>();
+    public IList<string> Extensions
+    {
+        get => _extensions ??= new List<string>();
+    }
 
     /// <summary>
     /// Creates the cookie options from the given <paramref name="context"/>.
@@ -113,9 +117,13 @@ public class CookieBuilder
             Secure = SecurePolicy == CookieSecurePolicy.Always || (SecurePolicy == CookieSecurePolicy.SameAsRequest && context.Request.IsHttps),
             Expires = Expiration.HasValue ? expiresFrom.Add(Expiration.GetValueOrDefault()) : default(DateTimeOffset?)
         };
-        foreach (var extension in Extensions)
+
+        if (_extensions?.Count > 0)
         {
-            options.Extensions.Add(extension);
+            foreach (var extension in _extensions)
+            {
+                options.Extensions.Add(extension);
+            }
         }
         return options;
     }

--- a/src/Http/Http.Abstractions/src/CookieBuilder.cs
+++ b/src/Http/Http.Abstractions/src/CookieBuilder.cs
@@ -78,6 +78,11 @@ public class CookieBuilder
     public virtual bool IsEssential { get; set; }
 
     /// <summary>
+    /// Gets a collection of additional values to append to the cookie.
+    /// </summary>
+    public IList<string> Extensions { get; } = new List<string>();
+
+    /// <summary>
     /// Creates the cookie options from the given <paramref name="context"/>.
     /// </summary>
     /// <param name="context">The <see cref="HttpContext"/>.</param>
@@ -97,7 +102,7 @@ public class CookieBuilder
             throw new ArgumentNullException(nameof(context));
         }
 
-        return new CookieOptions
+        var options = new CookieOptions
         {
             Path = Path ?? "/",
             SameSite = SameSite,
@@ -108,5 +113,10 @@ public class CookieBuilder
             Secure = SecurePolicy == CookieSecurePolicy.Always || (SecurePolicy == CookieSecurePolicy.SameAsRequest && context.Request.IsHttps),
             Expires = Expiration.HasValue ? expiresFrom.Add(Expiration.GetValueOrDefault()) : default(DateTimeOffset?)
         };
+        foreach (var extension in Extensions)
+        {
+            options.Extensions.Add(extension);
+        }
+        return options;
     }
 }

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@ Microsoft.AspNetCore.Builder.EndpointBuilder.ServiceProvider.get -> System.IServ
 Microsoft.AspNetCore.Builder.EndpointBuilder.ServiceProvider.set -> void
 Microsoft.AspNetCore.Http.AsParametersAttribute
 Microsoft.AspNetCore.Http.AsParametersAttribute.AsParametersAttribute() -> void
+Microsoft.AspNetCore.Http.CookieBuilder.Extensions.get -> System.Collections.Generic.IList<string!>!
 Microsoft.AspNetCore.Http.DefaultRouteHandlerInvocationContext
 Microsoft.AspNetCore.Http.DefaultRouteHandlerInvocationContext.DefaultRouteHandlerInvocationContext(Microsoft.AspNetCore.Http.HttpContext! httpContext, params object![]! arguments) -> void
 Microsoft.AspNetCore.Http.EndpointMetadataCollection.Enumerator.Current.get -> object!

--- a/src/Http/Http.Abstractions/test/CookieBuilderTests.cs
+++ b/src/Http/Http.Abstractions/test/CookieBuilderTests.cs
@@ -63,7 +63,7 @@ public class CookieBuilderTests
         Assert.Contains("simple", options.Extensions);
         Assert.Contains("key=value", options.Extensions);
 
-        var cookie = options.CreateCookie("name", "value");
+        var cookie = options.CreateCookieHeader("name", "value");
         Assert.Equal("name", cookie.Name);
         Assert.Equal("value", cookie.Value);
         Assert.Equal(2, cookie.Extensions.Count);

--- a/src/Http/Http.Abstractions/test/CookieBuilderTests.cs
+++ b/src/Http/Http.Abstractions/test/CookieBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.AspNetCore.Http.Abstractions.Tests;
@@ -49,5 +49,27 @@ public class CookieBuilderTests
     public void CookieBuilderPreservesDefaultPath()
     {
         Assert.Equal(new CookieOptions().Path, new CookieBuilder().Build(new DefaultHttpContext()).Path);
+    }
+
+    [Fact]
+    public void CookieBuilder_Extensions_Added()
+    {
+        var builder = new CookieBuilder();
+        builder.Extensions.Add("simple");
+        builder.Extensions.Add("key=value");
+
+        var options = builder.Build(new DefaultHttpContext());
+        Assert.Equal(2, options.Extensions.Count);
+        Assert.Contains("simple", options.Extensions);
+        Assert.Contains("key=value", options.Extensions);
+
+        var cookie = options.CreateCookie("name", "value");
+        Assert.Equal("name", cookie.Name);
+        Assert.Equal("value", cookie.Value);
+        Assert.Equal(2, cookie.Extensions.Count);
+        Assert.Contains("simple", cookie.Extensions);
+        Assert.Contains("key=value", cookie.Extensions);
+
+        Assert.Equal("name=value; path=/; simple; key=value", cookie.ToString());
     }
 }

--- a/src/Http/Http.Features/src/CookieOptions.cs
+++ b/src/Http/Http.Features/src/CookieOptions.cs
@@ -93,7 +93,7 @@ public class CookieOptions
     /// <summary>
     /// Creates a <see cref="SetCookieHeaderValue"/> using the current options.
     /// </summary>
-    public SetCookieHeaderValue CreateCookie(string name, string value)
+    public SetCookieHeaderValue CreateCookieHeader(string name, string value)
     {
         var cookie = new SetCookieHeaderValue(name, value)
         {

--- a/src/Http/Http.Features/src/CookieOptions.cs
+++ b/src/Http/Http.Features/src/CookieOptions.cs
@@ -10,13 +10,14 @@ namespace Microsoft.AspNetCore.Http;
 /// </summary>
 public class CookieOptions
 {
+    private List<string>? _extensions;
+
     /// <summary>
     /// Creates a default cookie with a path of '/'.
     /// </summary>
     public CookieOptions()
     {
         Path = "/";
-        Extensions = new List<string>();
     }
 
     /// <summary>
@@ -34,7 +35,11 @@ public class CookieOptions
         HttpOnly = options.HttpOnly;
         MaxAge = options.MaxAge;
         IsEssential = options.IsEssential;
-        Extensions = new List<string>(options.Extensions);
+
+        if (options._extensions?.Count > 0)
+        {
+            _extensions = new List<string>(options._extensions);
+        }
     }
 
     /// <summary>
@@ -88,7 +93,10 @@ public class CookieOptions
     /// <summary>
     /// Gets a collection of additional values to append to the cookie.
     /// </summary>
-    public IList<string> Extensions { get; }
+    public IList<string> Extensions
+    {
+        get => _extensions ??= new List<string>();
+    }
 
     /// <summary>
     /// Creates a <see cref="SetCookieHeaderValue"/> using the current options.
@@ -106,9 +114,12 @@ public class CookieOptions
             SameSite = (Net.Http.Headers.SameSiteMode)SameSite,
         };
 
-        foreach (var extension in Extensions)
+        if (_extensions?.Count > 0)
         {
-            cookie.Extensions.Add(extension);
+            foreach (var extension in _extensions)
+            {
+                cookie.Extensions.Add(extension);
+            }
         }
 
         return cookie;

--- a/src/Http/Http.Features/src/CookieOptions.cs
+++ b/src/Http/Http.Features/src/CookieOptions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Net.Http.Headers;
+
 namespace Microsoft.AspNetCore.Http;
 
 /// <summary>
@@ -14,6 +16,25 @@ public class CookieOptions
     public CookieOptions()
     {
         Path = "/";
+        Extensions = new List<string>();
+    }
+
+    /// <summary>
+    /// Creates a copy of the given <see cref="CookieOptions"/>.
+    /// </summary>
+    public CookieOptions(CookieOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        Domain = options.Domain;
+        Path = options.Path;
+        Expires = options.Expires;
+        Secure = options.Secure;
+        SameSite = options.SameSite;
+        HttpOnly = options.HttpOnly;
+        MaxAge = options.MaxAge;
+        IsEssential = options.IsEssential;
+        Extensions = new List<string>(options.Extensions);
     }
 
     /// <summary>
@@ -63,4 +84,33 @@ public class CookieOptions
     /// consent policy checks may be bypassed. The default value is false.
     /// </summary>
     public bool IsEssential { get; set; }
+
+    /// <summary>
+    /// Gets a collection of additional values to append to the cookie.
+    /// </summary>
+    public IList<string> Extensions { get; }
+
+    /// <summary>
+    /// Creates a <see cref="SetCookieHeaderValue"/> using the current options.
+    /// </summary>
+    public SetCookieHeaderValue CreateCookie(string name, string value)
+    {
+        var cookie = new SetCookieHeaderValue(name, value)
+        {
+            Domain = Domain,
+            Path = Path,
+            Expires = Expires,
+            Secure = Secure,
+            HttpOnly = HttpOnly,
+            MaxAge = MaxAge,
+            SameSite = (Net.Http.Headers.SameSiteMode)SameSite,
+        };
+
+        foreach (var extension in Extensions)
+        {
+            cookie.Extensions.Add(extension);
+        }
+
+        return cookie;
+    }
 }

--- a/src/Http/Http.Features/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Features/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 #nullable enable
+Microsoft.AspNetCore.Http.CookieOptions.CookieOptions(Microsoft.AspNetCore.Http.CookieOptions! options) -> void
+Microsoft.AspNetCore.Http.CookieOptions.CreateCookie(string! name, string! value) -> Microsoft.Net.Http.Headers.SetCookieHeaderValue!
+Microsoft.AspNetCore.Http.CookieOptions.Extensions.get -> System.Collections.Generic.IList<string!>!
 Microsoft.AspNetCore.Http.Features.IHttpExtendedConnectFeature
 Microsoft.AspNetCore.Http.Features.IHttpExtendedConnectFeature.AcceptAsync() -> System.Threading.Tasks.ValueTask<System.IO.Stream!>
 Microsoft.AspNetCore.Http.Features.IHttpExtendedConnectFeature.IsExtendedConnect.get -> bool

--- a/src/Http/Http.Features/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Features/src/PublicAPI.Unshipped.txt
@@ -1,6 +1,6 @@
 #nullable enable
 Microsoft.AspNetCore.Http.CookieOptions.CookieOptions(Microsoft.AspNetCore.Http.CookieOptions! options) -> void
-Microsoft.AspNetCore.Http.CookieOptions.CreateCookie(string! name, string! value) -> Microsoft.Net.Http.Headers.SetCookieHeaderValue!
+Microsoft.AspNetCore.Http.CookieOptions.CreateCookieHeader(string! name, string! value) -> Microsoft.Net.Http.Headers.SetCookieHeaderValue!
 Microsoft.AspNetCore.Http.CookieOptions.Extensions.get -> System.Collections.Generic.IList<string!>!
 Microsoft.AspNetCore.Http.Features.IHttpExtendedConnectFeature
 Microsoft.AspNetCore.Http.Features.IHttpExtendedConnectFeature.AcceptAsync() -> System.Threading.Tasks.ValueTask<System.IO.Stream!>

--- a/src/Http/Http/src/Internal/ResponseCookies.cs
+++ b/src/Http/Http/src/Internal/ResponseCookies.cs
@@ -68,22 +68,11 @@ internal sealed partial class ResponseCookies : IResponseCookies
             }
         }
 
-        var setCookieHeaderValue = new SetCookieHeaderValue(
+        var cookie = options.CreateCookie(
             _enableCookieNameEncoding ? Uri.EscapeDataString(key) : key,
-            Uri.EscapeDataString(value))
-        {
-            Domain = options.Domain,
-            Path = options.Path,
-            Expires = options.Expires,
-            MaxAge = options.MaxAge,
-            Secure = options.Secure,
-            SameSite = (Net.Http.Headers.SameSiteMode)options.SameSite,
-            HttpOnly = options.HttpOnly
-        };
+            Uri.EscapeDataString(value)).ToString();
 
-        var cookieValue = setCookieHeaderValue.ToString();
-
-        Headers.SetCookie = StringValues.Concat(Headers.SetCookie, cookieValue);
+        Headers.SetCookie = StringValues.Concat(Headers.SetCookie, cookie);
     }
 
     /// <inheritdoc />
@@ -112,25 +101,14 @@ internal sealed partial class ResponseCookies : IResponseCookies
             }
         }
 
-        var setCookieHeaderValue = new SetCookieHeaderValue(string.Empty)
-        {
-            Domain = options.Domain,
-            Path = options.Path,
-            Expires = options.Expires,
-            MaxAge = options.MaxAge,
-            Secure = options.Secure,
-            SameSite = (Net.Http.Headers.SameSiteMode)options.SameSite,
-            HttpOnly = options.HttpOnly
-        };
-
-        var cookierHeaderValue = setCookieHeaderValue.ToString()[1..];
+        var cookieSuffix = options.CreateCookie(string.Empty, string.Empty).ToString()[1..];
         var cookies = new string[keyValuePairs.Length];
         var position = 0;
 
         foreach (var keyValuePair in keyValuePairs)
         {
             var key = _enableCookieNameEncoding ? Uri.EscapeDataString(keyValuePair.Key) : keyValuePair.Key;
-            cookies[position] = string.Concat(key, "=", Uri.EscapeDataString(keyValuePair.Value), cookierHeaderValue);
+            cookies[position] = string.Concat(key, "=", Uri.EscapeDataString(keyValuePair.Value), cookieSuffix);
             position++;
         }
 
@@ -200,14 +178,9 @@ internal sealed partial class ResponseCookies : IResponseCookies
             Headers.SetCookie = new StringValues(newValues.ToArray());
         }
 
-        Append(key, string.Empty, new CookieOptions
+        Append(key, string.Empty, new CookieOptions(options)
         {
-            Path = options.Path,
-            Domain = options.Domain,
             Expires = DateTimeOffset.UnixEpoch,
-            Secure = options.Secure,
-            HttpOnly = options.HttpOnly,
-            SameSite = options.SameSite
         });
     }
 

--- a/src/Http/Http/src/Internal/ResponseCookies.cs
+++ b/src/Http/Http/src/Internal/ResponseCookies.cs
@@ -68,7 +68,7 @@ internal sealed partial class ResponseCookies : IResponseCookies
             }
         }
 
-        var cookie = options.CreateCookie(
+        var cookie = options.CreateCookieHeader(
             _enableCookieNameEncoding ? Uri.EscapeDataString(key) : key,
             Uri.EscapeDataString(value)).ToString();
 
@@ -101,7 +101,7 @@ internal sealed partial class ResponseCookies : IResponseCookies
             }
         }
 
-        var cookieSuffix = options.CreateCookie(string.Empty, string.Empty).ToString()[1..];
+        var cookieSuffix = options.CreateCookieHeader(string.Empty, string.Empty).ToString()[1..];
         var cookies = new string[keyValuePairs.Length];
         var position = 0;
 

--- a/src/Http/Http/test/CookieOptionsTests.cs
+++ b/src/Http/Http/test/CookieOptionsTests.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Http.Tests;
+
+public class CookieOptionsTests
+{
+    [Fact]
+    public void CopyCtor_AllPropertiesCopied()
+    {
+        var original = new CookieOptions()
+        {
+            Domain = "domain",
+            Expires = DateTime.UtcNow,
+            Extensions = { "ext1", "ext2=v2" },
+            HttpOnly = true,
+            IsEssential = true,
+            MaxAge = TimeSpan.FromSeconds(10),
+            Path = "/foo",
+            Secure = true,
+            SameSite = SameSiteMode.Strict,
+        };
+        var copy = new CookieOptions(original);
+
+        var properties = typeof(CookieOptions).GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        foreach (var property in properties)
+        {
+            switch (property.Name)
+            {
+                case "Domain":
+                case "Expires":
+                case "HttpOnly":
+                case "IsEssential":
+                case "MaxAge":
+                case "Path":
+                case "Secure":
+                case "SameSite":
+                    Assert.Equal(property.GetValue(original), property.GetValue(copy));
+                    break;
+                case "Extensions":
+                    Assert.NotSame(property.GetValue(original), property.GetValue(copy));
+                    break;
+                default:
+                    Assert.True(false, "Not implemented: " + property.Name);
+                    break;
+            }
+        }
+
+        Assert.Equal(original.Extensions.Count, copy.Extensions.Count);
+        foreach (var value in original.Extensions)
+        {
+            Assert.Contains(value, copy.Extensions);
+        }
+    }
+}

--- a/src/Http/Http/test/ResponseCookiesTest.cs
+++ b/src/Http/Http/test/ResponseCookiesTest.cs
@@ -55,6 +55,49 @@ public class ResponseCookiesTest
     }
 
     [Fact]
+    public void AppendWithExtensions()
+    {
+        var headers = (IHeaderDictionary)new HeaderDictionary();
+        var features = MakeFeatures(headers);
+        var cookies = new ResponseCookies(features);
+        var testCookie = "TestCookie";
+
+        cookies.Append(testCookie, "value", new CookieOptions()
+        {
+            Extensions = { "simple", "key=value" }
+        });
+
+        var cookieHeaderValues = headers.SetCookie;
+        Assert.Single(cookieHeaderValues);
+        Assert.StartsWith(testCookie, cookieHeaderValues[0]);
+        Assert.Contains("path=/", cookieHeaderValues[0]);
+        Assert.Contains("simple;", cookieHeaderValues[0]);
+        Assert.EndsWith("key=value", cookieHeaderValues[0]);
+    }
+
+    [Fact]
+    public void DeleteWithExtensions()
+    {
+        var headers = (IHeaderDictionary)new HeaderDictionary();
+        var features = MakeFeatures(headers);
+        var cookies = new ResponseCookies(features);
+        var testCookie = "TestCookie";
+
+        cookies.Delete(testCookie, new CookieOptions()
+        {
+            Extensions = { "simple", "key=value" }
+        });
+
+        var cookieHeaderValues = headers.SetCookie;
+        Assert.Single(cookieHeaderValues);
+        Assert.StartsWith(testCookie, cookieHeaderValues[0]);
+        Assert.Contains("path=/", cookieHeaderValues[0]);
+        Assert.Contains("expires=Thu, 01 Jan 1970 00:00:00 GMT", cookieHeaderValues[0]);
+        Assert.Contains("simple;", cookieHeaderValues[0]);
+        Assert.EndsWith("key=value", cookieHeaderValues[0]);
+    }
+
+    [Fact]
     public void DeleteCookieShouldSetDefaultPath()
     {
         var headers = (IHeaderDictionary)new HeaderDictionary();
@@ -144,7 +187,8 @@ public class ResponseCookiesTest
             Path = "/",
             Expires = time,
             Domain = "example.com",
-            SameSite = SameSiteMode.Lax
+            SameSite = SameSiteMode.Lax,
+            Extensions = { "extension" }
         };
 
         cookies.Delete(testCookie, options);
@@ -157,6 +201,7 @@ public class ResponseCookiesTest
         Assert.Contains("secure", cookieHeaderValues[0]);
         Assert.Contains("httponly", cookieHeaderValues[0]);
         Assert.Contains("samesite", cookieHeaderValues[0]);
+        Assert.Contains("extension", cookieHeaderValues[0]);
     }
 
     [Fact]

--- a/src/Security/Authentication/test/CookieTests.cs
+++ b/src/Security/Authentication/test/CookieTests.cs
@@ -261,6 +261,8 @@ public class CookieTests : SharedAuthenticationTests<CookieAuthenticationOptions
             o.Cookie.SecurePolicy = CookieSecurePolicy.Always;
             o.Cookie.SameSite = SameSiteMode.None;
             o.Cookie.HttpOnly = true;
+            o.Cookie.Extensions.Add("extension0");
+            o.Cookie.Extensions.Add("extension1=value1");
         }, SignInAsAlice, baseAddress: new Uri("http://example.com/base"));
 
         using var server1 = host.GetTestServer();
@@ -274,6 +276,8 @@ public class CookieTests : SharedAuthenticationTests<CookieAuthenticationOptions
         Assert.Contains(" secure", setCookie1);
         Assert.Contains(" samesite=none", setCookie1);
         Assert.Contains(" httponly", setCookie1);
+        Assert.Contains(" extension0", setCookie1);
+        Assert.Contains(" extension1=value1", setCookie1);
 
         using var host2 = await CreateHost(o =>
         {
@@ -294,6 +298,7 @@ public class CookieTests : SharedAuthenticationTests<CookieAuthenticationOptions
         Assert.DoesNotContain(" domain=", setCookie2);
         Assert.DoesNotContain(" secure", setCookie2);
         Assert.DoesNotContain(" httponly", setCookie2);
+        Assert.DoesNotContain(" extension", setCookie2);
     }
 
     [Fact]

--- a/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectTests.cs
+++ b/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectTests.cs
@@ -88,6 +88,7 @@ public class OpenIdConnectTests
                 AuthorizationEndpoint = "https://example.com/provider/login"
             };
             opt.NonceCookie.Path = "/";
+            opt.NonceCookie.Extensions.Add("ExtN");
         });
 
         var server = setting.CreateTestServer();
@@ -100,6 +101,7 @@ public class OpenIdConnectTests
         var setCookie = Assert.Single(res.Headers, h => h.Key == "Set-Cookie");
         var nonce = Assert.Single(setCookie.Value, v => v.StartsWith(OpenIdConnectDefaults.CookieNoncePrefix, StringComparison.Ordinal));
         Assert.Contains("path=/", nonce);
+        Assert.Contains("ExtN", nonce);
     }
 
     [Fact]
@@ -139,6 +141,7 @@ public class OpenIdConnectTests
                 AuthorizationEndpoint = "https://example.com/provider/login"
             };
             opt.CorrelationCookie.Path = "/";
+            opt.CorrelationCookie.Extensions.Add("ExtC");
         });
 
         var server = setting.CreateTestServer();
@@ -151,6 +154,7 @@ public class OpenIdConnectTests
         var setCookie = Assert.Single(res.Headers, h => h.Key == "Set-Cookie");
         var correlation = Assert.Single(setCookie.Value, v => v.StartsWith(".AspNetCore.Correlation.", StringComparison.Ordinal));
         Assert.Contains("path=/", correlation);
+        Assert.EndsWith("ExtC", correlation);
     }
 
     [Fact]

--- a/src/Security/CookiePolicy/src/ResponseCookiesWrapper.cs
+++ b/src/Security/CookiePolicy/src/ResponseCookiesWrapper.cs
@@ -98,20 +98,7 @@ internal sealed class ResponseCookiesWrapper : IResponseCookies, ITrackingConsen
         Debug.Assert(key != null);
         ApplyAppendPolicy(ref key, ref value, options);
 
-        var setCookieHeaderValue = new Net.Http.Headers.SetCookieHeaderValue(
-            Uri.EscapeDataString(key),
-            Uri.EscapeDataString(value))
-        {
-            Domain = options.Domain,
-            Path = options.Path,
-            Expires = options.Expires,
-            MaxAge = options.MaxAge,
-            Secure = options.Secure,
-            SameSite = (Net.Http.Headers.SameSiteMode)options.SameSite,
-            HttpOnly = options.HttpOnly
-        };
-
-        return setCookieHeaderValue.ToString();
+        return options.CreateCookie(Uri.EscapeDataString(key), Uri.EscapeDataString(value)).ToString();
     }
 
     private bool CheckPolicyRequired()

--- a/src/Security/CookiePolicy/src/ResponseCookiesWrapper.cs
+++ b/src/Security/CookiePolicy/src/ResponseCookiesWrapper.cs
@@ -98,7 +98,7 @@ internal sealed class ResponseCookiesWrapper : IResponseCookies, ITrackingConsen
         Debug.Assert(key != null);
         ApplyAppendPolicy(ref key, ref value, options);
 
-        return options.CreateCookie(Uri.EscapeDataString(key), Uri.EscapeDataString(value)).ToString();
+        return options.CreateCookieHeader(Uri.EscapeDataString(key), Uri.EscapeDataString(value)).ToString();
     }
 
     private bool CheckPolicyRequired()

--- a/src/Security/CookiePolicy/test/CookieChunkingTests.cs
+++ b/src/Security/CookiePolicy/test/CookieChunkingTests.cs
@@ -62,6 +62,25 @@ public class CookieChunkingTests
     }
 
     [Fact]
+    public void AppendLargeCookieWithExtensions_Chunked()
+    {
+        HttpContext context = new DefaultHttpContext();
+
+        string testString = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        new ChunkingCookieManager() { ChunkSize = 63 }.AppendResponseCookie(context, "TestCookie", testString,
+            new CookieOptions() { Extensions = { "simple", "key=value" } });
+        var values = context.Response.Headers["Set-Cookie"];
+        Assert.Equal(4, values.Count);
+        Assert.Equal<string[]>(new[]
+        {
+                "TestCookie=chunks-3; path=/; simple; key=value",
+                "TestCookieC1=abcdefghijklmnopqrstuv; path=/; simple; key=value",
+                "TestCookieC2=wxyz0123456789ABCDEFGH; path=/; simple; key=value",
+                "TestCookieC3=IJKLMNOPQRSTUVWXYZ; path=/; simple; key=value",
+            }, values);
+    }
+
+    [Fact]
     public void GetLargeChunkedCookie_Reassembled()
     {
         HttpContext context = new DefaultHttpContext();
@@ -129,19 +148,19 @@ public class CookieChunkingTests
         HttpContext context = new DefaultHttpContext();
         context.Request.Headers.Append("Cookie", "TestCookie=chunks-7;TestCookieC1=1;TestCookieC2=2;TestCookieC3=3;TestCookieC4=4;TestCookieC5=5;TestCookieC6=6;TestCookieC7=7");
 
-        new ChunkingCookieManager().DeleteCookie(context, "TestCookie", new CookieOptions() { Domain = "foo.com", Secure = true });
+        new ChunkingCookieManager().DeleteCookie(context, "TestCookie", new CookieOptions() { Domain = "foo.com", Secure = true, Extensions = { "extension" } });
         var cookies = context.Response.Headers["Set-Cookie"];
         Assert.Equal(8, cookies.Count);
         Assert.Equal(new[]
         {
-            "TestCookie=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure",
-            "TestCookieC1=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure",
-            "TestCookieC2=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure",
-            "TestCookieC3=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure",
-            "TestCookieC4=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure",
-            "TestCookieC5=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure",
-            "TestCookieC6=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure",
-            "TestCookieC7=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure",
+            "TestCookie=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure; extension",
+            "TestCookieC1=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure; extension",
+            "TestCookieC2=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure; extension",
+            "TestCookieC3=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure; extension",
+            "TestCookieC4=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure; extension",
+            "TestCookieC5=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure; extension",
+            "TestCookieC6=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure; extension",
+            "TestCookieC7=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure; extension",
         }, cookies);
     }
 
@@ -202,12 +221,13 @@ public class CookieChunkingTests
         {
             Domain = "foo.com",
             Path = "/",
-            Secure = true
+            Secure = true,
+            Extensions = { "extension" }
         };
 
         httpContext.Response.Headers[HeaderNames.SetCookie] = new[]
         {
-                "TestCookie=chunks-7; domain=foo.com; path=/; secure",
+                "TestCookie=chunks-7; domain=foo.com; path=/; secure; other=extension",
                 "TestCookieC1=STUVWXYZ; domain=foo.com; path=/; secure",
                 "TestCookieC2=123456789; domain=foo.com; path=/; secure",
                 "TestCookieC3=stuvwxyz0; domain=foo.com; path=/; secure",
@@ -221,14 +241,14 @@ public class CookieChunkingTests
         Assert.Equal(8, httpContext.Response.Headers[HeaderNames.SetCookie].Count);
         Assert.Equal(new[]
         {
-                "TestCookie=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure",
-                "TestCookieC1=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure",
-                "TestCookieC2=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure",
-                "TestCookieC3=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure",
-                "TestCookieC4=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure",
-                "TestCookieC5=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure",
-                "TestCookieC6=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure",
-                "TestCookieC7=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure"
+                "TestCookie=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure; extension",
+                "TestCookieC1=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure; extension",
+                "TestCookieC2=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure; extension",
+                "TestCookieC3=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure; extension",
+                "TestCookieC4=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure; extension",
+                "TestCookieC5=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure; extension",
+                "TestCookieC6=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure; extension",
+                "TestCookieC7=; expires=Thu, 01 Jan 1970 00:00:00 GMT; domain=foo.com; path=/; secure; extension"
             }, httpContext.Response.Headers[HeaderNames.SetCookie]);
     }
 }

--- a/src/Security/CookiePolicy/test/CookieConsentTests.cs
+++ b/src/Security/CookiePolicy/test/CookieConsentTests.cs
@@ -244,6 +244,7 @@ public class CookieConsentTests
                 Assert.Equal(Http.SameSiteMode.Strict, context.CookieOptions.SameSite);
                 context.CookieName += "1";
                 context.CookieValue += "1";
+                context.CookieOptions.Extensions.Add("extension");
             };
         },
         requestContext => { },
@@ -270,6 +271,7 @@ public class CookieConsentTests
         Assert.Equal("yes1", consentCookie.Value);
         Assert.Equal(Net.Http.Headers.SameSiteMode.Strict, consentCookie.SameSite);
         Assert.NotNull(consentCookie.Expires);
+        Assert.Contains("extension", consentCookie.Extensions);
     }
 
     [Fact]

--- a/src/Security/CookiePolicy/test/CookiePolicyTests.cs
+++ b/src/Security/CookiePolicy/test/CookiePolicyTests.cs
@@ -367,6 +367,7 @@ public class CookiePolicyTests
                         {
                             HttpOnly = HttpOnlyPolicy.Always,
                             Secure = CookieSecurePolicy.Always,
+                            OnAppendCookie = c => c.CookieOptions.Extensions.Add("extension")
                         });
                         app.UseAuthentication();
                         app.Run(context =>
@@ -401,6 +402,7 @@ public class CookiePolicyTests
         Assert.True(cookie.HttpOnly);
         Assert.True(cookie.Secure);
         Assert.Equal("/", cookie.Path);
+        Assert.Contains("extension", cookie.Extensions);
     }
 
     [Fact]
@@ -416,6 +418,7 @@ public class CookiePolicyTests
                         {
                             HttpOnly = HttpOnlyPolicy.Always,
                             Secure = CookieSecurePolicy.Always,
+                            OnAppendCookie = c => c.CookieOptions.Extensions.Add("ext")
                         });
                         app.UseAuthentication();
                         app.Run(context =>
@@ -452,18 +455,21 @@ public class CookiePolicyTests
         Assert.True(cookie.HttpOnly);
         Assert.True(cookie.Secure);
         Assert.Equal("/", cookie.Path);
+        Assert.Contains("ext", cookie.Extensions);
 
         cookie = SetCookieHeaderValue.Parse(transaction.SetCookie[1]);
         Assert.Equal("TestCookieC1", cookie.Name);
         Assert.True(cookie.HttpOnly);
         Assert.True(cookie.Secure);
         Assert.Equal("/", cookie.Path);
+        Assert.Contains("ext", cookie.Extensions);
 
         cookie = SetCookieHeaderValue.Parse(transaction.SetCookie[2]);
         Assert.Equal("TestCookieC2", cookie.Name);
         Assert.True(cookie.HttpOnly);
         Assert.True(cookie.Secure);
         Assert.Equal("/", cookie.Path);
+        Assert.Contains("ext", cookie.Extensions);
     }
 
     private class TestCookieFeature : IResponseCookiesFeature

--- a/src/Shared/ChunkingCookieManager/ChunkingCookieManager.cs
+++ b/src/Shared/ChunkingCookieManager/ChunkingCookieManager.cs
@@ -173,18 +173,7 @@ internal sealed class ChunkingCookieManager
             return;
         }
 
-        var template = new SetCookieHeaderValue(key)
-        {
-            Domain = options.Domain,
-            Expires = options.Expires,
-            SameSite = (Net.Http.Headers.SameSiteMode)options.SameSite,
-            HttpOnly = options.HttpOnly,
-            Path = options.Path,
-            Secure = options.Secure,
-            MaxAge = options.MaxAge,
-        };
-
-        var templateLength = template.ToString().Length;
+        var templateLength = options.CreateCookie(key, string.Empty).ToString().Length;
 
         // Normal cookie
         if (!ChunkSize.HasValue || ChunkSize.Value > templateLength + value.Length)
@@ -324,15 +313,9 @@ internal sealed class ChunkingCookieManager
             keyValuePairs[i] = KeyValuePair.Create(string.Concat(key, "C", i.ToString(CultureInfo.InvariantCulture)), string.Empty);
         }
 
-        responseCookies.Append(keyValuePairs, new CookieOptions()
+        responseCookies.Append(keyValuePairs, new CookieOptions(options)
         {
-            Path = options.Path,
-            Domain = options.Domain,
-            SameSite = options.SameSite,
-            Secure = options.Secure,
-            IsEssential = options.IsEssential,
             Expires = DateTimeOffset.UnixEpoch,
-            HttpOnly = options.HttpOnly,
         });
     }
 }

--- a/src/Shared/ChunkingCookieManager/ChunkingCookieManager.cs
+++ b/src/Shared/ChunkingCookieManager/ChunkingCookieManager.cs
@@ -173,7 +173,7 @@ internal sealed class ChunkingCookieManager
             return;
         }
 
-        var templateLength = options.CreateCookie(key, string.Empty).ToString().Length;
+        var templateLength = options.CreateCookieHeader(key, string.Empty).ToString().Length;
 
         // Normal cookie
         if (!ChunkSize.HasValue || ChunkSize.Value > templateLength + value.Length)


### PR DESCRIPTION
Fixes #39968

The cookie specs keep evolving and we keep having to add additional fields to cookies. It's hard to add APIs to old versions, so to increase flexibility we'll add a property bag for extra fields. Extensions are already a standard part of the cookie spec, no special syntax is required.

This support was already added to SetCookieHeaderValue back in 5.0, we just didn't expose it upwards.

Also, to make adding properties easier later, I've added a few APIs to consolidate where properties need to be copied. There should only be two places now, CookieOptions and CookieBuilder.