### PR TITLE
Fix branch name in mirror pipeline

### DIFF
--- a/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
+++ b/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
@@ -34,9 +34,9 @@ jobs:
         - name: AzdoRepo
           value: dotnet-aspnetcore
         - name: TargetBranchName
-          value: $(Build.SourceBranch)-nonstable
+          value: $(Build.SourceBranchName)-nonstable
         - name: BranchToMirror
-          value: $(Build.SourceBranch)
+          value: $(Build.SourceBranchName)
         steps:
         - script: |
             git clone https://dn-bot:$(dn-bot-dnceng-build-rw-code-rw)@dev.azure.com/dnceng/internal/_git/$(AzdoRepo) $(WorkingDirectoryName) --recursive --no-tags --branch $(TargetBranchName)


### PR DESCRIPTION
`SourceBranch` includes the `refs/heads` portion