### PR TITLE
Fix branch names again

### DIFF
--- a/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
+++ b/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
@@ -33,11 +33,13 @@ jobs:
           value: repo-dir
         - name: AzdoRepo
           value: dotnet-aspnetcore
-        - name: TargetBranchName
-          value: $(Build.SourceBranchName)-nonstable
-        - name: BranchToMirror
-          value: $(Build.SourceBranchName)
         steps:
+        - powershell: |
+          $branch = "$(Build.SourceBranchName)".Replace("refs/heads/", "");
+          $suffix = "-nonstable"
+          Write-Host "##vso[task.setvariable variable=BranchToMirror]$branch"
+          Write-Host "##vso[task.setvariable variable=TargetBranchName]$branch+$suffix"
+        displayName: Calculate Mirrored Branch Names
         - script: |
             git clone https://dn-bot:$(dn-bot-dnceng-build-rw-code-rw)@dev.azure.com/dnceng/internal/_git/$(AzdoRepo) $(WorkingDirectoryName) --recursive --no-tags --branch $(TargetBranchName)
           displayName: Clone AzDO repo

--- a/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
+++ b/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
@@ -35,7 +35,7 @@ jobs:
           value: dotnet-aspnetcore
         steps:
         - powershell: |
-            $branch = "$(Build.SourceBranchName)".Replace("refs/heads/", "");
+            $branch = "$(Build.SourceBranch)".Replace("refs/heads/", "");
             $suffix = "-nonstable"
             Write-Host "##vso[task.setvariable variable=BranchToMirror]$branch"
             Write-Host "##vso[task.setvariable variable=TargetBranchName]$branch+$suffix"

--- a/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
+++ b/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
@@ -35,11 +35,11 @@ jobs:
           value: dotnet-aspnetcore
         steps:
         - powershell: |
-          $branch = "$(Build.SourceBranchName)".Replace("refs/heads/", "");
-          $suffix = "-nonstable"
-          Write-Host "##vso[task.setvariable variable=BranchToMirror]$branch"
-          Write-Host "##vso[task.setvariable variable=TargetBranchName]$branch+$suffix"
-        displayName: Calculate Mirrored Branch Names
+            $branch = "$(Build.SourceBranchName)".Replace("refs/heads/", "");
+            $suffix = "-nonstable"
+            Write-Host "##vso[task.setvariable variable=BranchToMirror]$branch"
+            Write-Host "##vso[task.setvariable variable=TargetBranchName]$branch+$suffix"
+          displayName: Calculate Mirrored Branch Names
         - script: |
             git clone https://dn-bot:$(dn-bot-dnceng-build-rw-code-rw)@dev.azure.com/dnceng/internal/_git/$(AzdoRepo) $(WorkingDirectoryName) --recursive --no-tags --branch $(TargetBranchName)
           displayName: Clone AzDO repo


### PR DESCRIPTION
`SourceBranchName` removes everything up to and including the final `/`, so there's no variable that will return `internal/release/6.0`. Think this should work (copied from https://github.com/dotnet/arcade/blob/305085c46562ce8b339487e1812c3145772c2171/azure-pipelines-code-mirror.yml#L24)