### PR TITLE
Unquarantine GetWithRouteParameter_WriteMultiple_CancellationBefore_CallCanceled

### DIFF
--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/ServerStreamingTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/ServerStreamingTests.cs
@@ -80,7 +80,6 @@ public class ServerStreamingTests : IntegrationTestBase
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/41629")]
     public async Task GetWithRouteParameter_WriteMultiple_CancellationBefore_CallCanceled()
     {
         // Arrange


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/41629
