### PR TITLE
W3CLogger follow-ups

### DIFF
--- a/src/Middleware/HttpLogging/src/HttpLoggingServicesExtensions.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingServicesExtensions.cs
@@ -49,6 +49,7 @@ public static class HttpLoggingServicesExtensions
         }
 
         services.Configure(configureOptions);
+        services.AddSingleton<W3CLoggerProcessor>();
         services.AddSingleton<W3CLogger>();
         return services;
     }

--- a/src/Middleware/HttpLogging/src/StatusCodeHelper.cs
+++ b/src/Middleware/HttpLogging/src/StatusCodeHelper.cs
@@ -1,0 +1,148 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Net;
+
+namespace Microsoft.AspNetCore.HttpLogging;
+
+internal static class StatusCodeHelper
+{
+    public static string ToStatusString(int statusCode)
+    {
+        switch (statusCode)
+        {
+            case (int)HttpStatusCode.Continue:
+                return "100";
+            case (int)HttpStatusCode.SwitchingProtocols:
+                return "101";
+            case (int)HttpStatusCode.Processing:
+                return "102";
+
+            case (int)HttpStatusCode.OK:
+                return "200";
+            case (int)HttpStatusCode.Created:
+                return "201";
+            case (int)HttpStatusCode.Accepted:
+                return "202";
+            case (int)HttpStatusCode.NonAuthoritativeInformation:
+                return "203";
+            case (int)HttpStatusCode.NoContent:
+                return "204";
+            case (int)HttpStatusCode.ResetContent:
+                return "205";
+            case (int)HttpStatusCode.PartialContent:
+                return "206";
+            case (int)HttpStatusCode.MultiStatus:
+                return "207";
+            case (int)HttpStatusCode.AlreadyReported:
+                return "208";
+            case (int)HttpStatusCode.IMUsed:
+                return "226";
+
+            case (int)HttpStatusCode.MultipleChoices:
+                return "300";
+            case (int)HttpStatusCode.MovedPermanently:
+                return "301";
+            case (int)HttpStatusCode.Found:
+                return "302";
+            case (int)HttpStatusCode.SeeOther:
+                return "303";
+            case (int)HttpStatusCode.NotModified:
+                return "304";
+            case (int)HttpStatusCode.UseProxy:
+                return "305";
+            case (int)HttpStatusCode.Unused:
+                return "306";
+            case (int)HttpStatusCode.TemporaryRedirect:
+                return "307";
+            case (int)HttpStatusCode.PermanentRedirect:
+                return "308";
+
+            case (int)HttpStatusCode.BadRequest:
+                return "400";
+            case (int)HttpStatusCode.Unauthorized:
+                return "401";
+            case (int)HttpStatusCode.PaymentRequired:
+                return "402";
+            case (int)HttpStatusCode.Forbidden:
+                return "403";
+            case (int)HttpStatusCode.NotFound:
+                return "404";
+            case (int)HttpStatusCode.MethodNotAllowed:
+                return "405";
+            case (int)HttpStatusCode.NotAcceptable:
+                return "406";
+            case (int)HttpStatusCode.ProxyAuthenticationRequired:
+                return "407";
+            case (int)HttpStatusCode.RequestTimeout:
+                return "408";
+            case (int)HttpStatusCode.Conflict:
+                return "409";
+            case (int)HttpStatusCode.Gone:
+                return "410";
+            case (int)HttpStatusCode.LengthRequired:
+                return "411";
+            case (int)HttpStatusCode.PreconditionFailed:
+                return "412";
+            case (int)HttpStatusCode.RequestEntityTooLarge:
+                return "413";
+            case (int)HttpStatusCode.RequestUriTooLong:
+                return "414";
+            case (int)HttpStatusCode.UnsupportedMediaType:
+                return "415";
+            case (int)HttpStatusCode.RequestedRangeNotSatisfiable:
+                return "416";
+            case (int)HttpStatusCode.ExpectationFailed:
+                return "417";
+            case (int)418:
+                return "418";
+            case (int)419:
+                return "419";
+            case (int)HttpStatusCode.MisdirectedRequest:
+                return "421";
+            case (int)HttpStatusCode.UnprocessableEntity:
+                return "422";
+            case (int)HttpStatusCode.Locked:
+                return "423";
+            case (int)HttpStatusCode.FailedDependency:
+                return "424";
+            case (int)HttpStatusCode.UpgradeRequired:
+                return "426";
+            case (int)HttpStatusCode.PreconditionRequired:
+                return "428";
+            case (int)HttpStatusCode.TooManyRequests:
+                return "429";
+            case (int)HttpStatusCode.RequestHeaderFieldsTooLarge:
+                return "431";
+            case (int)HttpStatusCode.UnavailableForLegalReasons:
+                return "451";
+
+            case (int)HttpStatusCode.InternalServerError:
+                return "500";
+            case (int)HttpStatusCode.NotImplemented:
+                return "501";
+            case (int)HttpStatusCode.BadGateway:
+                return "502";
+            case (int)HttpStatusCode.ServiceUnavailable:
+                return "503";
+            case (int)HttpStatusCode.GatewayTimeout:
+                return "504";
+            case (int)HttpStatusCode.HttpVersionNotSupported:
+                return "505";
+            case (int)HttpStatusCode.VariantAlsoNegotiates:
+                return "506";
+            case (int)HttpStatusCode.InsufficientStorage:
+                return "507";
+            case (int)HttpStatusCode.LoopDetected:
+                return "508";
+            case (int)HttpStatusCode.NotExtended:
+                return "510";
+            case (int)HttpStatusCode.NetworkAuthenticationRequired:
+                return "511";
+
+            default:
+                return statusCode.ToString(CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/src/Middleware/HttpLogging/src/W3CLogger.cs
+++ b/src/Middleware/HttpLogging/src/W3CLogger.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.HttpLogging;
@@ -16,7 +14,7 @@ internal class W3CLogger : IAsyncDisposable
     private readonly IOptionsMonitor<W3CLoggerOptions> _options;
     private W3CLoggingFields _loggingFields;
 
-    public W3CLogger(IOptionsMonitor<W3CLoggerOptions> options, IHostEnvironment environment, ILoggerFactory factory)
+    public W3CLogger(IOptionsMonitor<W3CLoggerOptions> options, W3CLoggerProcessor messageQueue)
     {
         _options = options;
         _loggingFields = _options.CurrentValue.LoggingFields;
@@ -24,13 +22,7 @@ internal class W3CLogger : IAsyncDisposable
         {
             _loggingFields = options.LoggingFields;
         });
-        _messageQueue = InitializeMessageQueue(_options, environment, factory);
-    }
-
-    // Virtual for testing
-    internal virtual W3CLoggerProcessor InitializeMessageQueue(IOptionsMonitor<W3CLoggerOptions> options, IHostEnvironment environment, ILoggerFactory factory)
-    {
-        return new W3CLoggerProcessor(options, environment, factory);
+        _messageQueue = messageQueue;
     }
 
     public ValueTask DisposeAsync() => _messageQueue.DisposeAsync();

--- a/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
@@ -226,7 +226,7 @@ internal sealed class W3CLoggingMiddleware
 
         if (options.LoggingFields.HasFlag(W3CLoggingFields.ProtocolStatus))
         {
-            shouldLog |= AddToList(elements, _protocolStatusIndex, response.StatusCode.ToString(CultureInfo.InvariantCulture));
+            shouldLog |= AddToList(elements, _protocolStatusIndex, StatusCodeHelper.ToStatusString(response.StatusCode));
         }
 
         if (options.LoggingFields.HasFlag(W3CLoggingFields.TimeTaken))

--- a/src/Middleware/HttpLogging/test/FileLoggerProcessorTests.cs
+++ b/src/Middleware/HttpLogging/test/FileLoggerProcessorTests.cs
@@ -44,7 +44,7 @@ public class FileLoggerProcessorTests
             {
                 logger.SystemDateTime = mockSystemDateTime;
                 logger.EnqueueMessage(_messageOne);
-                filePath = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
+                filePath = GetLogFilePath(path, options.FileName, _today, 0);
                 // Pause for a bit before disposing so logger can finish logging
                 await WaitForFile(filePath, _messageOne.Length).DefaultTimeout();
             }
@@ -83,14 +83,14 @@ public class FileLoggerProcessorTests
                 logger.SystemDateTime = mockSystemDateTime;
                 logger.EnqueueMessage(_messageOne);
 
-                filePathToday = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
+                filePathToday = GetLogFilePath(path, options.FileName, _today, 0);
 
                 await WaitForFile(filePathToday, _messageOne.Length).DefaultTimeout();
 
                 mockSystemDateTime.Now = tomorrow;
                 logger.EnqueueMessage(_messageTwo);
 
-                filePathTomorrow = Helpers.GetLogFilePath(path, options.FileName, tomorrow, 0);
+                filePathTomorrow = GetLogFilePath(path, options.FileName, tomorrow, 0);
 
                 await WaitForFile(filePathTomorrow, _messageTwo.Length).DefaultTimeout();
             }
@@ -129,8 +129,8 @@ public class FileLoggerProcessorTests
                 logger.SystemDateTime = mockSystemDateTime;
                 logger.EnqueueMessage(_messageOne);
                 logger.EnqueueMessage(_messageTwo);
-                filePath1 = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
-                filePath2 = Helpers.GetLogFilePath(path, options.FileName, _today, 1);
+                filePath1 = GetLogFilePath(path, options.FileName, _today, 0);
+                filePath2 = GetLogFilePath(path, options.FileName, _today, 1);
                 // Pause for a bit before disposing so logger can finish logging
                 await WaitForFile(filePath2, _messageTwo.Length).DefaultTimeout();
             }
@@ -173,12 +173,12 @@ public class FileLoggerProcessorTests
                 {
                     logger.EnqueueMessage(_messageOne);
                 }
-                lastFilePath = Helpers.GetLogFilePath(path, options.FileName, _today, 9);
+                lastFilePath = GetLogFilePath(path, options.FileName, _today, 9);
                 // Pause for a bit before disposing so logger can finish logging
                 await WaitForFile(lastFilePath, _messageOne.Length).DefaultTimeout();
                 for (int i = 0; i < 6; i++)
                 {
-                    await WaitForRoll(Helpers.GetLogFilePath(path, options.FileName, _today, i)).DefaultTimeout();
+                    await WaitForRoll(GetLogFilePath(path, options.FileName, _today, i)).DefaultTimeout();
                 }
             }
 
@@ -192,7 +192,7 @@ public class FileLoggerProcessorTests
             Assert.Equal("randomFile.txt", actualFiles[0]);
             for (int i = 1; i < 4; i++)
             {
-                Assert.StartsWith(Helpers.GetLogFileBaseName(options.FileName, _today), actualFiles[i], StringComparison.InvariantCulture);
+                Assert.StartsWith(GetLogFileBaseName(options.FileName, _today), actualFiles[i], StringComparison.InvariantCulture);
             }
         }
         finally
@@ -229,7 +229,7 @@ public class FileLoggerProcessorTests
                 {
                     logger.EnqueueMessage(_messageOne);
                 }
-                lastFilePath = Helpers.GetLogFilePath(path, options.FileName, _today, 9999);
+                lastFilePath = GetLogFilePath(path, options.FileName, _today, 9999);
                 await WaitForFile(lastFilePath, _messageOne.Length).DefaultTimeout();
 
                 // directory is full, no warnings yet
@@ -287,7 +287,7 @@ public class FileLoggerProcessorTests
                 {
                     logger.EnqueueMessage(_messageOne);
                 }
-                var filePath = Helpers.GetLogFilePath(path, options.FileName, _today, 2);
+                var filePath = GetLogFilePath(path, options.FileName, _today, 2);
                 // Pause for a bit before disposing so logger can finish logging
                 await WaitForFile(filePath, _messageOne.Length).DefaultTimeout();
             }
@@ -300,7 +300,7 @@ public class FileLoggerProcessorTests
                 {
                     logger.EnqueueMessage(_messageOne);
                 }
-                var filePath = Helpers.GetLogFilePath(path, options.FileName, _today, 5);
+                var filePath = GetLogFilePath(path, options.FileName, _today, 5);
                 // Pause for a bit before disposing so logger can finish logging
                 await WaitForFile(filePath, _messageOne.Length).DefaultTimeout();
             }
@@ -314,7 +314,7 @@ public class FileLoggerProcessorTests
             Assert.Equal(6, actualFiles1.Length);
             for (int i = 0; i < 6; i++)
             {
-                Assert.Contains(Helpers.GetLogFileName(options.FileName, _today, i), actualFiles1[i]);
+                Assert.Contains(GetLogFileName(options.FileName, _today, i), actualFiles1[i]);
             }
 
             // Third instance should roll to 5 most recent files
@@ -324,9 +324,9 @@ public class FileLoggerProcessorTests
                 logger.SystemDateTime = mockSystemDateTime;
                 logger.EnqueueMessage(_messageOne);
                 // Pause for a bit before disposing so logger can finish logging
-                await WaitForFile(Helpers.GetLogFilePath(path, options.FileName, _today, 6), _messageOne.Length).DefaultTimeout();
-                await WaitForRoll(Helpers.GetLogFilePath(path, options.FileName, _today, 0)).DefaultTimeout();
-                await WaitForRoll(Helpers.GetLogFilePath(path, options.FileName, _today, 1)).DefaultTimeout();
+                await WaitForFile(GetLogFilePath(path, options.FileName, _today, 6), _messageOne.Length).DefaultTimeout();
+                await WaitForRoll(GetLogFilePath(path, options.FileName, _today, 0)).DefaultTimeout();
+                await WaitForRoll(GetLogFilePath(path, options.FileName, _today, 1)).DefaultTimeout();
             }
 
             var actualFiles2 = new DirectoryInfo(path)
@@ -338,7 +338,7 @@ public class FileLoggerProcessorTests
             Assert.Equal(5, actualFiles2.Length);
             for (int i = 0; i < 5; i++)
             {
-                Assert.Equal(Helpers.GetLogFileName(options.FileName, _today, i + 2), actualFiles2[i]);
+                Assert.Equal(GetLogFileName(options.FileName, _today, i + 2), actualFiles2[i]);
             }
         }
         finally
@@ -365,9 +365,9 @@ public class FileLoggerProcessorTests
                 LogDirectory = path,
                 FileSizeLimit = 5
             };
-            var filePath1 = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
-            var filePath2 = Helpers.GetLogFilePath(path, options.FileName, _today, 1);
-            var filePath3 = Helpers.GetLogFilePath(path, options.FileName, _today, 2);
+            var filePath1 = GetLogFilePath(path, options.FileName, _today, 0);
+            var filePath2 = GetLogFilePath(path, options.FileName, _today, 1);
+            var filePath3 = GetLogFilePath(path, options.FileName, _today, 2);
 
             await using (var logger = new FileLoggerProcessor(new OptionsWrapperMonitor<W3CLoggerOptions>(options), new HostingEnvironment(), NullLoggerFactory.Instance))
             {
@@ -429,10 +429,10 @@ public class FileLoggerProcessorTests
                 FileSizeLimit = 5,
                 RetainedFileCountLimit = 2,
             };
-            var filePath1 = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
-            var filePath2 = Helpers.GetLogFilePath(path, options.FileName, _today, 1);
-            var filePath3 = Helpers.GetLogFilePath(path, options.FileName, _today, 2);
-            var filePath4 = Helpers.GetLogFilePath(path, options.FileName, _today, 3);
+            var filePath1 = GetLogFilePath(path, options.FileName, _today, 0);
+            var filePath2 = GetLogFilePath(path, options.FileName, _today, 1);
+            var filePath3 = GetLogFilePath(path, options.FileName, _today, 2);
+            var filePath4 = GetLogFilePath(path, options.FileName, _today, 3);
 
             await using (var logger = new FileLoggerProcessor(new OptionsWrapperMonitor<W3CLoggerOptions>(options), new HostingEnvironment(), NullLoggerFactory.Instance))
             {
@@ -499,8 +499,8 @@ public class FileLoggerProcessorTests
                 FileSizeLimit = 10000,
             };
             options.AdditionalRequestHeaders.Add("one");
-            var filePath1 = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
-            var filePath2 = Helpers.GetLogFilePath(path, options.FileName, _today, 1);
+            var filePath1 = GetLogFilePath(path, options.FileName, _today, 0);
+            var filePath2 = GetLogFilePath(path, options.FileName, _today, 1);
             var monitor = new OptionsWrapperMonitor<W3CLoggerOptions>(options);
 
             await using (var logger = new FileLoggerProcessor(monitor, new HostingEnvironment(), NullLoggerFactory.Instance))
@@ -582,5 +582,20 @@ public class FileLoggerProcessorTests
         {
             await Task.Delay(100);
         }
+    }
+
+    private static string GetLogFilePath(string path, string prefix, DateTime dateTime, int fileNumber)
+    {
+        return Path.Combine(path, GetLogFileName(prefix, dateTime, fileNumber));
+    }
+
+    private static string GetLogFileName(string prefix, DateTime dateTime, int fileNumber)
+    {
+        return FormattableString.Invariant($"{GetLogFileBaseName(prefix, dateTime)}.{fileNumber:0000}.txt");
+    }
+
+    private static string GetLogFileBaseName(string prefix, DateTime dateTime)
+    {
+        return FormattableString.Invariant($"{prefix}{dateTime.Year:0000}{dateTime.Month:00}{dateTime.Day:00}");
     }
 }

--- a/src/Middleware/HttpLogging/test/FileLoggerProcessorTests.cs
+++ b/src/Middleware/HttpLogging/test/FileLoggerProcessorTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Concurrent;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Hosting.Internal;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -11,7 +10,6 @@ namespace Microsoft.AspNetCore.HttpLogging;
 
 public class FileLoggerProcessorTests
 {
-
     private string _messageOne = "Message one";
     private string _messageTwo = "Message two";
     private string _messageThree = "Message three";
@@ -37,7 +35,7 @@ public class FileLoggerProcessorTests
 
         try
         {
-            string fileName;
+            string filePath;
             var options = new W3CLoggerOptions()
             {
                 LogDirectory = path
@@ -46,13 +44,13 @@ public class FileLoggerProcessorTests
             {
                 logger.SystemDateTime = mockSystemDateTime;
                 logger.EnqueueMessage(_messageOne);
-                fileName = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
+                filePath = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
                 // Pause for a bit before disposing so logger can finish logging
-                await WaitForFile(fileName, _messageOne.Length).DefaultTimeout();
+                await WaitForFile(filePath, _messageOne.Length).DefaultTimeout();
             }
-            Assert.True(File.Exists(fileName));
+            Assert.True(File.Exists(filePath));
 
-            Assert.Equal(_messageOne + Environment.NewLine, File.ReadAllText(fileName));
+            Assert.Equal(_messageOne + Environment.NewLine, File.ReadAllText(filePath));
         }
         finally
         {
@@ -77,30 +75,30 @@ public class FileLoggerProcessorTests
 
         try
         {
-            string fileNameToday;
-            string fileNameTomorrow;
+            string filePathToday;
+            string filePathTomorrow;
 
             await using (var logger = new FileLoggerProcessor(new OptionsWrapperMonitor<W3CLoggerOptions>(options), new HostingEnvironment(), NullLoggerFactory.Instance))
             {
                 logger.SystemDateTime = mockSystemDateTime;
                 logger.EnqueueMessage(_messageOne);
 
-                fileNameToday = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
+                filePathToday = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
 
-                await WaitForFile(fileNameToday, _messageOne.Length).DefaultTimeout();
+                await WaitForFile(filePathToday, _messageOne.Length).DefaultTimeout();
 
                 mockSystemDateTime.Now = tomorrow;
                 logger.EnqueueMessage(_messageTwo);
 
-                fileNameTomorrow = Helpers.GetLogFilePath(path, options.FileName, tomorrow, 0);
+                filePathTomorrow = Helpers.GetLogFilePath(path, options.FileName, tomorrow, 0);
 
-                await WaitForFile(fileNameTomorrow, _messageTwo.Length).DefaultTimeout();
+                await WaitForFile(filePathTomorrow, _messageTwo.Length).DefaultTimeout();
             }
 
-            Assert.True(File.Exists(fileNameToday));
-            Assert.Equal(_messageOne + Environment.NewLine, File.ReadAllText(fileNameToday));
-            Assert.True(File.Exists(fileNameTomorrow));
-            Assert.Equal(_messageTwo + Environment.NewLine, File.ReadAllText(fileNameTomorrow));
+            Assert.True(File.Exists(filePathToday));
+            Assert.Equal(_messageOne + Environment.NewLine, File.ReadAllText(filePathToday));
+            Assert.True(File.Exists(filePathTomorrow));
+            Assert.Equal(_messageTwo + Environment.NewLine, File.ReadAllText(filePathTomorrow));
         }
         finally
         {
@@ -115,8 +113,8 @@ public class FileLoggerProcessorTests
 
         try
         {
-            string fileName1;
-            string fileName2;
+            string filePath1;
+            string filePath2;
             var mockSystemDateTime = new MockSystemDateTime
             {
                 Now = _today
@@ -131,16 +129,16 @@ public class FileLoggerProcessorTests
                 logger.SystemDateTime = mockSystemDateTime;
                 logger.EnqueueMessage(_messageOne);
                 logger.EnqueueMessage(_messageTwo);
-                fileName1 = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
-                fileName2 = Helpers.GetLogFilePath(path, options.FileName, _today, 1);
+                filePath1 = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
+                filePath2 = Helpers.GetLogFilePath(path, options.FileName, _today, 1);
                 // Pause for a bit before disposing so logger can finish logging
-                await WaitForFile(fileName2, _messageTwo.Length).DefaultTimeout();
+                await WaitForFile(filePath2, _messageTwo.Length).DefaultTimeout();
             }
-            Assert.True(File.Exists(fileName1));
-            Assert.True(File.Exists(fileName2));
+            Assert.True(File.Exists(filePath1));
+            Assert.True(File.Exists(filePath2));
 
-            Assert.Equal(_messageOne + Environment.NewLine, File.ReadAllText(fileName1));
-            Assert.Equal(_messageTwo + Environment.NewLine, File.ReadAllText(fileName2));
+            Assert.Equal(_messageOne + Environment.NewLine, File.ReadAllText(filePath1));
+            Assert.Equal(_messageTwo + Environment.NewLine, File.ReadAllText(filePath2));
         }
         finally
         {
@@ -161,7 +159,7 @@ public class FileLoggerProcessorTests
 
         try
         {
-            string lastFileName;
+            string lastFilePath;
             var options = new W3CLoggerOptions()
             {
                 LogDirectory = path,
@@ -175,9 +173,9 @@ public class FileLoggerProcessorTests
                 {
                     logger.EnqueueMessage(_messageOne);
                 }
-                lastFileName = Helpers.GetLogFilePath(path, options.FileName, _today, 9);
+                lastFilePath = Helpers.GetLogFilePath(path, options.FileName, _today, 9);
                 // Pause for a bit before disposing so logger can finish logging
-                await WaitForFile(lastFileName, _messageOne.Length).DefaultTimeout();
+                await WaitForFile(lastFilePath, _messageOne.Length).DefaultTimeout();
                 for (int i = 0; i < 6; i++)
                 {
                     await WaitForRoll(Helpers.GetLogFilePath(path, options.FileName, _today, i)).DefaultTimeout();
@@ -215,7 +213,7 @@ public class FileLoggerProcessorTests
 
         try
         {
-            string lastFileName;
+            string lastFilePath;
             var options = new W3CLoggerOptions()
             {
                 LogDirectory = path,
@@ -231,8 +229,8 @@ public class FileLoggerProcessorTests
                 {
                     logger.EnqueueMessage(_messageOne);
                 }
-                lastFileName = Helpers.GetLogFilePath(path, options.FileName, _today, 9999);
-                await WaitForFile(lastFileName, _messageOne.Length).DefaultTimeout();
+                lastFilePath = Helpers.GetLogFilePath(path, options.FileName, _today, 9999);
+                await WaitForFile(lastFilePath, _messageOne.Length).DefaultTimeout();
 
                 // directory is full, no warnings yet
                 Assert.Equal(0, testSink.Writes.Count);
@@ -367,9 +365,9 @@ public class FileLoggerProcessorTests
                 LogDirectory = path,
                 FileSizeLimit = 5
             };
-            var fileName1 = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
-            var fileName2 = Helpers.GetLogFilePath(path, options.FileName, _today, 1);
-            var fileName3 = Helpers.GetLogFilePath(path, options.FileName, _today, 2);
+            var filePath1 = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
+            var filePath2 = Helpers.GetLogFilePath(path, options.FileName, _today, 1);
+            var filePath3 = Helpers.GetLogFilePath(path, options.FileName, _today, 2);
 
             await using (var logger = new FileLoggerProcessor(new OptionsWrapperMonitor<W3CLoggerOptions>(options), new HostingEnvironment(), NullLoggerFactory.Instance))
             {
@@ -377,7 +375,7 @@ public class FileLoggerProcessorTests
                 logger.EnqueueMessage(_messageOne);
                 logger.EnqueueMessage(_messageTwo);
                 // Pause for a bit before disposing so logger can finish logging
-                await WaitForFile(fileName2, _messageTwo.Length).DefaultTimeout();
+                await WaitForFile(filePath2, _messageTwo.Length).DefaultTimeout();
             }
 
             // Even with a big enough FileSizeLimit, we still won't try to write to files from a previous instance.
@@ -388,7 +386,7 @@ public class FileLoggerProcessorTests
                 logger.SystemDateTime = mockSystemDateTime;
                 logger.EnqueueMessage(_messageThree);
                 // Pause for a bit before disposing so logger can finish logging
-                await WaitForFile(fileName3, _messageThree.Length).DefaultTimeout();
+                await WaitForFile(filePath3, _messageThree.Length).DefaultTimeout();
             }
 
             var actualFiles = new DirectoryInfo(path)
@@ -399,13 +397,13 @@ public class FileLoggerProcessorTests
 
             Assert.Equal(3, actualFiles.Length);
 
-            Assert.True(File.Exists(fileName1));
-            Assert.True(File.Exists(fileName2));
-            Assert.True(File.Exists(fileName3));
+            Assert.True(File.Exists(filePath1));
+            Assert.True(File.Exists(filePath2));
+            Assert.True(File.Exists(filePath3));
 
-            Assert.Equal(_messageOne + Environment.NewLine, File.ReadAllText(fileName1));
-            Assert.Equal(_messageTwo + Environment.NewLine, File.ReadAllText(fileName2));
-            Assert.Equal(_messageThree + Environment.NewLine, File.ReadAllText(fileName3));
+            Assert.Equal(_messageOne + Environment.NewLine, File.ReadAllText(filePath1));
+            Assert.Equal(_messageTwo + Environment.NewLine, File.ReadAllText(filePath2));
+            Assert.Equal(_messageThree + Environment.NewLine, File.ReadAllText(filePath3));
         }
         finally
         {
@@ -431,10 +429,10 @@ public class FileLoggerProcessorTests
                 FileSizeLimit = 5,
                 RetainedFileCountLimit = 2,
             };
-            var fileName1 = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
-            var fileName2 = Helpers.GetLogFilePath(path, options.FileName, _today, 1);
-            var fileName3 = Helpers.GetLogFilePath(path, options.FileName, _today, 2);
-            var fileName4 = Helpers.GetLogFilePath(path, options.FileName, _today, 3);
+            var filePath1 = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
+            var filePath2 = Helpers.GetLogFilePath(path, options.FileName, _today, 1);
+            var filePath3 = Helpers.GetLogFilePath(path, options.FileName, _today, 2);
+            var filePath4 = Helpers.GetLogFilePath(path, options.FileName, _today, 3);
 
             await using (var logger = new FileLoggerProcessor(new OptionsWrapperMonitor<W3CLoggerOptions>(options), new HostingEnvironment(), NullLoggerFactory.Instance))
             {
@@ -443,7 +441,7 @@ public class FileLoggerProcessorTests
                 logger.EnqueueMessage(_messageTwo);
                 logger.EnqueueMessage(_messageThree);
                 // Pause for a bit before disposing so logger can finish logging
-                await WaitForFile(fileName3, _messageThree.Length).DefaultTimeout();
+                await WaitForFile(filePath3, _messageThree.Length).DefaultTimeout();
             }
 
             // Even with a big enough FileSizeLimit, we still won't try to write to files from a previous instance.
@@ -454,7 +452,7 @@ public class FileLoggerProcessorTests
                 logger.SystemDateTime = mockSystemDateTime;
                 logger.EnqueueMessage(_messageFour);
                 // Pause for a bit before disposing so logger can finish logging
-                await WaitForFile(fileName4, _messageFour.Length).DefaultTimeout();
+                await WaitForFile(filePath4, _messageFour.Length).DefaultTimeout();
             }
 
             var actualFiles = new DirectoryInfo(path)
@@ -465,13 +463,13 @@ public class FileLoggerProcessorTests
 
             Assert.Equal(2, actualFiles.Length);
 
-            Assert.False(File.Exists(fileName1));
-            Assert.False(File.Exists(fileName2));
-            Assert.True(File.Exists(fileName3));
-            Assert.True(File.Exists(fileName4));
+            Assert.False(File.Exists(filePath1));
+            Assert.False(File.Exists(filePath2));
+            Assert.True(File.Exists(filePath3));
+            Assert.True(File.Exists(filePath4));
 
-            Assert.Equal(_messageThree + Environment.NewLine, File.ReadAllText(fileName3));
-            Assert.Equal(_messageFour + Environment.NewLine, File.ReadAllText(fileName4));
+            Assert.Equal(_messageThree + Environment.NewLine, File.ReadAllText(filePath3));
+            Assert.Equal(_messageFour + Environment.NewLine, File.ReadAllText(filePath4));
         }
         finally
         {
@@ -501,15 +499,15 @@ public class FileLoggerProcessorTests
                 FileSizeLimit = 10000,
             };
             options.AdditionalRequestHeaders.Add("one");
-            var fileName1 = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
-            var fileName2 = Helpers.GetLogFilePath(path, options.FileName, _today, 1);
+            var filePath1 = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
+            var filePath2 = Helpers.GetLogFilePath(path, options.FileName, _today, 1);
             var monitor = new OptionsWrapperMonitor<W3CLoggerOptions>(options);
 
             await using (var logger = new FileLoggerProcessor(monitor, new HostingEnvironment(), NullLoggerFactory.Instance))
             {
                 logger.SystemDateTime = mockSystemDateTime;
                 logger.EnqueueMessage(_messageOne);
-                await WaitForFile(fileName1, _messageOne.Length).DefaultTimeout();
+                await WaitForFile(filePath1, _messageOne.Length).DefaultTimeout();
 
                 if (fieldsChanged)
                 {
@@ -524,7 +522,7 @@ public class FileLoggerProcessorTests
                 monitor.InvokeChanged();
                 logger.EnqueueMessage(_messageTwo);
                 // Pause for a bit before disposing so logger can finish logging
-                await WaitForFile(fileName2, _messageTwo.Length).DefaultTimeout();
+                await WaitForFile(filePath2, _messageTwo.Length).DefaultTimeout();
             }
 
             var actualFiles = new DirectoryInfo(path)
@@ -535,11 +533,11 @@ public class FileLoggerProcessorTests
 
             Assert.Equal(2, actualFiles.Length);
 
-            Assert.True(File.Exists(fileName1));
-            Assert.True(File.Exists(fileName2));
+            Assert.True(File.Exists(filePath1));
+            Assert.True(File.Exists(filePath2));
 
-            Assert.Equal(_messageOne + Environment.NewLine, File.ReadAllText(fileName1));
-            Assert.Equal(_messageTwo + Environment.NewLine, File.ReadAllText(fileName2));
+            Assert.Equal(_messageOne + Environment.NewLine, File.ReadAllText(filePath1));
+            Assert.Equal(_messageTwo + Environment.NewLine, File.ReadAllText(filePath2));
         }
         finally
         {
@@ -547,9 +545,9 @@ public class FileLoggerProcessorTests
         }
     }
 
-    private async Task WaitForFile(string fileName, int length)
+    private async Task WaitForFile(string filePath, int length)
     {
-        while (!File.Exists(fileName))
+        while (!File.Exists(filePath))
         {
             await Task.Delay(100);
         }
@@ -557,7 +555,7 @@ public class FileLoggerProcessorTests
         {
             try
             {
-                if (File.ReadAllText(fileName).Length >= length)
+                if (File.ReadAllText(filePath).Length >= length)
                 {
                     break;
                 }
@@ -578,9 +576,9 @@ public class FileLoggerProcessorTests
         }
     }
 
-    private async Task WaitForRoll(string fileName)
+    private async Task WaitForRoll(string filePath)
     {
-        while (File.Exists(fileName))
+        while (File.Exists(filePath))
         {
             await Task.Delay(100);
         }

--- a/src/Middleware/HttpLogging/test/FileLoggerProcessorTests.cs
+++ b/src/Middleware/HttpLogging/test/FileLoggerProcessorTests.cs
@@ -46,7 +46,7 @@ public class FileLoggerProcessorTests
             {
                 logger.SystemDateTime = mockSystemDateTime;
                 logger.EnqueueMessage(_messageOne);
-                fileName = Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0000.txt"));
+                fileName = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
                 // Pause for a bit before disposing so logger can finish logging
                 await WaitForFile(fileName, _messageOne.Length).DefaultTimeout();
             }
@@ -85,14 +85,14 @@ public class FileLoggerProcessorTests
                 logger.SystemDateTime = mockSystemDateTime;
                 logger.EnqueueMessage(_messageOne);
 
-                fileNameToday = Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0000.txt"));
+                fileNameToday = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
 
                 await WaitForFile(fileNameToday, _messageOne.Length).DefaultTimeout();
 
                 mockSystemDateTime.Now = tomorrow;
                 logger.EnqueueMessage(_messageTwo);
 
-                fileNameTomorrow = Path.Combine(path, FormattableString.Invariant($"{options.FileName}{tomorrow.Year:0000}{tomorrow.Month:00}{tomorrow.Day:00}.0000.txt"));
+                fileNameTomorrow = Helpers.GetLogFilePath(path, options.FileName, tomorrow, 0);
 
                 await WaitForFile(fileNameTomorrow, _messageTwo.Length).DefaultTimeout();
             }
@@ -131,8 +131,8 @@ public class FileLoggerProcessorTests
                 logger.SystemDateTime = mockSystemDateTime;
                 logger.EnqueueMessage(_messageOne);
                 logger.EnqueueMessage(_messageTwo);
-                fileName1 = Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0000.txt"));
-                fileName2 = Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0001.txt"));
+                fileName1 = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
+                fileName2 = Helpers.GetLogFilePath(path, options.FileName, _today, 1);
                 // Pause for a bit before disposing so logger can finish logging
                 await WaitForFile(fileName2, _messageTwo.Length).DefaultTimeout();
             }
@@ -175,12 +175,12 @@ public class FileLoggerProcessorTests
                 {
                     logger.EnqueueMessage(_messageOne);
                 }
-                lastFileName = Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0009.txt"));
+                lastFileName = Helpers.GetLogFilePath(path, options.FileName, _today, 9);
                 // Pause for a bit before disposing so logger can finish logging
                 await WaitForFile(lastFileName, _messageOne.Length).DefaultTimeout();
                 for (int i = 0; i < 6; i++)
                 {
-                    await WaitForRoll(Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.{i:0000}.txt"))).DefaultTimeout();
+                    await WaitForRoll(Helpers.GetLogFilePath(path, options.FileName, _today, i)).DefaultTimeout();
                 }
             }
 
@@ -194,7 +194,7 @@ public class FileLoggerProcessorTests
             Assert.Equal("randomFile.txt", actualFiles[0]);
             for (int i = 1; i < 4; i++)
             {
-                Assert.True((actualFiles[i].StartsWith($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}", StringComparison.InvariantCulture)));
+                Assert.StartsWith(Helpers.GetLogFileBaseName(options.FileName, _today), actualFiles[i], StringComparison.InvariantCulture);
             }
         }
         finally
@@ -231,7 +231,7 @@ public class FileLoggerProcessorTests
                 {
                     logger.EnqueueMessage(_messageOne);
                 }
-                lastFileName = Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.9999.txt"));
+                lastFileName = Helpers.GetLogFilePath(path, options.FileName, _today, 9999);
                 await WaitForFile(lastFileName, _messageOne.Length).DefaultTimeout();
 
                 // directory is full, no warnings yet
@@ -289,7 +289,7 @@ public class FileLoggerProcessorTests
                 {
                     logger.EnqueueMessage(_messageOne);
                 }
-                var filePath = Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0002.txt"));
+                var filePath = Helpers.GetLogFilePath(path, options.FileName, _today, 2);
                 // Pause for a bit before disposing so logger can finish logging
                 await WaitForFile(filePath, _messageOne.Length).DefaultTimeout();
             }
@@ -302,7 +302,7 @@ public class FileLoggerProcessorTests
                 {
                     logger.EnqueueMessage(_messageOne);
                 }
-                var filePath = Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0005.txt"));
+                var filePath = Helpers.GetLogFilePath(path, options.FileName, _today, 5);
                 // Pause for a bit before disposing so logger can finish logging
                 await WaitForFile(filePath, _messageOne.Length).DefaultTimeout();
             }
@@ -316,7 +316,7 @@ public class FileLoggerProcessorTests
             Assert.Equal(6, actualFiles1.Length);
             for (int i = 0; i < 6; i++)
             {
-                Assert.Contains($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.{i:0000}.txt", actualFiles1[i]);
+                Assert.Contains(Helpers.GetLogFileName(options.FileName, _today, i), actualFiles1[i]);
             }
 
             // Third instance should roll to 5 most recent files
@@ -326,9 +326,9 @@ public class FileLoggerProcessorTests
                 logger.SystemDateTime = mockSystemDateTime;
                 logger.EnqueueMessage(_messageOne);
                 // Pause for a bit before disposing so logger can finish logging
-                await WaitForFile(Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0006.txt")), _messageOne.Length).DefaultTimeout();
-                await WaitForRoll(Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0000.txt"))).DefaultTimeout();
-                await WaitForRoll(Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0001.txt"))).DefaultTimeout();
+                await WaitForFile(Helpers.GetLogFilePath(path, options.FileName, _today, 6), _messageOne.Length).DefaultTimeout();
+                await WaitForRoll(Helpers.GetLogFilePath(path, options.FileName, _today, 0)).DefaultTimeout();
+                await WaitForRoll(Helpers.GetLogFilePath(path, options.FileName, _today, 1)).DefaultTimeout();
             }
 
             var actualFiles2 = new DirectoryInfo(path)
@@ -340,7 +340,7 @@ public class FileLoggerProcessorTests
             Assert.Equal(5, actualFiles2.Length);
             for (int i = 0; i < 5; i++)
             {
-                Assert.Equal($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.{i + 2:0000}.txt", actualFiles2[i]);
+                Assert.Equal(Helpers.GetLogFileName(options.FileName, _today, i + 2), actualFiles2[i]);
             }
         }
         finally
@@ -367,9 +367,9 @@ public class FileLoggerProcessorTests
                 LogDirectory = path,
                 FileSizeLimit = 5
             };
-            var fileName1 = Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0000.txt"));
-            var fileName2 = Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0001.txt"));
-            var fileName3 = Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0002.txt"));
+            var fileName1 = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
+            var fileName2 = Helpers.GetLogFilePath(path, options.FileName, _today, 1);
+            var fileName3 = Helpers.GetLogFilePath(path, options.FileName, _today, 2);
 
             await using (var logger = new FileLoggerProcessor(new OptionsWrapperMonitor<W3CLoggerOptions>(options), new HostingEnvironment(), NullLoggerFactory.Instance))
             {
@@ -431,10 +431,10 @@ public class FileLoggerProcessorTests
                 FileSizeLimit = 5,
                 RetainedFileCountLimit = 2,
             };
-            var fileName1 = Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0000.txt"));
-            var fileName2 = Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0001.txt"));
-            var fileName3 = Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0002.txt"));
-            var fileName4 = Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0003.txt"));
+            var fileName1 = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
+            var fileName2 = Helpers.GetLogFilePath(path, options.FileName, _today, 1);
+            var fileName3 = Helpers.GetLogFilePath(path, options.FileName, _today, 2);
+            var fileName4 = Helpers.GetLogFilePath(path, options.FileName, _today, 3);
 
             await using (var logger = new FileLoggerProcessor(new OptionsWrapperMonitor<W3CLoggerOptions>(options), new HostingEnvironment(), NullLoggerFactory.Instance))
             {
@@ -501,8 +501,8 @@ public class FileLoggerProcessorTests
                 FileSizeLimit = 10000,
             };
             options.AdditionalRequestHeaders.Add("one");
-            var fileName1 = Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0000.txt"));
-            var fileName2 = Path.Combine(path, FormattableString.Invariant($"{options.FileName}{_today.Year:0000}{_today.Month:00}{_today.Day:00}.0001.txt"));
+            var fileName1 = Helpers.GetLogFilePath(path, options.FileName, _today, 0);
+            var fileName2 = Helpers.GetLogFilePath(path, options.FileName, _today, 1);
             var monitor = new OptionsWrapperMonitor<W3CLoggerOptions>(options);
 
             await using (var logger = new FileLoggerProcessor(monitor, new HostingEnvironment(), NullLoggerFactory.Instance))

--- a/src/Middleware/HttpLogging/test/Helpers.cs
+++ b/src/Middleware/HttpLogging/test/Helpers.cs
@@ -1,9 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Extensions.Hosting.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
 namespace Microsoft.AspNetCore.HttpLogging;
 
-public class Helpers
+internal static class Helpers
 {
     public static void DisposeDirectory(string path)
     {
@@ -18,5 +22,15 @@ public class Helpers
         {
             // ignored
         }
+    }
+
+    public static TestW3CLogger CreateTestW3CLogger(IOptionsMonitor<W3CLoggerOptions> options)
+    {
+        return new TestW3CLogger(
+            options,
+            new TestW3CLoggerProcessor(
+                options,
+                new HostingEnvironment(),
+                NullLoggerFactory.Instance));
     }
 }

--- a/src/Middleware/HttpLogging/test/Helpers.cs
+++ b/src/Middleware/HttpLogging/test/Helpers.cs
@@ -33,19 +33,4 @@ internal static class Helpers
                 new HostingEnvironment(),
                 NullLoggerFactory.Instance));
     }
-
-    public static string GetLogFilePath(string path, string prefix, DateTime dateTime, int fileNumber)
-    {
-        return Path.Combine(path, GetLogFileName(prefix, dateTime, fileNumber));
-    }
-
-    public static string GetLogFileName(string prefix, DateTime dateTime, int fileNumber)
-    {
-        return FormattableString.Invariant($"{GetLogFileBaseName(prefix, dateTime)}.{fileNumber:0000}.txt");
-    }
-
-    public static string GetLogFileBaseName(string prefix, DateTime dateTime)
-    {
-        return FormattableString.Invariant($"{prefix}{dateTime.Year:0000}{dateTime.Month:00}{dateTime.Day:00}");
-    }
 }

--- a/src/Middleware/HttpLogging/test/Helpers.cs
+++ b/src/Middleware/HttpLogging/test/Helpers.cs
@@ -33,4 +33,19 @@ internal static class Helpers
                 new HostingEnvironment(),
                 NullLoggerFactory.Instance));
     }
+
+    public static string GetLogFilePath(string path, string prefix, DateTime dateTime, int fileNumber)
+    {
+        return Path.Combine(path, GetLogFileName(prefix, dateTime, fileNumber));
+    }
+
+    public static string GetLogFileName(string prefix, DateTime dateTime, int fileNumber)
+    {
+        return FormattableString.Invariant($"{GetLogFileBaseName(prefix, dateTime)}.{fileNumber:0000}.txt");
+    }
+
+    public static string GetLogFileBaseName(string prefix, DateTime dateTime)
+    {
+        return FormattableString.Invariant($"{prefix}{dateTime.Year:0000}{dateTime.Month:00}{dateTime.Day:00}");
+    }
 }

--- a/src/Middleware/HttpLogging/test/TestW3CLogger.cs
+++ b/src/Middleware/HttpLogging/test/TestW3CLogger.cs
@@ -1,22 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.HttpLogging;
 
 internal class TestW3CLogger : W3CLogger
 {
-
-    public TestW3CLogger(IOptionsMonitor<W3CLoggerOptions> options, IHostEnvironment environment, ILoggerFactory factory) : base(options, environment, factory) { }
+    public TestW3CLogger(IOptionsMonitor<W3CLoggerOptions> options, TestW3CLoggerProcessor processor) : base(options, processor)
+    {
+        Processor = processor;
+    }
 
     public TestW3CLoggerProcessor Processor { get; set; }
-
-    internal override W3CLoggerProcessor InitializeMessageQueue(IOptionsMonitor<W3CLoggerOptions> options, IHostEnvironment environment, ILoggerFactory factory)
-    {
-        Processor = new TestW3CLoggerProcessor(options, environment, factory);
-        return Processor;
-    }
 }

--- a/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggerTests.cs
@@ -3,8 +3,6 @@
 
 using System.Globalization;
 using Microsoft.AspNetCore.Testing;
-using Microsoft.Extensions.Hosting.Internal;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.AspNetCore.HttpLogging;
 
@@ -24,7 +22,7 @@ public class W3CLoggerTests
         };
         try
         {
-            await using (var logger = new TestW3CLogger(new OptionsWrapperMonitor<W3CLoggerOptions>(options), new HostingEnvironment(), NullLoggerFactory.Instance))
+            await using (var logger = Helpers.CreateTestW3CLogger(new OptionsWrapperMonitor<W3CLoggerOptions>(options)))
             {
                 var elements = new string[W3CLoggingMiddleware._fieldsLength];
                 var additionalHeaders = new string[0];
@@ -67,7 +65,7 @@ public class W3CLoggerTests
         };
         try
         {
-            await using (var logger = new TestW3CLogger(new OptionsWrapperMonitor<W3CLoggerOptions>(options), new HostingEnvironment(), NullLoggerFactory.Instance))
+            await using (var logger = Helpers.CreateTestW3CLogger(new OptionsWrapperMonitor<W3CLoggerOptions>(options)))
             {
                 var elements = new string[W3CLoggingMiddleware._fieldsLength];
                 var additionalHeaders = new string[0];

--- a/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggingMiddlewareTests.cs
@@ -4,8 +4,6 @@
 using System.Globalization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Testing;
-using Microsoft.Extensions.Hosting.Internal;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 
@@ -20,14 +18,14 @@ public class W3CLoggingMiddlewareTests
         Assert.Throws<ArgumentNullException>(() => new W3CLoggingMiddleware(
             null,
             options,
-            new TestW3CLogger(options, new HostingEnvironment(), NullLoggerFactory.Instance)));
+            Helpers.CreateTestW3CLogger(options)));
 
         Assert.Throws<ArgumentNullException>(() => new W3CLoggingMiddleware(c =>
             {
                 return Task.CompletedTask;
             },
             null,
-            new TestW3CLogger(options, new HostingEnvironment(), NullLoggerFactory.Instance)));
+            Helpers.CreateTestW3CLogger(options)));
 
         Assert.Throws<ArgumentNullException>(() => new W3CLoggingMiddleware(c =>
             {
@@ -42,7 +40,7 @@ public class W3CLoggingMiddlewareTests
     {
         var options = CreateOptionsAccessor();
         options.CurrentValue.LoggingFields = W3CLoggingFields.None;
-        var logger = new TestW3CLogger(options, new HostingEnvironment(), NullLoggerFactory.Instance);
+        var logger = Helpers.CreateTestW3CLogger(options);
 
         var middleware = new W3CLoggingMiddleware(
             c =>
@@ -69,7 +67,7 @@ public class W3CLoggingMiddlewareTests
     public async Task DefaultDoesNotLogOptionalFields()
     {
         var options = CreateOptionsAccessor();
-        var logger = new TestW3CLogger(options, new HostingEnvironment(), NullLoggerFactory.Instance);
+        var logger = Helpers.CreateTestW3CLogger(options);
 
         var middleware = new W3CLoggingMiddleware(
             c =>
@@ -111,7 +109,7 @@ public class W3CLoggingMiddlewareTests
         options.CurrentValue.AdditionalRequestHeaders.Add("x-client-ssl-protocol");
         options.CurrentValue.AdditionalRequestHeaders.Add(":invalid");
 
-        var logger = new TestW3CLogger(options, new HostingEnvironment(), NullLoggerFactory.Instance);
+        var logger = Helpers.CreateTestW3CLogger(options);
 
         var middleware = new W3CLoggingMiddleware(
             c =>
@@ -165,7 +163,7 @@ public class W3CLoggingMiddlewareTests
         options.CurrentValue.AdditionalRequestHeaders.Add("Cookie");
         options.CurrentValue.AdditionalRequestHeaders.Add("x-client-ssl-protocol");
 
-        var logger = new TestW3CLogger(options, new HostingEnvironment(), NullLoggerFactory.Instance);
+        var logger = Helpers.CreateTestW3CLogger(options);
 
         var middleware = new W3CLoggingMiddleware(
             c =>
@@ -209,7 +207,7 @@ public class W3CLoggingMiddlewareTests
     {
         var options = CreateOptionsAccessor();
         options.CurrentValue.LoggingFields = W3CLoggingFields.TimeTaken;
-        var logger = new TestW3CLogger(options, new HostingEnvironment(), NullLoggerFactory.Instance);
+        var logger = Helpers.CreateTestW3CLogger(options);
 
         var middleware = new W3CLoggingMiddleware(
             c =>


### PR DESCRIPTION
# W3CLogger follow-ups

Clean up tasks for the W3CLogger middleware

## Description

- Updates `W3CLogger.cs` to resolve `W3CLoggerProcessor` from DI
- Adds a helper method for converting status codes to strings (to avoid calling `int.ToString`)
- Adds helper methods for finding log file names and paths in `FileLoggerProcessorTests`
- Cleans up some variables in `FileLoggerProcessorTests` that were named like "fileName" but are actually file paths

Fixes #33945