### PR TITLE
Support binding parameters to type Uri in Minimal Actions

### DIFF
--- a/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
+++ b/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
@@ -42,6 +42,23 @@ public class ParameterBindingMethodCacheTests
         Assert.True(parameters[3].IsOut);
     }
 
+    [Fact]
+    public void FindUriTryCreateStringMethod_ReturnsTheExpectedUriTryCreateMethod()
+    {
+        var methodFound = new ParameterBindingMethodCache().FindTryParseMethod(typeof(Uri));
+
+        Assert.NotNull(methodFound);
+
+        var call = methodFound!(Expression.Variable(typeof(Uri), "parsedValue"), Expression.Constant(UriKind.RelativeOrAbsolute)) as MethodCallExpression;
+        Assert.NotNull(call);
+        var parameters = call!.Method.GetParameters();
+
+        Assert.Equal(3, parameters.Length);
+        Assert.Equal(typeof(string), parameters[0].ParameterType);
+        Assert.Equal(typeof(UriKind), parameters[1].ParameterType);
+        Assert.True(parameters[2].IsOut);
+    }
+
     [Theory]
     [InlineData(typeof(DateTime))]
     [InlineData(typeof(DateOnly))]

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -101,6 +101,7 @@ internal sealed class ParameterBindingMethodCache
 
             if (type == typeof(Uri))
             {
+                // UriKind.RelativeOrAbsolute is also used by UriTypeConverter which is used in MVC.
                 return (expression, formatProvider) => Expression.Call(
                     UriTryCreateMethod,
                     TempSourceStringExpr,

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -25,6 +25,7 @@ internal sealed class ParameterBindingMethodCache
     private static readonly MethodInfo ConvertValueTaskMethod = typeof(ParameterBindingMethodCache).GetMethod(nameof(ConvertValueTask), BindingFlags.NonPublic | BindingFlags.Static)!;
     private static readonly MethodInfo ConvertValueTaskOfNullableResultMethod = typeof(ParameterBindingMethodCache).GetMethod(nameof(ConvertValueTaskOfNullableResult), BindingFlags.NonPublic | BindingFlags.Static)!;
     private static readonly MethodInfo BindAsyncMethod = typeof(ParameterBindingMethodCache).GetMethod(nameof(BindAsync), BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly MethodInfo UriTryCreateMethod = typeof(Uri).GetMethod(nameof(Uri.TryCreate), BindingFlags.Public | BindingFlags.Static, new[] { typeof(string), typeof(UriKind), typeof(Uri).MakeByRefType() })!;
 
     internal static readonly ParameterExpression TempSourceStringExpr = Expression.Variable(typeof(string), "tempSourceString");
     internal static readonly ParameterExpression HttpContextExpr = Expression.Parameter(typeof(HttpContext), "httpContext");
@@ -96,6 +97,15 @@ internal sealed class ParameterBindingMethodCache
                         Expression.Condition(success, Expression.Convert(enumAsObject, type), Expression.Default(type))),
                     success);
                 };
+            }
+
+            if (type == typeof(Uri))
+            {
+                return (expression, formatProvider) => Expression.Call(
+                    UriTryCreateMethod,
+                    TempSourceStringExpr,
+                    Expression.Constant(UriKind.RelativeOrAbsolute),
+                    expression);
             }
 
             if (TryGetDateTimeTryParseMethod(type, out methodInfo))


### PR DESCRIPTION
# Support binding parameters to type Uri in Minimal Actions

Similar to the `DateXXX` types but using `Uri.TryCreate("...", UriKind.RelativeOrAbsolute, out var uri)`

Fixes #36649
