### PR TITLE
HttpSys log correct statuscode when application throws

### DIFF
--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
@@ -254,7 +254,6 @@ internal partial class RequestContext : NativeRequestContext, IThreadPoolWorkIte
     {
         Response.StatusCode = status;
         Response.ContentLength = 0;
-        Dispose();
     }
 
     internal unsafe void Delegate(DelegationRule destination)

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContextOfT.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContextOfT.cs
@@ -96,13 +96,14 @@ internal sealed partial class RequestContext<TContext> : RequestContext where TC
                 {
                     application.DisposeContext(context, applicationException);
                 }
-                Dispose();
 
                 if (messagePump.DecrementOutstandingRequest() == 0 && messagePump.Stopping)
                 {
                     Log.RequestsDrained(Logger);
                     messagePump.SetShutdownSignal();
                 }
+
+                Dispose();
             }
         }
         catch (Exception ex)

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContextOfT.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContextOfT.cs
@@ -32,6 +32,7 @@ internal sealed partial class RequestContext<TContext> : RequestContext where TC
             if (messagePump.Stopping)
             {
                 SetFatalResponse(503);
+                Dispose();
                 return;
             }
 
@@ -55,10 +56,6 @@ internal sealed partial class RequestContext<TContext> : RequestContext where TC
             catch (Exception ex)
             {
                 Log.RequestProcessError(Logger, ex);
-                if (context != null)
-                {
-                    application.DisposeContext(context, ex);
-                }
                 if (Response.HasStarted)
                 {
                     // Otherwise the default is Cancel = 0x8 (h2) or 0x010c (h3).
@@ -91,6 +88,11 @@ internal sealed partial class RequestContext<TContext> : RequestContext where TC
                         SetFatalResponse(StatusCodes.Status500InternalServerError);
                     }
                 }
+                if (context != null)
+                {
+                    application.DisposeContext(context, ex);
+                }
+                Dispose();
             }
             finally
             {

--- a/src/Servers/test/FunctionalTests/HelloWorldTest.cs
+++ b/src/Servers/test/FunctionalTests/HelloWorldTest.cs
@@ -122,9 +122,7 @@ public class HelloWorldTests : LoggedTest
     public async Task ApplicationException(TestVariant variant)
     {
         var testName = $"ApplicationException_{variant.Server}_{variant.Tfm}_{variant.Architecture}_{variant.ApplicationType}";
-        using (StartLog(out var loggerFactory,
-            variant.Server == ServerType.Nginx ? LogLevel.Trace : LogLevel.Debug, // https://github.com/aspnet/ServerTests/issues/144
-            testName))
+        using (StartLog(out var loggerFactory, LogLevel.Debug, testName))
         {
             var logger = loggerFactory.CreateLogger("ApplicationException");
 
@@ -132,16 +130,6 @@ public class HelloWorldTests : LoggedTest
             {
                 ApplicationPath = Helpers.GetApplicationPath()
             };
-
-            if (variant.Server == ServerType.Nginx)
-            {
-                deploymentParameters.ServerConfigTemplateContent = Helpers.GetNginxConfigContent("nginx.conf");
-            }
-
-            if (variant.Server == ServerType.IISExpress)
-            {
-                deploymentParameters.EnvironmentVariables[DebugEnvironmentVariable] = "console";
-            }
 
             var output = string.Empty;
             using (var deployer = new SelfHostDeployer(deploymentParameters, loggerFactory))

--- a/src/Servers/testassets/ServerComparison.TestSites/Startup.cs
+++ b/src/Servers/testassets/ServerComparison.TestSites/Startup.cs
@@ -12,6 +12,14 @@ public class Startup
 {
     public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
     {
+        app.Map("/throwexception", subApp =>
+        {
+            subApp.Run(context =>
+            {
+                throw new ApplicationException("Application exception");
+            });
+        });
+
         app.Run(ctx =>
         {
             return ctx.Response.WriteAsync("Hello World " + RuntimeInformation.ProcessArchitecture);


### PR DESCRIPTION
# HttpSys log correct statuscode when application throws

`application.DisposeContext` should be called after setting the status code when an application exception is thrown.
This is also mentioned in Kestrel:
https://github.com/dotnet/aspnetcore/blob/8897c2947e985fbfcea06ed67427dc10644024e0/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs#L728-L730

Fixes #42218
