### PR TITLE
[SignalR] Replace Single(connectionId) with Client(connectionId) and Caller

### DIFF
--- a/src/Components/Server/test/Circuits/ComponentHubTest.cs
+++ b/src/Components/Server/test/Circuits/ComponentHubTest.cs
@@ -85,7 +85,7 @@ public class ComponentHubTest
         mockClientProxy.Verify(m => m.SendCoreAsync("JS.Error", new[] { errorMessage }, It.IsAny<CancellationToken>()), Times.Once());
     }
 
-    private static (Mock<IClientProxy>, ComponentHub) InitializeComponentHub()
+    private static (Mock<ISingleClientProxy>, ComponentHub) InitializeComponentHub()
     {
         var ephemeralDataProtectionProvider = new EphemeralDataProtectionProvider();
         var circuitIdFactory = new CircuitIdFactory(ephemeralDataProtectionProvider);
@@ -112,7 +112,7 @@ public class ComponentHubTest
         // Here we mock out elements of the Hub that are typically configured
         // by SignalR as clients connect to the hub.
         var mockCaller = new Mock<IHubCallerClients>();
-        var mockClientProxy = new Mock<IClientProxy>();
+        var mockClientProxy = new Mock<ISingleClientProxy>();
         mockCaller.Setup(x => x.Caller).Returns(mockClientProxy.Object);
         hub.Clients = mockCaller.Object;
         var mockContext = new Mock<HubCallerContext>();

--- a/src/SignalR/clients/ts/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/ts/FunctionalTests/Startup.cs
@@ -232,7 +232,7 @@ public class Startup
             {
                 try
                 {
-                    var result = await hubContext.Clients.Single(id).InvokeAsync<int>("Result");
+                    var result = await hubContext.Clients.Client(id).InvokeAsync<int>("Result");
                     return result.ToString(CultureInfo.InvariantCulture);
                 }
                 catch (Exception ex)

--- a/src/SignalR/server/Core/src/IHubCallerClients.cs
+++ b/src/SignalR/server/Core/src/IHubCallerClients.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.SignalR.Internal;
+
 namespace Microsoft.AspNetCore.SignalR;
 
 /// <summary>
@@ -13,5 +15,11 @@ public interface IHubCallerClients : IHubCallerClients<IClientProxy>
     /// </summary>
     /// <param name="connectionId">The connection ID.</param>
     /// <returns>A client caller.</returns>
-    new ISingleClientProxy Single(string connectionId) => throw new NotImplementedException();
+    new ISingleClientProxy Client(string connectionId) => new NonInvokingSingleClientProxy(((IHubCallerClients<IClientProxy>)this).Client(connectionId), "IHubCallerClients.Client(string connectionId)");
+
+    /// <summary>
+    /// Gets a proxy that can be used to invoke methods on the calling client and receive results.
+    /// </summary>
+    /// <returns>A client caller.</returns>
+    new ISingleClientProxy Caller => new NonInvokingSingleClientProxy(((IHubCallerClients<IClientProxy>)this).Caller, "IHubCallerClients.Caller");
 }

--- a/src/SignalR/server/Core/src/IHubClients.cs
+++ b/src/SignalR/server/Core/src/IHubClients.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.SignalR.Internal;
+
 namespace Microsoft.AspNetCore.SignalR;
 
 /// <summary>
@@ -13,5 +15,5 @@ public interface IHubClients : IHubClients<IClientProxy>
     /// </summary>
     /// <param name="connectionId">The connection ID.</param>
     /// <returns>A client caller.</returns>
-    new ISingleClientProxy Single(string connectionId) => throw new NotImplementedException();
+    new ISingleClientProxy Client(string connectionId) => new NonInvokingSingleClientProxy(((IHubClients<IClientProxy>)this).Client(connectionId), "IHubClients.Client(string connectionId)");
 }

--- a/src/SignalR/server/Core/src/IHubClients`T.cs
+++ b/src/SignalR/server/Core/src/IHubClients`T.cs
@@ -10,13 +10,6 @@ namespace Microsoft.AspNetCore.SignalR;
 public interface IHubClients<T>
 {
     /// <summary>
-    /// Gets a <typeparamref name="T" /> that can be used to invoke methods on a single client connected to the hub and receive results.
-    /// </summary>
-    /// <param name="connectionId">The connection ID.</param>
-    /// <returns>A client caller.</returns>
-    T Single(string connectionId) => Client(connectionId);
-
-    /// <summary>
     /// Gets a <typeparamref name="T" /> that can be used to invoke methods on all clients connected to the hub.
     /// </summary>
     /// <returns>A client caller.</returns>

--- a/src/SignalR/server/Core/src/Internal/HubClients.cs
+++ b/src/SignalR/server/Core/src/Internal/HubClients.cs
@@ -13,11 +13,6 @@ internal sealed class HubClients<THub> : IHubClients where THub : Hub
         All = new AllClientProxy<THub>(_lifetimeManager);
     }
 
-    public ISingleClientProxy Single(string connectionId)
-    {
-        return new SingleClientProxy<THub>(_lifetimeManager, connectionId);
-    }
-
     public IClientProxy All { get; }
 
     public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds)
@@ -25,7 +20,8 @@ internal sealed class HubClients<THub> : IHubClients where THub : Hub
         return new AllClientsExceptProxy<THub>(_lifetimeManager, excludedConnectionIds);
     }
 
-    public IClientProxy Client(string connectionId)
+    IClientProxy IHubClients<IClientProxy>.Client(string connectionId) => Client(connectionId);
+    public ISingleClientProxy Client(string connectionId)
     {
         return new SingleClientProxy<THub>(_lifetimeManager, connectionId);
     }

--- a/src/SignalR/server/Core/src/Internal/NonInvokingSingleClientProxy.cs
+++ b/src/SignalR/server/Core/src/Internal/NonInvokingSingleClientProxy.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.SignalR.Internal;
+
+internal sealed class NonInvokingSingleClientProxy : ISingleClientProxy
+{
+    private readonly IClientProxy _clientProxy;
+    private readonly string _memberName;
+
+    public NonInvokingSingleClientProxy(IClientProxy clientProxy, string memberName)
+    {
+        _clientProxy = clientProxy;
+        _memberName = memberName;
+    }
+
+    public Task SendCoreAsync(string method, object?[] args, CancellationToken cancellationToken = default) =>
+        _clientProxy.SendCoreAsync(method, args, cancellationToken);
+
+    public Task<T> InvokeCoreAsync<T>(string method, object?[] args, CancellationToken cancellationToken = default) =>
+        throw new NotImplementedException($"The default implementation of {_memberName} does not support client return results.");
+}

--- a/src/SignalR/server/Core/src/Internal/TypedHubClients.cs
+++ b/src/SignalR/server/Core/src/Internal/TypedHubClients.cs
@@ -12,7 +12,7 @@ internal sealed class TypedHubClients<T> : IHubCallerClients<T>
         _hubClients = dynamicContext;
     }
 
-    public T Client(string connectionId) => TypedClientBuilder<T>.Build(_hubClients.Single(connectionId));
+    public T Client(string connectionId) => TypedClientBuilder<T>.Build(_hubClients.Client(connectionId));
 
     public T All => TypedClientBuilder<T>.Build(_hubClients.All);
 

--- a/src/SignalR/server/Core/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/server/Core/src/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 #nullable enable
 Microsoft.AspNetCore.SignalR.HubOptions.DisableImplicitFromServicesParameters.get -> bool
 Microsoft.AspNetCore.SignalR.HubOptions.DisableImplicitFromServicesParameters.set -> void
-Microsoft.AspNetCore.SignalR.IHubCallerClients.Single(string! connectionId) -> Microsoft.AspNetCore.SignalR.ISingleClientProxy!
-Microsoft.AspNetCore.SignalR.IHubClients.Single(string! connectionId) -> Microsoft.AspNetCore.SignalR.ISingleClientProxy!
-Microsoft.AspNetCore.SignalR.IHubClients<T>.Single(string! connectionId) -> T
+Microsoft.AspNetCore.SignalR.IHubCallerClients.Caller.get -> Microsoft.AspNetCore.SignalR.ISingleClientProxy!
+Microsoft.AspNetCore.SignalR.IHubCallerClients.Client(string! connectionId) -> Microsoft.AspNetCore.SignalR.ISingleClientProxy!
+Microsoft.AspNetCore.SignalR.IHubClients.Client(string! connectionId) -> Microsoft.AspNetCore.SignalR.ISingleClientProxy!
 Microsoft.AspNetCore.SignalR.ISingleClientProxy
 Microsoft.AspNetCore.SignalR.ISingleClientProxy.InvokeCoreAsync<T>(string! method, object?[]! args, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T>!
 override Microsoft.AspNetCore.SignalR.DefaultHubLifetimeManager<THub>.InvokeConnectionAsync<T>(string! connectionId, string! methodName, object?[]! args, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T>!

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -335,7 +335,7 @@ public class MethodHub : TestHub
 
     public async Task<int> GetClientResult(int num)
     {
-        var sum = await Clients.Single(Context.ConnectionId).InvokeAsync<int>("Sum", num);
+        var sum = await Clients.Caller.InvokeAsync<int>("Sum", num);
         return sum;
     }
 }
@@ -525,9 +525,8 @@ public class HubT : Hub<ITest>
         return Clients.Caller.Send(message);
     }
 
-    public async Task<ClientResults> GetClientResultThreeWays(int singleValue, int clientValue, int callerValue) =>
+    public async Task<ClientResults> GetClientResultTwoWays(int clientValue, int callerValue) =>
         new ClientResults(
-            await Clients.Single(Context.ConnectionId).GetClientResult(singleValue),
             await Clients.Client(Context.ConnectionId).GetClientResult(clientValue),
             await Clients.Caller.GetClientResult(callerValue));
 }
@@ -540,7 +539,7 @@ public interface ITest
     Task<int> GetClientResult(int value);
 }
 
-public record ClientResults(int SingleResult, int ClientResult, int CallerResult);
+public record ClientResults(int ClientResult, int CallerResult);
 
 public class OnConnectedThrowsHub : Hub
 {

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.ClientResult.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.ClientResult.cs
@@ -171,7 +171,7 @@ public partial class HubConnectionHandlerTests
     }
 
     [Fact]
-    public async Task CanReturnClientResultToTypedHubThreeWays()
+    public async Task CanReturnClientResultToTypedHubTwoWays()
     {
         using (StartVerifiableLog())
         {
@@ -191,7 +191,7 @@ public partial class HubConnectionHandlerTests
                 nameof(HubT.GetClientResultTwoWays),
                 new object[] { 7, 3 })).DefaultTimeout();
 
-            // Send back "value + 4" to all three invocations.
+            // Send back "value + 4" to both invocations.
             for (int i = 0; i < 2; i++)
             {
                 // Hub asks client for a result, this is an invocation message with an ID.


### PR DESCRIPTION
We recently discovered can add `new` `Caller` and `Client` members without breaking existing `IHubClients` and `IHubCallerClients` implementations unless they're being used for client results which never worked before .NET 7 making the change both non-binary and non-source breaking[1].

## Before

```csharp

public class MyHub : Hub
{
    public async Task BroadcastCallerResult()
    {
        var num = await Clients.Single(Context.ConnectionId).InvokeAsync<int>("GetNum");
        await Clients.Others.SendAsync("BroadcastNum", num);
    }
}
```

## After

```csharp

public class MyHub : Hub
{
    public async Task BroadcastCallerResult()
    {
        var num = await Clients.Caller.InvokeAsync<int>("GetNum");
        await Clients.Others.SendAsync("BroadcastNum", num);
    }
}
```

Fixes #41994

1. TODO Still manually test with a custom `IHubClients` implementation built against .NET 6.
