### PR TITLE
Partition more ConcurrentQueues in Kestrel

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionContextFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionContextFactory.cs
@@ -42,7 +42,6 @@ public sealed class SocketConnectionContextFactory : IDisposable
 
         _options = options;
         _logger = logger;
-        _memoryPool = _options.MemoryPoolFactory();
         _settingsCount = _options.IOQueueCount;
 
         var maxReadBufferSize = _options.MaxReadBufferSize ?? 0;

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionContextFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionContextFactory.cs
@@ -15,7 +15,6 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
 /// </summary>
 public sealed class SocketConnectionContextFactory : IDisposable
 {
-    private readonly MemoryPool<byte> _memoryPool;
     private readonly SocketConnectionFactoryOptions _options;
     private readonly ILogger _logger;
     private readonly int _settingsCount;
@@ -56,6 +55,7 @@ public sealed class SocketConnectionContextFactory : IDisposable
 
             for (var i = 0; i < _settingsCount; i++)
             {
+                var memoryPool = _options.MemoryPoolFactory();
                 var transportScheduler = options.UnsafePreferInlineScheduling ? PipeScheduler.Inline : new IOQueue();
                 // https://github.com/aspnet/KestrelHttpServer/issues/2573
                 var awaiterScheduler = OperatingSystem.IsWindows() ? transportScheduler : PipeScheduler.Inline;
@@ -63,26 +63,29 @@ public sealed class SocketConnectionContextFactory : IDisposable
                 _settings[i] = new QueueSettings()
                 {
                     Scheduler = transportScheduler,
-                    InputOptions = new PipeOptions(_memoryPool, applicationScheduler, transportScheduler, maxReadBufferSize, maxReadBufferSize / 2, useSynchronizationContext: false),
-                    OutputOptions = new PipeOptions(_memoryPool, transportScheduler, applicationScheduler, maxWriteBufferSize, maxWriteBufferSize / 2, useSynchronizationContext: false),
-                    SocketSenderPool = new SocketSenderPool(awaiterScheduler)
+                    InputOptions = new PipeOptions(memoryPool, applicationScheduler, transportScheduler, maxReadBufferSize, maxReadBufferSize / 2, useSynchronizationContext: false),
+                    OutputOptions = new PipeOptions(memoryPool, transportScheduler, applicationScheduler, maxWriteBufferSize, maxWriteBufferSize / 2, useSynchronizationContext: false),
+                    SocketSenderPool = new SocketSenderPool(awaiterScheduler),
+                    MemoryPool = memoryPool,
                 };
             }
         }
         else
         {
+            var memoryPool = _options.MemoryPoolFactory();
             var transportScheduler = options.UnsafePreferInlineScheduling ? PipeScheduler.Inline : PipeScheduler.ThreadPool;
             // https://github.com/aspnet/KestrelHttpServer/issues/2573
             var awaiterScheduler = OperatingSystem.IsWindows() ? transportScheduler : PipeScheduler.Inline;
             _settings = new QueueSettings[]
             {
-                    new QueueSettings()
-                    {
-                        Scheduler = transportScheduler,
-                        InputOptions = new PipeOptions(_memoryPool, applicationScheduler, transportScheduler, maxReadBufferSize, maxReadBufferSize / 2, useSynchronizationContext: false),
-                        OutputOptions = new PipeOptions(_memoryPool, transportScheduler, applicationScheduler, maxWriteBufferSize, maxWriteBufferSize / 2, useSynchronizationContext: false),
-                        SocketSenderPool = new SocketSenderPool(awaiterScheduler)
-                    }
+                new QueueSettings()
+                {
+                    Scheduler = transportScheduler,
+                    InputOptions = new PipeOptions(memoryPool, applicationScheduler, transportScheduler, maxReadBufferSize, maxReadBufferSize / 2, useSynchronizationContext: false),
+                    OutputOptions = new PipeOptions(memoryPool, transportScheduler, applicationScheduler, maxWriteBufferSize, maxWriteBufferSize / 2, useSynchronizationContext: false),
+                    SocketSenderPool = new SocketSenderPool(awaiterScheduler),
+                    MemoryPool = memoryPool,
+                }
             };
             _settingsCount = 1;
         }
@@ -98,7 +101,7 @@ public sealed class SocketConnectionContextFactory : IDisposable
         var setting = _settings[Interlocked.Increment(ref _settingsIndex) % _settingsCount];
 
         var connection = new SocketConnection(socket,
-            _memoryPool,
+            setting.MemoryPool,
             setting.Scheduler,
             _logger,
             setting.SocketSenderPool,
@@ -113,13 +116,11 @@ public sealed class SocketConnectionContextFactory : IDisposable
     /// <inheritdoc />
     public void Dispose()
     {
-        // Dispose the memory pool
-        _memoryPool.Dispose();
-
-        // Dispose any pooled senders
+        // Dispose any pooled senders and memory pools
         foreach (var setting in _settings)
         {
             setting.SocketSenderPool.Dispose();
+            setting.MemoryPool.Dispose();
         }
     }
 
@@ -129,5 +130,6 @@ public sealed class SocketConnectionContextFactory : IDisposable
         public PipeOptions InputOptions { get; init; } = default!;
         public PipeOptions OutputOptions { get; init; } = default!;
         public SocketSenderPool SocketSenderPool { get; init; } = default!;
+        public MemoryPool<byte> MemoryPool { get; init; } = default!;
     }
 }


### PR DESCRIPTION
- `PinnedMemoryPool` uses an `ConcurrentQueue` just like `IOQueue` so we should partition it the same way which this PR does
- We used to do the exact same thing per `LibuvThread`. I thought I did the same thing in `SocketConnectionListener`, but I guess not.

Ultimately, we can be smarter about how we partition `ConcurrentQueue`s at the Kestrel layer than we can be at a lower layer like within `ConcurrentQueue` itself. That's because we can ensure that each partition is exclusively used by code servicing sockets within that partition. These can still be accessed by the application from the thread pool, so it's not perfect. But especially when you're running inline, this should avoid issues related to high core counts and NUMA.

@sebastienros Can we benchmark on our high core count machines that are seeing a lot of contention in `ConcurrentQueue`?
