### PR TITLE
Add support for --output option in user-jwts create

### DIFF
--- a/src/Tools/dotnet-user-jwts/src/Resources.resx
+++ b/src/Tools/dotnet-user-jwts/src/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -173,6 +173,9 @@
   </data>
   <data name="CreateCommand_NotBeforeOption_Description" xml:space="preserve">
     <value>The UTC date &amp; time the JWT should not be valid before in the format 'yyyy-MM-dd [[HH:mm[[:ss]]]]'. Defaults to the date &amp; time the JWT is created.</value>
+  </data>
+  <data name="CreateCommand_OutputOption_Description" xml:space="preserve">
+    <value>The forma to use for displaying output from the command. Can be one of 'default', 'token', or 'json'.</value>
   </data>
   <data name="CreateCommand_RoleOption_Description" xml:space="preserve">
     <value>A role claim to add to the JWT. Specify once for each role.</value>

--- a/src/Tools/dotnet-user-jwts/src/Resources.resx
+++ b/src/Tools/dotnet-user-jwts/src/Resources.resx
@@ -175,7 +175,7 @@
     <value>The UTC date &amp; time the JWT should not be valid before in the format 'yyyy-MM-dd [[HH:mm[[:ss]]]]'. Defaults to the date &amp; time the JWT is created.</value>
   </data>
   <data name="CreateCommand_OutputOption_Description" xml:space="preserve">
-    <value>The forma to use for displaying output from the command. Can be one of 'default', 'token', or 'json'.</value>
+    <value>The format to use for displaying output from the command. Can be one of 'default', 'token', or 'json'.</value>
   </data>
   <data name="CreateCommand_RoleOption_Description" xml:space="preserve">
     <value>A role claim to add to the JWT. Specify once for each role.</value>


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/42146.

Adds `--output` option with support for `token`, `default`, or `json` formats.

```bash
$ dotnet user-jwts create --output json
{
  "Id": "5c25c91",
  "Scheme": "Bearer",
  "Name": "safia",
  "Audience": "https://localhost:5001, http://localhost:5000",
  "NotBefore": "2022-06-17T00:40:39+00:00",
  "Expires": "2022-09-17T00:40:39+00:00",
  "Issued": "2022-06-17T00:40:40+00:00",
  "Token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1bmlxdWVfbmFtZSI6InNhZmlhIiwic3ViIjoic2FmaWEiLCJqdGkiOiI1YzI1YzkxIiwiYXVkIjpbImh0dHBzOi8vbG9jYWxob3N0OjUwMDEiLCJodHRwOi8vbG9jYWxob3N0OjUwMDAiXSwibmJmIjoxNjU1NDI2NDM5LCJleHAiOjE2NjMzNzUyMzksImlhdCI6MTY1NTQyNjQ0MCwiaXNzIjoiZG90bmV0LXVzZXItand0cyJ9.10-htDV9iNvwJ0MR34TbW92PVAxBfgcHDwmONHOZ2M4",
  "Scopes": [],
  "Roles": [],
  "CustomClaims": {}
}
$ dotnet user-jwts create -o token
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1bmlxdWVfbmFtZSI6InNhZmlhIiwic3ViIjoic2FmaWEiLCJqdGkiOiI5ZGYwNzc4NSIsImF1ZCI6WyJodHRwczovL2xvY2FsaG9zdDo1MDAxIiwiaHR0cDovL2xvY2FsaG9zdDo1MDAwIl0sIm5iZiI6MTY1NTQyNjM2NywiZXhwIjoxNjYzMzc1MTY3LCJpYXQiOjE2NTU0MjYzNjcsImlzcyI6ImRvdG5ldC11c2VyLWp3dHMifQ.NetCzGHj_wHjXf3Vg6qI9KAPLLrUAJWY722QMDDCapA

```