### PR TITLE
Fix support for native AOT in minimal

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -104,6 +104,7 @@ public static partial class RequestDelegateFactory
 
     private static readonly ConstructorInfo DefaultRouteHandlerInvocationContextConstructor = typeof(DefaultRouteHandlerInvocationContext).GetConstructor(new[] { typeof(HttpContext), typeof(object[]) })!;
     private static readonly MethodInfo RouteHandlerInvocationContextGetArgument = typeof(RouteHandlerInvocationContext).GetMethod(nameof(RouteHandlerInvocationContext.GetArgument))!;
+    private static readonly PropertyInfo ListIndexer = typeof(IList<object>).GetProperty("Item")!;
     private static readonly ParameterExpression FilterContextExpr = Expression.Parameter(typeof(RouteHandlerInvocationContext), "context");
     private static readonly MemberExpression FilterContextHttpContextExpr = Expression.Property(FilterContextExpr, typeof(RouteHandlerInvocationContext).GetProperty(nameof(RouteHandlerInvocationContext.HttpContext))!);
     private static readonly MemberExpression FilterContextArgumentsExpr = Expression.Property(FilterContextExpr, typeof(RouteHandlerInvocationContext).GetProperty(nameof(RouteHandlerInvocationContext.Arguments))!);
@@ -547,9 +548,9 @@ public static partial class RequestDelegateFactory
                 }
                 else
                 {
-                    // We box if dynamic code isn't supportedfactoryContext.ContextArgAccess.Add(
+                    // We box if dynamic code isn't supported
                     factoryContext.ContextArgAccess.Add(Expression.Convert(
-                        Expression.Property(FilterContextArgumentsExpr, "Item", Expression.Constant(i)),
+                        Expression.Property(FilterContextArgumentsExpr, ListIndexer, Expression.Constant(i)),
                     parameters[i].ParameterType));
                 }
             }


### PR DESCRIPTION
- This includes 2 major changes to fix native AOT support in .NET 7. Explicitly rooting the indexers of various binding sources (query, formfile, header, routes). NativeAOT seems a bit more aggressive here.
- We avoid the filter optimization that uses generics to avoid boxing. NativeAOT needs to see generic instantiations statically which we cannot do here.
- This also fixes filters in minimal APIs with the addition of (https://github.com/dotnet/runtime/pull/70883)

This allows us to profile and improve the performance of minimal APIs and NativeAOT.

PS: Things that don't work and would be difficult to make work on NativeAOT without source generators:


```C#
using Microsoft.AspNetCore.Mvc;
using System.Text.Json.Serialization;

var builder = WebApplication.CreateBuilder(args);

builder.Services.ConfigureRouteHandlerJsonOptions(o =>
{
    o.SerializerOptions.AddContext<SourceGenerationContext>();
});

var app = builder.Build();


app.MapGet("/", () => "Hello World");

app.MapGet("/q", ([FromHeader(Name = "Accept")] string accept) => accept);

app.MapGet("/r/{id}", (int id) => $"Hello {id}");

app.MapGet("/p", () => Results.Ok(new Person("Name")));

app.MapPost("/", (Person p) => Results.Ok(p));

app.MapPost("/async", async (Person p) =>
{
    await Task.Delay(1000);
    return Results.Ok(p);
});

app.Run();

[JsonSourceGenerationOptions(WriteIndented = true)]
[JsonSerializable(typeof(Person))]
internal partial class SourceGenerationContext : JsonSerializerContext
{
}

record struct Person(string Name);
```


- Returning `Task/ValueTask<value type>` from these methods. We call an internal generic method to execute these. This counts as dynamic code generation so it will fail. e.g:
```
Connection id "0HMIHE6N43TIV", Request id "0HMIHE6N43TIV:00000001": An unhandled exception was thrown by the application.
      EETypeRva:0x018ED1F8(System.Reflection.MissingRuntimeArtifactException): MakeGenericMethod() cannot create this generic method instantiation because no code was generated for it: 'Microsoft.AspNetCore.Http.RequestDelegateFactory.ExecuteTaskOfT<Person>(System.Threading.Tasks.Task<Person>,Microsoft.AspNetCore.Http.HttpContext)'.
         at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x113
         at System.Reflection.Runtime.MethodInfos.RuntimeMethodInfo.get_MethodInvoker() + 0xa1
         at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x183
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.AddResponseWritingToMethodCall(Expression, Type) + 0x28e
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.CreateParamCheckingResponseWritingMethodCall(Type, RequestDelegateFactory.FactoryContext) + 0x239
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.CreateTargetableRequestDelegate(MethodInfo, Expression, RequestDelegateFactory.FactoryContext, Expression`1) + 0x305
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.Create(Delegate, RequestDelegateFactoryOptions) + 0x18e
         at Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.<>c__DisplayClass26_0.<Map>g__RouteHandlerBuilderConvention|0(EndpointBuilder) + 0x186
         at Microsoft.AspNetCore.Routing.DefaultEndpointConventionBuilder.Build() + 0x33
         at System.Linq.Enumerable.SelectListIterator`2.ToArray() + 0x7f
         at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.ToArray() + 0xad
         at Microsoft.AspNetCore.Routing.CompositeEndpointDataSource.Initialize() + 0x95
         at Microsoft.AspNetCore.Routing.CompositeEndpointDataSource.GetChangeToken() + 0x17
         at Microsoft.AspNetCore.Routing.DataSourceDependentCache`1.Initialize() + 0x31
         at System.Threading.LazyInitializer.EnsureInitializedCore[T](T&, Boolean&, Object&, Func`1) + 0x40
         at Microsoft.AspNetCore.Routing.Matching.DataSourceDependentMatcher..ctor(EndpointDataSource, DataSourceDependentMatcher.Lifetime, Func`1) + 0x96
         at Microsoft.AspNetCore.Routing.Matching.DfaMatcherFactory.CreateMatcher(EndpointDataSource) + 0x60
         at Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware.InitializeCoreAsync() + 0x8d
      --- End of stack trace from previous location ---
         at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20
         at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0xb6
         at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task) + 0x42
         at Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware.<<Invoke>g__AwaitMatcher|8_0>d.MoveNext() + 0xbc
      --- End of stack trace from previous location ---
         at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20
         at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0xb6
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.<ProcessRequests>d__231`1.MoveNext() + 0x499
```
- Binding a struct parameter via JSON (works with source generator, but still warns).
```
Connection id "0HMIHGLO2CISJ", Request id "0HMIHGLO2CISJ:00000001": An unhandled exception was thrown by the application.
      EETypeRva:0x018EAC38(System.Reflection.MissingRuntimeArtifactException): MakeGenericMethod() cannot create this generic method instantiation because no code was generated for it: 'System.Text.Json.JsonSerializerOptions.CreateReflectionJsonTypeInfo<Person>()'.
         at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x113
         at System.Reflection.Runtime.MethodInfos.RuntimeMethodInfo.get_MethodInvoker() + 0xa1
         at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x183
         at System.Text.Json.JsonSerializerOptions.<RootReflectionSerializerDependencies>g__CreateJsonTypeInfo|14_0(Type, JsonSerializerOptions) + 0x71
         at System.Text.Json.JsonSerializerOptions.GetJsonTypeInfoFromContextOrCreate(Type) + 0x47
         at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey, Func`2) + 0x85
         at System.Text.Json.JsonSerializer.GetTypeInfo(JsonSerializerOptions, Type) + 0x66
         at System.Text.Json.JsonSerializer.DeserializeAsync(Stream, Type, JsonSerializerOptions, CancellationToken) + 0x22
         at Microsoft.AspNetCore.Http.HttpRequestJsonExtensions.<ReadFromJsonAsync>d__5.MoveNext() + 0x13e
```
- Same for structs with BindAsync
```
Connection id "0HMIHGO2EODN6", Request id "0HMIHGO2EODN6:00000001": An unhandled exception was thrown by the application.
      EETypeRva:0x018EAA20(System.Reflection.MissingRuntimeArtifactException): MakeGenericMethod() cannot create this generic method instantiation because no code was generated for it: 'Microsoft.AspNetCore.Http.ParameterBindingMethodCache.ConvertValueTask<Person>(System.Threading.Tasks.ValueTask<Person>)'.
         at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x113
         at System.Reflection.Runtime.MethodInfos.RuntimeMethodInfo.get_MethodInvoker() + 0xa1
         at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x183
         at Microsoft.AspNetCore.Http.ParameterBindingMethodCache.<>c__DisplayClass15_0.<FindBindAsyncMethod>b__2(ParameterInfo) + 0x74
         at Microsoft.AspNetCore.Http.ParameterBindingMethodCache.FindBindAsyncMethod(ParameterInfo) + 0x95
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.CreateArgument(ParameterInfo, RequestDelegateFactory.FactoryContext) + 0x768
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.CreateArguments(ParameterInfo[], RequestDelegateFactory.FactoryContext) + 0x12d
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.CreateTargetableRequestDelegate(MethodInfo, Expression, RequestDelegateFactory.FactoryContext, Expression`1) + 0x53
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.Create(Delegate, RequestDelegateFactoryOptions) + 0x18e
         at Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.<>c__DisplayClass26_0.<Map>g__RouteHandlerBuilderConvention|0(EndpointBuilder) + 0x186
         at Microsoft.AspNetCore.Routing.DefaultEndpointConventionBuilder.Build() + 0x33
         at System.Linq.Enumerable.SelectListIterator`2.ToArray() + 0x7f
         at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.ToArray() + 0xad
         at Microsoft.AspNetCore.Routing.CompositeEndpointDataSource.Initialize() + 0x95
         at Microsoft.AspNetCore.Routing.CompositeEndpointDataSource.GetChangeToken() + 0x17
         at Microsoft.AspNetCore.Routing.DataSourceDependentCache`1.Initialize() + 0x31
         at System.Threading.LazyInitializer.EnsureInitializedCore[T](T&, Boolean&, Object&, Func`1) + 0x40
         at Microsoft.AspNetCore.Routing.Matching.DataSourceDependentMatcher..ctor(EndpointDataSource, DataSourceDependentMatcher.Lifetime, Func`1) + 0x96
         at Microsoft.AspNetCore.Routing.Matching.DfaMatcherFactory.CreateMatcher(EndpointDataSource) + 0x60
         at Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware.InitializeCoreAsync() + 0x8d
      --- End of stack trace from previous location ---
         at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20
         at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0xb6
         at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task) + 0x42
         at Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware.<<Invoke>g__AwaitMatcher|8_0>d.MoveNext() + 0xbc
      --- End of stack trace from previous location ---
         at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20
         at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0xb6
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.<ProcessRequests>d__231`1.MoveNext() + 0x499
```
- Usage of `IBindableFromHttpContext<T>` is broken with both value types and reference types (@MichalStrehovsky I don't understand this one).

```
 Connection id "0HMIHHTQQKJCL", Request id "0HMIHHTQQKJCL:00000001": An unhandled exception was thrown by the application.
      EETypeRva:0x018EB4B0(System.Reflection.MissingRuntimeArtifactException): MakeGenericMethod() cannot create this generic method instantiation because no code was generated for it: 'Microsoft.AspNetCore.Http.ParameterBindingMethodCache.BindAsync<Person2>(Microsoft.AspNetCore.Http.HttpContext,System.Reflection.ParameterInfo)'.
         at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x113
         at System.Reflection.Runtime.MethodInfos.RuntimeMethodInfo.get_MethodInvoker() + 0xa1
         at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x183
         at Microsoft.AspNetCore.Http.ParameterBindingMethodCache.GetIBindableFromHttpContextMethod(Type) + 0xc1
         at Microsoft.AspNetCore.Http.ParameterBindingMethodCache.<FindBindAsyncMethod>g__Finder|15_0(Type) + 0x50
         at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey, Func`2) + 0x9a
         at Microsoft.AspNetCore.Http.ParameterBindingMethodCache.FindBindAsyncMethod(ParameterInfo) + 0x76
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.CreateArgument(ParameterInfo, RequestDelegateFactory.FactoryContext) + 0x768
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.CreateArguments(ParameterInfo[], RequestDelegateFactory.FactoryContext) + 0x12d
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.CreateTargetableRequestDelegate(MethodInfo, Expression, RequestDelegateFactory.FactoryContext, Expression`1) + 0x53
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.Create(Delegate, RequestDelegateFactoryOptions) + 0x18e
         at Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.<>c__DisplayClass26_0.<Map>g__RouteHandlerBuilderConvention|0(EndpointBuilder) + 0x186
         at Microsoft.AspNetCore.Routing.DefaultEndpointConventionBuilder.Build() + 0x33
         at System.Linq.Enumerable.SelectListIterator`2.ToArray() + 0x7f
         at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.ToArray() + 0xad
         at Microsoft.AspNetCore.Routing.CompositeEndpointDataSource.Initialize() + 0x95
         at Microsoft.AspNetCore.Routing.CompositeEndpointDataSource.GetChangeToken() + 0x17
         at Microsoft.AspNetCore.Routing.DataSourceDependentCache`1.Initialize() + 0x31
         at System.Threading.LazyInitializer.EnsureInitializedCore[T](T&, Boolean&, Object&, Func`1) + 0x40
         at Microsoft.AspNetCore.Routing.Matching.DataSourceDependentMatcher..ctor(EndpointDataSource, DataSourceDependentMatcher.Lifetime, Func`1) + 0x96
         at Microsoft.AspNetCore.Routing.Matching.DfaMatcherFactory.CreateMatcher(EndpointDataSource) + 0x60
         at Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware.InitializeCoreAsync() + 0x8d
      --- End of stack trace from previous location ---
         at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20
         at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0xb6
         at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task) + 0x42
         at Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware.<<Invoke>g__AwaitMatcher|8_0>d.MoveNext() + 0xbc
      --- End of stack trace from previous location ---
         at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20
         at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0xb6
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.<ProcessRequests>d__231`1.MoveNext() + 0x499
```
- IEndpointParameterMetadataProvider/IEndpointMetadataProvider give a similar exception. I wonder if there's something fishy with static interface methods and how they are represented that make this fail for both value types and reference types.. Filed https://github.com/dotnet/runtime/issues/70951 (now https://github.com/dotnet/runtime/issues/67745)

```
Connection id "0HMIHI2ELKKKN", Request id "0HMIHI2ELKKKN:00000001": An unhandled exception was thrown by the application.
      EETypeRva:0x018EA520(System.Reflection.MissingRuntimeArtifactException): MakeGenericMethod() cannot create this generic method instantiation because no code was generated for it: 'Microsoft.AspNetCore.Http.RequestDelegateFactory.PopulateMetadataForParameter<Person2>(Microsoft.AspNetCore.Http.Metadata.EndpointParameterMetadataContext)'.
         at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x113
         at System.Reflection.Runtime.MethodInfos.RuntimeMethodInfo.get_MethodInvoker() + 0xa1
         at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x183
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.AddTypeProvidedMetadata(MethodInfo, List`1, IServiceProvider, ReadOnlySpan`1) + 0x19c
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.CreateTargetableRequestDelegate(MethodInfo, Expression, RequestDelegateFactory.FactoryContext, Expression`1) + 0xea
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.Create(Delegate, RequestDelegateFactoryOptions) + 0x18e
         at Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.<>c__DisplayClass26_0.<Map>g__RouteHandlerBuilderConvention|0(EndpointBuilder) + 0x186
         at Microsoft.AspNetCore.Routing.DefaultEndpointConventionBuilder.Build() + 0x33
         at System.Linq.Enumerable.SelectListIterator`2.ToArray() + 0x7f
         at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.ToArray() + 0xad
         at Microsoft.AspNetCore.Routing.CompositeEndpointDataSource.Initialize() + 0x95
         at Microsoft.AspNetCore.Routing.CompositeEndpointDataSource.GetChangeToken() + 0x17
         at Microsoft.AspNetCore.Routing.DataSourceDependentCache`1.Initialize() + 0x31
         at System.Threading.LazyInitializer.EnsureInitializedCore[T](T&, Boolean&, Object&, Func`1) + 0x40
         at Microsoft.AspNetCore.Routing.Matching.DataSourceDependentMatcher..ctor(EndpointDataSource, DataSourceDependentMatcher.Lifetime, Func`1) + 0x96
         at Microsoft.AspNetCore.Routing.Matching.DfaMatcherFactory.CreateMatcher(EndpointDataSource) + 0x60
         at Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware.InitializeCoreAsync() + 0x8d
      --- End of stack trace from previous location ---
         at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20
         at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0xb6
         at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task) + 0x42
         at Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware.<<Invoke>g__AwaitMatcher|8_0>d.MoveNext() + 0xbc
      --- End of stack trace from previous location ---
         at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20
         at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0xb6
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.<ProcessRequests>d__231`1.MoveNext() + 0x499
```

- TypedResults are also broken (for the same reasons as above) (Results.* works)

```
Microsoft.AspNetCore.Server.Kestrel[13]
      Connection id "0HMIHNST0HHHN", Request id "0HMIHNST0HHHN:00000001": An unhandled exception was thrown by the application.
      EETypeRva:0x01914A48(System.Reflection.MissingRuntimeArtifactException): MakeGenericMethod() cannot create this generic method instantiation because no code was generated for it: 'Microsoft.AspNetCore.Http.RequestDelegateFactory.PopulateMetadataForEndpoint<Microsoft.AspNetCore.Http.HttpResults.Ok<Person>>(Microsoft.AspNetCore.Http.Metadata.EndpointMetadataContext)'.
         at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x113
         at System.Reflection.Runtime.MethodInfos.RuntimeMethodInfo.get_MethodInvoker() + 0xa1
         at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x183
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.AddTypeProvidedMetadata(MethodInfo, List`1, IServiceProvider, ReadOnlySpan`1) + 0x3eb
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.CreateTargetableRequestDelegate(MethodInfo, Expression, RequestDelegateFactory.FactoryContext, Expression`1) + 0xea
         at Microsoft.AspNetCore.Http.RequestDelegateFactory.Create(Delegate, RequestDelegateFactoryOptions) + 0x18e
         at Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.<>c__DisplayClass26_0.<Map>g__RouteHandlerBuilderConvention|0(EndpointBuilder) + 0x186
         at Microsoft.AspNetCore.Routing.DefaultEndpointConventionBuilder.Build() + 0x33
         at System.Linq.Enumerable.SelectListIterator`2.ToArray() + 0x7f
         at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.ToArray() + 0xad
         at Microsoft.AspNetCore.Routing.CompositeEndpointDataSource.Initialize() + 0x95
         at Microsoft.AspNetCore.Routing.CompositeEndpointDataSource.GetChangeToken() + 0x17
         at Microsoft.AspNetCore.Routing.DataSourceDependentCache`1.Initialize() + 0x31
         at System.Threading.LazyInitializer.EnsureInitializedCore[T](T&, Boolean&, Object&, Func`1) + 0x40
         at Microsoft.AspNetCore.Routing.Matching.DataSourceDependentMatcher..ctor(EndpointDataSource, DataSourceDependentMatcher.Lifetime, Func`1) + 0x9
```

cc @MichalStrehovsky 