### PR TITLE
Fix CollectionModelBinder BindSimpleCollection null value handling

### DIFF
--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/CollectionModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/CollectionModelBinder.cs
@@ -273,6 +273,7 @@ public partial class CollectionModelBinder<TElement> : ICollectionModelBinder
         var boundCollection = new List<TElement?>();
 
         var elementMetadata = bindingContext.ModelMetadata.ElementMetadata!;
+        var valueProvider = bindingContext.ValueProvider;
 
         foreach (var value in values)
         {
@@ -283,7 +284,12 @@ public partial class CollectionModelBinder<TElement> : ICollectionModelBinder
                 modelName: bindingContext.ModelName,
                 model: null))
             {
-                bindingContext.ValueProvider = new ElementalValueProvider(bindingContext.ModelName, value, values.Culture);
+                bindingContext.ValueProvider = new CompositeValueProvider
+                {
+                    // our temporary provider goes at the front of the list
+                    new ElementalValueProvider(bindingContext.ModelName, value, values.Culture),
+                    valueProvider
+                };
 
                 await ElementBinder.BindModelAsync(bindingContext);
 

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/CollectionModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/CollectionModelBinder.cs
@@ -276,13 +276,6 @@ public partial class CollectionModelBinder<TElement> : ICollectionModelBinder
 
         foreach (var value in values)
         {
-            bindingContext.ValueProvider = new CompositeValueProvider
-                {
-                    // our temporary provider goes at the front of the list
-                    new ElementalValueProvider(bindingContext.ModelName, value, values.Culture),
-                    bindingContext.ValueProvider
-                };
-
             // Enter new scope to change ModelMetadata and isolate element binding operations.
             using (bindingContext.EnterNestedScope(
                 elementMetadata,
@@ -290,6 +283,8 @@ public partial class CollectionModelBinder<TElement> : ICollectionModelBinder
                 modelName: bindingContext.ModelName,
                 model: null))
             {
+                bindingContext.ValueProvider = new ElementalValueProvider(bindingContext.ModelName, value, values.Culture);
+
                 await ElementBinder.BindModelAsync(bindingContext);
 
                 if (bindingContext.Result.IsModelSet)

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/CollectionModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/CollectionModelBinderTest.cs
@@ -222,7 +222,7 @@ public class CollectionModelBinderTest
 
         // Assert
         Assert.NotNull(boundCollection.Model);
-        Assert.Equal(new[] { 42, 100, 200 }, boundCollection.Model);
+        Assert.Equal(new[] { 420, 42, 100, 420, 200 }, boundCollection.Model);
     }
 
     private IActionResult ActionWithListParameter(List<string> parameter) => null;

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/CollectionModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/CollectionModelBinderTest.cs
@@ -215,7 +215,7 @@ public class CollectionModelBinderTest
                 { "someName", "420" },
             };
         var context = GetModelBindingContext(valueProvider);
-        var valueProviderResult = new ValueProviderResult(new[] { null, "42", "100", null, "200" });
+        var valueProviderResult = new ValueProviderResult(new[] { null, "42", "", "100", null, "200" });
 
         // Act
         var boundCollection = await binder.BindSimpleCollection(context, valueProviderResult);

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/CollectionModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/CollectionModelBinderTest.cs
@@ -205,6 +205,25 @@ public class CollectionModelBinderTest
         Assert.Empty(boundCollection.Model);
     }
 
+    [Fact]
+    public async Task BindSimpleCollection_RawValueWithNull_ReturnsListWithoutNull()
+    {
+        // Arrange
+        var binder = new CollectionModelBinder<int>(CreateIntBinder(), NullLoggerFactory.Instance);
+        var valueProvider = new SimpleValueProvider
+            {
+                { "someName", "420" },
+            };
+        var context = GetModelBindingContext(valueProvider);
+
+        // Act
+        var boundCollection = await binder.BindSimpleCollection(context, new ValueProviderResult(new[] { null, "42", "100", null, "200" }));
+
+        // Assert
+        Assert.NotNull(boundCollection.Model);
+        Assert.Equal(new[] { 42, 100, 200 }, boundCollection.Model);
+    }
+
     private IActionResult ActionWithListParameter(List<string> parameter) => null;
 
     [Theory]

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/CollectionModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/CollectionModelBinderTest.cs
@@ -215,9 +215,10 @@ public class CollectionModelBinderTest
                 { "someName", "420" },
             };
         var context = GetModelBindingContext(valueProvider);
+        var valueProviderResult = new ValueProviderResult(new[] { null, "42", "100", null, "200" });
 
         // Act
-        var boundCollection = await binder.BindSimpleCollection(context, new ValueProviderResult(new[] { null, "42", "100", null, "200" }));
+        var boundCollection = await binder.BindSimpleCollection(context, valueProviderResult);
 
         // Assert
         Assert.NotNull(boundCollection.Model);

--- a/src/Mvc/test/Mvc.FunctionalTests/CustomValueProviderTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/CustomValueProviderTest.cs
@@ -71,6 +71,6 @@ public class CustomValueProviderTest : IClassFixture<MvcTestFixture<BasicWebSite
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
-        Assert.Equal(@"[""foo"",null,""bar"",""baz""]", content);
+        Assert.Equal(@"[null,""foo"",null,""bar"",null,""baz""]", content);
     }
 }

--- a/src/Mvc/test/Mvc.FunctionalTests/CustomValueProviderTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/CustomValueProviderTest.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.Http;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
+
+public class CustomValueProviderTest : IClassFixture<MvcTestFixture<BasicWebSite.StartupWithCustomValueProvider>>
+{
+    private IServiceCollection _serviceCollection;
+
+    public CustomValueProviderTest(MvcTestFixture<BasicWebSite.StartupWithCustomValueProvider> fixture)
+    {
+        var factory = fixture.Factories.FirstOrDefault() ?? fixture.WithWebHostBuilder(b => b.UseStartup<BasicWebSite.StartupWithCustomValueProvider>());
+        factory = factory.WithWebHostBuilder(b => b.ConfigureTestServices(serviceCollection => _serviceCollection = serviceCollection));
+
+        Client = factory.CreateDefaultClient();
+    }
+
+    public HttpClient Client { get; }
+
+    [Fact]
+    public async Task CustomValueProvider_DisplayName()
+    {
+        // Arrange
+        var url = "http://localhost/CustomValueProvider/CustomValueProviderDisplayName";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+        // Act
+        var response = await Client.SendAsync(request);
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
+        Assert.Equal("BasicWebSite.Controllers.CustomValueProviderController.CustomValueProviderDisplayName (BasicWebSite)", content);
+    }
+
+    [Fact]
+    public async Task CustomValueProvider_IntValues()
+    {
+        // Arrange
+        var url = "http://localhost/CustomValueProvider/CustomValueProviderIntValues";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+        // Act
+        var response = await Client.SendAsync(request);
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
+        Assert.Equal("[42,100,200]", content);
+    }
+
+    [Fact]
+    public async Task CustomValueProvider_StringValues()
+    {
+        // Arrange
+        var url = "http://localhost/CustomValueProvider/CustomValueProviderStringValues";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+        // Act
+        var response = await Client.SendAsync(request);
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
+        Assert.Equal(@"[""foo"",null,""bar"",""baz""]", content);
+    }
+}

--- a/src/Mvc/test/Mvc.FunctionalTests/CustomValueProviderTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/CustomValueProviderTest.cs
@@ -58,6 +58,23 @@ public class CustomValueProviderTest : IClassFixture<MvcTestFixture<BasicWebSite
     }
 
     [Fact]
+    public async Task CustomValueProvider_NullableIntValues()
+    {
+        // Arrange
+        var url = "http://localhost/CustomValueProvider/CustomValueProviderNullableIntValues";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+        // Act
+        var response = await Client.SendAsync(request);
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
+        Assert.Equal("[null,42,null,100,null,200]", content);
+    }
+
+    [Fact]
     public async Task CustomValueProvider_StringValues()
     {
         // Arrange

--- a/src/Mvc/test/WebSites/BasicWebSite/Controllers/CustomValueProviderController.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/Controllers/CustomValueProviderController.cs
@@ -17,6 +17,10 @@ public class CustomValueProviderController : Controller
         => customValueProviderIntValues;
 
     [HttpGet]
+    public int?[] CustomValueProviderNullableIntValues(int?[] customValueProviderNullableIntValues)
+        => customValueProviderNullableIntValues;
+
+    [HttpGet]
     public string[] CustomValueProviderStringValues(string[] customValueProviderStringValues)
         => customValueProviderStringValues;
 }

--- a/src/Mvc/test/WebSites/BasicWebSite/Controllers/CustomValueProviderController.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/Controllers/CustomValueProviderController.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BasicWebSite.Controllers;
+
+public class CustomValueProviderController : Controller
+{
+    [HttpGet]
+    public string CustomValueProviderDisplayName(string customValueProviderDisplayName)
+        => customValueProviderDisplayName;
+
+    [HttpGet]
+    public int[] CustomValueProviderIntValues(int[] customValueProviderIntValues)
+        => customValueProviderIntValues;
+
+    [HttpGet]
+    public string[] CustomValueProviderStringValues(string[] customValueProviderStringValues)
+        => customValueProviderStringValues;
+}

--- a/src/Mvc/test/WebSites/BasicWebSite/StartupWithCustomValueProvider.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/StartupWithCustomValueProvider.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using BasicWebSite.ValueProviders;
+
+namespace BasicWebSite;
+
+public class StartupWithCustomValueProvider
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services
+            .AddMvc(o =>
+            {
+                o.ValueProviderFactories.Add(new CustomValueProviderFactory());
+            });
+    }
+
+    public void Configure(IApplicationBuilder app)
+    {
+        app.UseDeveloperExceptionPage();
+
+        app.UseRouting();
+
+        app.UseEndpoints((endpoints) => endpoints.MapDefaultControllerRoute());
+    }
+}

--- a/src/Mvc/test/WebSites/BasicWebSite/ValueProviders/CustomValueProviderFactory.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/ValueProviders/CustomValueProviderFactory.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Primitives;
+
+namespace BasicWebSite.ValueProviders;
+
+public class CustomValueProviderFactory : IValueProviderFactory
+{
+    public Task CreateValueProviderAsync(ValueProviderFactoryContext context)
+    {
+        context.ValueProviders.Add(new CustomValueProvider(context));
+        return Task.CompletedTask;
+    }
+
+    private class CustomValueProvider : IValueProvider
+    {
+        private static readonly Dictionary<string, Func<ValueProviderFactoryContext, StringValues>> Values = new()
+        {
+            { "customValueProviderDisplayName", context => context.ActionContext.ActionDescriptor.DisplayName },
+            { "customValueProviderIntValues", _ => new []{ null, "42", "100", null, "200" } },
+            { "customValueProviderStringValues", _ => new []{ null, "foo", "", "bar", null, "baz" } },
+        };
+
+        private readonly ValueProviderFactoryContext _context;
+
+        public CustomValueProvider(ValueProviderFactoryContext context)
+        {
+            _context = context;
+        }
+
+        public bool ContainsPrefix(string prefix) => Values.ContainsKey(prefix);
+
+        public ValueProviderResult GetValue(string key)
+        {
+            if (Values.TryGetValue(key, out var fn))
+            {
+                return new ValueProviderResult(fn(_context));
+            }
+            return ValueProviderResult.None;
+        }
+    }
+}

--- a/src/Mvc/test/WebSites/BasicWebSite/ValueProviders/CustomValueProviderFactory.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/ValueProviders/CustomValueProviderFactory.cs
@@ -20,6 +20,7 @@ public class CustomValueProviderFactory : IValueProviderFactory
         {
             { "customValueProviderDisplayName", context => context.ActionContext.ActionDescriptor.DisplayName },
             { "customValueProviderIntValues", _ => new []{ null, "42", "100", null, "200" } },
+            { "customValueProviderNullableIntValues", _ => new []{ null, "42", "", "100", null, "200" } },
             { "customValueProviderStringValues", _ => new []{ null, "foo", "", "bar", null, "baz" } },
         };
 


### PR DESCRIPTION
# Fix CollectionModelBinder BindSimpleCollection null value handling

`null` is now ignored instead of receiving the previous value.
Because `StringValues` of `null` equals [`ValueProviderResult.None`](https://github.com/dotnet/aspnetcore/blob/c694dc70d72caa86a084c1cf51a6830264eaef84/src/Mvc/Mvc.Abstractions/src/ModelBinding/ValueProviderResult.cs#L33) and the `CompositeValueProvider` contained the `ElementalValueProvider` from the previous iteration, it got used instead.

There was also an interesting case when `null` is the first value, because then the original `IValueProvider` might be called again, which returns the original array (or something else if it is computed) and because the array can not be bound to an element value it received actually `null`.

I don't think the `CompositeValueProvider` is needed at all, also the `bindingContext.ValueProvider` should be set inside of `EnterNestedScope` so the original `bindingContext.ValueProvider` is properly restored afterwards.

| Input  | Before | After |
| ------------- | ------------- | ------------- |
| `[42,100,null,200]`  | `[42,100,100,200]`  | `[42,100,200]` |
| `[null,42,100,200]`  | `[null,42,100,200]` | `[42,100,200]` |

Fixes #40929


<details>
  <summary>⚠Dangerous hack to get `null` values ⚠</summary>

Since [`ValueProviderResult.None`](https://github.com/dotnet/aspnetcore/blob/c694dc70d72caa86a084c1cf51a6830264eaef84/src/Mvc/Mvc.Abstractions/src/ModelBinding/ValueProviderResult.cs#L33) is currently **not** `readonly` (I guess that's a bug?) you can set it to something else and then you would get `null` back instead of it being ignored:
```c#
ValueProviderResult.None = new ValueProviderResult(new[] { "please don't ignore null!" });
```
</details>