### PR TITLE
Add support for multi-segment parameters to gRPC JSON transcoding

### DIFF
--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Binding/JsonTranscodingProviderServiceBinder.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Binding/JsonTranscodingProviderServiceBinder.cs
@@ -230,9 +230,9 @@ internal sealed partial class JsonTranscodingProviderServiceBinder<TService> : S
     private static (RoutePattern routePattern, CallHandlerDescriptorInfo descriptorInfo) ParseRoute(string pattern, string body, string responseBody, MethodDescriptor methodDescriptor)
     {
         var httpRoutePattern = HttpRoutePattern.Parse(pattern);
-        var adaptor = JsonTranscodingRouteAdapter.Parse(httpRoutePattern!);
+        var adapter = JsonTranscodingRouteAdapter.Parse(httpRoutePattern);
 
-        return (RoutePatternFactory.Parse(adaptor.ResolvedRouteTemplate), CreateDescriptorInfo(body, responseBody, methodDescriptor, adaptor));
+        return (RoutePatternFactory.Parse(adapter.ResolvedRouteTemplate), CreateDescriptorInfo(body, responseBody, methodDescriptor, adapter));
     }
 
     private static CallHandlerDescriptorInfo CreateDescriptorInfo(string body, string responseBody, MethodDescriptor methodDescriptor, JsonTranscodingRouteAdapter routeAdapter)

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/CallHandlers/CallHandlerDescriptorInfo.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/CallHandlers/CallHandlerDescriptorInfo.cs
@@ -15,13 +15,15 @@ internal sealed class CallHandlerDescriptorInfo
         MessageDescriptor? bodyDescriptor,
         bool bodyDescriptorRepeated,
         List<FieldDescriptor>? bodyFieldDescriptors,
-        Dictionary<string, List<FieldDescriptor>> routeParameterDescriptors)
+        Dictionary<string, List<FieldDescriptor>> routeParameterDescriptors,
+        JsonTranscodingRouteAdapter routeAdapter)
     {
         ResponseBodyDescriptor = responseBodyDescriptor;
         BodyDescriptor = bodyDescriptor;
         BodyDescriptorRepeated = bodyDescriptorRepeated;
         BodyFieldDescriptors = bodyFieldDescriptors;
         RouteParameterDescriptors = routeParameterDescriptors;
+        RouteAdapter = routeAdapter;
         if (BodyFieldDescriptors != null)
         {
             BodyFieldDescriptorsPath = string.Join('.', BodyFieldDescriptors.Select(d => d.Name));
@@ -35,6 +37,7 @@ internal sealed class CallHandlerDescriptorInfo
     public bool BodyDescriptorRepeated { get; }
     public List<FieldDescriptor>? BodyFieldDescriptors { get; }
     public Dictionary<string, List<FieldDescriptor>> RouteParameterDescriptors { get; }
+    public JsonTranscodingRouteAdapter RouteAdapter { get; }
     public ConcurrentDictionary<string, List<FieldDescriptor>?> PathDescriptorsCache { get; }
     public string? BodyFieldDescriptorsPath { get; }
 }

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/CallHandlers/ServerCallHandlerBase.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/CallHandlers/ServerCallHandlerBase.cs
@@ -36,6 +36,11 @@ internal abstract class ServerCallHandlerBase<TService, TRequest, TResponse>
 
     public Task HandleCallAsync(HttpContext httpContext)
     {
+        foreach (var rewriteAction in DescriptorInfo.RouteAdapter.RewriteVariableActions)
+        {
+            rewriteAction(httpContext);
+        }
+
         var serverCallContext = new JsonTranscodingServerCallContext(httpContext, MethodInvoker.Options, MethodInvoker.Method, DescriptorInfo, Logger);
         httpContext.Features.Set<IServerCallContextFeature>(serverCallContext);
 

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonRequestHelpers.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonRequestHelpers.cs
@@ -338,7 +338,7 @@ internal static class JsonRequestHelpers
     {
         return serverCallContext.DescriptorInfo.PathDescriptorsCache.GetOrAdd(path, p =>
         {
-            ServiceDescriptorHelpers.TryResolveDescriptors(requestMessage.Descriptor, p, out var pathDescriptors);
+            ServiceDescriptorHelpers.TryResolveDescriptors(requestMessage.Descriptor, p.Split('.'), out var pathDescriptors);
             return pathDescriptors;
         });
     }

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonTranscodingRouteAdapter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonTranscodingRouteAdapter.cs
@@ -1,0 +1,196 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Linq;
+using Grpc.Shared;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
+
+/// <summary>
+/// Routes on HTTP rule are similar to ASP.NET Core routes but add and remove some features.
+/// - Constraints aren't supported.
+/// - Optional parameters aren't supported.
+/// - Parameters spanning multiple segments are supported.
+///
+/// This type transforms an HTTP route into an ASP.NET Core route by rewritting it to a compatible
+/// format and providing actions to reconstruct parameters that span multiple segments.
+/// </summary>
+internal class JsonTranscodingRouteAdapter
+{
+    public HttpRoutePattern HttpRoutePattern { get; }
+    public string ResolvedRouteTemplate { get; }
+    public List<Action<HttpContext>> RewriteVariableActions { get; }
+
+    private JsonTranscodingRouteAdapter(HttpRoutePattern httpRoutePattern, string resolvedRoutePattern, List<Action<HttpContext>> rewriteVariableActions)
+    {
+        HttpRoutePattern = httpRoutePattern;
+        ResolvedRouteTemplate = resolvedRoutePattern;
+        RewriteVariableActions = rewriteVariableActions;
+    }
+
+    public static JsonTranscodingRouteAdapter Parse(HttpRoutePattern pattern)
+    {
+        var rewriteActions = new List<Action<HttpContext>>();
+
+        var tempSegments = pattern.Segments.ToList();
+        var i = 0;
+        while (i < tempSegments.Count)
+        {
+            var segmentVariable = GetVariable(pattern, i);
+            if (segmentVariable != null)
+            {
+                var fullPath = string.Join(".", segmentVariable.FieldPath);
+
+                var segmentCount = segmentVariable.EndSegment - segmentVariable.StartSegment;
+                if (segmentCount == 1)
+                {
+                    // Single segment parameter. Include in route with its default name.
+                    tempSegments[i] = segmentVariable.HasCatchAllPath
+                        ? $"{{**{fullPath}}}"
+                        : $"{{{fullPath}}}";
+                    i++;
+                }
+                else
+                {
+                    var routeParameterParts = new List<string>();
+                    var routeValueFormatTemplateParts = new List<string>();
+                    var variableParts = new List<string>();
+                    var haveCatchAll = false;
+                    var catchAllSuffix = string.Empty;
+
+                    while (i < segmentVariable.EndSegment && !haveCatchAll)
+                    {
+                        var segment = tempSegments[i];
+                        var segmentType = GetSegmentType(segment);
+                        switch (segmentType)
+                        {
+                            case SegmentType.Literal:
+                                routeValueFormatTemplateParts.Add(segment);
+                                break;
+                            case SegmentType.Any:
+                                {
+                                    var parameterName = $"__Complex_{fullPath}_{i}";
+                                    tempSegments[i] = $"{{{parameterName}}}";
+
+                                    routeValueFormatTemplateParts.Add($"{{{variableParts.Count}}}");
+                                    variableParts.Add(parameterName);
+                                    break;
+                                }
+                            case SegmentType.CatchAll:
+                                {
+                                    var parameterName = $"__Complex_{fullPath}_{i}";
+                                    var suffix = string.Join("/", tempSegments.Skip(i + 1));
+                                    catchAllSuffix = string.Join("/", tempSegments.Skip(i + segmentCount - 1));
+
+                                    // It's possible to have multiple routes with catch-all parameters that have different suffixes.
+                                    // For example:
+                                    // - /{name=v1/**/b}/one
+                                    // - /{name=v1/**/b}/two
+                                    // The suffix is added as a route constraint to avoid matching multiple routes to a request.
+                                    var constraint = suffix.Length > 0 ? $":regex({suffix}$)" : string.Empty;
+                                    tempSegments[i] = $"{{**{parameterName}{constraint}}}";
+
+                                    routeValueFormatTemplateParts.Add($"{{{variableParts.Count}}}");
+                                    variableParts.Add(parameterName);
+                                    haveCatchAll = true;
+
+                                    // Remove remaining segments. They have been added in the route constraint.
+                                    while (i < tempSegments.Count - 1)
+                                    {
+                                        tempSegments.RemoveAt(tempSegments.Count - 1);
+                                    }
+                                    break;
+                                }
+                        }
+                        i++;
+                    }
+
+                    var routeValueFormatTemplate = string.Join("/", routeValueFormatTemplateParts);
+
+                    // Add an action to reconstruct the multiple segment parameter from ASP.NET Core
+                    // request route values. This should be called when the request is received.
+                    rewriteActions.Add(context =>
+                    {
+                        var values = new object?[variableParts.Count];
+                        for (var i = 0; i < values.Length; i++)
+                        {
+                            values[i] = context.Request.RouteValues[variableParts[i]];
+                        }
+                        var finalValue = string.Format(CultureInfo.InvariantCulture, routeValueFormatTemplate, values);
+
+                        // Catch-all route parameter is always the last parameter. The original HTTP pattern
+                        if (!string.IsNullOrEmpty(catchAllSuffix))
+                        {
+                            finalValue = finalValue.Substring(0, finalValue.Length - catchAllSuffix.Length - 1); // Trim "/{suffix}"
+                        }
+                        context.Request.RouteValues[fullPath] = finalValue;
+                    });
+                }
+            }
+            else
+            {
+                // HTTP route can match any value in a segment without a parameter.
+                // For example, v1/*/books. Add a parameter to match this behavior logic.
+                // Parameter value is never used.
+
+                var segmentType = GetSegmentType(tempSegments[i]);
+                switch (segmentType)
+                {
+                    case SegmentType.Literal:
+                        // Literal is unchanged.
+                        break;
+                    case SegmentType.Any:
+                        // Ignore any segment value.
+                        tempSegments[i] = $"{{__Discard_{i}}}";
+                        break;
+                    case SegmentType.CatchAll:
+                        // Ignore remaining segment values.
+                        tempSegments[i] = $"{{**__Discard_{i}}}";
+                        break;
+                }
+
+                i++;
+            }
+        }
+
+        return new JsonTranscodingRouteAdapter(pattern, "/" + string.Join("/", tempSegments), rewriteActions);
+    }
+
+    private static SegmentType GetSegmentType(string segment)
+    {
+        if (segment.StartsWith("**", StringComparison.Ordinal))
+        {
+            return SegmentType.CatchAll;
+        }
+        else if (segment.StartsWith("*", StringComparison.Ordinal))
+        {
+            return SegmentType.Any;
+        }
+        else
+        {
+            return SegmentType.Literal;
+        }
+    }
+
+    private enum SegmentType
+    {
+        Literal,
+        Any,
+        CatchAll
+    }
+
+    private static HttpRouteVariable? GetVariable(HttpRoutePattern pattern, int i)
+    {
+        foreach (var variable in pattern.Variables)
+        {
+            if (i >= variable.StartSegment && i < variable.EndSegment)
+            {
+                return variable;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonTranscodingRouteAdapter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonTranscodingRouteAdapter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 /// This type transforms an HTTP route into an ASP.NET Core route by rewritting it to a compatible
 /// format and providing actions to reconstruct parameters that span multiple segments.
 /// </summary>
-internal class JsonTranscodingRouteAdapter
+internal sealed class JsonTranscodingRouteAdapter
 {
     public HttpRoutePattern HttpRoutePattern { get; }
     public string ResolvedRouteTemplate { get; }

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Microsoft.AspNetCore.Grpc.JsonTranscoding.csproj
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Microsoft.AspNetCore.Grpc.JsonTranscoding.csproj
@@ -23,6 +23,8 @@
     <Compile Include="..\Shared\AuthContextHelpers.cs" Link="Internal\Shared\AuthContextHelpers.cs" />
     <Compile Include="..\Shared\ServiceDescriptorHelpers.cs" Link="Internal\Shared\ServiceDescriptorHelpers.cs" />
     <Compile Include="..\Shared\X509CertificateHelpers.cs" Link="Internal\Shared\X509CertificateHelpers.cs" />
+    <Compile Include="..\Shared\HttpRoutePattern.cs" Link="Internal\Shared\HttpRoutePattern.cs" />
+    <Compile Include="..\Shared\HttpRoutePatternParser.cs" Link="Internal\Shared\HttpRoutePatternParser.cs" />
     <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" LinkBase="Internal\Shared" />
 
     <Protobuf Include="Internal\Protos\errors.proto" Access="Internal" />

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/GrpcJsonTranscodingDescriptionProvider.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/GrpcJsonTranscodingDescriptionProvider.cs
@@ -84,7 +84,8 @@ internal sealed class GrpcJsonTranscodingDescriptionProvider : IApiDescriptionPr
         }
 
         var methodMetadata = routeEndpoint.Metadata.GetMetadata<GrpcMethodMetadata>()!;
-        var routeParameters = ServiceDescriptorHelpers.ResolveRouteParameterDescriptors(routeEndpoint.RoutePattern, methodDescriptor.InputType);
+        var httpRoutePattern = HttpRoutePattern.Parse(pattern);
+        var routeParameters = ServiceDescriptorHelpers.ResolveRouteParameterDescriptors(httpRoutePattern.Variables.Select(v => v.FieldPath).ToList(), methodDescriptor.InputType);
 
         foreach (var routeParameter in routeParameters)
         {

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.Swagger/Microsoft.AspNetCore.Grpc.Swagger.csproj
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.Swagger/Microsoft.AspNetCore.Grpc.Swagger.csproj
@@ -11,6 +11,8 @@
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Grpc.Swagger.Tests" />
 
     <Compile Include="..\Shared\ServiceDescriptorHelpers.cs" Link="Internal\Shared\ServiceDescriptorHelpers.cs" />
+    <Compile Include="..\Shared\HttpRoutePattern.cs" Link="Internal\Shared\HttpRoutePattern.cs" />
+    <Compile Include="..\Shared\HttpRoutePatternParser.cs" Link="Internal\Shared\HttpRoutePatternParser.cs" />
 
     <Reference Include="Microsoft.AspNetCore.Grpc.JsonTranscoding" />
     <Reference Include="Swashbuckle.AspNetCore" />

--- a/src/Grpc/JsonTranscoding/src/Shared/HttpRoutePattern.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/HttpRoutePattern.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Grpc.Shared;
+
+internal class HttpRoutePattern
+{
+    public List<string> Segments { get; }
+    public string? Verb { get; }
+    public List<HttpRouteVariable> Variables { get; }
+
+    private HttpRoutePattern(List<string> segments, string? verb, List<HttpRouteVariable> variables)
+    {
+        Segments = segments;
+        Verb = verb;
+        Variables = variables;
+    }
+
+    public static HttpRoutePattern Parse(string pattern)
+    {
+        var p = new HttpRoutePatternParser(pattern);
+        p.Parse();
+
+        return new HttpRoutePattern(p.Segments, p.Verb, p.Variables);
+    }
+}
+
+internal class HttpRouteVariable
+{
+    public int Index;
+    public int StartSegment;
+    public int EndSegment;
+    public List<string> FieldPath = new List<string>();
+    public bool HasCatchAllPath;
+}

--- a/src/Grpc/JsonTranscoding/src/Shared/HttpRoutePattern.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/HttpRoutePattern.cs
@@ -3,7 +3,7 @@
 
 namespace Grpc.Shared;
 
-internal class HttpRoutePattern
+internal sealed class HttpRoutePattern
 {
     public List<string> Segments { get; }
     public string? Verb { get; }
@@ -25,11 +25,11 @@ internal class HttpRoutePattern
     }
 }
 
-internal class HttpRouteVariable
+internal sealed class HttpRouteVariable
 {
-    public int Index;
-    public int StartSegment;
-    public int EndSegment;
-    public List<string> FieldPath = new List<string>();
-    public bool HasCatchAllPath;
+    public int Index { get; set; }
+    public int StartSegment { get; set; }
+    public int EndSegment { get; set; }
+    public List<string> FieldPath { get; } = new List<string>();
+    public bool HasCatchAllPath { get; set; }
 }

--- a/src/Grpc/JsonTranscoding/src/Shared/HttpRoutePatternParser.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/HttpRoutePatternParser.cs
@@ -1,0 +1,357 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace Grpc.Shared;
+
+// HTTP Template Grammar:
+//
+// Template = "/" | "/" Segments [ Verb ] ;
+// Segments = Segment { "/" Segment } ;
+// Segment  = "*" | "**" | LITERAL | Variable ;
+// Variable = "{" FieldPath [ "=" Segments ] "}" ;
+// FieldPath = IDENT { "." IDENT } ;
+// Verb     = ":" LITERAL ;
+internal class HttpRoutePatternParser
+{
+    private readonly string _input;
+
+    // Token delimiter indexes
+    private int _tokenStart;
+    private int _tokenEnd;
+
+    private bool _inVariable;
+
+    private readonly List<string> _segments;
+    private string? _verb;
+    private readonly List<HttpRouteVariable> _variables;
+    private bool _hasCatchAllSegment;
+
+    public List<string> Segments => _segments;
+    public string? Verb => _verb;
+    public List<HttpRouteVariable> Variables => _variables;
+
+    public HttpRoutePatternParser(string input)
+    {
+        _input = input;
+        _segments = new List<string>();
+        _variables = new List<HttpRouteVariable>();
+    }
+
+    public void Parse()
+    {
+        try
+        {
+            ParseTemplate();
+
+            if (_tokenStart < _input.Length)
+            {
+                throw new InvalidOperationException("Path template wasn't parsed to the end.");
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Error parsing path template '{_input}'.", ex);
+        }
+    }
+
+    // Template = "/" Segments [ Verb ] ;
+    private void ParseTemplate()
+    {
+        if (!Consume('/'))
+        {
+            throw new InvalidOperationException("Path template must start with a '/'.");
+        }
+        ParseSegments();
+
+        if (EnsureCurrent())
+        {
+            if (CurrentChar != ':')
+            {
+                throw new InvalidOperationException("Path segment must end with a '/'.");
+            }
+            ParseVerb();
+        }
+    }
+
+    // Segments = Segment { "/" Segment } ;
+    private void ParseSegments()
+    {
+        while (true)
+        {
+            if (!ParseSegment())
+            {
+                // Support '/' template.
+                if (_segments.Count > 0)
+                {
+                    throw new InvalidOperationException("Route template shouldn't end with a '/'.");
+                }
+            }
+            if (!Consume('/'))
+            {
+                break;
+            }
+        }
+    }
+
+    // Segment  = "*" | "**" | LITERAL | Variable ;
+    private bool ParseSegment()
+    {
+        if (!EnsureCurrent())
+        {
+            return false;
+        }
+        switch (CurrentChar)
+        {
+            case '*':
+                {
+                    if (_hasCatchAllSegment)
+                    {
+                        throw new InvalidOperationException("Only literal segments can follow a catch-all segment.");
+                    }
+
+                    ConsumeAndAssert('*');
+
+                    // Check for '**'
+                    if (Consume('*'))
+                    {
+                        _segments.Add("**");
+                        _hasCatchAllSegment = true;
+                        if (_inVariable)
+                        {
+                            MarkVariableHasWildardPath();
+                        }
+                        return true;
+                    }
+                    else
+                    {
+                        _segments.Add("*");
+                        return true;
+                    }
+                }
+
+            case '{':
+                if (_hasCatchAllSegment)
+                {
+                    throw new InvalidOperationException("Only literal segments can follow a catch-all segment.");
+                }
+
+                ParseVariable();
+                return true;
+            default:
+                ParseLiteralSegment();
+                return true;
+        }
+    }
+
+    // Variable = "{" FieldPath [ "=" Segments ] "}" ;
+    private void ParseVariable()
+    {
+        ConsumeAndAssert('{');
+        StartVariable();
+        ParseFieldPath();
+        if (Consume('='))
+        {
+            ParseSegments();
+        }
+        else
+        {
+            _segments.Add("*");
+        }
+        EndVariable();
+        ConsumeAndAssert('}');
+    }
+
+    private void ParseLiteralSegment()
+    {
+        if (!TryParseLiteral(out var literal))
+        {
+            throw new InvalidOperationException("Empty literal segment.");
+        }
+        _segments.Add(literal);
+    }
+
+    // FieldPath = IDENT { "." IDENT } ;
+    private void ParseFieldPath()
+    {
+        do
+        {
+            if (!ParseIdentifier())
+            {
+                throw new InvalidOperationException("Incomplete or empty field path.");
+            }
+        }
+        while (Consume('.'));
+    }
+
+    // Verb     = ":" LITERAL ;
+    private void ParseVerb()
+    {
+        ConsumeAndAssert(':');
+        if (!TryParseLiteral(out _verb))
+        {
+            throw new InvalidOperationException("Empty verb.");
+        }
+    }
+
+    private bool ParseIdentifier()
+    {
+        var identifier = string.Empty;
+        var hasEndChar = false;
+
+        while (!hasEndChar && NextChar())
+        {
+            var c = CurrentChar;
+            switch (c)
+            {
+                case '.':
+                case '}':
+                case '=':
+                    hasEndChar = true;
+                    break;
+                default:
+                    Consume(c);
+                    identifier += c;
+                    break;
+            }
+        }
+
+        if (string.IsNullOrEmpty(identifier))
+        {
+            return false;
+        }
+
+        AddFieldIdentifier(identifier);
+        return true;
+    }
+
+    private bool TryParseLiteral([NotNullWhen(true)] out string? literal)
+    {
+        literal = null;
+
+        if (!EnsureCurrent())
+        {
+            return false;
+        }
+
+        // Initialize to false in case we encounter an empty literal.
+        var result = false;
+
+        while (true)
+        {
+            var c = CurrentChar;
+            switch (c)
+            {
+                case '/':
+                case ':':
+                case '}':
+                    if (!result)
+                    {
+                        throw new InvalidOperationException("Path template has an empty segment.");
+                    }
+                    return result;
+                default:
+                    Consume(c);
+                    literal += c;
+                    break;
+            }
+
+            result = true;
+
+            if (!NextChar())
+            {
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    private void ConsumeAndAssert(char? c)
+    {
+        if (!Consume(c))
+        {
+            throw new InvalidOperationException($"Expected '{c}' when parsing path template.");
+        }
+    }
+
+    private bool Consume(char? c)
+    {
+        if (!EnsureCurrent())
+        {
+            return false;
+        }
+        if (CurrentChar != c)
+        {
+            return false;
+        }
+        _tokenStart++;
+        return true;
+    }
+
+    private bool EnsureCurrent() => _tokenStart < _tokenEnd || NextChar();
+
+    private bool NextChar()
+    {
+        if (_tokenEnd < _input.Length)
+        {
+            _tokenEnd++;
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    private char? CurrentChar => _tokenStart < _tokenEnd && _tokenEnd <= _input.Length ? _input[_tokenEnd - 1] : null;
+
+    private HttpRouteVariable CurrentVariable => _variables.Last();
+
+    private void StartVariable()
+    {
+        if (_inVariable)
+        {
+            throw new InvalidOperationException("Variable can't be nested.");
+        }
+
+        _variables.Add(new HttpRouteVariable());
+        CurrentVariable.StartSegment = _segments.Count;
+        CurrentVariable.HasCatchAllPath = false;
+        _inVariable = true;
+    }
+
+    private void EndVariable()
+    {
+        EnsureCurrentVariable();
+        CurrentVariable.EndSegment = _segments.Count;
+        _inVariable = false;
+
+        Debug.Assert(CurrentVariable.FieldPath.Any());
+        Debug.Assert(CurrentVariable.StartSegment < CurrentVariable.EndSegment);
+        Debug.Assert(CurrentVariable.EndSegment <= _segments.Count);
+    }
+
+    private void AddFieldIdentifier(string id)
+    {
+        EnsureCurrentVariable();
+        CurrentVariable.FieldPath.Add(id);
+    }
+
+    private void MarkVariableHasWildardPath()
+    {
+        EnsureCurrentVariable();
+        CurrentVariable.HasCatchAllPath = true;
+    }
+
+    private void EnsureCurrentVariable()
+    {
+        if (!_inVariable || !_variables.Any())
+        {
+            throw new InvalidOperationException("Unexpected error when updating variable.");
+        }
+    }
+}

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/Infrastructure/TestHelpers.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/Infrastructure/TestHelpers.cs
@@ -5,6 +5,8 @@ using System.Net;
 using Google.Protobuf.Reflection;
 using Grpc.AspNetCore.Server;
 using Grpc.Core.Interceptors;
+using Grpc.Shared;
+using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.CallHandlers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -67,6 +69,7 @@ internal static class TestHelpers
             bodyDescriptor,
             bodyDescriptorRepeated ?? false,
             bodyFieldDescriptors,
-            routeParameterDescriptors ?? new Dictionary<string, List<FieldDescriptor>>());
+            routeParameterDescriptors ?? new Dictionary<string, List<FieldDescriptor>>(),
+            JsonTranscodingRouteAdapter.Parse(HttpRoutePattern.Parse("/")));
     }
 }

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/RouteTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/RouteTests.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Grpc.Core;
+using IntegrationTestsWebsite;
+using Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests.Infrastructure;
+using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
+using Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.Infrastructure;
+using Microsoft.AspNetCore.Testing;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests;
+
+public class RouteTests : IntegrationTestBase
+{
+    public RouteTests(GrpcTestFixture<Startup> fixture, ITestOutputHelper outputHelper)
+        : base(fixture, outputHelper)
+    {
+    }
+
+    [Fact]
+    public async Task ComplexParameter_MatchUrl_SuccessResult()
+    {
+        // Arrange
+        Task<HelloReply> UnaryMethod(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply { Message = $"Hello {request.Name}!" });
+        }
+        var method = Fixture.DynamicGrpc.AddUnaryMethod<HelloRequest, HelloReply>(
+            UnaryMethod,
+            Greeter.Descriptor.FindMethodByName("SayHelloComplex"));
+
+        var client = new HttpClient(Fixture.Handler) { BaseAddress = new Uri("http://localhost") };
+
+        // Act
+        var response = await client.GetAsync("/v1/greeter/from/test").DefaultTimeout();
+        var responseStream = await response.Content.ReadAsStreamAsync();
+        using var result = await JsonDocument.ParseAsync(responseStream);
+
+        // Assert
+        Assert.Equal("Hello from/test!", result.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task MultipleComplexCatchAll_MatchUrl_SuccessResult()
+    {
+        // Arrange
+        Task<HelloReply> UnaryMethod1(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply { Message = $"One - Hello {request.Name}!" });
+        }
+        Task<HelloReply> UnaryMethod2(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply { Message = $"Two - Hello {request.Name}!" });
+        }
+        var method1 = Fixture.DynamicGrpc.AddUnaryMethod<HelloRequest, HelloReply>(
+            UnaryMethod1,
+            Greeter.Descriptor.FindMethodByName("SayHelloComplexCatchAll1"));
+        var method2 = Fixture.DynamicGrpc.AddUnaryMethod<HelloRequest, HelloReply>(
+            UnaryMethod2,
+            Greeter.Descriptor.FindMethodByName("SayHelloComplexCatchAll2"));
+
+        var client = new HttpClient(Fixture.Handler) { BaseAddress = new Uri("http://localhost") };
+
+        // Act 1
+        var response1 = await client.GetAsync("/v1/greeter/test1/b/c/d/one").DefaultTimeout();
+        var responseStream1 = await response1.Content.ReadAsStreamAsync();
+        using var result1 = await JsonDocument.ParseAsync(responseStream1);
+
+        // Assert 1
+        Assert.Equal("One - Hello v1/greeter/test1/b/c!", result1.RootElement.GetProperty("message").GetString());
+
+        // Act 2
+        var response2 = await client.GetAsync("/v1/greeter/test2/b/c/d/two").DefaultTimeout();
+        var responseStream2 = await response2.Content.ReadAsStreamAsync();
+        using var result2 = await JsonDocument.ParseAsync(responseStream2);
+
+        // Assert 2
+        Assert.Equal("Two - Hello v1/greeter/test2/b/c!", result2.RootElement.GetProperty("message").GetString());
+    }
+}

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/HttpRoutePatternParserTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/HttpRoutePatternParserTests.cs
@@ -1,0 +1,325 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Grpc.Shared;
+using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
+
+namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests;
+
+public class HttpRoutePatternParserTests
+{
+    [Fact]
+    public void ParseMultipleVariables()
+    {
+        var pattern = HttpRoutePattern.Parse("/shelves/{shelf}/books/{book}");
+        Assert.Null(pattern.Verb);
+        Assert.Collection(
+            pattern.Segments,
+            s => Assert.Equal("shelves", s),
+            s => Assert.Equal("*", s),
+            s => Assert.Equal("books", s),
+            s => Assert.Equal("*", s));
+        Assert.Collection(
+            pattern.Variables,
+            v =>
+            {
+                Assert.Equal(1, v.StartSegment);
+                Assert.Equal(2, v.EndSegment);
+                Assert.Equal("shelf", string.Join(".", v.FieldPath));
+                Assert.False(v.HasCatchAllPath);
+            },
+            v =>
+            {
+                Assert.Equal(3, v.StartSegment);
+                Assert.Equal(4, v.EndSegment);
+                Assert.Equal("book", string.Join(".", v.FieldPath));
+                Assert.False(v.HasCatchAllPath);
+            });
+    }
+
+    [Fact]
+    public void ParseComplexVariable()
+    {
+        var pattern = HttpRoutePattern.Parse("/v1/{book.name=shelves/*/books/*}");
+        Assert.Null(pattern.Verb);
+        Assert.Collection(
+            pattern.Segments,
+            s => Assert.Equal("v1", s),
+            s => Assert.Equal("shelves", s),
+            s => Assert.Equal("*", s),
+            s => Assert.Equal("books", s),
+            s => Assert.Equal("*", s));
+        Assert.Collection(
+            pattern.Variables,
+            v =>
+            {
+                Assert.Equal(1, v.StartSegment);
+                Assert.Equal(5, v.EndSegment);
+                Assert.Equal("book.name", string.Join(".", v.FieldPath));
+                Assert.False(v.HasCatchAllPath);
+            });
+    }
+
+    [Fact]
+    public void ParseCatchAllSegment()
+    {
+        var pattern = HttpRoutePattern.Parse("/shelves/**");
+        Assert.Collection(
+            pattern.Segments,
+            s => Assert.Equal("shelves", s),
+            s => Assert.Equal("**", s));
+        Assert.Empty(pattern.Variables);
+    }
+
+    [Fact]
+    public void ParseCatchAllSegment2()
+    {
+        var pattern = HttpRoutePattern.Parse("/**");
+        Assert.Collection(
+            pattern.Segments,
+            s => Assert.Equal("**", s));
+        Assert.Empty(pattern.Variables);
+    }
+
+    [Fact]
+    public void ParseAnySegment()
+    {
+        var pattern = HttpRoutePattern.Parse("/*");
+        Assert.Collection(
+            pattern.Segments,
+            s => Assert.Equal("*", s));
+        Assert.Empty(pattern.Variables);
+    }
+
+    [Fact]
+    public void ParseSlash()
+    {
+        var pattern = HttpRoutePattern.Parse("/");
+        Assert.Empty(pattern.Segments);
+        Assert.Empty(pattern.Variables);
+    }
+
+    [Fact]
+    public void ParseVerb()
+    {
+        var pattern = HttpRoutePattern.Parse("/a:foo");
+        Assert.Equal("foo", pattern.Verb);
+        Assert.Collection(
+            pattern.Segments,
+            s => Assert.Equal("a", s));
+        Assert.Empty(pattern.Variables);
+    }
+
+    [Fact]
+    public void ParseAnyAndCatchAllSegment()
+    {
+        var pattern = HttpRoutePattern.Parse("/*/**");
+        Assert.Collection(
+            pattern.Segments,
+            s => Assert.Equal("*", s),
+            s => Assert.Equal("**", s));
+        Assert.Empty(pattern.Variables);
+    }
+
+    [Fact]
+    public void ParseAnyAndCatchAllSegment2()
+    {
+        var pattern = HttpRoutePattern.Parse("/*/a/**");
+        Assert.Collection(
+            pattern.Segments,
+            s => Assert.Equal("*", s),
+            s => Assert.Equal("a", s),
+            s => Assert.Equal("**", s));
+        Assert.Empty(pattern.Variables);
+    }
+
+    [Fact]
+    public void ParseNestedFieldPath()
+    {
+        var pattern = HttpRoutePattern.Parse("/a/{a.b.c}");
+        Assert.Collection(
+            pattern.Segments,
+            s => Assert.Equal("a", s),
+            s => Assert.Equal("*", s));
+        Assert.Collection(
+            pattern.Variables,
+            v =>
+            {
+                Assert.Equal(1, v.StartSegment);
+                Assert.Equal(2, v.EndSegment);
+                Assert.Equal("a.b.c", string.Join(".", v.FieldPath));
+                Assert.False(v.HasCatchAllPath);
+            });
+    }
+
+    [Fact]
+    public void ParseComplexNestedFieldPath()
+    {
+        var pattern = HttpRoutePattern.Parse("/a/{a.b.c=*}");
+        Assert.Collection(
+            pattern.Segments,
+            s => Assert.Equal("a", s),
+            s => Assert.Equal("*", s));
+        Assert.Collection(
+            pattern.Variables,
+            v =>
+            {
+                Assert.Equal(1, v.StartSegment);
+                Assert.Equal(2, v.EndSegment);
+                Assert.Equal("a.b.c", string.Join(".", v.FieldPath));
+                Assert.False(v.HasCatchAllPath);
+            });
+    }
+
+    [Fact]
+    public void ParseComplexCatchAll()
+    {
+        var pattern = HttpRoutePattern.Parse("/a/{b=**}");
+        Assert.Collection(
+            pattern.Segments,
+            s => Assert.Equal("a", s),
+            s => Assert.Equal("**", s));
+        Assert.Collection(
+            pattern.Variables,
+            v =>
+            {
+                Assert.Equal(1, v.StartSegment);
+                Assert.Equal(2, v.EndSegment);
+                Assert.Equal("b", string.Join(".", v.FieldPath));
+                Assert.True(v.HasCatchAllPath);
+            });
+    }
+
+    [Fact]
+    public void ParseComplexPrefixSegment()
+    {
+        var pattern = HttpRoutePattern.Parse("/a/{b=c/*}");
+        Assert.Collection(
+            pattern.Segments,
+            s => Assert.Equal("a", s),
+            s => Assert.Equal("c", s),
+            s => Assert.Equal("*", s));
+        Assert.Collection(
+            pattern.Variables,
+            v =>
+            {
+                Assert.Equal(1, v.StartSegment);
+                Assert.Equal(3, v.EndSegment);
+                Assert.Equal("b", string.Join(".", v.FieldPath));
+                Assert.False(v.HasCatchAllPath);
+            });
+    }
+
+    [Fact]
+    public void ParseComplexPrefixSuffixSegment()
+    {
+        var pattern = HttpRoutePattern.Parse("/a/{b=c/*/d}");
+        Assert.Collection(
+            pattern.Segments,
+            s => Assert.Equal("a", s),
+            s => Assert.Equal("c", s),
+            s => Assert.Equal("*", s),
+            s => Assert.Equal("d", s));
+        Assert.Collection(
+            pattern.Variables,
+            v =>
+            {
+                Assert.Equal(1, v.StartSegment);
+                Assert.Equal(4, v.EndSegment);
+                Assert.Equal("b", string.Join(".", v.FieldPath));
+                Assert.False(v.HasCatchAllPath);
+            });
+    }
+
+    [Fact]
+    public void ParseComplexPathCatchAll()
+    {
+        var pattern = HttpRoutePattern.Parse("/a/{b=c/**}");
+        Assert.Collection(
+            pattern.Segments,
+            s => Assert.Equal("a", s),
+            s => Assert.Equal("c", s),
+            s => Assert.Equal("**", s));
+        Assert.Collection(
+            pattern.Variables,
+            v =>
+            {
+                Assert.Equal(1, v.StartSegment);
+                Assert.Equal(3, v.EndSegment);
+                Assert.Equal("b", string.Join(".", v.FieldPath));
+                Assert.True(v.HasCatchAllPath);
+            });
+    }
+
+    [Fact]
+    public void ParseComplexPrefixSuffixCatchAll()
+    {
+        var pattern = HttpRoutePattern.Parse("/{x.y.z=a/**/b}/c/d");
+        Assert.Collection(
+            pattern.Segments,
+            s => Assert.Equal("a", s),
+            s => Assert.Equal("**", s),
+            s => Assert.Equal("b", s),
+            s => Assert.Equal("c", s),
+            s => Assert.Equal("d", s));
+        Assert.Collection(
+            pattern.Variables,
+            v =>
+            {
+                Assert.Equal(0, v.StartSegment);
+                Assert.Equal(3, v.EndSegment);
+                Assert.Equal("x.y.z", string.Join(".", v.FieldPath));
+                Assert.True(v.HasCatchAllPath);
+            });
+    }
+
+    [Fact]
+    public void ParseCatchAllVerb()
+    {
+        var pattern = HttpRoutePattern.Parse("/a/{b=*}/**:verb");
+        Assert.Equal("verb", pattern.Verb);
+        Assert.Collection(
+            pattern.Segments,
+            s => Assert.Equal("a", s),
+            s => Assert.Equal("*", s),
+            s => Assert.Equal("**", s));
+        Assert.Collection(
+            pattern.Variables,
+            v =>
+            {
+                Assert.Equal(1, v.StartSegment);
+                Assert.Equal(2, v.EndSegment);
+                Assert.Equal("b", string.Join(".", v.FieldPath));
+                Assert.False(v.HasCatchAllPath);
+            });
+    }
+
+    [Theory]
+    [InlineData("", "Path template must start with a '/'.")]
+    [InlineData("//", "Path template has an empty segment.")]
+    [InlineData("/{}", "Incomplete or empty field path.")]
+    [InlineData("/a/", "Route template shouldn't end with a '/'.")]
+    [InlineData(":verb", "Path template must start with a '/'.")]
+    [InlineData(":", "Path template must start with a '/'.")]
+    [InlineData("/:", "Path template has an empty segment.")]
+    [InlineData("/{var}:", "Empty verb.")]
+    [InlineData("/{", "Incomplete or empty field path.")]
+    [InlineData("/a{x}", "Path segment must end with a '/'.")]
+    [InlineData("/{x}a", "Path segment must end with a '/'.")]
+    [InlineData("/{x}{y}", "Path segment must end with a '/'.")]
+    [InlineData("/{var=a/{nested=b}}", "Variable can't be nested.")]
+    [InlineData("/{x=**}/*", "Only literal segments can follow a catch-all segment.")]
+    [InlineData("/{x=}", "Path template has an empty segment.")]
+    [InlineData("/**/*", "Only literal segments can follow a catch-all segment.")]
+    [InlineData("/{x", "Expected '}' when parsing path template.")]
+    public void Error(string pattern, string errorMessage)
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => HttpRoutePattern.Parse(pattern));
+        Assert.Equal(errorMessage, ex.InnerException!.Message);
+    }
+}

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Infrastructure/TestHelpers.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Infrastructure/TestHelpers.cs
@@ -5,6 +5,8 @@ using System.Net;
 using Google.Protobuf.Reflection;
 using Grpc.AspNetCore.Server;
 using Grpc.Core.Interceptors;
+using Grpc.Shared;
+using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.CallHandlers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -68,6 +70,7 @@ internal static class TestHelpers
             bodyDescriptor,
             bodyDescriptorRepeated ?? false,
             bodyFieldDescriptors,
-            routeParameterDescriptors ?? new Dictionary<string, List<FieldDescriptor>>());
+            routeParameterDescriptors ?? new Dictionary<string, List<FieldDescriptor>>(),
+            JsonTranscodingRouteAdapter.Parse(HttpRoutePattern.Parse("/")!));
     }
 }

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Infrastructure/TestHelpers.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Infrastructure/TestHelpers.cs
@@ -71,6 +71,6 @@ internal static class TestHelpers
             bodyDescriptorRepeated ?? false,
             bodyFieldDescriptors,
             routeParameterDescriptors ?? new Dictionary<string, List<FieldDescriptor>>(),
-            JsonTranscodingRouteAdapter.Parse(HttpRoutePattern.Parse("/")!));
+            JsonTranscodingRouteAdapter.Parse(HttpRoutePattern.Parse("/")));
     }
 }

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/JsonTranscodingRouteAdapterTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/JsonTranscodingRouteAdapterTests.cs
@@ -1,0 +1,223 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Grpc.Shared;
+using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.FileSystemGlobbing.Internal;
+
+namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests;
+
+public class JsonTranscodingRouteAdapterTests
+{
+    [Fact]
+    public void ParseMultipleVariables()
+    {
+        var pattern = HttpRoutePattern.Parse("/shelves/{shelf}/books/{book}")!;
+        var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
+
+        Assert.Equal("/shelves/{shelf}/books/{book}", adapter.ResolvedRouteTemplate);
+        Assert.Empty(adapter.RewriteVariableActions);
+    }
+
+    [Fact]
+    public void ParseComplexVariable()
+    {
+        var route = HttpRoutePattern.Parse("/v1/{book.name=shelves/*/books/*}")!;
+        var adapter = JsonTranscodingRouteAdapter.Parse(route);
+
+        Assert.Equal("/v1/shelves/{__Complex_book.name_2}/books/{__Complex_book.name_4}", adapter.ResolvedRouteTemplate);
+        Assert.Single(adapter.RewriteVariableActions);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.RouteValues = new RouteValueDictionary
+        {
+            { "__Complex_book.name_2", "first" },
+            { "__Complex_book.name_4", "second" }
+        };
+
+        adapter.RewriteVariableActions[0](httpContext);
+
+        Assert.Equal("shelves/first/books/second", httpContext.Request.RouteValues["book.name"]);
+    }
+
+    [Fact]
+    public void ParseCatchAllSegment()
+    {
+        var pattern = HttpRoutePattern.Parse("/shelves/**")!;
+        var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
+
+        Assert.Equal("/shelves/{**__Discard_1}", adapter.ResolvedRouteTemplate);
+        Assert.Empty(adapter.RewriteVariableActions);
+    }
+
+    [Fact]
+    public void ParseAnySegment()
+    {
+        var pattern = HttpRoutePattern.Parse("/*")!;
+        var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
+
+        Assert.Equal("/{__Discard_0}", adapter.ResolvedRouteTemplate);
+        Assert.Empty(adapter.RewriteVariableActions);
+    }
+
+    [Fact]
+    public void ParseVerb()
+    {
+        var pattern = HttpRoutePattern.Parse("/a:foo")!;
+        var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
+
+        Assert.Equal("/a", adapter.ResolvedRouteTemplate);
+        Assert.Empty(adapter.RewriteVariableActions);
+    }
+
+    [Fact]
+    public void ParseAnyAndCatchAllSegment()
+    {
+        var pattern = HttpRoutePattern.Parse("/*/**")!;
+        var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
+
+        Assert.Equal("/{__Discard_0}/{**__Discard_1}", adapter.ResolvedRouteTemplate);
+        Assert.Empty(adapter.RewriteVariableActions);
+    }
+
+    [Fact]
+    public void ParseAnyAndCatchAllSegment2()
+    {
+        var pattern = HttpRoutePattern.Parse("/*/a/**")!;
+        var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
+
+        Assert.Equal("/{__Discard_0}/a/{**__Discard_2}", adapter.ResolvedRouteTemplate);
+        Assert.Empty(adapter.RewriteVariableActions);
+    }
+
+    [Fact]
+    public void ParseNestedFieldPath()
+    {
+        var pattern = HttpRoutePattern.Parse("/a/{a.b.c}")!;
+        var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
+
+        Assert.Equal("/a/{a.b.c}", adapter.ResolvedRouteTemplate);
+        Assert.Empty(adapter.RewriteVariableActions);
+    }
+
+    [Fact]
+    public void ParseComplexNestedFieldPath()
+    {
+        var pattern = HttpRoutePattern.Parse("/a/{a.b.c=*}")!;
+        var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
+
+        Assert.Equal("/a/{a.b.c}", adapter.ResolvedRouteTemplate);
+        Assert.Empty(adapter.RewriteVariableActions);
+    }
+
+    [Fact]
+    public void ParseComplexCatchAll()
+    {
+        var pattern = HttpRoutePattern.Parse("/a/{b=**}")!;
+        var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
+
+        Assert.Equal("/a/{**b}", adapter.ResolvedRouteTemplate);
+        Assert.Empty(adapter.RewriteVariableActions);
+    }
+
+    [Fact]
+    public void ParseComplexPrefixSuffixCatchAll()
+    {
+        var pattern = HttpRoutePattern.Parse("/{x.y.z=a/**/b}/c/d")!;
+        var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
+
+        Assert.Equal("/a/{**__Complex_x.y.z_1:regex(b/c/d$)}", adapter.ResolvedRouteTemplate);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.RouteValues = new RouteValueDictionary
+        {
+            { "__Complex_x.y.z_1", "my/value/b/c/d" }
+        };
+
+        adapter.RewriteVariableActions[0](httpContext);
+
+        Assert.Equal("a/my/value/b", httpContext.Request.RouteValues["x.y.z"]);
+    }
+
+    [Fact]
+    public void ParseComplexPrefixSegment()
+    {
+        var pattern = HttpRoutePattern.Parse("/a/{b=c/*}")!;
+        var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
+
+        Assert.Equal("/a/c/{__Complex_b_2}", adapter.ResolvedRouteTemplate);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.RouteValues = new RouteValueDictionary
+        {
+            { "__Complex_b_2", "value" }
+        };
+
+        adapter.RewriteVariableActions[0](httpContext);
+
+        Assert.Equal("c/value", httpContext.Request.RouteValues["b"]);
+    }
+
+    [Fact]
+    public void ParseComplexPrefixSuffixSegment()
+    {
+        var pattern = HttpRoutePattern.Parse("/a/{b=c/*/d}")!;
+        var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
+
+        Assert.Equal("/a/c/{__Complex_b_2}/d", adapter.ResolvedRouteTemplate);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.RouteValues = new RouteValueDictionary
+        {
+            { "__Complex_b_2", "value" }
+        };
+
+        adapter.RewriteVariableActions[0](httpContext);
+
+        Assert.Equal("c/value/d", httpContext.Request.RouteValues["b"]);
+    }
+
+    [Fact]
+    public void ParseComplexPathCatchAll()
+    {
+        var pattern = HttpRoutePattern.Parse("/a/{b=c/**}")!;
+        var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
+
+        Assert.Equal("/a/c/{**__Complex_b_2}", adapter.ResolvedRouteTemplate);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.RouteValues = new RouteValueDictionary
+        {
+            { "__Complex_b_2", "value" }
+        };
+
+        adapter.RewriteVariableActions[0](httpContext);
+
+        Assert.Equal("c/value", httpContext.Request.RouteValues["b"]);
+    }
+
+    [Fact]
+    public void ParseManyVariables()
+    {
+        var pattern = HttpRoutePattern.Parse("/{a}/{b}/{c}")!;
+        var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
+
+        Assert.Equal("/{a}/{b}/{c}", adapter.ResolvedRouteTemplate);
+    }
+
+    [Fact]
+    public void ParseCatchAllVerb()
+    {
+        var pattern = HttpRoutePattern.Parse("/a/{b=*}/**:verb")!;
+        var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
+
+        Assert.Equal("/a/{b}/{**__Discard_2}", adapter.ResolvedRouteTemplate);
+    }
+}

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/JsonTranscodingRouteAdapterTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/JsonTranscodingRouteAdapterTests.cs
@@ -19,7 +19,7 @@ public class JsonTranscodingRouteAdapterTests
     [Fact]
     public void ParseMultipleVariables()
     {
-        var pattern = HttpRoutePattern.Parse("/shelves/{shelf}/books/{book}")!;
+        var pattern = HttpRoutePattern.Parse("/shelves/{shelf}/books/{book}");
         var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
 
         Assert.Equal("/shelves/{shelf}/books/{book}", adapter.ResolvedRouteTemplate);
@@ -29,7 +29,7 @@ public class JsonTranscodingRouteAdapterTests
     [Fact]
     public void ParseComplexVariable()
     {
-        var route = HttpRoutePattern.Parse("/v1/{book.name=shelves/*/books/*}")!;
+        var route = HttpRoutePattern.Parse("/v1/{book.name=shelves/*/books/*}");
         var adapter = JsonTranscodingRouteAdapter.Parse(route);
 
         Assert.Equal("/v1/shelves/{__Complex_book.name_2}/books/{__Complex_book.name_4}", adapter.ResolvedRouteTemplate);
@@ -50,7 +50,7 @@ public class JsonTranscodingRouteAdapterTests
     [Fact]
     public void ParseCatchAllSegment()
     {
-        var pattern = HttpRoutePattern.Parse("/shelves/**")!;
+        var pattern = HttpRoutePattern.Parse("/shelves/**");
         var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
 
         Assert.Equal("/shelves/{**__Discard_1}", adapter.ResolvedRouteTemplate);
@@ -70,7 +70,7 @@ public class JsonTranscodingRouteAdapterTests
     [Fact]
     public void ParseVerb()
     {
-        var pattern = HttpRoutePattern.Parse("/a:foo")!;
+        var pattern = HttpRoutePattern.Parse("/a:foo");
         var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
 
         Assert.Equal("/a", adapter.ResolvedRouteTemplate);
@@ -80,7 +80,7 @@ public class JsonTranscodingRouteAdapterTests
     [Fact]
     public void ParseAnyAndCatchAllSegment()
     {
-        var pattern = HttpRoutePattern.Parse("/*/**")!;
+        var pattern = HttpRoutePattern.Parse("/*/**");
         var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
 
         Assert.Equal("/{__Discard_0}/{**__Discard_1}", adapter.ResolvedRouteTemplate);
@@ -90,7 +90,7 @@ public class JsonTranscodingRouteAdapterTests
     [Fact]
     public void ParseAnyAndCatchAllSegment2()
     {
-        var pattern = HttpRoutePattern.Parse("/*/a/**")!;
+        var pattern = HttpRoutePattern.Parse("/*/a/**");
         var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
 
         Assert.Equal("/{__Discard_0}/a/{**__Discard_2}", adapter.ResolvedRouteTemplate);
@@ -100,7 +100,7 @@ public class JsonTranscodingRouteAdapterTests
     [Fact]
     public void ParseNestedFieldPath()
     {
-        var pattern = HttpRoutePattern.Parse("/a/{a.b.c}")!;
+        var pattern = HttpRoutePattern.Parse("/a/{a.b.c}");
         var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
 
         Assert.Equal("/a/{a.b.c}", adapter.ResolvedRouteTemplate);
@@ -110,7 +110,7 @@ public class JsonTranscodingRouteAdapterTests
     [Fact]
     public void ParseComplexNestedFieldPath()
     {
-        var pattern = HttpRoutePattern.Parse("/a/{a.b.c=*}")!;
+        var pattern = HttpRoutePattern.Parse("/a/{a.b.c=*}");
         var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
 
         Assert.Equal("/a/{a.b.c}", adapter.ResolvedRouteTemplate);
@@ -120,7 +120,7 @@ public class JsonTranscodingRouteAdapterTests
     [Fact]
     public void ParseComplexCatchAll()
     {
-        var pattern = HttpRoutePattern.Parse("/a/{b=**}")!;
+        var pattern = HttpRoutePattern.Parse("/a/{b=**}");
         var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
 
         Assert.Equal("/a/{**b}", adapter.ResolvedRouteTemplate);
@@ -130,7 +130,7 @@ public class JsonTranscodingRouteAdapterTests
     [Fact]
     public void ParseComplexPrefixSuffixCatchAll()
     {
-        var pattern = HttpRoutePattern.Parse("/{x.y.z=a/**/b}/c/d")!;
+        var pattern = HttpRoutePattern.Parse("/{x.y.z=a/**/b}/c/d");
         var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
 
         Assert.Equal("/a/{**__Complex_x.y.z_1:regex(b/c/d$)}", adapter.ResolvedRouteTemplate);
@@ -149,7 +149,7 @@ public class JsonTranscodingRouteAdapterTests
     [Fact]
     public void ParseComplexPrefixSegment()
     {
-        var pattern = HttpRoutePattern.Parse("/a/{b=c/*}")!;
+        var pattern = HttpRoutePattern.Parse("/a/{b=c/*}");
         var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
 
         Assert.Equal("/a/c/{__Complex_b_2}", adapter.ResolvedRouteTemplate);
@@ -168,7 +168,7 @@ public class JsonTranscodingRouteAdapterTests
     [Fact]
     public void ParseComplexPrefixSuffixSegment()
     {
-        var pattern = HttpRoutePattern.Parse("/a/{b=c/*/d}")!;
+        var pattern = HttpRoutePattern.Parse("/a/{b=c/*/d}");
         var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
 
         Assert.Equal("/a/c/{__Complex_b_2}/d", adapter.ResolvedRouteTemplate);
@@ -187,7 +187,7 @@ public class JsonTranscodingRouteAdapterTests
     [Fact]
     public void ParseComplexPathCatchAll()
     {
-        var pattern = HttpRoutePattern.Parse("/a/{b=c/**}")!;
+        var pattern = HttpRoutePattern.Parse("/a/{b=c/**}");
         var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
 
         Assert.Equal("/a/c/{**__Complex_b_2}", adapter.ResolvedRouteTemplate);
@@ -206,7 +206,7 @@ public class JsonTranscodingRouteAdapterTests
     [Fact]
     public void ParseManyVariables()
     {
-        var pattern = HttpRoutePattern.Parse("/{a}/{b}/{c}")!;
+        var pattern = HttpRoutePattern.Parse("/{a}/{b}/{c}");
         var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
 
         Assert.Equal("/{a}/{b}/{c}", adapter.ResolvedRouteTemplate);
@@ -215,7 +215,7 @@ public class JsonTranscodingRouteAdapterTests
     [Fact]
     public void ParseCatchAllVerb()
     {
-        var pattern = HttpRoutePattern.Parse("/a/{b=*}/**:verb")!;
+        var pattern = HttpRoutePattern.Parse("/a/{b=*}/**:verb");
         var adapter = JsonTranscodingRouteAdapter.Parse(pattern);
 
         Assert.Equal("/a/{b}/{**__Discard_2}", adapter.ResolvedRouteTemplate);

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/JsonTranscodingServerCallContextTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/JsonTranscodingServerCallContextTests.cs
@@ -5,6 +5,7 @@ using System.Net;
 using Google.Protobuf.Reflection;
 using Grpc.AspNetCore.Server;
 using Grpc.Core;
+using Grpc.Shared;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.CallHandlers;
 using Microsoft.AspNetCore.Http;
@@ -99,7 +100,8 @@ public class JsonTranscodingServerCallContextTests
                 null,
                 false,
                 null,
-                new Dictionary<string, List<FieldDescriptor>>()),
+                new Dictionary<string, List<FieldDescriptor>>(),
+                JsonTranscodingRouteAdapter.Parse(HttpRoutePattern.Parse("/")!)),
             NullLogger.Instance);
     }
 }

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/JsonTranscodingServiceMethodProviderTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/JsonTranscodingServiceMethodProviderTests.cs
@@ -173,7 +173,8 @@ public class JsonTranscodingServiceMethodProviderTests
         // Assert
         Assert.Equal("Error binding gRPC service 'JsonTranscodingInvalidPatternGreeterService'.", ex.Message);
         Assert.Equal("Error binding BadPattern on JsonTranscodingInvalidPatternGreeterService to HTTP API.", ex.InnerException!.InnerException!.Message);
-        Assert.Equal("Path template 'v1/greeter/{name}' must start with a '/'.", ex.InnerException!.InnerException!.InnerException!.Message);
+        Assert.Equal("Error parsing path template 'v1/greeter/{name}'.", ex.InnerException!.InnerException!.InnerException!.Message);
+        Assert.Equal("Path template must start with a '/'.", ex.InnerException!.InnerException!.InnerException!.InnerException!.Message);
     }
 
     private static RouteEndpoint FindGrpcEndpoint(IReadOnlyList<Endpoint> endpoints, string methodName)

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/UnaryServerCallHandlerTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/UnaryServerCallHandlerTests.cs
@@ -222,7 +222,7 @@ public class UnaryServerCallHandlerTests : LoggedTest
             return Task.FromResult(new HelloReply { Message = $"Hello {r.Name}" });
         };
 
-        ServiceDescriptorHelpers.TryResolveDescriptors(HelloRequest.Descriptor, "sub", out var bodyFieldDescriptors);
+        ServiceDescriptorHelpers.TryResolveDescriptors(HelloRequest.Descriptor, new[] { "sub" }, out var bodyFieldDescriptors);
 
         var descriptorInfo = TestHelpers.CreateDescriptorInfo(
             bodyDescriptor: HelloRequest.Types.SubMessage.Descriptor,
@@ -264,7 +264,7 @@ public class UnaryServerCallHandlerTests : LoggedTest
             return Task.FromResult(new HelloReply { Message = $"Hello {r.Name}" });
         };
 
-        ServiceDescriptorHelpers.TryResolveDescriptors(HelloRequest.Descriptor, "repeated_strings", out var bodyFieldDescriptors);
+        ServiceDescriptorHelpers.TryResolveDescriptors(HelloRequest.Descriptor, new[] { "repeated_strings" }, out var bodyFieldDescriptors);
 
         var descriptorInfo = TestHelpers.CreateDescriptorInfo(
             bodyDescriptor: HelloRequest.Types.SubMessage.Descriptor,
@@ -318,7 +318,7 @@ public class UnaryServerCallHandlerTests : LoggedTest
             return Task.FromResult(new HelloReply { Message = $"Hello {r.Name}" });
         };
 
-        ServiceDescriptorHelpers.TryResolveDescriptors(HelloRequest.Descriptor, "sub.subfields", out var bodyFieldDescriptors);
+        ServiceDescriptorHelpers.TryResolveDescriptors(HelloRequest.Descriptor, new[] { "sub", "subfields" }, out var bodyFieldDescriptors);
 
         var descriptorInfo = TestHelpers.CreateDescriptorInfo(
             bodyDescriptor: HelloRequest.Types.SubMessage.Descriptor,
@@ -463,7 +463,7 @@ public class UnaryServerCallHandlerTests : LoggedTest
             return Task.FromResult(new HelloReply());
         };
 
-        ServiceDescriptorHelpers.TryResolveDescriptors(HelloRequest.Descriptor, "repeated_strings", out var bodyFieldDescriptors);
+        ServiceDescriptorHelpers.TryResolveDescriptors(HelloRequest.Descriptor, new[] { "repeated_strings" }, out var bodyFieldDescriptors);
 
         var descriptorInfo = TestHelpers.CreateDescriptorInfo(
             bodyDescriptor: HelloRequest.Types.SubMessage.Descriptor,
@@ -503,7 +503,7 @@ public class UnaryServerCallHandlerTests : LoggedTest
             invoker,
             descriptorInfo: TestHelpers.CreateDescriptorInfo(bodyDescriptor: HelloRequest.Descriptor));
         var httpContext = TestHelpers.CreateHttpContext();
-        httpContext.Request.Body = new MemoryStream("{}"u8);
+        httpContext.Request.Body = new MemoryStream("{}"u8.ToArray());
         httpContext.Request.ContentType = contentType;
         // Act
         await unaryServerCallHandler.HandleCallAsync(httpContext);
@@ -707,7 +707,7 @@ public class UnaryServerCallHandlerTests : LoggedTest
 
         var httpContext = TestHelpers.CreateHttpContext();
         httpContext.Request.ContentType = "application/json";
-        httpContext.Request.Body = new MemoryStream("null"u8);
+        httpContext.Request.Body = new MemoryStream("null"u8.ToArray());
 
         // Act
         await unaryServerCallHandler.HandleCallAsync(httpContext);
@@ -733,7 +733,7 @@ public class UnaryServerCallHandlerTests : LoggedTest
             return Task.FromResult(new HelloReply());
         };
 
-        Assert.True(ServiceDescriptorHelpers.TryResolveDescriptors(HelloRequest.Descriptor, "wrappers.float_value", out var bodyFieldDescriptors));
+        Assert.True(ServiceDescriptorHelpers.TryResolveDescriptors(HelloRequest.Descriptor, new[] { "wrappers", "float_value" }, out var bodyFieldDescriptors));
 
         var descriptorInfo = TestHelpers.CreateDescriptorInfo(
             bodyDescriptor: FloatValue.Descriptor,
@@ -795,7 +795,7 @@ public class UnaryServerCallHandlerTests : LoggedTest
             return Task.FromResult(new HelloReply { Message = $"Hello {r.Name}" });
         };
 
-        ServiceDescriptorHelpers.TryResolveDescriptors(HttpBodySubField.Descriptor, "sub", out var bodyFieldDescriptors);
+        ServiceDescriptorHelpers.TryResolveDescriptors(HttpBodySubField.Descriptor, new[] { "sub" }, out var bodyFieldDescriptors);
 
         var descriptorInfo = TestHelpers.CreateDescriptorInfo(
             bodyDescriptor: HttpBody.Descriptor,
@@ -834,7 +834,7 @@ public class UnaryServerCallHandlerTests : LoggedTest
             return Task.FromResult(new HelloReply { Message = $"Hello {r.Name}" });
         };
 
-        ServiceDescriptorHelpers.TryResolveDescriptors(NestedHttpBodySubField.Descriptor, "sub.sub", out var bodyFieldDescriptors);
+        ServiceDescriptorHelpers.TryResolveDescriptors(NestedHttpBodySubField.Descriptor, new[] { "sub", "sub" }, out var bodyFieldDescriptors);
 
         var descriptorInfo = TestHelpers.CreateDescriptorInfo(
             bodyDescriptor: HttpBody.Descriptor,

--- a/src/Grpc/JsonTranscoding/test/testassets/IntegrationTestsWebsite/Protos/greet.proto
+++ b/src/Grpc/JsonTranscoding/test/testassets/IntegrationTestsWebsite/Protos/greet.proto
@@ -20,6 +20,21 @@ service Greeter {
       body: "*"
     };
   }
+  rpc SayHelloComplex (HelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      get: "/v1/greeter/{name=from/*}"
+    };
+  }
+  rpc SayHelloComplexCatchAll1 (HelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      get: "/{name=v1/greeter/**/b}/c/d/one"
+    };
+  }
+  rpc SayHelloComplexCatchAll2 (HelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      get: "/{name=v1/greeter/**/b}/c/d/two"
+    };
+  }
 }
 
 // The request message containing the user's name.

--- a/src/Grpc/JsonTranscoding/test/testassets/IntegrationTestsWebsite/Protos/greet.proto
+++ b/src/Grpc/JsonTranscoding/test/testassets/IntegrationTestsWebsite/Protos/greet.proto
@@ -35,11 +35,24 @@ service Greeter {
       get: "/{name=v1/greeter/**/b}/c/d/two"
     };
   }
+  rpc SayHelloComplexCatchAll3 (ComplextHelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      get: "/v1/{name.last_name}/{name.first_name=complex_greeter/**/b}/c/d/two"
+    };
+  }
 }
 
 // The request message containing the user's name.
 message HelloRequest {
   string name = 1;
+}
+
+message ComplextHelloRequest {
+  NameDetail name = 1;
+  message NameDetail {
+    string first_name = 1;
+    string last_name = 2;
+  }
 }
 
 // The response message containing the greetings.


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/34524

gRPC JSON transcoding supports parameters that span multiple segments. This isn't in ASP.NET Core routing and errors if given this syntax.

For example: `/v1/{book=shelves/*/books/*}` specifies as mult-segment `book` parameter. It matches `/v1/shelves/james/books/cool-book` and the parameter has the value `shelves/james/books/cool-book`.

New in this PR is a parser that understands this routing syntax and adapts it to ASP.NET Core route.