### PR TITLE
Fix H3 Client Cert tests 

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
@@ -101,18 +101,15 @@ public class QuicConnectionListenerTests : TestApplicationErrorLoggerLoggedTest
 
     [ConditionalFact]
     [MsQuicSupported]
-    // https://github.com/dotnet/runtime/issues/57308, RemoteCertificateValidationCallback should allow us to accept a null cert,
-    // but it doesn't right now.
     [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/41894")]
-    public async Task ClientCertificate_Required_NotSent_ConnectionAborted()
+    public async Task ClientCertificate_Required_NotSent_AcceptedViaCallback()
     {
         await using var connectionListener = await QuicTestHelpers.CreateConnectionListenerFactory(LoggerFactory, clientCertificateRequired: true);
 
         var options = QuicTestHelpers.CreateClientConnectionOptions(connectionListener.EndPoint);
         using var clientConnection = new QuicConnection(options);
 
-        var qex = await Assert.ThrowsAnyAsync<QuicException>(async () => await clientConnection.ConnectAsync().DefaultTimeout());
-        Assert.StartsWith("Connection has been shutdown by transport:", qex.Message);
+        await clientConnection.ConnectAsync().DefaultTimeout();
+        Assert.True(clientConnection.Connected);
     }
 }

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -393,7 +393,6 @@ public class Http3RequestTests : LoggedTest
     [MsQuicSupported]
     [InlineData(HttpProtocols.Http3)]
     [InlineData(HttpProtocols.Http2)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35070")]
     public async Task POST_ServerAbort_ClientReceivesAbort(HttpProtocols protocol)
     {
         // Arrange


### PR DESCRIPTION
Fixes #41894 - These tests covered prior behavior before the client cert feature was fully implemented in runtime. They've been updated to reflect the new behavior.
- ClientCertificate_Allow_NotAvailable_Optional 
- ClientCertificate_Required_NotSent_ConnectionAborted

#35070 improvements. These are the last two tests for 35070, marking as test-fixed.
- POST_ServerAbort_ClientReceivesAbort has been passing 100% and is being unquarantined.
- ClientCertificate_AllowOrRequire_Available_Invalid_Refused fixed by properly draining/disposing the response.

