### PR TITLE
Implement analyzer to favor using builder.Logging over ConfigureLogging

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -82,7 +82,7 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor DoNotUseHostConfigureLogging = new(
         "ASP0011",
-        "Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLoggin",
+        "Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging",
         "Suggest using builder.Logging instead of {0}",
         "Usage",
         DiagnosticSeverity.Warning,

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -79,4 +79,13 @@ internal static class DiagnosticDescriptors
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         helpLinkUri: "https://aka.ms/aspnet/analyzers");
+
+    internal static readonly DiagnosticDescriptor DoNotUseHostConfigureLogging = new(
+        "ASP0011",
+        "Do not use ConfigureLogging with WebApplication.Host or WebApplication.WebHost",
+        "Favor using builder.Logging",
+        "Usage",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        helpLinkUri: "https://aka.ms/aspnet/analyzers");
 }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -82,8 +82,8 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor DoNotUseHostConfigureLogging = new(
         "ASP0011",
-        "Do not use ConfigureLogging with WebApplication.Host or WebApplication.WebHost",
-        "Favor using builder.Logging",
+        "Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLoggin",
+        "Suggest using builder.Logging instead of {0}",
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/WebApplicationBuilder/WebApplicationBuilderAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/WebApplicationBuilder/WebApplicationBuilderAnalyzer.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Net.NetworkInformation;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -46,7 +45,6 @@ public class WebApplicationBuilderAnalyzer : DiagnosticAnalyzer
                 wellKnownTypes.HostingAbstractionsWebHostBuilderExtensions,
                 wellKnownTypes.WebHostBuilderExtensions,
             };
-            //add INamedTypeSymbol[] wellKnownTypes.OURANALYZER
             INamedTypeSymbol[] configureLoggingTypes =
             {
                 wellKnownTypes.HostingHostBuilderExtensions,
@@ -106,7 +104,8 @@ public class WebApplicationBuilderAnalyzer : DiagnosticAnalyzer
                             invocation));
                 }
 
-                //Configure Logging
+                //var builder = WebApplication.CreateBuilder(args);
+                //builder.Host.ConfigureLogging(x => {})
                 if (IsDisallowedMethod(
                         operationAnalysisContext,
                         invocation,
@@ -121,6 +120,8 @@ public class WebApplicationBuilderAnalyzer : DiagnosticAnalyzer
                             invocation));
                 }
 
+                //var builder = WebApplication.CreateBuilder(args);
+                //builder.WebHost.ConfigureLogging(x => {})
                 if (IsDisallowedMethod(
                         operationAnalysisContext,
                         invocation,

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/WebApplicationBuilder/WebApplicationBuilderAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/WebApplicationBuilder/WebApplicationBuilderAnalyzer.cs
@@ -185,7 +185,7 @@ public class WebApplicationBuilderAnalyzer : DiagnosticAnalyzer
                         location = Location.Create(operation.Syntax.SyntaxTree, targetSpan);
                     }
 
-                    return Diagnostic.Create(descriptor, location);
+                    return Diagnostic.Create(descriptor, location, methodName);
                 }
 
             }, OperationKind.Invocation);

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/WebApplicationBuilder/WellKnownTypes.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/WebApplicationBuilder/WellKnownTypes.cs
@@ -42,6 +42,12 @@ internal sealed class WellKnownTypes
             return false;
         }
 
+        const string HostingHostBuilderExtensions = "Microsoft.Extensions.Hosting.HostingHostBuilderExtensions";
+        if (compilation.GetTypeByMetadataName(HostingHostBuilderExtensions) is not { } hostingHostBuilderExtensions)
+        {
+            return false;
+        }
+
         wellKnownTypes = new WellKnownTypes
         {
             ConfigureHostBuilder = configureHostBuilder,
@@ -49,6 +55,7 @@ internal sealed class WellKnownTypes
             GenericHostWebHostBuilderExtensions = genericHostWebHostBuilderExtensions,
             HostingAbstractionsWebHostBuilderExtensions = hostingAbstractionsWebHostBuilderExtensions,
             WebHostBuilderExtensions = webHostBuilderExtensions,
+            HostingHostBuilderExtensions = hostingHostBuilderExtensions
         };
 
         return true;
@@ -59,4 +66,5 @@ internal sealed class WellKnownTypes
     public INamedTypeSymbol GenericHostWebHostBuilderExtensions { get; private init; }
     public INamedTypeSymbol HostingAbstractionsWebHostBuilderExtensions { get; private init; }
     public INamedTypeSymbol WebHostBuilderExtensions { get; private init; }
+    public INamedTypeSymbol HostingHostBuilderExtensions { get; private init; }
 }

--- a/src/Framework/AspNetCoreAnalyzers/test/WebApplicationBuilder/DisallowConfigureHostLoggingTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/WebApplicationBuilder/DisallowConfigureHostLoggingTest.cs
@@ -1,0 +1,276 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Globalization;
+using Microsoft.AspNetCore.Analyzer.Testing;
+namespace Microsoft.AspNetCore.Analyzers.WebApplicationBuilder;
+public partial class DisallowConfigureHostLoggingTest
+{
+    private TestDiagnosticAnalyzerRunner Runner { get; } = new(new WebApplicationBuilderAnalyzer());
+
+    [Fact]
+    public async Task DoesNotWarnWhenBuilderLoggingIsUsed()
+    {
+        //arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+var builder = WebApplication.CreateBuilder(args);
+builder.Logging.AddJsonConsole();
+";
+        //act
+        var diagnostics = await Runner.GetDiagnosticsAsync(source);
+        //assert
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task DoesNotWarnWhenBuilderLoggingIsUsed_InMain()
+    {
+        //arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+public static class Program
+{
+    public static void Main (string[] args)
+    {
+        var builder = WebApplication.CreateBuilder(args);
+        builder.Logging.AddJsonConsole();
+    }
+}
+public class Startup { }
+";
+        //act
+        var diagnostics = await Runner.GetDiagnosticsAsync(source);
+        //assert
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task WarnsWhenBuilderLoggingIsNotUsed_Host()
+    {
+        //arrange
+        var source = TestSource.Read(@"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+var builder = WebApplication.CreateBuilder(args);
+builder.Host./*MM*/ConfigureLogging(logging =>
+{
+logging.AddJsonConsole();
+});
+");
+        //act
+        var diagnostics = await Runner.GetDiagnosticsAsync(source.Source);
+        //assert
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Same(DiagnosticDescriptors.DoNotUseHostConfigureLogging, diagnostic.Descriptor);
+        AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
+        Assert.Equal("Favor using builder.Logging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task WarnsWhenBuilderLoggingIsNotUsed_WebHost()
+    {
+        //arrange
+        var source = TestSource.Read(@"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Hosting;
+var builder = WebApplication.CreateBuilder(args);
+builder.WebHost./*MM*/ConfigureLogging(logging =>
+{
+logging.AddJsonConsole();
+});
+");
+        //act
+        var diagnostics = await Runner.GetDiagnosticsAsync(source.Source);
+        //assert
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Same(DiagnosticDescriptors.DoNotUseHostConfigureLogging, diagnostic.Descriptor);
+        AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
+        Assert.Equal("Favor using builder.Logging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task WarnsWhenBuilderLoggingIsNotUsed_OnDifferentLine_Host()
+    {
+        //arrange
+        var source = TestSource.Read(@"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+var builder = WebApplication.CreateBuilder(args);
+builder.Host.
+    /*MM*/ConfigureLogging(logging =>
+{
+    logging.AddJsonConsole();
+});
+");
+        //act
+        var diagnostics = await Runner.GetDiagnosticsAsync(source.Source);
+        //assert
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Same(DiagnosticDescriptors.DoNotUseHostConfigureLogging, diagnostic.Descriptor);
+        AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
+        Assert.Equal("Favor using builder.Logging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task WarnsWhenBuilderLoggingIsNotUsed_OnDifferentLine_WebHost()
+    {
+        //arrange
+        var source = TestSource.Read(@"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Hosting;
+var builder = WebApplication.CreateBuilder(args);
+builder.WebHost.
+    /*MM*/ConfigureLogging(logging =>
+{
+logging.AddJsonConsole();
+});
+");
+        //act
+        var diagnostics = await Runner.GetDiagnosticsAsync(source.Source);
+        //assert
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Same(DiagnosticDescriptors.DoNotUseHostConfigureLogging, diagnostic.Descriptor);
+        AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
+        Assert.Equal("Favor using builder.Logging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task WarnsWhenBuilderLoggingIsNotUsed_InMain_Host()
+    {
+        //arrange
+        var source = TestSource.Read(@"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+public static class Program
+{
+    public static void Main (string[] args)
+    {
+        var builder = WebApplication.CreateBuilder(args);
+        builder.Host./*MM*/ConfigureLogging(logging =>
+        {
+        logging.AddJsonConsole();
+        });
+    }
+}
+public class Startup { }
+");
+        //act
+        var diagnostics = await Runner.GetDiagnosticsAsync(source.Source);
+        //assert
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Same(DiagnosticDescriptors.DoNotUseHostConfigureLogging, diagnostic.Descriptor);
+        AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
+        Assert.Equal("Favor using builder.Logging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task WarnsWhenBuilderLoggingIsNotUsed_InMain_WebHost()
+    {
+        //arrange
+        var source = TestSource.Read(@"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Hosting;
+public static class Program
+{
+    public static void Main (string[] args)
+    {
+        var builder = WebApplication.CreateBuilder(args);
+        builder.WebHost./*MM*/ConfigureLogging(logging =>
+        {
+        logging.AddJsonConsole();
+        });
+    }
+}
+public class Startup { }
+");
+        //act
+        var diagnostics = await Runner.GetDiagnosticsAsync(source.Source);
+        //assert
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Same(DiagnosticDescriptors.DoNotUseHostConfigureLogging, diagnostic.Descriptor);
+        AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
+        Assert.Equal("Favor using builder.Logging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task WarnsWhenBuilderLoggingIsNotUsed_WhenChained_WebHost()
+    {
+        //arrange
+        var source = TestSource.Read(@"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Hosting;
+var builder = WebApplication.CreateBuilder(args);
+builder.WebHost.
+    /*MM*/ConfigureLogging(logging => { })
+    .ConfigureServices(services => { });
+");
+        //act
+        var diagnostics = await Runner.GetDiagnosticsAsync(source.Source);
+        //assert
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Same(DiagnosticDescriptors.DoNotUseHostConfigureLogging, diagnostic.Descriptor);
+        AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
+        Assert.Equal("Favor using builder.Logging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task WarnsTwiceWhenBuilderLoggingIsNotUsed_Host()
+    {
+        //arrange
+        var source = TestSource.Read(@"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+var builder = WebApplication.CreateBuilder(args);
+builder.Host./*MM1*/ConfigureLogging(logging =>
+{
+logging.AddJsonConsole();
+});
+builder.Host./*MM2*/ConfigureLogging(logging =>
+{
+logging.AddJsonConsole();
+});
+");
+        //act
+        var diagnostics = await Runner.GetDiagnosticsAsync(source.Source);
+        //assert
+        Assert.Equal(2, diagnostics.Length);
+        var diagnostic1 = diagnostics[0];
+        var diagnostic2 = diagnostics[1];
+
+        Assert.Same(DiagnosticDescriptors.DoNotUseHostConfigureLogging, diagnostic1.Descriptor);
+        AnalyzerAssert.DiagnosticLocation(source.MarkerLocations["MM1"], diagnostic1.Location);
+        Assert.Equal("Favor using builder.Logging", diagnostic1.GetMessage(CultureInfo.InvariantCulture));
+
+        Assert.Same(DiagnosticDescriptors.DoNotUseHostConfigureLogging, diagnostic2.Descriptor);
+        AnalyzerAssert.DiagnosticLocation(source.MarkerLocations["MM2"], diagnostic2.Location);
+        Assert.Equal("Favor using builder.Logging", diagnostic2.GetMessage(CultureInfo.InvariantCulture));
+    }
+
+}
+

--- a/src/Framework/AspNetCoreAnalyzers/test/WebApplicationBuilder/DisallowConfigureHostLoggingTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/WebApplicationBuilder/DisallowConfigureHostLoggingTest.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System.Globalization;
 using Microsoft.AspNetCore.Analyzer.Testing;
+using Microsoft.CodeAnalysis;
+
 namespace Microsoft.AspNetCore.Analyzers.WebApplicationBuilder;
 public partial class DisallowConfigureHostLoggingTest
 {
@@ -71,7 +73,7 @@ logging.AddJsonConsole();
         var diagnostic = Assert.Single(diagnostics);
         Assert.Same(DiagnosticDescriptors.DoNotUseHostConfigureLogging, diagnostic.Descriptor);
         AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
-        Assert.Equal("Favor using builder.Logging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+        Assert.Equal("Suggest using builder.Logging instead of ConfigureLogging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
     }
 
     [Fact]
@@ -96,7 +98,7 @@ logging.AddJsonConsole();
         var diagnostic = Assert.Single(diagnostics);
         Assert.Same(DiagnosticDescriptors.DoNotUseHostConfigureLogging, diagnostic.Descriptor);
         AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
-        Assert.Equal("Favor using builder.Logging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+        Assert.Equal("Suggest using builder.Logging instead of ConfigureLogging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
     }
 
     [Fact]
@@ -121,7 +123,7 @@ builder.Host.
         var diagnostic = Assert.Single(diagnostics);
         Assert.Same(DiagnosticDescriptors.DoNotUseHostConfigureLogging, diagnostic.Descriptor);
         AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
-        Assert.Equal("Favor using builder.Logging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+        Assert.Equal("Suggest using builder.Logging instead of ConfigureLogging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
     }
 
     [Fact]
@@ -147,7 +149,7 @@ logging.AddJsonConsole();
         var diagnostic = Assert.Single(diagnostics);
         Assert.Same(DiagnosticDescriptors.DoNotUseHostConfigureLogging, diagnostic.Descriptor);
         AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
-        Assert.Equal("Favor using builder.Logging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+        Assert.Equal("Suggest using builder.Logging instead of ConfigureLogging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
     }
 
     [Fact]
@@ -178,7 +180,7 @@ public class Startup { }
         var diagnostic = Assert.Single(diagnostics);
         Assert.Same(DiagnosticDescriptors.DoNotUseHostConfigureLogging, diagnostic.Descriptor);
         AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
-        Assert.Equal("Favor using builder.Logging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+        Assert.Equal("Suggest using builder.Logging instead of ConfigureLogging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
     }
 
     [Fact]
@@ -210,7 +212,7 @@ public class Startup { }
         var diagnostic = Assert.Single(diagnostics);
         Assert.Same(DiagnosticDescriptors.DoNotUseHostConfigureLogging, diagnostic.Descriptor);
         AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
-        Assert.Equal("Favor using builder.Logging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+        Assert.Equal("Suggest using builder.Logging instead of ConfigureLogging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
     }
 
     [Fact]
@@ -234,7 +236,7 @@ builder.WebHost.
         var diagnostic = Assert.Single(diagnostics);
         Assert.Same(DiagnosticDescriptors.DoNotUseHostConfigureLogging, diagnostic.Descriptor);
         AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
-        Assert.Equal("Favor using builder.Logging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+        Assert.Equal("Suggest using builder.Logging instead of ConfigureLogging", diagnostic.GetMessage(CultureInfo.InvariantCulture));
     }
 
     [Fact]
@@ -265,11 +267,11 @@ logging.AddJsonConsole();
 
         Assert.Same(DiagnosticDescriptors.DoNotUseHostConfigureLogging, diagnostic1.Descriptor);
         AnalyzerAssert.DiagnosticLocation(source.MarkerLocations["MM1"], diagnostic1.Location);
-        Assert.Equal("Favor using builder.Logging", diagnostic1.GetMessage(CultureInfo.InvariantCulture));
+        Assert.Equal("Suggest using builder.Logging instead of ConfigureLogging", diagnostic1.GetMessage(CultureInfo.InvariantCulture));
 
         Assert.Same(DiagnosticDescriptors.DoNotUseHostConfigureLogging, diagnostic2.Descriptor);
         AnalyzerAssert.DiagnosticLocation(source.MarkerLocations["MM2"], diagnostic2.Location);
-        Assert.Equal("Favor using builder.Logging", diagnostic2.GetMessage(CultureInfo.InvariantCulture));
+        Assert.Equal("Suggest using builder.Logging instead of ConfigureLogging", diagnostic2.GetMessage(CultureInfo.InvariantCulture));
     }
 
 }


### PR DESCRIPTION
# Add analyzer to suggest rewriting builder.Host.ConfigureLogging to builder.Logging

Analyzer that corresponds to issue #35816. 

## Description
Add analyzers that warns when using builder.Host.ConfigureLogging/builder.WebHost.ConfigureLogging, and favors using builder.Logging

Fixes 
#35816 