### PR TITLE
Update `dotnet new blazorwasm --exclude-launch-settings` to exclude launchSettings.json

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -293,6 +293,13 @@
             "Client/Shared/NavMenu.NoGraphOrApi.razor",
             "Client/Shared/NavMenu.CallsMicrosoftGraph.razor"
           ]
+        },
+        {
+          "condition": "(ExcludeLaunchSettings)",
+          "exclude": [
+            "Client/Properties/launchSettings.json",
+            "Server/Properties/launchSettings.json"
+          ]
         }
       ]
     }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/.template.config/template.json
@@ -54,7 +54,8 @@
         {
           "condition": "(ExcludeLaunchSettings)",
           "exclude": [
-            "Properties/launchSettings.json"
+            "Client/Properties/launchSettings.json",
+            "Server/Properties/launchSettings.json"
           ]
         },
         {

--- a/src/ProjectTemplates/test/Templates.Tests/template-baselines.json
+++ b/src/ProjectTemplates/test/Templates.Tests/template-baselines.json
@@ -1821,6 +1821,23 @@
           "MainLayout.razor",
           "Program.cs"
         ]
+      },
+      "ExcludeLaunchSettingsHosted": {
+        "Template": "blazorwasm-empty",
+        "Arguments": "new blazorwasm-empty --hosted --exclude-launch-settings",
+        "Files": [
+          "Client/_Imports.razor",
+          "Client/App.razor",
+          "Client/MainLayout.razor",
+          "Client/Program.cs",
+          "Client/Pages/Index.razor",
+          "Client/wwwroot/index.html",
+          "Client/wwwroot/css/app.css",
+          "Server/appsettings.Development.json",
+          "Server/appsettings.json",
+          "Server/Program.cs",
+          "Shared/SharedClass.cs"
+        ]
       }
     }
   }


### PR DESCRIPTION
Updated the modifiers for the Blazor WebAssembly project templates to exclude `launchSettings.json` when `--exclude-launch-settings` is specified.

Fixes #42331 
