### PR TITLE
Unquarantine WorkerTemplate test

### DIFF
--- a/src/ProjectTemplates/test/Templates.Tests/WorkerTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/WorkerTemplateTest.cs
@@ -31,11 +31,9 @@ public class WorkerTemplateTest : LoggedTest
     }
 
     [ConditionalTheory]
-    [OSSkipCondition(OperatingSystems.Linux, SkipReason = "https://github.com/dotnet/sdk/issues/12831")]
     [InlineData("C#", null)]
     [InlineData("C#", new [] { ArgConstants.UseProgramMain })]
     [InlineData("F#", null)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/25404")]
     public async Task WorkerTemplateAsync(string language, string[] args)
     {
         var project = await ProjectFactory.CreateProject(Output);


### PR DESCRIPTION
Test was quarantined 2 years ago, the last 30 days show 100s of passes no failures, so I think it deserves to be unquarantined.

Additionally, the linux issue was fixed last year, so let it run on linux.

Closes https://github.com/dotnet/aspnetcore/issues/25404