### PR TITLE
Small test assert changes for flaky tests

### DIFF
--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.FunctionalTests/WebHostFunctionalTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.FunctionalTests/WebHostFunctionalTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Http;
@@ -126,7 +126,7 @@ public class WebHostFunctionalTests : LoggedTest
 
                 logger.Log(LogLevel.Information, 0, "Message", null, (s, e) =>
                 {
-                    Assert.True(false);
+                    Assert.True(false, "Information log when log level set to warning in config");
                     return string.Empty;
                 });
 

--- a/src/Hosting/Hosting/test/HostingApplicationTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationTests.cs
@@ -115,6 +115,8 @@ public class HostingApplicationTests
         using var _ = dummySource.StartActivity("DummyActivity");
 
         Assert.Same(initialActivity, activityFeature.Activity);
+        Assert.Null(activityFeature.Activity.ParentId);
+        Assert.Equal(activityFeature.Activity.Id, Activity.Current.ParentId);
         Assert.NotEqual(Activity.Current, activityFeature.Activity);
 
         // Act/Assert
@@ -156,6 +158,8 @@ public class HostingApplicationTests
         using var _ = dummySource.StartActivity("DummyActivity");
 
         Assert.Same(initialActivity, activityFeature.Activity);
+        Assert.Null(activityFeature.Activity.ParentId);
+        Assert.Equal(activityFeature.Activity.Id, Activity.Current.ParentId);
         Assert.NotEqual(Activity.Current, activityFeature.Activity);
 
         // Act/Assert


### PR DESCRIPTION
Trying to understand some flaky test failures by adding additional info/different asserts.