### PR TITLE
Throw from OnConnected and OnDisconnected when using client results

### DIFF
--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -90,6 +90,9 @@ internal sealed partial class DefaultHubDispatcher<THub> : HubDispatcher<THub> w
             {
                 await hub.OnConnectedAsync();
             }
+
+            // OnConnectedAsync is finished, allow hub methods to use client results (ISingleClientProxy.InvokeAsync)
+            connection.HubCallerClients.InvokeAllowed = true;
         }
         finally
         {
@@ -106,6 +109,9 @@ internal sealed partial class DefaultHubDispatcher<THub> : HubDispatcher<THub> w
         try
         {
             InitializeHub(hub, connection);
+
+            // OnDisonnectedAsync is being called, we don't want to allow client results to be used (ISingleClientProxy.InvokeAsync)
+            connection.HubCallerClients.InvokeAllowed = false;
 
             if (_onDisconnectedMiddleware != null)
             {

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -110,9 +110,6 @@ internal sealed partial class DefaultHubDispatcher<THub> : HubDispatcher<THub> w
         {
             InitializeHub(hub, connection);
 
-            // OnDisonnectedAsync is being called, we don't want to allow client results to be used (ISingleClientProxy.InvokeAsync)
-            connection.HubCallerClients.InvokeAllowed = false;
-
             if (_onDisconnectedMiddleware != null)
             {
                 var context = new HubLifetimeContext(connection.HubCallerContext, scope.ServiceProvider, hub);

--- a/src/SignalR/server/Core/src/Internal/HubCallerClients.cs
+++ b/src/SignalR/server/Core/src/Internal/HubCallerClients.cs
@@ -10,7 +10,7 @@ internal sealed class HubCallerClients : IHubCallerClients
     private readonly string[] _currentConnectionId;
     private readonly bool _parallelEnabled;
 
-    // Client results don't work in OnConnectedAsync and OnDisconnectedAsync
+    // Client results don't work in OnConnectedAsync
     // This property is set by the hub dispatcher when those methods are being called
     // so we can prevent users from making blocking client calls by returning a custom ISingleClientProxy instance
     internal bool InvokeAllowed { get; set; }
@@ -129,7 +129,7 @@ internal sealed class HubCallerClients : IHubCallerClients
 
         public Task<T> InvokeCoreAsync<T>(string method, object?[] args, CancellationToken cancellationToken = default)
         {
-            throw new InvalidOperationException("Client results inside OnConnectedAsync or OnDisconnectedAsync Hub methods are not allowed.");
+            throw new InvalidOperationException("Client results inside OnConnectedAsync Hub methods are not allowed.");
         }
 
         public Task SendCoreAsync(string method, object?[] args, CancellationToken cancellationToken = default)

--- a/src/SignalR/server/Core/src/Internal/HubCallerClients.cs
+++ b/src/SignalR/server/Core/src/Internal/HubCallerClients.cs
@@ -10,6 +10,11 @@ internal sealed class HubCallerClients : IHubCallerClients
     private readonly string[] _currentConnectionId;
     private readonly bool _parallelEnabled;
 
+    // Client results don't work in OnConnectedAsync and OnDisconnectedAsync
+    // This property is set by the hub dispatcher when those methods are being called
+    // so we can prevent users from making blocking client calls by returning a custom ISingleClientProxy instance
+    internal bool InvokeAllowed { get; set; }
+
     public HubCallerClients(IHubClients hubClients, string connectionId, bool parallelEnabled)
     {
         _connectionId = connectionId;
@@ -26,6 +31,10 @@ internal sealed class HubCallerClients : IHubCallerClients
             if (!_parallelEnabled)
             {
                 return new NotParallelSingleClientProxy(_hubClients.Client(_connectionId));
+            }
+            if (!InvokeAllowed)
+            {
+                return new NoInvokeSingleClientProxy(_hubClients.Client(_connectionId));
             }
             return _hubClients.Client(_connectionId);
         }
@@ -46,6 +55,10 @@ internal sealed class HubCallerClients : IHubCallerClients
         if (!_parallelEnabled)
         {
             return new NotParallelSingleClientProxy(_hubClients.Client(connectionId));
+        }
+        if (!InvokeAllowed)
+        {
+            return new NoInvokeSingleClientProxy(_hubClients.Client(_connectionId));
         }
         return _hubClients.Client(connectionId);
     }
@@ -97,6 +110,26 @@ internal sealed class HubCallerClients : IHubCallerClients
         public Task<T> InvokeCoreAsync<T>(string method, object?[] args, CancellationToken cancellationToken = default)
         {
             throw new InvalidOperationException("Client results inside a Hub method requires HubOptions.MaximumParallelInvocationsPerClient to be greater than 1.");
+        }
+
+        public Task SendCoreAsync(string method, object?[] args, CancellationToken cancellationToken = default)
+        {
+            return _proxy.SendCoreAsync(method, args, cancellationToken);
+        }
+    }
+
+    private sealed class NoInvokeSingleClientProxy : ISingleClientProxy
+    {
+        private readonly ISingleClientProxy _proxy;
+
+        public NoInvokeSingleClientProxy(ISingleClientProxy hubClients)
+        {
+            _proxy = hubClients;
+        }
+
+        public Task<T> InvokeCoreAsync<T>(string method, object?[] args, CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("Client results inside OnConnectedAsync or OnDisconnectedAsync Hub methods are not allowed.");
         }
 
         public Task SendCoreAsync(string method, object?[] args, CancellationToken cancellationToken = default)

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -1231,6 +1231,22 @@ public class ConnectionLifetimeState
     public Exception DisconnectedException { get; set; }
 }
 
+public class OnConnectedClientResultHub : Hub
+{
+    public override async Task OnConnectedAsync()
+    {
+        await Clients.Caller.InvokeAsync<int>("Test");
+    }
+}
+
+public class OnDisconnectedClientResultHub : Hub
+{
+    public override async Task OnDisconnectedAsync(Exception ex)
+    {
+        await Clients.Caller.InvokeAsync<int>("Test");
+    }
+}
+
 public class CallerServiceHub : Hub
 {
     private readonly CallerService _service;

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.ClientResult.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.ClientResult.cs
@@ -105,6 +105,66 @@ public partial class HubConnectionHandlerTests
     }
 
     [Fact]
+    public async Task ThrowsWhenUsedInOnConnectedAsync()
+    {
+        using (StartVerifiableLog(write => write.EventId.Name == "ErrorDispatchingHubEvent"))
+        {
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(builder =>
+            {
+                builder.AddSignalR(o =>
+                {
+                    o.MaximumParallelInvocationsPerClient = 2;
+                    o.EnableDetailedErrors = true;
+                });
+            }, LoggerFactory);
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<OnConnectedClientResultHub>>();
+
+            using (var client = new TestClient())
+            {
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+                // Hub asks client for a result, this is an invocation message with an ID
+                var closeMessage = Assert.IsType<CloseMessage>(await client.ReadAsync().DefaultTimeout());
+                Assert.Equal("Connection closed with an error. InvalidOperationException: Client results inside OnConnectedAsync or OnDisconnectedAsync Hub methods are not allowed.", closeMessage.Error);
+            }
+        }
+
+        Assert.Single(TestSink.Writes.Where(write => write.EventId.Name == "ErrorDispatchingHubEvent"));
+    }
+
+    [Fact]
+    public async Task ThrowsWhenUsedInOnDisconnectedAsync()
+    {
+        using (StartVerifiableLog(write => write.EventId.Name == "ErrorDispatchingHubEvent"))
+        {
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(builder =>
+            {
+                builder.AddSignalR(o =>
+                {
+                    o.MaximumParallelInvocationsPerClient = 2;
+                    o.EnableDetailedErrors = true;
+                });
+            }, LoggerFactory);
+            var connectionHandler = serviceProvider.GetService<HubConnectionHandler<OnDisconnectedClientResultHub>>();
+
+            using (var client = new TestClient())
+            {
+                var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+                client.Connection.Abort();
+
+                // Hub asks client for a result, this is an invocation message with an ID
+                var closeMessage = Assert.IsType<CloseMessage>(await client.ReadAsync().DefaultTimeout());
+                Assert.Null(closeMessage.Error);
+
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => connectionHandlerTask).DefaultTimeout();
+                Assert.Equal("Client results inside OnConnectedAsync or OnDisconnectedAsync Hub methods are not allowed.", ex.Message);
+            }
+        }
+
+        Assert.Single(TestSink.Writes.Where(write => write.EventId.Name == "ErrorDispatchingHubEvent"));
+    }
+
+    [Fact]
     public async Task CanUseClientResultsWithIHubContext()
     {
         using (StartVerifiableLog())

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.ClientResult.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.ClientResult.cs
@@ -125,7 +125,7 @@ public partial class HubConnectionHandlerTests
 
                 // Hub asks client for a result, this is an invocation message with an ID
                 var closeMessage = Assert.IsType<CloseMessage>(await client.ReadAsync().DefaultTimeout());
-                Assert.Equal("Connection closed with an error. InvalidOperationException: Client results inside OnConnectedAsync or OnDisconnectedAsync Hub methods are not allowed.", closeMessage.Error);
+                Assert.Equal("Connection closed with an error. InvalidOperationException: Client results inside OnConnectedAsync Hub methods are not allowed.", closeMessage.Error);
             }
         }
 
@@ -156,8 +156,8 @@ public partial class HubConnectionHandlerTests
                 var closeMessage = Assert.IsType<CloseMessage>(await client.ReadAsync().DefaultTimeout());
                 Assert.Null(closeMessage.Error);
 
-                var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => connectionHandlerTask).DefaultTimeout();
-                Assert.Equal("Client results inside OnConnectedAsync or OnDisconnectedAsync Hub methods are not allowed.", ex.Message);
+                var ex = await Assert.ThrowsAsync<IOException>(() => connectionHandlerTask).DefaultTimeout();
+                Assert.Equal($"Connection '{client.Connection.ConnectionId}' disconnected.", ex.Message);
             }
         }
 


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/5280

Don't allow `Clients.Caller.InvokeAsync` or `Client.Client(...).InvokeAsync` inside special hub methods `OnConnectedAsync` ~~and `OnDisconnectedAsync`~~. These methods are meant to be used for connection management and are not made to work with blocking calls like `ISingleClientProxy.InvokeAsync`.