### PR TITLE
Fix up reading auth schemes and setting default scheme

### DIFF
--- a/src/Http/Authentication.Core/src/AuthenticationService.cs
+++ b/src/Http/Authentication.Core/src/AuthenticationService.cs
@@ -14,6 +14,7 @@ namespace Microsoft.AspNetCore.Authentication;
 public class AuthenticationService : IAuthenticationService
 {
     private HashSet<ClaimsPrincipal>? _transformCache;
+    private const string defaultSchemesOptionsMsg = "The default schemes can be set using either AddAuthentication(string defaultScheme) or AddAuthentication(Action<AuthenticationOptions> configureOptions) or by setting the Authentication:DefaultScheme property in configuration.";
 
     /// <summary>
     /// Constructor.
@@ -64,7 +65,7 @@ public class AuthenticationService : IAuthenticationService
             scheme = defaultScheme?.Name;
             if (scheme == null)
             {
-                throw new InvalidOperationException($"No authenticationScheme was specified, and there was no DefaultAuthenticateScheme found. The default schemes can be set using either AddAuthentication(string defaultScheme) or AddAuthentication(Action<AuthenticationOptions> configureOptions).");
+                throw new InvalidOperationException($"No authenticationScheme was specified, and there was no DefaultAuthenticateScheme found. {defaultSchemesOptionsMsg}");
             }
         }
 
@@ -112,7 +113,7 @@ public class AuthenticationService : IAuthenticationService
             scheme = defaultChallengeScheme?.Name;
             if (scheme == null)
             {
-                throw new InvalidOperationException($"No authenticationScheme was specified, and there was no DefaultChallengeScheme found. The default schemes can be set using either AddAuthentication(string defaultScheme) or AddAuthentication(Action<AuthenticationOptions> configureOptions).");
+                throw new InvalidOperationException($"No authenticationScheme was specified, and there was no DefaultChallengeScheme found. {defaultSchemesOptionsMsg}");
             }
         }
 
@@ -140,7 +141,7 @@ public class AuthenticationService : IAuthenticationService
             scheme = defaultForbidScheme?.Name;
             if (scheme == null)
             {
-                throw new InvalidOperationException($"No authenticationScheme was specified, and there was no DefaultForbidScheme found. The default schemes can be set using either AddAuthentication(string defaultScheme) or AddAuthentication(Action<AuthenticationOptions> configureOptions).");
+                throw new InvalidOperationException($"No authenticationScheme was specified, and there was no DefaultForbidScheme found. {defaultSchemesOptionsMsg}");
             }
         }
 
@@ -186,7 +187,7 @@ public class AuthenticationService : IAuthenticationService
             scheme = defaultScheme?.Name;
             if (scheme == null)
             {
-                throw new InvalidOperationException($"No authenticationScheme was specified, and there was no DefaultSignInScheme found. The default schemes can be set using either AddAuthentication(string defaultScheme) or AddAuthentication(Action<AuthenticationOptions> configureOptions).");
+                throw new InvalidOperationException($"No authenticationScheme was specified, and there was no DefaultSignInScheme found. {defaultSchemesOptionsMsg}");
             }
         }
 
@@ -220,7 +221,7 @@ public class AuthenticationService : IAuthenticationService
             scheme = defaultScheme?.Name;
             if (scheme == null)
             {
-                throw new InvalidOperationException($"No authenticationScheme was specified, and there was no DefaultSignOutScheme found. The default schemes can be set using either AddAuthentication(string defaultScheme) or AddAuthentication(Action<AuthenticationOptions> configureOptions).");
+                throw new InvalidOperationException($"No authenticationScheme was specified, and there was no DefaultSignOutScheme found. {defaultSchemesOptionsMsg}");
             }
         }
 

--- a/src/Security/Authentication/Core/src/AuthenticationConfigurationProviderExtensions.cs
+++ b/src/Security/Authentication/Core/src/AuthenticationConfigurationProviderExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Authentication;
 /// </summary>
 public static class AuthenticationConfigurationProviderExtensions
 {
-    private const string AuthenticationSchemesKey = "Authentication:Schemes";
+    private const string AuthenticationSchemesKey = "Schemes";
 
     /// <summary>
     /// Returns the specified <see cref="IConfiguration"/> object.

--- a/src/Security/Authentication/test/AuthenticationMiddlewareTests.cs
+++ b/src/Security/Authentication/test/AuthenticationMiddlewareTests.cs
@@ -178,6 +178,7 @@ public class AuthenticationMiddlewareTests
 
         var options = app.Services.GetService<IOptionsMonitor<JwtBearerOptions>>().Get(JwtBearerDefaults.AuthenticationScheme);
         Assert.Equal(new[] { "SomeIssuer" }, options.TokenValidationParameters.ValidIssuers);
+        Assert.Equal(new[] { "https://localhost:5001" }, options.TokenValidationParameters.ValidAudiences);
     }
 
     private HttpContext GetHttpContext(

--- a/src/Tools/dotnet-user-jwts/src/Commands/ClearCommand.cs
+++ b/src/Tools/dotnet-user-jwts/src/Commands/ClearCommand.cs
@@ -45,7 +45,7 @@ internal sealed class ClearCommand
 
         if (!force)
         {
-            reporter.Output(Resources.ClearCommand_Permission);
+            reporter.Output(Resources.FormatClearCommand_Permission(count, project));
             reporter.Output("[Y]es / [N]o");
             if (Console.ReadLine().Trim().ToUpperInvariant() != "Y")
             {

--- a/src/Tools/dotnet-user-jwts/src/Helpers/JwtAuthenticationSchemeSettings.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/JwtAuthenticationSchemeSettings.cs
@@ -10,6 +10,7 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools;
 internal sealed record JwtAuthenticationSchemeSettings(string SchemeName, List<string> Audiences, string ClaimsIssuer)
 {
     private const string AuthenticationKey = "Authentication";
+    private const string DefaultSchemeKey = "DefaultScheme";
     private const string SchemesKey = "Schemes";
 
     private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
@@ -35,7 +36,7 @@ internal sealed record JwtAuthenticationSchemeSettings(string SchemeName, List<s
             {
                 // If a scheme with the same name has already been registered, we
                 // override with the latest token's options
-                schemes[SchemeName] = settingsObject;    
+                schemes[SchemeName] = settingsObject;
             }
             else
             {
@@ -56,6 +57,15 @@ internal sealed record JwtAuthenticationSchemeSettings(string SchemeName, List<s
             };
         }
 
+        // Set the DefaultScheme if it has not already been set
+        // and only a single scheme has been configured thus far
+        if (config[AuthenticationKey][DefaultSchemeKey] is null
+            && config[AuthenticationKey][SchemesKey] is JsonObject setSchemes
+            && setSchemes.Count == 1)
+        {
+            config[AuthenticationKey][DefaultSchemeKey] = SchemeName;
+        }
+
         using var writer = new FileStream(filePath, FileMode.Open, FileAccess.Write);
         JsonSerializer.Serialize(writer, config, _jsonSerializerOptions);
     }
@@ -70,6 +80,11 @@ internal sealed record JwtAuthenticationSchemeSettings(string SchemeName, List<s
             authentication[SchemesKey] is JsonObject schemes)
         {
             schemes.Remove(name);
+            if (authentication[DefaultSchemeKey] is JsonValue defaultScheme
+                && defaultScheme.GetValue<string>() == name)
+            {
+                authentication.Remove(DefaultSchemeKey);
+            }
         }
 
         using var writer = new FileStream(filePath, FileMode.Create, FileAccess.Write);

--- a/src/Tools/dotnet-user-jwts/test/UserJwtsTestFixture.cs
+++ b/src/Tools/dotnet-user-jwts/test/UserJwtsTestFixture.cs
@@ -62,7 +62,7 @@ public class UserJwtsTestFixture : IDisposable
   }
 }";
 
-    public string CreateProject(bool hasSecret = true)
+    public string CreateProject(bool hasSecret = true, string appSettingsContent = "{}")
     {
         var projectPath = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "userjwtstest", Guid.NewGuid().ToString()));
         Directory.CreateDirectory(Path.Combine(projectPath.FullName, "Properties"));
@@ -81,7 +81,7 @@ public class UserJwtsTestFixture : IDisposable
 
         File.WriteAllText(
             Path.Combine(projectPath.FullName, "appsettings.Development.json"),
-            "{}");
+            appSettingsContent);
 
         if (hasSecret)
         {


### PR DESCRIPTION
## Description

This PR resolves issues with reading scheme options from config by name and setting the default authentication scheme automatically when creating tokens using the`user-jwts` tool.

Fixes https://github.com/dotnet/aspnetcore/issues/42454 and fixes https://github.com/dotnet/aspnetcore/issues/42453

## Customer Impact

The changes in this PR address issues that make it difficult for users to get an end-to-end of our simplified authentication flow working in conjunction with the `user-jwts` tool.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Changes only affect authentication area in ASP.NET Core and are limited to interactions with the `user-jwts` tool or the new `Authentication` property.

## Verification

- [ ] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A
