### PR TITLE
Updated VS workload manifests to Windows SDK 19041

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -12,7 +12,7 @@
     "Microsoft.VisualStudio.Component.VC.14.29.16.11.x86.x64",
     "Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL.ARM64",
     "Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL",
-    "Microsoft.VisualStudio.Component.Windows10SDK.18362",
+    "Microsoft.VisualStudio.Component.Windows10SDK.19041",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
     "Microsoft.VisualStudio.Workload.NativeDesktop",
     "Microsoft.VisualStudio.Workload.NetWeb",

--- a/eng/scripts/vs.17.buildtools.intpreview.json
+++ b/eng/scripts/vs.17.buildtools.intpreview.json
@@ -20,7 +20,7 @@
         "Microsoft.VisualStudio.Component.VC.14.29.16.11.x86.x64",
         "Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL.ARM64",
         "Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL",
-        "Microsoft.VisualStudio.Component.Windows10SDK.18362",
+        "Microsoft.VisualStudio.Component.Windows10SDK.19041",
         "Microsoft.VisualStudio.Workload.ManagedDesktopBuildTools",
         "Microsoft.VisualStudio.Workload.MSBuildTools",
         "Microsoft.VisualStudio.Workload.NetCoreBuildTools",

--- a/eng/scripts/vs.17.buildtools.json
+++ b/eng/scripts/vs.17.buildtools.json
@@ -20,7 +20,7 @@
         "Microsoft.VisualStudio.Component.VC.14.29.16.11.x86.x64",
         "Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL.ARM64",
         "Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL",
-        "Microsoft.VisualStudio.Component.Windows10SDK.18362",
+        "Microsoft.VisualStudio.Component.Windows10SDK.19041",
         "Microsoft.VisualStudio.Workload.ManagedDesktopBuildTools",
         "Microsoft.VisualStudio.Workload.MSBuildTools",
         "Microsoft.VisualStudio.Workload.NetCoreBuildTools",

--- a/eng/scripts/vs.17.buildtools.preview.json
+++ b/eng/scripts/vs.17.buildtools.preview.json
@@ -20,7 +20,7 @@
         "Microsoft.VisualStudio.Component.VC.14.29.16.11.x86.x64",
         "Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL.ARM64",
         "Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL",
-        "Microsoft.VisualStudio.Component.Windows10SDK.18362",
+        "Microsoft.VisualStudio.Component.Windows10SDK.19041",
         "Microsoft.VisualStudio.Workload.ManagedDesktopBuildTools",
         "Microsoft.VisualStudio.Workload.MSBuildTools",
         "Microsoft.VisualStudio.Workload.NetCoreBuildTools",

--- a/eng/scripts/vs.17.intpreview.json
+++ b/eng/scripts/vs.17.intpreview.json
@@ -17,7 +17,7 @@
         "Microsoft.VisualStudio.Component.VC.14.29.16.11.x86.x64",
         "Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL.ARM64",
         "Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL",
-        "Microsoft.VisualStudio.Component.Windows10SDK.18362",
+        "Microsoft.VisualStudio.Component.Windows10SDK.19041",
         "Microsoft.VisualStudio.Workload.ManagedDesktop",
         "Microsoft.VisualStudio.Workload.NativeDesktop",
         "Microsoft.VisualStudio.Workload.NetWeb",

--- a/eng/scripts/vs.17.json
+++ b/eng/scripts/vs.17.json
@@ -17,7 +17,7 @@
         "Microsoft.VisualStudio.Component.VC.14.29.16.11.x86.x64",
         "Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL.ARM64",
         "Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL",
-        "Microsoft.VisualStudio.Component.Windows10SDK.18362",
+        "Microsoft.VisualStudio.Component.Windows10SDK.19041",
         "Microsoft.VisualStudio.Workload.ManagedDesktop",
         "Microsoft.VisualStudio.Workload.NativeDesktop",
         "Microsoft.VisualStudio.Workload.NetWeb",

--- a/eng/scripts/vs.17.preview.json
+++ b/eng/scripts/vs.17.preview.json
@@ -17,7 +17,7 @@
         "Microsoft.VisualStudio.Component.VC.14.29.16.11.x86.x64",
         "Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL.ARM64",
         "Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL",
-        "Microsoft.VisualStudio.Component.Windows10SDK.18362",
+        "Microsoft.VisualStudio.Component.Windows10SDK.19041",
         "Microsoft.VisualStudio.Workload.ManagedDesktop",
         "Microsoft.VisualStudio.Workload.NativeDesktop",
         "Microsoft.VisualStudio.Workload.NetWeb",

--- a/eng/targets/Cpp.Common.props
+++ b/eng/targets/Cpp.Common.props
@@ -22,7 +22,7 @@
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <PlatformToolsetVersion>v143</PlatformToolsetVersion>
     <PlatformToolset>$(PlatformToolsetVersion)</PlatformToolset>
-    <!-- If the following line is updated ensure that the /eng/scripts/vs.17.*.json files are updated to point to the same version component too. -->
+    <!-- If the following line is updated ensure that the /eng/scripts/vs.17.*.json files are updated to include the same version component too. -->
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 

--- a/eng/targets/Cpp.Common.props
+++ b/eng/targets/Cpp.Common.props
@@ -22,6 +22,7 @@
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <PlatformToolsetVersion>v143</PlatformToolsetVersion>
     <PlatformToolset>$(PlatformToolsetVersion)</PlatformToolset>
+    <!-- If the following line is updated ensure that the /eng/scripts/vs.17.*.json files are updated to point to the same version component too. -->
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 

--- a/src/Installers/Windows/AspNetCoreModule-Setup/build/settings/common.props
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/build/settings/common.props
@@ -14,6 +14,7 @@
   <!-- General properties -->
 
   <PropertyGroup>
+    <!-- If the following line is updated ensure that the /eng/scripts/vs.17.*.json files are updated to include the same version component too. -->
     <IisOobWinSdkVersion Condition="'$(IisOobWinSdkVersion)' == ''">10.0.18362.0</IisOobWinSdkVersion>
     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(IisOobWinSdkVersion)</WindowsTargetPlatformVersion>
     <CharacterSet>Unicode</CharacterSet>

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/CommonLibTests.vcxproj
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/CommonLibTests.vcxproj
@@ -40,6 +40,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1eac8125-1765-4e2d-8cbe-56dc98a1c8c1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
+    <!-- If the following line is updated ensure that the /eng/scripts/vs.17.*.json files are updated to include the same version component too. -->
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.19041.0</WindowsTargetPlatformVersion>
     <PlatformToolsetVersion Condition=" '$(PlatformToolsetVersion)' == '' ">v143</PlatformToolsetVersion>
     <ConfigurationType>Application</ConfigurationType>


### PR DESCRIPTION
Update the vs workload manifests to match latest windows sdk version being used.