### PR TITLE
Allow file middlewares to run if there's an endpoint with a null request delegate

### DIFF
--- a/src/Http/Routing/src/EndpointMiddleware.cs
+++ b/src/Http/Routing/src/EndpointMiddleware.cs
@@ -31,41 +31,44 @@ internal sealed partial class EndpointMiddleware
     public Task Invoke(HttpContext httpContext)
     {
         var endpoint = httpContext.GetEndpoint();
-        if (endpoint?.RequestDelegate != null)
+        if (endpoint is not null)
         {
             if (!_routeOptions.SuppressCheckForUnhandledSecurityMetadata)
             {
-                if (endpoint.Metadata.GetMetadata<IAuthorizeData>() != null &&
+                if (endpoint.Metadata.GetMetadata<IAuthorizeData>() is not null &&
                     !httpContext.Items.ContainsKey(AuthorizationMiddlewareInvokedKey))
                 {
                     ThrowMissingAuthMiddlewareException(endpoint);
                 }
 
-                if (endpoint.Metadata.GetMetadata<ICorsMetadata>() != null &&
+                if (endpoint.Metadata.GetMetadata<ICorsMetadata>() is not null &&
                     !httpContext.Items.ContainsKey(CorsMiddlewareInvokedKey))
                 {
                     ThrowMissingCorsMiddlewareException(endpoint);
                 }
             }
 
-            Log.ExecutingEndpoint(_logger, endpoint);
-
-            try
+            if (endpoint.RequestDelegate is not null)
             {
-                var requestTask = endpoint.RequestDelegate(httpContext);
-                if (!requestTask.IsCompletedSuccessfully)
+                Log.ExecutingEndpoint(_logger, endpoint);
+
+                try
                 {
-                    return AwaitRequestTask(endpoint, requestTask, _logger);
+                    var requestTask = endpoint.RequestDelegate(httpContext);
+                    if (!requestTask.IsCompletedSuccessfully)
+                    {
+                        return AwaitRequestTask(endpoint, requestTask, _logger);
+                    }
                 }
-            }
-            catch (Exception exception)
-            {
-                Log.ExecutedEndpoint(_logger, endpoint);
-                return Task.FromException(exception);
-            }
+                catch (Exception exception)
+                {
+                    Log.ExecutedEndpoint(_logger, endpoint);
+                    return Task.FromException(exception);
+                }
 
-            Log.ExecutedEndpoint(_logger, endpoint);
-            return Task.CompletedTask;
+                Log.ExecutedEndpoint(_logger, endpoint);
+                return Task.CompletedTask;
+            }
         }
 
         return _next(httpContext);

--- a/src/Middleware/StaticFiles/src/DefaultFilesMiddleware.cs
+++ b/src/Middleware/StaticFiles/src/DefaultFilesMiddleware.cs
@@ -59,7 +59,7 @@ public class DefaultFilesMiddleware
     /// <returns></returns>
     public Task Invoke(HttpContext context)
     {
-        if (context.GetEndpoint()?.RequestDelegate == null
+        if (context.GetEndpoint()?.RequestDelegate is null
             && Helpers.IsGetOrHeadMethod(context.Request.Method)
             && Helpers.TryMatchPath(context, _matchUrl, forDirectory: true, subpath: out var subpath))
         {

--- a/src/Middleware/StaticFiles/src/DefaultFilesMiddleware.cs
+++ b/src/Middleware/StaticFiles/src/DefaultFilesMiddleware.cs
@@ -59,7 +59,7 @@ public class DefaultFilesMiddleware
     /// <returns></returns>
     public Task Invoke(HttpContext context)
     {
-        if (context.GetEndpoint() == null
+        if (context.GetEndpoint()?.RequestDelegate == null
             && Helpers.IsGetOrHeadMethod(context.Request.Method)
             && Helpers.TryMatchPath(context, _matchUrl, forDirectory: true, subpath: out var subpath))
         {

--- a/src/Middleware/StaticFiles/src/DirectoryBrowserMiddleware.cs
+++ b/src/Middleware/StaticFiles/src/DirectoryBrowserMiddleware.cs
@@ -75,8 +75,8 @@ public class DirectoryBrowserMiddleware
     /// <returns></returns>
     public Task Invoke(HttpContext context)
     {
-        // Check if the URL matches any expected paths, skip if an endpoint was selected
-        if (context.GetEndpoint() == null
+        // Check if the URL matches any expected paths, skip if an endpoint with a request delegate was selected
+        if (context.GetEndpoint()?.RequestDelegate == null
             && Helpers.IsGetOrHeadMethod(context.Request.Method)
             && Helpers.TryMatchPath(context, _matchUrl, forDirectory: true, subpath: out var subpath)
             && TryGetDirectoryInfo(subpath, out var contents))

--- a/src/Middleware/StaticFiles/src/DirectoryBrowserMiddleware.cs
+++ b/src/Middleware/StaticFiles/src/DirectoryBrowserMiddleware.cs
@@ -76,7 +76,7 @@ public class DirectoryBrowserMiddleware
     public Task Invoke(HttpContext context)
     {
         // Check if the URL matches any expected paths, skip if an endpoint with a request delegate was selected
-        if (context.GetEndpoint()?.RequestDelegate == null
+        if (context.GetEndpoint()?.RequestDelegate is null
             && Helpers.IsGetOrHeadMethod(context.Request.Method)
             && Helpers.TryMatchPath(context, _matchUrl, forDirectory: true, subpath: out var subpath)
             && TryGetDirectoryInfo(subpath, out var contents))

--- a/src/Middleware/StaticFiles/src/StaticFileMiddleware.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileMiddleware.cs
@@ -92,7 +92,7 @@ public class StaticFileMiddleware
     }
 
     // Return true because we only want to run if there is no endpoint delegate.
-    private static bool ValidateNoEndpointDelegate(HttpContext context) => context.GetEndpoint()?.RequestDelegate == null;
+    private static bool ValidateNoEndpointDelegate(HttpContext context) => context.GetEndpoint()?.RequestDelegate is null;
 
     private static bool ValidateMethod(HttpContext context)
     {

--- a/src/Middleware/StaticFiles/src/StaticFileMiddleware.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileMiddleware.cs
@@ -66,7 +66,7 @@ public class StaticFileMiddleware
     /// <returns></returns>
     public Task Invoke(HttpContext context)
     {
-        if (!ValidateNoEndpoint(context))
+        if (!ValidateNoEndpointDelegate(context))
         {
             _logger.EndpointMatched();
         }
@@ -91,8 +91,8 @@ public class StaticFileMiddleware
         return _next(context);
     }
 
-    // Return true because we only want to run if there is no endpoint.
-    private static bool ValidateNoEndpoint(HttpContext context) => context.GetEndpoint() == null;
+    // Return true because we only want to run if there is no endpoint delegate.
+    private static bool ValidateNoEndpointDelegate(HttpContext context) => context.GetEndpoint()?.RequestDelegate == null;
 
     private static bool ValidateMethod(HttpContext context)
     {

--- a/src/Middleware/StaticFiles/test/UnitTests/DefaultFilesMiddlewareTests.cs
+++ b/src/Middleware/StaticFiles/test/UnitTests/DefaultFilesMiddlewareTests.cs
@@ -78,7 +78,7 @@ public class DefaultFilesMiddlewareTests
     }
 
     [Fact]
-    public async Task Endpoint_PassesThrough()
+    public async Task Endpoint_With_RequestDelegate_PassesThrough()
     {
         using (var fileProvider = new PhysicalFileProvider(Path.Combine(AppContext.BaseDirectory, ".")))
         {
@@ -107,6 +107,9 @@ public class DefaultFilesMiddlewareTests
                     });
 
                     app.UseEndpoints(endpoints => { });
+
+                    // Echo back the current request path value
+                    app.Run(context => context.Response.WriteAsync(context.Request.Path.Value));
                 },
                 services => { services.AddDirectoryBrowser(); services.AddRouting(); });
             using var server = host.GetTestServer();
@@ -114,6 +117,48 @@ public class DefaultFilesMiddlewareTests
             var response = await server.CreateRequest("/SubFolder/").GetAsync();
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("/SubFolder/", await response.Content.ReadAsStringAsync()); // Should not be modified
+        }
+    }
+
+    [Fact]
+    public async Task Endpoint_With_Null_RequestDelegate_Does_Not_PassThrough()
+    {
+        using (var fileProvider = new PhysicalFileProvider(Path.Combine(AppContext.BaseDirectory, ".")))
+        {
+            using var host = await StaticFilesTestServer.Create(
+                app =>
+                {
+                    app.UseRouting();
+
+                    app.Use(next => context =>
+                    {
+                        // Assign an endpoint with a null RequestDelegate, the default files should still run
+                        context.SetEndpoint(new Endpoint(requestDelegate: null,
+                        new EndpointMetadataCollection(),
+                        "test"));
+
+                        return next(context);
+                    });
+
+                    app.UseDefaultFiles(new DefaultFilesOptions
+                    {
+                        RequestPath = new PathString(""),
+                        FileProvider = fileProvider
+                    });
+
+                    app.UseEndpoints(endpoints => { });
+
+                    // Echo back the current request path value
+                    app.Run(context => context.Response.WriteAsync(context.Request.Path.Value));
+                },
+                services => { services.AddDirectoryBrowser(); services.AddRouting(); });
+            using var server = host.GetTestServer();
+
+            var response = await server.CreateRequest("/SubFolder/").GetAsync();
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("/SubFolder/default.html", responseContent); // Should be modified and be valid path to file
         }
     }
 

--- a/src/Middleware/StaticFiles/test/UnitTests/DirectoryBrowserMiddlewareTests.cs
+++ b/src/Middleware/StaticFiles/test/UnitTests/DirectoryBrowserMiddlewareTests.cs
@@ -95,7 +95,7 @@ public class DirectoryBrowserMiddlewareTests
     }
 
     [Fact]
-    public async Task Endpoint_PassesThrough()
+    public async Task Endpoint_With_RequestDelegate_PassesThrough()
     {
         using (var fileProvider = new PhysicalFileProvider(Path.Combine(AppContext.BaseDirectory, ".")))
         {
@@ -132,6 +132,45 @@ public class DirectoryBrowserMiddlewareTests
             var response = await server.CreateRequest("/").GetAsync();
             Assert.Equal(HttpStatusCode.NotAcceptable, response.StatusCode);
             Assert.Equal("Hi from endpoint.", await response.Content.ReadAsStringAsync());
+        }
+    }
+
+    [Fact]
+    public async Task Endpoint_With_Null_RequestDelegate_Does_Not_PassThrough()
+    {
+        using (var fileProvider = new PhysicalFileProvider(Path.Combine(AppContext.BaseDirectory, ".")))
+        {
+            using var host = await StaticFilesTestServer.Create(
+                app =>
+                {
+                    app.UseRouting();
+
+                    app.Use(next => context =>
+                    {
+                        // Assign an endpoint with a null RequestDelegate, the directory browser should still run
+                        context.SetEndpoint(new Endpoint(requestDelegate: null,
+                        new EndpointMetadataCollection(),
+                        "test"));
+
+                        return next(context);
+                    });
+
+                    app.UseDirectoryBrowser(new DirectoryBrowserOptions
+                    {
+                        RequestPath = new PathString(""),
+                        FileProvider = fileProvider
+                    });
+
+                    app.UseEndpoints(endpoints => { });
+                },
+                services => { services.AddDirectoryBrowser(); services.AddRouting(); });
+            using var server = host.GetTestServer();
+
+            var response = await server.CreateRequest("/").GetAsync();
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("text/html; charset=utf-8", response.Content.Headers.ContentType.ToString());
+            Assert.True(response.Content.Headers.ContentLength > 0);
+            Assert.Equal(response.Content.Headers.ContentLength, (await response.Content.ReadAsByteArrayAsync()).Length);
         }
     }
 

--- a/src/Middleware/StaticFiles/test/UnitTests/StaticFileMiddlewareTests.cs
+++ b/src/Middleware/StaticFiles/test/UnitTests/StaticFileMiddlewareTests.cs
@@ -205,8 +205,7 @@ public class StaticFileMiddlewareTests
                 app.UseRouting();
                 app.Use((ctx, next) =>
                 {
-                    ctx.Features.Set<IEndpointFeature>(new EndpointFeature());
-                    ctx.Features.Get<IEndpointFeature>().Endpoint = new Endpoint(requestDelegate: null, new EndpointMetadataCollection(), "NullRequestDelegateEndpoint");
+                    ctx.SetEndpoint(new Endpoint(requestDelegate: null, new EndpointMetadataCollection(), "NullRequestDelegateEndpoint"));
                     return next();
                 });
                 app.UseStaticFiles(new StaticFileOptions
@@ -254,8 +253,7 @@ public class StaticFileMiddlewareTests
                 app.UseRouting();
                 app.Use((ctx, next) =>
                 {
-                    ctx.Features.Set<IEndpointFeature>(new EndpointFeature());
-                    ctx.Features.Get<IEndpointFeature>().Endpoint = new Endpoint(handler, new EndpointMetadataCollection(), "RequestDelegateEndpoint");
+                    ctx.SetEndpoint(new Endpoint(handler, new EndpointMetadataCollection(), "RequestDelegateEndpoint"));
                     return next();
                 });
                 app.UseStaticFiles(new StaticFileOptions
@@ -372,9 +370,4 @@ public class StaticFileMiddlewareTests
             new[] {"/somedir", @"SubFolder", "/somedir/ranges.txt"},
             new[] {"", @"SubFolder", "/Empty.txt"}
         };
-
-    private sealed class EndpointFeature : IEndpointFeature
-    {
-        public Endpoint Endpoint { get; set; }
-    }
 }

--- a/src/Middleware/StaticFiles/test/UnitTests/StaticFileMiddlewareTests.cs
+++ b/src/Middleware/StaticFiles/test/UnitTests/StaticFileMiddlewareTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Net;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -9,6 +10,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Moq;
@@ -193,6 +195,88 @@ public class StaticFileMiddlewareTests
         }
     }
 
+    [Fact]
+    public async Task File_Served_If_Endpoint_With_Null_RequestDelegate_Is_Active()
+    {
+        using (var fileProvider = new PhysicalFileProvider(Path.Combine(AppContext.BaseDirectory, ".")))
+        {
+            using var host = await StaticFilesTestServer.Create(app =>
+            {
+                app.UseRouting();
+                app.Use((ctx, next) =>
+                {
+                    ctx.Features.Set<IEndpointFeature>(new EndpointFeature());
+                    ctx.Features.Get<IEndpointFeature>().Endpoint = new Endpoint(requestDelegate: null, new EndpointMetadataCollection(), "NullRequestDelegateEndpoint");
+                    return next();
+                });
+                app.UseStaticFiles(new StaticFileOptions
+                {
+                    RequestPath = new PathString(),
+                    FileProvider = fileProvider
+                });
+                app.UseEndpoints(endpoints => { });
+            }, services => services.AddRouting());
+            using var server = host.GetTestServer();
+            var requestUrl = "/TestDocument.txt";
+            var fileInfo = fileProvider.GetFileInfo(Path.GetFileName(requestUrl));
+            var response = await server.CreateRequest(requestUrl).GetAsync();
+            var responseContent = await response.Content.ReadAsByteArrayAsync();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("text/plain", response.Content.Headers.ContentType.ToString());
+            Assert.True(response.Content.Headers.ContentLength == fileInfo.Length);
+            Assert.Equal(response.Content.Headers.ContentLength, responseContent.Length);
+            Assert.NotNull(response.Headers.ETag);
+
+            using (var stream = fileInfo.CreateReadStream())
+            {
+                var fileContents = new byte[stream.Length];
+                stream.Read(fileContents, 0, (int)stream.Length);
+                Assert.True(responseContent.SequenceEqual(fileContents));
+            }
+        }
+    }
+
+    [Fact]
+    public async Task File_NotServed_If_Endpoint_With_RequestDelegate_Is_Active()
+    {
+        var responseText = DateTime.UtcNow.Ticks.ToString(CultureInfo.InvariantCulture);
+        RequestDelegate handler = async (ctx) =>
+        {
+            ctx.Response.ContentType = "text/customfortest+plain";
+            await ctx.Response.WriteAsync(responseText);
+        };
+
+        using (var fileProvider = new PhysicalFileProvider(Path.Combine(AppContext.BaseDirectory, ".")))
+        {
+            using var host = await StaticFilesTestServer.Create(app =>
+            {
+                app.UseRouting();
+                app.Use((ctx, next) =>
+                {
+                    ctx.Features.Set<IEndpointFeature>(new EndpointFeature());
+                    ctx.Features.Get<IEndpointFeature>().Endpoint = new Endpoint(handler, new EndpointMetadataCollection(), "RequestDelegateEndpoint");
+                    return next();
+                });
+                app.UseStaticFiles(new StaticFileOptions
+                {
+                    RequestPath = new PathString(),
+                    FileProvider = fileProvider
+                });
+                app.UseEndpoints(endpoints => { });
+            }, services => services.AddRouting());
+            using var server = host.GetTestServer();
+            var requestUrl = "/TestDocument.txt";
+
+            var response = await server.CreateRequest(requestUrl).GetAsync();
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("text/customfortest+plain", response.Content.Headers.ContentType.ToString());
+            Assert.Equal(responseText, responseContent);
+        }
+    }
+
     [Theory]
     [MemberData(nameof(ExistingFiles))]
     public async Task HeadFile_HeadersButNotBodyServed(string baseUrl, string baseDir, string requestUrl)
@@ -288,4 +372,9 @@ public class StaticFileMiddlewareTests
             new[] {"/somedir", @"SubFolder", "/somedir/ranges.txt"},
             new[] {"", @"SubFolder", "/Empty.txt"}
         };
+
+    private sealed class EndpointFeature : IEndpointFeature
+    {
+        public Endpoint Endpoint { get; set; }
+    }
 }


### PR DESCRIPTION
This updates the `DefaultFilesMiddleware`, `DirectoryBrowserMiddleware`, and `StaticFileMiddleware` to not no-op (fall through to the next middleware in the pipeline) if they detect the request has an active endpoint with a null request delegate.

This allows the middleware to run in cases where there's an endpoint with a `null` `RequestDelegate`. This enables the ability to have an active endpoint for the purposes of communicating metadata to middleware while allowing middleware like the `StaticFileMiddleware` to keep performing its function, e.g. have a "dummy" endpoint to carry `IAuthorizeData` metadata so that the `AuthorizationMiddleware` performs authorization on a request before the `StaticFileMiddleware` runs ([example here](https://github.com/DamianEdwards/AspNetCorePathAuthorization)).

Fixes #42413
