### PR TITLE
Respond to C# 11 upcoming changes

### DIFF
--- a/src/Shared/ServerInfrastructure/BufferExtensions.cs
+++ b/src/Shared/ServerInfrastructure/BufferExtensions.cs
@@ -19,7 +19,7 @@ internal static class BufferExtensions
     private static byte[]? _numericBytesScratch;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ReadOnlySpan<byte> ToSpan(in this ReadOnlySequence<byte> buffer)
+    public static ReadOnlySpan<byte> ToSpan(scoped in this ReadOnlySequence<byte> buffer)
     {
         if (buffer.IsSingleSegment)
         {


### PR DESCRIPTION
### This PR should be merged when the new Roslyn compiler with C# 11 `ref` field support is consumed.

The following API is no longer safe in C# 11 with respect to lifetime rules. This applies the `scoped` keyword that will let Roslyn understand the necessary lifetime rules in play.

Full rules on `scoped` can be found at https://github.com/dotnet/csharplang/blob/main/proposals/low-level-struct-improvements.md.

Issue was discovered in https://github.com/dotnet/installer/pull/14029

/cc @adityamandaleeka @wtgodbe @jaredpar @cston 