### PR TITLE
Add use of onelocbuild.yml

### DIFF
--- a/.azure/pipelines/localization.yml
+++ b/.azure/pipelines/localization.yml
@@ -1,0 +1,29 @@
+#
+# See https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema for details on this file.
+#
+
+schedules:
+# Cron timezone is UTC.
+- cron: "0 18 * * *"
+  displayName: Run tests daily at 6 PM UTC (11 AM PT)
+  branches:
+    include:
+    - main
+  always: true
+
+# Do not run in PR builds nor support other triggers.
+pr: none
+trigger: none
+
+variables:
+- name: _TeamName
+  value: AspNetCore
+
+jobs:
+# When doing this for real, use eq(variables['Build.SourceBranch'], 'refs/heads/main') instead of PR check.
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: /eng/common/templates/job/onelocbuild.yml
+    parameters:
+      LclPackageId: 'LCL-JUNO-PROD-ASPNETCORE'
+      LclSource: lclFilesFromPackage
+      MirrorRepo: aspnetcore


### PR DESCRIPTION
- part of #36998
- use a separate pipeline to avoid default submodule checkout
  - we will handle dotnet/spa-templates localization separately