### PR TITLE
Fixed typo for ArgumentNullException.ThrowIfNull

### DIFF
--- a/src/Shared/PropertyAsParameterInfo.cs
+++ b/src/Shared/PropertyAsParameterInfo.cs
@@ -61,8 +61,8 @@ internal sealed class PropertyAsParameterInfo : ParameterInfo
     [UnconditionalSuppressMessage("Trimmer", "IL2075", Justification = "PropertyAsParameterInfo.Flatten requires unreferenced code.")]
     public static ReadOnlySpan<ParameterInfo> Flatten(ParameterInfo[] parameters, ParameterBindingMethodCache cache)
     {
-        ArgumentNullException.ThrowIfNull(parameters, nameof(parameters));
-        ArgumentNullException.ThrowIfNull(cache, nameof(cache));
+        ArgumentNullException.ThrowIfNull(parameters);
+        ArgumentNullException.ThrowIfNull(cache);
 
         if (parameters.Length == 0)
         {

--- a/src/Shared/PropertyAsParameterInfo.cs
+++ b/src/Shared/PropertyAsParameterInfo.cs
@@ -61,8 +61,8 @@ internal sealed class PropertyAsParameterInfo : ParameterInfo
     [UnconditionalSuppressMessage("Trimmer", "IL2075", Justification = "PropertyAsParameterInfo.Flatten requires unreferenced code.")]
     public static ReadOnlySpan<ParameterInfo> Flatten(ParameterInfo[] parameters, ParameterBindingMethodCache cache)
     {
-        ArgumentNullException.ThrowIfNull(nameof(parameters));
-        ArgumentNullException.ThrowIfNull(nameof(cache));
+        ArgumentNullException.ThrowIfNull(parameters, nameof(parameters));
+        ArgumentNullException.ThrowIfNull(cache, nameof(cache));
 
         if (parameters.Length == 0)
         {


### PR DESCRIPTION
# Fixed typo for ArgumentNullException.ThrowIfNull

## Description

Fixes #42558
