### PR TITLE
CreatedResult should accept null location

### DIFF
--- a/src/Http/Http.Results/src/Created.cs
+++ b/src/Http/Http.Results/src/Created.cs
@@ -20,7 +20,7 @@ public sealed class Created : IResult, IEndpointMetadataProvider, IStatusCodeHtt
     /// provided.
     /// </summary>
     /// <param name="location">The location at which the content has been created.</param>
-    internal Created(string location)
+    internal Created(string? location)
     {
         Location = location;
     }
@@ -30,20 +30,18 @@ public sealed class Created : IResult, IEndpointMetadataProvider, IStatusCodeHtt
     /// provided.
     /// </summary>
     /// <param name="locationUri">The location at which the content has been created.</param>
-    internal Created(Uri locationUri)
+    internal Created(Uri? locationUri)
     {
-        if (locationUri == null)
+        if (locationUri != null)
         {
-            throw new ArgumentNullException(nameof(locationUri));
-        }
-
-        if (locationUri.IsAbsoluteUri)
-        {
-            Location = locationUri.AbsoluteUri;
-        }
-        else
-        {
-            Location = locationUri.GetComponents(UriComponents.SerializationInfoString, UriFormat.UriEscaped);
+            if (locationUri.IsAbsoluteUri)
+            {
+                Location = locationUri.AbsoluteUri;
+            }
+            else
+            {
+                Location = locationUri.GetComponents(UriComponents.SerializationInfoString, UriFormat.UriEscaped);
+            }
         }
     }
 

--- a/src/Http/Http.Results/src/CreatedOfT.cs
+++ b/src/Http/Http.Results/src/CreatedOfT.cs
@@ -22,7 +22,7 @@ public sealed class Created<TValue> : IResult, IEndpointMetadataProvider, IStatu
     /// </summary>
     /// <param name="location">The location at which the content has been created.</param>
     /// <param name="value">The value to format in the entity body.</param>
-    internal Created(string location, TValue? value)
+    internal Created(string? location, TValue? value)
     {
         Value = value;
         Location = location;
@@ -35,23 +35,21 @@ public sealed class Created<TValue> : IResult, IEndpointMetadataProvider, IStatu
     /// </summary>
     /// <param name="locationUri">The location at which the content has been created.</param>
     /// <param name="value">The value to format in the entity body.</param>
-    internal Created(Uri locationUri, TValue? value)
+    internal Created(Uri? locationUri, TValue? value)
     {
         Value = value;
         HttpResultsHelper.ApplyProblemDetailsDefaultsIfNeeded(Value, StatusCode);
 
-        if (locationUri == null)
+        if (locationUri != null)
         {
-            throw new ArgumentNullException(nameof(locationUri));
-        }
-
-        if (locationUri.IsAbsoluteUri)
-        {
-            Location = locationUri.AbsoluteUri;
-        }
-        else
-        {
-            Location = locationUri.GetComponents(UriComponents.SerializationInfoString, UriFormat.UriEscaped);
+            if (locationUri.IsAbsoluteUri)
+            {
+                Location = locationUri.AbsoluteUri;
+            }
+            else
+            {
+                Location = locationUri.GetComponents(UriComponents.SerializationInfoString, UriFormat.UriEscaped);
+            }
         }
     }
 

--- a/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
@@ -159,8 +159,13 @@ static Microsoft.AspNetCore.Http.Results.Content(string? content, Microsoft.Net.
 static Microsoft.AspNetCore.Http.Results.Content(string? content, string? contentType = null, System.Text.Encoding? contentEncoding = null, int? statusCode = null) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.Content(string? content, string? contentType, System.Text.Encoding? contentEncoding) -> Microsoft.AspNetCore.Http.IResult!
 *REMOVED*static Microsoft.AspNetCore.Http.Results.Text(string! content, string? contentType = null, System.Text.Encoding? contentEncoding = null) -> Microsoft.AspNetCore.Http.IResult!
-static Microsoft.AspNetCore.Http.Results.Created<TValue>(System.Uri! uri, TValue? value) -> Microsoft.AspNetCore.Http.IResult!
-static Microsoft.AspNetCore.Http.Results.Created<TValue>(string! uri, TValue? value) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.Created() -> Microsoft.AspNetCore.Http.IResult!
+*REMOVED*static Microsoft.AspNetCore.Http.Results.Created(string! uri, object? value) -> Microsoft.AspNetCore.Http.IResult!
+*REMOVED*static Microsoft.AspNetCore.Http.Results.Created(System.Uri! uri, object? value) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.Created(string? uri, object? value) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.Created(System.Uri? uri, object? value) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.Created<TValue>(string? uri, TValue? value) -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.Results.Created<TValue>(System.Uri? uri, TValue? value) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.CreatedAtRoute<TValue>(string? routeName = null, object? routeValues = null, TValue? value = default(TValue?)) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.Json<TValue>(TValue? data, System.Text.Json.JsonSerializerOptions? options = null, string? contentType = null, int? statusCode = null) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.Results.NotFound<TValue>(TValue? value) -> Microsoft.AspNetCore.Http.IResult!
@@ -171,6 +176,11 @@ static Microsoft.AspNetCore.Http.Results.Text(System.ReadOnlySpan<byte> utf8Cont
 static Microsoft.AspNetCore.Http.Results.UnprocessableEntity<TValue>(TValue? error) -> Microsoft.AspNetCore.Http.IResult!
 static Microsoft.AspNetCore.Http.TypedResults.Content(string? content, string? contentType = null, System.Text.Encoding? contentEncoding = null, int? statusCode = null) -> Microsoft.AspNetCore.Http.HttpResults.ContentHttpResult!
 static Microsoft.AspNetCore.Http.TypedResults.Content(string? content, string? contentType, System.Text.Encoding? contentEncoding) -> Microsoft.AspNetCore.Http.HttpResults.ContentHttpResult!
+static Microsoft.AspNetCore.Http.TypedResults.Created() -> Microsoft.AspNetCore.Http.HttpResults.Created!
+static Microsoft.AspNetCore.Http.TypedResults.Created(string? uri) -> Microsoft.AspNetCore.Http.HttpResults.Created!
+static Microsoft.AspNetCore.Http.TypedResults.Created(System.Uri? uri) -> Microsoft.AspNetCore.Http.HttpResults.Created!
+static Microsoft.AspNetCore.Http.TypedResults.Created<TValue>(string? uri, TValue? value) -> Microsoft.AspNetCore.Http.HttpResults.Created<TValue>!
+static Microsoft.AspNetCore.Http.TypedResults.Created<TValue>(System.Uri? uri, TValue? value) -> Microsoft.AspNetCore.Http.HttpResults.Created<TValue>!
 static Microsoft.AspNetCore.Http.TypedResults.Text(string? content, string? contentType = null, System.Text.Encoding? contentEncoding = null, int? statusCode = null) -> Microsoft.AspNetCore.Http.HttpResults.ContentHttpResult!
 static Microsoft.AspNetCore.Http.TypedResults.Text(string? content, string? contentType, System.Text.Encoding? contentEncoding) -> Microsoft.AspNetCore.Http.HttpResults.ContentHttpResult!
 static Microsoft.AspNetCore.Http.TypedResults.Text(System.ReadOnlySpan<byte> utf8Content, string? contentType = null, int? statusCode = null) -> Microsoft.AspNetCore.Http.HttpResults.Utf8ContentHttpResult!
@@ -243,10 +253,6 @@ static Microsoft.AspNetCore.Http.TypedResults.Challenge(Microsoft.AspNetCore.Aut
 static Microsoft.AspNetCore.Http.TypedResults.Conflict() -> Microsoft.AspNetCore.Http.HttpResults.Conflict!
 static Microsoft.AspNetCore.Http.TypedResults.Conflict<TValue>(TValue? error) -> Microsoft.AspNetCore.Http.HttpResults.Conflict<TValue>!
 static Microsoft.AspNetCore.Http.TypedResults.Content(string? content, Microsoft.Net.Http.Headers.MediaTypeHeaderValue! contentType) -> Microsoft.AspNetCore.Http.HttpResults.ContentHttpResult!
-static Microsoft.AspNetCore.Http.TypedResults.Created(System.Uri! uri) -> Microsoft.AspNetCore.Http.HttpResults.Created!
-static Microsoft.AspNetCore.Http.TypedResults.Created(string! uri) -> Microsoft.AspNetCore.Http.HttpResults.Created!
-static Microsoft.AspNetCore.Http.TypedResults.Created<TValue>(System.Uri! uri, TValue? value) -> Microsoft.AspNetCore.Http.HttpResults.Created<TValue>!
-static Microsoft.AspNetCore.Http.TypedResults.Created<TValue>(string! uri, TValue? value) -> Microsoft.AspNetCore.Http.HttpResults.Created<TValue>!
 static Microsoft.AspNetCore.Http.TypedResults.CreatedAtRoute(string? routeName = null, object? routeValues = null) -> Microsoft.AspNetCore.Http.HttpResults.CreatedAtRoute!
 static Microsoft.AspNetCore.Http.TypedResults.CreatedAtRoute<TValue>(TValue? value, string? routeName = null, object? routeValues = null) -> Microsoft.AspNetCore.Http.HttpResults.CreatedAtRoute<TValue>!
 static Microsoft.AspNetCore.Http.TypedResults.Empty.get -> Microsoft.AspNetCore.Http.HttpResults.EmptyHttpResult!

--- a/src/Http/Http.Results/src/Results.cs
+++ b/src/Http/Http.Results/src/Results.cs
@@ -680,6 +680,13 @@ public static partial class Results
 
     /// <summary>
     /// Produces a <see cref="StatusCodes.Status201Created"/> response.
+    /// </summary>   
+    /// <returns>The created <see cref="IResult"/> for the response.</returns>
+    public static IResult Created()
+        => TypedResults.Created();
+
+    /// <summary>
+    /// Produces a <see cref="StatusCodes.Status201Created"/> response.
     /// </summary>
     /// <param name="uri">The URI at which the content has been created.</param>
     /// <param name="value">The value to be included in the HTTP response body.</param>

--- a/src/Http/Http.Results/src/Results.cs
+++ b/src/Http/Http.Results/src/Results.cs
@@ -684,7 +684,7 @@ public static partial class Results
     /// <param name="uri">The URI at which the content has been created.</param>
     /// <param name="value">The value to be included in the HTTP response body.</param>
     /// <returns>The created <see cref="IResult"/> for the response.</returns>
-    public static IResult Created(string uri, object? value)
+    public static IResult Created(string? uri, object? value)
         => Created<object>(uri, value);
 
     /// <summary>
@@ -693,7 +693,7 @@ public static partial class Results
     /// <param name="uri">The URI at which the content has been created.</param>
     /// <param name="value">The value to be included in the HTTP response body.</param>
     /// <returns>The created <see cref="IResult"/> for the response.</returns>
-    public static IResult Created<TValue>(string uri, TValue? value)
+    public static IResult Created<TValue>(string? uri, TValue? value)
         => value is null ? TypedResults.Created(uri) : TypedResults.Created(uri, value);
 
     /// <summary>
@@ -702,7 +702,7 @@ public static partial class Results
     /// <param name="uri">The URI at which the content has been created.</param>
     /// <param name="value">The value to be included in the HTTP response body.</param>
     /// <returns>The created <see cref="IResult"/> for the response.</returns>
-    public static IResult Created(Uri uri, object? value)
+    public static IResult Created(Uri? uri, object? value)
         => Created<object>(uri, value);
 
     /// <summary>
@@ -711,7 +711,7 @@ public static partial class Results
     /// <param name="uri">The URI at which the content has been created.</param>
     /// <param name="value">The value to be included in the HTTP response body.</param>
     /// <returns>The created <see cref="IResult"/> for the response.</returns>
-    public static IResult Created<TValue>(Uri uri, TValue? value)
+    public static IResult Created<TValue>(Uri? uri, TValue? value)
         => value is null ? TypedResults.Created(uri) : TypedResults.Created(uri, value);
 
     /// <summary>

--- a/src/Http/Http.Results/src/TypedResults.cs
+++ b/src/Http/Http.Results/src/TypedResults.cs
@@ -795,13 +795,8 @@ public static class TypedResults
     /// </summary>
     /// <param name="uri">The URI at which the content has been created.</param>
     /// <returns>The created <see cref="HttpResults.Created"/> for the response.</returns>
-    public static Created Created(string uri)
+    public static Created Created(string? uri)
     {
-        if (string.IsNullOrEmpty(uri))
-        {
-            throw new ArgumentException("Argument cannot be null or empty", nameof(uri));
-        }
-
         return new(uri);
     }
 
@@ -812,13 +807,8 @@ public static class TypedResults
     /// <param name="uri">The URI at which the content has been created.</param>
     /// <param name="value">The value to be included in the HTTP response body.</param>
     /// <returns>The created <see cref="HttpResults.Created{TValue}"/> for the response.</returns>
-    public static Created<TValue> Created<TValue>(string uri, TValue? value)
+    public static Created<TValue> Created<TValue>(string? uri, TValue? value)
     {
-        if (string.IsNullOrEmpty(uri))
-        {
-            throw new ArgumentException("Argument cannot be null or empty", nameof(uri));
-        }
-
         return new(uri, value);
     }
 
@@ -827,10 +817,8 @@ public static class TypedResults
     /// </summary>
     /// <param name="uri">The URI at which the content has been created.</param>
     /// <returns>The created <see cref="HttpResults.Created"/> for the response.</returns>
-    public static Created Created(Uri uri)
+    public static Created Created(Uri? uri)
     {
-        ArgumentNullException.ThrowIfNull(uri);
-
         return new(uri);
     }
 
@@ -841,10 +829,8 @@ public static class TypedResults
     /// <param name="uri">The URI at which the content has been created.</param>
     /// <param name="value">The value to be included in the HTTP response body.</param>
     /// <returns>The created <see cref="HttpResults.Created{TValue}"/> for the response.</returns>
-    public static Created<TValue> Created<TValue>(Uri uri, TValue? value)
+    public static Created<TValue> Created<TValue>(Uri? uri, TValue? value)
     {
-        ArgumentNullException.ThrowIfNull(uri);
-
         return new(uri, value);
     }
 

--- a/src/Http/Http.Results/src/TypedResults.cs
+++ b/src/Http/Http.Results/src/TypedResults.cs
@@ -792,6 +792,15 @@ public static class TypedResults
 
     /// <summary>
     /// Produces a <see cref="StatusCodes.Status201Created"/> response.
+    /// </summary>   
+    /// <returns>The created <see cref="HttpResults.Created"/> for the response.</returns>
+    public static Created Created()
+    {
+        return new(default(string));
+    }
+
+    /// <summary>
+    /// Produces a <see cref="StatusCodes.Status201Created"/> response.
     /// </summary>
     /// <param name="uri">The URI at which the content has been created.</param>
     /// <returns>The created <see cref="HttpResults.Created"/> for the response.</returns>

--- a/src/Http/Http.Results/test/ResultsTests.cs
+++ b/src/Http/Http.Results/test/ResultsTests.cs
@@ -541,39 +541,69 @@ public class ResultsTests
     }
 
     [Fact]
-    public void Created_WithNullStringUri_ThrowsArgException()
+    public void Created_WithNullStringUri_SetsLocationNull()
     {
-        Assert.Throws<ArgumentException>("uri", () => Results.Created(default(string), null));
+        //Act
+        var result = Results.Created(default(string), null) as Created;
+
+        //Assert
+        Assert.Null(result.Location);
     }
 
     [Fact]
-    public void Created_WithEmptyStringUri_ThrowsArgException()
+    public void Created_WithEmptyStringUri_SetsLocationEmpty()
     {
-        Assert.Throws<ArgumentException>("uri", () => Results.Created(string.Empty, null));
+        //Act
+        var result = Results.Created(string.Empty, null) as Created;
+
+        //Assert
+        Assert.Empty(result.Location);
     }
 
     [Fact]
-    public void Created_WithNullUri_ThrowsArgNullException()
+    public void Created_WithNullUri_SetsLocationNull()
     {
-        Assert.Throws<ArgumentNullException>("uri", () => Results.Created(default(Uri), null));
+        // Act
+        var result = Results.Created(default(Uri), null) as Created;
+
+        //Assert
+        Assert.Null(result.Location);
     }
 
     [Fact]
-    public void Created_WithNullStringUriAndValue_ThrowsArgException()
+    public void Created_WithNullStringUriAndValue_SetsLocationNull()
     {
-        Assert.Throws<ArgumentException>("uri", () => Results.Created(default(string), new { }));
+        // Act
+        object value = new { };
+        var result = Results.Created(default(string), value) as Created<object>;
+
+        //Assert
+        Assert.Null(result.Location);
+        Assert.Equal(value, result.Value);
     }
 
     [Fact]
-    public void Created_WithEmptyStringUriAndValue_ThrowsArgException()
+    public void Created_WithEmptyStringUriAndValue_SetsLocationEmpty()
     {
-        Assert.Throws<ArgumentException>("uri", () => Results.Created(string.Empty, new { }));
+        // Act
+        object value = new { };
+        var result = Results.Created(string.Empty, value) as Created<object>;
+
+        //Assert
+        Assert.Empty(result.Location);
+        Assert.Equal(value, result.Value);
     }
 
     [Fact]
-    public void Created_WithNullUriAndValue_ThrowsArgNullException()
+    public void Created_WithNullUriAndValue_SetsLocationNull()
     {
-        Assert.Throws<ArgumentNullException>("uri", () => Results.Created(default(Uri), new { }));
+        // Act
+        object value = new { };
+        var result = Results.Created(default(Uri), value) as Created<object>;
+
+        //Assert
+        Assert.Null(result.Location);
+        Assert.Equal(value, result.Value);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/ResultsTests.cs
+++ b/src/Http/Http.Results/test/ResultsTests.cs
@@ -449,6 +449,16 @@ public class ResultsTests
     }
 
     [Fact]
+    public void Created_WithNoArgs_SetsLocationNull()
+    {
+        //Act
+        var result = Results.Created() as Created;
+
+        //Assert
+        Assert.Null(result.Location);
+    }
+
+    [Fact]
     public void Created_WithStringUriAndValue_ResultHasCorrectValues()
     {
         // Arrange
@@ -1331,6 +1341,7 @@ public class ResultsTests
         (() => Results.Content("content", null, null), typeof(ContentHttpResult)),
         (() => Results.Content("content", null, null, null), typeof(ContentHttpResult)),
         (() => Results.Created("/path", null), typeof(Created)),
+        (() => Results.Created(), typeof(Created)),
         (() => Results.Created("/path", new()), typeof(Created<object>)),
         (() => Results.CreatedAtRoute("routeName", null, null), typeof(CreatedAtRoute)),
         (() => Results.CreatedAtRoute("routeName", null, new()), typeof(CreatedAtRoute<object>)),

--- a/src/Http/Http.Results/test/ResultsTests.cs
+++ b/src/Http/Http.Results/test/ResultsTests.cs
@@ -573,8 +573,10 @@ public class ResultsTests
     [Fact]
     public void Created_WithNullStringUriAndValue_SetsLocationNull()
     {
-        // Act
+        //Arrange
         object value = new { };
+
+        // Act        
         var result = Results.Created(default(string), value) as Created<object>;
 
         //Assert
@@ -585,8 +587,10 @@ public class ResultsTests
     [Fact]
     public void Created_WithEmptyStringUriAndValue_SetsLocationEmpty()
     {
-        // Act
+        //Arrange
         object value = new { };
+
+        // Act        
         var result = Results.Created(string.Empty, value) as Created<object>;
 
         //Assert
@@ -597,8 +601,10 @@ public class ResultsTests
     [Fact]
     public void Created_WithNullUriAndValue_SetsLocationNull()
     {
-        // Act
+        //Arrange
         object value = new { };
+
+        // Act       
         var result = Results.Created(default(Uri), value) as Created<object>;
 
         //Assert

--- a/src/Http/Http.Results/test/TypedResultsTests.cs
+++ b/src/Http/Http.Results/test/TypedResultsTests.cs
@@ -562,39 +562,58 @@ public class TypedResultsTests
     }
 
     [Fact]
-    public void Created_WithNullStringUri_ThrowsArgException()
+    public void Created_WithNullStringUri_SetsLocationNull()
     {
-        Assert.Throws<ArgumentException>("uri", () => TypedResults.Created(default(string)));
+        // Act
+        var result = TypedResults.Created(default(string));
+
+        // Assert
+        Assert.Null(result.Location);
     }
 
     [Fact]
-    public void Created_WithEmptyStringUri_ThrowsArgException()
+    public void Created_WithEmptyStringUri_SetsLocationEmpty()
     {
-        Assert.Throws<ArgumentException>("uri", () => TypedResults.Created(string.Empty));
+        var result = TypedResults.Created(string.Empty);
+        Assert.Empty(result.Location);
     }
 
     [Fact]
-    public void Created_WithNullUri_ThrowsArgNullException()
+    public void Created_WithNullUri_SetsLocationNull()
     {
-        Assert.Throws<ArgumentNullException>("uri", () => TypedResults.Created(default(Uri)));
+        // Act
+        var result = TypedResults.Created(default(Uri));
+        Assert.Null(result.Location);
     }
 
     [Fact]
-    public void CreatedOfT_WithNullStringUri_ThrowsArgException()
+    public void CreatedOfT_WithNullStringUri_SetsLocationNull()
     {
-        Assert.Throws<ArgumentException>("uri", () => TypedResults.Created(default(string), default(object)));
+        // Act
+        var result = TypedResults.Created(default(string), default(object));
+
+        // Assert
+        Assert.Null(result.Location);
     }
 
     [Fact]
-    public void CreatedOfT_WithEmptyStringUri_ThrowsArgException()
+    public void CreatedOfT_WithEmptyStringUri_SetsLocationEmpty()
     {
-        Assert.Throws<ArgumentException>("uri", () => TypedResults.Created(string.Empty, default(object)));
+        // Act
+        var result = TypedResults.Created(string.Empty, default(object));
+
+        // Assert
+        Assert.Empty(result.Location);
     }
 
     [Fact]
-    public void CreatedOfT_WithNullUri_ThrowsArgNullException()
+    public void CreatedOfT_WithNullUri_SetsLocationNull()
     {
-        Assert.Throws<ArgumentNullException>("uri", () => TypedResults.Created(default(Uri), default(object)));
+        // Act
+        var result = TypedResults.Created(default(Uri), default(object));
+
+        // Assert
+        Assert.Null(result.Location);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/TypedResultsTests.cs
+++ b/src/Http/Http.Results/test/TypedResultsTests.cs
@@ -502,6 +502,17 @@ public class TypedResultsTests
     }
 
     [Fact]
+    public void Created_WithNoArgs_ResultHasCorrectValues()
+    {       
+        // Act
+        var result = TypedResults.Created();
+
+        // Assert
+        Assert.Equal(StatusCodes.Status201Created, result.StatusCode);
+        Assert.Null(result.Location);
+    }
+
+    [Fact]
     public void Created_WithStringUriAndValue_ResultHasCorrectValues()
     {
         // Arrange

--- a/src/Http/Http.Results/test/TypedResultsTests.cs
+++ b/src/Http/Http.Results/test/TypedResultsTests.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.ObjectModel;
 using System.IO.Pipelines;
-using System.Linq.Expressions;
-using System.Reflection;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
@@ -503,7 +501,7 @@ public class TypedResultsTests
 
     [Fact]
     public void Created_WithNoArgs_ResultHasCorrectValues()
-    {       
+    {
         // Act
         var result = TypedResults.Created();
 
@@ -707,7 +705,7 @@ public class TypedResultsTests
         var options = new JsonSerializerOptions();
         var contentType = "application/custom+json";
         var statusCode = StatusCodes.Status208AlreadyReported;
-            
+
         // Act
         var result = TypedResults.Json(data, options, contentType, statusCode);
 

--- a/src/Mvc/Mvc.Core/src/ControllerBase.cs
+++ b/src/Mvc/Mvc.Core/src/ControllerBase.cs
@@ -2018,6 +2018,15 @@ public abstract class ControllerBase
             StatusCode = validationProblem?.Status
         };
     }
+    /// <summary>
+    /// Creates a <see cref="CreatedResult"/> object that produces a <see cref="StatusCodes.Status201Created"/> response.
+    /// </summary>   
+    /// <returns>The created <see cref="CreatedResult"/> for the response.</returns>
+    [NonAction]
+    public virtual CreatedResult Created()
+    {
+        return new CreatedResult();
+    }
 
     /// <summary>
     /// Creates a <see cref="CreatedResult"/> object that produces a <see cref="StatusCodes.Status201Created"/> response.

--- a/src/Mvc/Mvc.Core/src/ControllerBase.cs
+++ b/src/Mvc/Mvc.Core/src/ControllerBase.cs
@@ -2026,13 +2026,8 @@ public abstract class ControllerBase
     /// <param name="value">The content value to format in the entity body.</param>
     /// <returns>The created <see cref="CreatedResult"/> for the response.</returns>
     [NonAction]
-    public virtual CreatedResult Created(string uri, [ActionResultObjectValue] object? value)
+    public virtual CreatedResult Created(string? uri, [ActionResultObjectValue] object? value)
     {
-        if (uri == null)
-        {
-            throw new ArgumentNullException(nameof(uri));
-        }
-
         return new CreatedResult(uri, value);
     }
 
@@ -2043,16 +2038,11 @@ public abstract class ControllerBase
     /// <param name="value">The content value to format in the entity body.</param>
     /// <returns>The created <see cref="CreatedResult"/> for the response.</returns>
     [NonAction]
-    public virtual CreatedResult Created(Uri uri, [ActionResultObjectValue] object? value)
+    public virtual CreatedResult Created(Uri? uri, [ActionResultObjectValue] object? value)
     {
-        if (uri == null)
-        {
-            throw new ArgumentNullException(nameof(uri));
-        }
-
-        return new CreatedResult(uri, value);
+        return new CreatedResult(uri, value);                                                  
     }
-
+   
     /// <summary>
     /// Creates a <see cref="CreatedAtActionResult"/> object that produces a <see cref="StatusCodes.Status201Created"/> response.
     /// </summary>

--- a/src/Mvc/Mvc.Core/src/ControllerBase.cs
+++ b/src/Mvc/Mvc.Core/src/ControllerBase.cs
@@ -2049,9 +2049,9 @@ public abstract class ControllerBase
     [NonAction]
     public virtual CreatedResult Created(Uri? uri, [ActionResultObjectValue] object? value)
     {
-        return new CreatedResult(uri, value);                                                  
+        return new CreatedResult(uri, value);
     }
-   
+
     /// <summary>
     /// Creates a <see cref="CreatedAtActionResult"/> object that produces a <see cref="StatusCodes.Status201Created"/> response.
     /// </summary>

--- a/src/Mvc/Mvc.Core/src/ControllerBase.cs
+++ b/src/Mvc/Mvc.Core/src/ControllerBase.cs
@@ -2018,6 +2018,7 @@ public abstract class ControllerBase
             StatusCode = validationProblem?.Status
         };
     }
+
     /// <summary>
     /// Creates a <see cref="CreatedResult"/> object that produces a <see cref="StatusCodes.Status201Created"/> response.
     /// </summary>   

--- a/src/Mvc/Mvc.Core/src/CreatedResult.cs
+++ b/src/Mvc/Mvc.Core/src/CreatedResult.cs
@@ -15,7 +15,7 @@ public class CreatedResult : ObjectResult
 {
     private const int DefaultStatusCode = StatusCodes.Status201Created;
 
-    private string _location;
+    private string? _location;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CreatedResult"/> class with the values
@@ -23,15 +23,14 @@ public class CreatedResult : ObjectResult
     /// </summary>
     /// <param name="location">The location at which the content has been created.</param>
     /// <param name="value">The value to format in the entity body.</param>
-    public CreatedResult(string location, object? value)
+    public CreatedResult(string? location, object? value)
         : base(value)
     {
-        if (location == null)
+        if (location != null)
         {
-            throw new ArgumentNullException(nameof(location));
+            Location = location;
         }
-
-        Location = location;
+        
         StatusCode = DefaultStatusCode;
     }
 
@@ -41,21 +40,19 @@ public class CreatedResult : ObjectResult
     /// </summary>
     /// <param name="location">The location at which the content has been created.</param>
     /// <param name="value">The value to format in the entity body.</param>
-    public CreatedResult(Uri location, object? value)
+    public CreatedResult(Uri? location, object? value)
         : base(value)
     {
-        if (location == null)
+        if (location != null)
         {
-            throw new ArgumentNullException(nameof(location));
-        }
-
-        if (location.IsAbsoluteUri)
-        {
-            Location = location.AbsoluteUri;
-        }
-        else
-        {
-            Location = location.GetComponents(UriComponents.SerializationInfoString, UriFormat.UriEscaped);
+            if (location.IsAbsoluteUri)
+            {
+                Location = location.AbsoluteUri;
+            }
+            else
+            {
+                Location = location.GetComponents(UriComponents.SerializationInfoString, UriFormat.UriEscaped);
+            }
         }
 
         StatusCode = DefaultStatusCode;
@@ -64,19 +61,10 @@ public class CreatedResult : ObjectResult
     /// <summary>
     /// Gets or sets the location at which the content has been created.
     /// </summary>
-    public string Location
+    public string? Location
     {
         get => _location;
-        [MemberNotNull(nameof(_location))]
-        set
-        {
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
-            _location = value;
-        }
+        set => _location = value;
     }
 
     /// <inheritdoc />

--- a/src/Mvc/Mvc.Core/src/CreatedResult.cs
+++ b/src/Mvc/Mvc.Core/src/CreatedResult.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 
@@ -23,7 +22,6 @@ public class CreatedResult : ObjectResult
     public CreatedResult()
         : base(null)
     {
-        
     }
 
     /// <summary>
@@ -39,7 +37,7 @@ public class CreatedResult : ObjectResult
         {
             Location = location;
         }
-        
+
         StatusCode = DefaultStatusCode;
     }
 

--- a/src/Mvc/Mvc.Core/src/CreatedResult.cs
+++ b/src/Mvc/Mvc.Core/src/CreatedResult.cs
@@ -18,6 +18,15 @@ public class CreatedResult : ObjectResult
     private string? _location;
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="CreatedResult"/> class 
+    /// </summary>  
+    public CreatedResult()
+        : base(null)
+    {
+        
+    }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="CreatedResult"/> class with the values
     /// provided.
     /// </summary>

--- a/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
@@ -8,6 +8,13 @@ Microsoft.AspNetCore.Mvc.ApplicationModels.InferParameterBindingInfoConvention.I
 *REMOVED*Microsoft.AspNetCore.Mvc.ControllerBase.TryUpdateModelAsync<TModel>(TModel! model, string! prefix, params System.Linq.Expressions.Expression<System.Func<TModel!, object!>!>![]! includeExpressions) -> System.Threading.Tasks.Task<bool>!
 Microsoft.AspNetCore.Mvc.ControllerBase.TryUpdateModelAsync<TModel>(TModel! model, string! prefix, Microsoft.AspNetCore.Mvc.ModelBinding.IValueProvider! valueProvider, params System.Linq.Expressions.Expression<System.Func<TModel!, object?>!>![]! includeExpressions) -> System.Threading.Tasks.Task<bool>!
 Microsoft.AspNetCore.Mvc.ControllerBase.TryUpdateModelAsync<TModel>(TModel! model, string! prefix, params System.Linq.Expressions.Expression<System.Func<TModel!, object?>!>![]! includeExpressions) -> System.Threading.Tasks.Task<bool>!
+Microsoft.AspNetCore.Mvc.CreatedResult.CreatedResult() -> void
+*REMOVED*Microsoft.AspNetCore.Mvc.CreatedResult.CreatedResult(string! location, object? value) -> void
+*REMOVED*Microsoft.AspNetCore.Mvc.CreatedResult.CreatedResult(System.Uri! location, object? value) -> void
+Microsoft.AspNetCore.Mvc.CreatedResult.CreatedResult(string? location, object? value) -> void
+Microsoft.AspNetCore.Mvc.CreatedResult.CreatedResult(System.Uri? location, object? value) -> void
+*REMOVED*Microsoft.AspNetCore.Mvc.CreatedResult.Location.get -> string!
+Microsoft.AspNetCore.Mvc.CreatedResult.Location.get -> string?
 Microsoft.AspNetCore.Mvc.ProblemDetails (forwarded, contained in Microsoft.AspNetCore.Http.Abstractions)
 Microsoft.AspNetCore.Mvc.ProblemDetails.Detail.get -> string? (forwarded, contained in Microsoft.AspNetCore.Http.Abstractions)
 Microsoft.AspNetCore.Mvc.ProblemDetails.Detail.set -> void (forwarded, contained in Microsoft.AspNetCore.Http.Abstractions)
@@ -32,6 +39,11 @@ Microsoft.AspNetCore.Mvc.ModelBinding.Metadata.SystemTextJsonValidationMetadataP
 Microsoft.AspNetCore.Mvc.ModelBinding.Metadata.ValidationMetadata.ValidationModelName.get -> string?
 Microsoft.AspNetCore.Mvc.ModelBinding.Metadata.ValidationMetadata.ValidationModelName.set -> void
 override Microsoft.AspNetCore.Mvc.ModelBinding.JQueryFormValueProvider.GetValue(string! key) -> Microsoft.AspNetCore.Mvc.ModelBinding.ValueProviderResult
+virtual Microsoft.AspNetCore.Mvc.ControllerBase.Created() -> Microsoft.AspNetCore.Mvc.CreatedResult!
+*REMOVED*virtual Microsoft.AspNetCore.Mvc.ControllerBase.Created(string! uri, object? value) -> Microsoft.AspNetCore.Mvc.CreatedResult!
+*REMOVED*virtual Microsoft.AspNetCore.Mvc.ControllerBase.Created(System.Uri! uri, object? value) -> Microsoft.AspNetCore.Mvc.CreatedResult!
+virtual Microsoft.AspNetCore.Mvc.ControllerBase.Created(string? uri, object? value) -> Microsoft.AspNetCore.Mvc.CreatedResult!
+virtual Microsoft.AspNetCore.Mvc.ControllerBase.Created(System.Uri? uri, object? value) -> Microsoft.AspNetCore.Mvc.CreatedResult!
 virtual Microsoft.AspNetCore.Mvc.Infrastructure.ConfigureCompatibilityOptions<TOptions>.PostConfigure(string? name, TOptions! options) -> void
 static Microsoft.AspNetCore.Mvc.ControllerBase.Empty.get -> Microsoft.AspNetCore.Mvc.EmptyResult!
 *REMOVED*virtual Microsoft.AspNetCore.Mvc.ModelBinding.DefaultPropertyFilterProvider<TModel>.PropertyIncludeExpressions.get -> System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression<System.Func<TModel!, object!>!>!>?

--- a/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
+++ b/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
@@ -1294,7 +1294,7 @@ public class ControllerBaseTest
         var controller = new TestableController();
 
         // Act
-        var result = controller.Created((string?)null, null);
+        var result = controller.Created((string)null, null);
 
         // Assert
         Assert.IsType<CreatedResult>(result);
@@ -1325,7 +1325,7 @@ public class ControllerBaseTest
         var controller = new TestableController();
 
         // Act
-        var result = controller.Created((Uri?)null, null);
+        var result = controller.Created((Uri)null, null);
 
         // Assert
         Assert.IsType<CreatedResult>(result);

--- a/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
+++ b/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
@@ -1288,6 +1288,21 @@ public class ControllerBaseTest
     }
 
     [Fact]
+    public void Created_WithNullStringParameter_CreatedLocationNull()
+    {
+        // Arrange
+        var controller = new TestableController();
+
+        // Act
+        var result = controller.Created((string?)null, null);
+
+        // Assert
+        Assert.IsType<CreatedResult>(result);
+        Assert.Equal(StatusCodes.Status201Created, result.StatusCode);
+        Assert.Null(result.Location);
+    }
+
+    [Fact]
     public void Created_WithAbsoluteUriParameter_SetsCreatedLocation()
     {
         // Arrange
@@ -1301,6 +1316,21 @@ public class ControllerBaseTest
         Assert.IsType<CreatedResult>(result);
         Assert.Equal(StatusCodes.Status201Created, result.StatusCode);
         Assert.Equal(uri.OriginalString, result.Location);
+    }
+
+    [Fact]
+    public void Created_WithNullUriParameter_CreatedLocationNull()
+    {
+        // Arrange
+        var controller = new TestableController();
+
+        // Act
+        var result = controller.Created((Uri?)null, null);
+
+        // Assert
+        Assert.IsType<CreatedResult>(result);
+        Assert.Equal(StatusCodes.Status201Created, result.StatusCode);
+        Assert.Null(result.Location);
     }
 
     [Fact]

--- a/src/Mvc/Mvc.Core/test/CreatedResultTests.cs
+++ b/src/Mvc/Mvc.Core/test/CreatedResultTests.cs
@@ -32,7 +32,7 @@ public class CreatedResultTests
     public void CreatedResult_SetsLocationNull()
     {
         // Act
-        var result = new CreatedResult((string?)null, "testInput");
+        var result = new CreatedResult((string)null, "testInput");
 
         // Assert
         Assert.Null(result.Location);
@@ -61,7 +61,7 @@ public class CreatedResultTests
         // Arrange        
         var httpContext = GetHttpContext();
         var actionContext = GetActionContext(httpContext);
-        var result = new CreatedResult((string?)null, "testInput");
+        var result = new CreatedResult((string)null, "testInput");
 
         // Act
         await result.ExecuteResultAsync(actionContext);

--- a/src/Mvc/Mvc.Core/test/CreatedResultTests.cs
+++ b/src/Mvc/Mvc.Core/test/CreatedResultTests.cs
@@ -29,6 +29,16 @@ public class CreatedResultTests
     }
 
     [Fact]
+    public void CreatedResult_WithNoArgs_SetsLocationNull()
+    {
+        // Act
+        var result = new CreatedResult();
+
+        // Assert
+        Assert.Null(result.Location);
+    }
+
+    [Fact]
     public void CreatedResult_SetsLocationNull()
     {
         // Act

--- a/src/Mvc/Mvc.Core/test/CreatedResultTests.cs
+++ b/src/Mvc/Mvc.Core/test/CreatedResultTests.cs
@@ -29,6 +29,16 @@ public class CreatedResultTests
     }
 
     [Fact]
+    public void CreatedResult_SetsLocationNull()
+    {
+        // Act
+        var result = new CreatedResult((string?)null, "testInput");
+
+        // Assert
+        Assert.Null(result.Location);
+    }
+
+    [Fact]
     public async Task CreatedResult_ReturnsStatusCode_SetsLocationHeader()
     {
         // Arrange
@@ -43,6 +53,22 @@ public class CreatedResultTests
         // Assert
         Assert.Equal(StatusCodes.Status201Created, httpContext.Response.StatusCode);
         Assert.Equal(location, httpContext.Response.Headers["Location"]);
+    }
+
+    [Fact]
+    public async Task CreatedResult_ReturnsStatusCode_NotSetLocationHeader()
+    {
+        // Arrange        
+        var httpContext = GetHttpContext();
+        var actionContext = GetActionContext(httpContext);
+        var result = new CreatedResult((string?)null, "testInput");
+
+        // Act
+        await result.ExecuteResultAsync(actionContext);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status201Created, httpContext.Response.StatusCode);
+        Assert.Empty(httpContext.Response.Headers["Location"]);
     }
 
     [Fact]

--- a/src/Mvc/Mvc.ViewFeatures/test/ControllerUnitTestabilityTests.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/ControllerUnitTestabilityTests.cs
@@ -81,6 +81,7 @@ public class ControllerUnitTestabilityTests
     [Theory]
     [InlineData("/Created_1", "<html>CreatedBody</html>")]
     [InlineData("/Created_2", null)]
+    [InlineData(null, null)]
     public void ControllerCreated_InvokedInUnitTests(string uri, string content)
     {
         // Arrange


### PR DESCRIPTION
Task #39454

CreatedResult should accept null location

Description
The primary resource created by the request is identified by either a Location header field in the response or, if no Location field is received, by the effective request URI.