### PR TITLE
Remove Auth validation when Form File upload

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -1239,8 +1239,6 @@ public static partial class RequestDelegateFactory
                     return (null, false);
                 }
 
-                ThrowIfRequestIsAuthenticated(httpContext);
-
                 try
                 {
                     formValue = await httpContext.Request.ReadFormAsync();
@@ -1259,33 +1257,6 @@ public static partial class RequestDelegateFactory
             }
 
             return (formValue, true);
-        }
-
-        static void ThrowIfRequestIsAuthenticated(HttpContext httpContext)
-        {
-            if (httpContext.Connection.ClientCertificate is not null)
-            {
-                throw new BadHttpRequestException(
-                    "Support for binding parameters from an HTTP request's form is not currently supported " +
-                    "if the request is associated with a client certificate. Use of an HTTP request form is " +
-                    "not currently secure for HTTP requests in scenarios which require authentication.");
-            }
-
-            if (!StringValues.IsNullOrEmpty(httpContext.Request.Headers.Authorization))
-            {
-                throw new BadHttpRequestException(
-                    "Support for binding parameters from an HTTP request's form is not currently supported " +
-                    "if the request contains an \"Authorization\" HTTP request header. Use of an HTTP request form is " +
-                    "not currently secure for HTTP requests in scenarios which require authentication.");
-            }
-
-            if (!StringValues.IsNullOrEmpty(httpContext.Request.Headers.Cookie))
-            {
-                throw new BadHttpRequestException(
-                    "Support for binding parameters from an HTTP request's form is not currently supported " +
-                    "if the request contains a \"Cookie\" HTTP request header. Use of an HTTP request form is " +
-                    "not currently secure for HTTP requests in scenarios which require authentication.");
-            }
         }
     }
 


### PR DESCRIPTION
Today, a Minimal endpoint does not allow a Form File(s) upload when any kind of authentication is detected, and a request will fail for all the following scenarios:

 - A client certificate is present, or
 - A `Authorization` header is set, or
 - Has cookies

This behavior was initially decided since we do not have any kind of `in-box` antiforgery mechanism for Minimal APIs.

This PR is related to our decision the change it and remove all these validations (same behavior existing in `API Controllers`) and allow all Form File(s) requests as default.

In addition, the documentation will be improved to show how to manually add support for `antiforgery` scenarios using `IAntiforgery` services.

Closes #38630