### PR TITLE
Fix Blazor WebView Streaming Race Condition

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/ByteArrayJsonConverter.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/ByteArrayJsonConverter.cs
@@ -76,7 +76,7 @@ internal sealed class ByteArrayJsonConverter : JsonConverter<byte[]>
 
     public override void Write(Utf8JsonWriter writer, byte[] value, JsonSerializerOptions options)
     {
-        var id = ++_byteArrayId;
+        var id = Interlocked.Increment(ref _byteArrayId);
 
         JSRuntime.SendByteArray(id, value);
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/7865

With two simultaneous streams (running as [background](https://github.com/michal-puczynski/repro_dotnet_maui_issue_7865/blob/f556f7e712955fb00e65157a27b50c81760c6d2b/ImagePeriodicRefresh/ImagePeriodicRefresh/Components/Display.razor#L54-L66) [tasks](https://github.com/michal-puczynski/repro_dotnet_maui_issue_7865/blob/f556f7e712955fb00e65157a27b50c81760c6d2b/ImagePeriodicRefresh/ImagePeriodicRefresh/Pages/Index.razor#L9-L12)), there was a race condition where both streams sent unique byte arrays, but using the same `_byteArrayId`. This was sent to `receiveByteArray` in JS which saves the the data within a `byteArraysToBeRevived: Map<id: number, data: Uint8Array>`. 

https://github.com/dotnet/aspnetcore/blob/645702a601fa0da94f50fbd30677357cb2f6c79b/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts#L421-L428

Thus, when we `set` duplicate `id`s within the `Map`, prior entries are overwritten.

Subsequently, when the byte arrays are "revived", we lookup the `id -> byte[]` mapping, and delete that `byte[]` from the `byteArraysToBeRevived` `Map`. 

https://github.com/dotnet/aspnetcore/blob/645702a601fa0da94f50fbd30677357cb2f6c79b/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts#L510-L515

The first time we do this operation it succeeds, but when we try to do this operation again (for the second `byte[]` sent with the same `id`), it fails as we already deleted the `byte[]` with that `id` in the previous step.

This PR ensures we [atomically increment](https://docs.microsoft.com/en-us/dotnet/api/system.threading.interlocked.increment?view=net-6.0) the `_byteArrayId` in .NET to ensure we never share the same `_byteArrayId` across streams.

Note, this issue is specific to Blazor WebView. I was not able to repro on `server` or `wasm`.