### PR TITLE
Make ResultsOfTGenerator non-packable

### DIFF
--- a/src/Http/Http.Results/tools/ResultsOfTGenerator/ResultsOfTGenerator.csproj
+++ b/src/Http/Http.Results/tools/ResultsOfTGenerator/ResultsOfTGenerator.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <AddPublicApiAnalyzers>false</AddPublicApiAnalyzers>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
- used only as an internal code gen tool