### PR TITLE
Update custom marshallers for source-generated interop to the V2 shapes.

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISConfigurationData.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISConfigurationData.cs
@@ -19,8 +19,8 @@ internal struct IISConfigurationData
     public string pwzBindings;
     public uint maxRequestBodySize;
 
-    [CustomTypeMarshaller(typeof(IISConfigurationData), CustomTypeMarshallerKind.Value, Features = CustomTypeMarshallerFeatures.UnmanagedResources | CustomTypeMarshallerFeatures.TwoStageMarshalling)]
-    public unsafe ref struct Marshaller
+    [CustomMarshaller(typeof(IISConfigurationData), MarshalMode.Default, typeof(Marshaller))]
+    public static class Marshaller
     {
         public struct Native
         {
@@ -36,51 +36,49 @@ internal struct IISConfigurationData
 
         private Native _native;
 
-        public Marshaller(IISConfigurationData managed)
+        public static Native ConvertToUnmanaged(IISConfigurationData managed)
         {
-            _native.pNativeApplication = managed.pNativeApplication;
-            _native.pwzFullApplicationPath = managed.pwzFullApplicationPath is null ? IntPtr.Zero : Marshal.StringToBSTR(managed.pwzFullApplicationPath);
-            _native.pwzVirtualApplicationPath = managed.pwzVirtualApplicationPath is null ? IntPtr.Zero : Marshal.StringToBSTR(managed.pwzVirtualApplicationPath);
-            _native.fWindowsAuthEnabled = managed.fWindowsAuthEnabled ? 1 : 0;
-            _native.fBasicAuthEnabled = managed.fBasicAuthEnabled ? 1 : 0;
-            _native.fAnonymousAuthEnable = managed.fAnonymousAuthEnable ? 1 : 0;
-            _native.pwzBindings = managed.pwzBindings is null ? IntPtr.Zero : Marshal.StringToBSTR(managed.pwzBindings);
-            _native.maxRequestBodySize = managed.maxRequestBodySize;
+            Native native;
+            native.pNativeApplication = managed.pNativeApplication;
+            native.pwzFullApplicationPath = managed.pwzFullApplicationPath is null ? IntPtr.Zero : Marshal.StringToBSTR(managed.pwzFullApplicationPath);
+            native.pwzVirtualApplicationPath = managed.pwzVirtualApplicationPath is null ? IntPtr.Zero : Marshal.StringToBSTR(managed.pwzVirtualApplicationPath);
+            native.fWindowsAuthEnabled = managed.fWindowsAuthEnabled ? 1 : 0;
+            native.fBasicAuthEnabled = managed.fBasicAuthEnabled ? 1 : 0;
+            native.fAnonymousAuthEnable = managed.fAnonymousAuthEnable ? 1 : 0;
+            native.pwzBindings = managed.pwzBindings is null ? IntPtr.Zero : Marshal.StringToBSTR(managed.pwzBindings);
+            native.maxRequestBodySize = managed.maxRequestBodySize;
+            return native;
         }
 
-        public Native ToNativeValue() => _native;
+        public static void Free(Native native)
+        {
+            if (native.pwzFullApplicationPath != IntPtr.Zero)
+            {
+                Marshal.FreeBSTR(native.pwzFullApplicationPath);
+            }
+            if (native.pwzVirtualApplicationPath != IntPtr.Zero)
+            {
+                Marshal.FreeBSTR(native.pwzVirtualApplicationPath);
+            }
+            if (native.pwzBindings != IntPtr.Zero)
+            {
+                Marshal.FreeBSTR(native.pwzBindings);
+            }
+        }
 
-        public void FromNativeValue(Native value) => _native = value;
-
-        public IISConfigurationData ToManaged()
+        public static IISConfigurationData ConvertToManaged(Native native)
         {
             return new()
             {
-                pNativeApplication = _native.pNativeApplication,
-                pwzFullApplicationPath = _native.pwzFullApplicationPath == IntPtr.Zero ? string.Empty : Marshal.PtrToStringBSTR(_native.pwzFullApplicationPath),
-                pwzVirtualApplicationPath = _native.pwzVirtualApplicationPath == IntPtr.Zero ? string.Empty : Marshal.PtrToStringBSTR(_native.pwzVirtualApplicationPath),
-                fWindowsAuthEnabled = _native.fWindowsAuthEnabled != 0,
-                fBasicAuthEnabled = _native.fBasicAuthEnabled != 0,
-                fAnonymousAuthEnable = _native.fAnonymousAuthEnable != 0,
-                pwzBindings = _native.pwzBindings == IntPtr.Zero ? string.Empty : Marshal.PtrToStringBSTR(_native.pwzBindings),
-                maxRequestBodySize = _native.maxRequestBodySize
+                pNativeApplication = native.pNativeApplication,
+                pwzFullApplicationPath = native.pwzFullApplicationPath == IntPtr.Zero ? string.Empty : Marshal.PtrToStringBSTR(_native.pwzFullApplicationPath),
+                pwzVirtualApplicationPath = native.pwzVirtualApplicationPath == IntPtr.Zero ? string.Empty : Marshal.PtrToStringBSTR(_native.pwzVirtualApplicationPath),
+                fWindowsAuthEnabled = native.fWindowsAuthEnabled != 0,
+                fBasicAuthEnabled = native.fBasicAuthEnabled != 0,
+                fAnonymousAuthEnable = native.fAnonymousAuthEnable != 0,
+                pwzBindings = native.pwzBindings == IntPtr.Zero ? string.Empty : Marshal.PtrToStringBSTR(_native.pwzBindings),
+                maxRequestBodySize = native.maxRequestBodySize
             };
-        }
-
-        public void FreeNative()
-        {
-            if (_native.pwzFullApplicationPath != IntPtr.Zero)
-            {
-                Marshal.FreeBSTR(_native.pwzFullApplicationPath);
-            }
-            if (_native.pwzVirtualApplicationPath != IntPtr.Zero)
-            {
-                Marshal.FreeBSTR(_native.pwzVirtualApplicationPath);
-            }
-            if (_native.pwzBindings != IntPtr.Zero)
-            {
-                Marshal.FreeBSTR(_native.pwzBindings);
-            }
         }
     }
 }

--- a/src/Servers/IIS/IIS/src/Core/IISConfigurationData.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISConfigurationData.cs
@@ -34,7 +34,6 @@ internal struct IISConfigurationData
             public uint maxRequestBodySize;
         }
 
-        private Native _native;
 
         public static Native ConvertToUnmanaged(IISConfigurationData managed)
         {

--- a/src/Servers/IIS/IIS/src/Core/IISConfigurationData.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISConfigurationData.cs
@@ -34,7 +34,6 @@ internal struct IISConfigurationData
             public uint maxRequestBodySize;
         }
 
-
         public static Native ConvertToUnmanaged(IISConfigurationData managed)
         {
             Native native;
@@ -70,12 +69,12 @@ internal struct IISConfigurationData
             return new()
             {
                 pNativeApplication = native.pNativeApplication,
-                pwzFullApplicationPath = native.pwzFullApplicationPath == IntPtr.Zero ? string.Empty : Marshal.PtrToStringBSTR(_native.pwzFullApplicationPath),
-                pwzVirtualApplicationPath = native.pwzVirtualApplicationPath == IntPtr.Zero ? string.Empty : Marshal.PtrToStringBSTR(_native.pwzVirtualApplicationPath),
+                pwzFullApplicationPath = native.pwzFullApplicationPath == IntPtr.Zero ? string.Empty : Marshal.PtrToStringBSTR(native.pwzFullApplicationPath),
+                pwzVirtualApplicationPath = native.pwzVirtualApplicationPath == IntPtr.Zero ? string.Empty : Marshal.PtrToStringBSTR(native.pwzVirtualApplicationPath),
                 fWindowsAuthEnabled = native.fWindowsAuthEnabled != 0,
                 fBasicAuthEnabled = native.fBasicAuthEnabled != 0,
                 fAnonymousAuthEnable = native.fAnonymousAuthEnable != 0,
-                pwzBindings = native.pwzBindings == IntPtr.Zero ? string.Empty : Marshal.PtrToStringBSTR(_native.pwzBindings),
+                pwzBindings = native.pwzBindings == IntPtr.Zero ? string.Empty : Marshal.PtrToStringBSTR(native.pwzBindings),
                 maxRequestBodySize = native.maxRequestBodySize
             };
         }

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
@@ -471,6 +472,7 @@ public partial class IISExpressDeployer : IISDeployerBase
 
                 public void OnInvoked() => GC.KeepAlive(_handle.Wrapper);
 
+                [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "This method is part of the marshaller shape and is required to be an instance method.")]
                 public void Free() {}
             }
         }

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISExpressDeployer.cs
@@ -455,19 +455,24 @@ public partial class IISExpressDeployer : IISDeployerBase
         [LibraryImport("user32.dll", EntryPoint = "GetClassNameW", SetLastError = true)]
         internal static partial int GetClassName(IntPtr hWnd, [Out, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2)] char[] lpClassName, int nMaxCount);
 
-        [CustomTypeMarshaller(typeof(HandleRef), Direction = CustomTypeMarshallerDirection.In, Features = CustomTypeMarshallerFeatures.UnmanagedResources | CustomTypeMarshallerFeatures.TwoStageMarshalling)]
-        internal struct HandleRefMarshaller
+        [CustomMarshaller(typeof(HandleRef), MarshalMode.ManagedToUnmanagedIn, typeof(ManagedToUnmanagedIn))]
+        internal static class HandleRefMarshaller
         {
-            private readonly HandleRef _handle;
-
-            public HandleRefMarshaller(HandleRef handle)
+            internal struct ManagedToUnmanagedIn
             {
-                _handle = handle;
+                private HandleRef _handle;
+
+                public void FromManaged(HandleRef handle)
+                {
+                    _handle = handle;
+                }
+
+                public IntPtr ToUnmanaged() => _handle.Handle;
+
+                public void OnInvoked() => GC.KeepAlive(_handle.Wrapper);
+
+                public void Free() {}
             }
-
-            public IntPtr ToNativeValue() => _handle.Handle;
-
-            public void FreeNative() => GC.KeepAlive(_handle.Wrapper);
         }
     }
 


### PR DESCRIPTION
# Update custom marshallers for source-generated interop to the V2 shapes.

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

We've updated the shape of the custom marshallers based on significant feedback. This PR moves the custom marshallers in ASP.NET Core to use the new shapes so we can remove support for the old shapes.

Contributes to https://github.com/dotnet/runtime/issues/70859

cc: @AaronRobinsonMSFT @elinor-fung 
