### PR TITLE
Log a warning when using an untrusted developer certificate 

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/LoggerExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/LoggerExtensions.cs
@@ -38,6 +38,6 @@ internal static partial class LoggerExtensions
     [LoggerMessage(7, LogLevel.Error, "The certificate key file at '{CertificateKeyFilePath}' can not be found, contains malformed data or does not contain a PEM encoded key in PKCS8 format.", EventName = "MissingOrInvalidCertificateKeyFile")]
     public static partial void FailedToLoadCertificateKey(this ILogger<KestrelServer> logger, string certificateKeyFilePath);
 
-    [LoggerMessage(8, LogLevel.Warning, "The ASP.NET Core developer certificate is not trusted. See https://aka.ms/aspnet/https-trust-dev-cert.", EventName = "DeveloperCertificateNotTrusted")]
+    [LoggerMessage(8, LogLevel.Warning, "The ASP.NET Core developer certificate is not trusted. For information about trusting the ASP.NET Core developer certificate, see https://aka.ms/aspnet/https-trust-dev-cert.", EventName = "DeveloperCertificateNotTrusted")]
     public static partial void DeveloperCertificateNotTrusted(this ILogger<KestrelServer> logger);
 }

--- a/src/Servers/Kestrel/Core/src/Internal/LoggerExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/LoggerExtensions.cs
@@ -37,4 +37,7 @@ internal static partial class LoggerExtensions
 
     [LoggerMessage(7, LogLevel.Error, "The certificate key file at '{CertificateKeyFilePath}' can not be found, contains malformed data or does not contain a PEM encoded key in PKCS8 format.", EventName = "MissingOrInvalidCertificateKeyFile")]
     public static partial void FailedToLoadCertificateKey(this ILogger<KestrelServer> logger, string certificateKeyFilePath);
+
+    [LoggerMessage(8, LogLevel.Warning, "The ASP.NET Core developer certificate is not trusted.", EventName = "DeveloperCertificateNotTrusted")]
+    public static partial void DeveloperCertificateNotTrusted(this ILogger<KestrelServer> logger);
 }

--- a/src/Servers/Kestrel/Core/src/Internal/LoggerExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/LoggerExtensions.cs
@@ -38,6 +38,6 @@ internal static partial class LoggerExtensions
     [LoggerMessage(7, LogLevel.Error, "The certificate key file at '{CertificateKeyFilePath}' can not be found, contains malformed data or does not contain a PEM encoded key in PKCS8 format.", EventName = "MissingOrInvalidCertificateKeyFile")]
     public static partial void FailedToLoadCertificateKey(this ILogger<KestrelServer> logger, string certificateKeyFilePath);
 
-    [LoggerMessage(8, LogLevel.Warning, "The ASP.NET Core developer certificate is not trusted.", EventName = "DeveloperCertificateNotTrusted")]
+    [LoggerMessage(8, LogLevel.Warning, "The ASP.NET Core developer certificate is not trusted. See https://aka.ms/aspnet/https-trust-dev-cert.", EventName = "DeveloperCertificateNotTrusted")]
     public static partial void DeveloperCertificateNotTrusted(this ILogger<KestrelServer> logger);
 }

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -295,6 +295,11 @@ public class KestrelServerOptions
                     }
 
                     logger.LocatedDevelopmentCertificate(DefaultCertificate);
+
+                    if (!CertificateManager.Instance.IsTrusted(DefaultCertificate))
+                    {
+                        logger.DeveloperCertificateNotTrusted();
+                    }
                 }
                 else
                 {

--- a/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
@@ -41,12 +41,7 @@ internal sealed class WindowsCertificateManager : CertificateManager
 
     internal override CheckCertificateStateResult CheckCertificateState(X509Certificate2 candidate, bool interactive)
     {
-        if (IsTrusted(candidate))
-        {
-            return new CheckCertificateStateResult(true, null);
-        }
-
-        return new CheckCertificateStateResult(false, "The ASP.NET Core developer certificate is not trusted.");
+        return new CheckCertificateStateResult(true, null);
     }
 
     internal override void CorrectCertificateState(X509Certificate2 candidate)

--- a/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/WindowsCertificateManager.cs
@@ -41,8 +41,12 @@ internal sealed class WindowsCertificateManager : CertificateManager
 
     internal override CheckCertificateStateResult CheckCertificateState(X509Certificate2 candidate, bool interactive)
     {
-        // Return true as we don't perform any check.
-        return new CheckCertificateStateResult(true, null);
+        if (IsTrusted(candidate))
+        {
+            return new CheckCertificateStateResult(true, null);
+        }
+
+        return new CheckCertificateStateResult(false, "The ASP.NET Core developer certificate is not trusted.");
     }
 
     internal override void CorrectCertificateState(X509Certificate2 candidate)


### PR DESCRIPTION
Fixes #41990 

If the developer certificate is present but untrusted, today Kestrel will load it without comment:
```
dbug: Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServer[0]
      Using development certificate: CN=localhost (Thumbprint: 35775CD3DF9AD7ED5835C7AC665095CA89B001B1)
```

I've added a check to ensure the certificate is trusted. Now it shows:
```
warn: Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServer[5]
      The ASP.NET Core developer certificate is not trusted.
fail: Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServer[4]
      The ASP.NET Core developer certificate is in an invalid state. To fix this issue, run the following commands 'dotnet dev-certs https --clean' and 'dotnet dev-certs https' to remove all existing ASP.NET Core development certificates and create a new untrusted developer certificate. On macOS or Windows, use 'dotnet dev-certs https --trust' to trust the new certificate.
dbug: Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServer[0]
      Using development certificate: CN=localhost (Thumbprint: 35775CD3DF9AD7ED5835C7AC665095CA89B001B1)
```

The second log is the same message used on mac clients when the cert isn't valid.

We do not attempt to trigger the interactive trust prompt from Kestrel.