### PR TITLE
Reuse Http3MessageBody

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3MessageBody.cs
@@ -14,10 +14,11 @@ internal sealed class Http3MessageBody : MessageBody
     private readonly Http3Stream _context;
     private ReadResult _readResult;
 
-    private Http3MessageBody(Http3Stream context)
+    public Http3MessageBody(Http3Stream context)
         : base(context)
     {
         _context = context;
+        ExtendedConnect = _context.IsExtendedConnectRequest;
     }
 
     protected override void OnReadStarting()
@@ -31,9 +32,11 @@ internal sealed class Http3MessageBody : MessageBody
         }
     }
 
-    public static MessageBody For(Http3Stream context)
+    public override void Reset()
     {
-        return new Http3MessageBody(context);
+        base.Reset();
+        _readResult = default;
+        ExtendedConnect = _context.IsExtendedConnectRequest;
     }
 
     public override void AdvanceTo(SequencePosition consumed, SequencePosition examined)

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -52,6 +52,7 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
     private PseudoHeaderFields _parsedPseudoHeaderFields;
     private int _totalParsedHeaderSize;
     private bool _isMethodConnect;
+    private Http3MessageBody? _messageBody;
 
     private readonly ManualResetValueTaskSource<object?> _appCompletedTaskSource = new ManualResetValueTaskSource<object?>();
 
@@ -921,7 +922,18 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
     }
 
     protected override MessageBody CreateMessageBody()
-        => Http3MessageBody.For(this);
+    {
+        if (_messageBody != null)
+        {
+            _messageBody.Reset();
+        }
+        else
+        {
+            _messageBody = new Http3MessageBody(this);
+        }
+
+        return _messageBody;
+    }
 
     protected override bool TryParseRequest(ReadResult result, out bool endConnection)
     {


### PR DESCRIPTION
Replicate HTTP/2 optimization to reuse Http3MessageBody between requests.