### PR TITLE
[SignalR] [.NET Client] Retry HTTP request on auth failure

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.Transport.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.Transport.cs
@@ -341,10 +341,8 @@ public partial class HttpConnectionTests
             Assert.Equal(1, accessTokenCallCount);
         }
 
-        [Theory]
-        [InlineData(HttpStatusCode.Unauthorized)]
-        [InlineData(HttpStatusCode.Forbidden)]
-        public async Task HttpConnectionRetriesAccessTokenProviderWhenAuthFailsLongPolling(HttpStatusCode httpStatusCode)
+        [Fact]
+        public async Task HttpConnectionRetriesAccessTokenProviderWhenAuthFailsLongPolling()
         {
             var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
             var requestsExecuted = false;
@@ -365,7 +363,7 @@ public partial class HttpConnectionTests
                 if (pollCount % 2 == 0)
                 {
                     pollCount++;
-                    return ResponseUtils.CreateResponse(httpStatusCode);
+                    return ResponseUtils.CreateResponse(HttpStatusCode.Unauthorized);
                 }
                 if (pollCount / 2 >= messageFragments.Length)
                 {
@@ -385,7 +383,7 @@ public partial class HttpConnectionTests
                 if (!requestsExecuted)
                 {
                     requestsExecuted = true;
-                    return Task.FromResult(ResponseUtils.CreateResponse(httpStatusCode));
+                    return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.Unauthorized));
                 }
 
                 Assert.Equal("Bearer", request.Headers.Authorization.Scheme);
@@ -419,10 +417,8 @@ public partial class HttpConnectionTests
             Assert.Equal(7, accessTokenCallCount);
         }
 
-        [Theory]
-        [InlineData(HttpStatusCode.Unauthorized)]
-        [InlineData(HttpStatusCode.Forbidden)]
-        public async Task HttpConnectionFailsAfterFirstRetryFailsLongPolling(HttpStatusCode httpStatusCode)
+        [Fact]
+        public async Task HttpConnectionFailsAfterFirstRetryFailsLongPolling()
         {
             var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
             var accessTokenCallCount = 0;
@@ -434,7 +430,7 @@ public partial class HttpConnectionTests
 
             testHttpHandler.OnLongPoll(_ =>
             {
-                return ResponseUtils.CreateResponse(httpStatusCode);
+                return ResponseUtils.CreateResponse(HttpStatusCode.Unauthorized);
             });
 
             Task<string> AccessTokenProvider()
@@ -455,10 +451,8 @@ public partial class HttpConnectionTests
             Assert.Equal(2, accessTokenCallCount);
         }
 
-        [Theory]
-        [InlineData(HttpStatusCode.Unauthorized)]
-        [InlineData(HttpStatusCode.Forbidden)]
-        public async Task HttpConnectionRetriesAccessTokenProviderWhenAuthFailsServerSentEvents(HttpStatusCode httpStatusCode)
+        [Fact]
+        public async Task HttpConnectionRetriesAccessTokenProviderWhenAuthFailsServerSentEvents()
         {
             var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
             var requestsExecuted = false;
@@ -476,7 +470,7 @@ public partial class HttpConnectionTests
                 if (!sendRequestExecuted)
                 {
                     sendRequestExecuted = true;
-                    return ResponseUtils.CreateResponse(httpStatusCode);
+                    return ResponseUtils.CreateResponse(HttpStatusCode.Unauthorized);
                 }
                 sendFinishedTcs.SetResult();
                 return ResponseUtils.CreateResponse(HttpStatusCode.OK);
@@ -489,7 +483,7 @@ public partial class HttpConnectionTests
                 if (!requestsExecuted)
                 {
                     requestsExecuted = true;
-                    return Task.FromResult(ResponseUtils.CreateResponse(httpStatusCode));
+                    return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.Unauthorized));
                 }
 
                 Assert.Equal("Bearer", request.Headers.Authorization.Scheme);
@@ -519,10 +513,8 @@ public partial class HttpConnectionTests
             Assert.Equal(3, accessTokenCallCount);
         }
 
-        [Theory]
-        [InlineData(HttpStatusCode.Unauthorized)]
-        [InlineData(HttpStatusCode.Forbidden)]
-        public async Task HttpConnectionFailsAfterFirstRetryFailsServerSentEvents(HttpStatusCode httpStatusCode)
+        [Fact]
+        public async Task HttpConnectionFailsAfterFirstRetryFailsServerSentEvents()
         {
             var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
             var accessTokenCallCount = 0;
@@ -534,7 +526,7 @@ public partial class HttpConnectionTests
 
             testHttpHandler.OnSocketSend((_, _) =>
             {
-                return ResponseUtils.CreateResponse(httpStatusCode);
+                return ResponseUtils.CreateResponse(HttpStatusCode.Unauthorized);
             });
 
             var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.Transport.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HttpConnectionTests.Transport.cs
@@ -72,6 +72,7 @@ public partial class HttpConnectionTests
                 });
             // Fail safe in case the code is modified and some requests don't execute as a result
             Assert.True(requestsExecuted);
+            Assert.Equal(1, callCount);
         }
 
         [Theory]
@@ -309,6 +310,323 @@ public partial class HttpConnectionTests
 
                     Assert.Equal(TransferFormat.Text, transport.Format);
                 });
+        }
+
+        [Fact]
+        public async Task HttpConnectionFailsOnNegotiateWhenAuthFails()
+        {
+            var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+            var accessTokenCallCount = 0;
+            var negotiateCount = 0;
+
+            testHttpHandler.OnNegotiate((_, cancellationToken) =>
+            {
+                negotiateCount++;
+                return ResponseUtils.CreateResponse(HttpStatusCode.Unauthorized);
+            });
+
+            Task<string> AccessTokenProvider()
+            {
+                accessTokenCallCount++;
+                return Task.FromResult(accessTokenCallCount.ToString(CultureInfo.InvariantCulture));
+            }
+
+            await WithConnectionAsync(
+                CreateConnection(testHttpHandler, transportType: HttpTransportType.ServerSentEvents, accessTokenProvider: AccessTokenProvider),
+                async (connection) =>
+                {
+                    await Assert.ThrowsAsync<HttpRequestException>(async () => await connection.StartAsync().DefaultTimeout());
+                });
+            Assert.Equal(1, negotiateCount);
+            Assert.Equal(1, accessTokenCallCount);
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.Unauthorized)]
+        [InlineData(HttpStatusCode.Forbidden)]
+        public async Task HttpConnectionRetriesAccessTokenProviderWhenAuthFailsLongPolling(HttpStatusCode httpStatusCode)
+        {
+            var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+            var requestsExecuted = false;
+            var accessTokenCallCount = 0;
+            var pollCount = 0;
+
+            testHttpHandler.OnNegotiate((_, cancellationToken) =>
+            {
+                return ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationContent());
+            });
+
+            var startSendTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var longPollTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var messageFragments = new[] { "This ", "is ", "a ", "test" };
+            testHttpHandler.OnLongPoll(async _ =>
+            {
+                // fail every other request
+                if (pollCount % 2 == 0)
+                {
+                    pollCount++;
+                    return ResponseUtils.CreateResponse(httpStatusCode);
+                }
+                if (pollCount / 2 >= messageFragments.Length)
+                {
+                    startSendTcs.SetResult();
+                    await longPollTcs.Task;
+                    return ResponseUtils.CreateResponse(HttpStatusCode.NoContent);
+                }
+
+                var resp = ResponseUtils.CreateResponse(HttpStatusCode.OK, messageFragments[pollCount / 2]);
+                pollCount++;
+                return resp;
+            });
+
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            testHttpHandler.OnRequest((request, next, token) =>
+            {
+                if (!requestsExecuted)
+                {
+                    requestsExecuted = true;
+                    return Task.FromResult(ResponseUtils.CreateResponse(httpStatusCode));
+                }
+
+                Assert.Equal("Bearer", request.Headers.Authorization.Scheme);
+
+                Assert.Equal(accessTokenCallCount.ToString(CultureInfo.InvariantCulture), request.Headers.Authorization.Parameter);
+
+                tcs.SetResult();
+
+                return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK));
+            });
+
+            Task<string> AccessTokenProvider()
+            {
+                accessTokenCallCount++;
+                return Task.FromResult(accessTokenCallCount.ToString(CultureInfo.InvariantCulture));
+            }
+
+            await WithConnectionAsync(
+                CreateConnection(testHttpHandler, transportType: HttpTransportType.LongPolling, accessTokenProvider: AccessTokenProvider),
+                async (connection) =>
+                {
+                    await connection.StartAsync().DefaultTimeout();
+                    var message = await connection.Transport.Input.ReadAtLeastAsync(14);
+                    Assert.Equal("This is a test", Encoding.UTF8.GetString(message.Buffer));
+                    await startSendTcs.Task;
+                    await connection.Transport.Output.WriteAsync(Encoding.UTF8.GetBytes("Hello world 1"));
+                    await tcs.Task;
+                    longPollTcs.SetResult();
+                });
+            // 1 negotiate + 4 (number of polls) + 1 for last poll + 1 for send
+            Assert.Equal(7, accessTokenCallCount);
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.Unauthorized)]
+        [InlineData(HttpStatusCode.Forbidden)]
+        public async Task HttpConnectionFailsAfterFirstRetryFailsLongPolling(HttpStatusCode httpStatusCode)
+        {
+            var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+            var accessTokenCallCount = 0;
+
+            testHttpHandler.OnNegotiate((_, cancellationToken) =>
+            {
+                return ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationContent());
+            });
+
+            testHttpHandler.OnLongPoll(_ =>
+            {
+                return ResponseUtils.CreateResponse(httpStatusCode);
+            });
+
+            Task<string> AccessTokenProvider()
+            {
+                accessTokenCallCount++;
+                return Task.FromResult(accessTokenCallCount.ToString(CultureInfo.InvariantCulture));
+            }
+
+            await WithConnectionAsync(
+                CreateConnection(testHttpHandler, transportType: HttpTransportType.LongPolling, accessTokenProvider: AccessTokenProvider),
+                async (connection) =>
+                {
+                    await connection.StartAsync().DefaultTimeout();
+                    await Assert.ThrowsAsync<HttpRequestException>(async () => await connection.Transport.Input.ReadAllAsync());
+                });
+
+            // 1 negotiate + 1 retry initial poll
+            Assert.Equal(2, accessTokenCallCount);
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.Unauthorized)]
+        [InlineData(HttpStatusCode.Forbidden)]
+        public async Task HttpConnectionRetriesAccessTokenProviderWhenAuthFailsServerSentEvents(HttpStatusCode httpStatusCode)
+        {
+            var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+            var requestsExecuted = false;
+            var accessTokenCallCount = 0;
+
+            testHttpHandler.OnNegotiate((_, cancellationToken) =>
+            {
+                return ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationContent());
+            });
+
+            var sendRequestExecuted = false;
+            var sendFinishedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            testHttpHandler.OnSocketSend((_, _) =>
+            {
+                if (!sendRequestExecuted)
+                {
+                    sendRequestExecuted = true;
+                    return ResponseUtils.CreateResponse(httpStatusCode);
+                }
+                sendFinishedTcs.SetResult();
+                return ResponseUtils.CreateResponse(HttpStatusCode.OK);
+            });
+
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var stream = new BlockingStream(tcs);
+            testHttpHandler.OnRequest((request, next, token) =>
+            {
+                if (!requestsExecuted)
+                {
+                    requestsExecuted = true;
+                    return Task.FromResult(ResponseUtils.CreateResponse(httpStatusCode));
+                }
+
+                Assert.Equal("Bearer", request.Headers.Authorization.Scheme);
+
+                Assert.Equal(accessTokenCallCount.ToString(CultureInfo.InvariantCulture), request.Headers.Authorization.Parameter);
+
+                return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK, new StreamContent(stream)));
+            });
+
+            Task<string> AccessTokenProvider()
+            {
+                accessTokenCallCount++;
+                return Task.FromResult(accessTokenCallCount.ToString(CultureInfo.InvariantCulture));
+            }
+
+            await WithConnectionAsync(
+                CreateConnection(testHttpHandler, transportType: HttpTransportType.ServerSentEvents, accessTokenProvider: AccessTokenProvider),
+                async (connection) =>
+                {
+                    await connection.StartAsync().DefaultTimeout();
+                    await connection.Transport.Output.WriteAsync(Encoding.UTF8.GetBytes("Hello world 1"));
+                    await sendFinishedTcs.Task;
+                    tcs.TrySetResult();
+                    await connection.Transport.Input.ReadAllAsync();
+                });
+            // 1 negotiate + 1 retry stream request + 1 retry send
+            Assert.Equal(3, accessTokenCallCount);
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.Unauthorized)]
+        [InlineData(HttpStatusCode.Forbidden)]
+        public async Task HttpConnectionFailsAfterFirstRetryFailsServerSentEvents(HttpStatusCode httpStatusCode)
+        {
+            var testHttpHandler = new TestHttpMessageHandler(autoNegotiate: false);
+            var accessTokenCallCount = 0;
+
+            testHttpHandler.OnNegotiate((_, cancellationToken) =>
+            {
+                return ResponseUtils.CreateResponse(HttpStatusCode.OK, ResponseUtils.CreateNegotiationContent());
+            });
+
+            testHttpHandler.OnSocketSend((_, _) =>
+            {
+                return ResponseUtils.CreateResponse(httpStatusCode);
+            });
+
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var stream = new BlockingStream(tcs);
+            testHttpHandler.OnRequest((request, next, token) =>
+            {
+                return Task.FromResult(ResponseUtils.CreateResponse(HttpStatusCode.OK, new StreamContent(stream)));
+            });
+
+            Task<string> AccessTokenProvider()
+            {
+                accessTokenCallCount++;
+                return Task.FromResult(accessTokenCallCount.ToString(CultureInfo.InvariantCulture));
+            }
+
+            await WithConnectionAsync(
+                CreateConnection(testHttpHandler, transportType: HttpTransportType.ServerSentEvents, accessTokenProvider: AccessTokenProvider),
+                async (connection) =>
+                {
+                    await connection.StartAsync().DefaultTimeout();
+                    await connection.Transport.Output.WriteAsync(Encoding.UTF8.GetBytes("Hello world 1"));
+                    await Assert.ThrowsAsync<HttpRequestException>(async () => await connection.Transport.Input.ReadAllAsync());
+                });
+            // 1 negotiate + 1 retry stream request
+            Assert.Equal(2, accessTokenCallCount);
+        }
+
+        private class BlockingStream : Stream
+        {
+            private readonly TaskCompletionSource _tcs;
+            private bool _ignoreFirstWrite = true;
+
+            public BlockingStream(TaskCompletionSource tcs)
+            {
+                _tcs = tcs;
+            }
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => throw new NotImplementedException();
+            public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+            public override void Flush()
+            {
+            }
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                throw new NotImplementedException();
+            }
+            public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                cancellationToken.Register(() => _tcs.TrySetResult());
+                await _tcs.Task;
+                return 0;
+            }
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotImplementedException();
+            }
+            public override void SetLength(long value)
+            {
+                throw new NotImplementedException();
+            }
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotImplementedException();
+            }
+            public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                if (_ignoreFirstWrite)
+                {
+                    // SSE does an initial write of :\r\n that we want to ignore in testing
+                    _ignoreFirstWrite = false;
+                    return;
+                }
+                await _tcs.Task;
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+            public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                if (_ignoreFirstWrite)
+                {
+                    // SSE does an initial write of :\r\n that we want to ignore in testing
+                    _ignoreFirstWrite = false;
+                    return;
+                }
+                await _tcs.Task;
+                cancellationToken.ThrowIfCancellationRequested();
+            }
         }
     }
 }

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.Log.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.Log.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Net;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Logging;
 
@@ -9,7 +10,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client;
 
 public partial class HttpConnection
 {
-    private static partial class Log
+    internal static partial class Log
     {
         [LoggerMessage(1, LogLevel.Debug, "Starting HttpConnection.", EventName = "Starting")]
         public static partial void Starting(ILogger logger);
@@ -104,5 +105,8 @@ public partial class HttpConnection
 
         [LoggerMessage(20, LogLevel.Trace, "Cookies are not supported on this platform.", EventName = "CookiesNotSupported")]
         public static partial void CookiesNotSupported(ILogger logger);
+
+        [LoggerMessage(21, LogLevel.Debug, "{StatusCode} received, getting a new access token and retrying request.", EventName = "RetryAccessToken")]
+        public static partial void RetryAccessToken(ILogger logger, HttpStatusCode statusCode);
     }
 }

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -464,6 +464,12 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
                 // Corefx changed the default version and High Sierra curlhandler tries to upgrade request
                 request.Version = new Version(1, 1);
 
+#if NET5_0_OR_GREATER
+                request.Options.Set(new HttpRequestOptionsKey<bool>("IsNegotiate"), true);
+#else
+                request.Properties.Add("IsNegotiate", true);
+#endif
+
                 // ResponseHeadersRead instructs SendAsync to return once headers are read
                 // rather than buffer the entire response. This gives a small perf boost.
                 // Note that it is important to dispose of the response when doing this to

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -32,7 +32,7 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
 
     private static readonly TimeSpan HttpClientTimeout = TimeSpan.FromSeconds(120);
 
-    private readonly ILogger _logger;
+    internal readonly ILogger _logger;
 
     private readonly SemaphoreSlim _connectionLock = new SemaphoreSlim(1, 1);
     private bool _started;

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/AccessTokenHttpMessageHandler.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/AccessTokenHttpMessageHandler.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
@@ -11,6 +12,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal;
 internal sealed class AccessTokenHttpMessageHandler : DelegatingHandler
 {
     private readonly HttpConnection _httpConnection;
+    private string? _accessToken;
 
     public AccessTokenHttpMessageHandler(HttpMessageHandler inner, HttpConnection httpConnection) : base(inner)
     {
@@ -19,13 +21,36 @@ internal sealed class AccessTokenHttpMessageHandler : DelegatingHandler
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var accessToken = await _httpConnection.GetAccessTokenAsync().ConfigureAwait(false);
-
-        if (!string.IsNullOrEmpty(accessToken))
+        var isNegotiate = false;
+        if (string.IsNullOrEmpty(_accessToken) ||
+            // Negotiate redirects likely will have a new access token so let's always grab a (potentially) new access token on negotiate
+            request.RequestUri!.OriginalString.Contains("/negotiate?"))
         {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+            isNegotiate = true;
+            _accessToken = await _httpConnection.GetAccessTokenAsync().ConfigureAwait(false);
         }
 
-        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(_accessToken))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
+        }
+
+        var result = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        // retry once with a new token on auth failure
+        if (!isNegotiate && result.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized)
+        {
+            HttpConnection.Log.RetryAccessToken(_httpConnection._logger, result.StatusCode);
+            result.Dispose();
+            _accessToken = await _httpConnection.GetAccessTokenAsync().ConfigureAwait(false);
+
+            if (!string.IsNullOrEmpty(_accessToken))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
+            }
+            // Retrying the request relies on any HttpContent being non-disposable.
+            // Currently this is true, the only HttpContent we send is type ReadOnlySequenceContent which is used by SSE and LongPolling for sending an already buffered byte[]
+            result = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        return result;
     }
 }

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/SendUtils.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/SendUtils.cs
@@ -88,6 +88,7 @@ internal static partial class SendUtils
         Log.SendStopped(logger);
     }
 
+    // AccessTokenHttpMessageHandler relies on this being reusable
     private sealed class ReadOnlySequenceContent : HttpContent
     {
         private readonly ReadOnlySequence<byte> _buffer;


### PR DESCRIPTION
Change how AccessTokenFactory is called, once during startup, then only on auth failure.
Retry auth failures (once) when using LongPolling and SSE after getting (potentially) a new token