### PR TITLE
Efficiently buffer to disk

### DIFF
--- a/src/Http/WebUtilities/src/PublicAPI.Unshipped.txt
+++ b/src/Http/WebUtilities/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 #nullable enable
+Microsoft.AspNetCore.WebUtilities.FileBufferingReadStream.BufferAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.WebUtilities.FileBufferingReadStream.FileIOBufferSize.get -> int
+Microsoft.AspNetCore.WebUtilities.FileBufferingReadStream.FileIOBufferSize.set -> void
 Microsoft.AspNetCore.WebUtilities.FormMultipartSection.GetValueAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<string!>
 override Microsoft.AspNetCore.WebUtilities.BufferedReadStream.WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask
 override Microsoft.AspNetCore.WebUtilities.FileBufferingReadStream.WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask

--- a/src/Http/WebUtilities/test/FileBufferingReadStreamTests.cs
+++ b/src/Http/WebUtilities/test/FileBufferingReadStreamTests.cs
@@ -505,6 +505,25 @@ public class FileBufferingReadStreamTests
         Assert.InRange(withBufferMs.NumberOfWrites, 1, mostExpectedWrites);
     }
 
+    [Theory]
+    [InlineData(1024 * 4)]
+    [InlineData(1024 * 16)]
+    [InlineData(1024 * 64)]
+    [InlineData(1024 * 1024)]
+    [InlineData(1024 * 1024 * 16)]
+    public async Task BufferAsyncWorks(int length)
+    {
+        var data = new byte[length];
+        var inner = new MemoryStream(data);
+
+        using var stream = new FileBufferingReadStream(inner, 1024 * 1024 * 5 + 3, // A strange number to ensure we're not lining up cleanly on boundaries.
+            bufferLimit: null, GetCurrentDirectory());
+
+        await stream.BufferAsync();
+        Assert.Equal(inner.Length, stream.Length);
+        Assert.Equal(inner.Position, stream.Position);
+    }
+
     [Fact]
     public async Task ReadAsyncThenCopyToAsyncWorks()
     {


### PR DESCRIPTION
We're exploring some performance problems with FileBufferingReadStream. One theory is that we should limit the number of writes to disk by temporarily buffering more in-memory, especially when trying to bulk buffer the stream.