### PR TITLE
[dotnet user-jwts] Move signing key details to top-level property

### DIFF
--- a/src/Security/Authentication/JwtBearer/src/JwtBearerConfigureOptions.cs
+++ b/src/Security/Authentication/JwtBearer/src/JwtBearerConfigureOptions.cs
@@ -84,14 +84,12 @@ internal sealed class JwtBearerConfigureOptions : IConfigureNamedOptions<JwtBear
     {
         foreach (var issuer in issuers)
         {
-            var signingKeys = configuration.GetSection("SigningKeys")
+            var signingKey = configuration.GetSection("SigningKeys")
                 .GetChildren()
-                .Where(key => key["Issuer"] == issuer)
-                .Select(key => key["Value"])
-                .OfType<string>();
-            foreach (var signingKey in signingKeys)
+                .SingleOrDefault(key => key["Issuer"] == issuer);
+            if (signingKey is not null && signingKey["Value"] is string keyValue)
             {
-                yield return new SymmetricSecurityKey(Convert.FromBase64String(signingKey));
+                yield return new SymmetricSecurityKey(Convert.FromBase64String(keyValue));
             }
         }
     }

--- a/src/Security/Authentication/JwtBearer/src/JwtBearerConfigureOptions.cs
+++ b/src/Security/Authentication/JwtBearer/src/JwtBearerConfigureOptions.cs
@@ -84,10 +84,14 @@ internal sealed class JwtBearerConfigureOptions : IConfigureNamedOptions<JwtBear
     {
         foreach (var issuer in issuers)
         {
-            var keyFromSecret = configuration[$"{issuer}:KeyMaterial"];
-            if (!string.IsNullOrEmpty(keyFromSecret))
+            var signingKeys = configuration.GetSection("SigningKeys")
+                .GetChildren()
+                .Where(key => key["Issuer"] == issuer)
+                .Select(key => key["Value"])
+                .OfType<string>();
+            foreach (var signingKey in signingKeys)
             {
-                yield return new SymmetricSecurityKey(Convert.FromBase64String(keyFromSecret));
+                yield return new SymmetricSecurityKey(Convert.FromBase64String(signingKey));
             }
         }
     }

--- a/src/Security/Authentication/test/JwtBearerTests.cs
+++ b/src/Security/Authentication/test/JwtBearerTests.cs
@@ -924,15 +924,17 @@ public class JwtBearerTests : SharedAuthenticationTests<JwtBearerOptions>
     public void CanReadMultipleIssuersFromConfig()
     {
         var services = new ServiceCollection().AddLogging();
+        var firstKey = "qPG6tDtfxFYZifHW3sEueQ==";
+        var secondKey = "6JPzXj6aOPdojlZdeLshaA==";
         var config = new ConfigurationBuilder().AddInMemoryCollection(new[]
         {
             new KeyValuePair<string, string>("Authentication:Schemes:Bearer:ValidIssuers:0", "dotnet-user-jwts"),
             new KeyValuePair<string, string>("Authentication:Schemes:Bearer:ValidIssuers:1", "dotnet-user-jwts-2"),
             new KeyValuePair<string, string>("Authentication:Schemes:Bearer:SigningKeys:0:Issuer", "dotnet-user-jwts"),
-            new KeyValuePair<string, string>("Authentication:Schemes:Bearer:SigningKeys:0:Value", "qPG6tDtfxFYZifHW3sEueQ=="),
+            new KeyValuePair<string, string>("Authentication:Schemes:Bearer:SigningKeys:0:Value", firstKey),
             new KeyValuePair<string, string>("Authentication:Schemes:Bearer:SigningKeys:0:Length", "32"),
             new KeyValuePair<string, string>("Authentication:Schemes:Bearer:SigningKeys:1:Issuer", "dotnet-user-jwts-2"),
-            new KeyValuePair<string, string>("Authentication:Schemes:Bearer:SigningKeys:1:Value", "6JPzXj6aOPdojlZdeLshaA=="),
+            new KeyValuePair<string, string>("Authentication:Schemes:Bearer:SigningKeys:1:Value", secondKey),
             new KeyValuePair<string, string>("Authentication:Schemes:Bearer:SigningKeys:1:Length", "32"),
         }).Build();
         services.AddSingleton<IConfiguration>(config);
@@ -949,6 +951,8 @@ public class JwtBearerTests : SharedAuthenticationTests<JwtBearerOptions>
         // Assert
         var jwtBearerOptions = sp.GetRequiredService<IOptionsMonitor<JwtBearerOptions>>().Get(JwtBearerDefaults.AuthenticationScheme);
         Assert.Equal(2, jwtBearerOptions.TokenValidationParameters.IssuerSigningKeys.Count());
+        Assert.Equal(firstKey, Convert.ToBase64String(jwtBearerOptions.TokenValidationParameters.IssuerSigningKeys.OfType<SymmetricSecurityKey>().FirstOrDefault()?.Key));
+        Assert.Equal(secondKey, Convert.ToBase64String(jwtBearerOptions.TokenValidationParameters.IssuerSigningKeys.OfType<SymmetricSecurityKey>().LastOrDefault()?.Key));
     }
 
     class InvalidTokenValidator : ISecurityTokenValidator

--- a/src/Tools/dotnet-user-jwts/src/Commands/CreateCommand.cs
+++ b/src/Tools/dotnet-user-jwts/src/Commands/CreateCommand.cs
@@ -233,7 +233,7 @@ internal sealed class CreateCommand
         {
             return 1;
         }
-        var keyMaterial = DevJwtCliHelpers.GetOrCreateSigningKeyMaterial(userSecretsId, options.Scheme);
+        var keyMaterial = SigningKeysHandler.GetOrCreateSigningKeyMaterial(userSecretsId, options.Scheme, options.Issuer);
 
         var jwtIssuer = new JwtIssuer(options.Issuer, keyMaterial);
         var jwtToken = jwtIssuer.Create(options);

--- a/src/Tools/dotnet-user-jwts/src/Commands/CreateCommand.cs
+++ b/src/Tools/dotnet-user-jwts/src/Commands/CreateCommand.cs
@@ -233,7 +233,7 @@ internal sealed class CreateCommand
         {
             return 1;
         }
-        var keyMaterial = DevJwtCliHelpers.GetOrCreateSigningKeyMaterial(userSecretsId, options.Scheme, options.Issuer);
+        var keyMaterial = DevJwtCliHelpers.GetOrCreateSigningKeyMaterial(userSecretsId, options.Scheme);
 
         var jwtIssuer = new JwtIssuer(options.Issuer, keyMaterial);
         var jwtToken = jwtIssuer.Create(options);

--- a/src/Tools/dotnet-user-jwts/src/Commands/KeyCommand.cs
+++ b/src/Tools/dotnet-user-jwts/src/Commands/KeyCommand.cs
@@ -21,12 +21,6 @@ internal sealed class KeyCommand
                 CommandOptionType.SingleValue
             );
 
-            var issuerOption = cmd.Option(
-                "--issuer",
-                Resources.KeyCommand_IssuerOption_Description,
-                CommandOptionType.SingleValue
-            );
-
             var resetOption = cmd.Option(
                 "--reset",
                 Resources.KeyCommand_ResetOption_Description,
@@ -44,13 +38,12 @@ internal sealed class KeyCommand
                 return Execute(cmd.Reporter,
                     cmd.ProjectOption.Value(),
                     schemeOption.Value() ?? DevJwtsDefaults.Scheme,
-                    issuerOption.Value() ?? DevJwtsDefaults.Issuer,
                     resetOption.HasValue(), forceOption.HasValue());
             });
         });
     }
 
-    private static int Execute(IReporter reporter, string projectPath, string schemeName, string issuer, bool reset, bool force)
+    private static int Execute(IReporter reporter, string projectPath, string schemeName, bool reset, bool force)
     {
         if (!DevJwtCliHelpers.GetProjectAndSecretsId(projectPath, reporter, out var _, out var userSecretsId))
         {
@@ -70,7 +63,7 @@ internal sealed class KeyCommand
                 }
             }
 
-            var key = DevJwtCliHelpers.CreateSigningKeyMaterial(userSecretsId, schemeName, issuer, reset: true);
+            var key = DevJwtCliHelpers.CreateSigningKeyMaterial(userSecretsId, schemeName, reset: true);
             reporter.Output(Resources.FormatKeyCommand_KeyCreated(Convert.ToBase64String(key)));
             return 0;
         }
@@ -78,7 +71,7 @@ internal sealed class KeyCommand
         var projectConfiguration = new ConfigurationBuilder()
             .AddUserSecrets(userSecretsId)
             .Build();
-        var signingKeyMaterial = projectConfiguration[DevJwtCliHelpers.GetSigningKeyPropertyName(schemeName, issuer)];
+        var signingKeyMaterial = projectConfiguration[DevJwtCliHelpers.GetSigningKeyValuePropertyName(schemeName)];
 
         if (signingKeyMaterial is null)
         {

--- a/src/Tools/dotnet-user-jwts/src/Helpers/DevJwtDefaults.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/DevJwtDefaults.cs
@@ -8,7 +8,7 @@ internal static class DevJwtsDefaults
     public static string Scheme => "Bearer";
     public static string Issuer => "dotnet-user-jwts";
 
-    public static string SigningKeyConfigurationKey => "KeyMaterial";
+    public static string SigningKeyConfigurationKey => "SigningKey";
 
     public static int SigningKeyLength => 32;
 }

--- a/src/Tools/dotnet-user-jwts/src/Helpers/DevJwtDefaults.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/DevJwtDefaults.cs
@@ -8,7 +8,7 @@ internal static class DevJwtsDefaults
     public static string Scheme => "Bearer";
     public static string Issuer => "dotnet-user-jwts";
 
-    public static string SigningKeyConfigurationKey => "SigningKey";
+    public static string SigningKeyConfigurationKey => "SigningKeys";
 
     public static int SigningKeyLength => 32;
 }

--- a/src/Tools/dotnet-user-jwts/src/Helpers/SigningKey.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/SigningKey.cs
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools;
+public record SigningKey(string Id, string Issuer, string Value, int Length)
+{
+}

--- a/src/Tools/dotnet-user-jwts/src/Helpers/SigningKeysHandler.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/SigningKeysHandler.cs
@@ -10,6 +10,25 @@ using System.Globalization;
 
 namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools;
 
+// This class manages signing keys for JWT tokens stored in user secrets.
+// These signing keys are stored under the following configuration scheme:
+//
+//   Authentication:
+//     Schemes:
+//          Bearer:
+//              SigningKeys: [{
+//                  Id: abcdefghi,
+//                  Value: somekeyhere,
+//                  Issuer: someissuer,
+//                  Length: 32
+//              },
+//              {
+//                  Id: ihgfedcba,
+//                  Value: somekeyhere,
+//                  Issuer: someissuer2,
+//                  Length: 32
+//              }]
+
 internal static class SigningKeysHandler
 {
     public static byte[] GetSigningKeyMaterial(string userSecretsId, string scheme, string issuer)
@@ -37,7 +56,7 @@ internal static class SigningKeysHandler
 
     public static byte[] GetOrCreateSigningKeyMaterial(string userSecretsId, string scheme, string issuer) =>
         GetSigningKeyMaterial(userSecretsId, scheme, issuer) ?? CreateSigningKeyMaterial(userSecretsId, scheme, issuer);
- 
+
 
     public static byte[] CreateSigningKeyMaterial(string userSecretsId, string scheme, string issuer, int signingKeyLength = 32, bool reset = false)
     {

--- a/src/Tools/dotnet-user-jwts/src/Helpers/SigningKeysHandler.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/SigningKeysHandler.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Configuration.UserSecrets;
+using Microsoft.Extensions.Configuration;
+using System.Text.Json.Nodes;
+using System.Text.Json;
+using System.Linq;
+using System.Globalization;
+
+namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools;
+
+internal static class SigningKeysHandler
+{
+    public static byte[] GetSigningKeyMaterial(string userSecretsId, string scheme, string issuer)
+    {
+        var projectConfiguration = new ConfigurationBuilder()
+            .AddUserSecrets(userSecretsId)
+            .Build();
+
+        var signingKey = projectConfiguration
+            .GetSection(GetSigningKeyPropertyName(scheme))
+            .Get<SigningKey[]>()
+            ?.SingleOrDefault(key => key.Issuer == issuer);
+        var signingKeyLength = signingKey?.Length ?? DevJwtsDefaults.SigningKeyLength;
+
+        var keyMaterial = new byte[signingKeyLength];
+        if (!string.IsNullOrEmpty(signingKey?.Value)
+            && Convert.TryFromBase64String(signingKey.Value, keyMaterial, out var bytesWritten)
+            && bytesWritten == signingKeyLength)
+        {
+            return keyMaterial;
+        }
+
+        return null;
+    }
+
+    public static byte[] GetOrCreateSigningKeyMaterial(string userSecretsId, string scheme, string issuer) =>
+        GetSigningKeyMaterial(userSecretsId, scheme, issuer) ?? CreateSigningKeyMaterial(userSecretsId, scheme, issuer);
+ 
+
+    public static byte[] CreateSigningKeyMaterial(string userSecretsId, string scheme, string issuer, int signingKeyLength = 32, bool reset = false)
+    {
+        // Create signing material and save to user secrets
+        var newKeyMaterial = System.Security.Cryptography.RandomNumberGenerator.GetBytes(signingKeyLength);
+        var secretsFilePath = PathHelper.GetSecretsPathFromSecretsId(userSecretsId);
+        Directory.CreateDirectory(Path.GetDirectoryName(secretsFilePath));
+
+        JsonObject secrets = null;
+        if (File.Exists(secretsFilePath))
+        {
+            using var secretsFileStream = new FileStream(secretsFilePath, FileMode.Open, FileAccess.Read);
+            if (secretsFileStream.Length > 0)
+            {
+                secrets = JsonSerializer.Deserialize<JsonObject>(secretsFileStream);
+            }
+        }
+
+        secrets ??= new JsonObject();
+        var signkingKeysPropertyName = GetSigningKeyPropertyName(scheme);
+        var shortId = Guid.NewGuid().ToString("N").Substring(0, 8);
+        var key = new SigningKey(shortId, issuer, Convert.ToBase64String(newKeyMaterial), signingKeyLength);
+
+        if (secrets.ContainsKey(signkingKeysPropertyName))
+        {
+            var signingKeys = secrets[signkingKeysPropertyName].AsArray();
+            if (reset)
+            {
+                var toRemove = signingKeys.SingleOrDefault(key => key["Issuer"].GetValue<string>() == issuer);
+                signingKeys.Remove(toRemove);
+            }
+            signingKeys.Add(key);
+        }
+        else
+        {
+            secrets.Add(signkingKeysPropertyName, JsonValue.Create(new[] { key }));
+        }
+
+        using var secretsWriteStream = new FileStream(secretsFilePath, FileMode.Create, FileAccess.Write);
+        JsonSerializer.Serialize(secretsWriteStream, secrets);
+
+        return newKeyMaterial;
+    }
+
+    public static string GetSigningKeyPropertyName(string scheme)
+        => $"Authentication:Schemes:{scheme}:{DevJwtsDefaults.SigningKeyConfigurationKey}";
+}

--- a/src/Tools/dotnet-user-jwts/src/Helpers/SigningKeysHandler.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/SigningKeysHandler.cs
@@ -28,7 +28,6 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools;
 //                  Issuer: someissuer2,
 //                  Length: 32
 //              }]
-
 internal static class SigningKeysHandler
 {
     public static byte[] GetSigningKeyMaterial(string userSecretsId, string scheme, string issuer)
@@ -56,7 +55,6 @@ internal static class SigningKeysHandler
 
     public static byte[] GetOrCreateSigningKeyMaterial(string userSecretsId, string scheme, string issuer) =>
         GetSigningKeyMaterial(userSecretsId, scheme, issuer) ?? CreateSigningKeyMaterial(userSecretsId, scheme, issuer);
-
 
     public static byte[] CreateSigningKeyMaterial(string userSecretsId, string scheme, string issuer, int signingKeyLength = 32, bool reset = false)
     {

--- a/src/Tools/dotnet-user-jwts/src/Resources.resx
+++ b/src/Tools/dotnet-user-jwts/src/Resources.resx
@@ -246,9 +246,6 @@
   <data name="KeyCommand_ForceOption_Description" xml:space="preserve">
     <value>Don't prompt for confirmation before resetting the signing key.</value>
   </data>
-  <data name="KeyCommand_IssuerOption_Description" xml:space="preserve">
-    <value>The issuer associated with the signing key to be reset or displayed. Defaults to 'dotnet-user-jwts'.</value>
-  </data>
   <data name="KeyCommand_KeyCreated" xml:space="preserve">
     <value>New signing key created: '{0}'</value>
   </data>

--- a/src/Tools/dotnet-user-jwts/src/Resources.resx
+++ b/src/Tools/dotnet-user-jwts/src/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -311,5 +311,8 @@
   </data>
   <data name="RemoveCommand_NoJwtFound" xml:space="preserve">
     <value>No JWT with ID '{0}' found.</value>
+  </data>
+  <data name="KeyCommand_IssuerOption_Description" xml:space="preserve">
+    <value>The issuer associated with the signing key to be reset or displayed. Defaults to 'dotnet-user-jwts'.</value>
   </data>
 </root>

--- a/src/Tools/dotnet-user-jwts/test/UserJwtsTestFixture.cs
+++ b/src/Tools/dotnet-user-jwts/test/UserJwtsTestFixture.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools.Tests;
 public class UserJwtsTestFixture : IDisposable
 {
     private Stack<Action> _disposables = new Stack<Action>();
-    internal string TestSecretsId = Guid.NewGuid().ToString();
+    internal string TestSecretsId;
 
     private const string ProjectTemplate = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
@@ -66,6 +66,7 @@ public class UserJwtsTestFixture : IDisposable
     {
         var projectPath = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "userjwtstest", Guid.NewGuid().ToString()));
         Directory.CreateDirectory(Path.Combine(projectPath.FullName, "Properties"));
+        TestSecretsId = Guid.NewGuid().ToString("N");
         var prop = hasSecret ? $"<UserSecretsId>{TestSecretsId}</UserSecretsId>" : string.Empty;
         if (hasSecret)
         {

--- a/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
+++ b/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
@@ -175,7 +175,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
         using FileStream openStream = File.OpenRead(secretsFilePath);
         var secretsJson = await JsonSerializer.DeserializeAsync<JsonObject>(openStream);
         Assert.NotNull(secretsJson);
-        Assert.True(secretsJson.ContainsKey(DevJwtCliHelpers.GetSigningKeyPropertyName(DevJwtsDefaults.Scheme, DevJwtsDefaults.Issuer)));
+        Assert.True(secretsJson.ContainsKey(DevJwtCliHelpers.GetSigningKeyValuePropertyName(DevJwtsDefaults.Scheme)));
         Assert.True(secretsJson.TryGetPropertyValue("Foo", out var fooField));
         Assert.Equal("baz", fooField["Bar"].GetValue<string>());
     }
@@ -374,7 +374,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
         using FileStream openStream = File.OpenRead(secretsFilePath);
         var secretsJson = await JsonSerializer.DeserializeAsync<JsonObject>(openStream);
         Assert.NotNull(secretsJson);
-        Assert.True(secretsJson.ContainsKey(DevJwtCliHelpers.GetSigningKeyPropertyName(DevJwtsDefaults.Scheme, DevJwtsDefaults.Issuer)));
+        Assert.True(secretsJson.ContainsKey(DevJwtCliHelpers.GetSigningKeyValuePropertyName(DevJwtsDefaults.Scheme)));
         Assert.True(secretsJson.TryGetPropertyValue("Foo", out var fooField));
         Assert.Equal("baz", fooField["Bar"].GetValue<string>());
     }
@@ -414,7 +414,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
 
         using FileStream openStream = File.OpenRead(secretsFilePath);
         var secretsJson = await JsonSerializer.DeserializeAsync<JsonObject>(openStream);
-        Assert.True(secretsJson.ContainsKey(DevJwtCliHelpers.GetSigningKeyPropertyName("test-scheme", "test-issuer")));
+        Assert.True(secretsJson.ContainsKey(DevJwtCliHelpers.GetSigningKeyValuePropertyName("test-scheme")));
     }
 
     [Fact]
@@ -432,8 +432,8 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
 
         using FileStream openStream = File.OpenRead(secretsFilePath);
         var secretsJson = await JsonSerializer.DeserializeAsync<JsonObject>(openStream);
-        Assert.True(secretsJson.ContainsKey(DevJwtCliHelpers.GetSigningKeyPropertyName("test-scheme", "test-issuer")));
-        Assert.True(secretsJson.ContainsKey(DevJwtCliHelpers.GetSigningKeyPropertyName("test-scheme", "test-issuer-2")));
+        Assert.True(secretsJson.ContainsKey(DevJwtCliHelpers.GetSigningKeyValuePropertyName("test-scheme")));
+        Assert.True(secretsJson.ContainsKey(DevJwtCliHelpers.GetSigningKeyValuePropertyName("test-scheme")));
     }
 
     [Fact]
@@ -451,8 +451,8 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
 
         using FileStream openStream = File.OpenRead(secretsFilePath);
         var secretsJson = await JsonSerializer.DeserializeAsync<JsonObject>(openStream);
-        Assert.True(secretsJson.ContainsKey(DevJwtCliHelpers.GetSigningKeyPropertyName("test-scheme", "test-issuer")));
-        Assert.True(secretsJson.ContainsKey(DevJwtCliHelpers.GetSigningKeyPropertyName("test-scheme-2", "test-issuer")));
+        Assert.True(secretsJson.ContainsKey(DevJwtCliHelpers.GetSigningKeyValuePropertyName("test-scheme")));
+        Assert.True(secretsJson.ContainsKey(DevJwtCliHelpers.GetSigningKeyValuePropertyName("test-scheme-2")));
     }
 
     [Fact]
@@ -470,12 +470,12 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
         Assert.Contains("New JWT saved", _console.GetOutput());
         _console.ClearOutput();
 
-        app.Run(new[] { "key", "--project", project, "--issuer", "test-issuer", "--scheme", "test-scheme" });
+        app.Run(new[] { "key", "--project", project, "--scheme", "test-scheme" });
         var printMatches = Regex.Matches(_console.GetOutput(), "Signing Key: '(.*?)'");
         var key = printMatches.SingleOrDefault().Groups[1].Value;
         _console.ClearOutput();
 
-        app.Run(new[] { "key", "--project", project, "--reset", "--force", "--issuer", "test-issuer", "--scheme", "test-scheme" });
+        app.Run(new[] { "key", "--project", project, "--reset", "--force", "--scheme", "test-scheme" });
         var resetMatches = Regex.Matches(_console.GetOutput(), "New signing key created: '(.*?)'");
         var resetKey = resetMatches.SingleOrDefault().Groups[1].Value;
         Assert.NotEqual(key, resetKey);


### PR DESCRIPTION
This PR changes the schema for storing signing keys for the user-jwts tool in user secrets to support more modifications in the future. Currently, the signing key is stored in a schema that looks like this:

```json
{
  "Authentication": {
    "Schemes": {
      "Bearer": {
         "dotnet-user-jwts": {
            "KeyMaterial": "somesigningkeyhere"
        }
      }
    }
  }
}
```

Where the key is stored relative to the issuer and the scheme name. The new format is as follows:

```json
{
  "Authentication": {
    "Schemes": {
      "Bearer": {
         "SigningKey": {
            "Value": "somesigningkeyhere",
            "KeyLength": 32
        }
      }
    }
  }
}
```

The `Issuer` is not a top-level unique identifier (only the schemes are) so it doesn't make sense to nest the key under this. The top-level `SigningKey` property gives us a place to add more options in the future (key algo and key modifications for key length).