### PR TITLE
Add `CreateHandler` method that allows additonal configuration

### DIFF
--- a/src/Hosting/TestHost/src/PublicAPI.Shipped.txt
+++ b/src/Hosting/TestHost/src/PublicAPI.Shipped.txt
@@ -21,7 +21,6 @@ Microsoft.AspNetCore.TestHost.TestServer.BaseAddress.get -> System.Uri!
 Microsoft.AspNetCore.TestHost.TestServer.BaseAddress.set -> void
 Microsoft.AspNetCore.TestHost.TestServer.CreateClient() -> System.Net.Http.HttpClient!
 Microsoft.AspNetCore.TestHost.TestServer.CreateHandler() -> System.Net.Http.HttpMessageHandler!
-Microsoft.AspNetCore.TestHost.TestServer.CreateHandler(System.Action<Microsoft.AspNetCore.Http.HttpContext!>! additionalContextConfiguration) -> System.Net.Http.HttpMessageHandler!
 Microsoft.AspNetCore.TestHost.TestServer.CreateRequest(string! path) -> Microsoft.AspNetCore.TestHost.RequestBuilder!
 Microsoft.AspNetCore.TestHost.TestServer.CreateWebSocketClient() -> Microsoft.AspNetCore.TestHost.WebSocketClient!
 Microsoft.AspNetCore.TestHost.TestServer.Dispose() -> void

--- a/src/Hosting/TestHost/src/PublicAPI.Shipped.txt
+++ b/src/Hosting/TestHost/src/PublicAPI.Shipped.txt
@@ -21,6 +21,7 @@ Microsoft.AspNetCore.TestHost.TestServer.BaseAddress.get -> System.Uri!
 Microsoft.AspNetCore.TestHost.TestServer.BaseAddress.set -> void
 Microsoft.AspNetCore.TestHost.TestServer.CreateClient() -> System.Net.Http.HttpClient!
 Microsoft.AspNetCore.TestHost.TestServer.CreateHandler() -> System.Net.Http.HttpMessageHandler!
+Microsoft.AspNetCore.TestHost.TestServer.CreateHandler(System.Action<Microsoft.AspNetCore.Http.HttpContext!>! additionalContextConfiguration) -> System.Net.Http.HttpMessageHandler!
 Microsoft.AspNetCore.TestHost.TestServer.CreateRequest(string! path) -> Microsoft.AspNetCore.TestHost.RequestBuilder!
 Microsoft.AspNetCore.TestHost.TestServer.CreateWebSocketClient() -> Microsoft.AspNetCore.TestHost.WebSocketClient!
 Microsoft.AspNetCore.TestHost.TestServer.Dispose() -> void

--- a/src/Hosting/TestHost/src/PublicAPI.Unshipped.txt
+++ b/src/Hosting/TestHost/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.AspNetCore.TestHost.TestServer.CreateHandler(System.Action<Microsoft.AspNetCore.Http.HttpContext!>! additionalContextConfiguration) -> System.Net.Http.HttpMessageHandler!

--- a/src/Hosting/TestHost/src/TestServer.cs
+++ b/src/Hosting/TestHost/src/TestServer.cs
@@ -146,13 +146,30 @@ public class TestServer : IServer
         get => _application ?? throw new InvalidOperationException("The server has not been started or no web application was configured.");
     }
 
+    private PathString PathBase => BaseAddress == null ? PathString.Empty : PathString.FromUriComponent(BaseAddress);
+
     /// <summary>
     /// Creates a custom <see cref="HttpMessageHandler" /> for processing HTTP requests/responses with the test server.
     /// </summary>
     public HttpMessageHandler CreateHandler()
     {
-        var pathBase = BaseAddress == null ? PathString.Empty : PathString.FromUriComponent(BaseAddress);
-        return new ClientHandler(pathBase, Application) { AllowSynchronousIO = AllowSynchronousIO, PreserveExecutionContext = PreserveExecutionContext };
+        return new ClientHandler(PathBase, Application)
+        {
+            AllowSynchronousIO = AllowSynchronousIO,
+            PreserveExecutionContext = PreserveExecutionContext
+        };
+    }
+
+    /// <summary>
+    /// Creates a custom <see cref="HttpMessageHandler" /> for processing HTTP requests/responses with custom configuration with the test server.
+    /// </summary>
+    public HttpMessageHandler CreateHandler(Action<HttpContext> additionalContextConfiguration)
+    {
+        return new ClientHandler(PathBase, Application, additionalContextConfiguration)
+        {
+            AllowSynchronousIO = AllowSynchronousIO,
+            PreserveExecutionContext = PreserveExecutionContext
+        };
     }
 
     /// <summary>

--- a/src/Hosting/TestHost/test/ClientHandlerTests.cs
+++ b/src/Hosting/TestHost/test/ClientHandlerTests.cs
@@ -36,7 +36,7 @@ public class ClientHandlerTests
             Assert.Null(features.Get<IHttpResponseFeature>().ReasonPhrase);
             Assert.Equal("example.com", features.Get<IHttpRequestFeature>().Headers["host"]);
             Assert.NotNull(features.Get<IHttpRequestLifetimeFeature>());
-        }), _ => { });
+        }));
         var httpClient = new HttpClient(handler);
         await httpClient.GetAsync("https://example.com/api/a%2Fb%20c");
     }


### PR DESCRIPTION
# Add `CreateHandler` method that allows additonal configuration

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->
Adds an additional `CreateHandler` method for configuring the `HttpContext` before the request is sent through the application pipeline.

## Description

As mentioned in the linked issue, the current experiencing of being able to use an `HttpClient` to make fake requests against a `TestServer` is really great and even required if you want to use that `HttpClient` to mock a real world connection amongst multiple applications. But it doesn't quite have all the customization as you might need to configure the `HttpContext` before it gets sent through your application. This change makes it so that a developer can create a handler that allows you one last chance to customize a call to your application so for example you can set `Connection` information. 

Fixes #42567

## Implementation Notes
I made the additional argument to the `ClientHandler` constructor an optional one that will connect to a method that does nothing if it isn't provided. This is a bit different from the api I proposed in the linked issue but it made for fewer changes in the tests. I could also just have it be supplied through a property. I am more than willing to change it to however others prefer.  
