### PR TITLE
Support loading OIDC options from configuration

### DIFF
--- a/AspNetCore.sln
+++ b/AspNetCore.sln
@@ -1737,6 +1737,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Templates.Blazor.WebAssembl
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RateLimitingSample", "src\Middleware\RateLimiting\samples\RateLimitingSample\RateLimitingSample.csproj", "{91C3C03E-EA56-4ABA-9E73-A3DA4C2833D9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MinimalOpenIdConnectSample", "src\Security\Authentication\OpenIdConnect\samples\MinimalOpenIdConnectSample\MinimalOpenIdConnectSample.csproj", "{07FDBE0D-B7A1-43DE-B120-F699C30E7CEF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -10434,6 +10436,22 @@ Global
 		{91C3C03E-EA56-4ABA-9E73-A3DA4C2833D9}.Release|x64.Build.0 = Release|Any CPU
 		{91C3C03E-EA56-4ABA-9E73-A3DA4C2833D9}.Release|x86.ActiveCfg = Release|Any CPU
 		{91C3C03E-EA56-4ABA-9E73-A3DA4C2833D9}.Release|x86.Build.0 = Release|Any CPU
+		{07FDBE0D-B7A1-43DE-B120-F699C30E7CEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{07FDBE0D-B7A1-43DE-B120-F699C30E7CEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{07FDBE0D-B7A1-43DE-B120-F699C30E7CEF}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{07FDBE0D-B7A1-43DE-B120-F699C30E7CEF}.Debug|arm64.Build.0 = Debug|Any CPU
+		{07FDBE0D-B7A1-43DE-B120-F699C30E7CEF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{07FDBE0D-B7A1-43DE-B120-F699C30E7CEF}.Debug|x64.Build.0 = Debug|Any CPU
+		{07FDBE0D-B7A1-43DE-B120-F699C30E7CEF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{07FDBE0D-B7A1-43DE-B120-F699C30E7CEF}.Debug|x86.Build.0 = Debug|Any CPU
+		{07FDBE0D-B7A1-43DE-B120-F699C30E7CEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{07FDBE0D-B7A1-43DE-B120-F699C30E7CEF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{07FDBE0D-B7A1-43DE-B120-F699C30E7CEF}.Release|arm64.ActiveCfg = Release|Any CPU
+		{07FDBE0D-B7A1-43DE-B120-F699C30E7CEF}.Release|arm64.Build.0 = Release|Any CPU
+		{07FDBE0D-B7A1-43DE-B120-F699C30E7CEF}.Release|x64.ActiveCfg = Release|Any CPU
+		{07FDBE0D-B7A1-43DE-B120-F699C30E7CEF}.Release|x64.Build.0 = Release|Any CPU
+		{07FDBE0D-B7A1-43DE-B120-F699C30E7CEF}.Release|x86.ActiveCfg = Release|Any CPU
+		{07FDBE0D-B7A1-43DE-B120-F699C30E7CEF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -11292,6 +11310,7 @@ Global
 		{0BB58FB6-8B66-4C6D-BA8A-DF3AFAF9AB8F} = {60D51C98-2CC0-40DF-B338-44154EFEE2FF}
 		{7CA0A9AF-9088-471C-B0B6-EBF43F21D3B9} = {08D53E58-4AAE-40C4-8497-63EC8664F304}
 		{91C3C03E-EA56-4ABA-9E73-A3DA4C2833D9} = {1D865E78-7A66-4CA9-92EE-2B350E45281F}
+		{07FDBE0D-B7A1-43DE-B120-F699C30E7CEF} = {E19E55A2-1562-47A7-8EA6-B51F2CA0CC4C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3E8720B3-DBDD-498C-B383-2CC32A054E8F}

--- a/src/Security/Authentication/JwtBearer/samples/MinimalJwtBearerSample/appsettings.Development.json
+++ b/src/Security/Authentication/JwtBearer/samples/MinimalJwtBearerSample/appsettings.Development.json
@@ -9,25 +9,25 @@
     "DefaultScheme":  "ClaimedDetails",
     "Schemes": {
       "Bearer": {
-        "Audiences": [
+        "ValidAudiences": [
           "https://localhost:7259",
           "http://localhost:5259"
         ],
-        "ClaimsIssuer": "dotnet-user-jwts"
+        "ValidIssuer": "dotnet-user-jwts"
       },
       "ClaimedDetails": {
-        "Audiences": [
+        "ValidAudiences": [
           "https://localhost:7259",
           "http://localhost:5259"
         ],
-        "ClaimsIssuer": "dotnet-user-jwts"
+        "ValidIssuer": "dotnet-user-jwts"
       },
       "InvalidScheme": {
-        "Audiences": [
+        "ValidAudiences": [
           "https://localhost:7259",
           "http://localhost:5259"
         ],
-        "ClaimsIssuer": "invalid-issuer"
+        "ValidIssuer": "invalid-issuer"
       }
     }
   }

--- a/src/Security/Authentication/JwtBearer/src/JwtBearerConfigureOptions.cs
+++ b/src/Security/Authentication/JwtBearer/src/JwtBearerConfigureOptions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -13,6 +14,7 @@ namespace Microsoft.AspNetCore.Authentication;
 internal sealed class JwtBearerConfigureOptions : IConfigureNamedOptions<JwtBearerOptions>
 {
     private readonly IAuthenticationConfigurationProvider _authenticationConfigurationProvider;
+    private static readonly Func<string, TimeSpan> _invariantTimeSpanParse = (string timespanString) => TimeSpan.Parse(timespanString, CultureInfo.InvariantCulture);
 
     /// <summary>
     /// Initializes a new <see cref="JwtBearerConfigureOptions"/> given the configuration
@@ -53,9 +55,7 @@ internal sealed class JwtBearerConfigureOptions : IConfigureNamedOptions<JwtBear
         }
 
         options.Authority = configSection[nameof(options.Authority)];
-        options.BackchannelTimeout = TimeSpan.TryParse(configSection[nameof(options.BackchannelTimeout)], out var backChannelTimeout)
-            ? backChannelTimeout
-            : options.BackchannelTimeout;
+        options.BackchannelTimeout = StringHelpers.ParseValueOrDefault(options.BackchannelTimeout, configSection[nameof(options.BackchannelTimeout)], _invariantTimeSpanParse);
         options.Challenge = configSection[nameof(options.Challenge)] ?? options.Challenge;
         options.ForwardAuthenticate = configSection[nameof(options.ForwardAuthenticate)];
         options.ForwardChallenge = configSection[nameof(options.ForwardChallenge)];
@@ -63,25 +63,13 @@ internal sealed class JwtBearerConfigureOptions : IConfigureNamedOptions<JwtBear
         options.ForwardForbid = configSection[nameof(options.ForwardForbid)];
         options.ForwardSignIn = configSection[nameof(options.ForwardSignIn)];
         options.ForwardSignOut = configSection[nameof(options.ForwardSignOut)];
-        options.IncludeErrorDetails = bool.TryParse(configSection[nameof(options.IncludeErrorDetails)], out var includeErrorDetails)
-            ? includeErrorDetails
-            : options.IncludeErrorDetails;
-        options.MapInboundClaims = bool.TryParse(configSection[nameof(options.MapInboundClaims)], out var mapInboundClaims)
-            ? mapInboundClaims
-            : options.MapInboundClaims;
+        options.IncludeErrorDetails = StringHelpers.ParseValueOrDefault(options.IncludeErrorDetails, configSection[nameof(options.IncludeErrorDetails)], bool.Parse);
+        options.MapInboundClaims = StringHelpers.ParseValueOrDefault(options.MapInboundClaims, configSection[nameof(options.MapInboundClaims)], bool.Parse);
         options.MetadataAddress = configSection[nameof(options.MetadataAddress)] ?? options.MetadataAddress;
-        options.RefreshInterval = TimeSpan.TryParse(configSection[nameof(options.RefreshInterval)], out var refreshInternval)
-            ? refreshInternval
-            : options.RefreshInterval;
-        options.RefreshOnIssuerKeyNotFound = bool.TryParse(configSection[nameof(options.RefreshOnIssuerKeyNotFound)], out var refreshOnIssuerKeyNotFound)
-            ? refreshOnIssuerKeyNotFound
-            : options.RefreshOnIssuerKeyNotFound;
-        options.RequireHttpsMetadata = bool.TryParse(configSection[nameof(options.RequireHttpsMetadata)], out var requireHttpsMetadata)
-            ? requireHttpsMetadata
-            : options.RequireHttpsMetadata;
-        options.SaveToken = bool.TryParse(configSection[nameof(options.SaveToken)], out var saveToken)
-            ? saveToken
-            : options.SaveToken;
+        options.RefreshInterval = StringHelpers.ParseValueOrDefault(options.RefreshInterval, configSection[nameof(options.RefreshInterval)], _invariantTimeSpanParse);
+        options.RefreshOnIssuerKeyNotFound = StringHelpers.ParseValueOrDefault(options.RefreshOnIssuerKeyNotFound, configSection[nameof(options.RefreshOnIssuerKeyNotFound)], bool.Parse);
+        options.RequireHttpsMetadata = StringHelpers.ParseValueOrDefault(options.RequireHttpsMetadata, configSection[nameof(options.RequireHttpsMetadata)], bool.Parse);
+        options.SaveToken = StringHelpers.ParseValueOrDefault(options.SaveToken, configSection[nameof(options.SaveToken)], bool.Parse);
         options.TokenValidationParameters = new()
         {
             ValidateIssuer = issuers.Count > 0,

--- a/src/Security/Authentication/JwtBearer/src/JwtBearerConfigureOptions.cs
+++ b/src/Security/Authentication/JwtBearer/src/JwtBearerConfigureOptions.cs
@@ -53,15 +53,15 @@ internal sealed class JwtBearerConfigureOptions : IConfigureNamedOptions<JwtBear
             audiences.Add(audience);
         }
 
-        options.Authority = configSection[nameof(options.Authority)];
+        options.Authority = configSection[nameof(options.Authority)] ?? options.Authority;
         options.BackchannelTimeout = StringHelpers.ParseValueOrDefault(configSection[nameof(options.BackchannelTimeout)], _invariantTimeSpanParse, options.BackchannelTimeout);
         options.Challenge = configSection[nameof(options.Challenge)] ?? options.Challenge;
-        options.ForwardAuthenticate = configSection[nameof(options.ForwardAuthenticate)];
-        options.ForwardChallenge = configSection[nameof(options.ForwardChallenge)];
-        options.ForwardDefault = configSection[nameof(options.ForwardDefault)];
-        options.ForwardForbid = configSection[nameof(options.ForwardForbid)];
-        options.ForwardSignIn = configSection[nameof(options.ForwardSignIn)];
-        options.ForwardSignOut = configSection[nameof(options.ForwardSignOut)];
+        options.ForwardAuthenticate = configSection[nameof(options.ForwardAuthenticate)] ?? options.ForwardAuthenticate;
+        options.ForwardChallenge = configSection[nameof(options.ForwardChallenge)] ?? options.ForwardChallenge;
+        options.ForwardDefault = configSection[nameof(options.ForwardDefault)] ?? options.ForwardDefault;
+        options.ForwardForbid = configSection[nameof(options.ForwardForbid)] ?? options.ForwardForbid;
+        options.ForwardSignIn = configSection[nameof(options.ForwardSignIn)] ?? options.ForwardSignIn;
+        options.ForwardSignOut = configSection[nameof(options.ForwardSignOut)] ?? options.ForwardSignOut;
         options.IncludeErrorDetails = StringHelpers.ParseValueOrDefault(configSection[nameof(options.IncludeErrorDetails)], bool.Parse, options.IncludeErrorDetails);
         options.MapInboundClaims = StringHelpers.ParseValueOrDefault( configSection[nameof(options.MapInboundClaims)], bool.Parse, options.MapInboundClaims);
         options.MetadataAddress = configSection[nameof(options.MetadataAddress)] ?? options.MetadataAddress;

--- a/src/Security/Authentication/JwtBearer/src/Microsoft.AspNetCore.Authentication.JwtBearer.csproj
+++ b/src/Security/Authentication/JwtBearer/src/Microsoft.AspNetCore.Authentication.JwtBearer.csproj
@@ -13,4 +13,8 @@
     <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="$(SharedSourceRoot)StringHelpers.cs" LinkBase="Shared" />
+  </ItemGroup>
+
 </Project>

--- a/src/Security/Authentication/OpenIdConnect/samples/MinimalOpenIdConnectSample/MinimalOpenIdConnectSample.csproj
+++ b/src/Security/Authentication/OpenIdConnect/samples/MinimalOpenIdConnectSample/MinimalOpenIdConnectSample.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore" />
+    <Reference Include="Microsoft.AspNetCore.Authentication.Cookies" />
+    <Reference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
+  </ItemGroup>
+
+</Project>

--- a/src/Security/Authentication/OpenIdConnect/samples/MinimalOpenIdConnectSample/Program.cs
+++ b/src/Security/Authentication/OpenIdConnect/samples/MinimalOpenIdConnectSample/Program.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Security.Claims;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services
+    .AddAuthentication("OpenIdConnect")
+    .AddCookie()
+    .AddOpenIdConnect();
+builder.Services.AddAuthorization();
+
+var app = builder.Build();
+
+app.MapGet("/protected", (ClaimsPrincipal user) => $"Hello {user.Identity?.Name}!")
+    .RequireAuthorization();
+
+app.Run();

--- a/src/Security/Authentication/OpenIdConnect/samples/MinimalOpenIdConnectSample/Properties/launchSettings.json
+++ b/src/Security/Authentication/OpenIdConnect/samples/MinimalOpenIdConnectSample/Properties/launchSettings.json
@@ -1,0 +1,37 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:2726",
+      "sslPort": 44308
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5204",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7282;http://localhost:5204",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Security/Authentication/OpenIdConnect/samples/MinimalOpenIdConnectSample/appsettings.Development.json
+++ b/src/Security/Authentication/OpenIdConnect/samples/MinimalOpenIdConnectSample/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/Security/Authentication/OpenIdConnect/samples/MinimalOpenIdConnectSample/appsettings.json
+++ b/src/Security/Authentication/OpenIdConnect/samples/MinimalOpenIdConnectSample/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Security/Authentication/OpenIdConnect/src/Microsoft.AspNetCore.Authentication.OpenIdConnect.csproj
+++ b/src/Security/Authentication/OpenIdConnect/src/Microsoft.AspNetCore.Authentication.OpenIdConnect.csproj
@@ -13,4 +13,8 @@
     <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="$(SharedSourceRoot)StringHelpers.cs" LinkBase="Shared" />
+  </ItemGroup>
+
 </Project>

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectConfigureOptions.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectConfigureOptions.cs
@@ -1,0 +1,170 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Authentication.OpenIdConnect;
+
+internal sealed class OpenIdConnectConfigureOptions : IConfigureNamedOptions<OpenIdConnectOptions>
+{
+    private readonly IAuthenticationConfigurationProvider _authenticationConfigurationProvider;
+
+    /// <summary>
+    /// Initializes a new <see cref="OpenIdConnectConfigureOptions"/> given the configuration
+    /// provided by the <paramref name="configurationProvider"/>.
+    /// </summary>
+    /// <param name="configurationProvider">An <see cref="IAuthenticationConfigurationProvider"/> instance.</param>
+    public OpenIdConnectConfigureOptions(IAuthenticationConfigurationProvider configurationProvider)
+    {
+        _authenticationConfigurationProvider = configurationProvider;
+    }
+
+    /// <inheritdoc />
+    public void Configure(string? name, OpenIdConnectOptions options)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return;
+        }
+
+        var configSection = _authenticationConfigurationProvider.GetSchemeConfiguration(name);
+
+        if (configSection is null || !configSection.GetChildren().Any())
+        {
+            return;
+        }
+
+        options.AccessDeniedPath = configSection[nameof(options.AccessDeniedPath)];
+        options.Authority = configSection[nameof(options.Authority)];
+        options.AutomaticRefreshInterval = TimeSpan.TryParse(configSection[nameof(options.AutomaticRefreshInterval)], out var automaticRefreshInterval)
+            ? automaticRefreshInterval
+            : options.AutomaticRefreshInterval;
+        options.BackchannelTimeout = TimeSpan.TryParse(configSection[nameof(options.BackchannelTimeout)], out var backChannelTimeout)
+            ? backChannelTimeout
+            : options.BackchannelTimeout;
+        options.CallbackPath = new PathString(configSection[nameof(options.CallbackPath)] ?? options.CallbackPath);
+        options.ClaimsIssuer = configSection[nameof(options.ClaimsIssuer)];
+        options.ClientId = configSection[nameof(options.ClientId)];
+        options.ClientSecret = configSection[nameof(options.ClientSecret)];
+        options.CorrelationCookie = GetCookieFromConfig(configSection.GetSection(nameof(options.CorrelationCookie)), options.CorrelationCookie);
+        options.DisableTelemetry = bool.TryParse(configSection[nameof(options.DisableTelemetry)], out var disableTelemetry)
+            ? disableTelemetry
+            : options.DisableTelemetry;
+        options.ForwardAuthenticate = configSection[nameof(options.ForwardAuthenticate)];
+        options.ForwardChallenge = configSection[nameof(options.ForwardChallenge)];
+        options.ForwardDefault = configSection[nameof(options.ForwardDefault)];
+        options.ForwardForbid = configSection[nameof(options.ForwardForbid)];
+        options.ForwardSignIn = configSection[nameof(options.ForwardSignIn)];
+        options.ForwardSignOut = configSection[nameof(options.ForwardSignOut)];
+        options.GetClaimsFromUserInfoEndpoint = bool.TryParse(configSection[nameof(options.GetClaimsFromUserInfoEndpoint)], out var getClaimsFromUserInfoEndpoint)
+            ? getClaimsFromUserInfoEndpoint
+            : options.GetClaimsFromUserInfoEndpoint;
+        options.MapInboundClaims = bool.TryParse(configSection[nameof(options.MapInboundClaims)], out var mapInboundClaims)
+            ? mapInboundClaims
+            : options.MapInboundClaims;
+        options.MaxAge = TimeSpan.TryParse(configSection[nameof(options.MaxAge)], out var maxAge)
+            ? maxAge
+            : options.MaxAge;
+        options.MetadataAddress = configSection[nameof(options.MetadataAddress)];
+        options.NonceCookie = GetCookieFromConfig(configSection.GetSection(nameof(options.NonceCookie)), options.NonceCookie);
+        options.Prompt = configSection[nameof(options.Prompt)];
+        options.RefreshInterval = TimeSpan.TryParse(configSection[nameof(options.RefreshInterval)], out var refreshInterval)
+            ? refreshInterval
+            : options.RefreshInterval;
+        options.RefreshOnIssuerKeyNotFound = bool.TryParse(configSection[nameof(options.RefreshOnIssuerKeyNotFound)], out var refreshOnIssuerKeyNotFound)
+            ? refreshOnIssuerKeyNotFound
+            : options.RefreshOnIssuerKeyNotFound;
+        options.RemoteAuthenticationTimeout = TimeSpan.TryParse(configSection[nameof(options.RemoteAuthenticationTimeout)], out var remoteAuthenticationTimeout)
+            ? remoteAuthenticationTimeout
+            : options.RemoteAuthenticationTimeout;
+        options.RemoteSignOutPath = new PathString(configSection[nameof(options.RemoteSignOutPath)] ?? options.RemoteSignOutPath);
+        options.RequireHttpsMetadata = bool.TryParse(configSection[nameof(options.RequireHttpsMetadata)], out var requireHttpsMetadata)
+            ? requireHttpsMetadata
+            : options.RequireHttpsMetadata;
+        options.Resource = configSection[nameof(options.Resource)];
+        options.ResponseMode = configSection[nameof(options.ResponseMode)] ?? options.ResponseMode;
+        options.ResponseType = configSection[nameof(options.ResponseType)] ?? options.ResponseType;
+        options.ReturnUrlParameter = configSection[nameof(options.ReturnUrlParameter)] ?? options.ReturnUrlParameter;
+        options.SaveTokens = bool.TryParse(configSection[nameof(options.SaveTokens)], out var saveTokens)
+            ? saveTokens
+            : options.SaveTokens;
+        var scopes = configSection.GetSection(nameof(options.Scope)).GetChildren().Select(scope => scope.Value).OfType<string>();
+        foreach (var scope in scopes)
+        {
+            options.Scope.Add(scope);
+        }
+        options.SignedOutCallbackPath = new PathString(configSection[nameof(options.SignedOutCallbackPath)] ?? options.SignedOutCallbackPath);
+        options.SignedOutRedirectUri = configSection[nameof(options.SignedOutRedirectUri)] ?? options.SignedOutRedirectUri;
+        options.SignInScheme = configSection[nameof(options.SignInScheme)];
+        options.SignOutScheme = configSection[nameof(options.SignOutScheme)];
+        options.SkipUnrecognizedRequests = bool.TryParse(configSection[nameof(options.SkipUnrecognizedRequests)], out var skipUnreccognizedRequests)
+            ? skipUnreccognizedRequests
+            : options.SkipUnrecognizedRequests;
+        options.UsePkce = bool.TryParse(configSection[nameof(options.UsePkce)], out var usePkce)
+            ? usePkce
+            : options.UsePkce;
+        options.UseTokenLifetime = bool.TryParse(configSection[nameof(options.UseTokenLifetime)], out var useTokenLifetime)
+            ? useTokenLifetime
+            : options.UseTokenLifetime;
+    }
+
+    private static CookieBuilder GetCookieFromConfig(IConfiguration cookieConfigSection, CookieBuilder cookieBuilder)
+    {
+        if (cookieConfigSection is not null && cookieConfigSection.GetChildren().Any())
+        {
+            // Defaults match those used in https://github.com/dotnet/aspnetcore/blob/69c7a87cd8f05da9c05c373edfc0337c9e864d9e/src/Security/Authentication/Core/src/RemoteAuthenticationOptions.cs#L24-L31
+            // and https://github.com/dotnet/aspnetcore/blob/69c7a87cd8f05da9c05c373edfc0337c9e864d9e/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs#L68-L76
+            cookieBuilder = new()
+            {
+                Domain = cookieConfigSection[nameof(CookieBuilder.Domain)],
+                HttpOnly = bool.TryParse(cookieConfigSection[nameof(CookieBuilder.HttpOnly)], out var httpOnly)
+                    ? httpOnly
+                    : cookieBuilder.HttpOnly,
+                IsEssential = bool.TryParse(cookieConfigSection[nameof(CookieBuilder.IsEssential)], out var isEssential)
+                    ? isEssential
+                    : cookieBuilder.IsEssential,
+                Expiration = TimeSpan.TryParse(cookieConfigSection[nameof(CookieBuilder.Expiration)], out var expiration)
+                    ? expiration
+                    : null,
+                MaxAge = TimeSpan.TryParse(cookieConfigSection[nameof(CookieBuilder.MaxAge)], out var maxAge)
+                    ? maxAge
+                    : null,
+                Name = cookieConfigSection[nameof(CookieBuilder.Name)] ?? cookieBuilder.Name,
+                Path = cookieConfigSection[nameof(CookieBuilder.Path)],
+                SameSite = cookieConfigSection[nameof(CookieBuilder.SameSite)] switch
+                {
+                    "Lax" => SameSiteMode.Lax,
+                    "Strict" => SameSiteMode.Strict,
+                    "Unspecified" => SameSiteMode.Unspecified,
+                    "None" => SameSiteMode.None,
+                    _ => cookieBuilder.SameSite
+                },
+
+                SecurePolicy = cookieConfigSection[nameof(CookieBuilder.SecurePolicy)] switch
+                {
+                    "Always" => CookieSecurePolicy.Always,
+                    "None" => CookieSecurePolicy.None,
+                    "SameAsRequest" => CookieSecurePolicy.SameAsRequest,
+                    _ => cookieBuilder.SecurePolicy
+                }
+            };
+
+            var extensions = cookieConfigSection.GetSection(nameof(CookieBuilder.Extensions)).GetChildren().Select(ext => ext.Value).OfType<string>();
+            foreach (var extension in extensions)
+            {
+                cookieBuilder.Extensions.Add(extension);
+            }
+        }
+
+        return cookieBuilder;
+    }
+
+    /// <inheritdoc />
+    public void Configure(OpenIdConnectOptions options)
+    {
+        Configure(Options.DefaultName, options);
+    }
+}

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectConfigureOptions.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectConfigureOptions.cs
@@ -40,47 +40,43 @@ internal sealed class OpenIdConnectConfigureOptions : IConfigureNamedOptions<Ope
             return;
         }
 
-        options.AccessDeniedPath = new PathString(configSection[nameof(options.AccessDeniedPath.Value)]);
+        options.AccessDeniedPath = new PathString(configSection[nameof(options.AccessDeniedPath)] ?? options.AccessDeniedPath.Value);
         options.Authority = configSection[nameof(options.Authority)];
         options.AutomaticRefreshInterval = StringHelpers.ParseValueOrDefault(configSection[nameof(options.AutomaticRefreshInterval)], _invariantTimeSpanParse, options.AutomaticRefreshInterval);
         options.BackchannelTimeout = StringHelpers.ParseValueOrDefault(configSection[nameof(options.BackchannelTimeout)], _invariantTimeSpanParse, options.BackchannelTimeout);
         options.CallbackPath = new PathString(configSection[nameof(options.CallbackPath)] ?? options.CallbackPath.Value);
-        options.ClaimsIssuer = configSection[nameof(options.ClaimsIssuer)];
-        options.ClientId = configSection[nameof(options.ClientId)];
-        options.ClientSecret = configSection[nameof(options.ClientSecret)];
+        options.ClaimsIssuer = configSection[nameof(options.ClaimsIssuer)] ?? options.ClaimsIssuer;
+        options.ClientId = configSection[nameof(options.ClientId)] ?? options.ClientId;
+        options.ClientSecret = configSection[nameof(options.ClientSecret)] ?? options.ClientSecret;
         SetCookieFromConfig(configSection.GetSection(nameof(options.CorrelationCookie)), options.CorrelationCookie);
         options.DisableTelemetry = StringHelpers.ParseValueOrDefault(configSection[nameof(options.DisableTelemetry)], bool.Parse, options.DisableTelemetry);
-        options.ForwardAuthenticate = configSection[nameof(options.ForwardAuthenticate)];
-        options.ForwardChallenge = configSection[nameof(options.ForwardChallenge)];
-        options.ForwardDefault = configSection[nameof(options.ForwardDefault)];
-        options.ForwardForbid = configSection[nameof(options.ForwardForbid)];
-        options.ForwardSignIn = configSection[nameof(options.ForwardSignIn)];
-        options.ForwardSignOut = configSection[nameof(options.ForwardSignOut)];
+        options.ForwardAuthenticate = configSection[nameof(options.ForwardAuthenticate)] ?? options.ForwardAuthenticate;
+        options.ForwardChallenge = configSection[nameof(options.ForwardChallenge)] ?? options.ForwardChallenge;
+        options.ForwardDefault = configSection[nameof(options.ForwardDefault)] ?? options.ForwardDefault;
+        options.ForwardForbid = configSection[nameof(options.ForwardForbid)] ?? options.ForwardForbid;
+        options.ForwardSignIn = configSection[nameof(options.ForwardSignIn)] ?? options.ForwardSignIn;
+        options.ForwardSignOut = configSection[nameof(options.ForwardSignOut)] ?? options.ForwardSignOut;
         options.GetClaimsFromUserInfoEndpoint = StringHelpers.ParseValueOrDefault(configSection[nameof(options.GetClaimsFromUserInfoEndpoint)], bool.Parse, options.GetClaimsFromUserInfoEndpoint);
         options.MapInboundClaims = StringHelpers.ParseValueOrDefault(configSection[nameof(options.MapInboundClaims)], bool.Parse, options.MapInboundClaims);
         options.MaxAge = StringHelpers.ParseValueOrDefault(configSection[nameof(options.MaxAge)], _invariantNullableTimeSpanParse, options.MaxAge);
-        options.MetadataAddress = configSection[nameof(options.MetadataAddress)];
+        options.MetadataAddress = configSection[nameof(options.MetadataAddress)] ?? options.MetadataAddress;
         SetCookieFromConfig(configSection.GetSection(nameof(options.NonceCookie)), options.NonceCookie);
-        options.Prompt = configSection[nameof(options.Prompt)];
+        options.Prompt = configSection[nameof(options.Prompt)] ?? options.Prompt;
         options.RefreshInterval = StringHelpers.ParseValueOrDefault(configSection[nameof(options.RefreshInterval)], _invariantTimeSpanParse, options.RefreshInterval);
         options.RefreshOnIssuerKeyNotFound = StringHelpers.ParseValueOrDefault(configSection[nameof(options.RefreshOnIssuerKeyNotFound)], bool.Parse, options.RefreshOnIssuerKeyNotFound);
         options.RemoteAuthenticationTimeout = StringHelpers.ParseValueOrDefault(configSection[nameof(options.RemoteAuthenticationTimeout)], _invariantTimeSpanParse, options.RemoteAuthenticationTimeout);
         options.RemoteSignOutPath = new PathString(configSection[nameof(options.RemoteSignOutPath)] ?? options.RemoteSignOutPath.Value);
         options.RequireHttpsMetadata = StringHelpers.ParseValueOrDefault(configSection[nameof(options.RequireHttpsMetadata)], bool.Parse, options.RequireHttpsMetadata);
-        options.Resource = configSection[nameof(options.Resource)];
+        options.Resource = configSection[nameof(options.Resource)] ?? options.Resource;
         options.ResponseMode = configSection[nameof(options.ResponseMode)] ?? options.ResponseMode;
         options.ResponseType = configSection[nameof(options.ResponseType)] ?? options.ResponseType;
         options.ReturnUrlParameter = configSection[nameof(options.ReturnUrlParameter)] ?? options.ReturnUrlParameter;
         options.SaveTokens = StringHelpers.ParseValueOrDefault(configSection[nameof(options.SaveTokens)], bool.Parse, options.SaveTokens);
-        var scopes = configSection.GetSection(nameof(options.Scope)).GetChildren().Select(scope => scope.Value).OfType<string>();
-        foreach (var scope in scopes)
-        {
-            options.Scope.Add(scope);
-        }
+        ClearAndSetListOption(options.Scope, configSection.GetSection(nameof(options.Scope)));
         options.SignedOutCallbackPath = new PathString(configSection[nameof(options.SignedOutCallbackPath)] ?? options.SignedOutCallbackPath.Value);
         options.SignedOutRedirectUri = configSection[nameof(options.SignedOutRedirectUri)] ?? options.SignedOutRedirectUri;
-        options.SignInScheme = configSection[nameof(options.SignInScheme)];
-        options.SignOutScheme = configSection[nameof(options.SignOutScheme)];
+        options.SignInScheme = configSection[nameof(options.SignInScheme)] ?? options.SignInScheme;
+        options.SignOutScheme = configSection[nameof(options.SignOutScheme)] ?? options.SignOutScheme;
         options.SkipUnrecognizedRequests = StringHelpers.ParseValueOrDefault(configSection[nameof(options.SkipUnrecognizedRequests)], bool.Parse, options.SkipUnrecognizedRequests);
         options.UsePkce = StringHelpers.ParseValueOrDefault(configSection[nameof(options.UsePkce)], bool.Parse, options.UsePkce);
         options.UseTokenLifetime = StringHelpers.ParseValueOrDefault(configSection[nameof(options.UseTokenLifetime)], bool.Parse, options.UseTokenLifetime);
@@ -122,10 +118,19 @@ internal sealed class OpenIdConnectConfigureOptions : IConfigureNamedOptions<Ope
             _ => throw new InvalidOperationException($"{nameof(CookieBuilder.SameSite)} option must be a valid {nameof(SameSiteMode)}")
         };
 
-        var extensions = cookieConfigSection.GetSection(nameof(CookieBuilder.Extensions)).GetChildren().Select(ext => ext.Value).OfType<string>();
-        foreach (var extension in extensions)
+        ClearAndSetListOption(cookieBuilder.Extensions, cookieConfigSection.GetSection(nameof(cookieBuilder.Extensions)));
+    }
+
+    private static void ClearAndSetListOption(ICollection<string> listOption, IConfigurationSection listConfigSection)
+    {
+        var elementsFromConfig = listConfigSection.GetChildren().Select(element => element.Value).OfType<string>();
+        if (elementsFromConfig.Any())
         {
-            cookieBuilder.Extensions.Add(extension);
+            listOption.Clear();
+            foreach (var element in elementsFromConfig)
+            {
+                listOption.Add(element);
+            }
         }
     }
 

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectConfigureOptions.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectConfigureOptions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
@@ -11,6 +12,7 @@ namespace Microsoft.AspNetCore.Authentication.OpenIdConnect;
 internal sealed class OpenIdConnectConfigureOptions : IConfigureNamedOptions<OpenIdConnectOptions>
 {
     private readonly IAuthenticationConfigurationProvider _authenticationConfigurationProvider;
+    private static readonly Func<string, TimeSpan> _invariantTimeSpanParse = (string timespanString) => TimeSpan.Parse(timespanString, CultureInfo.InvariantCulture);
 
     /// <summary>
     /// Initializes a new <see cref="OpenIdConnectConfigureOptions"/> given the configuration
@@ -37,60 +39,38 @@ internal sealed class OpenIdConnectConfigureOptions : IConfigureNamedOptions<Ope
             return;
         }
 
-        options.AccessDeniedPath = configSection[nameof(options.AccessDeniedPath)];
+        options.AccessDeniedPath = new PathString(configSection[nameof(options.AccessDeniedPath)]);
         options.Authority = configSection[nameof(options.Authority)];
-        options.AutomaticRefreshInterval = TimeSpan.TryParse(configSection[nameof(options.AutomaticRefreshInterval)], out var automaticRefreshInterval)
-            ? automaticRefreshInterval
-            : options.AutomaticRefreshInterval;
-        options.BackchannelTimeout = TimeSpan.TryParse(configSection[nameof(options.BackchannelTimeout)], out var backChannelTimeout)
-            ? backChannelTimeout
-            : options.BackchannelTimeout;
+        options.AutomaticRefreshInterval = StringHelpers.ParseValueOrDefault(options.AutomaticRefreshInterval, configSection[nameof(options.AutomaticRefreshInterval)], _invariantTimeSpanParse);
+        options.BackchannelTimeout = StringHelpers.ParseValueOrDefault(options.BackchannelTimeout, configSection[nameof(options.BackchannelTimeout)], _invariantTimeSpanParse);
         options.CallbackPath = new PathString(configSection[nameof(options.CallbackPath)] ?? options.CallbackPath);
         options.ClaimsIssuer = configSection[nameof(options.ClaimsIssuer)];
         options.ClientId = configSection[nameof(options.ClientId)];
         options.ClientSecret = configSection[nameof(options.ClientSecret)];
         options.CorrelationCookie = GetCookieFromConfig(configSection.GetSection(nameof(options.CorrelationCookie)), options.CorrelationCookie);
-        options.DisableTelemetry = bool.TryParse(configSection[nameof(options.DisableTelemetry)], out var disableTelemetry)
-            ? disableTelemetry
-            : options.DisableTelemetry;
+        options.DisableTelemetry = StringHelpers.ParseValueOrDefault(options.DisableTelemetry, configSection[nameof(options.DisableTelemetry)], bool.Parse);
         options.ForwardAuthenticate = configSection[nameof(options.ForwardAuthenticate)];
         options.ForwardChallenge = configSection[nameof(options.ForwardChallenge)];
         options.ForwardDefault = configSection[nameof(options.ForwardDefault)];
         options.ForwardForbid = configSection[nameof(options.ForwardForbid)];
         options.ForwardSignIn = configSection[nameof(options.ForwardSignIn)];
         options.ForwardSignOut = configSection[nameof(options.ForwardSignOut)];
-        options.GetClaimsFromUserInfoEndpoint = bool.TryParse(configSection[nameof(options.GetClaimsFromUserInfoEndpoint)], out var getClaimsFromUserInfoEndpoint)
-            ? getClaimsFromUserInfoEndpoint
-            : options.GetClaimsFromUserInfoEndpoint;
-        options.MapInboundClaims = bool.TryParse(configSection[nameof(options.MapInboundClaims)], out var mapInboundClaims)
-            ? mapInboundClaims
-            : options.MapInboundClaims;
-        options.MaxAge = TimeSpan.TryParse(configSection[nameof(options.MaxAge)], out var maxAge)
-            ? maxAge
-            : options.MaxAge;
+        options.GetClaimsFromUserInfoEndpoint = StringHelpers.ParseValueOrDefault(options.GetClaimsFromUserInfoEndpoint, configSection[nameof(options.GetClaimsFromUserInfoEndpoint)], bool.Parse);
+        options.MapInboundClaims = StringHelpers.ParseValueOrDefault(options.MapInboundClaims, configSection[nameof(options.MapInboundClaims)], bool.Parse);
+        options.MaxAge = options.MaxAge is TimeSpan maxAge ? StringHelpers.ParseValueOrDefault(maxAge, configSection[nameof(options.MaxAge)], _invariantTimeSpanParse) : options.MaxAge;
         options.MetadataAddress = configSection[nameof(options.MetadataAddress)];
         options.NonceCookie = GetCookieFromConfig(configSection.GetSection(nameof(options.NonceCookie)), options.NonceCookie);
         options.Prompt = configSection[nameof(options.Prompt)];
-        options.RefreshInterval = TimeSpan.TryParse(configSection[nameof(options.RefreshInterval)], out var refreshInterval)
-            ? refreshInterval
-            : options.RefreshInterval;
-        options.RefreshOnIssuerKeyNotFound = bool.TryParse(configSection[nameof(options.RefreshOnIssuerKeyNotFound)], out var refreshOnIssuerKeyNotFound)
-            ? refreshOnIssuerKeyNotFound
-            : options.RefreshOnIssuerKeyNotFound;
-        options.RemoteAuthenticationTimeout = TimeSpan.TryParse(configSection[nameof(options.RemoteAuthenticationTimeout)], out var remoteAuthenticationTimeout)
-            ? remoteAuthenticationTimeout
-            : options.RemoteAuthenticationTimeout;
+        options.RefreshInterval = StringHelpers.ParseValueOrDefault(options.RefreshInterval, configSection[nameof(options.RefreshInterval)], _invariantTimeSpanParse);
+        options.RefreshOnIssuerKeyNotFound = StringHelpers.ParseValueOrDefault(options.RefreshOnIssuerKeyNotFound, configSection[nameof(options.RefreshOnIssuerKeyNotFound)], bool.Parse);
+        options.RemoteAuthenticationTimeout = StringHelpers.ParseValueOrDefault(options.RemoteAuthenticationTimeout, configSection[nameof(options.RemoteAuthenticationTimeout)], _invariantTimeSpanParse);
         options.RemoteSignOutPath = new PathString(configSection[nameof(options.RemoteSignOutPath)] ?? options.RemoteSignOutPath);
-        options.RequireHttpsMetadata = bool.TryParse(configSection[nameof(options.RequireHttpsMetadata)], out var requireHttpsMetadata)
-            ? requireHttpsMetadata
-            : options.RequireHttpsMetadata;
+        options.RequireHttpsMetadata = StringHelpers.ParseValueOrDefault(options.RequireHttpsMetadata, configSection[nameof(options.RequireHttpsMetadata)], bool.Parse);
         options.Resource = configSection[nameof(options.Resource)];
         options.ResponseMode = configSection[nameof(options.ResponseMode)] ?? options.ResponseMode;
         options.ResponseType = configSection[nameof(options.ResponseType)] ?? options.ResponseType;
         options.ReturnUrlParameter = configSection[nameof(options.ReturnUrlParameter)] ?? options.ReturnUrlParameter;
-        options.SaveTokens = bool.TryParse(configSection[nameof(options.SaveTokens)], out var saveTokens)
-            ? saveTokens
-            : options.SaveTokens;
+        options.SaveTokens = StringHelpers.ParseValueOrDefault(options.SaveTokens, configSection[nameof(options.SaveTokens)], bool.Parse);
         var scopes = configSection.GetSection(nameof(options.Scope)).GetChildren().Select(scope => scope.Value).OfType<string>();
         foreach (var scope in scopes)
         {
@@ -100,56 +80,42 @@ internal sealed class OpenIdConnectConfigureOptions : IConfigureNamedOptions<Ope
         options.SignedOutRedirectUri = configSection[nameof(options.SignedOutRedirectUri)] ?? options.SignedOutRedirectUri;
         options.SignInScheme = configSection[nameof(options.SignInScheme)];
         options.SignOutScheme = configSection[nameof(options.SignOutScheme)];
-        options.SkipUnrecognizedRequests = bool.TryParse(configSection[nameof(options.SkipUnrecognizedRequests)], out var skipUnreccognizedRequests)
-            ? skipUnreccognizedRequests
-            : options.SkipUnrecognizedRequests;
-        options.UsePkce = bool.TryParse(configSection[nameof(options.UsePkce)], out var usePkce)
-            ? usePkce
-            : options.UsePkce;
-        options.UseTokenLifetime = bool.TryParse(configSection[nameof(options.UseTokenLifetime)], out var useTokenLifetime)
-            ? useTokenLifetime
-            : options.UseTokenLifetime;
+        options.SkipUnrecognizedRequests = StringHelpers.ParseValueOrDefault(options.SkipUnrecognizedRequests, configSection[nameof(options.SkipUnrecognizedRequests)], bool.Parse);
+        options.UsePkce = StringHelpers.ParseValueOrDefault(options.UsePkce, configSection[nameof(options.UsePkce)], bool.Parse);
+        options.UseTokenLifetime = StringHelpers.ParseValueOrDefault(options.UseTokenLifetime, configSection[nameof(options.UseTokenLifetime)], bool.Parse);
     }
 
     private static CookieBuilder GetCookieFromConfig(IConfiguration cookieConfigSection, CookieBuilder cookieBuilder)
     {
         if (cookieConfigSection is not null && cookieConfigSection.GetChildren().Any())
         {
-            // Defaults match those used in https://github.com/dotnet/aspnetcore/blob/69c7a87cd8f05da9c05c373edfc0337c9e864d9e/src/Security/Authentication/Core/src/RemoteAuthenticationOptions.cs#L24-L31
-            // and https://github.com/dotnet/aspnetcore/blob/69c7a87cd8f05da9c05c373edfc0337c9e864d9e/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs#L68-L76
-            cookieBuilder = new()
+            // Override the existing defaults when values are set instead of constructing
+            // an entirely new CookieBuilder.
+            cookieBuilder.Domain = cookieConfigSection[nameof(cookieBuilder.Domain)];
+            cookieBuilder.HttpOnly = StringHelpers.ParseValueOrDefault(cookieBuilder.HttpOnly, cookieConfigSection[nameof(cookieBuilder.HttpOnly)], bool.Parse);
+            cookieBuilder.IsEssential = StringHelpers.ParseValueOrDefault(cookieBuilder.IsEssential, cookieConfigSection[nameof(cookieBuilder.IsEssential)], bool.Parse);
+            cookieBuilder.Expiration = cookieBuilder.Expiration is TimeSpan expiration ? StringHelpers.ParseValueOrDefault(expiration, cookieConfigSection[nameof(cookieBuilder.Expiration)], _invariantTimeSpanParse) : cookieBuilder.Expiration;
+            cookieBuilder.MaxAge = cookieBuilder.MaxAge is TimeSpan maxAge ? StringHelpers.ParseValueOrDefault(maxAge, cookieConfigSection[nameof(cookieBuilder.MaxAge)], _invariantTimeSpanParse) : cookieBuilder.MaxAge;
+            cookieBuilder.Name = cookieConfigSection[nameof(CookieBuilder.Name)] ?? cookieBuilder.Name;
+            cookieBuilder.Path = cookieConfigSection[nameof(CookieBuilder.Path)];
+            cookieBuilder.SameSite = cookieConfigSection[nameof(CookieBuilder.SameSite)]?.ToLowerInvariant() switch
             {
-                Domain = cookieConfigSection[nameof(CookieBuilder.Domain)],
-                HttpOnly = bool.TryParse(cookieConfigSection[nameof(CookieBuilder.HttpOnly)], out var httpOnly)
-                    ? httpOnly
-                    : cookieBuilder.HttpOnly,
-                IsEssential = bool.TryParse(cookieConfigSection[nameof(CookieBuilder.IsEssential)], out var isEssential)
-                    ? isEssential
-                    : cookieBuilder.IsEssential,
-                Expiration = TimeSpan.TryParse(cookieConfigSection[nameof(CookieBuilder.Expiration)], out var expiration)
-                    ? expiration
-                    : null,
-                MaxAge = TimeSpan.TryParse(cookieConfigSection[nameof(CookieBuilder.MaxAge)], out var maxAge)
-                    ? maxAge
-                    : null,
-                Name = cookieConfigSection[nameof(CookieBuilder.Name)] ?? cookieBuilder.Name,
-                Path = cookieConfigSection[nameof(CookieBuilder.Path)],
-                SameSite = cookieConfigSection[nameof(CookieBuilder.SameSite)] switch
-                {
-                    "Lax" => SameSiteMode.Lax,
-                    "Strict" => SameSiteMode.Strict,
-                    "Unspecified" => SameSiteMode.Unspecified,
-                    "None" => SameSiteMode.None,
-                    _ => cookieBuilder.SameSite
-                },
-
-                SecurePolicy = cookieConfigSection[nameof(CookieBuilder.SecurePolicy)] switch
-                {
-                    "Always" => CookieSecurePolicy.Always,
-                    "None" => CookieSecurePolicy.None,
-                    "SameAsRequest" => CookieSecurePolicy.SameAsRequest,
-                    _ => cookieBuilder.SecurePolicy
-                }
+                "lax" => SameSiteMode.Lax,
+                "strict" => SameSiteMode.Strict,
+                "unspecified" => SameSiteMode.Unspecified,
+                "none" => SameSiteMode.None,
+                null => cookieBuilder.SameSite,
+                "" => cookieBuilder.SameSite,
+                _ => throw new InvalidOperationException($"{nameof(CookieBuilder.SameSite)} option must be a valid {nameof(SameSiteMode)}")
+            };
+            cookieBuilder.SecurePolicy = cookieConfigSection[nameof(CookieBuilder.SecurePolicy)]?.ToLowerInvariant() switch
+            {
+                "always" => CookieSecurePolicy.Always,
+                "none" => CookieSecurePolicy.None,
+                "sameasrequest" => CookieSecurePolicy.SameAsRequest,
+                null => cookieBuilder.SecurePolicy,
+                "" => cookieBuilder.SecurePolicy,
+                _ => throw new InvalidOperationException($"{nameof(CookieBuilder.SameSite)} option must be a valid {nameof(SameSiteMode)}")
             };
 
             var extensions = cookieConfigSection.GetSection(nameof(CookieBuilder.Extensions)).GetChildren().Select(ext => ext.Value).OfType<string>();

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectConfigureOptions.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectConfigureOptions.cs
@@ -13,6 +13,7 @@ internal sealed class OpenIdConnectConfigureOptions : IConfigureNamedOptions<Ope
 {
     private readonly IAuthenticationConfigurationProvider _authenticationConfigurationProvider;
     private static readonly Func<string, TimeSpan> _invariantTimeSpanParse = (string timespanString) => TimeSpan.Parse(timespanString, CultureInfo.InvariantCulture);
+    private static readonly Func<string, TimeSpan?> _invariantNullableTimeSpanParse = (string timespanString) => TimeSpan.Parse(timespanString, CultureInfo.InvariantCulture);
 
     /// <summary>
     /// Initializes a new <see cref="OpenIdConnectConfigureOptions"/> given the configuration
@@ -39,93 +40,93 @@ internal sealed class OpenIdConnectConfigureOptions : IConfigureNamedOptions<Ope
             return;
         }
 
-        options.AccessDeniedPath = new PathString(configSection[nameof(options.AccessDeniedPath)]);
+        options.AccessDeniedPath = new PathString(configSection[nameof(options.AccessDeniedPath.Value)]);
         options.Authority = configSection[nameof(options.Authority)];
-        options.AutomaticRefreshInterval = StringHelpers.ParseValueOrDefault(options.AutomaticRefreshInterval, configSection[nameof(options.AutomaticRefreshInterval)], _invariantTimeSpanParse);
-        options.BackchannelTimeout = StringHelpers.ParseValueOrDefault(options.BackchannelTimeout, configSection[nameof(options.BackchannelTimeout)], _invariantTimeSpanParse);
-        options.CallbackPath = new PathString(configSection[nameof(options.CallbackPath)] ?? options.CallbackPath);
+        options.AutomaticRefreshInterval = StringHelpers.ParseValueOrDefault(configSection[nameof(options.AutomaticRefreshInterval)], _invariantTimeSpanParse, options.AutomaticRefreshInterval);
+        options.BackchannelTimeout = StringHelpers.ParseValueOrDefault(configSection[nameof(options.BackchannelTimeout)], _invariantTimeSpanParse, options.BackchannelTimeout);
+        options.CallbackPath = new PathString(configSection[nameof(options.CallbackPath)] ?? options.CallbackPath.Value);
         options.ClaimsIssuer = configSection[nameof(options.ClaimsIssuer)];
         options.ClientId = configSection[nameof(options.ClientId)];
         options.ClientSecret = configSection[nameof(options.ClientSecret)];
-        options.CorrelationCookie = GetCookieFromConfig(configSection.GetSection(nameof(options.CorrelationCookie)), options.CorrelationCookie);
-        options.DisableTelemetry = StringHelpers.ParseValueOrDefault(options.DisableTelemetry, configSection[nameof(options.DisableTelemetry)], bool.Parse);
+        SetCookieFromConfig(configSection.GetSection(nameof(options.CorrelationCookie)), options.CorrelationCookie);
+        options.DisableTelemetry = StringHelpers.ParseValueOrDefault(configSection[nameof(options.DisableTelemetry)], bool.Parse, options.DisableTelemetry);
         options.ForwardAuthenticate = configSection[nameof(options.ForwardAuthenticate)];
         options.ForwardChallenge = configSection[nameof(options.ForwardChallenge)];
         options.ForwardDefault = configSection[nameof(options.ForwardDefault)];
         options.ForwardForbid = configSection[nameof(options.ForwardForbid)];
         options.ForwardSignIn = configSection[nameof(options.ForwardSignIn)];
         options.ForwardSignOut = configSection[nameof(options.ForwardSignOut)];
-        options.GetClaimsFromUserInfoEndpoint = StringHelpers.ParseValueOrDefault(options.GetClaimsFromUserInfoEndpoint, configSection[nameof(options.GetClaimsFromUserInfoEndpoint)], bool.Parse);
-        options.MapInboundClaims = StringHelpers.ParseValueOrDefault(options.MapInboundClaims, configSection[nameof(options.MapInboundClaims)], bool.Parse);
-        options.MaxAge = options.MaxAge is TimeSpan maxAge ? StringHelpers.ParseValueOrDefault(maxAge, configSection[nameof(options.MaxAge)], _invariantTimeSpanParse) : options.MaxAge;
+        options.GetClaimsFromUserInfoEndpoint = StringHelpers.ParseValueOrDefault(configSection[nameof(options.GetClaimsFromUserInfoEndpoint)], bool.Parse, options.GetClaimsFromUserInfoEndpoint);
+        options.MapInboundClaims = StringHelpers.ParseValueOrDefault(configSection[nameof(options.MapInboundClaims)], bool.Parse, options.MapInboundClaims);
+        options.MaxAge = StringHelpers.ParseValueOrDefault(configSection[nameof(options.MaxAge)], _invariantNullableTimeSpanParse, options.MaxAge);
         options.MetadataAddress = configSection[nameof(options.MetadataAddress)];
-        options.NonceCookie = GetCookieFromConfig(configSection.GetSection(nameof(options.NonceCookie)), options.NonceCookie);
+        SetCookieFromConfig(configSection.GetSection(nameof(options.NonceCookie)), options.NonceCookie);
         options.Prompt = configSection[nameof(options.Prompt)];
-        options.RefreshInterval = StringHelpers.ParseValueOrDefault(options.RefreshInterval, configSection[nameof(options.RefreshInterval)], _invariantTimeSpanParse);
-        options.RefreshOnIssuerKeyNotFound = StringHelpers.ParseValueOrDefault(options.RefreshOnIssuerKeyNotFound, configSection[nameof(options.RefreshOnIssuerKeyNotFound)], bool.Parse);
-        options.RemoteAuthenticationTimeout = StringHelpers.ParseValueOrDefault(options.RemoteAuthenticationTimeout, configSection[nameof(options.RemoteAuthenticationTimeout)], _invariantTimeSpanParse);
-        options.RemoteSignOutPath = new PathString(configSection[nameof(options.RemoteSignOutPath)] ?? options.RemoteSignOutPath);
-        options.RequireHttpsMetadata = StringHelpers.ParseValueOrDefault(options.RequireHttpsMetadata, configSection[nameof(options.RequireHttpsMetadata)], bool.Parse);
+        options.RefreshInterval = StringHelpers.ParseValueOrDefault(configSection[nameof(options.RefreshInterval)], _invariantTimeSpanParse, options.RefreshInterval);
+        options.RefreshOnIssuerKeyNotFound = StringHelpers.ParseValueOrDefault(configSection[nameof(options.RefreshOnIssuerKeyNotFound)], bool.Parse, options.RefreshOnIssuerKeyNotFound);
+        options.RemoteAuthenticationTimeout = StringHelpers.ParseValueOrDefault(configSection[nameof(options.RemoteAuthenticationTimeout)], _invariantTimeSpanParse, options.RemoteAuthenticationTimeout);
+        options.RemoteSignOutPath = new PathString(configSection[nameof(options.RemoteSignOutPath)] ?? options.RemoteSignOutPath.Value);
+        options.RequireHttpsMetadata = StringHelpers.ParseValueOrDefault(configSection[nameof(options.RequireHttpsMetadata)], bool.Parse, options.RequireHttpsMetadata);
         options.Resource = configSection[nameof(options.Resource)];
         options.ResponseMode = configSection[nameof(options.ResponseMode)] ?? options.ResponseMode;
         options.ResponseType = configSection[nameof(options.ResponseType)] ?? options.ResponseType;
         options.ReturnUrlParameter = configSection[nameof(options.ReturnUrlParameter)] ?? options.ReturnUrlParameter;
-        options.SaveTokens = StringHelpers.ParseValueOrDefault(options.SaveTokens, configSection[nameof(options.SaveTokens)], bool.Parse);
+        options.SaveTokens = StringHelpers.ParseValueOrDefault(configSection[nameof(options.SaveTokens)], bool.Parse, options.SaveTokens);
         var scopes = configSection.GetSection(nameof(options.Scope)).GetChildren().Select(scope => scope.Value).OfType<string>();
         foreach (var scope in scopes)
         {
             options.Scope.Add(scope);
         }
-        options.SignedOutCallbackPath = new PathString(configSection[nameof(options.SignedOutCallbackPath)] ?? options.SignedOutCallbackPath);
+        options.SignedOutCallbackPath = new PathString(configSection[nameof(options.SignedOutCallbackPath)] ?? options.SignedOutCallbackPath.Value);
         options.SignedOutRedirectUri = configSection[nameof(options.SignedOutRedirectUri)] ?? options.SignedOutRedirectUri;
         options.SignInScheme = configSection[nameof(options.SignInScheme)];
         options.SignOutScheme = configSection[nameof(options.SignOutScheme)];
-        options.SkipUnrecognizedRequests = StringHelpers.ParseValueOrDefault(options.SkipUnrecognizedRequests, configSection[nameof(options.SkipUnrecognizedRequests)], bool.Parse);
-        options.UsePkce = StringHelpers.ParseValueOrDefault(options.UsePkce, configSection[nameof(options.UsePkce)], bool.Parse);
-        options.UseTokenLifetime = StringHelpers.ParseValueOrDefault(options.UseTokenLifetime, configSection[nameof(options.UseTokenLifetime)], bool.Parse);
+        options.SkipUnrecognizedRequests = StringHelpers.ParseValueOrDefault(configSection[nameof(options.SkipUnrecognizedRequests)], bool.Parse, options.SkipUnrecognizedRequests);
+        options.UsePkce = StringHelpers.ParseValueOrDefault(configSection[nameof(options.UsePkce)], bool.Parse, options.UsePkce);
+        options.UseTokenLifetime = StringHelpers.ParseValueOrDefault(configSection[nameof(options.UseTokenLifetime)], bool.Parse, options.UseTokenLifetime);
     }
 
-    private static CookieBuilder GetCookieFromConfig(IConfiguration cookieConfigSection, CookieBuilder cookieBuilder)
+    private static void SetCookieFromConfig(IConfiguration cookieConfigSection, CookieBuilder cookieBuilder)
     {
-        if (cookieConfigSection is not null && cookieConfigSection.GetChildren().Any())
+        if (cookieConfigSection is null || !cookieConfigSection.GetChildren().Any())
         {
-            // Override the existing defaults when values are set instead of constructing
-            // an entirely new CookieBuilder.
-            cookieBuilder.Domain = cookieConfigSection[nameof(cookieBuilder.Domain)];
-            cookieBuilder.HttpOnly = StringHelpers.ParseValueOrDefault(cookieBuilder.HttpOnly, cookieConfigSection[nameof(cookieBuilder.HttpOnly)], bool.Parse);
-            cookieBuilder.IsEssential = StringHelpers.ParseValueOrDefault(cookieBuilder.IsEssential, cookieConfigSection[nameof(cookieBuilder.IsEssential)], bool.Parse);
-            cookieBuilder.Expiration = cookieBuilder.Expiration is TimeSpan expiration ? StringHelpers.ParseValueOrDefault(expiration, cookieConfigSection[nameof(cookieBuilder.Expiration)], _invariantTimeSpanParse) : cookieBuilder.Expiration;
-            cookieBuilder.MaxAge = cookieBuilder.MaxAge is TimeSpan maxAge ? StringHelpers.ParseValueOrDefault(maxAge, cookieConfigSection[nameof(cookieBuilder.MaxAge)], _invariantTimeSpanParse) : cookieBuilder.MaxAge;
-            cookieBuilder.Name = cookieConfigSection[nameof(CookieBuilder.Name)] ?? cookieBuilder.Name;
-            cookieBuilder.Path = cookieConfigSection[nameof(CookieBuilder.Path)];
-            cookieBuilder.SameSite = cookieConfigSection[nameof(CookieBuilder.SameSite)]?.ToLowerInvariant() switch
-            {
-                "lax" => SameSiteMode.Lax,
-                "strict" => SameSiteMode.Strict,
-                "unspecified" => SameSiteMode.Unspecified,
-                "none" => SameSiteMode.None,
-                null => cookieBuilder.SameSite,
-                "" => cookieBuilder.SameSite,
-                _ => throw new InvalidOperationException($"{nameof(CookieBuilder.SameSite)} option must be a valid {nameof(SameSiteMode)}")
-            };
-            cookieBuilder.SecurePolicy = cookieConfigSection[nameof(CookieBuilder.SecurePolicy)]?.ToLowerInvariant() switch
-            {
-                "always" => CookieSecurePolicy.Always,
-                "none" => CookieSecurePolicy.None,
-                "sameasrequest" => CookieSecurePolicy.SameAsRequest,
-                null => cookieBuilder.SecurePolicy,
-                "" => cookieBuilder.SecurePolicy,
-                _ => throw new InvalidOperationException($"{nameof(CookieBuilder.SameSite)} option must be a valid {nameof(SameSiteMode)}")
-            };
-
-            var extensions = cookieConfigSection.GetSection(nameof(CookieBuilder.Extensions)).GetChildren().Select(ext => ext.Value).OfType<string>();
-            foreach (var extension in extensions)
-            {
-                cookieBuilder.Extensions.Add(extension);
-            }
+            return;
         }
 
-        return cookieBuilder;
+        // Override the existing defaults when values are set instead of constructing
+        // an entirely new CookieBuilder.
+        cookieBuilder.Domain = cookieConfigSection[nameof(cookieBuilder.Domain)] ?? cookieBuilder.Domain;
+        cookieBuilder.HttpOnly = StringHelpers.ParseValueOrDefault(cookieConfigSection[nameof(cookieBuilder.HttpOnly)], bool.Parse, cookieBuilder.HttpOnly);
+        cookieBuilder.IsEssential = StringHelpers.ParseValueOrDefault(cookieConfigSection[nameof(cookieBuilder.IsEssential)], bool.Parse, cookieBuilder.IsEssential);
+        cookieBuilder.Expiration = StringHelpers.ParseValueOrDefault(cookieConfigSection[nameof(cookieBuilder.Expiration)], _invariantNullableTimeSpanParse, cookieBuilder.Expiration);
+        cookieBuilder.MaxAge = StringHelpers.ParseValueOrDefault<TimeSpan?>(cookieConfigSection[nameof(cookieBuilder.MaxAge)], _invariantNullableTimeSpanParse, cookieBuilder.MaxAge);
+        cookieBuilder.Name = cookieConfigSection[nameof(CookieBuilder.Name)] ?? cookieBuilder.Name;
+        cookieBuilder.Path = cookieConfigSection[nameof(CookieBuilder.Path)] ?? cookieBuilder.Path;
+        cookieBuilder.SameSite = cookieConfigSection[nameof(CookieBuilder.SameSite)]?.ToLowerInvariant() switch
+        {
+            "lax" => SameSiteMode.Lax,
+            "strict" => SameSiteMode.Strict,
+            "unspecified" => SameSiteMode.Unspecified,
+            "none" => SameSiteMode.None,
+            null => cookieBuilder.SameSite,
+            "" => cookieBuilder.SameSite,
+            _ => throw new InvalidOperationException($"{nameof(CookieBuilder.SameSite)} option must be a valid {nameof(SameSiteMode)}")
+        };
+        cookieBuilder.SecurePolicy = cookieConfigSection[nameof(CookieBuilder.SecurePolicy)]?.ToLowerInvariant() switch
+        {
+            "always" => CookieSecurePolicy.Always,
+            "none" => CookieSecurePolicy.None,
+            "sameasrequest" => CookieSecurePolicy.SameAsRequest,
+            null => cookieBuilder.SecurePolicy,
+            "" => cookieBuilder.SecurePolicy,
+            _ => throw new InvalidOperationException($"{nameof(CookieBuilder.SameSite)} option must be a valid {nameof(SameSiteMode)}")
+        };
+
+        var extensions = cookieConfigSection.GetSection(nameof(CookieBuilder.Extensions)).GetChildren().Select(ext => ext.Value).OfType<string>();
+        foreach (var extension in extensions)
+        {
+            cookieBuilder.Extensions.Add(extension);
+        }
     }
 
     /// <inheritdoc />

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectConfigureOptions.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectConfigureOptions.cs
@@ -41,7 +41,7 @@ internal sealed class OpenIdConnectConfigureOptions : IConfigureNamedOptions<Ope
         }
 
         options.AccessDeniedPath = new PathString(configSection[nameof(options.AccessDeniedPath)] ?? options.AccessDeniedPath.Value);
-        options.Authority = configSection[nameof(options.Authority)];
+        options.Authority = configSection[nameof(options.Authority)] ?? options.Authority;
         options.AutomaticRefreshInterval = StringHelpers.ParseValueOrDefault(configSection[nameof(options.AutomaticRefreshInterval)], _invariantTimeSpanParse, options.AutomaticRefreshInterval);
         options.BackchannelTimeout = StringHelpers.ParseValueOrDefault(configSection[nameof(options.BackchannelTimeout)], _invariantTimeSpanParse, options.BackchannelTimeout);
         options.CallbackPath = new PathString(configSection[nameof(options.CallbackPath)] ?? options.CallbackPath.Value);
@@ -98,26 +98,12 @@ internal sealed class OpenIdConnectConfigureOptions : IConfigureNamedOptions<Ope
         cookieBuilder.MaxAge = StringHelpers.ParseValueOrDefault<TimeSpan?>(cookieConfigSection[nameof(cookieBuilder.MaxAge)], _invariantNullableTimeSpanParse, cookieBuilder.MaxAge);
         cookieBuilder.Name = cookieConfigSection[nameof(CookieBuilder.Name)] ?? cookieBuilder.Name;
         cookieBuilder.Path = cookieConfigSection[nameof(CookieBuilder.Path)] ?? cookieBuilder.Path;
-        cookieBuilder.SameSite = cookieConfigSection[nameof(CookieBuilder.SameSite)]?.ToLowerInvariant() switch
-        {
-            "lax" => SameSiteMode.Lax,
-            "strict" => SameSiteMode.Strict,
-            "unspecified" => SameSiteMode.Unspecified,
-            "none" => SameSiteMode.None,
-            null => cookieBuilder.SameSite,
-            "" => cookieBuilder.SameSite,
-            _ => throw new InvalidOperationException($"{nameof(CookieBuilder.SameSite)} option must be a valid {nameof(SameSiteMode)}")
-        };
-        cookieBuilder.SecurePolicy = cookieConfigSection[nameof(CookieBuilder.SecurePolicy)]?.ToLowerInvariant() switch
-        {
-            "always" => CookieSecurePolicy.Always,
-            "none" => CookieSecurePolicy.None,
-            "sameasrequest" => CookieSecurePolicy.SameAsRequest,
-            null => cookieBuilder.SecurePolicy,
-            "" => cookieBuilder.SecurePolicy,
-            _ => throw new InvalidOperationException($"{nameof(CookieBuilder.SameSite)} option must be a valid {nameof(SameSiteMode)}")
-        };
-
+        cookieBuilder.SameSite = cookieConfigSection[nameof(CookieBuilder.SameSite)] is string sameSiteMode
+            ? Enum.Parse<SameSiteMode>(sameSiteMode, ignoreCase: true)
+            : cookieBuilder.SameSite;
+        cookieBuilder.SecurePolicy = cookieConfigSection[nameof(CookieBuilder.SecurePolicy)] is string securePolicy
+            ? Enum.Parse<CookieSecurePolicy>(securePolicy, ignoreCase: true)
+            : cookieBuilder.SecurePolicy;
         ClearAndSetListOption(cookieBuilder.Extensions, cookieConfigSection.GetSection(nameof(cookieBuilder.Extensions)));
     }
 

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectExtensions.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectExtensions.cs
@@ -68,6 +68,7 @@ public static class OpenIdConnectExtensions
     /// <returns>A reference to <paramref name="builder"/> after the operation has completed.</returns>
     public static AuthenticationBuilder AddOpenIdConnect(this AuthenticationBuilder builder, string authenticationScheme, string? displayName, Action<OpenIdConnectOptions> configureOptions)
     {
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<OpenIdConnectOptions>, OpenIdConnectConfigureOptions>());
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<OpenIdConnectOptions>, OpenIdConnectPostConfigureOptions>());
         return builder.AddRemoteScheme<OpenIdConnectOptions, OpenIdConnectHandler>(authenticationScheme, displayName, configureOptions);
     }

--- a/src/Security/Authentication/test/AuthenticationMiddlewareTests.cs
+++ b/src/Security/Authentication/test/AuthenticationMiddlewareTests.cs
@@ -159,8 +159,8 @@ public class AuthenticationMiddlewareTests
         var builder = WebApplication.CreateBuilder();
         builder.Configuration.AddInMemoryCollection(new[]
         {
-            new KeyValuePair<string, string>("Authentication:Schemes:Bearer:ClaimsIssuer", "SomeIssuer"),
-            new KeyValuePair<string, string>("Authentication:Schemes:Bearer:Audiences:0", "https://localhost:5001")
+            new KeyValuePair<string, string>("Authentication:Schemes:Bearer:ValidIssuer", "SomeIssuer"),
+            new KeyValuePair<string, string>("Authentication:Schemes:Bearer:ValidAudiences:0", "https://localhost:5001")
         });
         builder.Services.AddAuthorization();
         builder.Services.AddAuthentication().AddJwtBearer();

--- a/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectTests.cs
+++ b/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectTests.cs
@@ -459,7 +459,7 @@ public class OpenIdConnectTests
             new KeyValuePair<string, string>("Authentication:Schemes:OpenIdConnect:ClientSecret", "client-secret"),
             new KeyValuePair<string, string>("Authentication:Schemes:OpenIdConnect:CorrelationCookie:Domain", "https://localhost:5000"),
             new KeyValuePair<string, string>("Authentication:Schemes:OpenIdConnect:CorrelationCookie:IsEssential", "False"),
-            new KeyValuePair<string, string>("Authentication:Schemes:OpenIdConnect:CorrelationCookie:SecurePolicy", "Always"),
+            new KeyValuePair<string, string>("Authentication:Schemes:OpenIdConnect:CorrelationCookie:SecurePolicy", "always"),
         }).Build();
         services.AddSingleton<IConfiguration>(config);
 

--- a/src/Security/Security.slnf
+++ b/src/Security/Security.slnf
@@ -46,6 +46,7 @@
       "src\\Security\\Authentication\\Negotiate\\test\\Negotiate.FunctionalTest\\Microsoft.AspNetCore.Authentication.Negotiate.FunctionalTest.csproj",
       "src\\Security\\Authentication\\Negotiate\\test\\Negotiate.Test\\Microsoft.AspNetCore.Authentication.Negotiate.Test.csproj",
       "src\\Security\\Authentication\\OAuth\\src\\Microsoft.AspNetCore.Authentication.OAuth.csproj",
+      "src\\Security\\Authentication\\OpenIdConnect\\samples\\MinimalOpenIdConnectSample\\MinimalOpenIdConnectSample.csproj",
       "src\\Security\\Authentication\\OpenIdConnect\\samples\\OpenIdConnectSample\\OpenIdConnectSample.csproj",
       "src\\Security\\Authentication\\OpenIdConnect\\src\\Microsoft.AspNetCore.Authentication.OpenIdConnect.csproj",
       "src\\Security\\Authentication\\Twitter\\src\\Microsoft.AspNetCore.Authentication.Twitter.csproj",

--- a/src/Shared/StringHelpers.cs
+++ b/src/Shared/StringHelpers.cs
@@ -5,7 +5,7 @@ namespace System;
 
 internal static class StringHelpers
 {
-    public static T ParseValueOrDefault<T>(T defaultValue, string? stringValue, Func<string, T> parser)
+    public static T ParseValueOrDefault<T>(string? stringValue, Func<string, T> parser, T defaultValue)
     {
         if (string.IsNullOrEmpty(stringValue))
         {

--- a/src/Shared/StringHelpers.cs
+++ b/src/Shared/StringHelpers.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System;
+
+internal static class StringHelpers
+{
+    public static T ParseValueOrDefault<T>(T defaultValue, string? stringValue, Func<string, T> parser)
+    {
+        if (string.IsNullOrEmpty(stringValue))
+        {
+            return defaultValue;
+        }
+
+        return parser(stringValue);
+    }
+}

--- a/src/Tools/dotnet-user-jwts/src/Helpers/JwtAuthenticationSchemeSettings.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/JwtAuthenticationSchemeSettings.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools;
 
@@ -25,8 +26,8 @@ internal sealed record JwtAuthenticationSchemeSettings(string SchemeName, List<s
 
         var settingsObject = new JsonObject
         {
-            [nameof(Audiences)] = new JsonArray(Audiences.Select(aud => JsonValue.Create(aud)).ToArray()),
-            [nameof(ClaimsIssuer)] = ClaimsIssuer
+            [nameof(TokenValidationParameters.ValidAudiences)] = new JsonArray(Audiences.Select(aud => JsonValue.Create(aud)).ToArray()),
+            [nameof(TokenValidationParameters.ValidIssuer)] = ClaimsIssuer
         };
 
         if (config[AuthenticationKey] is JsonObject authentication)


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/42170 and fixes #42000.

- Support configuring more options from config for `OpenIdConnectOptions` and `JwtBearerOptions`
- Support multiple issuers being set via array from config for `JwtBearerOptions`
- Support single audience being set via string from config for `JwtBearerOptions`
- Update writing of config properties in `user-jwts` to use `ValidIssuer` and `ValidAudiences` names to match `TokenValidationParameters`
- Support multiple signing keys in JWT bearer-based authentication

This does not add support for setting nested properties under `JwtBearerOptions.TokenValidationParameters` since I don't think that level of customization is necessary at the moment.