### PR TITLE
HTTP/3: Don't wait for writes to complete in sends

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -368,6 +368,9 @@ internal partial class QuicStreamContext : TransportConnection, IPooledStream, I
         Exception? shutdownReason = null;
         Exception? unexpectedError = null;
 
+        // A client can abort a stream after it has finished sending data. We need a way to get that notification
+        // which is why we listen for a notification that the write-side of the stream is done.
+        // An exception can be thrown from the stream on client abort which will be captured and then wake up the output read.
         _ = WaitForWritesCompleted();
 
         try

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -368,7 +368,7 @@ internal partial class QuicStreamContext : TransportConnection, IPooledStream, I
         Exception? shutdownReason = null;
         Exception? unexpectedError = null;
 
-        var sendCompletedTask = WaitForWritesCompleted();
+        _ = WaitForWritesCompleted();
 
         try
         {
@@ -465,7 +465,6 @@ internal partial class QuicStreamContext : TransportConnection, IPooledStream, I
         finally
         {
             ShutdownWrite(_shutdownWriteReason ?? _shutdownReason ?? shutdownReason);
-            await sendCompletedTask;
 
             // Complete the output after completing stream sends
             Output.Complete(unexpectedError);


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/42289

~There's no reason to wait for the client to indicate it has shutdown its side of the stream in the `QuicStreamContext.DoSends` method.~

~Won't be merged until the networking team figures out what is going on with the client not reporting it's done. This gives us a chance to still test that problem - https://github.com/dotnet/runtime/issues/71927~

Talked with S.N.Q team more and DisposeAsync always awaits completion anyway. Remove this await is still worthwhile because we complete the output earlier.