### PR TITLE
HTTP/3: Avoid per-request cancellation token allocations

### DIFF
--- a/src/Servers/Connections.Abstractions/src/Features/IStreamClosedFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/IStreamClosedFeature.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using System;
+
+namespace Microsoft.AspNetCore.Connections.Features;
+
+/// <summary>
+/// Represents the close action for a stream.
+/// </summary>
+public interface IStreamClosedFeature
+{
+    /// <summary>
+    /// Registers a callback to be invoked when a stream is closed.
+    /// If the stream is already in a closed state, the callback will be run immediately.
+    /// </summary>
+    /// <param name="callback">The callback to invoke after the stream is closed.</param>
+    /// <param name="state">The state to pass into the callback.</param>
+    void OnClosed(Action<object?> callback, object? state);
+}

--- a/src/Servers/Connections.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Connections.Features.IStreamClosedFeature
+Microsoft.AspNetCore.Connections.Features.IStreamClosedFeature.OnClosed(System.Action<object?>! callback, object? state) -> void

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -46,6 +46,7 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
     private IProtocolErrorCodeFeature _errorCodeFeature = default!;
     private IStreamIdFeature _streamIdFeature = default!;
     private IStreamAbortFeature _streamAbortFeature = default!;
+    private IStreamClosedFeature _streamClosedFeature = default!;
     private PseudoHeaderFields _parsedPseudoHeaderFields;
     private StreamCompletionFlags _completionState;
     private int _isClosed;
@@ -88,6 +89,7 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
         _errorCodeFeature = _context.ConnectionFeatures.GetRequiredFeature<IProtocolErrorCodeFeature>();
         _streamIdFeature = _context.ConnectionFeatures.GetRequiredFeature<IStreamIdFeature>();
         _streamAbortFeature = _context.ConnectionFeatures.GetRequiredFeature<IStreamAbortFeature>();
+        _streamClosedFeature = _context.ConnectionFeatures.GetRequiredFeature<IStreamClosedFeature>();
 
         _appCompletedTaskSource.Reset();
         _isClosed = 0;
@@ -144,7 +146,7 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
     {
         lock (_completionLock)
         {
-            if (IsCompleted)
+            if (IsCompleted || IsAborted)
             {
                 return;
             }
@@ -573,6 +575,28 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
     {
         Exception? error = null;
 
+        // With HTTP/3 the write-side of the stream can be aborted by the client after the server
+        // has finished reading incoming content. That means errors can happen after the Input loop
+        // has finished reading.
+        //
+        // To get notification of request aborted we register to the stream closing or complete.
+        // It will notify this type that the client has aborted the request and Kestrel will complete
+        // pipes and cancel the HttpContext.RequestAborted token.
+        _streamClosedFeature.OnClosed(static s =>
+        {
+            var stream = (Http3Stream)s!;
+
+            if (!stream.IsCompleted)
+            {
+                // An error code value other than -1 indicates a value was set and the request didn't gracefully complete.
+                var errorCode = stream._errorCodeFeature.Error;
+                if (errorCode >= 0)
+                {
+                    stream.AbortCore(new IOException(CoreStrings.HttpStreamResetByClient), (Http3ErrorCode)errorCode);
+                }
+            }
+        }, this);
+
         try
         {
             while (_isClosed == 0)
@@ -643,44 +667,9 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
                 ? new ValueTask(_appCompletedTaskSource, _appCompletedTaskSource.Version)
                 : ValueTask.CompletedTask;
 
-            if (!appCompletedTask.IsCompletedSuccessfully)
-            {
-                // At this point in the stream's read-side is complete. However, with HTTP/3
-                // the write-side of the stream can still be aborted by the client on request
-                // aborted.
-                //
-                // To get notification of request aborted we register to connection closed
-                // token. It will notify this type that the client has aborted the request
-                // and Kestrel will complete pipes and cancel the RequestAborted token.
-                //
-                // Only subscribe to this event after the stream's read-side is complete to
-                // avoid interactions between reading that is in-progress and an abort.
-                // This means while reading, read-side abort will handle getting abort notifications.
-                //
-                // We don't need to hang on to the CancellationTokenRegistration from register.
-                // The CTS is cleaned up in StreamContext.DisposeAsync.
-                //
-                // TODO: Consider a better way to provide this notification. For perf we want to
-                // make the ConnectionClosed CTS pay-for-play, and change this event to use
-                // something that is more lightweight than a CTS.
-                _context.StreamContext.ConnectionClosed.Register(static s =>
-                {
-                    var stream = (Http3Stream)s!;
-
-                    if (!stream.IsCompleted)
-                    {
-                        // An error code value other than -1 indicates a value was set and the request didn't gracefully complete.
-                        var errorCode = stream._errorCodeFeature.Error;
-                        if (errorCode >= 0)
-                        {
-                            stream.AbortCore(new IOException(CoreStrings.HttpStreamResetByClient), (Http3ErrorCode)errorCode);
-                        }
-                    }
-                }, this);
-
-                // Make sure application func is completed before completing writer.
-                await appCompletedTask;
-            }
+            // At this point, assuming an error wasn't thrown, the stream's read-side is complete.
+            // Make sure application func is completed before completing writer.
+            await appCompletedTask;
 
             try
             {

--- a/src/Servers/Kestrel/Core/test/Http3/Http3HttpProtocolFeatureCollectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http3/Http3HttpProtocolFeatureCollectionTests.cs
@@ -67,7 +67,7 @@ public class Http3HttpProtocolFeatureCollectionTests
         }
     }
 
-    private class TestConnectionFeatures : IProtocolErrorCodeFeature, IStreamIdFeature, IStreamAbortFeature
+    private class TestConnectionFeatures : IProtocolErrorCodeFeature, IStreamIdFeature, IStreamAbortFeature, IStreamClosedFeature
     {
         public TestConnectionFeatures()
         {
@@ -75,6 +75,7 @@ public class Http3HttpProtocolFeatureCollectionTests
             featureCollection.Set<IProtocolErrorCodeFeature>(this);
             featureCollection.Set<IStreamIdFeature>(this);
             featureCollection.Set<IStreamAbortFeature>(this);
+            featureCollection.Set<IStreamClosedFeature>(this);
 
             FeatureCollection = featureCollection;
         }
@@ -89,6 +90,11 @@ public class Http3HttpProtocolFeatureCollectionTests
         }
 
         void IStreamAbortFeature.AbortWrite(long errorCode, ConnectionAbortedException abortReason)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IStreamClosedFeature.OnClosed(Action<object> callback, object state)
         {
             throw new NotImplementedException();
         }

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.FeatureCollection.cs
@@ -7,10 +7,19 @@ using Microsoft.AspNetCore.Connections.Features;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal;
 
-internal sealed partial class QuicStreamContext : IPersistentStateFeature, IStreamDirectionFeature, IProtocolErrorCodeFeature, IStreamIdFeature, IStreamAbortFeature
+internal sealed partial class QuicStreamContext :
+    IPersistentStateFeature,
+    IStreamDirectionFeature,
+    IProtocolErrorCodeFeature,
+    IStreamIdFeature,
+    IStreamAbortFeature,
+    IStreamClosedFeature
 {
+    private readonly record struct CloseAction(Action<object?> Callback, object? State);
+
     private IDictionary<object, object?>? _persistentState;
     private long? _error;
+    private List<CloseAction>? _onClosed;
 
     public bool CanRead { get; private set; }
     public bool CanWrite { get; private set; }
@@ -72,6 +81,25 @@ internal sealed partial class QuicStreamContext : IPersistentStateFeature, IStre
         }
     }
 
+    void IStreamClosedFeature.OnClosed(Action<object?> callback, object? state)
+    {
+        lock (_shutdownLock)
+        {
+            if (!_streamClosed)
+            {
+                if (_onClosed == null)
+                {
+                    _onClosed = new List<CloseAction>();
+                }
+                _onClosed.Add(new CloseAction(callback, state));
+                return;
+            }
+        }
+
+        // Stream has already closed. Execute callback inline.
+        callback(state);
+    }
+
     private void InitializeFeatures()
     {
         _currentIPersistentStateFeature = this;
@@ -79,5 +107,6 @@ internal sealed partial class QuicStreamContext : IPersistentStateFeature, IStre
         _currentIProtocolErrorCodeFeature = this;
         _currentIStreamIdFeature = this;
         _currentIStreamAbortFeature = this;
+        _currentIStreamClosedFeature = this;
     }
 }

--- a/src/Servers/Kestrel/shared/TransportConnection.Generated.cs
+++ b/src/Servers/Kestrel/shared/TransportConnection.Generated.cs
@@ -34,6 +34,7 @@ namespace Microsoft.AspNetCore.Connections
         internal protected IStreamDirectionFeature? _currentIStreamDirectionFeature;
         internal protected IStreamIdFeature? _currentIStreamIdFeature;
         internal protected IStreamAbortFeature? _currentIStreamAbortFeature;
+        internal protected IStreamClosedFeature? _currentIStreamClosedFeature;
 
         private int _featureRevision;
 
@@ -53,6 +54,7 @@ namespace Microsoft.AspNetCore.Connections
             _currentIStreamDirectionFeature = null;
             _currentIStreamIdFeature = null;
             _currentIStreamAbortFeature = null;
+            _currentIStreamClosedFeature = null;
         }
 
         // Internal for testing
@@ -168,6 +170,10 @@ namespace Microsoft.AspNetCore.Connections
                 {
                     feature = _currentIStreamAbortFeature;
                 }
+                else if (key == typeof(IStreamClosedFeature))
+                {
+                    feature = _currentIStreamClosedFeature;
+                }
                 else if (MaybeExtra != null)
                 {
                     feature = ExtraFeatureGet(key);
@@ -223,6 +229,10 @@ namespace Microsoft.AspNetCore.Connections
                 else if (key == typeof(IStreamAbortFeature))
                 {
                     _currentIStreamAbortFeature = (IStreamAbortFeature?)value;
+                }
+                else if (key == typeof(IStreamClosedFeature))
+                {
+                    _currentIStreamClosedFeature = (IStreamClosedFeature?)value;
                 }
                 else
                 {
@@ -281,6 +291,10 @@ namespace Microsoft.AspNetCore.Connections
             else if (typeof(TFeature) == typeof(IStreamAbortFeature))
             {
                 feature = Unsafe.As<IStreamAbortFeature?, TFeature?>(ref _currentIStreamAbortFeature);
+            }
+            else if (typeof(TFeature) == typeof(IStreamClosedFeature))
+            {
+                feature = Unsafe.As<IStreamClosedFeature?, TFeature?>(ref _currentIStreamClosedFeature);
             }
             else if (MaybeExtra != null)
             {
@@ -346,6 +360,10 @@ namespace Microsoft.AspNetCore.Connections
             {
                 _currentIStreamAbortFeature = Unsafe.As<TFeature?, IStreamAbortFeature?>(ref feature);
             }
+            else if (typeof(TFeature) == typeof(IStreamClosedFeature))
+            {
+                _currentIStreamClosedFeature = Unsafe.As<TFeature?, IStreamClosedFeature?>(ref feature);
+            }
             else
             {
                 ExtraFeatureSet(typeof(TFeature), feature);
@@ -397,6 +415,10 @@ namespace Microsoft.AspNetCore.Connections
             if (_currentIStreamAbortFeature != null)
             {
                 yield return new KeyValuePair<Type, object>(typeof(IStreamAbortFeature), _currentIStreamAbortFeature);
+            }
+            if (_currentIStreamClosedFeature != null)
+            {
+                yield return new KeyValuePair<Type, object>(typeof(IStreamClosedFeature), _currentIStreamClosedFeature);
             }
 
             if (MaybeExtra != null)

--- a/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
@@ -9,51 +9,51 @@ public class HttpProtocolFeatureCollection
     {
         var alwaysFeatures = new[]
         {
-                "IHttpRequestFeature",
-                "IHttpResponseFeature",
-                "IHttpResponseBodyFeature",
-                "IRouteValuesFeature",
-                "IEndpointFeature",
-                "IServiceProvidersFeature",
-                "IHttpActivityFeature"
-            };
+            "IHttpRequestFeature",
+            "IHttpResponseFeature",
+            "IHttpResponseBodyFeature",
+            "IRouteValuesFeature",
+            "IEndpointFeature",
+            "IServiceProvidersFeature",
+            "IHttpActivityFeature"
+        };
 
         var commonFeatures = new[]
         {
-                "IItemsFeature",
-                "IQueryFeature",
-                "IRequestBodyPipeFeature",
-                "IFormFeature",
-                "IHttpAuthenticationFeature",
-                "IHttpRequestIdentifierFeature",
-            };
+            "IItemsFeature",
+            "IQueryFeature",
+            "IRequestBodyPipeFeature",
+            "IFormFeature",
+            "IHttpAuthenticationFeature",
+            "IHttpRequestIdentifierFeature",
+        };
 
         var sometimesFeatures = new[]
         {
-                "IHttpConnectionFeature",
-                "ISessionFeature",
-                "IResponseCookiesFeature",
-                "IHttpRequestTrailersFeature",
-                "IHttpResponseTrailersFeature",
-                "ITlsConnectionFeature",
-                "IHttpExtendedConnectFeature",
-                "IHttpUpgradeFeature",
-                "IHttpWebSocketFeature",
-                "IHttpWebTransportFeature",
-                "IBadRequestExceptionFeature"
-            };
+            "IHttpConnectionFeature",
+            "ISessionFeature",
+            "IResponseCookiesFeature",
+            "IHttpRequestTrailersFeature",
+            "IHttpResponseTrailersFeature",
+            "ITlsConnectionFeature",
+            "IHttpExtendedConnectFeature",
+            "IHttpUpgradeFeature",
+            "IHttpWebSocketFeature",
+            "IHttpWebTransportFeature",
+            "IBadRequestExceptionFeature"
+        };
         var maybeFeatures = new[]
         {
-                "IHttp2StreamIdFeature",
-                "IHttpRequestLifetimeFeature",
-                "IHttpMaxRequestBodySizeFeature",
-                "IHttpMinRequestBodyDataRateFeature",
-                "IHttpMinResponseDataRateFeature",
-                "IHttpBodyControlFeature",
-                "IHttpRequestBodyDetectionFeature",
-                "IHttpResetFeature",
-                "IPersistentStateFeature"
-            };
+            "IHttp2StreamIdFeature",
+            "IHttpRequestLifetimeFeature",
+            "IHttpMaxRequestBodySizeFeature",
+            "IHttpMinRequestBodyDataRateFeature",
+            "IHttpMinResponseDataRateFeature",
+            "IHttpBodyControlFeature",
+            "IHttpRequestBodyDetectionFeature",
+            "IHttpResetFeature",
+            "IPersistentStateFeature"
+        };
 
         var allFeatures = alwaysFeatures
             .Concat(commonFeatures)
@@ -65,24 +65,24 @@ public class HttpProtocolFeatureCollection
         // See also: src/Kestrel.Core/Internal/Http/HttpProtocol.FeatureCollection.cs
         var implementedFeatures = new[]
         {
-                "IHttpRequestFeature",
-                "IHttpResponseFeature",
-                "IHttpResponseBodyFeature",
-                "IRouteValuesFeature",
-                "IEndpointFeature",
-                "IHttpRequestIdentifierFeature",
-                "IHttpRequestTrailersFeature",
-                "IHttpExtendedConnectFeature",
-                "IHttpUpgradeFeature",
-                "IRequestBodyPipeFeature",
-                "IHttpConnectionFeature",
-                "IHttpRequestLifetimeFeature",
-                "IHttpBodyControlFeature",
-                "IHttpMaxRequestBodySizeFeature",
-                "IHttpRequestBodyDetectionFeature",
-                "IHttpWebTransportFeature",
-                "IBadRequestExceptionFeature"
-            };
+            "IHttpRequestFeature",
+            "IHttpResponseFeature",
+            "IHttpResponseBodyFeature",
+            "IRouteValuesFeature",
+            "IEndpointFeature",
+            "IHttpRequestIdentifierFeature",
+            "IHttpRequestTrailersFeature",
+            "IHttpExtendedConnectFeature",
+            "IHttpUpgradeFeature",
+            "IRequestBodyPipeFeature",
+            "IHttpConnectionFeature",
+            "IHttpRequestLifetimeFeature",
+            "IHttpBodyControlFeature",
+            "IHttpMaxRequestBodySizeFeature",
+            "IHttpRequestBodyDetectionFeature",
+            "IHttpWebTransportFeature",
+            "IBadRequestExceptionFeature"
+        };
 
         var usings = $@"
 using Microsoft.AspNetCore.Connections.Features;

--- a/src/Servers/Kestrel/tools/CodeGenerator/TransportConnectionFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/TransportConnectionFeatureCollection.cs
@@ -12,27 +12,28 @@ public class TransportConnectionFeatureCollection
 
         var allFeatures = new[]
         {
-                "IConnectionIdFeature",
-                "IConnectionTransportFeature",
-                "IConnectionItemsFeature",
-                "IPersistentStateFeature",
-                "IMemoryPoolFeature",
-                "IConnectionLifetimeFeature",
-                "IConnectionSocketFeature",
-                "IProtocolErrorCodeFeature",
-                "IStreamDirectionFeature",
-                "IStreamIdFeature",
-                "IStreamAbortFeature"
-            };
+            "IConnectionIdFeature",
+            "IConnectionTransportFeature",
+            "IConnectionItemsFeature",
+            "IPersistentStateFeature",
+            "IMemoryPoolFeature",
+            "IConnectionLifetimeFeature",
+            "IConnectionSocketFeature",
+            "IProtocolErrorCodeFeature",
+            "IStreamDirectionFeature",
+            "IStreamIdFeature",
+            "IStreamAbortFeature",
+            "IStreamClosedFeature"
+        };
 
         var implementedFeatures = new[]
         {
-                "IConnectionIdFeature",
-                "IConnectionTransportFeature",
-                "IConnectionItemsFeature",
-                "IMemoryPoolFeature",
-                "IConnectionLifetimeFeature"
-            };
+            "IConnectionIdFeature",
+            "IConnectionTransportFeature",
+            "IConnectionItemsFeature",
+            "IMemoryPoolFeature",
+            "IConnectionLifetimeFeature"
+        };
 
         var usings = $@"
 using Microsoft.AspNetCore.Connections.Features;


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/42652
Fixes https://github.com/dotnet/aspnetcore/issues/42725

Add `IConnectionCompleteFeature` to QUIC stream abstraction and use it to get complete notification instead of `ConnectionClosed` cancellation token.