### PR TITLE
HTTP/3: Avoid ConnectionAbortedException allocations

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -637,9 +637,6 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
         }
         finally
         {
-            var streamError = error as ConnectionAbortedException
-                ?? new ConnectionAbortedException("The stream has completed.", error!);
-
             await Input.CompleteAsync();
 
             // Once the header is finished being received then the app has started.
@@ -692,6 +689,9 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
             }
             catch
             {
+                var streamError = error as ConnectionAbortedException
+                   ?? new ConnectionAbortedException("The stream has completed.", error!);
+
                 Abort(streamError, Http3ErrorCode.ProtocolError);
                 throw;
             }

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -14,6 +14,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal;
 
 internal partial class QuicStreamContext : TransportConnection, IPooledStream, IDisposable
 {
+    private static readonly ConnectionAbortedException SendGracefullyCompletedException = new ConnectionAbortedException("The QUIC transport's send loop completed gracefully.");
+
     // Internal for testing.
     internal Task _processingTask = Task.CompletedTask;
 
@@ -499,8 +501,7 @@ internal partial class QuicStreamContext : TransportConnection, IPooledStream, I
         {
             lock (_shutdownLock)
             {
-                // TODO: Exception is always allocated. Consider only allocating if receive hasn't completed.
-                _shutdownReason = shutdownReason ?? new ConnectionAbortedException("The QUIC transport's send loop completed gracefully.");
+                _shutdownReason = shutdownReason ?? SendGracefullyCompletedException;
                 QuicLog.StreamShutdownWrite(_log, this, _shutdownReason.Message);
 
                 _stream.Shutdown();


### PR DESCRIPTION
Each request is allocating two ConnectionAbortedException instances.

![image](https://user-images.githubusercontent.com/303201/178689610-b2814281-df0b-4336-a1c0-3afcde403372.png)

After:

![image](https://user-images.githubusercontent.com/303201/178692323-284c10bd-f079-42d2-be76-0a88f0879475.png)

No more ConnectionAbortedException allocations.