### PR TITLE
Fix TreatSpecificWarningsAsErrors elements

### DIFF
--- a/src/Installers/Windows/AspNetCoreModule-Setup/build/settings/common.props
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/build/settings/common.props
@@ -26,7 +26,7 @@
       <!-- Microsoft.Security.SystemsADM.10086 - SDL required warnings -->
       <!-- See https://github.com/dotnet/aspnetcore/issues/40525 -->
       <WarningLevel>Level4</WarningLevel>
-      <TreatSpecificWarningsAsErrors>4018;4055;4146;4242;4244;4267;4302;4308;4509;4510;4532;4533;4610;4611;4700;4701;4703;4789;4995;4996</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4018;4055;4146;4242;4244;4267;4302;4308;4509;4510;4532;4533;4610;4611;4700;4701;4703;4789;4995;4996</TreatSpecificWarningsAsErrors>
     </ClCompile>
   </ItemDefinitionGroup>
 

--- a/src/Servers/IIS/build/Build.Common.Settings
+++ b/src/Servers/IIS/build/Build.Common.Settings
@@ -42,7 +42,7 @@
       <!-- Microsoft.Security.SystemsADM.10086 - SDL required warnings -->
       <!-- See https://github.com/dotnet/aspnetcore/issues/40525 -->
       <WarningLevel>Level4</WarningLevel>
-      <TreatSpecificWarningsAsErrors>4018;4055;4146;4242;4244;4267;4302;4308;4509;4510;4532;4533;4610;4611;4700;4701;4703;4789;4995;4996</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);4018;4055;4146;4242;4244;4267;4302;4308;4509;4510;4532;4533;4610;4611;4700;4701;4703;4789;4995;4996</TreatSpecificWarningsAsErrors>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <ShowIncludes>false</ShowIncludes>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>


### PR DESCRIPTION
Using the below syntax performs a complete replacement of warning codes which should be treated as errors.

```xml
<TreatSpecificWarningsAsErrors>aaaaa;bbbbb;ccccc;...</TreatSpecificWarningsAsErrors>
```

Instead, the following syntax should be used, which inherits the base list coming from the SDK (or a higher level props file) and augments the list with your desired warning codes.

```xml
<TreatSpecificWarningsAsErrors>$(TreatSpecificWarningsAsErrors);aaaaa;bbbbb;ccccc;...</TreatSpecificWarningsAsErrors>
```

> Exception: If you're intentionally trying to suppress the inherited list list, please ignore this rule.