### PR TITLE
Change to summary for IEndpointConventionBuilder.WithName method

### DIFF
--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -95,7 +95,7 @@ public static class RoutingEndpointConventionBuilderExtensions
     }
 
     /// <summary>
-    /// Sets the <see cref="EndpointNameAttribute"/> for all endpoints produced
+    /// Adds the <see cref="IEndpointNameMetadata"/> for all endpoints produced
     /// on the target <see cref="IEndpointConventionBuilder"/> given the <paramref name="endpointName" />.
     /// The <see cref="IEndpointNameMetadata" /> on the endpoint is used for link generation and
     /// is treated as the operation ID in the given endpoint's OpenAPI specification.

--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -95,7 +95,7 @@ public static class RoutingEndpointConventionBuilderExtensions
     }
 
     /// <summary>
-    /// Adds the <see cref="IEndpointNameMetadata"/> for all endpoints produced
+    /// Adds the <see cref="IEndpointNameMetadata"/> to the Metadata collection for all endpoints produced
     /// on the target <see cref="IEndpointConventionBuilder"/> given the <paramref name="endpointName" />.
     /// The <see cref="IEndpointNameMetadata" /> on the endpoint is used for link generation and
     /// is treated as the operation ID in the given endpoint's OpenAPI specification.


### PR DESCRIPTION
# Fix incorrect/stale summary description for `IEndpointConventionBuilder.WithName`
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Change the description: "Sets the EndpointNameAttribute" => "Adds the IEndpointNameMetadata"

The current implementation of the `WithName` extension method does not set any Attribute on the endpoints but we add an `EndpointNameMatadata` object instance. So I've changed the description instead of saying "Sets the `EndpointNameAttribute`..." to "Adds `IEndpointNameMetadata`".

Same should be done for the `WithGroupName` method (and possible other methods) at least once we change that as well to use a Matadata class directly.

The mention of "Sets the XXX**Attribute**" is confusing, hence when I first have seen the method description until I checked the source code I was confused I got the impression that you use code generation to actually generate Endpoint method and "set `EndpointNameAttribute`s " in c#


