### PR TITLE
Avoid always setting request body parameter

### DIFF
--- a/src/OpenApi/src/OpenApiGenerator.cs
+++ b/src/OpenApi/src/OpenApiGenerator.cs
@@ -261,7 +261,6 @@ internal sealed class OpenApiGenerator
 
         var acceptsMetadata = metadata.GetMetadata<IAcceptsMetadata>();
         var requestBodyContent = new Dictionary<string, OpenApiMediaType>();
-        var isRequired = false;
 
         if (acceptsMetadata is not null)
         {
@@ -269,16 +268,15 @@ internal sealed class OpenApiGenerator
             {
                 requestBodyContent[contentType] = new OpenApiMediaType();
             }
-            isRequired = !acceptsMetadata.IsOptional;
-        }
 
-        if (!hasFormOrBodyParameter)
-        {
-            return new OpenApiRequestBody()
+            if (!hasFormOrBodyParameter)
             {
-                Required = isRequired,
-                Content = requestBodyContent
-            };
+                return new OpenApiRequestBody()
+                {
+                    Required = !acceptsMetadata.IsOptional,
+                    Content = requestBodyContent
+                };
+            }
         }
 
         if (requestBodyParameter is not null)

--- a/src/OpenApi/test/OpenApiGeneratorTests.cs
+++ b/src/OpenApi/test/OpenApiGeneratorTests.cs
@@ -783,6 +783,19 @@ public class OpenApiOperationGeneratorTests
         Assert.Equal(expectedName, param.Name);
     }
 
+    [Fact]
+    public void HandlesEndpointWithNoRequestBody()
+    {
+        var operationWithNoParams = GetOpenApiOperation(() => "", "/");
+        var operationWithNoBodyParams = GetOpenApiOperation((int id) => "", "/", httpMethods: new[] { "PUT"});
+
+        Assert.Empty(operationWithNoParams.Parameters);
+        Assert.Null(operationWithNoParams.RequestBody);
+
+        Assert.Single(operationWithNoBodyParams.Parameters);
+        Assert.Null(operationWithNoBodyParams.RequestBody);
+    }
+
     private static OpenApiOperation GetOpenApiOperation(
         Delegate action,
         string pattern = null,

--- a/src/OpenApi/test/OpenApiGeneratorTests.cs
+++ b/src/OpenApi/test/OpenApiGeneratorTests.cs
@@ -548,7 +548,7 @@ public class OpenApiOperationGeneratorTests
     }
 
     [Fact]
-    public void HandleAcceptsMetadata()
+    public void HandleAcceptsMetadataWithNoParams()
     {
         // Arrange
         var operation = GetOpenApiOperation(() => "",
@@ -784,13 +784,18 @@ public class OpenApiOperationGeneratorTests
     }
 
     [Fact]
-    public void HandlesEndpointWithNoRequestBody()
+    public void HandlesEndpointWithNoRequestBodyOrParams()
     {
         var operationWithNoParams = GetOpenApiOperation(() => "", "/");
-        var operationWithNoBodyParams = GetOpenApiOperation((int id) => "", "/", httpMethods: new[] { "PUT"});
 
         Assert.Empty(operationWithNoParams.Parameters);
         Assert.Null(operationWithNoParams.RequestBody);
+    }
+
+    [Fact]
+    public void HandlesEndpointWithNoRequestBody()
+    {
+        var operationWithNoBodyParams = GetOpenApiOperation((int id) => "", "/", httpMethods: new[] { "PUT" });
 
         Assert.Single(operationWithNoBodyParams.Parameters);
         Assert.Null(operationWithNoBodyParams.RequestBody);


### PR DESCRIPTION
I was observing behavior where in the `RequestBody` property was always set for endpoints, even when they didn't accept requests.

![image](https://user-images.githubusercontent.com/1857993/179305774-d0848021-2908-49d1-8d46-9ae6b55f93b8.png)

And the associated JSON definition...

```json
"/trainers": {
      "get": {
        "tags": [
          "TrainingApi"
        ],
        "requestBody": {
          "content": {
            
          }
        },
```

It turns out that we were always setting the request body because if this misplaced condition check.
