### PR TITLE
Cleanup Mvc Analyzers

### DIFF
--- a/src/Mvc/Mvc.Analyzers/src/AttributesShouldNotBeAppliedToPageModelAnalyzer.cs
+++ b/src/Mvc/Mvc.Analyzers/src/AttributesShouldNotBeAppliedToPageModelAnalyzer.cs
@@ -20,24 +20,24 @@ public class AttributesShouldNotBeAppliedToPageModelAnalyzer : DiagnosticAnalyze
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-        context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
+        context.RegisterCompilationStartAction(context =>
         {
-            var typeCache = new TypeCache(compilationStartAnalysisContext.Compilation);
+            var typeCache = new TypeCache(context.Compilation);
             if (typeCache.PageModelAttribute == null || typeCache.PageModelAttribute.TypeKind == TypeKind.Error)
             {
                 // No-op if we can't find types we care about.
                 return;
             }
 
-            InitializeWorker(compilationStartAnalysisContext, typeCache);
+            InitializeWorker(context, typeCache);
         });
     }
 
-    private static void InitializeWorker(CompilationStartAnalysisContext compilationStartAnalysisContext, TypeCache typeCache)
+    private static void InitializeWorker(CompilationStartAnalysisContext context, TypeCache typeCache)
     {
-        compilationStartAnalysisContext.RegisterSymbolAction(symbolAnalysisContext =>
+        context.RegisterSymbolAction(context =>
         {
-            var method = (IMethodSymbol)symbolAnalysisContext.Symbol;
+            var method = (IMethodSymbol)context.Symbol;
 
             var declaringType = method.ContainingType;
             if (!IsPageModel(declaringType, typeCache.PageModelAttribute) || !IsPageHandlerMethod(method))
@@ -45,22 +45,22 @@ public class AttributesShouldNotBeAppliedToPageModelAnalyzer : DiagnosticAnalyze
                 return;
             }
 
-            ReportFilterDiagnostic(ref symbolAnalysisContext, method, typeCache.IFilterMetadata);
-            ReportFilterDiagnostic(ref symbolAnalysisContext, method, typeCache.AuthorizeAttribute);
-            ReportFilterDiagnostic(ref symbolAnalysisContext, method, typeCache.AllowAnonymousAttribute);
+            ReportFilterDiagnostic(context, method, typeCache.IFilterMetadata);
+            ReportFilterDiagnostic(context, method, typeCache.AuthorizeAttribute);
+            ReportFilterDiagnostic(context, method, typeCache.AllowAnonymousAttribute);
 
-            ReportRouteDiagnostic(ref symbolAnalysisContext, method, typeCache.IRouteTemplateProvider);
+            ReportRouteDiagnostic(context, method, typeCache.IRouteTemplateProvider);
         }, SymbolKind.Method);
 
-        compilationStartAnalysisContext.RegisterSymbolAction(symbolAnalysisContext =>
+        context.RegisterSymbolAction(context =>
         {
-            var type = (INamedTypeSymbol)symbolAnalysisContext.Symbol;
+            var type = (INamedTypeSymbol)context.Symbol;
             if (!IsPageModel(type, typeCache.PageModelAttribute))
             {
                 return;
             }
 
-            ReportRouteDiagnosticOnModel(ref symbolAnalysisContext, type, typeCache.IRouteTemplateProvider);
+            ReportRouteDiagnosticOnModel(context, type, typeCache.IRouteTemplateProvider);
         }, SymbolKind.NamedType);
     }
 
@@ -79,42 +79,42 @@ public class AttributesShouldNotBeAppliedToPageModelAnalyzer : DiagnosticAnalyze
             type.HasAttribute(pageAttributeModel, inherit: true);
     }
 
-    private static void ReportRouteDiagnosticOnModel(ref SymbolAnalysisContext symbolAnalysisContext, INamedTypeSymbol typeSymbol, INamedTypeSymbol routeAttribute)
+    private static void ReportRouteDiagnosticOnModel(SymbolAnalysisContext context, INamedTypeSymbol typeSymbol, INamedTypeSymbol routeAttribute)
     {
         var attribute = GetAttribute(typeSymbol, routeAttribute);
         if (attribute != null)
         {
-            var location = GetAttributeLocation(ref symbolAnalysisContext, attribute);
+            var location = GetAttributeLocation(context, attribute);
 
-            symbolAnalysisContext.ReportDiagnostic(Diagnostic.Create(
+            context.ReportDiagnostic(Diagnostic.Create(
                 DiagnosticDescriptors.MVC1003_RouteAttributesShouldNotBeAppliedToPageModels,
                 location,
                 attribute.AttributeClass.Name));
         }
     }
 
-    private static void ReportRouteDiagnostic(ref SymbolAnalysisContext symbolAnalysisContext, IMethodSymbol method, INamedTypeSymbol routeAttribute)
+    private static void ReportRouteDiagnostic(SymbolAnalysisContext context, IMethodSymbol method, INamedTypeSymbol routeAttribute)
     {
         var attribute = GetAttribute(method, routeAttribute);
         if (attribute != null)
         {
-            var location = GetAttributeLocation(ref symbolAnalysisContext, attribute);
+            var location = GetAttributeLocation(context, attribute);
 
-            symbolAnalysisContext.ReportDiagnostic(Diagnostic.Create(
+            context.ReportDiagnostic(Diagnostic.Create(
                 DiagnosticDescriptors.MVC1002_RouteAttributesShouldNotBeAppliedToPageHandlerMethods,
                 location,
                 attribute.AttributeClass.Name));
         }
     }
 
-    private static void ReportFilterDiagnostic(ref SymbolAnalysisContext symbolAnalysisContext, IMethodSymbol method, INamedTypeSymbol filterAttribute)
+    private static void ReportFilterDiagnostic(SymbolAnalysisContext context, IMethodSymbol method, INamedTypeSymbol filterAttribute)
     {
         var attribute = GetAttribute(method, filterAttribute);
         if (attribute != null)
         {
-            var location = GetAttributeLocation(ref symbolAnalysisContext, attribute);
+            var location = GetAttributeLocation(context, attribute);
 
-            symbolAnalysisContext.ReportDiagnostic(Diagnostic.Create(
+            context.ReportDiagnostic(Diagnostic.Create(
                 DiagnosticDescriptors.MVC1001_FiltersShouldNotBeAppliedToPageHandlerMethods,
                 location,
                 attribute.AttributeClass.Name));
@@ -134,9 +134,9 @@ public class AttributesShouldNotBeAppliedToPageModelAnalyzer : DiagnosticAnalyze
         return null;
     }
 
-    private static Location GetAttributeLocation(ref SymbolAnalysisContext symbolAnalysisContext, AttributeData attribute)
+    private static Location GetAttributeLocation(SymbolAnalysisContext context, AttributeData attribute)
     {
-        var syntax = attribute.ApplicationSyntaxReference.GetSyntax(symbolAnalysisContext.CancellationToken);
+        var syntax = attribute.ApplicationSyntaxReference.GetSyntax(context.CancellationToken);
         return syntax?.GetLocation() ?? Location.None;
     }
 

--- a/src/Mvc/Mvc.Analyzers/src/AvoidHtmlPartialAnalyzer.cs
+++ b/src/Mvc/Mvc.Analyzers/src/AvoidHtmlPartialAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Mvc/Mvc.Analyzers/src/TagHelpersInCodeBlocksAnalyzer.cs
+++ b/src/Mvc/Mvc.Analyzers/src/TagHelpersInCodeBlocksAnalyzer.cs
@@ -14,11 +14,8 @@ public class TagHelpersInCodeBlocksAnalyzer : DiagnosticAnalyzer
 {
     public TagHelpersInCodeBlocksAnalyzer()
     {
-        TagHelperInCodeBlockDiagnostic = DiagnosticDescriptors.MVC1006_FunctionsContainingTagHelpersMustBeAsyncAndReturnTask;
-        SupportedDiagnostics = ImmutableArray.Create(new[] { TagHelperInCodeBlockDiagnostic });
+        SupportedDiagnostics = ImmutableArray.Create(DiagnosticDescriptors.MVC1006_FunctionsContainingTagHelpersMustBeAsyncAndReturnTask);
     }
-
-    private DiagnosticDescriptor TagHelperInCodeBlockDiagnostic { get; }
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
 
@@ -39,7 +36,7 @@ public class TagHelpersInCodeBlocksAnalyzer : DiagnosticAnalyzer
         });
     }
 
-    private void InitializeWorker(CompilationStartAnalysisContext context, SymbolCache symbolCache)
+    private static void InitializeWorker(CompilationStartAnalysisContext context, SymbolCache symbolCache)
     {
         context.RegisterOperationBlockStartAction(startBlockContext =>
         {
@@ -97,7 +94,7 @@ public class TagHelpersInCodeBlocksAnalyzer : DiagnosticAnalyzer
                 foreach (var location in capturedDiagnosticLocations)
                 {
                     context.ReportDiagnostic(
-                        Diagnostic.Create(TagHelperInCodeBlockDiagnostic, location));
+                        Diagnostic.Create(DiagnosticDescriptors.MVC1006_FunctionsContainingTagHelpersMustBeAsyncAndReturnTask, location));
                 }
             });
         });

--- a/src/Mvc/Mvc.Analyzers/src/TopLevelParameterNameAnalyzer.cs
+++ b/src/Mvc/Mvc.Analyzers/src/TopLevelParameterNameAnalyzer.cs
@@ -20,23 +20,23 @@ public class TopLevelParameterNameAnalyzer : DiagnosticAnalyzer
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-        context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
+        context.RegisterCompilationStartAction(context =>
         {
-            if (!SymbolCache.TryCreate(compilationStartAnalysisContext.Compilation, out var typeCache))
+            if (!SymbolCache.TryCreate(context.Compilation, out var typeCache))
             {
                 // No-op if we can't find types we care about.
                 return;
             }
 
-            InitializeWorker(compilationStartAnalysisContext, typeCache);
+            InitializeWorker(context, typeCache);
         });
     }
 
-    private static void InitializeWorker(CompilationStartAnalysisContext compilationStartAnalysisContext, SymbolCache symbolCache)
+    private static void InitializeWorker(CompilationStartAnalysisContext context, SymbolCache symbolCache)
     {
-        compilationStartAnalysisContext.RegisterSymbolAction(symbolAnalysisContext =>
+        context.RegisterSymbolAction(context =>
         {
-            var method = (IMethodSymbol)symbolAnalysisContext.Symbol;
+            var method = (IMethodSymbol)context.Symbol;
             if (method.MethodKind != MethodKind.Ordinary)
             {
                 return;
@@ -69,7 +69,7 @@ public class TopLevelParameterNameAnalyzer : DiagnosticAnalyzer
                         parameter.Locations[0] :
                         Location.None;
 
-                    symbolAnalysisContext.ReportDiagnostic(
+                    context.ReportDiagnostic(
                         Diagnostic.Create(
                             DiagnosticDescriptors.MVC1004_ParameterNameCollidesWithTopLevelProperty,
                             location,

--- a/src/Mvc/Mvc.Analyzers/src/ViewFeatureAnalyzerBase.cs
+++ b/src/Mvc/Mvc.Analyzers/src/ViewFeatureAnalyzerBase.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
@@ -23,9 +23,9 @@ public abstract class ViewFeatureAnalyzerBase : DiagnosticAnalyzer
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
-        context.RegisterCompilationStartAction(compilationContext =>
+        context.RegisterCompilationStartAction(context =>
         {
-            var analyzerContext = new ViewFeaturesAnalyzerContext(compilationContext);
+            var analyzerContext = new ViewFeaturesAnalyzerContext(context);
 
             // Only do work if we can locate IHtmlHelper.
             if (analyzerContext.HtmlHelperType == null)

--- a/src/Mvc/Mvc.Api.Analyzers/src/AddResponseTypeAttributeCodeFixProvider.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/src/AddResponseTypeAttributeCodeFixProvider.cs
@@ -21,18 +21,7 @@ public class AddResponseTypeAttributeCodeFixProvider : CodeFixProvider
 
     public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        if (context.Diagnostics.Length == 0)
-        {
-            return Task.CompletedTask;
-        }
-
         var diagnostic = context.Diagnostics[0];
-        if ((diagnostic.Descriptor.Id != ApiDiagnosticDescriptors.API1000_ActionReturnsUndocumentedStatusCode.Id) &&
-            (diagnostic.Descriptor.Id != ApiDiagnosticDescriptors.API1001_ActionReturnsUndocumentedSuccessResult.Id))
-        {
-            return Task.CompletedTask;
-        }
-
         var codeFix = new AddResponseTypeAttributeCodeFixAction(context.Document, diagnostic);
 
         context.RegisterCodeFix(codeFix, diagnostic);

--- a/src/Mvc/Mvc.Api.Analyzers/src/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzer.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/src/ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzer.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -75,15 +73,10 @@ public class ApiActionsDoNotRequireExplicitModelValidationCheckAnalyzer : Diagno
                 return;
             }
 
-            if (!(parent.Syntax is MethodDeclarationSyntax methodSyntax))
+            if (context.ContainingSymbol is not IMethodSymbol methodSymbol)
             {
                 return;
             }
-
-#pragma warning disable RS1030 // Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer
-            var semanticModel = context.Compilation.GetSemanticModel(methodSyntax.SyntaxTree);
-#pragma warning restore RS1030 // Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer
-            var methodSymbol = semanticModel.GetDeclaredSymbol(methodSyntax, context.CancellationToken);
 
             if (!ApiControllerFacts.IsApiControllerAction(symbolCache, methodSymbol))
             {

--- a/src/Mvc/Mvc.Api.Analyzers/src/ApiActionsDoNotRequireExplicitModelValidationCodeFixProvider.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/src/ApiActionsDoNotRequireExplicitModelValidationCodeFixProvider.cs
@@ -30,11 +30,6 @@ public class ApiActionsDoNotRequireExplicitModelValidationCheckCodeFixProvider :
         }
 
         var diagnostic = context.Diagnostics[0];
-        if (diagnostic.Id != ApiDiagnosticDescriptors.API1003_ApiActionsDoNotRequireExplicitModelValidationCheck.Id)
-        {
-            return Task.CompletedTask;
-        }
-
         context.RegisterCodeFix(new MyCodeAction(context.Document, context.Span), diagnostic);
         return Task.CompletedTask;
     }


### PR DESCRIPTION
Minor code cleanup.

- Renaming of all analysis contexts to just `context` is intentional, and the shadowing is intentional. This is a common pattern in roslyn analyzers to avoid usage of outer contexts when they shouldn't be used. One common issue is accidentally using `outerContext.CancellationToken` instead of `innerContext.CancellationToken`. The name `context` is also shorter :)
- Removed unnecessary `ref` in `AttributesShouldNotBeAppliedToPageModelAnalyzer`.
- Minor changes to `ActualApiResponseMetadataFactory`:
    - Fixed a doc comment.
    - Removed unnecessary conditions that are already handled
    - Avoid unnecessary semantic model calls.
- Cleanup unreachable conditions in codefix providers.