### PR TITLE
Remove 20H2 from the test matrix

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -51,7 +51,6 @@
         <HelixAvailableTargetQueue Include="OSX.1015.Amd64.Open" Platform="OSX" />
 
         <!-- Windows -->
-        <HelixAvailableTargetQueue Include="Windows.10.Amd64.Server20H2.Open" Platform="Windows" />
         <HelixAvailableTargetQueue Include="Windows.Amd64.Server2022.Open" Platform="Windows" />
 
         <!-- IIS Express isn't supported on arm64 and most of the IsWindowsOnlyTests depend on its setup scripts. -->


### PR DESCRIPTION
This agent category is being retired.