### PR TITLE
Fix typo

### DIFF
--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/Register.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/Register.cshtml.cs
@@ -19,13 +19,13 @@ public class RegisterModel : PageModel
 {
     private readonly SignInManager<ApplicationUser> _signInManager;
     private readonly UserManager<ApplicationUser> _userManager;
-    private readonly ILogger<LoginModel> _logger;
+    private readonly ILogger<RegisterModel> _logger;
     private readonly IEmailSender _emailSender;
 
     public RegisterModel(
         UserManager<ApplicationUser> userManager,
         SignInManager<ApplicationUser> signInManager,
-        ILogger<LoginModel> logger,
+        ILogger<RegisterModel> logger,
         IEmailSender emailSender)
     {
         _userManager = userManager;


### PR DESCRIPTION
Fix typo in a sample project where the logger's type doesn't match the current class's type