### PR TITLE
Allow Collection Default Value binding

### DIFF
--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/CollectionModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/CollectionModelBinder.cs
@@ -127,10 +127,10 @@ public partial class CollectionModelBinder<TElement> : ICollectionModelBinder
             Logger.FoundNoValueInRequest(bindingContext);
 
             // If we failed to find data for a top-level model, then generate a
-            // default 'empty' model (or use existing Model) and return it.
+            // default 'empty' model (or use existing Model when not null or a default value is available) and return it.
             if (bindingContext.IsTopLevelObject)
             {
-                if (model == null)
+                if (model == null && !bindingContext.ModelMetadata.HasDefaultValue)
                 {
                     model = CreateEmptyCollection(bindingContext.ModelType);
                 }

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/CollectionModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/CollectionModelBinderTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using Microsoft.AspNetCore.Http;
@@ -226,6 +227,7 @@ public class CollectionModelBinderTest
     }
 
     private IActionResult ActionWithListParameter(List<string> parameter) => null;
+    private IActionResult ActionWithListParameterDefaultValue(List<string> parameter = null) => null;
 
     [Theory]
     [InlineData(false, false)]
@@ -303,6 +305,43 @@ public class CollectionModelBinderTest
         Assert.Equal("modelName", keyValuePair.Key);
         var error = Assert.Single(keyValuePair.Value.Errors);
         Assert.Equal("A value for the 'fieldName' parameter or property was not provided.", error.ErrorMessage);
+    }
+
+    // Setup like CollectionModelBinder_CreatesEmptyCollection_IfIsTopLevelObject except
+    // Model has a default value.
+    [Fact]
+    public async Task CollectionModelBinder_DoesNotCreateEmptyCollection_IfModelHasDefaultValue()
+    {
+        // Arrange
+        var binder = new CollectionModelBinder<string>(
+            new StubModelBinder(result: ModelBindingResult.Failed()),
+            NullLoggerFactory.Instance,
+            allowValidatingTopLevelNodes: true);
+
+        var bindingContext = CreateContext();
+        bindingContext.IsTopLevelObject = true;
+
+        // Lack of prefix and non-empty model name both ignored.
+        bindingContext.ModelName = "modelName";
+
+        var metadataProvider = new TestModelMetadataProvider();
+        var parameter = typeof(CollectionModelBinderTest)
+            .GetMethod(nameof(ActionWithListParameterDefaultValue), BindingFlags.Instance | BindingFlags.NonPublic)
+            .GetParameters()[0];
+        metadataProvider
+            .ForParameter(parameter)
+            .BindingDetails(b => b.IsBindingRequired = false);
+        bindingContext.ModelMetadata = metadataProvider.GetMetadataForParameter(parameter);
+
+        bindingContext.ValueProvider = new TestValueProvider(new Dictionary<string, object>());
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.Null(bindingContext.Result.Model);
+        Assert.True(bindingContext.Result.IsModelSet);
+        Assert.Equal(0, bindingContext.ModelState.ErrorCount);
     }
 
     // Setup like CollectionModelBinder_CreatesEmptyCollection_IfIsTopLevelObject  except


### PR DESCRIPTION
#Fix #42320

The `CollectionModelBinder` creates an `empty list` when binding a `top-level` object that the `valueprovider` does not contain the prefix and the model is `null`. 

Because of this behavior the following action controller, will create an unexpected `empty list`:

``` c#
    [HttpGet(Name = "GetWeatherForecast")]
    public IEnumerable<WeatherForecast> Get([FromQuery] string[]? abc = null)
```

In this PR I am suggesting a very small change to add another condition to the `empty list` creation:

``` diff
-if (model == null)
+if (model == null && !bindingContext.ModelMetadata.HasDefaultValue)
{
    model = CreateEmptyCollection(bindingContext.ModelType);
}
```

/cc @Lyra2108