### PR TITLE
Do not treat warnings as errors for `SendHelixJob`

### DIFF
--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -1,4 +1,5 @@
-<Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test" TreatAsLocalProperty="ProjectToBuild">
+<Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test"
+    TreatAsLocalProperty="ProjectToBuild;TreatWarningsAsErrors">
   <PropertyGroup>
     <!--
       When invoking helix.proj for the whole repo with build.cmd, ProjectToBuild will be set to the path to this project.
@@ -161,5 +162,16 @@
         SkipNonexistentTargets="true">
       <Output TaskParameter="TargetOutputs" ItemName="HelixWorkItem" />
     </MSBuild>
+  </Target>
+
+  <!--
+    The inner (per-queue) CoreTest target executes the SendHelixJob task and that may warn about expiring
+    queues. Those warnings should not break the build but should be visible. Disable warn-as-error as close
+    to target as we can get to avoid ignoring the many warnings that _should_ fail our build.
+  -->
+  <Target Name="TreatWarningsAsWarnings" BeforeTargets="CoreTest" Condition=" '$(HelixTargetQueue)' != '' ">
+    <PropertyGroup>
+      <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    </PropertyGroup>
   </Target>
 </Project>


### PR DESCRIPTION
- expiring queue warnings should just be warnings
- change is intentionally narrowly scoped
