### PR TITLE
IdentityUI: Accessability Fix focus contrast

### DIFF
--- a/src/Identity/UI/src/assets/V5/css/site.css
+++ b/src/Identity/UI/src/assets/V5/css/site.css
@@ -69,7 +69,7 @@ html {
 }
 
 .box-shadow {
-  box-shadow: none;
+  box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05);
 }
 
 button.accept-policy {

--- a/src/Identity/UI/src/assets/V5/css/site.css
+++ b/src/Identity/UI/src/assets/V5/css/site.css
@@ -13,13 +13,25 @@ a {
 
 .form-control:focus {
     border-color: #0077cc;
-    box-shadow: 0 0 0 0.2rem #0077cc;
+    outline: black auto 1px;
+    box-shadow: none;
+}
+
+.form-check-input:focus {
+    border-color: #0077cc;
+    box-shadow: none;
+    outline: black auto 1px;
 }
 
 .btn-primary {
-  color: #fff;
-  background-color: #1b6ec2;
-  border-color: #1861ac;
+    color: #fff;
+    background-color: #1b6ec2;
+    border-color: #1861ac;
+}
+
+.btn-primary:focus {
+    box-shadow: none;
+    outline: black auto 1px;
 }
 
 .nav-pills .nav-link.active, .nav-pills .show > .nav-link {
@@ -57,7 +69,7 @@ html {
 }
 
 .box-shadow {
-  box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05);
+  box-shadow: none;
 }
 
 button.accept-policy {


### PR DESCRIPTION
For https://github.com/dotnet/aspnetcore/issues/42335

Updated focus outline is a single black line similar to the link buttons instead of the light blue box shadow which doesn't have enough contrast for accessiblity:

![image](https://user-images.githubusercontent.com/6537861/180089982-c1c7b8b3-262f-4bb3-b174-c2eb26318890.png)

Which results in 21:1 contrast

![image](https://user-images.githubusercontent.com/6537861/180090070-4dd279db-d087-4142-8b71-8f86e91ac16e.png)
