### PR TITLE
Add logging to QUIC tests and disable parallel execution

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/test/NoParallelCollection.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/NoParallelCollection.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests;
+
+// Define test collection for tests to avoid all other tests.
+// Parallelization disable for QUIC test to avoid test flakeness msquic refusing connection
+// because of high CPU usage. See https://github.com/dotnet/runtime/issues/55979
+[CollectionDefinition(nameof(NoParallelCollection), DisableParallelization = true)]
+public partial class NoParallelCollection { }

--- a/src/Servers/Kestrel/Transport.Quic/test/NoParallelCollection.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/NoParallelCollection.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests;
 
 // Define test collection for tests to avoid all other tests.
-// Parallelization disable for QUIC test to avoid test flakeness msquic refusing connection
-// because of high CPU usage. See https://github.com/dotnet/runtime/issues/55979
+// Parallelization disable for QUIC test to avoid test flakiness from msquic refusing connections
+// because of high resource usage. See https://github.com/dotnet/runtime/issues/55979
 [CollectionDefinition(nameof(NoParallelCollection), DisableParallelization = true)]
 public partial class NoParallelCollection { }

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
@@ -9,11 +9,13 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests;
 
+[Collection(nameof(NoParallelCollection))]
 public class QuicConnectionListenerTests : TestApplicationErrorLoggerLoggedTest
 {
     private static readonly byte[] TestData = Encoding.UTF8.GetBytes("Hello world");
@@ -103,6 +105,8 @@ public class QuicConnectionListenerTests : TestApplicationErrorLoggerLoggedTest
     [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/42389")]
     public async Task ClientCertificate_Required_NotSent_AcceptedViaCallback()
     {
+        using var httpEventSource = new HttpEventSourceListener(LoggerFactory);
+
         await using var connectionListener = await QuicTestHelpers.CreateConnectionListenerFactory(LoggerFactory, clientCertificateRequired: true);
 
         var options = QuicTestHelpers.CreateClientConnectionOptions(connectionListener.EndPoint);

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicTestHelpers.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicTestHelpers.cs
@@ -19,7 +19,6 @@ using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using Serilog.Core;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests;

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicTransportFactoryTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicTransportFactoryTests.cs
@@ -16,6 +16,7 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests;
 
+[Collection(nameof(NoParallelCollection))]
 public class QuicTransportFactoryTests : TestApplicationErrorLoggerLoggedTest
 {
     [ConditionalFact]

--- a/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
@@ -7,12 +7,14 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests;
 
+[Collection(nameof(NoParallelCollection))]
 public class WebHostTests : LoggedTest
 {
     [ConditionalFact]
@@ -21,6 +23,8 @@ public class WebHostTests : LoggedTest
     public async Task UseUrls_HelloWorld_ClientSuccess()
     {
         // Arrange
+        using var httpEventSource = new HttpEventSourceListener(LoggerFactory);
+
         var builder = new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>
             {

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Interop.FunctionalTests.Http2;
 
+[Collection(nameof(NoParallelCollection))]
 public class Http2RequestTests : LoggedTest
 {
     [Fact]

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -22,6 +22,7 @@ using Xunit;
 
 namespace Interop.FunctionalTests.Http3;
 
+[Collection(nameof(NoParallelCollection))]
 public class Http3RequestTests : LoggedTest
 {
     private class StreamingHttpContent : HttpContent

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
@@ -15,6 +15,7 @@ using Xunit;
 
 namespace Interop.FunctionalTests.Http3;
 
+[Collection(nameof(NoParallelCollection))]
 public class Http3TlsTests : LoggedTest
 {
     [ConditionalFact]

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/NoParallelCollection.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/NoParallelCollection.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Interop.FunctionalTests;
+
+// Define test collection for tests to avoid all other tests.
+// Parallelization disable for QUIC test to avoid test flakiness from msquic refusing connections
+// because of high resource usage. See https://github.com/dotnet/runtime/issues/55979
+[CollectionDefinition(nameof(NoParallelCollection), DisableParallelization = true)]
+public partial class NoParallelCollection { }


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/38954, https://github.com/dotnet/aspnetcore/issues/42388, https://github.com/dotnet/aspnetcore/issues/42389

More logging in complex tests and attempt to reduce flakiness caused by https://github.com/dotnet/runtime/issues/55979