### PR TITLE
Suppress downgrade error in SharedFx bundle

### DIFF
--- a/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
+++ b/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
@@ -4,6 +4,7 @@
         <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense">
             <bal:WixStandardBootstrapperApplication LicenseUrl="https://go.microsoft.com/fwlink/?LinkId=329770"
                                                     LogoFile="DotNetLogo.bmp"
+                                                    SuppressDowngradeFailure="yes"
                                                     SuppressOptionsUI="yes"
                                                     ThemeFile="thm.xml"
                                                     LocalizationFile="thm.wxl"/>


### PR DESCRIPTION
Should fix https://github.com/dotnet/aspnetcore/issues/42764

Allows a windows hosting bundle to be installed on a machine that already has a newer asp.net runtime installed. We should backport this to all servicing branches.