### PR TITLE
Issue #42810 : Changes `StringBuilder` to `ValueStringBuilder` in QueryBuilder.cs

### DIFF
--- a/src/Http/Http.Extensions/src/Microsoft.AspNetCore.Http.Extensions.csproj
+++ b/src/Http/Http.Extensions/src/Microsoft.AspNetCore.Http.Extensions.csproj
@@ -4,6 +4,7 @@
     <Description>ASP.NET Core common extension methods for HTTP abstractions, HTTP headers, HTTP request/response, and session state.</Description>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>
     <IsPackable>false</IsPackable>

--- a/src/Http/Http.Extensions/src/Microsoft.AspNetCore.Http.Extensions.csproj
+++ b/src/Http/Http.Extensions/src/Microsoft.AspNetCore.Http.Extensions.csproj
@@ -18,6 +18,7 @@
     <Compile Include="$(SharedSourceRoot)RoutingMetadata\AcceptsMetadata.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)TypeNameHelper\TypeNameHelper.cs" LinkBase="Shared"/>
     <Compile Include="$(SharedSourceRoot)ProblemDetails\ProblemDetailsDefaults.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)ValueStringBuilder\**\*.cs" LingBase="Shared"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Http/Http.Extensions/src/QueryBuilder.cs
+++ b/src/Http/Http.Extensions/src/QueryBuilder.cs
@@ -69,7 +69,7 @@ public class QueryBuilder : IEnumerable<KeyValuePair<string, string>>
     /// <inheritdoc/>
     public override string ToString()
     {
-        var builder = new StringBuilder();
+        var builder = new ValueStringBuilder();
         bool first = true;
         for (var i = 0; i < _params.Count; i++)
         {


### PR DESCRIPTION
# Faster creating query string in 'Microsoft.AspNetCore.Http.Extensions.QueryBuilder'

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description
Changed `StringBuilder` To `ValueStringBuilder` in QueryBuilder.cs related to issue #42810 .
This is for performance reasons, string builder allocates unreasonably big amount of memory.

I've tested two new approaches and here are results:

|                      Method | QueryPairsCount |     Mean |    Error |   StdDev |  StdErr |   Median |      Min |       Q1 |       Q3 |      Max |        Op/s |  Gen 0 | Allocated |
|---------------------------- |---------------- |---------:|---------:|---------:|--------:|---------:|---------:|---------:|---------:|---------:|------------:|-------:|----------:|
| QueryBuilderWithValueString |               1 | 163.5 ns |  1.47 ns |  1.30 ns | 0.35 ns | 163.4 ns | 161.7 ns | 162.6 ns | 164.3 ns | 166.7 ns | 6,116,935.0 | 0.0305 |     128 B |
|                QueryBuilder |               1 | 186.1 ns | 13.94 ns | 41.10 ns | 4.11 ns | 163.0 ns | 146.1 ns | 150.7 ns | 216.3 ns | 292.7 ns | 5,373,457.4 | 0.0553 |     232 B |
|                             |                 |          |          |          |         |          |          |          |          |          |             |        |           |
| QueryBuilderWithValueString |               2 | 243.3 ns |  2.69 ns |  2.39 ns | 0.64 ns | 243.4 ns | 238.5 ns | 242.3 ns | 244.1 ns | 247.4 ns | 4,109,647.2 | 0.0420 |     176 B |
|                QueryBuilder |               2 | 265.2 ns |  5.20 ns |  4.61 ns | 1.23 ns | 264.8 ns | 258.2 ns | 261.7 ns | 268.1 ns | 272.7 ns | 3,770,565.1 | 0.0918 |     384 B |
|                             |                 |          |          |          |         |          |          |          |          |          |             |        |           |
| QueryBuilderWithValueString |               5 | 408.8 ns |  8.23 ns |  8.81 ns | 2.08 ns | 410.7 ns | 395.2 ns | 402.7 ns | 414.4 ns | 425.8 ns | 2,445,909.0 | 0.0763 |     320 B |
|                QueryBuilder |               5 | 492.9 ns |  5.73 ns |  5.08 ns | 1.36 ns | 491.3 ns | 486.7 ns | 489.5 ns | 495.2 ns | 503.5 ns | 2,028,768.2 | 0.1583 |     664 B |
|                             |                 |          |          |          |         |          |          |          |          |          |             |        |           |
| QueryBuilderWithValueString |              10 | 700.0 ns |  5.44 ns |  5.08 ns | 1.31 ns | 698.7 ns | 694.1 ns | 695.9 ns | 703.5 ns | 712.1 ns | 1,428,641.8 | 0.1335 |     560 B |
|                QueryBuilder |              10 | 828.1 ns | 11.08 ns | 10.37 ns | 2.68 ns | 824.7 ns | 814.2 ns | 820.6 ns | 836.8 ns | 843.9 ns | 1,207,515.4 | 0.2632 |   1,104 B |

![Query Benchmarks Benchmarks QueryBuilderBenchmarks-barplot](https://user-images.githubusercontent.com/50595040/180458629-041a6472-d2da-4473-96bc-b1429b2187e6.png)

We achieve about approx. 15% performance increase in time and approx 50% in allocated memory!

## Related to tests:
No tests were added as current set of tests, that covered `StringBuilder` also covers `ValueStringBuilder
{Detail}

Fixes #42810 
