### PR TITLE
Route tooling: Add framework route parameter completion

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
@@ -1,0 +1,536 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
+using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure.VirtualChars;
+using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.RoutePattern;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Tags;
+using Microsoft.CodeAnalysis.Text;
+using Document = Microsoft.CodeAnalysis.Document;
+using RoutePatternToken = Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure.EmbeddedSyntax.EmbeddedSyntaxToken<Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.RoutePattern.RoutePatternKind>;
+
+namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage;
+
+[ExportCompletionProvider(nameof(RoutePatternCompletionProvider), LanguageNames.CSharp)]
+[Shared]
+public class FrameworkParametersCompletionProvider : CompletionProvider
+{
+    private const string StartKey = nameof(StartKey);
+    private const string LengthKey = nameof(LengthKey);
+    private const string NewTextKey = nameof(NewTextKey);
+    private const string NewPositionKey = nameof(NewPositionKey);
+    private const string DescriptionKey = nameof(DescriptionKey);
+
+    // Always soft-select these completion items.  Also, never filter down.
+    private static readonly CompletionItemRules s_rules = CompletionItemRules.Create(
+        selectionBehavior: CompletionItemSelectionBehavior.SoftSelection,
+        filterCharacterRules: ImmutableArray.Create(CharacterSetModificationRule.Create(CharacterSetModificationKind.Replace, Array.Empty<char>())));
+
+    // The space between type and parameter name.
+    // void TestMethod(int // <- space after type name
+    public ImmutableHashSet<char> TriggerCharacters { get; } = ImmutableHashSet.Create(' ');
+
+    public override bool ShouldTriggerCompletion(SourceText text, int caretPosition, CompletionTrigger trigger, OptionSet options)
+    {
+        if (trigger.Kind == CompletionTriggerKind.Insertion)
+        {
+            return TriggerCharacters.Contains(trigger.Character);
+        }
+
+        return false;
+    }
+
+    public override Task<CompletionDescription> GetDescriptionAsync(Document document, CompletionItem item, CancellationToken cancellationToken)
+    {
+        if (!item.Properties.TryGetValue(DescriptionKey, out var description))
+        {
+            return Task.FromResult<CompletionDescription>(null);
+        }
+
+        return Task.FromResult(CompletionDescription.Create(
+            ImmutableArray.Create(new TaggedText(TextTags.Text, description))));
+    }
+
+    public override Task<CompletionChange> GetChangeAsync(Document document, CompletionItem item, char? commitKey, CancellationToken cancellationToken)
+    {
+        // These values have always been added by us.
+        var startString = item.Properties[StartKey];
+        var lengthString = item.Properties[LengthKey];
+        var newText = item.Properties[NewTextKey];
+
+        // This value is optionally added in some cases and may not always be there.
+        item.Properties.TryGetValue(NewPositionKey, out var newPositionString);
+
+        return Task.FromResult(CompletionChange.Create(
+            new TextChange(new TextSpan(int.Parse(startString, CultureInfo.InvariantCulture), int.Parse(lengthString, CultureInfo.InvariantCulture)), newText),
+            newPositionString == null ? null : int.Parse(newPositionString, CultureInfo.InvariantCulture)));
+    }
+
+    public override async Task ProvideCompletionsAsync(CompletionContext context)
+    {
+        if (context.Trigger.Kind is not CompletionTriggerKind.Insertion)
+        {
+            return;
+        }
+
+        var position = context.Position;
+
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root == null)
+        {
+            return;
+        }
+        var token = root.FindToken(position);
+
+        // If space is before a close paren then change current token to the previous argument.
+        if (token.IsKind(SyntaxKind.CloseParenToken) || token.IsKind(SyntaxKind.CommaToken))
+        {
+            token = token.GetPreviousToken();
+        }
+
+        // If space is after ? then it's likely a nullable type and move to previous type token.
+        if (token.IsKind(SyntaxKind.QuestionToken))
+        {
+            token = token.GetPreviousToken();
+        }
+
+        // Whitespace should follow the identifier token of the parameter.
+        if (!SyntaxFacts.IsPredefinedType(token.Kind()) &&
+            !token.IsKind(SyntaxKind.IdentifierToken))
+        {
+            return;
+        }
+
+        var container = TryFindMinimalApiArgument(token.Parent) ?? TryFindMvcActionParameter(token.Parent);
+        if (container == null)
+        {
+            return;
+        }
+
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel == null)
+        {
+            return;
+        }
+
+        if (!WellKnownTypes.TryGetOrCreate(semanticModel.Compilation, out var wellKnownTypes))
+        {
+            return;
+        }
+
+        // Don't offer route parameter names when the parameter type can't be bound to route parameters. e.g. HttpContext.
+        var isCurrentParameterSpecialType = IsCurrentParameterNotBindable(token, semanticModel, wellKnownTypes, context.CancellationToken);
+        if (isCurrentParameterSpecialType)
+        {
+            return;
+        }
+
+        // Don't offer route parameter names when the parameter has an attribute that can't be bound to route parameters.
+        // e.g [AsParameters] or [IFromBodyMetadata].
+        var hasNonRouteAttribute = HasNonRouteAttribute(token, semanticModel, wellKnownTypes, context.CancellationToken);
+        if (hasNonRouteAttribute)
+        {
+            return;
+        }
+
+        SyntaxToken routeStringToken;
+        SyntaxNode methodNode;
+
+        if (container.Parent.IsKind(SyntaxKind.Argument))
+        {
+            // Minimal API
+            var mapMethodParts = RoutePatternUsageDetector.FindMapMethodParts(semanticModel, wellKnownTypes, container, context.CancellationToken);
+            if (mapMethodParts == null)
+            {
+                return;
+            }
+            var (_, routeStringExpression, delegateExpression) = mapMethodParts.Value;
+
+            routeStringToken = routeStringExpression.Token;
+            methodNode = delegateExpression;
+        }
+        else if (container.Parent.IsKind(SyntaxKind.Parameter))
+        {
+            // MVC
+            var methodSyntax = container.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+            var methodSymbol = semanticModel.GetDeclaredSymbol(methodSyntax, context.CancellationToken);
+
+            // Check method is a valid MVC action.
+            if (methodSymbol?.ContainingType is not INamedTypeSymbol typeSymbol ||
+                !MvcDetector.IsController(typeSymbol, wellKnownTypes) ||
+                !MvcDetector.IsAction(methodSymbol, wellKnownTypes))
+            {
+                return;
+            }
+
+            var routeToken = TryGetMvcActionRouteToken(context, semanticModel, methodSyntax);
+            if (routeToken == null)
+            {
+                return;
+            }
+
+            routeStringToken = routeToken.Value;
+            methodNode = methodSyntax;
+        }
+        else
+        {
+            return;
+        }
+
+        var virtualChars = CSharpVirtualCharService.Instance.TryConvertToVirtualChars(routeStringToken);
+        var tree = RoutePatternParser.TryParse(virtualChars, supportTokenReplacement: false);
+        if (tree == null)
+        {
+            return;
+        }
+
+        var routePatternCompletionContext = new EmbeddedCompletionContext(context, tree, wellKnownTypes);
+
+        var existingParameterNames = GetExistingParameterNames(methodNode);
+        foreach (var parameterName in existingParameterNames)
+        {
+            routePatternCompletionContext.AddUsedParameterName(parameterName);
+        }
+
+        ProvideCompletions(routePatternCompletionContext);
+
+        if (routePatternCompletionContext.Items == null || routePatternCompletionContext.Items.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var embeddedItem in routePatternCompletionContext.Items)
+        {
+            var change = embeddedItem.Change;
+            var textChange = change.TextChange;
+
+            var properties = ImmutableDictionary.CreateBuilder<string, string>();
+            properties.Add(StartKey, textChange.Span.Start.ToString(CultureInfo.InvariantCulture));
+            properties.Add(LengthKey, textChange.Span.Length.ToString(CultureInfo.InvariantCulture));
+            properties.Add(NewTextKey, textChange.NewText);
+            properties.Add(DescriptionKey, embeddedItem.FullDescription);
+
+            if (change.NewPosition != null)
+            {
+                properties.Add(NewPositionKey, change.NewPosition.ToString());
+            }
+
+            // Keep everything sorted in the order we just produced the items in.
+            var sortText = routePatternCompletionContext.Items.Count.ToString("0000", CultureInfo.InvariantCulture);
+            context.AddItem(CompletionItem.Create(
+                displayText: embeddedItem.DisplayText,
+                inlineDescription: "",
+                sortText: sortText,
+                properties: properties.ToImmutable(),
+                rules: s_rules,
+                tags: ImmutableArray.Create(embeddedItem.Glyph)));
+        }
+
+        context.SuggestionModeItem = CompletionItem.Create(
+            displayText: "<Name>",
+            inlineDescription: "",
+            rules: CompletionItemRules.Default);
+
+        context.IsExclusive = true;
+    }
+
+    private static SyntaxToken? TryGetMvcActionRouteToken(CompletionContext context, SemanticModel? semanticModel, MethodDeclarationSyntax? method)
+    {
+        foreach (var attributeList in method.AttributeLists)
+        {
+            foreach (var attribute in attributeList.Attributes)
+            {
+                foreach (var attributeArgument in attribute.ArgumentList.Arguments)
+                {
+                    if (RouteStringSyntaxDetector.IsArgumentToAttributeParameterWithMatchingStringSyntaxAttribute(
+                        semanticModel,
+                        attributeArgument,
+                        context.CancellationToken,
+                        out var identifer) &&
+                        identifer == "Route" &&
+                        attributeArgument.Expression is LiteralExpressionSyntax literalExpression)
+                    {
+                        return literalExpression.Token;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static SyntaxNode? TryFindMvcActionParameter(SyntaxNode node)
+    {
+        var current = node;
+        while (current != null)
+        {
+            if (current.Parent?.IsKind(SyntaxKind.Parameter) ?? false)
+            {
+                return current;
+            }
+
+            current = current.Parent;
+        }
+
+        return null;
+    }
+
+    private static SyntaxNode? TryFindMinimalApiArgument(SyntaxNode node)
+    {
+        var current = node;
+        while (current != null)
+        {
+            if (current.Parent?.IsKind(SyntaxKind.Argument) ?? false)
+            {
+                if (current.Parent?.Parent?.IsKind(SyntaxKind.ArgumentList) ?? false)
+                {
+                    return current;
+                }
+            }
+
+            current = current.Parent;
+        }
+
+        return null;
+    }
+
+    private static bool HasNonRouteAttribute(SyntaxToken token, SemanticModel semanticModel, WellKnownTypes wellKnownTypes, CancellationToken cancellationToken)
+    {
+        if (token.Parent?.Parent is ParameterSyntax parameter)
+        {
+            foreach (var attributeList in parameter.AttributeLists.OfType<AttributeListSyntax>())
+            {
+                foreach (var attribute in attributeList.Attributes)
+                {
+                    var attributeTypeSymbol = semanticModel.GetSymbolInfo(attribute, cancellationToken).GetAnySymbol();
+
+                    if (attributeTypeSymbol != null)
+                    {
+                        foreach (var nonRouteMetadataType in wellKnownTypes.NonRouteMetadataTypes)
+                        {
+                            if (attributeTypeSymbol.ContainingSymbol is ITypeSymbol typeSymbol &&
+                                typeSymbol.Implements(nonRouteMetadataType))
+                            {
+                                return true;
+                            }
+                        }
+                        if (SymbolEqualityComparer.Default.Equals(attributeTypeSymbol.ContainingSymbol, wellKnownTypes.AsParametersAttribute))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsCurrentParameterNotBindable(SyntaxToken token, SemanticModel semanticModel, WellKnownTypes wellKnownTypes, CancellationToken cancellationToken)
+    {
+        if (token.Parent.IsKind(SyntaxKind.PredefinedType))
+        {
+            return false;
+        }
+
+        var parameterTypeSymbol = semanticModel.GetSymbolInfo(token.Parent, cancellationToken).GetAnySymbol();
+        if (parameterTypeSymbol is INamedTypeSymbol typeSymbol)
+        {
+            // Check if the parameter type is a minimal API special type. e.g. HttpContext.
+            foreach (var specialType in wellKnownTypes.ParameterSpecialTypes)
+            {
+                if (typeSymbol.IsType(specialType))
+                {
+                    return true;
+                }
+            }
+        }
+        else if (parameterTypeSymbol is IMethodSymbol)
+        {
+            // If the parameter type is a method then the method is bound to the minimal API.
+            return true;
+        }
+
+        return false;
+    }
+
+    private static ImmutableArray<string> GetExistingParameterNames(SyntaxNode node)
+    {
+        var builder = ImmutableArray.CreateBuilder<string>();
+
+        if (node is TupleExpressionSyntax tupleExpression)
+        {
+            foreach (var argument in tupleExpression.Arguments)
+            {
+                if (argument.Expression is DeclarationExpressionSyntax declarationExpression &&
+                    declarationExpression.Designation is SingleVariableDesignationSyntax variableDesignationSyntax &&
+                    variableDesignationSyntax.Identifier is { } identifer &&
+                    !identifer.IsMissing)
+                {
+                    builder.Add(identifer.ValueText);
+                }
+            }
+        }
+        else
+        {
+            var parameterList = node switch
+            {
+                ParenthesizedLambdaExpressionSyntax parenthesizedLambdaExpression => parenthesizedLambdaExpression.ParameterList,
+                MethodDeclarationSyntax methodDeclaration => methodDeclaration.ParameterList,
+                _ => null
+            };
+
+            if (parameterList != null)
+            {
+                foreach (var p in parameterList.Parameters)
+                {
+                    if (p is ParameterSyntax parameter &&
+                        parameter.Identifier is { } identifer && !identifer.IsMissing)
+                    {
+                        builder.Add(identifer.ValueText);
+                    }
+                }
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static void ProvideCompletions(EmbeddedCompletionContext context)
+    {
+        foreach (var parameterSymbol in context.Tree.RouteParameters)
+        {
+            context.AddIfMissing(parameterSymbol.Key, suffix: null, description: null, WellKnownTags.Parameter, parentOpt: null);
+        }
+    }
+
+    private (RoutePatternNode parent, RoutePatternToken Token)? FindToken(RoutePatternNode parent, VirtualChar ch)
+    {
+        foreach (var child in parent)
+        {
+            if (child.IsNode)
+            {
+                var result = FindToken(child.Node, ch);
+                if (result != null)
+                {
+                    return result;
+                }
+            }
+            else
+            {
+                if (child.Token.VirtualChars.Contains(ch))
+                {
+                    return (parent, child.Token);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private readonly struct RoutePatternItem
+    {
+        public readonly string DisplayText;
+        public readonly string InlineDescription;
+        public readonly string FullDescription;
+        public readonly string Glyph;
+        public readonly CompletionChange Change;
+
+        public RoutePatternItem(
+            string displayText, string inlineDescription, string fullDescription, string glyph, CompletionChange change)
+        {
+            DisplayText = displayText;
+            InlineDescription = inlineDescription;
+            FullDescription = fullDescription;
+            Glyph = glyph;
+            Change = change;
+        }
+    }
+
+    private readonly struct EmbeddedCompletionContext
+    {
+        private readonly CompletionContext _context;
+        private readonly HashSet<string> _names = new(StringComparer.OrdinalIgnoreCase);
+
+        public readonly RoutePatternTree Tree;
+        public readonly WellKnownTypes WellKnownTypes;
+        public readonly CancellationToken CancellationToken;
+        public readonly int Position;
+        public readonly CompletionTrigger Trigger;
+        public readonly List<RoutePatternItem> Items = new();
+
+        public EmbeddedCompletionContext(
+            CompletionContext context,
+            RoutePatternTree tree,
+            WellKnownTypes wellKnownTypes)
+        {
+            _context = context;
+            Tree = tree;
+            WellKnownTypes = wellKnownTypes;
+            Position = _context.Position;
+            Trigger = _context.Trigger;
+            CancellationToken = _context.CancellationToken;
+        }
+
+        public void AddUsedParameterName(string name)
+        {
+            _names.Add(name);
+        }
+
+        public void AddIfMissing(
+            string displayText, string suffix, string description, string glyph,
+            RoutePatternNode parentOpt, int? positionOffset = null, string insertionText = null)
+        {
+            var replacementStart = parentOpt != null
+                ? parentOpt.GetSpan().Start
+                : Position;
+
+            var replacementSpan = TextSpan.FromBounds(replacementStart, Position);
+            var newPosition = replacementStart + positionOffset;
+
+            insertionText ??= displayText;
+
+            AddIfMissing(new RoutePatternItem(
+                displayText, suffix, description, glyph,
+                CompletionChange.Create(
+                    new TextChange(replacementSpan, insertionText),
+                    newPosition)));
+        }
+
+        public void AddIfMissing(RoutePatternItem item)
+        {
+            if (_names.Add(item.DisplayText))
+            {
+                Items.Add(item);
+            }
+        }
+
+        public static string EscapeText(string text, SyntaxToken token)
+        {
+            // This function is called when Completion needs to escape something its going to
+            // insert into the user's string token.  This means that we only have to escape
+            // things that completion could insert.  In this case, the only regex character
+            // that is relevant is the \ character, and it's only relevant if we insert into
+            // a normal string and not a verbatim string.  There are no other regex characters
+            // that completion will produce that need any escaping. 
+            Debug.Assert(token.IsKind(SyntaxKind.StringLiteralToken));
+            return token.IsVerbatimStringLiteral()
+                ? text
+                : text.Replace(@"\", @"\\");
+        }
+    }
+}

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
@@ -449,9 +449,9 @@ public class FrameworkParametersCompletionProvider : CompletionProvider
 
     private static void ProvideCompletions(EmbeddedCompletionContext context, SyntaxToken? parentOpt)
     {
-        foreach (var parameterSymbol in context.Tree.RouteParameters)
+        foreach (var routeParameter in context.Tree.RouteParameters)
         {
-            context.AddIfMissing(parameterSymbol.Key, suffix: null, description: "(Route parameter)", WellKnownTags.Parameter, parentOpt);
+            context.AddIfMissing(routeParameter.Name, suffix: null, description: "(Route parameter)", WellKnownTags.Parameter, parentOpt);
         }
     }
 

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
@@ -130,7 +130,7 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
 
         // Don't offer route parameter names when the parameter type can't be bound to route parameters.
         // e.g. special types like HttpContext, non-primative types that don't have a static TryParse method.
-        if (!IsCurrentParameterBindable(token, semanticModel, wellKnownTypes, context.CancellationToken))
+        if (!IsCurrentParameterBindable(token, semanticModel, context.CancellationToken))
         {
             return;
         }
@@ -377,7 +377,7 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
         return false;
     }
 
-    private static bool IsCurrentParameterBindable(SyntaxToken token, SemanticModel semanticModel, WellKnownTypes wellKnownTypes, CancellationToken cancellationToken)
+    private static bool IsCurrentParameterBindable(SyntaxToken token, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
         if (token.Parent.IsKind(SyntaxKind.PredefinedType))
         {

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
@@ -415,8 +415,7 @@ public class FrameworkParametersCompletionProvider : CompletionProvider
             {
                 if (argument.Expression is DeclarationExpressionSyntax declarationExpression &&
                     declarationExpression.Designation is SingleVariableDesignationSyntax variableDesignationSyntax &&
-                    variableDesignationSyntax.Identifier is { } identifer &&
-                    !identifer.IsMissing)
+                    variableDesignationSyntax.Identifier is { IsMissing: false } identifer)
                 {
                     builder.Add(identifer.ValueText);
                 }
@@ -436,7 +435,7 @@ public class FrameworkParametersCompletionProvider : CompletionProvider
                 foreach (var p in parameterList.Parameters)
                 {
                     if (p is ParameterSyntax parameter &&
-                        parameter.Identifier is { } identifer && !identifer.IsMissing)
+                        parameter.Identifier is { IsMissing: false } identifer)
                     {
                         builder.Add(identifer.ValueText);
                     }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
@@ -129,7 +129,7 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
         }
 
         // Don't offer route parameter names when the parameter type can't be bound to route parameters.
-        // e.g. special types like HttpContext, non-primative types that don't have a static TryParse method.
+        // e.g. special types like HttpContext, non-primitive types that don't have a static TryParse method.
         if (!IsCurrentParameterBindable(token, semanticModel, context.CancellationToken))
         {
             return;

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/WellKnownTypes.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/WellKnownTypes.cs
@@ -144,6 +144,18 @@ internal sealed class WellKnownTypes
             return false;
         }
 
+        const string IFormatProvider = "System.IFormatProvider";
+        if (compilation.GetTypeByMetadataName(IFormatProvider) is not { } iFormatProvider)
+        {
+            return false;
+        }
+
+        const string Uri = "System.Uri";
+        if (compilation.GetTypeByMetadataName(Uri) is not { } uri)
+        {
+            return false;
+        }
+
         wellKnownTypes = new()
         {
             IFromBodyMetadata = iFromBodyMetadata,
@@ -165,6 +177,8 @@ internal sealed class WellKnownTypes
             IFormFile = iFormFile,
             Stream = stream,
             PipeReader = pipeReader,
+            IFormatProvider = iFormatProvider,
+            Uri = uri,
         };
 
         return true;
@@ -189,6 +203,8 @@ internal sealed class WellKnownTypes
     public INamedTypeSymbol Stream { get; private init; }
     public INamedTypeSymbol PipeReader { get; private init; }
     public INamedTypeSymbol IFormFile { get; private init; }
+    public INamedTypeSymbol IFormatProvider { get; private init; }
+    public INamedTypeSymbol Uri { get; private init; }
 
     private INamedTypeSymbol[]? _parameterSpecialTypes;
     public INamedTypeSymbol[] ParameterSpecialTypes

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/FrameworkParametersCompletionProviderTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/FrameworkParametersCompletionProviderTests.cs
@@ -1,10 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO.Pipelines;
-using System.Security.Claims;
 using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
-using Microsoft.AspNetCore.Http;
 using Microsoft.CodeAnalysis.Completion;
 
 namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage;
@@ -138,6 +135,8 @@ class Program
 {
     static void Main()
     {
+        // Out parameters are not supported by Minimal API.
+        // It's useful to provide completion here and then allow dev to fix parameter later.
         EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (out int $$
     }
 }
@@ -316,10 +315,6 @@ class Program
         var result = await GetCompletionsAndServiceAsync(@"
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.IO.Pipelines;
-using System.Security.Claims;
-using System.Threading;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 
@@ -345,12 +340,7 @@ class Program
         var result = await GetCompletionsAndServiceAsync(@"
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.IO.Pipelines;
-using System.Security.Claims;
-using System.Threading;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 
 class Program
 {
@@ -366,18 +356,86 @@ class Program
     }
 
     [Fact]
+    public async Task Insertion_Space_MultipleArgs_OneParameterAlreadyUsed_EndpointMapGet_HasDelegate_HasItems()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}/{id2}"", (string id, int $$
+    }
+}
+");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.ItemsList,
+            i => Assert.Equal("id2", i.DisplayText));
+    }
+
+    [Fact]
+    public async Task Insertion_Space_MultipleParameters_EndpointMapGet_HasDelegate_HasItems()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}/{id2}"", (string $$
+    }
+}
+");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.ItemsList,
+            i => Assert.Equal("id", i.DisplayText),
+            i => Assert.Equal("id2", i.DisplayText));
+    }
+
+    [Fact]
+    public async Task Insertion_Space_DuplicateParameters_EndpointMapGet_HasDelegate_HasItems()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}/{id}"", (string $$
+    }
+}
+");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.ItemsList,
+            i => Assert.Equal("id", i.DisplayText));
+    }
+
+    [Fact]
     public async Task Insertion_Space_MultipleArgs_ParameterAlreadyUsed_EndpointMapGet_HasCompleteDelegate_NoItems()
     {
         // Arrange & Act
         var result = await GetCompletionsAndServiceAsync(@"
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.IO.Pipelines;
-using System.Security.Claims;
-using System.Threading;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 
 class Program
 {
@@ -399,12 +457,7 @@ class Program
         var result = await GetCompletionsAndServiceAsync(@"
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.IO.Pipelines;
-using System.Security.Claims;
-using System.Threading;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 
 class Program
 {

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/FrameworkParametersCompletionProviderTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/FrameworkParametersCompletionProviderTests.cs
@@ -5,6 +5,7 @@ using System.IO.Pipelines;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
 using Microsoft.AspNetCore.Http;
+using Microsoft.CodeAnalysis.Completion;
 
 namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage;
 
@@ -32,8 +33,12 @@ class Program
 
         // Assert
         Assert.Collection(
-            result.Completions.Items,
+            result.Completions.ItemsList,
             i => Assert.Equal("id", i.DisplayText));
+
+        var change = await result.Service.GetChangeAsync(result.Document, result.Completions.ItemsList[0]);
+        Assert.Equal("id", change.TextChange.NewText);
+        Assert.Equal(result.CompletionListSpan, change.TextChange.Span);
     }
 
     [Fact]
@@ -56,8 +61,12 @@ class Program
 
         // Assert
         Assert.Collection(
-            result.Completions.Items,
+            result.Completions.ItemsList,
             i => Assert.Equal("id", i.DisplayText));
+
+        var change = await result.Service.GetChangeAsync(result.Document, result.Completions.ItemsList[0]);
+        Assert.Equal("id", change.TextChange.NewText);
+        Assert.Equal(result.CompletionListSpan, change.TextChange.Span);
     }
 
     [Fact]
@@ -80,8 +89,12 @@ class Program
 
         // Assert
         Assert.Collection(
-            result.Completions.Items,
+            result.Completions.ItemsList,
             i => Assert.Equal("id", i.DisplayText));
+
+        var change = await result.Service.GetChangeAsync(result.Document, result.Completions.ItemsList[0]);
+        Assert.Equal("id", change.TextChange.NewText);
+        Assert.Equal(result.CompletionListSpan, change.TextChange.Span);
     }
 
     [Fact]
@@ -104,8 +117,196 @@ class Program
 
         // Assert
         Assert.Collection(
-            result.Completions.Items,
+            result.Completions.ItemsList,
             i => Assert.Equal("id", i.DisplayText));
+
+        var change = await result.Service.GetChangeAsync(result.Document, result.Completions.ItemsList[0]);
+        Assert.Equal("id", change.TextChange.NewText);
+        Assert.Equal(result.CompletionListSpan, change.TextChange.Span);
+    }
+
+    [Fact]
+    public async Task Insertion_Space_OutInt_EndpointMapGet_HasDelegate_ReturnRouteParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (out int $$
+    }
+}
+");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.ItemsList,
+            i => Assert.Equal("id", i.DisplayText));
+
+        var change = await result.Service.GetChangeAsync(result.Document, result.Completions.ItemsList[0]);
+        Assert.Equal("id", change.TextChange.NewText);
+        Assert.Equal(result.CompletionListSpan, change.TextChange.Span);
+    }
+
+    [Fact]
+    public async Task Insertion_Space_Generic_EndpointMapGet_HasDelegate_ReturnRouteParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (Nullable<int> $$
+    }
+}
+");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.ItemsList,
+            i => Assert.Equal("id", i.DisplayText));
+
+        var change = await result.Service.GetChangeAsync(result.Document, result.Completions.ItemsList[0]);
+        Assert.Equal("id", change.TextChange.NewText);
+        Assert.Equal(result.CompletionListSpan, change.TextChange.Span);
+    }
+
+    [Fact]
+    public async Task Invoke_Space_Generic_EndpointMapGet_HasDelegate_HasText_ReturnRouteParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (int [|i|]$$
+    }
+}
+", CompletionTrigger.Invoke);
+
+        // Assert
+        Assert.Collection(
+            result.Completions.ItemsList,
+            i => Assert.Equal("id", i.DisplayText));
+
+        var change = await result.Service.GetChangeAsync(result.Document, result.Completions.ItemsList[0]);
+        Assert.Equal("id", change.TextChange.NewText);
+        Assert.Equal(result.CompletionListSpan, change.TextChange.Span);
+    }
+
+    [Fact]
+    public async Task Invoke_Space_Generic_EndpointMapGet_HasDelegate_InText_ReturnRouteParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (int [|i$$d|]
+    }
+}
+", CompletionTrigger.Invoke);
+
+        // Assert
+        Assert.Collection(
+            result.Completions.ItemsList,
+            i => Assert.Equal("id", i.DisplayText));
+
+        var change = await result.Service.GetChangeAsync(result.Document, result.Completions.ItemsList[0]);
+        Assert.Equal("id", change.TextChange.NewText);
+        Assert.Equal(result.CompletionListSpan, change.TextChange.Span);
+    }
+
+    [Fact]
+    public async Task Invoke_Space_Generic_EndpointMapGet_HasCompleteDelegate_InText_ReturnRouteParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{ids}"", (int [|i$$d|]) => {});
+    }
+}
+", CompletionTrigger.Invoke);
+
+        // Assert
+        Assert.Collection(
+            result.Completions.ItemsList,
+            i => Assert.Equal("ids", i.DisplayText));
+
+        var change = await result.Service.GetChangeAsync(result.Document, result.Completions.ItemsList[0]);
+        Assert.Equal("ids", change.TextChange.NewText);
+        Assert.Equal(result.CompletionListSpan, change.TextChange.Span);
+    }
+
+    [Fact]
+    public async Task Insertion_FirstArgument_SpaceAfterIdentifer_EndpointMapGet_HasDelegate_NoItems()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (int i $$
+    }
+}
+");
+
+        // Assert
+        Assert.Empty(result.Completions.ItemsList);
+    }
+
+    [Fact]
+    public async Task Insertion_SecondArgument_SpaceAfterIdentifer_EndpointMapGet_HasDelegate_NoItems()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (int o, string i $$
+    }
+}
+");
+
+        // Assert
+        Assert.Empty(result.Completions.ItemsList);
     }
 
     [Fact]
@@ -133,7 +334,7 @@ class Program
 
         // Assert
         Assert.Collection(
-            result.Completions.Items,
+            result.Completions.ItemsList,
             i => Assert.Equal("id", i.DisplayText));
     }
 
@@ -161,7 +362,7 @@ class Program
 ");
 
         // Assert
-        Assert.Empty(result.Completions.Items);
+        Assert.Empty(result.Completions.ItemsList);
     }
 
     [Fact]
@@ -188,7 +389,7 @@ class Program
 ");
 
         // Assert
-        Assert.Empty(result.Completions.Items);
+        Assert.Empty(result.Completions.ItemsList);
     }
 
     [Fact]
@@ -215,7 +416,7 @@ class Program
 ");
 
         // Assert
-        Assert.Empty(result.Completions.Items);
+        Assert.Empty(result.Completions.ItemsList);
     }
 
     [Theory]
@@ -228,7 +429,7 @@ class Program
     [InlineData("IFormFile")]
     [InlineData("Stream")]
     [InlineData("PipeReader")]
-    public async Task Insertion_Space_SpecialType_EndpointMapGet_HasDelegate_ReturnRouteParameterItem(string parameterType)
+    public async Task Insertion_Space_SpecialType_EndpointMapGet_HasDelegate_NoItems(string parameterType)
     {
         // Arrange & Act
         var result = await GetCompletionsAndServiceAsync(@"
@@ -251,7 +452,7 @@ class Program
 ");
 
         // Assert
-        Assert.Empty(result.Completions.Items);
+        Assert.Empty(result.Completions.ItemsList);
     }
 
     [Fact]
@@ -278,7 +479,7 @@ class Program
 ");
 
         // Assert
-        Assert.Empty(result.Completions.Items);
+        Assert.Empty(result.Completions.ItemsList);
     }
 
     [Fact]
@@ -301,7 +502,7 @@ class Program
 
         // Assert
         Assert.Collection(
-            result.Completions.Items,
+            result.Completions.ItemsList,
             i => Assert.Equal("id", i.DisplayText));
     }
 
@@ -310,7 +511,6 @@ class Program
     [InlineData("FromQuery")]
     [InlineData("FromForm")]
     [InlineData("FromHeader")]
-    [InlineData("FromQuery")]
     [InlineData("FromServices")]
     public async Task Insertion_Space_EndpointMapGet_AsParameters_NoItem(string attributeName)
     {
@@ -332,11 +532,11 @@ class Program
 ");
 
         // Assert
-        Assert.Empty(result.Completions.Items);
+        Assert.Empty(result.Completions.ItemsList);
     }
 
     [Fact]
-    public async Task Insertion_Space_EndpointMapGet_UnknownAttribute_NoItem()
+    public async Task Insertion_Space_EndpointMapGet_UnknownAttribute_ReturnItems()
     {
         // Arrange & Act
         var result = await GetCompletionsAndServiceAsync(@"
@@ -356,7 +556,7 @@ class Program
 
         // Assert
         Assert.Collection(
-            result.Completions.Items,
+            result.Completions.ItemsList,
             i => Assert.Equal("id", i.DisplayText));
     }
 
@@ -379,7 +579,7 @@ class Program
 ");
 
         // Assert
-        Assert.Empty(result.Completions.Items);
+        Assert.Empty(result.Completions.ItemsList);
     }
 
     [Fact]
@@ -401,7 +601,7 @@ class Program
 ");
 
         // Assert
-        var item = result.Completions.Items.FirstOrDefault(i => i.DisplayText == "id");
+        var item = result.Completions.ItemsList.FirstOrDefault(i => i.DisplayText == "id");
         Assert.Null(item);
     }
 
@@ -430,7 +630,7 @@ class Program
 
         // Assert
         Assert.Collection(
-            result.Completions.Items,
+            result.Completions.ItemsList,
             i => Assert.Equal("id", i.DisplayText));
     }
 
@@ -458,7 +658,7 @@ class Program
 ");
 
         // Assert
-        Assert.Empty(result.Completions.Items);
+        Assert.Empty(result.Completions.ItemsList);
     }
 
     [Fact]
@@ -490,7 +690,7 @@ class Program
 
         // Assert
         Assert.Collection(
-            result.Completions.Items,
+            result.Completions.ItemsList,
             i => Assert.Equal("id", i.DisplayText));
     }
 
@@ -520,8 +720,70 @@ class Program
 
         // Assert
         Assert.Collection(
-            result.Completions.Items,
+            result.Completions.ItemsList,
             i => Assert.Equal("id", i.DisplayText));
+    }
+
+    [Fact]
+    public async Task Invoke_ControllerAction_HasParameter_Incomplete_ReturnActionParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Mvc;
+
+    class Program
+    {
+        static void Main()
+        {
+        }
+    }
+
+    public class TestController
+    {
+        [HttpGet(@""{id}"")]
+        public object TestAction(int [|i|]$$
+    }
+    ", CompletionTrigger.Invoke);
+
+        // Assert
+        Assert.Collection(
+            result.Completions.ItemsList,
+            i => Assert.Equal("id", i.DisplayText));
+
+        var change = await result.Service.GetChangeAsync(result.Document, result.Completions.ItemsList[0]);
+        Assert.Equal("id", change.TextChange.NewText);
+        Assert.Equal(result.CompletionListSpan, change.TextChange.Span);
+    }
+
+    [Fact]
+    public async Task Insertion_ControllerAction_HasParameter_Incomplete_NoItems()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Mvc;
+
+    class Program
+    {
+        static void Main()
+        {
+        }
+    }
+
+    public class TestController
+    {
+        [HttpGet(@""{id}"")]
+        public object TestAction(int i $$
+    }
+    ");
+
+        // Assert
+        Assert.Empty(result.Completions.ItemsList);
     }
 
     [Fact]
@@ -553,12 +815,12 @@ class Program
 
         // Assert
         Assert.Collection(
-            result.Completions.Items,
+            result.Completions.ItemsList,
             i => Assert.Equal("id", i.DisplayText));
     }
 
     [Fact]
-    public async Task Insertion_Space_NonControllerAction_HasParameter_ReturnActionParameterItem()
+    public async Task Insertion_Space_NonControllerAction_HasParameter_NoItems()
     {
         // Arrange & Act
         var result = await GetCompletionsAndServiceAsync(@"
@@ -585,15 +847,11 @@ class Program
     ");
 
         // Assert
-        Assert.Empty(result.Completions.Items);
+        Assert.Empty(result.Completions.ItemsList);
     }
 
-    private async Task<CompletionResult> GetCompletionsAndServiceAsync(string source)
+    private Task<CompletionResult> GetCompletionsAndServiceAsync(string source, CompletionTrigger? completionTrigger = null)
     {
-        MarkupTestFile.GetPosition(source, out var output, out int cursorPosition);
-
-        var completions = await Runner.GetCompletionsAndServiceAsync(cursorPosition, output);
-
-        return completions;
+        return CompletionTestHelpers.GetCompletionsAndServiceAsync(Runner, source, completionTrigger);
     }
 }

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/FrameworkParametersCompletionProviderTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/FrameworkParametersCompletionProviderTests.cs
@@ -531,6 +531,70 @@ public class CustomParsableType
     }
 
     [Fact]
+    public async Task Insertion_Space_CustomParsableWithFormatType_EndpointMapGet_HasDelegate_HasItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (CustomParsableType $$
+    }
+}
+
+public class CustomParsableType
+{
+    public static bool TryParse(string s, IFormatProvider provider, out CustomParsableType result)
+    {
+        result = new CustomParsableType();
+        return true;
+    }
+}
+");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.ItemsList,
+            i => Assert.Equal("id", i.DisplayText));
+    }
+
+    [Fact]
+    public async Task Insertion_Space_CustomParsableWithFormatType_NonPublic_EndpointMapGet_HasDelegate_NoItems()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (CustomParsableType $$
+    }
+}
+
+public class CustomParsableType
+{
+    private static bool TryParse(string s, IFormatProvider provider, out CustomParsableType result)
+    {
+        result = new CustomParsableType();
+        return true;
+    }
+}
+");
+
+        // Assert
+        Assert.Empty(result.Completions.ItemsList);
+    }
+
+    [Fact]
     public async Task Insertion_Space_NonParsableType_EndpointMapGet_HasDelegate_NoItems()
     {
         // Arrange & Act
@@ -570,6 +634,8 @@ public interface NonParsableType
     [InlineData("int?")]
     [InlineData("Nullable<int>")]
     [InlineData("Nullable<Int32>")]
+    [InlineData("StringComparison")]
+    [InlineData("Uri")]
     public async Task Insertion_Space_SupportedBuiltinTypes_EndpointMapGet_HasDelegate_HasItem(string parameterType)
     {
         // Arrange & Act

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/FrameworkParametersCompletionProviderTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/FrameworkParametersCompletionProviderTests.cs
@@ -1,0 +1,599 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Pipelines;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage;
+
+public partial class FrameworkParametersCompletionProviderTests
+{
+    private TestDiagnosticAnalyzerRunner Runner { get; } = new(new RoutePatternAnalyzer());
+
+    [Fact]
+    public async Task Insertion_Space_Int_EndpointMapGet_HasDelegate_ReturnRouteParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (int $$
+    }
+}
+");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.Items,
+            i => Assert.Equal("id", i.DisplayText));
+    }
+
+    [Fact]
+    public async Task Insertion_Space_DateTime_EndpointMapGet_HasDelegate_ReturnRouteParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (DateTime $$
+    }
+}
+");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.Items,
+            i => Assert.Equal("id", i.DisplayText));
+    }
+
+    [Fact]
+    public async Task Insertion_Space_NullableInt_CloseParen_EndpointMapGet_HasDelegate_ReturnRouteParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (int? $$)
+    }
+}
+");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.Items,
+            i => Assert.Equal("id", i.DisplayText));
+    }
+
+    [Fact]
+    public async Task Insertion_Space_NullableInt_EndpointMapGet_HasDelegate_ReturnRouteParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (int? $$
+    }
+}
+");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.Items,
+            i => Assert.Equal("id", i.DisplayText));
+    }
+
+    [Fact]
+    public async Task Insertion_Space_MultipleArgs_EndpointMapGet_HasDelegate_ReturnRouteParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.IO.Pipelines;
+using System.Security.Claims;
+using System.Threading;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (HttpContext context, int $$
+    }
+}
+");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.Items,
+            i => Assert.Equal("id", i.DisplayText));
+    }
+
+    [Fact]
+    public async Task Insertion_Space_MultipleArgs_ParameterAlreadyUsed_EndpointMapGet_HasDelegate_NoItems()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.IO.Pipelines;
+using System.Security.Claims;
+using System.Threading;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (string id, int $$
+    }
+}
+");
+
+        // Assert
+        Assert.Empty(result.Completions.Items);
+    }
+
+    [Fact]
+    public async Task Insertion_Space_MultipleArgs_ParameterAlreadyUsed_EndpointMapGet_HasCompleteDelegate_NoItems()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.IO.Pipelines;
+using System.Security.Claims;
+using System.Threading;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (string id, int $$) => { });
+    }
+}
+");
+
+        // Assert
+        Assert.Empty(result.Completions.Items);
+    }
+
+    [Fact]
+    public async Task Insertion_Space_MultipleArgs_ParameterAlreadyUsed_DifferentCase_EndpointMapGet_HasCompleteDelegate_NoItems()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.IO.Pipelines;
+using System.Security.Claims;
+using System.Threading;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{ID}"", (string id, int $$) => { });
+    }
+}
+");
+
+        // Assert
+        Assert.Empty(result.Completions.Items);
+    }
+
+    [Theory]
+    [InlineData("HttpContext")]
+    [InlineData("CancellationToken")]
+    [InlineData("HttpRequest")]
+    [InlineData("HttpResponse")]
+    [InlineData("ClaimsPrincipal")]
+    [InlineData("IFormFileCollection")]
+    [InlineData("IFormFile")]
+    [InlineData("Stream")]
+    [InlineData("PipeReader")]
+    public async Task Insertion_Space_SpecialType_EndpointMapGet_HasDelegate_ReturnRouteParameterItem(string parameterType)
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.IO.Pipelines;
+using System.Security.Claims;
+using System.Threading;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (" + parameterType + @" $$
+    }
+}
+");
+
+        // Assert
+        Assert.Empty(result.Completions.Items);
+    }
+
+    [Fact]
+    public async Task Insertion_Space_EndpointMapGet_HasMethod_NoItems()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", ExecuteGet $$);
+    }
+
+    static string ExecuteGet(string id)
+    {
+        return """";
+    }
+}
+");
+
+        // Assert
+        Assert.Empty(result.Completions.Items);
+    }
+
+    [Fact]
+    public async Task Insertion_Space_EndpointMapGet_HasMethod_NamedParameters_ReturnDelegateParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(pattern: @""{id}"", endpoints: null, handler: (string blah, int $$)
+    }
+}
+");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.Items,
+            i => Assert.Equal("id", i.DisplayText));
+    }
+
+    [Theory]
+    [InlineData("AsParameters")]
+    [InlineData("FromQuery")]
+    [InlineData("FromForm")]
+    [InlineData("FromHeader")]
+    [InlineData("FromQuery")]
+    [InlineData("FromServices")]
+    public async Task Insertion_Space_EndpointMapGet_AsParameters_NoItem(string attributeName)
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", ([" + attributeName + @"] int $$) => {});
+    }
+}
+");
+
+        // Assert
+        Assert.Empty(result.Completions.Items);
+    }
+
+    [Fact]
+    public async Task Insertion_Space_EndpointMapGet_UnknownAttribute_NoItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", ([PurpleMonkeyDishwasher] int $$) => {});
+    }
+}
+");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.Items,
+            i => Assert.Equal("id", i.DisplayText));
+    }
+
+    [Fact]
+    public async Task Insertion_Space_EndpointMapGet_NullDelegate_NoResults()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", null $$
+    }
+}
+");
+
+        // Assert
+        Assert.Empty(result.Completions.Items);
+    }
+
+    [Fact]
+    public async Task Insertion_Space_EndpointMapGet_Incomplete_NoResults()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", $$
+    }
+}
+");
+
+        // Assert
+        var item = result.Completions.Items.FirstOrDefault(i => i.DisplayText == "id");
+        Assert.Null(item);
+    }
+
+    [Fact]
+    public async Task Insertion_Space_CustomMapGet_ReturnDelegateParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+
+class Program
+{
+    static void Main()
+    {
+        MapCustomThing(null, @""{id}"", (string $$) => "");
+    }
+
+    static void MapCustomThing(IEndpointRouteBuilder endpoints, [StringSyntax(""Route"")] string pattern, Delegate delegate)
+    {
+    }
+}
+");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.Items,
+            i => Assert.Equal("id", i.DisplayText));
+    }
+
+    [Fact]
+    public async Task Insertion_Space_CustomMapGet_NoRouteSyntax_NoItems()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+
+class Program
+{
+    static void Main()
+    {
+        MapCustomThing(null, @""{id}"", (string $$) => "");
+    }
+
+    static void MapCustomThing(IEndpointRouteBuilder endpoints, string pattern, Delegate delegate)
+    {
+    }
+}
+");
+
+        // Assert
+        Assert.Empty(result.Completions.Items);
+    }
+
+    [Fact]
+    public async Task Insertion_Space_ControllerAction_HasParameter_ReturnActionParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Mvc;
+
+    class Program
+    {
+        static void Main()
+        {
+        }
+    }
+
+    public class TestController
+    {
+        [HttpGet(@""{id}"")]
+        public object TestAction(int $$)
+        {
+            return null;
+        }
+    }
+    ");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.Items,
+            i => Assert.Equal("id", i.DisplayText));
+    }
+
+    [Fact]
+    public async Task Insertion_Space_ControllerAction_HasParameter_Incomplete_ReturnActionParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Mvc;
+
+    class Program
+    {
+        static void Main()
+        {
+        }
+    }
+
+    public class TestController
+    {
+        [HttpGet(@""{id}"")]
+        public object TestAction(int $$
+    }
+    ");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.Items,
+            i => Assert.Equal("id", i.DisplayText));
+    }
+
+    [Fact]
+    public async Task Insertion_Space_ControllerAction_HasParameter_BeforeComma_ReturnActionParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Mvc;
+
+    class Program
+    {
+        static void Main()
+        {
+        }
+    }
+
+    public class TestController
+    {
+        [HttpGet(@""{id}"")]
+        public object TestAction(int $$, string blah)
+        {
+            return null;
+        }
+    }
+    ");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.Items,
+            i => Assert.Equal("id", i.DisplayText));
+    }
+
+    [Fact]
+    public async Task Insertion_Space_NonControllerAction_HasParameter_ReturnActionParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Mvc;
+
+    class Program
+    {
+        static void Main()
+        {
+        }
+    }
+
+    public class TestController
+    {
+        [HttpGet(@""{id}"")]
+        internal object TestAction(int $$)
+        {
+            return null;
+        }
+    }
+    ");
+
+        // Assert
+        Assert.Empty(result.Completions.Items);
+    }
+
+    private async Task<CompletionResult> GetCompletionsAndServiceAsync(string source)
+    {
+        MarkupTestFile.GetPosition(source, out var output, out int cursorPosition);
+
+        var completions = await Runner.GetCompletionsAndServiceAsync(cursorPosition, output);
+
+        return completions;
+    }
+}

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/FrameworkParametersCompletionProviderTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/FrameworkParametersCompletionProviderTests.cs
@@ -334,6 +334,31 @@ class Program
     }
 
     [Fact]
+    public async Task Insertion_Space_SystemString_EndpointMapGet_HasDelegate_ReturnRouteParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (String $$
+    }
+}
+");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.ItemsList,
+            i => Assert.Equal("id", i.DisplayText));
+    }
+
+    [Fact]
     public async Task Insertion_Space_MultipleArgs_ParameterAlreadyUsed_EndpointMapGet_HasDelegate_NoItems()
     {
         // Arrange & Act
@@ -470,6 +495,76 @@ class Program
 
         // Assert
         Assert.Empty(result.Completions.ItemsList);
+    }
+
+    [Fact]
+    public async Task Insertion_Space_CustomParsableType_EndpointMapGet_HasDelegate_HasItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (CustomParsableType $$
+    }
+}
+
+public class CustomParsableType
+{
+    public static bool TryParse(string s, out CustomParsableType result)
+    {
+        result = new CustomParsableType();
+        return true;
+    }
+}
+");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.ItemsList,
+            i => Assert.Equal("id", i.DisplayText));
+    }
+
+    [Theory]
+    [InlineData("int")]
+    [InlineData("decimal")]
+    [InlineData("DateTime")]
+    [InlineData("Guid")]
+    [InlineData("TimeSpan")]
+    [InlineData("string")]
+    [InlineData("String")]
+    [InlineData("string?")]
+    [InlineData("String?")]
+    [InlineData("Int32")]
+    [InlineData("int?")]
+    [InlineData("Nullable<int>")]
+    [InlineData("Nullable<Int32>")]
+    public async Task Insertion_Space_SupportedBuiltinTypes_EndpointMapGet_HasDelegate_HasItem(string parameterType)
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (" + parameterType + @" $$
+    }
+}
+");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.ItemsList,
+            i => Assert.Equal("id", i.DisplayText));
     }
 
     [Theory]

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/FrameworkParametersCompletionProviderTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/FrameworkParametersCompletionProviderTests.cs
@@ -530,6 +530,32 @@ public class CustomParsableType
             i => Assert.Equal("id", i.DisplayText));
     }
 
+    [Fact]
+    public async Task Insertion_Space_NonParsableType_EndpointMapGet_HasDelegate_NoItems()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+
+class Program
+{
+    static void Main()
+    {
+        EndpointRouteBuilderExtensions.MapGet(null, @""{id}"", (NonParsableType $$
+    }
+}
+
+public interface NonParsableType
+{
+}
+");
+
+        // Assert
+        Assert.Empty(result.Completions.ItemsList);
+    }
+
     [Theory]
     [InlineData("int")]
     [InlineData("decimal")]

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -67,6 +67,9 @@ internal sealed class ParameterBindingMethodCache
     [RequiresUnreferencedCode("Performs reflection on type hierarchy. This cannot be statically analyzed.")]
     public Func<ParameterExpression, Expression, Expression>? FindTryParseMethod(Type type)
     {
+        // This method is used to find TryParse methods from .NET types using reflection. It's used at app runtime.
+        // Routing analyzers also detect TryParse methods when calculating what types are valid in routes.
+        // Changes here to support new types should be reflected in analyzers.
         Func<ParameterExpression, Expression, Expression>? Finder(Type type)
         {
             MethodInfo? methodInfo;
@@ -410,7 +413,7 @@ internal sealed class ParameterBindingMethodCache
     {
         return TValue.BindAsync(httpContext, parameter);
     }
-        
+
     [RequiresUnreferencedCode("Performs reflection on type hierarchy. This cannot be statically analyzed.")]
     private MethodInfo? GetStaticMethodFromHierarchy(Type type, string name, Type[] parameterTypes, Func<MethodInfo, bool> validateReturnType)
     {


### PR DESCRIPTION
A completion provider that suggests names for parameters on minimal API and MVC methods based on the route.

For example, `api/customers/{id}` has route parameter `id`. When a new parameter is added to a minimal API or MVC action, an autocomplete dropdown with `id` is shown as the user types a parameter name.

@DamianEdwards This is your idea from the all-hands demo 😄 

**Minimal API demo:**

![completion-minimal-api](https://user-images.githubusercontent.com/303201/180929845-5f41cbfd-60c1-4cb6-87c6-79050d4c3b81.gif)

**MVC demo:**

![completion-mvc](https://user-images.githubusercontent.com/303201/180929857-153494c3-397f-43dc-9396-68b71e1ea895.gif)