### PR TITLE
Quarantine EnableCoreHostTraceLogging_PipeCaptureNativeLogs

### DIFF
--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/StdOutRedirectionTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/StdOutRedirectionTests.cs
@@ -106,6 +106,7 @@ public class StdOutRedirectionTests : IISFunctionalTestBase
     }
 
     [ConditionalTheory]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/42913")]
     [RequiresIIS(IISCapability.PoolEnvironmentVariables)]
     [SkipIfDebug]
     [InlineData("CheckLargeStdErrWrites")]


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/42913

IIS tests already have retry enabled.