### PR TITLE
Update retry list for helix-matrix failures

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -9,8 +9,9 @@
     {"testName": {"contains": "AttributeRouting_RouteNameTokenReplace_Reachable" }},
     {"testName": {"contains": "ServerCertificateSelector_Invoked"}},
     {"testName": {"contains": "TraceIdentifierIsUnique"}},
+    {"testName": {"contains": "LocationChangingHandlers_CannotCancelTheNavigationAsynchronously_UntilReturning"}},
     {"testAssembly": {"contains": "IIS"}},
-    {"failureMessage": {"contains":"(Site is started but no worker process found) (Site is started but no worker process found)"}},
+    {"failureMessage": {"contains":"(Site is started but no worker process found)"}},
     {"failureMessage": {"contains": "network disconnected"}}
   ],
   "failOnRules": [


### PR DESCRIPTION
LocationChangingHandlers_CannotCancelTheNavigationAsynchronously_UntilReturning failed on two different queues for

https://dev.azure.com/dnceng/public/_build/results?buildId=1903723&view=ms.vss-test-web.build-test-results-tab&runId=49501196&paneView=debug&resultId=120277

