### PR TITLE
Wrap Columns that are too long in the Console Table

### DIFF
--- a/src/Tools/dotnet-user-jwts/src/Helpers/ConsoleTable.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/ConsoleTable.cs
@@ -93,7 +93,6 @@ internal sealed class ConsoleTable
         builder.AppendLine(rowDivider);
         builder.AppendLine(columnHeaders);
 
-        // Call buildString() on formattedRows to wrap the items that are way too long
         var newFormattedRows = WriteTableContent(formattedRows, maxColumnLengths, rowDivider);
 
         builder.AppendLine(rowDivider);

--- a/src/Tools/dotnet-user-jwts/src/Helpers/ConsoleTable.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/ConsoleTable.cs
@@ -133,12 +133,13 @@ internal sealed class ConsoleTable
             for (var i = 0; i < rows.Count; i++)
             {
                 var updatedRow = rows[i];
-
                 var status = true;
+
                 while (status)
                 {
                     var outputRow = "";
                     var wroteAnything = false;
+
                     for (var j = 0; j < updatedRow.Count; j++)
                     {
                         outputRow = string.Concat(outputRow, " | ");


### PR DESCRIPTION
# Wrap the columns in the Console Table that are long

## Description
Fixed the issue where some columns were too long and overflowed

Fixes #42130

![image](https://user-images.githubusercontent.com/82739341/181637386-2504570f-ca8d-48c4-b0dc-16d9b5045441.png)

![image](https://user-images.githubusercontent.com/82739341/181637513-563f2fc7-707f-4965-a7f6-760729a14c34.png)
