### PR TITLE
[release/6.0] Add missing ConfigureAwait(false) to PolicyHttpMessageHandler

### DIFF
--- a/src/HttpClientFactory/Polly/src/PolicyHttpMessageHandler.cs
+++ b/src/HttpClientFactory/Polly/src/PolicyHttpMessageHandler.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Extensions.Http
                 disposable.Dispose();
             }
 
-            var result = await base.SendAsync(request, cancellationToken);
+            var result = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             request.Properties[PriorResponseKey] = result;
 


### PR DESCRIPTION
# Add missing ConfigureAwait(false) to PolicyHttpMessageHandler

Fixes a deadlock when using the `Microsoft.Extensions.Http.Polly` package in a Full Framework application.

## Description

There is a missing `ConfigureAwait(false)` in the `Microsoft.Extensions.Http.Polly` library, which when used on Full Framework applications can result in a deadlock. The fix is to add the missing `ConfigureAwait(false)`.

Fixes #42883

## Customer Impact

Deadlocks in customer code.

## Regression?

- [x] Yes
- [ ] No

Regressed in 6.0-rc2 from previous versions.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Adding a `ConfigureAwait(false)` which is a very safe change.

## Verification

- [ ] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A