### PR TITLE
Pin Microsoft.SourceBuild.Intermediate.source-build-externals

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -181,7 +181,7 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>34ea1351bdf2697d775e9145f59eb6df2741a084</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="7.0.0-alpha.1.22369.2">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="7.0.0-alpha.1.22369.2" Pinned="true">
       <Uri>https://github.com/dotnet/source-build-externals</Uri>
       <Sha>3a88d1dbd4557702aa2cb89d5f8bf927bb263a3b</Sha>
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />


### PR DESCRIPTION
Should stop our dashboard from showing this dependency as being out-of-date.

@MichaelSimons will this have any unexpected effects on source-build?