### PR TITLE
Observe exception instead of hanging in HTTP2 test

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -4775,10 +4775,10 @@ public class Http2StreamTests : Http2TestBase
         var clientTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var headers = new[]
         {
-                new KeyValuePair<string, string>(PseudoHeaderNames.Method, "GET"),
-                new KeyValuePair<string, string>(PseudoHeaderNames.Path, "/"),
-                new KeyValuePair<string, string>(PseudoHeaderNames.Scheme, "http"),
-            };
+            new KeyValuePair<string, string>(PseudoHeaderNames.Method, "GET"),
+            new KeyValuePair<string, string>(PseudoHeaderNames.Path, "/"),
+            new KeyValuePair<string, string>(PseudoHeaderNames.Scheme, "http"),
+        };
         await InitializeConnectionAsync(async context =>
         {
             try
@@ -4823,7 +4823,7 @@ public class Http2StreamTests : Http2TestBase
             withLength: 25,
             withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
             withStreamId: 1);
-        await WaitForStreamErrorAsync(1, Http2ErrorCode.INTERNAL_ERROR, expectedErrorMessage: null);
+        await Task.WhenAny(WaitForStreamErrorAsync(1, Http2ErrorCode.INTERNAL_ERROR, expectedErrorMessage: null), appTcs.Task).Unwrap();
 
         clientTcs.SetResult();
         await appTcs.Task;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -4823,6 +4823,7 @@ public class Http2StreamTests : Http2TestBase
             withLength: 25,
             withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
             withStreamId: 1);
+        // Stream should return an INTERNAL_ERROR. If there is an unexpected exception from app TCS instead, then throw it here to avoid timeout waiting for the stream error.
         await Task.WhenAny(WaitForStreamErrorAsync(1, Http2ErrorCode.INTERNAL_ERROR, expectedErrorMessage: null), appTcs.Task).Unwrap();
 
         clientTcs.SetResult();


### PR DESCRIPTION
Test failed once with
```
[0.018s] [Microsoft.AspNetCore.Server.Kestrel.Http2] [Verbose] Connection id "TestConnectionId" sending HEADERS frame for stream ID 1 with length 25 and flags END_STREAM, END_HEADERS.
[30.036s] [Microsoft.AspNetCore.Server.Kestrel.Core.Tests.Http2StreamTests] [Error] Test threw an exception.
System.TimeoutException: The operation has timed out.
   at Microsoft.AspNetCore.Testing.TaskExtensions.TimeoutAfter[T](Task`1 task, TimeSpan timeout, String filePath, Int32 lineNumber) in /_/src/Shared/TaskExtensions.cs:line 106
   at Microsoft.AspNetCore.Server.Kestrel.Core.Tests.Http2TestBase.ReceiveFrameAsync(UInt32 maxFrameSize) in /_/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs:line 1207
   at Microsoft.AspNetCore.Server.Kestrel.Core.Tests.Http2TestBase.WaitForStreamErrorAsync(Int32 expectedStreamId, Http2ErrorCode expectedErrorCode, String expectedErrorMessage) in /_/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs:line 1291
   at Microsoft.AspNetCore.Server.Kestrel.Core.Tests.Http2StreamTests.AbortAfterCompleteAsync_GETWithResponseBodyAndTrailers_ResetsAfterResponse() in /_/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs:line 4826
```
Looking into it I couldn't see a way for the test to fail, however I did note that an exception from the application would be swallowed and set the exception on a tcs, however the test code would hang because it's waiting for an Abort to be called on the connection, which may not occur if the application threw.

Fixing the code to now observe the exception (if there is one). Leaving unquarantined so if it fails again we'll have a hopefully better exception.