### PR TITLE
HTTP/3: QUIC address in use

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Connections.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Connections.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Connections.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Connections.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicLog.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicLog.cs
@@ -207,7 +207,7 @@ internal static partial class QuicLog
     [LoggerMessage(20, LogLevel.Debug, "QUIC listener starting with configured endpoint {listenEndPoint}.", EventName = "ConnectionListenerStarting")]
     public static partial void ConnectionListenerStarting(ILogger logger, IPEndPoint listenEndPoint);
 
-    [LoggerMessage(22, LogLevel.Debug, "QUIC listener aborted.", EventName = "ConnectionListenerAborted")]
+    [LoggerMessage(21, LogLevel.Debug, "QUIC listener aborted.", EventName = "ConnectionListenerAborted")]
     public static partial void ConnectionListenerAborted(ILogger logger, Exception exception);
 
     private static StreamType GetStreamType(QuicStreamContext streamContext) =>

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicLog.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicLog.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
 using System.Net.Security;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Logging;
@@ -202,6 +203,12 @@ internal static partial class QuicLog
 
     [LoggerMessage(19, LogLevel.Warning, $"{nameof(SslServerAuthenticationOptions)} must provide at least one application protocol using {nameof(SslServerAuthenticationOptions.ApplicationProtocols)}.", EventName = "ConnectionListenerApplicationProtocolsNotSpecified")]
     public static partial void ConnectionListenerApplicationProtocolsNotSpecified(ILogger logger);
+
+    [LoggerMessage(20, LogLevel.Debug, "QUIC listener starting with configured endpoint {listenEndPoint}.", EventName = "ConnectionListenerStarting")]
+    public static partial void ConnectionListenerStarting(ILogger logger, IPEndPoint listenEndPoint);
+
+    [LoggerMessage(22, LogLevel.Debug, "QUIC listener aborted.", EventName = "ConnectionListenerAborted")]
+    public static partial void ConnectionListenerAborted(ILogger logger, Exception exception);
 
     private static StreamType GetStreamType(QuicStreamContext streamContext) =>
         streamContext.CanRead && streamContext.CanWrite

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
@@ -146,6 +146,19 @@ public class QuicConnectionListenerTests : TestApplicationErrorLoggerLoggedTest
 
     [ConditionalFact]
     [MsQuicSupported]
+    public async Task BindAsync_ListenersSharePort_ThrowAddressInUse()
+    {
+        // Arrange
+        await using var connectionListener = await QuicTestHelpers.CreateConnectionListenerFactory(LoggerFactory);
+
+        // Act & Assert
+        var port = ((IPEndPoint)connectionListener.EndPoint).Port;
+
+        await Assert.ThrowsAsync<AddressInUseException>(() => QuicTestHelpers.CreateConnectionListenerFactory(LoggerFactory, port: port));
+    }
+
+    [ConditionalFact]
+    [MsQuicSupported]
     public async Task AcceptAsync_NoApplicationProtocolsInCallback_DefaultToConnectionProtocols()
     {
         // Arrange

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
@@ -154,7 +154,9 @@ public class QuicConnectionListenerTests : TestApplicationErrorLoggerLoggedTest
         // Act & Assert
         var port = ((IPEndPoint)connectionListener.EndPoint).Port;
 
-        await Assert.ThrowsAsync<AddressInUseException>(() => QuicTestHelpers.CreateConnectionListenerFactory(LoggerFactory, port: port));
+        // TODO - update to check for AddressInUseException when System.Net.Quic is updated to throw a descriptive error.
+        // See https://github.com/dotnet/aspnetcore/issues/43061
+        await Assert.ThrowsAsync<QuicException>(() => QuicTestHelpers.CreateConnectionListenerFactory(LoggerFactory, port: port));
     }
 
     [ConditionalFact]

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicTestHelpers.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicTestHelpers.cs
@@ -49,26 +49,29 @@ internal static class QuicTestHelpers
         ILoggerFactory loggerFactory = null,
         ISystemClock systemClock = null,
         bool clientCertificateRequired = false,
-        long defaultCloseErrorCode = 0)
+        long defaultCloseErrorCode = 0,
+        int port = 0)
     {
         var transportFactory = CreateTransportFactory(
             loggerFactory,
             systemClock,
             defaultCloseErrorCode: defaultCloseErrorCode);
 
-        // Use ephemeral port 0. OS will assign unused port.
-        var endpoint = new IPEndPoint(IPAddress.Loopback, 0);
+        var endpoint = new IPEndPoint(IPAddress.Parse("127.0.0.1"), port);
 
         var features = CreateBindAsyncFeatures(clientCertificateRequired);
         return (QuicConnectionListener)await transportFactory.BindAsync(endpoint, features, cancellationToken: CancellationToken.None);
     }
 
-    public static async Task<QuicConnectionListener> CreateConnectionListenerFactory(TlsConnectionCallbackOptions tlsConnectionOptions, ILoggerFactory loggerFactory = null, ISystemClock systemClock = null)
+    public static async Task<QuicConnectionListener> CreateConnectionListenerFactory(
+        TlsConnectionCallbackOptions tlsConnectionOptions,
+        ILoggerFactory loggerFactory = null,
+        ISystemClock systemClock = null,
+        int port = 0)
     {
         var transportFactory = CreateTransportFactory(loggerFactory, systemClock);
 
-        // Use ephemeral port 0. OS will assign unused port.
-        var endpoint = new IPEndPoint(IPAddress.Loopback, 0);
+        var endpoint = new IPEndPoint(IPAddress.Loopback, port);
 
         var features = new FeatureCollection();
         features.Set(tlsConnectionOptions);


### PR DESCRIPTION
Sockets listener throws this exception when address is already in use.