### PR TITLE
[release/6.0] Set WebApplication.New().ServerFeatures

### DIFF
--- a/src/DefaultBuilder/src/WebApplication.cs
+++ b/src/DefaultBuilder/src/WebApplication.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Builder
         internal WebApplication(IHost host)
         {
             _host = host;
-            ApplicationBuilder = new ApplicationBuilder(host.Services);
+            ApplicationBuilder = new ApplicationBuilder(host.Services, ServerFeatures);
             Logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger(Environment.ApplicationName);
 
             Properties[GlobalEndpointRouteBuilderKey] = this;

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -32,6 +32,16 @@ namespace Microsoft.AspNetCore.Tests
     public class WebApplicationTests
     {
         [Fact]
+        public async Task WebApplicationBuilder_New()
+        {
+            var builder = WebApplication.CreateBuilder(new string[] { "--urls", "http://localhost:5001" });
+
+            await using var app = builder.Build();
+            var newApp = (app as IApplicationBuilder).New();
+            Assert.NotNull(newApp.ServerFeatures);
+        }
+
+        [Fact]
         public async Task WebApplicationBuilderConfiguration_IncludesCommandLineArguments()
         {
             var builder = WebApplication.CreateBuilder(new string[] { "--urls", "http://localhost:5001" });
@@ -1696,13 +1706,13 @@ namespace Microsoft.AspNetCore.Tests
                 createdDirectory = true;
                 Directory.CreateDirectory(wwwroot);
             }
-    
+
             try
             {
                 var builder = WebApplication.CreateBuilder();
-    
+
                 builder.WebHost.ConfigureAppConfiguration((ctx, config) => { });
-    
+
                 using var app = builder.Build();
                 var hostEnv = app.Services.GetRequiredService<Hosting.IWebHostEnvironment>();
                 Assert.Equal(wwwroot, hostEnv.WebRootPath);


### PR DESCRIPTION
# [release/6.0] Set WebApplication.New().ServerFeatures
Backport https://github.com/dotnet/aspnetcore/pull/40183 to release/6.0.

Fixes #42959 

## Customer Impact

When using minimal APIs in ASP.NET Core 6, after creating a new application from the existing app, the `ServerFeatures` property of the new application is null.

We fixed this in 7 but never backported it as there is a workaround available. We've since had [another report](https://github.com/dotnet/aspnetcore/issues/42959) of it, and the cost/risk of the fix is so small that we think it's worth just fixing in 6.

## Regression?

- [ ] Yes
- [x] No


## Risk

- [ ] High
- [ ] Medium
- [x] Low

## Verification

- [x] Manual
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
