### PR TITLE
HTTP/3: Fix per-request context allocation, QuicStream.DisposeAsync

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -498,18 +498,17 @@ internal partial class QuicStreamContext : TransportConnection, IPooledStream, I
         var resolvedErrorCode = _error ?? 0;
         QuicLog.StreamAbort(_log, this, resolvedErrorCode, abortReason.Message);
 
-        lock (_shutdownLock)
+        // Make local copy of reference to avoid possibility of race with stream being set to null in dispose.
+        var stream = _stream;
+        if (stream != null)
         {
-            if (_stream != null)
+            if (stream.CanRead)
             {
-                if (_stream.CanRead)
-                {
-                    _stream.Abort(QuicAbortDirection.Read, resolvedErrorCode);
-                }
-                if (_stream.CanWrite)
-                {
-                    _stream.Abort(QuicAbortDirection.Write, resolvedErrorCode);
-                }
+                stream.Abort(QuicAbortDirection.Read, resolvedErrorCode);
+            }
+            if (stream.CanWrite)
+            {
+                stream.Abort(QuicAbortDirection.Write, resolvedErrorCode);
             }
         }
 

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -566,15 +566,17 @@ internal partial class QuicStreamContext : TransportConnection, IPooledStream, I
                 && !_serverAborted
                 && _shutdownReadReason == null
                 && _shutdownWriteReason == null;
-
-            if (!CanReuse)
-            {
-                DisposeCore();
-            }
-
-            _stream.Dispose();
-            _stream = null!;
         }
+
+        if (!CanReuse)
+        {
+            DisposeCore();
+        }
+
+        await _stream.DisposeAsync();
+
+        // QuicStream can't be reused. Don't hang onto it when QuicStreamContext it potentially cached.
+        _stream = null!;
     }
 
     public void Dispose()

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -712,65 +712,77 @@ public class Http3RequestTests : LoggedTest
     public async Task GET_MultipleRequests_RequestVersionOrHigher_UpgradeToHttp3()
     {
         // Arrange
-        var requestHeaders = new List<Dictionary<string, StringValues>>();
-
-        var builder = CreateHostBuilder(context =>
+        await ServerRetryHelper.BindPortsWithRetry(async port =>
         {
-            requestHeaders.Add(context.Request.Headers.ToDictionary(k => k.Key, k => k.Value, StringComparer.OrdinalIgnoreCase));
-            return Task.CompletedTask;
-        }, HttpProtocols.Http1AndHttp2AndHttp3);
+            var requestHeaders = new List<Dictionary<string, StringValues>>();
 
-        using (var host = builder.Build())
-        using (var client = HttpHelpers.CreateClient())
-        {
-            await host.StartAsync();
+            var builder = CreateHostBuilder(
+                context =>
+                {
+                    requestHeaders.Add(context.Request.Headers.ToDictionary(k => k.Key, k => k.Value, StringComparer.OrdinalIgnoreCase));
+                    return Task.CompletedTask;
+                },
+                configureKestrel: o =>
+                {
+                    o.Listen(IPAddress.Parse("127.0.0.1"), port, listenOptions =>
+                    {
+                        listenOptions.Protocols = HttpProtocols.Http1AndHttp2AndHttp3;
+                        listenOptions.UseHttps();
+                    });
+                });
 
-            // Act 1
-            var request1 = new HttpRequestMessage(HttpMethod.Get, $"https://127.0.0.1:{host.GetPort()}/");
-            request1.Headers.Add("id", "1");
-            request1.VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+            using (var host = builder.Build())
+            using (var client = HttpHelpers.CreateClient())
+            {
+                await host.StartAsync();
 
-            var response1 = await client.SendAsync(request1, CancellationToken.None);
-            response1.EnsureSuccessStatusCode();
-            var request1Headers = requestHeaders.Single(i => i["id"] == "1");
+                // Act 1
+                var request1 = new HttpRequestMessage(HttpMethod.Get, $"https://127.0.0.1:{host.GetPort()}/");
+                request1.Headers.Add("id", "1");
+                request1.VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
 
-            // Assert 1
-            Assert.Equal(HttpVersion.Version20, response1.Version);
-            Assert.False(request1Headers.ContainsKey("alt-used"));
+                var response1 = await client.SendAsync(request1, CancellationToken.None);
+                response1.EnsureSuccessStatusCode();
+                var request1Headers = requestHeaders.Single(i => i["id"] == "1");
 
-            // Act 2
-            var request2 = new HttpRequestMessage(HttpMethod.Get, $"https://127.0.0.1:{host.GetPort()}/");
-            request2.Headers.Add("id", "2");
-            request2.VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+                // Assert 1
+                Assert.Equal(HttpVersion.Version20, response1.Version);
+                Assert.False(request1Headers.ContainsKey("alt-used"));
 
-            var response2 = await client.SendAsync(request2, CancellationToken.None);
-            response2.EnsureSuccessStatusCode();
-            var request2Headers = requestHeaders.Single(i => i["id"] == "2");
+                // Act 2
+                var request2 = new HttpRequestMessage(HttpMethod.Get, $"https://127.0.0.1:{host.GetPort()}/");
+                request2.Headers.Add("id", "2");
+                request2.VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
 
-            // Assert 2
-            Assert.Equal(HttpVersion.Version30, response2.Version);
-            Assert.True(request2Headers.ContainsKey("alt-used"));
+                var response2 = await client.SendAsync(request2, CancellationToken.None);
+                response2.EnsureSuccessStatusCode();
+                var request2Headers = requestHeaders.Single(i => i["id"] == "2");
 
-            // Delay to ensure the stream has enough time to return to pool
-            await Task.Delay(100);
+                // Assert 2
+                Assert.Equal(HttpVersion.Version30, response2.Version);
+                Assert.True(request2Headers.ContainsKey("alt-used"));
 
-            // Act 3
-            var request3 = new HttpRequestMessage(HttpMethod.Get, $"https://127.0.0.1:{host.GetPort()}/");
-            request3.Headers.Add("id", "3");
-            request3.VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+                // Delay to ensure the stream has enough time to return to pool
+                await Task.Delay(100);
 
-            var response3 = await client.SendAsync(request3, CancellationToken.None);
-            response3.EnsureSuccessStatusCode();
-            var request3Headers = requestHeaders.Single(i => i["id"] == "3");
+                // Act 3
+                var request3 = new HttpRequestMessage(HttpMethod.Get, $"https://127.0.0.1:{host.GetPort()}/");
+                request3.Headers.Add("id", "3");
+                request3.VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
 
-            // Assert 3
-            Assert.Equal(HttpVersion.Version30, response3.Version);
-            Assert.True(request3Headers.ContainsKey("alt-used"));
+                var response3 = await client.SendAsync(request3, CancellationToken.None);
+                response3.EnsureSuccessStatusCode();
+                var request3Headers = requestHeaders.Single(i => i["id"] == "3");
 
-            Assert.Same((string)request2Headers["alt-used"], (string)request3Headers["alt-used"]);
+                // Assert 3
+                Assert.Equal(HttpVersion.Version30, response3.Version);
+                Assert.True(request3Headers.ContainsKey("alt-used"));
 
-            await host.StopAsync();
-        }
+                Assert.Same((string)request2Headers["alt-used"], (string)request3Headers["alt-used"]);
+
+                await host.StopAsync();
+            }
+        }, Logger);
     }
 
     // Verify HTTP/2 and HTTP/3 match behavior


### PR DESCRIPTION
WebTransport changes started allocating context for every request.
QuicStream.Dispose just calls DisposeAsync but blocks. Call DisposeAsync directly.