### PR TITLE
HTTP/3: Support QUIC idle timeout more cleanly

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -713,4 +713,7 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="NonzeroContentLengthNotAllowedOn205" xml:space="preserve">
     <value>Responses with status code 205 cannot have a non-zero Content-Length value.</value>
   </data>
+  <data name="Http3ErrorControlStreamClosed" xml:space="preserve">
+    <value>A control stream used by the connection was closed or reset.</value>
+  </data>
 </root>

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -311,7 +311,7 @@ internal sealed class Http3Connection : IHttp3StreamLifetimeHandler, IRequestPro
                     {
                         // Cancel connection to be consistent with other data rate limits.
                         Log.ResponseMinimumDataRateNotSatisfied(_context.ConnectionId, stream.TraceIdentifier);
-                        Abort(new ConnectionAbortedException(CoreStrings.ConnectionTimedBecauseResponseMininumDataRateNotSatisfied), Http3ErrorCode.InternalError);
+                        OnStreamConnectionError(new Http3ConnectionErrorException(CoreStrings.ConnectionTimedBecauseResponseMininumDataRateNotSatisfied, Http3ErrorCode.InternalError));
                     }
                 }
             }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -198,7 +198,49 @@ internal sealed class Http3Connection : IHttp3StreamLifetimeHandler, IRequestPro
             return;
         }
 
+        ValidateOpenControlStreams(now);
         UpdateStreamTimeouts(now);
+    }
+
+    private void ValidateOpenControlStreams(DateTimeOffset now)
+    {
+        var ticks = now.Ticks;
+
+        // This method validates that a connnection's control streams are open.
+        //
+        // They're checked on a delayed timer because when a connection is aborted or timed out, notifications are sent to open streams
+        // and the connection simultaneously. This is a problem because when a control stream is closed the connection should be aborted
+        // with the H3_CLOSED_CRITICAL_STREAM status. There is a race between the connection closing for the real reason, and control
+        // streams closing the connection with H3_CLOSED_CRITICAL_STREAM.
+        //
+        // Realistically, control streams are never closed except when the connection is. A small delay in aborting the connection in the
+        // unlikely situation where a control stream is incorrectly closed should be fine.
+        ValidateOpenControlStream(OutboundControlStream, this, ticks);
+        ValidateOpenControlStream(ControlStream, this, ticks);
+        ValidateOpenControlStream(EncoderStream, this, ticks);
+        ValidateOpenControlStream(DecoderStream, this, ticks);
+
+        static void ValidateOpenControlStream(Http3ControlStream? stream, Http3Connection connection, long ticks)
+        {
+            if (stream != null)
+            {
+                if (stream.IsCompleted || stream.IsAborted || stream.EndStreamReceived)
+                {
+                    // If a control stream is no longer active then set a timeout so that the connection is aborted next tick.
+                    if (stream.StreamTimeoutTicks == default)
+                    {
+                        // On overflow, use max value.
+                        var connectionCloseTicks = ticks + (TimeSpan.TicksPerSecond / 2);
+                        stream.StreamTimeoutTicks = connectionCloseTicks >= 0 ? connectionCloseTicks : long.MaxValue;
+                    }
+
+                    if (stream.StreamTimeoutTicks < ticks)
+                    {
+                        connection.Abort(new ConnectionAbortedException("A control stream used by the connection was closed or reset."), Http3ErrorCode.ClosedCriticalStream);
+                    }
+                }
+            }
+        }
     }
 
     private void UpdateStreamTimeouts(DateTimeOffset now)

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
@@ -59,8 +59,8 @@ internal abstract class Http3ControlStream : IHttp3Stream, IThreadPoolWorkItem
 
     private void OnStreamClosed()
     {
-        Abort(new ConnectionAbortedException("HTTP_CLOSED_CRITICAL_STREAM"), Http3ErrorCode.InternalError);
-        _connectionClosed = true;
+        //Abort(new ConnectionAbortedException("HTTP_CLOSED_CRITICAL_STREAM"), Http3ErrorCode.ClosedCriticalStream);
+        //_connectionClosed = true;
     }
 
     public PipeReader Input => _context.Transport.Input;

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3ControlStream.cs
@@ -59,6 +59,9 @@ internal abstract class Http3ControlStream : IHttp3Stream, IThreadPoolWorkItem
 
     private void OnStreamClosed()
     {
+        _connectionClosed = true;
+        _connectionClosed = false;
+
         //Abort(new ConnectionAbortedException("HTTP_CLOSED_CRITICAL_STREAM"), Http3ErrorCode.ClosedCriticalStream);
         //_connectionClosed = true;
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -62,8 +62,8 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
     protected readonly Http3RawFrame _incomingFrame = new();
 
     public bool EndStreamReceived => (_completionState & StreamCompletionFlags.EndStreamReceived) == StreamCompletionFlags.EndStreamReceived;
-    private bool IsAborted => (_completionState & StreamCompletionFlags.Aborted) == StreamCompletionFlags.Aborted;
-    private bool IsCompleted => (_completionState & StreamCompletionFlags.Completed) == StreamCompletionFlags.Completed;
+    public bool IsAborted => (_completionState & StreamCompletionFlags.Aborted) == StreamCompletionFlags.Aborted;
+    public bool IsCompleted => (_completionState & StreamCompletionFlags.Completed) == StreamCompletionFlags.Completed;
 
     public Pipe RequestBodyPipe { get; private set; } = default!;
     public long? InputRemaining { get; internal set; }
@@ -1230,16 +1230,6 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
         Status = 0x10,
         Protocol = 0x20,
         Unknown = 0x40000000
-    }
-
-    [Flags]
-    private enum StreamCompletionFlags
-    {
-        None = 0,
-        EndStreamReceived = 1,
-        AbortedRead = 2,
-        Aborted = 4,
-        Completed = 8,
     }
 
     private static class GracefulCloseInitiator

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/IHttp3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/IHttp3Stream.cs
@@ -36,6 +36,10 @@ internal interface IHttp3Stream
 
     bool IsRequestStream { get; }
 
+    bool EndStreamReceived { get; }
+    bool IsAborted { get; }
+    bool IsCompleted { get; }
+
     string TraceIdentifier { get; }
 
     void Abort(ConnectionAbortedException abortReason, Http3ErrorCode errorCode);

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/StreamCompletionFlags.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/StreamCompletionFlags.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
+
+[Flags]
+internal enum StreamCompletionFlags
+{
+    None = 0,
+    EndStreamReceived = 1,
+    AbortedRead = 2,
+    Aborted = 4,
+    Completed = 8,
+}

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicLog.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicLog.cs
@@ -210,7 +210,6 @@ internal static partial class QuicLog
     [LoggerMessage(21, LogLevel.Debug, "QUIC listener aborted.", EventName = "ConnectionListenerAborted")]
     public static partial void ConnectionListenerAborted(ILogger logger, Exception exception);
 
-
     [LoggerMessage(22, LogLevel.Debug, @"Stream id ""{ConnectionId}"" read timed out.", EventName = "StreamTimeoutRead", SkipEnabledCheck = true)]
     private static partial void StreamTimeoutReadCore(ILogger logger, string connectionId);
 

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicLog.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicLog.cs
@@ -120,7 +120,7 @@ internal static partial class QuicLog
         }
     }
 
-    [LoggerMessage(11, LogLevel.Debug, @"Stream id ""{ConnectionId}"" read aborted by peer with error code {ErrorCode}.", EventName = "StreamAborted", SkipEnabledCheck = true)]
+    [LoggerMessage(11, LogLevel.Debug, @"Stream id ""{ConnectionId}"" read aborted by peer with error code {ErrorCode}.", EventName = "StreamAbortedRead", SkipEnabledCheck = true)]
     private static partial void StreamAbortedReadCore(ILogger logger, string connectionId, long errorCode);
 
     public static void StreamAbortedRead(ILogger logger, QuicStreamContext streamContext, long errorCode)
@@ -131,7 +131,7 @@ internal static partial class QuicLog
         }
     }
 
-    [LoggerMessage(12, LogLevel.Debug, @"Stream id ""{ConnectionId}"" write aborted by peer with error code {ErrorCode}.", EventName = "StreamAborted", SkipEnabledCheck = true)]
+    [LoggerMessage(12, LogLevel.Debug, @"Stream id ""{ConnectionId}"" write aborted by peer with error code {ErrorCode}.", EventName = "StreamAbortedWrite", SkipEnabledCheck = true)]
     private static partial void StreamAbortedWriteCore(ILogger logger, string connectionId, long errorCode);
 
     public static void StreamAbortedWrite(ILogger logger, QuicStreamContext streamContext, long errorCode)
@@ -209,6 +209,29 @@ internal static partial class QuicLog
 
     [LoggerMessage(21, LogLevel.Debug, "QUIC listener aborted.", EventName = "ConnectionListenerAborted")]
     public static partial void ConnectionListenerAborted(ILogger logger, Exception exception);
+
+
+    [LoggerMessage(22, LogLevel.Debug, @"Stream id ""{ConnectionId}"" read timed out.", EventName = "StreamTimeoutRead", SkipEnabledCheck = true)]
+    private static partial void StreamTimeoutReadCore(ILogger logger, string connectionId);
+
+    public static void StreamTimeoutRead(ILogger logger, QuicStreamContext streamContext)
+    {
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            StreamTimeoutReadCore(logger, streamContext.ConnectionId);
+        }
+    }
+
+    [LoggerMessage(23, LogLevel.Debug, @"Stream id ""{ConnectionId}"" write timed out.", EventName = "StreamTimeoutWrite", SkipEnabledCheck = true)]
+    private static partial void StreamTimeoutWriteCore(ILogger logger, string connectionId);
+
+    public static void StreamTimeoutWrite(ILogger logger, QuicStreamContext streamContext)
+    {
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            StreamTimeoutWriteCore(logger, streamContext.ConnectionId);
+        }
+    }
 
     private static StreamType GetStreamType(QuicStreamContext streamContext) =>
         streamContext.CanRead && streamContext.CanWrite

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicStreamContext.cs
@@ -270,7 +270,7 @@ internal partial class QuicStreamContext : TransportConnection, IPooledStream, I
                 }
             }
         }
-        catch (QuicException ex) when (ex.QuicError == QuicError.StreamAborted)
+        catch (QuicException ex) when (ex.QuicError is QuicError.StreamAborted or QuicError.ConnectionAborted)
         {
             // Abort from peer.
             _error = ex.ApplicationErrorCode;
@@ -281,18 +281,15 @@ internal partial class QuicStreamContext : TransportConnection, IPooledStream, I
 
             _clientAbort = true;
         }
-        catch (QuicException ex) when (ex.QuicError == QuicError.ConnectionAborted)
+        catch (QuicException ex) when (ex.QuicError is QuicError.ConnectionIdle)
         {
-            // Abort from peer.
-            _error = ex.ApplicationErrorCode;
-            QuicLog.StreamAbortedRead(_log, this, ex.ApplicationErrorCode.GetValueOrDefault());
+            // Abort from timeout.
+            QuicLog.StreamTimeoutRead(_log, this);
 
             // This could be ignored if _shutdownReason is already set.
             error = new ConnectionResetException(ex.Message, ex);
-
-            _clientAbort = true;
         }
-        catch (QuicException ex) when (ex.QuicError == QuicError.OperationAborted)
+        catch (QuicException ex) when (ex.QuicError is QuicError.OperationAborted)
         {
             // AbortRead has been called for the stream.
             error = new ConnectionAbortedException(ex.Message, ex);
@@ -434,7 +431,7 @@ internal partial class QuicStreamContext : TransportConnection, IPooledStream, I
                 }
             }
         }
-        catch (QuicException ex) when (ex.QuicError == QuicError.StreamAborted)
+        catch (QuicException ex) when (ex.QuicError is QuicError.StreamAborted or QuicError.ConnectionAborted)
         {
             // Abort from peer.
             _error = ex.ApplicationErrorCode;
@@ -445,18 +442,15 @@ internal partial class QuicStreamContext : TransportConnection, IPooledStream, I
 
             _clientAbort = true;
         }
-        catch (QuicException ex) when (ex.QuicError == QuicError.ConnectionAborted)
+        catch (QuicException ex) when (ex.QuicError is QuicError.ConnectionIdle)
         {
-            // Abort from peer.
-            _error = ex.ApplicationErrorCode;
-            QuicLog.StreamAbortedWrite(_log, this, ex.ApplicationErrorCode.GetValueOrDefault());
+            // Abort from timeout.
+            QuicLog.StreamTimeoutWrite(_log, this);
 
             // This could be ignored if _shutdownReason is already set.
             shutdownReason = new ConnectionResetException(ex.Message, ex);
-
-            _clientAbort = true;
         }
-        catch (QuicException ex) when (ex.QuicError == QuicError.OperationAborted)
+        catch (QuicException ex) when (ex.QuicError is QuicError.OperationAborted)
         {
             // AbortWrite has been called for the stream.
             // Possibily might also get here from connection closing.

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -174,7 +174,7 @@ internal class Http3InMemory
         }
     }
 
-    internal void AssertConnectionError<TException>(Http3ErrorCode expectedErrorCode, Action<Type, string[]> matchExpectedErrorMessage = null, params string[] expectedErrorMessage) where TException : Exception
+    private void AssertConnectionError<TException>(Http3ErrorCode expectedErrorCode, Action<Type, string[]> matchExpectedErrorMessage = null, params string[] expectedErrorMessage) where TException : Exception
     {
         var currentError = (Http3ErrorCode)MultiplexedConnectionContext.Error;
         if (currentError != expectedErrorCode)
@@ -1276,5 +1276,16 @@ internal class TestStreamContext : ConnectionContext, IStreamDirectionFeature, I
             _onClosed = new List<CloseAction>();
         }
         _onClosed.Add(new CloseAction(callback, state));
+    }
+
+    public void Close()
+    {
+        if (_onClosed != null)
+        {
+            foreach (var onClose in _onClosed)
+            {
+                onClose.Callback(onClose.State);
+            }
+        }
     }
 }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -2105,6 +2105,7 @@ public class Http3StreamTests : Http3TestBase
             ignoreNonGoAwayFrames: true,
             expectedLastStreamId: 4,
             expectedErrorCode: Http3ErrorCode.UnexpectedFrame,
+            matchExpectedErrorMessage: AssertExpectedErrorMessages,
             expectedErrorMessage: CoreStrings.FormatHttp3ErrorUnsupportedFrameOnRequestStream(Http3Formatting.ToFormattedType(f)));
     }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TimeoutTests.cs
@@ -306,7 +306,7 @@ public class Http3TimeoutTests : Http3TestBase
 
         requestStream.StartStreamDisposeTcs.TrySetResult();
 
-        await Http3Api.WaitForConnectionErrorAsync<ConnectionAbortedException>(
+        await Http3Api.WaitForConnectionErrorAsync<Http3ConnectionErrorException>(
             ignoreNonGoAwayFrames: false,
             expectedLastStreamId: 4,
             Http3ErrorCode.InternalError,

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TimeoutTests.cs
@@ -310,6 +310,7 @@ public class Http3TimeoutTests : Http3TestBase
             ignoreNonGoAwayFrames: false,
             expectedLastStreamId: 4,
             Http3ErrorCode.InternalError,
+            matchExpectedErrorMessage: AssertExpectedErrorMessages,
             expectedErrorMessage: CoreStrings.ConnectionTimedBecauseResponseMininumDataRateNotSatisfied);
 
         Assert.Contains(TestSink.Writes, w => w.EventId.Name == "ResponseMinimumDataRateNotSatisfied");


### PR DESCRIPTION
* An HTTP/3 connection that ends because of an idle timeout logs a number of messy exception details. Look for idle exceptions and make logs cleaner.
* Delay aborting connection with critical stream closed. Avoids race between connection and stream closing.