### PR TITLE
Add missing "Blazor" project type tag for empty Blazor project templates

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyBlazorServerWeb-CSharp/.template.config/ide.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyBlazorServerWeb-CSharp/.template.config/ide.host.json
@@ -7,7 +7,7 @@
   "tags": [
     {
       "type": "projectType",
-      "add": [ "Cloud", "Web" ],
+      "add": [ "Blazor", "Cloud", "Web" ],
       "remove": [ "*" ]
     },
     {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/.template.config/ide.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/.template.config/ide.host.json
@@ -18,7 +18,7 @@
   "tags": [
     {
       "type": "projectType",
-      "add": [ "Cloud", "Web" ],
+      "add": [ "Blazor", "Cloud", "Web" ],
       "remove": [ "*" ]
     },
     {


### PR DESCRIPTION
This adds the "Blazor" project type tag for all Blazor templates in the new project dialog in Visual Studio. This was initially missing for both `Blazor Server App Empty` and `Blazor WebAssembly App Empty`.

![image](https://user-images.githubusercontent.com/59468977/182432364-38b0ef15-6450-4ca6-bc3d-51d5146ccdd1.png)

Fixes https://github.com/aspnet/AspNetCore-ManualTests/issues/1526