### PR TITLE
Add RateLimiting libraries to SharedFx

### DIFF
--- a/eng/SharedFramework.External.props
+++ b/eng/SharedFramework.External.props
@@ -42,6 +42,7 @@
     <ExternalAspNetCoreAppReference Include="Microsoft.Extensions.Primitives"                              Version="$(MicrosoftExtensionsPrimitivesVersion)" />
     <ExternalAspNetCoreAppReference Include="System.IO.Pipelines"                                          Version="$(SystemIOPipelinesVersion)" />
     <ExternalAspNetCoreAppReference Include="System.Security.Cryptography.Xml"                             Version="$(SystemSecurityCryptographyXmlVersion)" />
+    <ExternalAspNetCoreAppReference Include="System.Threading.RateLimiting"                                Version="$(SystemThreadingRateLimitingVersion)" />
 
     <!--
       Transitive dependencies of other assemblies in the shared framework. These are listed separately and should not be included directly

--- a/eng/SharedFramework.Local.props
+++ b/eng/SharedFramework.Local.props
@@ -18,6 +18,7 @@
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.Extensions.Identity.Stores" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Connections.Abstractions" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Authorization" />
+    <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.RateLimiting" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Http.Connections.Common" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.SignalR.Protocols.Json" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.SignalR.Common" />

--- a/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
+++ b/src/Framework/App.Ref/src/Microsoft.AspNetCore.App.Ref.csproj
@@ -158,7 +158,8 @@ This package is an internal implementation of the .NET Core SDK and is not meant
             @(ReferencePathWithRefAssemblies->WithMetadataValue('Filename', 'System.Diagnostics.EventLog'));
             @(ReferencePathWithRefAssemblies->WithMetadataValue('Filename', 'System.IO.Pipelines'));
             @(ReferencePathWithRefAssemblies->WithMetadataValue('Filename', 'System.Security.Cryptography.Pkcs'));
-            @(ReferencePathWithRefAssemblies->WithMetadataValue('Filename', 'System.Security.Cryptography.Xml'))" />
+            @(ReferencePathWithRefAssemblies->WithMetadataValue('Filename', 'System.Security.Cryptography.Xml'));
+            @(ReferencePathWithRefAssemblies->WithMetadataValue('Filename', 'System.Threading.RateLimiting'))"/>
 
       <AspNetCoreReferenceAssemblyPath
           Include="@(_ReferencedRuntimeRefAssemblies->'$(RuntimeTransportReferenceDirectory)%(FileName)%(Extension)')" />

--- a/src/Framework/test/TestData.cs
+++ b/src/Framework/test/TestData.cs
@@ -74,6 +74,7 @@ public static class TestData
                 "Microsoft.AspNetCore.Mvc.TagHelpers",
                 "Microsoft.AspNetCore.Mvc.ViewFeatures",
                 "Microsoft.AspNetCore.OutputCaching",
+                "Microsoft.AspNetCore.RateLimiting",
                 "Microsoft.AspNetCore.Razor",
                 "Microsoft.AspNetCore.Razor.Runtime",
                 "Microsoft.AspNetCore.RequestDecompression",
@@ -149,6 +150,7 @@ public static class TestData
                 "System.IO.Pipelines",
                 "System.Security.Cryptography.Pkcs",
                 "System.Security.Cryptography.Xml",
+                "System.Threading.RateLimiting",
             };
 
         ListedTargetingPackAssemblies = new SortedDictionary<string, string>
@@ -211,6 +213,7 @@ public static class TestData
                 { "Microsoft.AspNetCore.Mvc.TagHelpers", "7.0.0.0" },
                 { "Microsoft.AspNetCore.Mvc.ViewFeatures", "7.0.0.0" },
                 { "Microsoft.AspNetCore.OutputCaching", "7.0.0.0" },
+                { "Microsoft.AspNetCore.RateLimiting", "7.0.0.0" },
                 { "Microsoft.AspNetCore.Razor", "7.0.0.0" },
                 { "Microsoft.AspNetCore.Razor.Runtime", "7.0.0.0" },
                 { "Microsoft.AspNetCore.RequestDecompression", "7.0.0.0" },
@@ -284,6 +287,7 @@ public static class TestData
                 { "System.Diagnostics.EventLog", "7.0.0.0" },
                 { "System.IO.Pipelines", "7.0.0.0" },
                 { "System.Security.Cryptography.Xml", "7.0.0.0" },
+                { "System.Threading.RateLimiting", "7.0.0.0" },
             };
 
         if (!VerifyAncmBinary())

--- a/src/Middleware/RateLimiting/src/Microsoft.AspNetCore.RateLimiting.csproj
+++ b/src/Middleware/RateLimiting/src/Microsoft.AspNetCore.RateLimiting.csproj
@@ -6,6 +6,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>
     <IsTrimmable>true</IsTrimmable>
+    <IsAspNetCoreApp>true</IsAspNetCoreApp>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds `Microsoft.AspNetCore.RateLimiting` and `System.Threading.RateLimiting` to the Shared Framework. `System.Threading.RateLimiting` (from dotnet/runtime) is needed because it isn't included in `Microsoft.NetCore.App`.