### PR TITLE
Remove IsAvailable check on CommitAsync.

### DIFF
--- a/src/Middleware/Session/src/DistributedSession.cs
+++ b/src/Middleware/Session/src/DistributedSession.cs
@@ -262,12 +262,6 @@ public class DistributedSession : ISession
     /// <inheritdoc />
     public async Task CommitAsync(CancellationToken cancellationToken = default)
     {
-        if (!IsAvailable)
-        {
-            _logger.SessionNotAvailable();
-            return;
-        }
-
         using (var timeout = new CancellationTokenSource(_ioTimeout))
         {
             var cts = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellationToken);


### PR DESCRIPTION
Fix https://github.com/dotnet/aspnetcore/issues/42009

I did some archaeology into how we ended up adding this check. I _think_ (but am not certain yet) this was added because [one of the incremental states](https://github.com/dotnet/aspnetcore/pull/26098/commits/12d5f37b3725d46bed4dd40a1ae32e88f73cbe14#diff-143902782fe943cbff15b8d422e2996896dfef96590ff2b7058bc50056322544L126) of #26098 had a null-forgiving operator on the `IdBytes` getter. `IdBytes` could return null if `IsAvailable` wasn't set.

This led to the addition of the `if (!IsAvailable)` check in `Serialize` which was subsequently moved to `CommitAsync` based on [this comment](https://github.com/dotnet/aspnetcore/pull/26098/#discussion_r508667599).

However, the `IdBytes` getter was changed to make its result non-null:

https://github.com/dotnet/aspnetcore/blob/bf02bf2325f4752dd8a28c17d420e01961219f91/src/Middleware/Session/src/DistributedSession.cs#L119-L131

Assuming this was the concern that led to the `IsAvailable` check being added to `CommitAsync`, I think we're okay to remove it. I'd like another pair of eyes on this though.