### PR TITLE
HTTP/3: Fix accepting simultaneous connections

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
@@ -60,7 +60,6 @@ internal sealed class QuicConnectionListener : IMultiplexedConnectionListener, I
                 // Create the connection context inside the callback because it's passed
                 // to the connection callback. The field is then read once AcceptConnectionAsync
                 // finishes awaiting.
-                this._log.LogWarning("IN CALLBACK");
                 var currentAcceptingConnection = new QuicConnectionContext(connection, _context);
                 _pendingConnections.Add(connection, currentAcceptingConnection);
 

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
@@ -21,9 +21,9 @@ internal sealed class QuicConnectionListener : IMultiplexedConnectionListener, I
     private readonly TlsConnectionCallbackOptions _tlsConnectionCallbackOptions;
     private readonly QuicTransportContext _context;
     private readonly QuicListenerOptions _quicListenerOptions;
+    private readonly ConditionalWeakTable<QuicConnection, QuicConnectionContext> _pendingConnections;
     private bool _disposed;
     private QuicListener? _listener;
-    private ConditionalWeakTable<QuicConnection, QuicConnectionContext> _pendingConnections;
 
     public QuicConnectionListener(
         QuicTransportOptions options,

--- a/src/Servers/Kestrel/Transport.Quic/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests.csproj
+++ b/src/Servers/Kestrel/Transport.Quic/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)NullScope.cs" />
     <Compile Include="$(SharedSourceRoot)HttpClient\HttpEventSourceListener.cs" Link="shared\HttpEventSourceListener.cs" />
+    <Compile Include="$(SharedSourceRoot)SyncPoint\SyncPoint.cs" Link="SyncPoint.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TestResources.cs" Link="shared\TestResources.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\StreamExtensions.cs" Link="shared\StreamExtensions.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\KestrelTestLoggerProvider.cs" Link="shared\KestrelTestLoggerProvider.cs" />

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
@@ -163,14 +163,112 @@ public class QuicConnectionListenerTests : TestApplicationErrorLoggerLoggedTest
             LoggerFactory);
 
         // Act
-        var acceptTask = connectionListener.AcceptAndAddFeatureAsync().DefaultTimeout();
+        var acceptTask = connectionListener.AcceptAndAddFeatureAsync();
 
         var options = QuicTestHelpers.CreateClientConnectionOptions(connectionListener.EndPoint);
 
         await using var clientConnection = await QuicConnection.ConnectAsync(options).DefaultTimeout();
+        await using var serverConnection = await acceptTask.DefaultTimeout();
 
         // Assert
         Assert.Equal(SslApplicationProtocol.Http3, clientConnection.NegotiatedApplicationProtocol);
+        Assert.NotNull(serverConnection);
+    }
+
+    [ConditionalFact]
+    [MsQuicSupported]
+    public async Task AcceptAsync_Success_RemovedFromPendingConnections()
+    {
+        // Arrange
+        var syncPoint = new SyncPoint();
+
+        await using var connectionListener = await QuicTestHelpers.CreateConnectionListenerFactory(
+            new TlsConnectionCallbackOptions
+            {
+                ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http3 },
+                OnConnection = async (context, cancellationToken) =>
+                {
+                    await syncPoint.WaitToContinue();
+
+                    var options = new SslServerAuthenticationOptions();
+                    options.ServerCertificate = TestResources.GetTestCertificate();
+                    return options;
+                }
+            },
+            LoggerFactory);
+
+        // Act
+        var acceptTask = connectionListener.AcceptAndAddFeatureAsync();
+
+        var options = QuicTestHelpers.CreateClientConnectionOptions(connectionListener.EndPoint);
+
+        var clientConnectionTask = QuicConnection.ConnectAsync(options);
+
+        await syncPoint.WaitForSyncPoint().DefaultTimeout();
+        Assert.Single(connectionListener._pendingConnections);
+
+        syncPoint.Continue();
+
+        await using var serverConnection = await acceptTask.DefaultTimeout();
+        await using var clientConnection = await clientConnectionTask.DefaultTimeout();
+
+        // Assert
+        Assert.NotNull(serverConnection);
+        Assert.NotNull(clientConnection);
+        Assert.Empty(connectionListener._pendingConnections);
+    }
+
+    [ConditionalFact]
+    [MsQuicSupported]
+    public async Task AcceptAsync_NoCertificateCallback_RemovedFromPendingConnections()
+    {
+        // Arrange
+        var syncPoint = new SyncPoint();
+
+        await using var connectionListener = await QuicTestHelpers.CreateConnectionListenerFactory(
+            new TlsConnectionCallbackOptions
+            {
+                ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http3 },
+                OnConnection = async (context, cancellationToken) =>
+                {
+                    await syncPoint.WaitToContinue();
+
+                    // Options are invalid and S.N.Q will throw an error from AcceptConnectionAsync.
+                    return new SslServerAuthenticationOptions();
+                }
+            },
+            LoggerFactory);
+
+        // Act
+        var acceptTask = connectionListener.AcceptAndAddFeatureAsync();
+
+        var options = QuicTestHelpers.CreateClientConnectionOptions(connectionListener.EndPoint);
+        var clientConnectionTask = QuicConnection.ConnectAsync(options);
+
+        await syncPoint.WaitForSyncPoint().DefaultTimeout();
+        Assert.Single(connectionListener._pendingConnections);
+
+        syncPoint.Continue();
+
+        await Assert.ThrowsAsync<ArgumentException>(() => acceptTask.AsTask()).DefaultTimeout();
+        await Assert.ThrowsAsync<QuicException>(() => clientConnectionTask.AsTask()).DefaultTimeout();
+
+        // Assert
+        for (var i = 0; i < 20; i++)
+        {
+            // Wait until msquic and S.N.Q have finished with QuicConnection and verify it's removed from CWT.
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            if (connectionListener._pendingConnections.Count() == 0)
+            {
+                return;
+            }
+
+            await Task.Delay(100 * i);
+        }
+
+        throw new Exception("Connection not removed from CWT.");
     }
 
     [ConditionalFact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/73282

The previous way of capturing context doesn't work because the connection callback is executed in a background thread and not when `AcceptConnectionAsync` is called.

So, what do we think of using a weak table here?