### PR TITLE
Quarantine GET_MultipleRequests_RequestVersionOrHigher_UpgradeToHttp3

### DIFF
--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -709,6 +709,7 @@ public class Http3RequestTests : LoggedTest
 
     [ConditionalFact]
     [MsQuicSupported]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/43069")]
     public async Task GET_MultipleRequests_RequestVersionOrHigher_UpgradeToHttp3()
     {
         // Arrange


### PR DESCRIPTION
See https://github.com/dotnet/aspnetcore/issues/43069

The code reviewers here should decide if we actually want to quarantine this, as you will have more background on whether the failure cause is external to the test or not. I'm following buildops process.