### PR TITLE
RequestAbort token stays the same after abort

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -281,7 +281,7 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
                     return new CancellationToken(false);
                 }
 
-                if (_connectionAborted)
+                if (_connectionAborted && _abortedCts == null)
                 {
                     return new CancellationToken(true);
                 }
@@ -465,7 +465,6 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
                 if (_abortedCts != null && !_preventRequestAbortedCancellation)
                 {
                     localAbortCts = _abortedCts;
-                    _abortedCts = null;
                 }
             }
 

--- a/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
@@ -508,6 +508,8 @@ public class RequestTests : LoggedTest
             beforeAbort = context.RequestAborted;
 
             context.Abort();
+
+            // Abort doesn't happen inline. Need to wait for it to complete before reading token again.
             await abortedTcs.Task;
 
             afterAbort = context.RequestAborted;

--- a/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
@@ -490,6 +490,49 @@ public class RequestTests : LoggedTest
     }
 
     [Fact]
+    public async Task RequestAbortedTokenUnchangedOnAbort()
+    {
+        var appDoneTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        CancellationToken? beforeAbort = null;
+        CancellationToken? afterAbort = null;
+
+        await using (var server = new TestServer(async context =>
+        {
+            var abortedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            context.RequestAborted.Register(() =>
+            {
+                abortedTcs.SetResult();
+            });
+
+            beforeAbort = context.RequestAborted;
+
+            context.Abort();
+            await abortedTcs.Task;
+
+            afterAbort = context.RequestAborted;
+
+            appDoneTcs.SetResult();
+        }, new TestServiceContext(LoggerFactory)))
+        {
+            using (var connection1 = server.CreateConnection())
+            {
+                await connection1.Send(
+                    "GET / HTTP/1.1",
+                    "Host:",
+                    "",
+                    "");
+
+                await appDoneTcs.Task.DefaultTimeout();
+            }
+        }
+
+        Assert.NotNull(beforeAbort);
+        Assert.NotNull(afterAbort);
+        Assert.Equal(beforeAbort.Value, afterAbort.Value);
+    }
+
+    [Fact]
     public async Task AbortingTheConnectionSendsFIN()
     {
         var builder = TransportSelector.GetHostBuilder()


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/42547