### PR TITLE
Add more info to UnrecognizedMediaType

### DIFF
--- a/src/Middleware/HttpLogging/src/BufferingStream.cs
+++ b/src/Middleware/HttpLogging/src/BufferingStream.cs
@@ -59,7 +59,8 @@ internal abstract class BufferingStream : Stream, IBufferWriter<byte>
 
             if (encoding == null)
             {
-                _logger.UnrecognizedMediaType();
+                // This method is used only for the response body
+                _logger.ResponseUnrecognizedMediaType();
                 return "";
             }
 

--- a/src/Middleware/HttpLogging/src/BufferingStream.cs
+++ b/src/Middleware/HttpLogging/src/BufferingStream.cs
@@ -60,7 +60,7 @@ internal abstract class BufferingStream : Stream, IBufferWriter<byte>
             if (encoding == null)
             {
                 // This method is used only for the response body
-                _logger.ResponseUnrecognizedMediaType();
+                _logger.UnrecognizedMediaType("response");
                 return "";
             }
 

--- a/src/Middleware/HttpLogging/src/HttpLoggingExtensions.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingExtensions.cs
@@ -29,9 +29,6 @@ internal static partial class HttpLoggingExtensions
     [LoggerMessage(5, LogLevel.Debug, "Decode failure while converting body.", EventName = "DecodeFailure")]
     public static partial void DecodeFailure(this ILogger logger, Exception ex);
 
-    [LoggerMessage(6, LogLevel.Debug, "Unrecognized Content-Type for request body.", EventName = "RequestUnrecognizedMediaType")]
-    public static partial void RequestUnrecognizedMediaType(this ILogger logger);
-    
-    [LoggerMessage(7, LogLevel.Debug, "Unrecognized Content-Type for response body.", EventName = "ResponseUnrecognizedMediaType")]
-    public static partial void ResponseUnrecognizedMediaType(this ILogger logger);
+    [LoggerMessage(6, LogLevel.Debug, "Unrecognized Content-Type for {Name} body.", EventName = "UnrecognizedMediaType")]
+    public static partial void UnrecognizedMediaType(this ILogger logger, string name);
 }

--- a/src/Middleware/HttpLogging/src/HttpLoggingExtensions.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingExtensions.cs
@@ -31,4 +31,7 @@ internal static partial class HttpLoggingExtensions
 
     [LoggerMessage(6, LogLevel.Debug, "Unrecognized Content-Type for {Name} body.", EventName = "UnrecognizedMediaType")]
     public static partial void UnrecognizedMediaType(this ILogger logger, string name);
+
+    [LoggerMessage(7, LogLevel.Debug, "No Content-Type header for {Name} body.", EventName = "NoMediaType")]
+    public static partial void NoMediaType(this ILogger logger, string name);
 }

--- a/src/Middleware/HttpLogging/src/HttpLoggingExtensions.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingExtensions.cs
@@ -29,6 +29,6 @@ internal static partial class HttpLoggingExtensions
     [LoggerMessage(5, LogLevel.Debug, "Decode failure while converting body.", EventName = "DecodeFailure")]
     public static partial void DecodeFailure(this ILogger logger, Exception ex);
 
-    [LoggerMessage(6, LogLevel.Debug, "Unrecognized Content-Type for body.", EventName = "UnrecognizedMediaType")]
-    public static partial void UnrecognizedMediaType(this ILogger logger);
+    [LoggerMessage(6, LogLevel.Debug, "Unrecognized Content-Type for request body.", EventName = "RequestUnrecognizedMediaType")]
+    public static partial void RequestUnrecognizedMediaType(this ILogger logger);
 }

--- a/src/Middleware/HttpLogging/src/HttpLoggingExtensions.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingExtensions.cs
@@ -31,4 +31,7 @@ internal static partial class HttpLoggingExtensions
 
     [LoggerMessage(6, LogLevel.Debug, "Unrecognized Content-Type for request body.", EventName = "RequestUnrecognizedMediaType")]
     public static partial void RequestUnrecognizedMediaType(this ILogger logger);
+    
+    [LoggerMessage(7, LogLevel.Debug, "Unrecognized Content-Type for response body.", EventName = "ResponseUnrecognizedMediaType")]
+    public static partial void ResponseUnrecognizedMediaType(this ILogger logger);
 }

--- a/src/Middleware/HttpLogging/src/HttpLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingMiddleware.cs
@@ -105,7 +105,11 @@ internal sealed class HttpLoggingMiddleware
 
             if (options.LoggingFields.HasFlag(HttpLoggingFields.RequestBody))
             {
-                if (MediaTypeHelpers.TryGetEncodingForMediaType(request.ContentType,
+                if (request.ContentType is null)
+                {
+                    _logger.NoMediaType("request");
+                }
+                else if (MediaTypeHelpers.TryGetEncodingForMediaType(request.ContentType,
                     options.MediaTypeOptions.MediaTypeStates,
                     out var encoding))
                 {

--- a/src/Middleware/HttpLogging/src/HttpLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingMiddleware.cs
@@ -119,7 +119,7 @@ internal sealed class HttpLoggingMiddleware
                 }
                 else
                 {
-                    _logger.RequestUnrecognizedMediaType();
+                    _logger.UnrecognizedMediaType("request");
                 }
             }
 

--- a/src/Middleware/HttpLogging/src/HttpLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingMiddleware.cs
@@ -119,7 +119,7 @@ internal sealed class HttpLoggingMiddleware
                 }
                 else
                 {
-                    _logger.UnrecognizedMediaType();
+                    _logger.RequestUnrecognizedMediaType();
                 }
             }
 

--- a/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
@@ -511,7 +511,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
         await middleware.Invoke(httpContext);
 
         Assert.DoesNotContain(TestSink.Writes, w => w.Message.Contains(expected));
-        Assert.Contains(TestSink.Writes, w => w.Message.Contains("Unrecognized Content-Type for body."));
+        Assert.Contains(TestSink.Writes, w => w.Message.Contains("Unrecognized Content-Type for request body."));
     }
 
     [Fact]
@@ -837,6 +837,37 @@ public class HttpLoggingMiddlewareTests : LoggedTest
         await middleware.Invoke(httpContext);
 
         Assert.Contains(TestSink.Writes, w => w.Message.Contains("Unrecognized Content-Type for response body."));
+    }
+
+    [Fact]
+    public async Task NoMediaType()
+    {
+        var options = CreateOptionsAccessor();
+        options.CurrentValue.LoggingFields = HttpLoggingFields.RequestBody;
+        var middleware = new HttpLoggingMiddleware(
+            async c =>
+            {
+                c.Request.ContentType = null;
+                var arr = new byte[4096];
+                while (true)
+                {
+                    var res = await c.Request.Body.ReadAsync(arr);
+                    if (res == 0)
+                    {
+                        break;
+                    }
+                }
+            },
+            options,
+            LoggerFactory.CreateLogger<HttpLoggingMiddleware>());
+
+        var httpContext = new DefaultHttpContext();
+
+        httpContext.Request.Headers["foo"] = "bar";
+
+        await middleware.Invoke(httpContext);
+
+        Assert.Contains(TestSink.Writes, w => w.Message.Contains("No Content-Type header for request body."));
     }
 
     [Fact]

--- a/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
@@ -836,7 +836,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
 
         await middleware.Invoke(httpContext);
 
-        Assert.Contains(TestSink.Writes, w => w.Message.Contains("Unrecognized Content-Type for body."));
+        Assert.Contains(TestSink.Writes, w => w.Message.Contains("Unrecognized Content-Type for request body."));
     }
 
     [Fact]

--- a/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
@@ -836,7 +836,7 @@ public class HttpLoggingMiddlewareTests : LoggedTest
 
         await middleware.Invoke(httpContext);
 
-        Assert.Contains(TestSink.Writes, w => w.Message.Contains("Unrecognized Content-Type for request body."));
+        Assert.Contains(TestSink.Writes, w => w.Message.Contains("Unrecognized Content-Type for response body."));
     }
 
     [Fact]


### PR DESCRIPTION
This only ever gets fired for the request body, not the response body.