### PR TITLE
Kestrel Content-Length handling changes

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -710,4 +710,7 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="DynamicPortOnMultipleTransportsNotSupported" xml:space="preserve">
     <value>Dynamic port binding is not supported when binding multiple transports. HTTP/3 not enabled. A port must be specified to support TCP based HTTP/1.1 and HTTP/2, and QUIC based HTTP/3 with the same endpoint.</value>
   </data>
+  <data name="NonzeroContentLengthNotAllowedOn205" xml:space="preserve">
+    <value>Responses with status code 205 cannot have a non-zero Content-Length value.</value>
+  </data>
 </root>

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -2671,7 +2671,7 @@ public class Http2ConnectionTests : Http2TestBase
         await SendHeadersAsync(1, Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM, headers);
 
         await ExpectAsync(Http2FrameType.HEADERS,
-            withLength: 36,
+            withLength: 32,
             withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
             withStreamId: 1);
 
@@ -4574,7 +4574,7 @@ public class Http2ConnectionTests : Http2TestBase
         await SendEmptyContinuationFrameAsync(1, Http2ContinuationFrameFlags.END_HEADERS);
 
         await ExpectAsync(Http2FrameType.HEADERS,
-            withLength: 36,
+            withLength: 32,
             withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
             withStreamId: 1);
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -282,7 +282,7 @@ public class Http2StreamTests : Http2TestBase
         await SendHeadersAsync(1, Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM, headers);
 
         var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
-            withLength: 52,
+            withLength: 48,
             withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
             withStreamId: 1);
 
@@ -290,11 +290,10 @@ public class Http2StreamTests : Http2TestBase
 
         _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
-        Assert.Equal(4, _decodedHeaders.Count);
+        Assert.Equal(3, _decodedHeaders.Count);
         Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
         Assert.Equal("200", _decodedHeaders[InternalHeaderNames.Status]);
         Assert.Equal("CONNECT", _decodedHeaders["Method"]);
-        Assert.Equal("0", _decodedHeaders["content-length"]);
     }
 
     [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2WebSocketTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2WebSocketTests.cs
@@ -69,7 +69,7 @@ public class Http2WebSocketTests : Http2TestBase
         await SendDataAsync(1, Array.Empty<byte>(), endStream: true);
 
         var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
-            withLength: 36,
+            withLength: 32,
             withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
             withStreamId: 1);
 
@@ -77,10 +77,9 @@ public class Http2WebSocketTests : Http2TestBase
 
         _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
 
-        Assert.Equal(3, _decodedHeaders.Count);
+        Assert.Equal(2, _decodedHeaders.Count);
         Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
         Assert.Equal("200", _decodedHeaders[InternalHeaderNames.Status]);
-        Assert.Equal("0", _decodedHeaders["content-length"]);
     }
 
     [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -156,11 +156,10 @@ public class Http3StreamTests : Http3TestBase
 
         var responseHeaders = await requestStream.ExpectHeadersAsync();
 
-        Assert.Equal(4, responseHeaders.Count);
+        Assert.Equal(3, responseHeaders.Count);
         Assert.Contains("date", responseHeaders.Keys, StringComparer.OrdinalIgnoreCase);
         Assert.Equal("200", responseHeaders[InternalHeaderNames.Status]);
         Assert.Equal("CONNECT", responseHeaders["Method"]);
-        Assert.Equal("0", responseHeaders["content-length"]);
     }
 
     [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTargetProcessingTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/RequestTargetProcessingTests.cs
@@ -90,11 +90,10 @@ public class RequestTargetProcessingTests : LoggedTest
     }
 
     [Theory]
-    [InlineData((int)HttpMethod.Options, "*")]
-    [InlineData((int)HttpMethod.Connect, "host")]
-    public async Task NonPathRequestTargetSetInRawTarget(int intMethod, string requestTarget)
+    [InlineData(HttpMethod.Options, "*")]
+    [InlineData(HttpMethod.Connect, "host")]
+    public async Task NonPathRequestTargetSetInRawTarget(HttpMethod method, string requestTarget)
     {
-        var method = (HttpMethod)intMethod;
         var testContext = new TestServiceContext(LoggerFactory);
 
         await using (var server = new TestServer(async context =>
@@ -104,8 +103,7 @@ public class RequestTargetProcessingTests : LoggedTest
             Assert.Empty(context.Request.PathBase.Value);
             Assert.Empty(context.Request.QueryString.Value);
 
-            context.Response.Headers["Content-Length"] = new[] { "11" };
-            await context.Response.WriteAsync("Hello World");
+            await context.Response.CompleteAsync();
         }, testContext))
         {
             using (var connection = server.CreateConnection())
@@ -119,12 +117,6 @@ public class RequestTargetProcessingTests : LoggedTest
                     $"Host: {host}",
                     "",
                     "");
-                await connection.Receive(
-                    "HTTP/1.1 200 OK",
-                    "Content-Length: 11",
-                    $"Date: {testContext.DateHeaderValue}",
-                    "",
-                    "Hello World");
             }
         }
     }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -626,7 +626,7 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
     [Theory]
     [MemberData(nameof(Get1xxAnd204MethodCombinations))]
     public async Task AttemptingToWriteContentLengthFailsFor1xxAnd204Responses(int statusCode, HttpMethod method)
-        => await AttemptingToWriteContentLengthFails(statusCode, method, contentLength: 0).ConfigureAwait(true);
+        => await AttemptingToWriteContentLengthFails(statusCode, method).ConfigureAwait(true);
 
     [Theory]
     [InlineData(StatusCodes.Status200OK)]
@@ -640,16 +640,16 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
     [InlineData(StatusCodes.Status208AlreadyReported)]
     [InlineData(StatusCodes.Status226IMUsed)]
     public async Task AttemptingToWriteContentLengthFailsFor2xxResponsesOnConnect(int statusCode)
-        => await AttemptingToWriteContentLengthFails(statusCode, HttpMethod.Connect, contentLength: 0).ConfigureAwait(true);
+        => await AttemptingToWriteContentLengthFails(statusCode, HttpMethod.Connect).ConfigureAwait(true);
 
-    private async Task AttemptingToWriteContentLengthFails(int statusCode, HttpMethod method, long contentLength)
+    private async Task AttemptingToWriteContentLengthFails(int statusCode, HttpMethod method)
     {
         var responseWriteTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         await using (var server = new TestServer(async httpContext =>
         {
             httpContext.Response.StatusCode = statusCode;
-            httpContext.Response.Headers.ContentLength = contentLength;
+            httpContext.Response.Headers.ContentLength = 0;
 
             try
             {


### PR DESCRIPTION
This includes two changes to how we handle Content-Length on responses:

- Forbid the inclusion of the Content-Length header on 1xx, 204 responses, or any 2xx responses to a CONNECT request.
- Forbid non-zero Content-Length for 205 responses.

Fixes https://github.com/dotnet/aspnetcore/issues/42956