### PR TITLE
Update CODEOWNERS to catch more API updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 # See https://help.github.com/articles/about-code-owners/
 
 *                                                                                 @Pilchie
+/**/PublicAPI.*Shipped.txt                                                        @dotnet/aspnet-api-review
 /global.json                                                                      @dotnet/aspnet-build @dougbu @wtgodbe
 /.azure/                                                                          @dotnet/aspnet-build @dougbu @wtgodbe
 /.azuredevops/                                                                    @dotnet/aspnet-build @dougbu @wtgodbe


### PR DESCRIPTION
I'm hoping this will notify API reviewers for all public API changes.