### PR TITLE
Obsolete LeakTrackingObjectPool and LeakTrackingObjectPoolProvider

### DIFF
--- a/src/ObjectPool/src/LeakTrackingObjectPool.cs
+++ b/src/ObjectPool/src/LeakTrackingObjectPool.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Extensions.ObjectPool;
 /// </para>
 /// </summary>
 /// <typeparam name="T">The type of object which is being pooled.</typeparam>
+[Obsolete("LeakTrackingObjectPool<T> was only intended for use in diagnostic builds and may be removed in a future release.")]
 public class LeakTrackingObjectPool<T> : ObjectPool<T> where T : class
 {
     private readonly ConditionalWeakTable<T, Tracker> _trackers = new ConditionalWeakTable<T, Tracker>();

--- a/src/ObjectPool/src/LeakTrackingObjectPool.cs
+++ b/src/ObjectPool/src/LeakTrackingObjectPool.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Extensions.ObjectPool;
 /// </para>
 /// </summary>
 /// <typeparam name="T">The type of object which is being pooled.</typeparam>
-[Obsolete("LeakTrackingObjectPool<T> was only intended for use in diagnostic builds and may be removed in a future release.")]
+[Obsolete("LeakTrackingObjectPool<T> was only intended for use in diagnostic builds of .NET. It does not "+
+    "function in any publicly shipped .NET versions and may be removed in a future release.")]
 public class LeakTrackingObjectPool<T> : ObjectPool<T> where T : class
 {
     private readonly ConditionalWeakTable<T, Tracker> _trackers = new ConditionalWeakTable<T, Tracker>();

--- a/src/ObjectPool/src/LeakTrackingObjectPool.cs
+++ b/src/ObjectPool/src/LeakTrackingObjectPool.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Extensions.ObjectPool;
 /// </para>
 /// </summary>
 /// <typeparam name="T">The type of object which is being pooled.</typeparam>
-[Obsolete("LeakTrackingObjectPool<T> was only intended for use in diagnostic builds of .NET. It does not "+
-    "function in any publicly shipped .NET versions and may be removed in a future release.")]
+[Obsolete("LeakTrackingObjectPool<T> was only intended for internal use in diagnostic builds of .NET. " +
+    "It never functioned in publicly shipped .NET versions and may be removed in a future release.")]
 public class LeakTrackingObjectPool<T> : ObjectPool<T> where T : class
 {
     private readonly ConditionalWeakTable<T, Tracker> _trackers = new ConditionalWeakTable<T, Tracker>();

--- a/src/ObjectPool/src/LeakTrackingObjectPoolProvider.cs
+++ b/src/ObjectPool/src/LeakTrackingObjectPoolProvider.cs
@@ -9,7 +9,8 @@ namespace Microsoft.Extensions.ObjectPool;
 /// An <see cref="ObjectPoolProvider"/> that produces instances of
 /// <see cref="LeakTrackingObjectPool{T}"/>.
 /// </summary>
-[Obsolete("LeakTrackingObjectPoolProvider was only intended for use in diagnostic builds and may be removed in a future release.")]
+[Obsolete("LeakTrackingObjectPoolProvider was only intended for use in diagnostic builds of .NET. It does not "+
+    "function in any publicly shipped .NET versions and may be removed in a future release.")]
 public class LeakTrackingObjectPoolProvider : ObjectPoolProvider
 {
     private readonly ObjectPoolProvider _inner;

--- a/src/ObjectPool/src/LeakTrackingObjectPoolProvider.cs
+++ b/src/ObjectPool/src/LeakTrackingObjectPoolProvider.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Extensions.ObjectPool;
 /// An <see cref="ObjectPoolProvider"/> that produces instances of
 /// <see cref="LeakTrackingObjectPool{T}"/>.
 /// </summary>
-[Obsolete("LeakTrackingObjectPoolProvider was only intended for use in diagnostic builds of .NET. It does not "+
-    "function in any publicly shipped .NET versions and may be removed in a future release.")]
+[Obsolete("LeakTrackingObjectPoolProvider was only intended for internal use in diagnostic builds of .NET. " +
+    "It never functioned in publicly shipped .NET versions and may be removed in a future release.")]
 public class LeakTrackingObjectPoolProvider : ObjectPoolProvider
 {
     private readonly ObjectPoolProvider _inner;

--- a/src/ObjectPool/src/LeakTrackingObjectPoolProvider.cs
+++ b/src/ObjectPool/src/LeakTrackingObjectPoolProvider.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.ObjectPool;
 /// An <see cref="ObjectPoolProvider"/> that produces instances of
 /// <see cref="LeakTrackingObjectPool{T}"/>.
 /// </summary>
+[Obsolete("LeakTrackingObjectPoolProvider was only intended for use in diagnostic builds and may be removed in a future release.")]
 public class LeakTrackingObjectPoolProvider : ObjectPoolProvider
 {
     private readonly ObjectPoolProvider _inner;


### PR DESCRIPTION
`LeakTrackingObjectPool` doesn't work on release builds, and nothing else depends on it, so we've chosen to mark it (and `LeakTrackingObjectPoolProvider`) obsolete.

Address https://github.com/dotnet/aspnetcore/issues/42524