### PR TITLE
Update the worker template to use `CreateApplicationBuilder`

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.Main.cs
@@ -4,12 +4,11 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        IHost host = Host.CreateDefaultBuilder(args)
-            .ConfigureServices(services =>
-            {
-                services.AddHostedService<Worker>();
-            })
-            .Build();
+        var builder = Host.CreateApplicationBuilder(args);
+
+        builder.Services.AddHostedService<Worker>();
+
+        var host = builder.Build();
 
         host.Run();
     }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.cs
@@ -1,10 +1,9 @@
 using Company.Application1;
 
-IHost host = Host.CreateDefaultBuilder(args)
-    .ConfigureServices(services =>
-    {
-        services.AddHostedService<Worker>();
-    })
-    .Build();
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddHostedService<Worker>();
+
+var host = builder.Build();
 
 host.Run();


### PR DESCRIPTION
# Update the worker template to use `CreateApplicationBuilder`

Update both the _Program.cs_ and _Program.Main.cs_ files for the `Worker` template to use the `CreateApplicationBuilder` API for consistency.

Fixes #43113

/CC @bradygaster @davidfowl 

When this is merged, we can update the [docs](https://docs.microsoft.com/dotnet/core/extensions/workers#worker-service-template) accordingly.