### PR TITLE
[6.0] macOS dev-certs - Handle keychain paths with spaces

### DIFF
--- a/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
@@ -19,17 +19,17 @@ namespace Microsoft.AspNetCore.Certificates.Generation
         private static readonly string MacOSUserKeyChain = Environment.GetEnvironmentVariable("HOME") + "/Library/Keychains/login.keychain-db";
         private const string MacOSSystemKeyChain = "/Library/Keychains/System.keychain";
         private const string MacOSFindCertificateCommandLine = "security";
-        private const string MacOSFindCertificateCommandLineArgumentsFormat = "find-certificate -c {0} -a -Z -p " + MacOSSystemKeyChain;
+        private const string MacOSFindCertificateCommandLineArgumentsFormat = "find-certificate -c {0} -a -Z -p \"" + MacOSSystemKeyChain +"\"";
         private const string MacOSFindCertificateOutputRegex = "SHA-1 hash: ([0-9A-Z]+)";
         private const string MacOSRemoveCertificateTrustCommandLine = "sudo";
-        private const string MacOSRemoveCertificateTrustCommandLineArgumentsFormat = "security remove-trusted-cert -d {0}";
+        private const string MacOSRemoveCertificateTrustCommandLineArgumentsFormat = "security remove-trusted-cert -d \"{0}\"";
         private const string MacOSDeleteCertificateCommandLine = "sudo";
-        private const string MacOSDeleteCertificateCommandLineArgumentsFormat = "security delete-certificate -Z {0} {1}";
+        private const string MacOSDeleteCertificateCommandLineArgumentsFormat = "security delete-certificate -Z {0} \"{1}\"";
         private const string MacOSTrustCertificateCommandLine = "sudo";
-        private const string MacOSTrustCertificateCommandLineArguments = "security add-trusted-cert -d -r trustRoot -k " + MacOSSystemKeyChain + " ";
+        private const string MacOSTrustCertificateCommandLineArguments = "security add-trusted-cert -d -r trustRoot -k \"" + MacOSSystemKeyChain + "\" ";
 
         private const string MacOSAddCertificateToKeyChainCommandLine = "security";
-        private static readonly string MacOSAddCertificateToKeyChainCommandLineArgumentsFormat = "import {0} -k " + MacOSUserKeyChain + " -t cert -f pkcs12 -P {1} -A";
+        private static readonly string MacOSAddCertificateToKeyChainCommandLineArgumentsFormat = "import \"{0}\" -k \"" + MacOSUserKeyChain + "\" -t cert -f pkcs12 -P {1} -A";
 
         public const string InvalidCertificateState = "The ASP.NET Core developer certificate is in an invalid state. " +
             "To fix this issue, run the following commands 'dotnet dev-certs https --clean' and 'dotnet dev-certs https' to remove all existing ASP.NET Core development certificates " +

--- a/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
         private static readonly string MacOSUserKeyChain = Environment.GetEnvironmentVariable("HOME") + "/Library/Keychains/login.keychain-db";
         private const string MacOSSystemKeyChain = "/Library/Keychains/System.keychain";
         private const string MacOSFindCertificateCommandLine = "security";
-        private const string MacOSFindCertificateCommandLineArgumentsFormat = "find-certificate -c {0} -a -Z -p \"" + MacOSSystemKeyChain +"\"";
+        private const string MacOSFindCertificateCommandLineArgumentsFormat = "find-certificate -c {0} -a -Z -p \"" + MacOSSystemKeyChain + "\"";
         private const string MacOSFindCertificateOutputRegex = "SHA-1 hash: ([0-9A-Z]+)";
         private const string MacOSRemoveCertificateTrustCommandLine = "sudo";
         private const string MacOSRemoveCertificateTrustCommandLineArgumentsFormat = "security remove-trusted-cert -d \"{0}\"";


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/43120
Issue: https://github.com/dotnet/aspnetcore/issues/42887

Update the macOS dev-certs tool to handle keychains with spaces in their paths.

## Description

As seen in the linked issue, users may have their macOS home directory set to a non-standard path which could include spaces. We should include quotes around the paths when running the security commands so that they get parsed properly.

Fixes #42887

## Customer Impact

Without this fix, macOS developers with spaces in their keychain paths are unable to create/manage the certificates used by Kestrel for HTTPS at development time.

## Regression?

- [ ] Yes
- [x] No


## Risk

- [ ] High
- [ ] Medium
- [x] Low

It's just putting quotes around paths.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----
