### PR TITLE
ApplicationBuilder server features defaults to empty collection

### DIFF
--- a/src/Http/Http.Abstractions/src/IApplicationBuilder.cs
+++ b/src/Http/Http.Abstractions/src/IApplicationBuilder.cs
@@ -19,6 +19,9 @@ public interface IApplicationBuilder
     /// <summary>
     /// Gets the set of HTTP features the application's server provides.
     /// </summary>
+    /// <remarks>
+    /// An empty collection is returned if a server wasn't specified for the application builder.
+    /// </remarks>
     IFeatureCollection ServerFeatures { get; }
 
     /// <summary>

--- a/src/Http/Http/src/Builder/ApplicationBuilder.cs
+++ b/src/Http/Http/src/Builder/ApplicationBuilder.cs
@@ -21,10 +21,8 @@ public class ApplicationBuilder : IApplicationBuilder
     /// Initializes a new instance of <see cref="ApplicationBuilder"/>.
     /// </summary>
     /// <param name="serviceProvider">The <see cref="IServiceProvider"/> for application services.</param>
-    public ApplicationBuilder(IServiceProvider serviceProvider)
+    public ApplicationBuilder(IServiceProvider serviceProvider) : this(serviceProvider, new FeatureCollection())
     {
-        Properties = new Dictionary<string, object?>(StringComparer.Ordinal);
-        ApplicationServices = serviceProvider;
     }
 
     /// <summary>
@@ -33,8 +31,10 @@ public class ApplicationBuilder : IApplicationBuilder
     /// <param name="serviceProvider">The <see cref="IServiceProvider"/> for application services.</param>
     /// <param name="server">The server instance that hosts the application.</param>
     public ApplicationBuilder(IServiceProvider serviceProvider, object server)
-        : this(serviceProvider)
     {
+        Properties = new Dictionary<string, object?>(StringComparer.Ordinal);
+        ApplicationServices = serviceProvider;
+
         SetProperty(ServerFeaturesKey, server);
     }
 
@@ -61,6 +61,9 @@ public class ApplicationBuilder : IApplicationBuilder
     /// <summary>
     /// Gets the <see cref="IFeatureCollection"/> for server features.
     /// </summary>
+    /// <remarks>
+    /// An empty collection is returned if a server wasn't specified for the application builder.
+    /// </remarks>
     public IFeatureCollection ServerFeatures
     {
         get

--- a/src/Http/Http/test/ApplicationBuilderTests.cs
+++ b/src/Http/Http/test/ApplicationBuilderTests.cs
@@ -20,6 +20,14 @@ public class ApplicationBuilderTests
     }
 
     [Fact]
+    public void ServerFeaturesEmptyWhenNotSpecified()
+    {
+        var builder = new ApplicationBuilder(null);
+
+        Assert.Empty(builder.ServerFeatures);
+    }
+
+    [Fact]
     public async Task BuildImplicitlyThrowsForMatchedEndpointAsLastStep()
     {
         var builder = new ApplicationBuilder(null);


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/43036

I asked what to do [here](https://github.com/dotnet/aspnetcore/issues/43036#issuecomment-1204667519) and didn't get an answer. The alternative approach here is to make ServerFeatures nullable. IMO returning null feels more technically correct but might add extra null checking to apps.