### PR TITLE
Update DataProtectionKey to use DynamicDependency

### DIFF
--- a/src/DataProtection/EntityFrameworkCore/src/DataProtectionKey.cs
+++ b/src/DataProtection/EntityFrameworkCore/src/DataProtectionKey.cs
@@ -1,17 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 
 /// <summary>
 /// Code first model used by <see cref="EntityFrameworkCoreXmlRepository{TContext}"/>.
 /// </summary>
-// DataProtectionKey.Id is not used anywhere. Add DynamicallyAccessedMembers to prevent it from being trimmed.
-// Note that in the future EF may annotate itself to include properties automatically, and the annotation here could be removed.
-// Fixes https://github.com/dotnet/aspnetcore/issues/43187
-[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
 public class DataProtectionKey
 {
     /// <summary>

--- a/src/DataProtection/EntityFrameworkCore/src/EntityFrameworkCoreXmlRepository.cs
+++ b/src/DataProtection/EntityFrameworkCore/src/EntityFrameworkCoreXmlRepository.cs
@@ -33,6 +33,10 @@ public class EntityFrameworkCoreXmlRepository<TContext> : IXmlRepository
 
         _logger = loggerFactory.CreateLogger<EntityFrameworkCoreXmlRepository<TContext>>();
         _services = services ?? throw new ArgumentNullException(nameof(services));
+
+        // Access DataProtectionKey properties dynamically to trigger DynamicallyAccessedMembers on the type
+        // and preserve the unused DataProtectionKey.Id property.
+        _ = typeof(DataProtectionKey).GetProperties();
     }
 
     /// <inheritdoc />

--- a/src/DataProtection/EntityFrameworkCore/src/EntityFrameworkCoreXmlRepository.cs
+++ b/src/DataProtection/EntityFrameworkCore/src/EntityFrameworkCoreXmlRepository.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.DataProtection.Repositories;
@@ -24,6 +25,10 @@ public class EntityFrameworkCoreXmlRepository<TContext> : IXmlRepository
     /// </summary>
     /// <param name="services"></param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
+    // DataProtectionKey.Id is not used anywhere. Add DynamicDependency to prevent it from being trimmed.
+    // Note that in the future EF may annotate itself to include properties automatically, and the annotation here could be removed.
+    // Fixes https://github.com/dotnet/aspnetcore/issues/43187
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(DataProtectionKey))]
     public EntityFrameworkCoreXmlRepository(IServiceProvider services, ILoggerFactory loggerFactory)
     {
         if (loggerFactory == null)
@@ -33,10 +38,6 @@ public class EntityFrameworkCoreXmlRepository<TContext> : IXmlRepository
 
         _logger = loggerFactory.CreateLogger<EntityFrameworkCoreXmlRepository<TContext>>();
         _services = services ?? throw new ArgumentNullException(nameof(services));
-
-        // Access DataProtectionKey properties dynamically to trigger DynamicallyAccessedMembers on the type
-        // and preserve the unused DataProtectionKey.Id property.
-        _ = typeof(DataProtectionKey).GetProperties();
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/43187
Feedback from https://github.com/dotnet/aspnetcore/pull/43204#issuecomment-1211450778

I tested publishing an app using `Microsoft.AspNetCore.DataProtection.EntityFrameworkCore` and it seemed to work.