### PR TITLE
Reuse PolicyAuthorizationResult

### DIFF
--- a/src/Security/Authorization/Policy/src/PolicyAuthorizationResult.cs
+++ b/src/Security/Authorization/Policy/src/PolicyAuthorizationResult.cs
@@ -8,6 +8,10 @@ namespace Microsoft.AspNetCore.Authorization.Policy;
 /// </summary>
 public class PolicyAuthorizationResult
 {
+    private static readonly PolicyAuthorizationResult _challengedResult = new() { Challenged = true };
+    private static readonly PolicyAuthorizationResult _forbiddenResult = new() { Forbidden = true };
+    private static readonly PolicyAuthorizationResult _succeededResult = new() { Succeeded = true };
+
     private PolicyAuthorizationResult() { }
 
     /// <summary>
@@ -34,15 +38,13 @@ public class PolicyAuthorizationResult
     ///Indicates that an unauthenticated user requested access to an endpoint that requires authentication.
     /// </summary>
     /// <returns>The <see cref="PolicyAuthorizationResult"/>.</returns>
-    public static PolicyAuthorizationResult Challenge()
-        => new PolicyAuthorizationResult { Challenged = true };
+    public static PolicyAuthorizationResult Challenge() => _challengedResult;
 
     /// <summary>
     /// Indicates that the access to a resource was forbidden.
     /// </summary>
     /// <returns>The <see cref="PolicyAuthorizationResult"/>.</returns>
-    public static PolicyAuthorizationResult Forbid()
-        => Forbid(null);
+    public static PolicyAuthorizationResult Forbid() => _forbiddenResult;
 
     /// <summary>
     /// Indicates that the access to a resource was forbidden.
@@ -50,12 +52,13 @@ public class PolicyAuthorizationResult
     /// <param name="authorizationFailure">Specifies the reason the authorization failed.s</param>
     /// <returns>The <see cref="PolicyAuthorizationResult"/>.</returns>
     public static PolicyAuthorizationResult Forbid(AuthorizationFailure? authorizationFailure)
-        => new PolicyAuthorizationResult { Forbidden = true, AuthorizationFailure = authorizationFailure };
+        => authorizationFailure is null
+        ? _forbiddenResult
+        : new PolicyAuthorizationResult { Forbidden = true, AuthorizationFailure = authorizationFailure };
 
     /// <summary>
     /// Indicates a successful authorization.
     /// </summary>
     /// <returns>The <see cref="PolicyAuthorizationResult"/>.</returns>
-    public static PolicyAuthorizationResult Success()
-        => new PolicyAuthorizationResult { Succeeded = true };
+    public static PolicyAuthorizationResult Success() => _succeededResult;
 }


### PR DESCRIPTION
`PolicyAuthorizationResult` is immutable. It could be stored and reused to avoid allocation.