### PR TITLE
Only create context if an event is set

### DIFF
--- a/src/Security/Authentication/Cookies/src/CookieAuthenticationEvents.cs
+++ b/src/Security/Authentication/Cookies/src/CookieAuthenticationEvents.cs
@@ -11,10 +11,12 @@ namespace Microsoft.AspNetCore.Authentication.Cookies;
 /// </summary>
 public class CookieAuthenticationEvents
 {
+    private static readonly Func<CookieValidatePrincipalContext, Task> _onValidatePrincipal = _ => Task.CompletedTask;
+
     /// <summary>
     /// Invoked to validate the principal.
     /// </summary>
-    public Func<CookieValidatePrincipalContext, Task> OnValidatePrincipal { get; set; } = context => Task.CompletedTask;
+    public Func<CookieValidatePrincipalContext, Task> OnValidatePrincipal { get; set; } = _onValidatePrincipal;
 
     /// <summary>
     /// Invoked to check if the cookie should be renewed.
@@ -161,4 +163,10 @@ public class CookieAuthenticationEvents
     /// </summary>
     /// <param name="context">The <see cref="RedirectContext{TOptions}"/>.</param>
     public virtual Task RedirectToAccessDenied(RedirectContext<CookieAuthenticationOptions> context) => OnRedirectToAccessDenied(context);
+
+    internal bool ShouldRunValidatePrincipal()
+    {
+        return GetType() != typeof(CookieAuthenticationEvents)
+            || OnValidatePrincipal != _onValidatePrincipal;
+    }
 }


### PR DESCRIPTION
# Only create context if an event is set
There are multiple events in CookieAuthenticationHandler and each has its own context type which some of them are created per request even when there's no event has been set. 
We could avoid creating the context if the event has been set.
## Description

I did `OnValidatePrincipal` for start. I will do the same for other events when the solution is accepted.

Fixes https://github.com/dotnet/aspnetcore/issues/42325