### PR TITLE
Fix typo in trimmer annotation

### DIFF
--- a/src/Http/Routing/src/RouteOptions.cs
+++ b/src/Http/Routing/src/RouteOptions.cs
@@ -70,7 +70,7 @@ public class RouteOptions
     /// </summary>
     public IDictionary<string, Type> ConstraintMap
     {
-        [RequiresUnreferencedCode($"The linker cannot determine what constraints are being added via the ConstraintMap property. Prefer {nameof(RouteOptions)}.{nameof(SetParameterPolicy)} instead for setting constraints. This warning can be suppressed if this property is being used to read of delete constraints.")]
+        [RequiresUnreferencedCode($"The linker cannot determine what constraints are being added via the ConstraintMap property. Prefer {nameof(RouteOptions)}.{nameof(SetParameterPolicy)} instead for setting constraints. This warning can be suppressed if this property is being used to read or delete constraints.")]
         get
         {
             return _constraintTypeMap;


### PR DESCRIPTION
Noticed a silly little typo, but can't unsee it.