### PR TITLE
Exclude some .wxl files from localization

### DIFF
--- a/eng/Localize/LocExclusions.json
+++ b/eng/Localize/LocExclusions.json
@@ -1,5 +1,7 @@
-[
+{
+  "Exclusions": [
     "src\\Installers\\Windows\\AspNetCoreModule-Setup\\setupstrings.wxl",
     "src\\Installers\\Windows\\SharedFramework\\Strings.wxl",
     "src\\Installers\\Windows\\TargetingPack\\Strings.wxl"
-]
+  ]
+}

--- a/eng/Localize/LocExclusions.json
+++ b/eng/Localize/LocExclusions.json
@@ -1,0 +1,5 @@
+[
+    "src\\Installers\\Windows\\AspNetCoreModule-Setup\\setupstrings.wxl",
+    "src\\Installers\\Windows\\SharedFramework\\Strings.wxl",
+    "src\\Installers\\Windows\\TargetingPack\\Strings.wxl"
+]


### PR DESCRIPTION
- preparing for dotnet/arcade#10383 merge and migration to this repo
- without this, `OneLocBuild` will generate multiple unused translation files