### PR TITLE
Skip empty lines between requests

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -55,14 +55,6 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
     /// </summary>
     public bool ParseRequestLine(TRequestHandler handler, ref SequenceReader<byte> reader)
     {
-        // Skip any leading \r or \n on the request line. This is not technically allowed,
-        // but apparently there are enough clients relying on this that it's worth allowing.
-        // Peek first as a minor performance optimization; it's a quick inlined check.
-        if (reader.TryPeek(out byte b) && (b == ByteCR || b == ByteLF))
-        {
-            reader.AdvancePastAny(ByteCR, ByteLF);
-        }
-
         if (reader.TryReadTo(out ReadOnlySpan<byte> requestLine, ByteLF, advancePastDelimiter: true))
         {
             ParseRequestLine(handler, requestLine);

--- a/src/Servers/Kestrel/Core/test/StartLineTests.cs
+++ b/src/Servers/Kestrel/Core/test/StartLineTests.cs
@@ -517,55 +517,6 @@ public class StartLineTests : IDisposable
         DifferentFormsWorkTogether();
     }
 
-    public static IEnumerable<object[]> GetCrLfAndMethodCombinations()
-    {
-        // HTTP methods to test
-        var methods = new string[] {
-            HttpMethods.Connect,
-            HttpMethods.Delete,
-            HttpMethods.Get,
-            HttpMethods.Head,
-            HttpMethods.Options,
-            HttpMethods.Patch,
-            HttpMethods.Post,
-            HttpMethods.Put,
-            HttpMethods.Trace
-        };
-
-        // Prefixes to test
-        var crLfPrefixes = new string[] {
-            "\r",
-            "\n",
-            "\r\r\r\r\r",
-            "\r\n",
-            "\n\r"
-        };
-
-        foreach (var method in methods)
-        {
-            foreach (var prefix in crLfPrefixes)
-            {
-                yield return new object[] { prefix, method };
-            }
-        }
-    }
-
-    [Theory]
-    [MemberData(nameof(GetCrLfAndMethodCombinations))]
-    public void LeadingCrLfAreAllowed(string startOfRequestLine, string httpMethod)
-    {
-        var rawTarget = "http://localhost/path1?q=123&w=xyzw";
-        Http1Connection.Reset();
-        // RawTarget, Path, QueryString are null after reset
-        Assert.Null(Http1Connection.RawTarget);
-        Assert.Null(Http1Connection.Path);
-        Assert.Null(Http1Connection.QueryString);
-
-        var ros = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes($"{startOfRequestLine}{httpMethod} {rawTarget} HTTP/1.1\r\n"));
-        var reader = new SequenceReader<byte>(ros);
-        Assert.True(Parser.ParseRequestLine(ParsingHandler, ref reader));
-    }
-
     public StartLineTests()
     {
         MemoryPool = PinnedBlockMemoryPoolFactory.Create();

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -291,6 +292,190 @@ public class BadHttpRequestTests : LoggedTest
         Assert.True(badRequestEventListener.EventFired);
         Assert.Equal("Microsoft.AspNetCore.Server.Kestrel.BadRequest", eventProviderName);
         Assert.Contains(expectedExceptionMessage, exceptionString);
+    }
+
+    [Theory]
+    [InlineData("\r")]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    [InlineData("\n\r")]
+    [InlineData("\r\n\r\n")]
+    [InlineData("\r\r\r\r\r")]
+    public async Task ExtraLinesBetweenRequestsIgnored(string extraLines)
+    {
+        BadHttpRequestException loggedException = null;
+
+        TestSink.MessageLogged += context =>
+        {
+            if (context.EventId.Name == "ConnectionBadRequest" && context.Exception is BadHttpRequestException ex)
+            {
+                loggedException = ex;
+            }
+        };
+
+        // Set up a listener to catch the BadRequest event
+        var diagListener = new DiagnosticListener("NotBadRequestTestsDiagListener");
+        var badRequestEventListener = new BadRequestEventListener(diagListener, (pair) => { });
+
+        await using (var server = new TestServer(context => context.Request.Body.DrainAsync(default), new TestServiceContext(LoggerFactory) { DiagnosticSource = diagListener }))
+        {
+            using (var connection = server.CreateConnection())
+            {
+                await connection.SendAll(
+                    "POST / HTTP/1.1",
+                    "Host:",
+                    "Content-Length: 5",
+                    "",
+                    "funny",
+                    extraLines);
+
+                await connection.Receive(
+                    "HTTP/1.1 200 OK",
+                    "Content-Length: 0",
+                    $"Date: {server.Context.DateHeaderValue}",
+                    "",
+                    "");
+
+                await connection.SendAll(
+                    "POST / HTTP/1.1",
+                    "Host:",
+                    "Content-Length: 5",
+                    "",
+                    "funny");
+
+                await connection.Receive(
+                    "HTTP/1.1 200 OK",
+                    "Content-Length: 0",
+                    $"Date: {server.Context.DateHeaderValue}",
+                    "",
+                    "");
+
+                connection.ShutdownSend();
+
+                await connection.ReceiveEnd();
+            }
+        }
+
+        Assert.Null(loggedException);
+        // Verify DiagnosticSource event for bad request
+        Assert.False(badRequestEventListener.EventFired);
+    }
+
+    [Fact]
+    public async Task ExtraLinesIgnoredBetweenAdjacentRequests()
+    {
+        BadHttpRequestException loggedException = null;
+
+        TestSink.MessageLogged += context =>
+        {
+            if (context.EventId.Name == "ConnectionBadRequest" && context.Exception is BadHttpRequestException ex)
+            {
+                loggedException = ex;
+            }
+        };
+
+        // Set up a listener to catch the BadRequest event
+        var diagListener = new DiagnosticListener("NotBadRequestTestsDiagListener");
+        var badRequestEventListener = new BadRequestEventListener(diagListener, (pair) => { });
+
+        await using (var server = new TestServer(context => context.Request.Body.DrainAsync(default), new TestServiceContext(LoggerFactory) { DiagnosticSource = diagListener }))
+        {
+            using (var connection = server.CreateConnection())
+            {
+                await connection.SendAll(
+                    "POST / HTTP/1.1",
+                    "Host:",
+                    "Content-Length: 5",
+                    "",
+                    "funny",
+                    "",
+                    "",
+                    "",
+                    "POST /"); // Split the request line
+
+                await connection.Receive(
+                    "HTTP/1.1 200 OK",
+                    "Content-Length: 0",
+                    $"Date: {server.Context.DateHeaderValue}",
+                    "",
+                    "");
+
+                await connection.SendAll(
+                    " HTTP/1.1",
+                    "Host:",
+                    "Content-Length: 5",
+                    "",
+                    "funny");
+
+                await connection.Receive(
+                    "HTTP/1.1 200 OK",
+                    "Content-Length: 0",
+                    $"Date: {server.Context.DateHeaderValue}",
+                    "",
+                    "");
+
+                connection.ShutdownSend();
+
+                await connection.ReceiveEnd();
+            }
+        }
+
+        Assert.Null(loggedException);
+        // Verify DiagnosticSource event for bad request
+        Assert.False(badRequestEventListener.EventFired);
+    }
+
+    [Theory]
+    [InlineData("\r")]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    [InlineData("\n\r")]
+    [InlineData("\r\n\r\n")]
+    [InlineData("\r\r\r\r\r")]
+    public async Task ExtraLinesAtEndOfConnectionIgnored(string extraLines)
+    {
+        BadHttpRequestException loggedException = null;
+
+        TestSink.MessageLogged += context =>
+        {
+            if (context.EventId.Name == "ConnectionBadRequest" && context.Exception is BadHttpRequestException ex)
+            {
+                loggedException = ex;
+            }
+        };
+
+        // Set up a listener to catch the BadRequest event
+        var diagListener = new DiagnosticListener("NotBadRequestTestsDiagListener");
+        var badRequestEventListener = new BadRequestEventListener(diagListener, (pair) => { });
+
+        await using (var server = new TestServer(context => context.Request.Body.DrainAsync(default), new TestServiceContext(LoggerFactory) { DiagnosticSource = diagListener }))
+        {
+            using (var connection = server.CreateConnection())
+            {
+                await connection.SendAll(
+                    "POST / HTTP/1.1",
+                    "Host:",
+                    "Content-Length: 5",
+                    "",
+                    "funny",
+                    extraLines);
+
+                await connection.Receive(
+                    "HTTP/1.1 200 OK",
+                    "Content-Length: 0",
+                    $"Date: {server.Context.DateHeaderValue}",
+                    "",
+                    "");
+
+                connection.ShutdownSend();
+
+                await connection.ReceiveEnd();
+            }
+        }
+
+        Assert.Null(loggedException);
+        // Verify DiagnosticSource event for bad request
+        Assert.False(badRequestEventListener.EventFired);
     }
 
     private async Task ReceiveBadRequestResponse(InMemoryConnection connection, string expectedResponseStatusCode, string expectedDateHeaderValue, string expectedAllowHeader = null)


### PR DESCRIPTION
Fix https://github.com/dotnet/aspnetcore/issues/42697

Some clients send extra new lines (CRLF) between requests. This updates Kestrel to allow that.

The extra lines were being interpreted as an invalid start of the next request, causing a 400 response after the first response. We previously fixed a case where we consumed these at the start of a request, but we missed a case where they were not consumed at the end of a connection.