### PR TITLE
Add another testcase for ExtraLinesBetweenRequestsIgnored

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
@@ -299,6 +299,7 @@ public class BadHttpRequestTests : LoggedTest
     [InlineData("\n")]
     [InlineData("\r\n")]
     [InlineData("\n\r")]
+    [InlineData("\n\n")]
     [InlineData("\r\n\r\n")]
     [InlineData("\r\r\r\r\r")]
     public async Task ExtraLinesBetweenRequestsIgnored(string extraLines)


### PR DESCRIPTION
Added another case based on feedback in this 6.0 PR: https://github.com/dotnet/aspnetcore/pull/43229

Doing it in main too to keep them consistent.