### PR TITLE
Remove QuicTransportOptions.IdleTimeout 

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -97,6 +97,7 @@ internal sealed class Http3Connection : IHttp3StreamLifetimeHandler, IRequestPro
     public Http3ControlStream? EncoderStream { get; set; }
     public Http3ControlStream? DecoderStream { get; set; }
     public string ConnectionId => _context.ConnectionId;
+    public ITimeoutControl TimeoutControl => _context.TimeoutControl;
 
     public void StopProcessingNextRequest()
         => StopProcessingNextRequest(serverInitiated: true);
@@ -264,7 +265,7 @@ internal sealed class Http3Connection : IHttp3StreamLifetimeHandler, IRequestPro
 
                     if (stream.StreamTimeoutTicks == default)
                     {
-                        stream.StreamTimeoutTicks = _context.TimeoutControl.GetResponseDrainDeadline(ticks, minDataRate);
+                        stream.StreamTimeoutTicks = TimeoutControl.GetResponseDrainDeadline(ticks, minDataRate);
                     }
 
                     if (stream.StreamTimeoutTicks < ticks)
@@ -305,6 +306,9 @@ internal sealed class Http3Connection : IHttp3StreamLifetimeHandler, IRequestPro
 
             // Don't delay on waiting to send outbound control stream settings.
             outboundControlStreamTask = ProcessOutboundControlStreamAsync(outboundControlStream);
+
+            // Close the connection if we don't receive any request streams
+            TimeoutControl.SetTimeout(Limits.KeepAliveTimeout.Ticks, TimeoutReason.KeepAlive);
 
             while (_stoppedAcceptingStreams == 0)
             {
@@ -494,7 +498,7 @@ internal sealed class Http3Connection : IHttp3StreamLifetimeHandler, IRequestPro
                     await _streamCompletionAwaitable;
                 }
 
-                _context.TimeoutControl.CancelTimeout();
+                TimeoutControl.CancelTimeout();
             }
             catch
             {
@@ -754,6 +758,11 @@ internal sealed class Http3Connection : IHttp3StreamLifetimeHandler, IRequestPro
         {
             if (stream.IsRequestStream)
             {
+                if (_activeRequestCount == 0 && TimeoutControl.TimerReason == TimeoutReason.KeepAlive)
+                {
+                    TimeoutControl.CancelTimeout();
+                }
+
                 _activeRequestCount++;
             }
             _streams[stream.StreamId] = stream;
@@ -767,6 +776,11 @@ internal sealed class Http3Connection : IHttp3StreamLifetimeHandler, IRequestPro
             if (stream.IsRequestStream)
             {
                 _activeRequestCount--;
+
+                if (_activeRequestCount == 0)
+                {
+                    TimeoutControl.SetTimeout(Limits.KeepAliveTimeout.Ticks, TimeoutReason.KeepAlive);
+                }
             }
             _streams.Remove(stream.StreamId);
         }

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
@@ -88,7 +88,7 @@ internal sealed class QuicConnectionListener : IMultiplexedConnectionListener, I
                 var connectionOptions = new QuicServerConnectionOptions
                 {
                     ServerAuthenticationOptions = serverAuthenticationOptions,
-                    IdleTimeout = options.IdleTimeout,
+                    IdleTimeout = Timeout.InfiniteTimeSpan, // Kestrel manages connection lifetimes itself so it can send GoAway's.
                     MaxInboundBidirectionalStreams = options.MaxBidirectionalStreamCount,
                     MaxInboundUnidirectionalStreams = options.MaxUnidirectionalStreamCount,
                     DefaultCloseErrorCode = options.DefaultCloseErrorCode,

--- a/src/Servers/Kestrel/Transport.Quic/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Transport.Quic/src/PublicAPI.Unshipped.txt
@@ -5,5 +5,7 @@ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportOptions.DefaultS
 Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportOptions.DefaultStreamErrorCode.set -> void
 Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportOptions.MaxBidirectionalStreamCount.get -> int
 Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportOptions.MaxUnidirectionalStreamCount.get -> int
+*REMOVED*Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportOptions.IdleTimeout.get -> System.TimeSpan
+*REMOVED*Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportOptions.IdleTimeout.set -> void
 *REMOVED*Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportOptions.MaxBidirectionalStreamCount.get -> ushort
 *REMOVED*Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportOptions.MaxUnidirectionalStreamCount.get -> ushort

--- a/src/Servers/Kestrel/Transport.Quic/src/QuicTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/QuicTransportOptions.cs
@@ -24,11 +24,6 @@ public sealed class QuicTransportOptions
     public int MaxUnidirectionalStreamCount { get; set; } = 10;
 
     /// <summary>
-    /// Sets the idle timeout for connections and streams.
-    /// </summary>
-    public TimeSpan IdleTimeout { get; set; } = TimeSpan.FromSeconds(130); // Matches KestrelServerLimits.KeepAliveTimeout.
-
-    /// <summary>
     /// The maximum read size.
     /// </summary>
     public long? MaxReadBufferSize { get; set; } = 1024 * 1024;

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicTestHelpers.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicTestHelpers.cs
@@ -33,7 +33,6 @@ internal static class QuicTestHelpers
         long defaultCloseErrorCode = 0)
     {
         var quicTransportOptions = new QuicTransportOptions();
-        quicTransportOptions.IdleTimeout = TimeSpan.FromMinutes(1);
         quicTransportOptions.MaxBidirectionalStreamCount = 200;
         quicTransportOptions.MaxUnidirectionalStreamCount = 200;
         quicTransportOptions.DefaultCloseErrorCode = defaultCloseErrorCode;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TimeoutTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TimeoutTests.cs
@@ -1,27 +1,122 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
-using System.Reflection.PortableExecutable;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Xunit;
-using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
 
 public class Http3TimeoutTests : Http3TestBase
 {
+    [Fact]
+    public async Task KeepAliveTimeout_ControlStreamNotReceived_ConnectionClosed()
+    {
+        var limits = _serviceContext.ServerOptions.Limits;
+
+        await Http3Api.InitializeConnectionAsync(_noopApplication).DefaultTimeout();
+
+        var controlStream = await Http3Api.GetInboundControlStream().DefaultTimeout();
+        await controlStream.ExpectSettingsAsync().DefaultTimeout();
+
+        Http3Api.AdvanceClock(limits.KeepAliveTimeout + TimeSpan.FromTicks(1));
+
+        await Http3Api.WaitForConnectionStopAsync(0, false, expectedErrorCode: Http3ErrorCode.NoError);
+    }
+
+    [Fact]
+    public async Task KeepAliveTimeout_RequestNotReceived_ConnectionClosed()
+    {
+        var limits = _serviceContext.ServerOptions.Limits;
+
+        await Http3Api.InitializeConnectionAsync(_noopApplication).DefaultTimeout();
+        await Http3Api.CreateControlStream();
+
+        var controlStream = await Http3Api.GetInboundControlStream().DefaultTimeout();
+        await controlStream.ExpectSettingsAsync().DefaultTimeout();
+
+        Http3Api.AdvanceClock(limits.KeepAliveTimeout + TimeSpan.FromTicks(1));
+
+        await Http3Api.WaitForConnectionStopAsync(0, false, expectedErrorCode: Http3ErrorCode.NoError);
+    }
+
+    [Fact]
+    public async Task KeepAliveTimeout_AfterRequestComplete_ConnectionClosed()
+    {
+        var requestHeaders = new[]
+        {
+            new KeyValuePair<string, string>(InternalHeaderNames.Method, "GET"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Path, "/"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
+        };
+
+        var limits = _serviceContext.ServerOptions.Limits;
+
+        await Http3Api.InitializeConnectionAsync(_noopApplication).DefaultTimeout();
+
+        await Http3Api.CreateControlStream();
+        var controlStream = await Http3Api.GetInboundControlStream().DefaultTimeout();
+        await controlStream.ExpectSettingsAsync().DefaultTimeout();
+        var requestStream = await Http3Api.CreateRequestStream(requestHeaders, endStream: true);
+        await requestStream.ExpectHeadersAsync();
+
+        await requestStream.ExpectReceiveEndOfStream();
+        await requestStream.OnDisposedTask.DefaultTimeout();
+
+        Http3Api.AdvanceClock(limits.KeepAliveTimeout + Heartbeat.Interval + TimeSpan.FromTicks(1));
+
+        await Http3Api.WaitForConnectionStopAsync(4, false, expectedErrorCode: Http3ErrorCode.NoError);
+    }
+
+    [Fact]
+    public async Task KeepAliveTimeout_LongRunningRequest_KeepsConnectionAlive()
+    {
+        var requestHeaders = new[]
+        {
+            new KeyValuePair<string, string>(InternalHeaderNames.Method, "GET"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Path, "/"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
+        };
+
+        var limits = _serviceContext.ServerOptions.Limits;
+        var requestReceivedTcs = new TaskCompletionSource();
+        var requestFinishedTcs = new TaskCompletionSource();
+
+        await Http3Api.InitializeConnectionAsync(_ =>
+        {
+            requestReceivedTcs.SetResult();
+            return requestFinishedTcs.Task;
+        }).DefaultTimeout();
+
+        await Http3Api.CreateControlStream();
+        var controlStream = await Http3Api.GetInboundControlStream().DefaultTimeout();
+        await controlStream.ExpectSettingsAsync().DefaultTimeout();
+        var requestStream = await Http3Api.CreateRequestStream(requestHeaders, endStream: true);
+
+        await requestReceivedTcs.Task;
+
+        Http3Api.AdvanceClock(limits.KeepAliveTimeout);
+        Http3Api.AdvanceClock(limits.KeepAliveTimeout);
+        Http3Api.AdvanceClock(limits.KeepAliveTimeout);
+        Http3Api.AdvanceClock(limits.KeepAliveTimeout);
+        Http3Api.AdvanceClock(limits.KeepAliveTimeout);
+
+        requestFinishedTcs.SetResult();
+
+        await requestStream.ExpectHeadersAsync();
+
+        await requestStream.ExpectReceiveEndOfStream();
+        await requestStream.OnDisposedTask.DefaultTimeout();
+
+        Http3Api.AdvanceClock(limits.KeepAliveTimeout + Heartbeat.Interval + TimeSpan.FromTicks(1));
+
+        await Http3Api.WaitForConnectionStopAsync(4, false, expectedErrorCode: Http3ErrorCode.NoError);
+    }
 
     [Fact]
     public async Task HEADERS_IncompleteFrameReceivedWithinRequestHeadersTimeout_StreamError()


### PR DESCRIPTION
Fixes #34955

Uses Timeout.InfinateTimeSpan as shown here to disable S.N.Quic's idle timeout in favor of Kestrel's KeepAliveTimeout.
https://github.com/dotnet/runtime/blob/d8226260c9630c2fb196acaa6af7f5dbb45685ee/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs#L127

(Why am I still seeing a timeout from MSQuic? I'll continue to investigate, but either way we want this API removed before RC1)