### PR TITLE
Expose entire EndpointBuilder to filter factories

### DIFF
--- a/src/Http/Http.Abstractions/src/EndpointFilterFactoryContext.cs
+++ b/src/Http/Http.Abstractions/src/EndpointFilterFactoryContext.cs
@@ -13,34 +13,15 @@ namespace Microsoft.AspNetCore.Http;
 public sealed class EndpointFilterFactoryContext
 {
     /// <summary>
-    /// Creates a new instance of the <see cref="EndpointFilterFactoryContext"/>.
+    /// The <see cref="MethodInfo"/> associated with the current route handler, <see cref="RequestDelegate"/> or MVC action.
     /// </summary>
-    /// <param name="methodInfo">The <see cref="MethodInfo"/> associated with the route handler of the current request.</param>
-    /// <param name="endpointMetadata">The <see cref="EndpointBuilder.Metadata"/> associated with the endpoint the filter is targeting.</param>
-    /// <param name="applicationServices">The <see cref="IServiceProvider"/> instance used to access the application services.</param>
-    public EndpointFilterFactoryContext(MethodInfo methodInfo, IList<object> endpointMetadata, IServiceProvider applicationServices)
-    {
-        ArgumentNullException.ThrowIfNull(methodInfo);
-        ArgumentNullException.ThrowIfNull(endpointMetadata);
-        ArgumentNullException.ThrowIfNull(applicationServices);
-
-        MethodInfo = methodInfo;
-        EndpointMetadata = endpointMetadata;
-        ApplicationServices = applicationServices;
-    }
+    /// <remarks>
+    /// In the future this could support more endpoint types.
+    /// </remarks>
+    public required MethodInfo MethodInfo { get; init; }
 
     /// <summary>
-    /// The <see cref="MethodInfo"/> associated with the current route handler.
+    /// The <see cref="EndpointBuilder"/> associated with the current endpoint being filtered.
     /// </summary>
-    public MethodInfo MethodInfo { get; }
-
-    /// <summary>
-    /// The <see cref="EndpointMetadataCollection"/> associated with the current endpoint.
-    /// </summary>
-    public IList<object> EndpointMetadata { get; }
-
-    /// <summary>
-    /// Gets the <see cref="IServiceProvider"/> instance used to access application services.
-    /// </summary>
-    public IServiceProvider ApplicationServices { get; }
+    public required EndpointBuilder EndpointBuilder { get; init; }
 }

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -14,10 +14,11 @@ Microsoft.AspNetCore.Http.DefaultEndpointFilterInvocationContext
 Microsoft.AspNetCore.Http.DefaultEndpointFilterInvocationContext.DefaultEndpointFilterInvocationContext(Microsoft.AspNetCore.Http.HttpContext! httpContext, params object![]! arguments) -> void
 Microsoft.AspNetCore.Http.EndpointFilterDelegate
 Microsoft.AspNetCore.Http.EndpointFilterFactoryContext
-Microsoft.AspNetCore.Http.EndpointFilterFactoryContext.ApplicationServices.get -> System.IServiceProvider!
-Microsoft.AspNetCore.Http.EndpointFilterFactoryContext.EndpointFilterFactoryContext(System.Reflection.MethodInfo! methodInfo, System.Collections.Generic.IList<object!>! endpointMetadata, System.IServiceProvider! applicationServices) -> void
-Microsoft.AspNetCore.Http.EndpointFilterFactoryContext.EndpointMetadata.get -> System.Collections.Generic.IList<object!>!
+Microsoft.AspNetCore.Http.EndpointFilterFactoryContext.EndpointBuilder.get -> Microsoft.AspNetCore.Builder.EndpointBuilder!
+Microsoft.AspNetCore.Http.EndpointFilterFactoryContext.EndpointBuilder.init -> void
+Microsoft.AspNetCore.Http.EndpointFilterFactoryContext.EndpointFilterFactoryContext() -> void
 Microsoft.AspNetCore.Http.EndpointFilterFactoryContext.MethodInfo.get -> System.Reflection.MethodInfo!
+Microsoft.AspNetCore.Http.EndpointFilterFactoryContext.MethodInfo.init -> void
 Microsoft.AspNetCore.Http.EndpointFilterInvocationContext
 Microsoft.AspNetCore.Http.EndpointFilterInvocationContext.EndpointFilterInvocationContext() -> void
 Microsoft.AspNetCore.Http.EndpointMetadataCollection.Enumerator.Current.get -> object!

--- a/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Extensions/src/PublicAPI.Unshipped.txt
@@ -38,6 +38,8 @@ Microsoft.AspNetCore.Http.ProblemDetailsOptions.ProblemDetailsOptions() -> void
 *REMOVED*Microsoft.AspNetCore.Mvc.ProblemDetails.Title.set -> void
 *REMOVED*Microsoft.AspNetCore.Mvc.ProblemDetails.Type.get -> string?
 *REMOVED*Microsoft.AspNetCore.Mvc.ProblemDetails.Type.set -> void
+Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.EndpointBuilder.get -> Microsoft.AspNetCore.Builder.EndpointBuilder?
+Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.EndpointBuilder.init -> void
 Microsoft.AspNetCore.Mvc.ProblemDetails (forwarded, contained in Microsoft.AspNetCore.Http.Abstractions)
 Microsoft.AspNetCore.Mvc.ProblemDetails.Detail.get -> string? (forwarded, contained in Microsoft.AspNetCore.Http.Abstractions)
 Microsoft.AspNetCore.Mvc.ProblemDetails.Detail.set -> void (forwarded, contained in Microsoft.AspNetCore.Http.Abstractions)
@@ -52,10 +54,6 @@ Microsoft.AspNetCore.Mvc.ProblemDetails.Title.set -> void (forwarded, contained 
 Microsoft.AspNetCore.Mvc.ProblemDetails.Type.get -> string? (forwarded, contained in Microsoft.AspNetCore.Http.Abstractions)
 Microsoft.AspNetCore.Mvc.ProblemDetails.Type.set -> void (forwarded, contained in Microsoft.AspNetCore.Http.Abstractions)
 Microsoft.Extensions.DependencyInjection.ProblemDetailsServiceCollectionExtensions
-Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.EndpointFilterFactories.get -> System.Collections.Generic.IReadOnlyList<System.Func<Microsoft.AspNetCore.Http.EndpointFilterFactoryContext!, Microsoft.AspNetCore.Http.EndpointFilterDelegate!, Microsoft.AspNetCore.Http.EndpointFilterDelegate!>!>?
-Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.EndpointFilterFactories.init -> void
-Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.EndpointMetadata.get -> System.Collections.Generic.IList<object!>?
-Microsoft.AspNetCore.Http.RequestDelegateFactoryOptions.EndpointMetadata.init -> void
 Microsoft.Extensions.DependencyInjection.HttpJsonServiceExtensions
 static Microsoft.AspNetCore.Http.HttpRequestJsonExtensions.ReadFromJsonAsync(this Microsoft.AspNetCore.Http.HttpRequest! request, System.Type! type, System.Text.Json.Serialization.JsonSerializerContext! context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<object?>
 static Microsoft.AspNetCore.Http.HttpRequestJsonExtensions.ReadFromJsonAsync<TValue>(this Microsoft.AspNetCore.Http.HttpRequest! request, System.Text.Json.Serialization.Metadata.JsonTypeInfo<TValue>! jsonTypeInfo, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<TValue?>

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -205,7 +205,7 @@ public static partial class RequestDelegateFactory
     {
         if (options?.EndpointBuilder?.RequestDelegate is not null)
         {
-            throw new ArgumentException($"{nameof(RequestDelegateFactoryOptions)}.{nameof(RequestDelegateFactoryOptions.EndpointBuilder)} must be null.", nameof(options));
+            throw new ArgumentException($"{nameof(RequestDelegateFactoryOptions)}.{nameof(RequestDelegateFactoryOptions.EndpointBuilder)}.{nameof(EndpointBuilder.RequestDelegate)} must be null.", nameof(options));
         }
 
         var endpointBuilder = options?.EndpointBuilder ?? new RDFEndpointBuilder();

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -149,15 +149,6 @@ public static partial class RequestDelegateFactory
             _ => httpContext => targetableRequestDelegate(handler.Target, httpContext),
         };
 
-        if (targetableRequestDelegate is null)
-        {
-            finalRequestDelegate = (RequestDelegate)handler;
-        }
-        else
-        {
-            finalRequestDelegate = httpContext => targetableRequestDelegate(handler.Target, httpContext);
-        }
-
         return CreateRequestDelegateResult(finalRequestDelegate, factoryContext.EndpointBuilder);
     }
 

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -217,8 +217,8 @@ public static partial class RequestDelegateFactory
             throw new ArgumentException($"{nameof(RequestDelegateFactoryOptions)}.{nameof(RequestDelegateFactoryOptions.EndpointBuilder)} must be null.", nameof(options));
         }
 
-        var endointBuilder = options?.EndpointBuilder ?? new RDFEndpointBuilder();
-        var serviceProvider = options?.ServiceProvider ?? endointBuilder.ApplicationServices;
+        var endpointBuilder = options?.EndpointBuilder ?? new RDFEndpointBuilder();
+        var serviceProvider = options?.ServiceProvider ?? endpointBuilder.ApplicationServices;
 
         return new FactoryContext
         {
@@ -228,7 +228,7 @@ public static partial class RequestDelegateFactory
             RouteParameters = options?.RouteParameterNames?.ToList(),
             ThrowOnBadRequest = options?.ThrowOnBadRequest ?? false,
             DisableInferredFromBody = options?.DisableInferBodyFromParameters ?? false,
-            EndpointBuilder = endointBuilder,
+            EndpointBuilder = endpointBuilder,
         };
     }
 
@@ -281,7 +281,7 @@ public static partial class RequestDelegateFactory
 
         // If there are filters registered on the route handler, then we update the method call and
         // return type associated with the request to allow for the filter invocation pipeline.
-        if (factoryContext.EndpointBuilder.FilterFactories.Count > 0 )
+        if (factoryContext.EndpointBuilder.FilterFactories.Count > 0)
         {
             filterPipeline = CreateFilterPipeline(methodInfo, targetExpression, factoryContext, targetFactory);
 
@@ -864,7 +864,7 @@ public static partial class RequestDelegateFactory
 
         // If filters have been registered, we set the `wasParamCheckFailure` property
         // but do not return from the invocation to allow the filters to run.
-        if (factoryContext.EndpointBuilder.FilterFactories.Count > 0 )
+        if (factoryContext.EndpointBuilder.FilterFactories.Count > 0)
         {
             // if (wasParamCheckFailure)
             // {

--- a/src/Http/Http.Extensions/src/RequestDelegateFactoryOptions.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactoryOptions.cs
@@ -34,25 +34,18 @@ public sealed class RequestDelegateFactoryOptions
     public bool DisableInferBodyFromParameters { get; init; }
 
     /// <summary>
-    /// The list of filters that must run in the pipeline for a given route handler.
-    /// </summary>
-    public IReadOnlyList<Func<EndpointFilterFactoryContext, EndpointFilterDelegate, EndpointFilterDelegate>>? EndpointFilterFactories { get; init; }
-
-    /// <summary>
-    /// The mutable initial endpoint metadata to add as part of the creation of the <see cref="RequestDelegateResult.RequestDelegate"/>. In most cases,
-    /// this should come from <see cref="EndpointBuilder.Metadata"/>.
+    /// The mutable <see cref="Builder.EndpointBuilder"/> used to assist in the creation of the <see cref="RequestDelegateResult.RequestDelegate"/>.
+    /// This is primarily used to run <see cref="EndpointBuilder.FilterFactories"/> and populate inferred <see cref="EndpointBuilder.Metadata"/>.
+    /// The <see cref="EndpointBuilder.RequestDelegate"/> must be <see langword="null"/>. After the call to <see cref="RequestDelegateFactory.Create(Delegate, RequestDelegateFactoryOptions?)"/>,
+    /// <see cref="EndpointBuilder.RequestDelegate"/> will be the same as <see cref="RequestDelegateResult.RequestDelegate"/>.
     /// </summary>
     /// <remarks>
-    /// This metadata will be included in <see cref="RequestDelegateResult.EndpointMetadata" /> <b>before</b> most metadata inferred during creation of the
-    /// <see cref="RequestDelegateResult.RequestDelegate"/> and <b>before</b> any metadata provided by types in the delegate signature that implement
-    /// <see cref="IEndpointMetadataProvider" /> or <see cref="IEndpointParameterMetadataProvider" />. The exception to this general rule is the
+    /// Any metadata already in <see cref="EndpointBuilder.Metadata"/> will be included in <see cref="RequestDelegateResult.EndpointMetadata" /> <b>before</b>
+    /// most metadata inferred during creation of the <see cref="RequestDelegateResult.RequestDelegate"/> and <b>before</b> any metadata provided by types in
+    /// the delegate signature that implement <see cref="IEndpointMetadataProvider" /> or <see cref="IEndpointParameterMetadataProvider" />. The exception to this general rule is the
     /// <see cref="IAcceptsMetadata"/> that <see cref="RequestDelegateFactory.Create(Delegate, RequestDelegateFactoryOptions?)"/> infers automatically
     /// without any custom metadata providers which instead is inserted at the start to give it lower precedence. Custom metadata providers can choose to
     /// insert their metadata at the start to give lower precedence, but this is unusual.
     /// </remarks>
-    public IList<object>? EndpointMetadata { get; init; }
-
-    // TODO: Add a RouteEndpointBuilder property and remove the EndpointMetadata property. Then do the same in RouteHandlerContext, EndpointMetadataContext
-    // and EndpointParameterMetadataContext. This will allow seeing the entire route pattern if the caller chooses to allow it.
-    // We'll probably want to add the RouteEndpointBuilder constructor without a RequestDelegate back and make it public too.
+    public EndpointBuilder? EndpointBuilder { get; init; }
 }

--- a/src/Http/Routing/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Routing/src/PublicAPI.Unshipped.txt
@@ -1,8 +1,10 @@
 #nullable enable
+*REMOVED*Microsoft.AspNetCore.Routing.RouteEndpointBuilder.RouteEndpointBuilder(Microsoft.AspNetCore.Http.RequestDelegate! requestDelegate, Microsoft.AspNetCore.Routing.Patterns.RoutePattern! routePattern, int order) -> void
 Microsoft.AspNetCore.Http.EndpointFilterExtensions
 Microsoft.AspNetCore.Routing.CompositeEndpointDataSource.Dispose() -> void
 Microsoft.AspNetCore.Routing.HttpMethodMetadata.AcceptCorsPreflight.set -> void
 Microsoft.AspNetCore.Routing.IHttpMethodMetadata.AcceptCorsPreflight.set -> void
+Microsoft.AspNetCore.Routing.RouteEndpointBuilder.RouteEndpointBuilder(Microsoft.AspNetCore.Http.RequestDelegate? requestDelegate, Microsoft.AspNetCore.Routing.Patterns.RoutePattern! routePattern, int order) -> void
 Microsoft.AspNetCore.Routing.RouteGroupBuilder
 Microsoft.AspNetCore.Routing.RouteGroupContext
 Microsoft.AspNetCore.Routing.RouteGroupContext.ApplicationServices.get -> System.IServiceProvider!

--- a/src/Http/Routing/src/RouteEndpointBuilder.cs
+++ b/src/Http/Routing/src/RouteEndpointBuilder.cs
@@ -30,10 +30,12 @@ public sealed class RouteEndpointBuilder : EndpointBuilder
     /// <param name="routePattern">The <see cref="RoutePattern"/> to use in URL matching.</param>
     /// <param name="order">The order assigned to the endpoint.</param>
     public RouteEndpointBuilder(
-       RequestDelegate requestDelegate,
+       RequestDelegate? requestDelegate,
        RoutePattern routePattern,
        int order)
     {
+        ArgumentNullException.ThrowIfNull(routePattern);
+
         RequestDelegate = requestDelegate;
         RoutePattern = routePattern;
         Order = order;

--- a/src/Http/Routing/test/UnitTests/Builder/RequestDelegateEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/RequestDelegateEndpointRouteBuilderExtensionsTest.cs
@@ -115,7 +115,7 @@ public class RequestDelegateEndpointRouteBuilderExtensionsTest
 
         var endpointBuilder = map(builder, "/", initialRequestDelegate).AddEndpointFilterFactory(filterFactory: (routeHandlerContext, next) =>
         {
-            routeHandlerContext.EndpointMetadata.Add(filterTag);
+            routeHandlerContext.EndpointBuilder.Metadata.Add(filterTag);
             return async invocationContext =>
             {
                 Assert.IsAssignableFrom<HttpContext>(Assert.Single(invocationContext.Arguments));
@@ -151,7 +151,7 @@ public class RequestDelegateEndpointRouteBuilderExtensionsTest
 
         var endpointBuilder = map(builder, "/", initialRequestDelegate).AddEndpointFilterFactory((routeHandlerContext, next) =>
         {
-            routeHandlerContext.EndpointMetadata.Add(filterTag);
+            routeHandlerContext.EndpointBuilder.Metadata.Add(filterTag);
             return next;
         });
 

--- a/src/Http/Routing/test/UnitTests/Builder/RouteHandlerEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/RouteHandlerEndpointRouteBuilderExtensionsTest.cs
@@ -6,6 +6,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -871,7 +872,7 @@ public class RouteHandlerEndpointRouteBuilderExtensionsTest : LoggedTest
                 {
                     Assert.NotNull(routeHandlerContext.MethodInfo);
                     Assert.NotNull(routeHandlerContext.MethodInfo.DeclaringType);
-                    Assert.NotNull(routeHandlerContext.ApplicationServices);
+                    Assert.NotNull(routeHandlerContext.EndpointBuilder.ApplicationServices);
                     Assert.Equal("RouteHandlerEndpointRouteBuilderExtensionsTest", routeHandlerContext.MethodInfo.DeclaringType?.Name);
                     context.Arguments[0] = context.GetArgument<int>(0) + 1;
                     return await next(context);
@@ -981,7 +982,7 @@ public class RouteHandlerEndpointRouteBuilderExtensionsTest : LoggedTest
     }
 
     [Fact]
-    public void RequestDelegateFactory_ProvidesAppServiceProvider_ToFilterFactory()
+    public void RequestDelegateFactory_ProvidesRouteEndpointBuilder_ToFilterFactory()
     {
         var appServiceCollection = new ServiceCollection();
         var appService = new MyService();
@@ -991,39 +992,29 @@ public class RouteHandlerEndpointRouteBuilderExtensionsTest : LoggedTest
 
         string? PrintLogger(HttpContext context) => $"loggerErrorIsEnabled: {context.Items["loggerErrorIsEnabled"]}, parentName: {context.Items["parentName"]}";
         var routeHandlerBuilder = builder.Map("/", PrintLogger);
+
+        var customDisplayName = "MyFilterFactory";
+        var customRoutePattern = RoutePatternFactory.Parse("/MyFilteredPattern");
+
         routeHandlerBuilder.AddEndpointFilterFactory((rhc, next) =>
         {
-            Assert.NotNull(rhc.ApplicationServices);
-            var myService = rhc.ApplicationServices.GetRequiredService<MyService>();
+            Assert.NotNull(rhc.EndpointBuilder.ApplicationServices);
+            var myService = rhc.EndpointBuilder.ApplicationServices.GetRequiredService<MyService>();
             Assert.Equal(appService, myService);
+
+            rhc.EndpointBuilder.DisplayName = customDisplayName;
+            ((RouteEndpointBuilder)rhc.EndpointBuilder).RoutePattern = customRoutePattern;
+
             filterFactoryRan = true;
             return next;
         });
 
         var dataSource = GetBuilderEndpointDataSource(builder);
         // Trigger Endpoint build by calling getter.
-        Assert.Single(dataSource.Endpoints);
+        var routeEndpoint = Assert.Single(dataSource.Endpoints);
+        Assert.Equal(customDisplayName, routeEndpoint.DisplayName);
+        Assert.Equal(customRoutePattern, routeEndpoint.RoutePattern);
         Assert.True(filterFactoryRan);
-    }
-
-    [Fact]
-    public void RouteHandlerContext_ThrowsArgumentNullException_ForMethodInfo()
-    {
-        Assert.Throws<ArgumentNullException>("methodInfo", () => new EndpointFilterFactoryContext(null!, new List<object>(), new ServiceCollection().BuildServiceProvider()));
-    }
-
-    [Fact]
-    public void RouteHandlerContext_ThrowsArgumentNullException_ForEndpointMetadata()
-    {
-        var handler = () => { };
-        Assert.Throws<ArgumentNullException>("endpointMetadata", () => new EndpointFilterFactoryContext(handler.Method, null!, new ServiceCollection().BuildServiceProvider()));
-    }
-
-    [Fact]
-    public void RouteHandlerContext_ThrowsArgumentNullException_ForApplicationServices()
-    {
-        var handler = () => { };
-        Assert.Throws<ArgumentNullException>("applicationServices", () => new EndpointFilterFactoryContext(handler.Method, new List<object>(), null!));
     }
 
     class MyService { }

--- a/src/Http/Routing/test/UnitTests/RouteEndpointBuilderTest.cs
+++ b/src/Http/Routing/test/UnitTests/RouteEndpointBuilderTest.cs
@@ -10,6 +10,20 @@ namespace Microsoft.AspNetCore.Routing;
 public class RouteEndpointBuilderTest
 {
     [Fact]
+    public void Constructor_AllowsNullRequestDelegate()
+    {
+        var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
+        Assert.Null(builder.RequestDelegate);
+    }
+
+    [Fact]
+    public void Constructor_DoesNotAllowNullRoutePattern()
+    {
+        var ex = Assert.Throws<ArgumentNullException>(() => new RouteEndpointBuilder(context => Task.CompletedTask, routePattern: null, order: 0));
+        Assert.Equal("routePattern", ex.ParamName);
+    }
+
+    [Fact]
     public void Build_AllValuesSet_EndpointCreated()
     {
         const int defaultOrder = 0;

--- a/src/Http/samples/MinimalSample/Program.cs
+++ b/src/Http/samples/MinimalSample/Program.cs
@@ -23,7 +23,7 @@ var inner = outer.MapGroup("/inner");
 
 inner.AddEndpointFilterFactory((routeContext, next) =>
 {
-    var tags = routeContext.EndpointMetadata.OfType<ITagsMetadata>().FirstOrDefault();
+    var tags = routeContext.EndpointBuilder.Metadata.OfType<ITagsMetadata>().FirstOrDefault();
 
     return async invocationContext =>
     {

--- a/src/Mvc/Mvc.Core/src/Routing/ActionEndpointFactory.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/ActionEndpointFactory.cs
@@ -324,7 +324,7 @@ internal sealed class ActionEndpointFactory
         return (attributeRoutePattern, resolvedRequiredValues ?? action.RouteValues);
     }
 
-    private void AddActionDataToBuilder(
+    private static void AddActionDataToBuilder(
         EndpointBuilder builder,
         HashSet<string> routeNames,
         ActionDescriptor action,
@@ -451,7 +451,11 @@ internal sealed class ActionEndpointFactory
                 return controllerInvocationContext.ActionDescriptor.CacheEntry!.InnerActionMethodExecutor.Execute(controllerInvocationContext);
             };
 
-            var context = new EndpointFilterFactoryContext(cad.MethodInfo, builder.Metadata, _serviceProvider);
+            var context = new EndpointFilterFactoryContext
+            {
+                MethodInfo = cad.MethodInfo,
+                EndpointBuilder = builder,
+            };
 
             var initialFilteredInvocation = del;
 


### PR DESCRIPTION
This flows the entire `EndpointBuilder` through to endpoint filter factories. This gives more context like the display name to filters, and reduces the number of properties in `RequestDelegateFactoryOptions` and `EndpointFilterFactoryContext`. And since the `EndpointBuilder` is usually a `RouteEndpointBuilder`, filters can observe the route pattern as well.

`EndpointBuilder.RequestDelegate` must be `null` if it is passed into the `RequestDelegateFactory.Create()`. The `RequestDelegateFactory` sets the `RequestDelegate` to the same instance returned via `RequestDelegateResult.RequestDelegate`. This is similar to how we were already mutating the passed-in metadata that was also then returned.

Fixes #43000