### PR TITLE
Trimming: Validate DataProtection custom algorithm has a constructor

### DIFF
--- a/src/DataProtection/DataProtection/src/AuthenticatedEncryption/AuthenticatedEncryptorFactory.cs
+++ b/src/DataProtection/DataProtection/src/AuthenticatedEncryption/AuthenticatedEncryptorFactory.cs
@@ -163,6 +163,7 @@ public sealed class AuthenticatedEncryptorFactory : IAuthenticatedEncryptorFacto
         }
     }
 
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     private static Type GetManagedTypeFromEncryptionAlgorithm(EncryptionAlgorithm algorithm)
     {
         switch (algorithm)

--- a/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/ManagedAlgorithmHelpers.cs
+++ b/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/ManagedAlgorithmHelpers.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using System.Xml.Linq;
+
+namespace Microsoft.AspNetCore.DataProtection.AuthenticatedEncryption.ConfigurationModel;
+
+internal static class ManagedAlgorithmHelpers
+{
+    private static readonly List<Type> KnownAlgorithmTypes = new List<Type>
+    {
+        typeof(Aes),
+        typeof(HMACSHA1),
+        typeof(HMACSHA256),
+        typeof(HMACSHA384),
+        typeof(HMACSHA512)
+    };
+
+    // Any changes to this method should also be be reflected in FriendlyNameToType.
+    public static string TypeToFriendlyName(Type type)
+    {
+        if (KnownAlgorithmTypes.Contains(type))
+        {
+            return type.Name;
+        }
+        else
+        {
+            return type.AssemblyQualifiedName!;
+        }
+    }
+
+    // Any changes to this method should also be be reflected in TypeToFriendlyName.
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    [UnconditionalSuppressMessage("Trimmer", "IL2075", Justification = "Unknown type is checked for whether it has a public parameterless constructor. Handle trimmed types by providing a useful error message.")]
+    [UnconditionalSuppressMessage("Trimmer", "IL2073", Justification = "Unknown type is checked for whether it has a public parameterless constructor. Handle trimmed types by providing a useful error message.")]
+    public static Type FriendlyNameToType(string typeName)
+    {
+        foreach (var knownType in KnownAlgorithmTypes)
+        {
+            if (knownType.Name == typeName)
+            {
+                return knownType;
+            }
+        }
+
+        var type = TypeExtensions.GetTypeWithTrimFriendlyErrorMessage(typeName);
+
+        // Type name could be full or assembly qualified name of known type.
+        if (KnownAlgorithmTypes.Contains(type))
+        {
+            return type;
+        }
+
+        // All other types are created using Activator.CreateInstance. Validate it has a valid constructor.
+        if (type.GetConstructor(Type.EmptyTypes) == null)
+        {
+            throw new InvalidOperationException($"Algorithm type {type} doesn't have a public parameterless constructor. If the app is published with trimming then the constructor may have been trimmed. Ensure the type's assembly is excluded from trimming.");
+        }
+
+        return type;
+    }
+}

--- a/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/ManagedAuthenticatedEncryptorConfiguration.cs
+++ b/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/ManagedAuthenticatedEncryptorConfiguration.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -24,6 +25,7 @@ public sealed class ManagedAuthenticatedEncryptorConfiguration : AlgorithmConfig
     /// The default algorithm is AES.
     /// </remarks>
     [ApplyPolicy]
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public Type EncryptionAlgorithmType { get; set; } = typeof(Aes);
 
     /// <summary>
@@ -47,6 +49,7 @@ public sealed class ManagedAuthenticatedEncryptorConfiguration : AlgorithmConfig
     /// The default algorithm is HMACSHA256.
     /// </remarks>
     [ApplyPolicy]
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public Type ValidationAlgorithmType { get; set; } = typeof(HMACSHA256);
 
     /// <inheritdoc />

--- a/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/ManagedAuthenticatedEncryptorDescriptor.cs
+++ b/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/ManagedAuthenticatedEncryptorDescriptor.cs
@@ -49,11 +49,11 @@ public sealed class ManagedAuthenticatedEncryptorDescriptor : IAuthenticatedEncr
         // </descriptor>
 
         var encryptionElement = new XElement("encryption",
-            new XAttribute("algorithm", TypeToFriendlyName(Configuration.EncryptionAlgorithmType)),
+            new XAttribute("algorithm", ManagedAlgorithmHelpers.TypeToFriendlyName(Configuration.EncryptionAlgorithmType)),
             new XAttribute("keyLength", Configuration.EncryptionAlgorithmKeySize));
 
         var validationElement = new XElement("validation",
-            new XAttribute("algorithm", TypeToFriendlyName(Configuration.ValidationAlgorithmType)));
+            new XAttribute("algorithm", ManagedAlgorithmHelpers.TypeToFriendlyName(Configuration.ValidationAlgorithmType)));
 
         var rootElement = new XElement("descriptor",
             new XComment(" Algorithms provided by specified SymmetricAlgorithm and KeyedHashAlgorithm "),
@@ -62,35 +62,5 @@ public sealed class ManagedAuthenticatedEncryptorDescriptor : IAuthenticatedEncr
             MasterKey.ToMasterKeyElement());
 
         return new XmlSerializedDescriptorInfo(rootElement, typeof(ManagedAuthenticatedEncryptorDescriptorDeserializer));
-    }
-
-    // Any changes to this method should also be be reflected
-    // in ManagedAuthenticatedEncryptorDescriptorDeserializer.FriendlyNameToType.
-    private static string TypeToFriendlyName(Type type)
-    {
-        if (type == typeof(Aes))
-        {
-            return nameof(Aes);
-        }
-        else if (type == typeof(HMACSHA1))
-        {
-            return nameof(HMACSHA1);
-        }
-        else if (type == typeof(HMACSHA256))
-        {
-            return nameof(HMACSHA256);
-        }
-        else if (type == typeof(HMACSHA384))
-        {
-            return nameof(HMACSHA384);
-        }
-        else if (type == typeof(HMACSHA512))
-        {
-            return nameof(HMACSHA512);
-        }
-        else
-        {
-            return type.AssemblyQualifiedName!;
-        }
     }
 }

--- a/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/ManagedAuthenticatedEncryptorDescriptorDeserializer.cs
+++ b/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/ManagedAuthenticatedEncryptorDescriptorDeserializer.cs
@@ -34,44 +34,14 @@ public sealed class ManagedAuthenticatedEncryptorDescriptorDeserializer : IAuthe
         var configuration = new ManagedAuthenticatedEncryptorConfiguration();
 
         var encryptionElement = element.Element("encryption")!;
-        configuration.EncryptionAlgorithmType = FriendlyNameToType((string)encryptionElement.Attribute("algorithm")!);
+        configuration.EncryptionAlgorithmType = ManagedAlgorithmHelpers.FriendlyNameToType((string)encryptionElement.Attribute("algorithm")!);
         configuration.EncryptionAlgorithmKeySize = (int)encryptionElement.Attribute("keyLength")!;
 
         var validationElement = element.Element("validation")!;
-        configuration.ValidationAlgorithmType = FriendlyNameToType((string)validationElement.Attribute("algorithm")!);
+        configuration.ValidationAlgorithmType = ManagedAlgorithmHelpers.FriendlyNameToType((string)validationElement.Attribute("algorithm")!);
 
         Secret masterKey = ((string)element.Element("masterKey")!).ToSecret();
 
         return new ManagedAuthenticatedEncryptorDescriptor(configuration, masterKey);
-    }
-
-    // Any changes to this method should also be be reflected
-    // in ManagedAuthenticatedEncryptorDescriptor.TypeToFriendlyName.
-    private static Type FriendlyNameToType(string typeName)
-    {
-        if (typeName == nameof(Aes))
-        {
-            return typeof(Aes);
-        }
-        else if (typeName == nameof(HMACSHA1))
-        {
-            return typeof(HMACSHA1);
-        }
-        else if (typeName == nameof(HMACSHA256))
-        {
-            return typeof(HMACSHA256);
-        }
-        else if (typeName == nameof(HMACSHA384))
-        {
-            return typeof(HMACSHA384);
-        }
-        else if (typeName == nameof(HMACSHA512))
-        {
-            return typeof(HMACSHA512);
-        }
-        else
-        {
-            return TypeExtensions.GetTypeWithTrimFriendlyErrorMessage(typeName);
-        }
     }
 }

--- a/src/DataProtection/DataProtection/src/RegistryPolicyResolver.cs
+++ b/src/DataProtection/DataProtection/src/RegistryPolicyResolver.cs
@@ -177,7 +177,7 @@ internal sealed class RegistryPolicyResolver : IRegistryPolicyResolver
         var valueFromRegistry = key.GetValue(nameof(ManagedAuthenticatedEncryptorConfiguration.EncryptionAlgorithmType));
         if (valueFromRegistry != null)
         {
-            options.EncryptionAlgorithmType = TypeExtensions.GetTypeWithTrimFriendlyErrorMessage(Convert.ToString(valueFromRegistry, CultureInfo.InvariantCulture)!);
+            options.EncryptionAlgorithmType = ManagedAlgorithmHelpers.FriendlyNameToType(Convert.ToString(valueFromRegistry, CultureInfo.InvariantCulture)!);
         }
 
         valueFromRegistry = key.GetValue(nameof(ManagedAuthenticatedEncryptorConfiguration.EncryptionAlgorithmKeySize));
@@ -189,7 +189,7 @@ internal sealed class RegistryPolicyResolver : IRegistryPolicyResolver
         valueFromRegistry = key.GetValue(nameof(ManagedAuthenticatedEncryptorConfiguration.ValidationAlgorithmType));
         if (valueFromRegistry != null)
         {
-            options.ValidationAlgorithmType = TypeExtensions.GetTypeWithTrimFriendlyErrorMessage(Convert.ToString(valueFromRegistry, CultureInfo.InvariantCulture)!);
+            options.ValidationAlgorithmType = ManagedAlgorithmHelpers.FriendlyNameToType(Convert.ToString(valueFromRegistry, CultureInfo.InvariantCulture)!);
         }
 
         return options;

--- a/src/DataProtection/DataProtection/test/RegistryPolicyResolverTests.cs
+++ b/src/DataProtection/DataProtection/test/RegistryPolicyResolverTests.cs
@@ -226,13 +226,13 @@ public class RegistryPolicyResolverTests
         var registryEntries = new Dictionary<string, object>()
         {
             ["EncryptionType"] = "managed",
-            ["EncryptionAlgorithmType"] = typeof(TripleDES).AssemblyQualifiedName,
+            ["EncryptionAlgorithmType"] = typeof(Aes).AssemblyQualifiedName,
             ["EncryptionAlgorithmKeySize"] = 2048,
             ["ValidationAlgorithmType"] = typeof(HMACSHA1).AssemblyQualifiedName
         };
         var expectedConfiguration = new ManagedAuthenticatedEncryptorConfiguration()
         {
-            EncryptionAlgorithmType = typeof(TripleDES),
+            EncryptionAlgorithmType = typeof(Aes),
             EncryptionAlgorithmKeySize = 2048,
             ValidationAlgorithmType = typeof(HMACSHA1)
         };


### PR DESCRIPTION
Trimming analytics has introduced a new warning. This PR fixes it. Maybe. ASP.NET Core doesn't have the SDK with the warning yet. However, it should involve adding a follow-up suppression if it's not fixed.

Addresses https://github.com/dotnet/aspnetcore/issues/43253