### PR TITLE
Kestrel sample: only enable delayed client cert negotiation on non-macOS

### DIFF
--- a/src/Servers/Kestrel/samples/SampleApp/Startup.cs
+++ b/src/Servers/Kestrel/samples/SampleApp/Startup.cs
@@ -87,7 +87,12 @@ public class Startup
                         options.ConfigureHttpsDefaults(httpsOptions =>
                         {
                             httpsOptions.SslProtocols = SslProtocols.Tls12;
-                            httpsOptions.ClientCertificateMode = ClientCertificateMode.DelayCertificate;
+
+                            if (!OperatingSystem.IsMacOS())
+                            {
+                                // Delayed client certificate negotiation is not supported on macOS.
+                                httpsOptions.ClientCertificateMode = ClientCertificateMode.DelayCertificate;
+                            }
                         });
 
                         options.Listen(IPAddress.Loopback, basePort, listenOptions =>


### PR DESCRIPTION
The Kestrel sample has been broken on macOS for a while since delayed client cert negotiation isn't supported.
