### PR TITLE
Removing .NET Core from documentation and updating it to the .NET as Core has been removed from .NET 5 onwards.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ASP.NET Core
 ============
 
-ASP.NET Core is an open-source and cross-platform framework for building modern cloud based internet connected applications, such as web apps, IoT apps and mobile backends. ASP.NET Core apps run on [.NET Core](https://dot.net), a free, cross-platform and open-source application runtime. It was architected to provide an optimized development framework for apps that are deployed to the cloud or run on-premises. It consists of modular components with minimal overhead, so you retain flexibility while constructing your solutions. You can develop and run your ASP.NET Core apps cross-platform on Windows, Mac and Linux. [Learn more about ASP.NET Core](https://docs.microsoft.com/aspnet/core/).
+ASP.NET Core is an open-source and cross-platform framework for building modern cloud based internet connected applications, such as web apps, IoT apps and mobile backends. ASP.NET Core apps run on [.NET](https://dot.net), a free, cross-platform and open-source application runtime. It was architected to provide an optimized development framework for apps that are deployed to the cloud or run on-premises. It consists of modular components with minimal overhead, so you retain flexibility while constructing your solutions. You can develop and run your ASP.NET Core apps cross-platform on Windows, Mac and Linux. [Learn more about ASP.NET Core](https://docs.microsoft.com/aspnet/core/).
 
 ## Get Started
 


### PR DESCRIPTION
Removing .NET Core from documentation and updating it to the .NET as Core has been removed from .NET 5  onwards.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Readme file still using .NET Core terminology , But from .NET 5 onwards , It is only termed as .NET, a single unified platform even through asp.net core still contains core extension.

Fixes #{bug number} (in this specific format)
