### PR TITLE
Perf-up the AuthZ!

### DIFF
--- a/src/Http/Authentication.Abstractions/src/AuthenticateResult.cs
+++ b/src/Http/Authentication.Abstractions/src/AuthenticateResult.cs
@@ -11,6 +11,8 @@ namespace Microsoft.AspNetCore.Authentication;
 /// </summary>
 public class AuthenticateResult
 {
+    private static readonly AuthenticateResult _noResult = new() { None = true };
+
     /// <summary>
     /// Creates a new <see cref="AuthenticateResult"/> instance.
     /// </summary>
@@ -89,7 +91,7 @@ public class AuthenticateResult
     /// <returns>The result.</returns>
     public static AuthenticateResult NoResult()
     {
-        return new AuthenticateResult() { None = true };
+        return _noResult;
     }
 
     /// <summary>

--- a/src/Security/Authorization/Core/src/AuthorizationFailure.cs
+++ b/src/Security/Authorization/Core/src/AuthorizationFailure.cs
@@ -12,6 +12,8 @@ namespace Microsoft.AspNetCore.Authorization;
 /// </summary>
 public class AuthorizationFailure
 {
+    private static readonly AuthorizationFailure _explicitFailure = new() { FailCalled = true };
+
     private AuthorizationFailure() { }
 
     /// <summary>
@@ -33,11 +35,7 @@ public class AuthorizationFailure
     /// Return a failure due to <see cref="AuthorizationHandlerContext.Fail()"/> being called.
     /// </summary>
     /// <returns>The failure.</returns>
-    public static AuthorizationFailure ExplicitFail()
-        => new AuthorizationFailure
-        {
-            FailCalled = true
-        };
+    public static AuthorizationFailure ExplicitFail() => _explicitFailure;
 
     /// <summary>
     /// Return a failure due to <see cref="AuthorizationHandlerContext.Fail(AuthorizationFailureReason)"/> being called.

--- a/src/Security/Authorization/Core/src/AuthorizationOptions.cs
+++ b/src/Security/Authorization/Core/src/AuthorizationOptions.cs
@@ -12,10 +12,10 @@ namespace Microsoft.AspNetCore.Authorization;
 /// </summary>
 public class AuthorizationOptions
 {
-    private static readonly Task<AuthorizationPolicy?> _nullPolicyTask = Task.FromResult<AuthorizationPolicy>(null);
+    private static readonly Task<AuthorizationPolicy?> _nullPolicyTask = Task.FromResult<AuthorizationPolicy?>(null);
 
     private Dictionary<string, AuthorizationPolicy> PolicyMap { get; } = new Dictionary<string, AuthorizationPolicy>(StringComparer.OrdinalIgnoreCase);
-    private Dictionary<string, Task<AuthorizationPolicy>> PolicyTaskMap { get; } = new Dictionary<string, Task<AuthorizationPolicy>>(StringComparer.OrdinalIgnoreCase);
+    private Dictionary<string, Task<AuthorizationPolicy?>> PolicyTaskMap { get; } = new Dictionary<string, Task<AuthorizationPolicy?>>(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Determines whether authorization handlers should be invoked after <see cref="AuthorizationHandlerContext.HasFailed"/>.
@@ -59,7 +59,7 @@ public class AuthorizationOptions
         }
 
         PolicyMap[name] = policy;
-        PolicyTaskMap[name] = Task.FromResult(policy);
+        PolicyTaskMap[name] = Task.FromResult<AuthorizationPolicy?>(policy);
     }
 
     /// <summary>
@@ -83,7 +83,7 @@ public class AuthorizationOptions
         configurePolicy(policyBuilder);
         var policy = policyBuilder.Build();
         PolicyMap[name] = policy;
-        PolicyTaskMap[name] = Task.FromResult(policy);
+        PolicyTaskMap[name] = Task.FromResult<AuthorizationPolicy?>(policy);
     }
 
     /// <summary>

--- a/src/Security/Authorization/Core/src/AuthorizationOptions.cs
+++ b/src/Security/Authorization/Core/src/AuthorizationOptions.cs
@@ -14,8 +14,7 @@ public class AuthorizationOptions
 {
     private static readonly Task<AuthorizationPolicy?> _nullPolicyTask = Task.FromResult<AuthorizationPolicy?>(null);
 
-    private Dictionary<string, AuthorizationPolicy> PolicyMap { get; } = new Dictionary<string, AuthorizationPolicy>(StringComparer.OrdinalIgnoreCase);
-    private Dictionary<string, Task<AuthorizationPolicy?>> PolicyTaskMap { get; } = new Dictionary<string, Task<AuthorizationPolicy?>>(StringComparer.OrdinalIgnoreCase);
+    private Dictionary<string, Task<AuthorizationPolicy?>> PolicyMap { get; } = new Dictionary<string, Task<AuthorizationPolicy?>>(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Determines whether authorization handlers should be invoked after <see cref="AuthorizationHandlerContext.HasFailed"/>.
@@ -58,8 +57,7 @@ public class AuthorizationOptions
             throw new ArgumentNullException(nameof(policy));
         }
 
-        PolicyMap[name] = policy;
-        PolicyTaskMap[name] = Task.FromResult<AuthorizationPolicy?>(policy);
+        PolicyMap[name] = Task.FromResult<AuthorizationPolicy?>(policy);
     }
 
     /// <summary>
@@ -81,9 +79,7 @@ public class AuthorizationOptions
 
         var policyBuilder = new AuthorizationPolicyBuilder();
         configurePolicy(policyBuilder);
-        var policy = policyBuilder.Build();
-        PolicyMap[name] = policy;
-        PolicyTaskMap[name] = Task.FromResult<AuthorizationPolicy?>(policy);
+        PolicyMap[name] = Task.FromResult<AuthorizationPolicy?>(policyBuilder.Build());
     }
 
     /// <summary>
@@ -100,7 +96,7 @@ public class AuthorizationOptions
 
         if (PolicyMap.TryGetValue(name, out var value))
         {
-            return value;
+            return value.Result;
         }
 
         return null;
@@ -113,7 +109,7 @@ public class AuthorizationOptions
             throw new ArgumentNullException(nameof(name));
         }
 
-        if (PolicyTaskMap.TryGetValue(name, out var value))
+        if (PolicyMap.TryGetValue(name, out var value))
         {
             return value;
         }

--- a/src/Security/Authorization/Core/src/AuthorizationPolicyBuilder.cs
+++ b/src/Security/Authorization/Core/src/AuthorizationPolicyBuilder.cs
@@ -14,6 +14,8 @@ namespace Microsoft.AspNetCore.Authorization;
 /// </summary>
 public class AuthorizationPolicyBuilder
 {
+    private static readonly DenyAnonymousAuthorizationRequirement _denyAnonymousAuthorizationRequirement = new();
+
     /// <summary>
     /// Creates a new instance of <see cref="AuthorizationPolicyBuilder"/>
     /// </summary>
@@ -201,7 +203,7 @@ public class AuthorizationPolicyBuilder
     /// <returns>A reference to this instance after the operation has completed.</returns>
     public AuthorizationPolicyBuilder RequireAuthenticatedUser()
     {
-        Requirements.Add(new DenyAnonymousAuthorizationRequirement());
+        Requirements.Add(_denyAnonymousAuthorizationRequirement);
         return this;
     }
 

--- a/src/Security/Authorization/Core/src/AuthorizationResult.cs
+++ b/src/Security/Authorization/Core/src/AuthorizationResult.cs
@@ -11,6 +11,9 @@ namespace Microsoft.AspNetCore.Authorization;
 /// </summary>
 public class AuthorizationResult
 {
+    private static readonly AuthorizationResult _succeededResult = new() { Succeeded = true };
+    private static readonly AuthorizationResult _failedResult = new() { Failure = AuthorizationFailure.ExplicitFail() };
+
     private AuthorizationResult() { }
 
     /// <summary>
@@ -27,7 +30,7 @@ public class AuthorizationResult
     /// Returns a successful result.
     /// </summary>
     /// <returns>A successful result.</returns>
-    public static AuthorizationResult Success() => new AuthorizationResult { Succeeded = true };
+    public static AuthorizationResult Success() => _succeededResult;
 
     /// <summary>
     /// Creates a failed authorization result.
@@ -40,5 +43,5 @@ public class AuthorizationResult
     /// Creates a failed authorization result.
     /// </summary>
     /// <returns>The <see cref="AuthorizationResult"/>.</returns>
-    public static AuthorizationResult Failed() => new AuthorizationResult { Failure = AuthorizationFailure.ExplicitFail() };
+    public static AuthorizationResult Failed() => _failedResult;
 }

--- a/src/Security/Authorization/Core/src/ClaimsAuthorizationRequirement.cs
+++ b/src/Security/Authorization/Core/src/ClaimsAuthorizationRequirement.cs
@@ -15,6 +15,8 @@ namespace Microsoft.AspNetCore.Authorization.Infrastructure;
 /// </summary>
 public class ClaimsAuthorizationRequirement : AuthorizationHandler<ClaimsAuthorizationRequirement>, IAuthorizationRequirement
 {
+    private readonly bool _emptyAllowedValues;
+
     /// <summary>
     /// Creates a new instance of <see cref="ClaimsAuthorizationRequirement"/>.
     /// </summary>
@@ -29,6 +31,7 @@ public class ClaimsAuthorizationRequirement : AuthorizationHandler<ClaimsAuthori
 
         ClaimType = claimType;
         AllowedValues = allowedValues;
+        _emptyAllowedValues = AllowedValues == null || !AllowedValues.Any();
     }
 
     /// <summary>
@@ -52,14 +55,28 @@ public class ClaimsAuthorizationRequirement : AuthorizationHandler<ClaimsAuthori
         if (context.User != null)
         {
             var found = false;
-            if (requirement.AllowedValues == null || !requirement.AllowedValues.Any())
+            if (requirement._emptyAllowedValues)
             {
-                found = context.User.Claims.Any(c => string.Equals(c.Type, requirement.ClaimType, StringComparison.OrdinalIgnoreCase));
+                foreach (var claim in context.User.Claims)
+                {
+                    if (string.Equals(claim.Type, requirement.ClaimType, StringComparison.OrdinalIgnoreCase))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
             }
             else
             {
-                found = context.User.Claims.Any(c => string.Equals(c.Type, requirement.ClaimType, StringComparison.OrdinalIgnoreCase)
-                                                    && requirement.AllowedValues.Contains(c.Value, StringComparer.Ordinal));
+                foreach (var claim in context.User.Claims)
+                {
+                    if (string.Equals(claim.Type, requirement.ClaimType, StringComparison.OrdinalIgnoreCase)
+                        && requirement.AllowedValues.Contains(claim.Value, StringComparer.Ordinal))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
             }
             if (found)
             {
@@ -72,7 +89,7 @@ public class ClaimsAuthorizationRequirement : AuthorizationHandler<ClaimsAuthori
     /// <inheritdoc />
     public override string ToString()
     {
-        var value = (AllowedValues == null || !AllowedValues.Any())
+        var value = (_emptyAllowedValues)
             ? string.Empty
             : $" and Claim.Value is one of the following values: ({string.Join("|", AllowedValues)})";
 

--- a/src/Security/Authorization/Core/src/ClaimsAuthorizationRequirement.cs
+++ b/src/Security/Authorization/Core/src/ClaimsAuthorizationRequirement.cs
@@ -71,7 +71,7 @@ public class ClaimsAuthorizationRequirement : AuthorizationHandler<ClaimsAuthori
                 foreach (var claim in context.User.Claims)
                 {
                     if (string.Equals(claim.Type, requirement.ClaimType, StringComparison.OrdinalIgnoreCase)
-                        && requirement.AllowedValues.Contains(claim.Value, StringComparer.Ordinal))
+                        && requirement.AllowedValues!.Contains(claim.Value, StringComparer.Ordinal))
                     {
                         found = true;
                         break;
@@ -91,7 +91,7 @@ public class ClaimsAuthorizationRequirement : AuthorizationHandler<ClaimsAuthori
     {
         var value = (_emptyAllowedValues)
             ? string.Empty
-            : $" and Claim.Value is one of the following values: ({string.Join("|", AllowedValues)})";
+            : $" and Claim.Value is one of the following values: ({string.Join("|", AllowedValues!)})";
 
         return $"{nameof(ClaimsAuthorizationRequirement)}:Claim.Type={ClaimType}{value}";
     }

--- a/src/Security/Authorization/Core/src/DefaultAuthorizationPolicyProvider.cs
+++ b/src/Security/Authorization/Core/src/DefaultAuthorizationPolicyProvider.cs
@@ -69,6 +69,6 @@ public class DefaultAuthorizationPolicyProvider : IAuthorizationPolicyProvider
         // MVC caches policies specifically for this class, so this method MUST return the same policy per
         // policyName for every request or it could allow undesired access. It also must return synchronously.
         // A change to either of these behaviors would require shipping a patch of MVC as well.
-        return Task.FromResult(_options.GetPolicy(policyName));
+        return _options.GetPolicyTask(policyName);
     }
 }

--- a/src/Security/Authorization/Core/src/Microsoft.AspNetCore.Authorization.csproj
+++ b/src/Security/Authorization/Core/src/Microsoft.AspNetCore.Authorization.csproj
@@ -18,6 +18,7 @@ Microsoft.AspNetCore.Authorization.AuthorizeAttribute</Description>
     <Reference Include="Microsoft.AspNetCore.Metadata" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.Options" />
+    <Reference Include="System.ValueTuple" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authorization/Core/src/Microsoft.AspNetCore.Authorization.csproj
+++ b/src/Security/Authorization/Core/src/Microsoft.AspNetCore.Authorization.csproj
@@ -18,7 +18,6 @@ Microsoft.AspNetCore.Authorization.AuthorizeAttribute</Description>
     <Reference Include="Microsoft.AspNetCore.Metadata" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.Options" />
-    <Reference Include="System.ValueTuple" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authorization/Core/src/NameAuthorizationRequirement.cs
+++ b/src/Security/Authorization/Core/src/NameAuthorizationRequirement.cs
@@ -41,7 +41,18 @@ public class NameAuthorizationRequirement : AuthorizationHandler<NameAuthorizati
     {
         if (context.User != null)
         {
-            if (context.User.Identities.Any(i => string.Equals(i.Name, requirement.RequiredName, StringComparison.Ordinal)))
+            var succeed = false;
+
+            foreach (var identity in context.User.Identities)
+            {
+                if (string.Equals(identity.Name, requirement.RequiredName, StringComparison.Ordinal))
+                {
+                    succeed = true;
+                    break;
+                }
+            }
+
+            if (succeed)
             {
                 context.Succeed(requirement);
             }

--- a/src/Security/Authorization/Core/src/RolesAuthorizationRequirement.cs
+++ b/src/Security/Authorization/Core/src/RolesAuthorizationRequirement.cs
@@ -46,15 +46,17 @@ public class RolesAuthorizationRequirement : AuthorizationHandler<RolesAuthoriza
     {
         if (context.User != null)
         {
-            bool found = false;
-            if (requirement.AllowedRoles == null || !requirement.AllowedRoles.Any())
+            var found = false;
+
+            foreach (var role in requirement.AllowedRoles)
             {
-                // Review: What do we want to do here?  No roles requested is auto success?
+                if (context.User.IsInRole(role))
+                {
+                    found = true;
+                    break;
+                }
             }
-            else
-            {
-                found = requirement.AllowedRoles.Any(r => context.User.IsInRole(r));
-            }
+
             if (found)
             {
                 context.Succeed(requirement);


### PR DESCRIPTION
- Reuse the `AuthenticateResult`, `AuthorizationResult`, `AuthorizationFailure`, `DenyAnonymousAuthorizationRequirement` instances
- Store `Task<Policy>` to avoid creating a new Task on each call.
- Use `foreach` instead of `Any` in authz requirements to avoid the closure allocations.