### PR TITLE
Default to zero byte reads when we use PipeReader.Create

### DIFF
--- a/src/Http/Http/src/Features/RequestBodyPipeFeature.cs
+++ b/src/Http/Http/src/Features/RequestBodyPipeFeature.cs
@@ -14,6 +14,9 @@ public class RequestBodyPipeFeature : IRequestBodyPipeFeature
     private Stream? _streamInstanceWhenWrapped;
     private readonly HttpContext _context;
 
+    // We want to use zero byte reads for the request body
+    private static readonly StreamPipeReaderOptions _defaultReaderOptions = new(useZeroByteReads: true);
+
     /// <summary>
     /// Initializes a new instance of <see cref="IRequestBodyPipeFeature"/>.
     /// </summary>
@@ -36,7 +39,7 @@ public class RequestBodyPipeFeature : IRequestBodyPipeFeature
                 !ReferenceEquals(_streamInstanceWhenWrapped, _context.Request.Body))
             {
                 _streamInstanceWhenWrapped = _context.Request.Body;
-                _internalPipeReader = PipeReader.Create(_context.Request.Body);
+                _internalPipeReader = PipeReader.Create(_context.Request.Body, _defaultReaderOptions);
 
                 _context.Response.OnCompleted((self) =>
                 {

--- a/src/Http/Http/test/Features/RequestBodyPipeFeatureTests.cs
+++ b/src/Http/Http/test/Features/RequestBodyPipeFeatureTests.cs
@@ -4,6 +4,7 @@
 using System.Buffers;
 using System.IO.Pipelines;
 using System.Text;
+using Moq;
 
 namespace Microsoft.AspNetCore.Http.Features;
 
@@ -35,6 +36,29 @@ public class RequestBodyPipeFeatureTests
         context.Request.Body = new MemoryStream(Encoding.ASCII.GetBytes(expectedString));
         var data = await feature.Reader.ReadAsync();
         Assert.Equal(expectedString, GetStringFromReadResult(data));
+    }
+
+    [Fact]
+    public async Task RequestBodyDoesZeroByteRead()
+    {
+        var context = new DefaultHttpContext();
+        var mockStream = new Mock<Stream>();
+
+        var bufferLengths = new List<int>();
+
+        mockStream.Setup(s => s.CanRead).Returns(true);
+        mockStream.Setup(s => s.ReadAsync(It.IsAny<Memory<byte>>(), It.IsAny<CancellationToken>())).Returns<Memory<byte>, CancellationToken>((buffer, token) =>
+        {
+            bufferLengths.Add(buffer.Length);
+            return ValueTask.FromResult(0);
+        });
+
+        context.Request.Body = mockStream.Object;
+        var feature = new RequestBodyPipeFeature(context);
+        var data = await feature.Reader.ReadAsync();
+
+        Assert.Equal(0, bufferLengths[0]);
+        Assert.Equal(4096, bufferLengths[1]);
     }
 
     private static string GetStringFromReadResult(ReadResult data)

--- a/src/Http/Http/test/Features/RequestBodyPipeFeatureTests.cs
+++ b/src/Http/Http/test/Features/RequestBodyPipeFeatureTests.cs
@@ -57,6 +57,7 @@ public class RequestBodyPipeFeatureTests
         var feature = new RequestBodyPipeFeature(context);
         var data = await feature.Reader.ReadAsync();
 
+        Assert.Equal(2, bufferLengths.Count);
         Assert.Equal(0, bufferLengths[0]);
         Assert.Equal(4096, bufferLengths[1]);
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -92,7 +92,7 @@ internal partial class HttpProtocol
             if (!ReferenceEquals(_requestStreamInternal, RequestBody))
             {
                 _requestStreamInternal = RequestBody;
-                RequestBodyPipeReader = PipeReader.Create(RequestBody, new StreamPipeReaderOptions(_context.MemoryPool, _context.MemoryPool.GetMinimumSegmentSize(), _context.MemoryPool.GetMinimumAllocSize()));
+                RequestBodyPipeReader = PipeReader.Create(RequestBody, new StreamPipeReaderOptions(_context.MemoryPool, _context.MemoryPool.GetMinimumSegmentSize(), _context.MemoryPool.GetMinimumAllocSize(), useZeroByteReads: true));
 
                 OnCompleted((self) =>
                 {

--- a/src/Servers/Kestrel/Core/src/Middleware/Internal/LoggingStream.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/Internal/LoggingStream.cs
@@ -76,28 +76,40 @@ internal sealed class LoggingStream : Stream
     public override int Read(byte[] buffer, int offset, int count)
     {
         int read = _inner.Read(buffer, offset, count);
-        Log("Read", new ReadOnlySpan<byte>(buffer, offset, read));
+        if (count > 0)
+        {
+            Log("Read", new ReadOnlySpan<byte>(buffer, offset, read));
+        }
         return read;
     }
 
     public override int Read(Span<byte> destination)
     {
         int read = _inner.Read(destination);
-        Log("Read", destination.Slice(0, read));
+        if (!destination.IsEmpty)
+        {
+            Log("Read", destination.Slice(0, read));
+        }
         return read;
     }
 
     public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
     {
         int read = await _inner.ReadAsync(buffer.AsMemory(offset, count), cancellationToken);
-        Log("ReadAsync", new ReadOnlySpan<byte>(buffer, offset, read));
+        if (count > 0)
+        {
+            Log("ReadAsync", new ReadOnlySpan<byte>(buffer, offset, read));
+        }
         return read;
     }
 
     public override async ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default)
     {
         int read = await _inner.ReadAsync(destination, cancellationToken);
-        Log("ReadAsync", destination.Span.Slice(0, read));
+        if (!destination.IsEmpty)
+        {
+            Log("ReadAsync", destination.Span.Slice(0, read));
+        }
         return read;
     }
 

--- a/src/Servers/Kestrel/Core/src/Middleware/LoggingDuplexPipe.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/LoggingDuplexPipe.cs
@@ -8,8 +8,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 
 internal sealed class LoggingDuplexPipe : DuplexPipeStreamAdapter<LoggingStream>
 {
+    private static readonly StreamPipeReaderOptions _defaultReaderOptions = new(useZeroByteReads: true);
+    private static readonly StreamPipeWriterOptions _defaultWriterOptions = new();
+
     public LoggingDuplexPipe(IDuplexPipe transport, ILogger logger) :
-        base(transport, stream => new LoggingStream(stream, logger))
+        base(transport, _defaultReaderOptions, _defaultWriterOptions, stream => new LoggingStream(stream, logger))
     {
     }
 }

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/ServerSentEventsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/ServerSentEventsTransport.cs
@@ -26,6 +26,7 @@ internal sealed partial class ServerSentEventsTransport : ITransport
     private readonly ServerSentEventsMessageParser _parser = new ServerSentEventsMessageParser();
     private IDuplexPipe? _transport;
     private IDuplexPipe? _application;
+    private static readonly StreamPipeReaderOptions _defaultReaderOptions = new(useZeroByteReads: true);
 
     internal Task Running { get; private set; } = Task.CompletedTask;
 
@@ -138,7 +139,7 @@ internal sealed partial class ServerSentEventsTransport : ITransport
         using (var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
 #pragma warning restore CA2016 // Forward the 'CancellationToken' parameter to methods
         {
-            var reader = PipeReader.Create(stream);
+            var reader = PipeReader.Create(stream, _defaultReaderOptions);
 
             using var registration = cancellationToken.Register(CancelReader, reader);
 

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/ServerSentEventsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/ServerSentEventsTransport.cs
@@ -26,7 +26,6 @@ internal sealed partial class ServerSentEventsTransport : ITransport
     private readonly ServerSentEventsMessageParser _parser = new ServerSentEventsMessageParser();
     private IDuplexPipe? _transport;
     private IDuplexPipe? _application;
-    private static readonly StreamPipeReaderOptions _defaultReaderOptions = new(useZeroByteReads: true);
 
     internal Task Running { get; private set; } = Task.CompletedTask;
 
@@ -139,7 +138,7 @@ internal sealed partial class ServerSentEventsTransport : ITransport
         using (var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
 #pragma warning restore CA2016 // Forward the 'CancellationToken' parameter to methods
         {
-            var reader = PipeReader.Create(stream, _defaultReaderOptions);
+            var reader = PipeReader.Create(stream);
 
             using var registration = cancellationToken.Register(CancelReader, reader);
 


### PR DESCRIPTION
- This will avoid allocating buffers until there's data available to read.

Fixes https://github.com/dotnet/aspnetcore/issues/42829
