### PR TITLE
[SignalR] [JS Client] Retry HTTP request on auth failure

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/AccessTokenHttpClient.ts
+++ b/src/SignalR/clients/ts/signalr/src/AccessTokenHttpClient.ts
@@ -54,4 +54,8 @@ export class AccessTokenHttpClient extends HttpClient {
             }
         }
     }
+
+    public getCookieString(url: string): string {
+        return this._innerClient.getCookieString(url);
+    }
 }

--- a/src/SignalR/clients/ts/signalr/src/AccessTokenHttpClient.ts
+++ b/src/SignalR/clients/ts/signalr/src/AccessTokenHttpClient.ts
@@ -7,7 +7,7 @@ import { HttpClient, HttpRequest, HttpResponse } from "./HttpClient";
 /** @private */
 export class AccessTokenHttpClient extends HttpClient {
     private _innerClient: HttpClient;
-    private _accessToken: string | undefined;
+    _accessToken: string | undefined;
     private _accessTokenFactory: (() => string | Promise<string>) | undefined;
 
     constructor(innerClient: HttpClient, currentAccessToken: string | undefined, accessTokenFactory: (() => string | Promise<string>) | undefined) {

--- a/src/SignalR/clients/ts/signalr/src/AccessTokenHttpClient.ts
+++ b/src/SignalR/clients/ts/signalr/src/AccessTokenHttpClient.ts
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+import { HeaderNames } from "./HeaderNames";
+import { HttpClient, HttpRequest, HttpResponse } from "./HttpClient";
+
+/** @private */
+export class AccessTokenHttpClient extends HttpClient {
+    private _innerClient: HttpClient;
+    private _accessToken: string | undefined;
+    private _accessTokenFactory: (() => string | Promise<string>) | undefined;
+
+    constructor(innerClient: HttpClient, currentAccessToken: string | undefined, accessTokenFactory: (() => string | Promise<string>) | undefined) {
+        super();
+
+        this._innerClient = innerClient;
+        this._accessToken = currentAccessToken;
+        this._accessTokenFactory = accessTokenFactory;
+    }
+
+    public async send(request: HttpRequest): Promise<HttpResponse> {
+        let allowRetry = true;
+        if (this._accessTokenFactory && (!this._accessToken || (request.url && request.url.indexOf("/negotiate?") > 0))) {
+            // don't retry if the request is a negotiate or if we just got a potentially new token from the access token factory
+            allowRetry = false;
+            this._accessToken = await this._accessTokenFactory();
+        }
+        this._setAuthorizationHeader(request);
+        const response = await this._innerClient.send(request);
+
+        if (allowRetry && response.statusCode === 401 && this._accessTokenFactory) {
+            this._accessToken = await this._accessTokenFactory();
+            this._setAuthorizationHeader(request);
+            return await this._innerClient.send(request);
+        }
+        return response;
+    }
+
+    public replaceAccessTokenFactory(accessTokenFactory: (() => string | Promise<string>) | undefined): void {
+        this._accessTokenFactory = accessTokenFactory;
+    }
+
+    private _setAuthorizationHeader(request: HttpRequest) {
+        if (!request.headers) {
+            request.headers = {};
+        }
+        if (this._accessToken) {
+            request.headers[HeaderNames.Authorization] = `Bearer ${this._accessToken}`
+        }
+        // don't remove the header if there isn't an access token factory, the user manually added the header in this case
+        else if (this._accessTokenFactory) {
+            if (request.headers[HeaderNames.Authorization]) {
+                delete request.headers[HeaderNames.Authorization];
+            }
+        }
+    }
+}

--- a/src/SignalR/clients/ts/signalr/src/HttpConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HttpConnection.ts
@@ -267,7 +267,9 @@ export class HttpConnection implements IConnection {
                         // the returned access token
                         const accessToken = negotiateResponse.accessToken;
                         this._accessTokenFactory = () => accessToken;
-                        this._httpClient.replaceAccessTokenFactory(this._accessTokenFactory);
+                        // set the factory to undefined so the httpClient won't retry with the same token, since we know it won't change until a connection restart
+                        this._httpClient._accessToken = accessToken;
+                        this._httpClient.replaceAccessTokenFactory(undefined);
                     }
 
                     redirects++;
@@ -418,7 +420,7 @@ export class HttpConnection implements IConnection {
                 if (!this._options.EventSource) {
                     throw new Error("'EventSource' is not supported in your environment.");
                 }
-                return new ServerSentEventsTransport(this._httpClient, this._accessTokenFactory, this._logger, this._options);
+                return new ServerSentEventsTransport(this._httpClient, this._httpClient._accessToken, this._logger, this._options);
             case HttpTransportType.LongPolling:
                 return new LongPollingTransport(this._httpClient, this._logger, this._options);
             default:

--- a/src/SignalR/clients/ts/signalr/src/HttpConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HttpConnection.ts
@@ -4,7 +4,6 @@
 import { AccessTokenHttpClient } from "./AccessTokenHttpClient";
 import { DefaultHttpClient } from "./DefaultHttpClient";
 import { AggregateErrors, DisabledTransportError, FailedToNegotiateWithServerError, FailedToStartTransportError, HttpError, UnsupportedTransportError, AbortError } from "./Errors";
-import { HeaderNames } from "./HeaderNames";
 import { IConnection } from "./IConnection";
 import { IHttpConnectionOptions } from "./IHttpConnectionOptions";
 import { ILogger, LogLevel } from "./ILogger";

--- a/src/SignalR/clients/ts/signalr/src/ServerSentEventsTransport.ts
+++ b/src/SignalR/clients/ts/signalr/src/ServerSentEventsTransport.ts
@@ -38,7 +38,7 @@ export class ServerSentEventsTransport implements ITransport {
 
         this._logger.log(LogLevel.Trace, "(SSE transport) Connecting.");
 
-        // set url before accessTokenFactory because this.url is only for send and we set the auth header instead of the query string for send
+        // set url before accessTokenFactory because this._url is only for send and we set the auth header instead of the query string for send
         this._url = url;
 
         if (this._accessTokenFactory) {
@@ -111,7 +111,7 @@ export class ServerSentEventsTransport implements ITransport {
         if (!this._eventSource) {
             return Promise.reject(new Error("Cannot send until the transport is connected"));
         }
-        return sendMessage(this._logger, "SSE", this._httpClient, this._url!, this._accessTokenFactory, data, this._options);
+        return sendMessage(this._logger, "SSE", this._httpClient, this._url!, data, this._options);
     }
 
     public stop(): Promise<void> {

--- a/src/SignalR/clients/ts/signalr/src/ServerSentEventsTransport.ts
+++ b/src/SignalR/clients/ts/signalr/src/ServerSentEventsTransport.ts
@@ -11,7 +11,7 @@ import { IHttpConnectionOptions } from "./IHttpConnectionOptions";
 /** @private */
 export class ServerSentEventsTransport implements ITransport {
     private readonly _httpClient: HttpClient;
-    private readonly _accessTokenFactory: (() => string | Promise<string>) | undefined;
+    private readonly _accessToken: string | undefined;
     private readonly _logger: ILogger;
     private readonly _options: IHttpConnectionOptions;
     private _eventSource?: EventSource;
@@ -20,10 +20,10 @@ export class ServerSentEventsTransport implements ITransport {
     public onreceive: ((data: string | ArrayBuffer) => void) | null;
     public onclose: ((error?: Error) => void) | null;
 
-    constructor(httpClient: HttpClient, accessTokenFactory: (() => string | Promise<string>) | undefined, logger: ILogger,
+    constructor(httpClient: HttpClient, accessToken: string | undefined, logger: ILogger,
                 options: IHttpConnectionOptions) {
         this._httpClient = httpClient;
-        this._accessTokenFactory = accessTokenFactory;
+        this._accessToken = accessToken;
         this._logger = logger;
         this._options = options;
 
@@ -41,11 +41,8 @@ export class ServerSentEventsTransport implements ITransport {
         // set url before accessTokenFactory because this._url is only for send and we set the auth header instead of the query string for send
         this._url = url;
 
-        if (this._accessTokenFactory) {
-            const token = await this._accessTokenFactory();
-            if (token) {
-                url += (url.indexOf("?") < 0 ? "?" : "&") + `access_token=${encodeURIComponent(token)}`;
-            }
+        if (this._accessToken) {
+            url += (url.indexOf("?") < 0 ? "?" : "&") + `access_token=${encodeURIComponent(this._accessToken)}`;
         }
 
         return new Promise<void>((resolve, reject) => {

--- a/src/SignalR/clients/ts/signalr/src/Utils.ts
+++ b/src/SignalR/clients/ts/signalr/src/Utils.ts
@@ -99,17 +99,9 @@ export function isArrayBuffer(val: any): val is ArrayBuffer {
 }
 
 /** @private */
-export async function sendMessage(logger: ILogger, transportName: string, httpClient: HttpClient, url: string, accessTokenFactory: (() => string | Promise<string>) | undefined,
+export async function sendMessage(logger: ILogger, transportName: string, httpClient: HttpClient, url: string,
                                   content: string | ArrayBuffer, options: IHttpConnectionOptions): Promise<void> {
-    let headers: {[k: string]: string} = {};
-    if (accessTokenFactory) {
-        const token = await accessTokenFactory();
-        if (token) {
-            headers = {
-                ["Authorization"]: `Bearer ${token}`,
-            };
-        }
-    }
+    const headers: {[k: string]: string} = {};
 
     const [name, value] = getUserAgentHeader();
     headers[name] = value;

--- a/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
@@ -772,8 +772,11 @@ describe("HttpConnection", () => {
                         httpClientGetCount++;
                         const authorizationValue = r.headers![HeaderNames.Authorization];
                         if (httpClientGetCount === 1) {
+                            // Auth failure to cause a retry with a call to accessTokenFactory
+                            return new HttpResponse(401);
+                        } else if (httpClientGetCount === 2) {
                             if (authorizationValue) {
-                                fail("First long poll request should have a authorization header.");
+                                fail("First long poll request should have no authorization header.");
                             }
                             // First long polling request must succeed so start completes
                             return "";

--- a/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
@@ -668,6 +668,7 @@ describe("HttpConnection", () => {
         await VerifyLogger.run(async (logger) => {
             let firstNegotiate = true;
             let firstPoll = true;
+            const pollingPromiseSource = new PromiseSource();
             const httpClient = new TestHttpClient()
                 .on("POST", /\/negotiate/, (r) => {
                     if (firstNegotiate) {
@@ -689,7 +690,7 @@ describe("HttpConnection", () => {
                         connectionId: "0rge0d00-0040-0030-0r00-000q00r00e00",
                     };
                 })
-                .on("GET", (r) => {
+                .on("GET", async (r) => {
                     if (r.headers && r.headers.Authorization !== "Bearer secondSecret") {
                         return new HttpResponse(401, "Unauthorized", "");
                     }
@@ -698,6 +699,7 @@ describe("HttpConnection", () => {
                         firstPoll = false;
                         return "";
                     }
+                    await pollingPromiseSource.promise;
                     return new HttpResponse(204, "No Content", "");
                 })
                 .on("DELETE", () => new HttpResponse(202));
@@ -719,6 +721,8 @@ describe("HttpConnection", () => {
                 expect(httpClient.sentRequests[1].url).toBe("https://another.domain.url/chat/negotiate?negotiateVersion=1");
                 expect(httpClient.sentRequests[2].url).toMatch(/^https:\/\/another\.domain\.url\/chat\?id=0rge0d00-0040-0030-0r00-000q00r00e00/i);
                 expect(httpClient.sentRequests[3].url).toMatch(/^https:\/\/another\.domain\.url\/chat\?id=0rge0d00-0040-0030-0r00-000q00r00e00/i);
+
+                pollingPromiseSource.resolve();
             } finally {
                 await connection.stop();
             }

--- a/src/SignalR/clients/ts/signalr/tests/LongPollingTransport.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/LongPollingTransport.test.ts
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+import { AccessTokenHttpClient } from "../src/AccessTokenHttpClient";
 import { HttpResponse } from "../src/HttpClient";
 import { TransferFormat } from "../src/ITransport";
 import { LongPollingTransport } from "../src/LongPollingTransport";
@@ -40,7 +41,7 @@ describe("LongPollingTransport", () => {
                     }
                 })
                 .on("DELETE", () => new HttpResponse(202));
-            const transport = new LongPollingTransport(client, undefined, logger, { logMessageContent: false, withCredentials: true, headers: {} });
+            const transport = new LongPollingTransport(client, logger, { logMessageContent: false, withCredentials: true, headers: {} });
 
             await transport.connect("http://example.com", TransferFormat.Text);
             const stopPromise = transport.stop();
@@ -64,7 +65,7 @@ describe("LongPollingTransport", () => {
                         return new HttpResponse(204);
                     }
                 });
-            const transport = new LongPollingTransport(client, undefined, logger, { logMessageContent: false, withCredentials: true, headers: {} });
+            const transport = new LongPollingTransport(client, logger, { logMessageContent: false, withCredentials: true, headers: {} });
 
             const stopPromise = makeClosedPromise(transport);
 
@@ -97,7 +98,7 @@ describe("LongPollingTransport", () => {
                     return new HttpResponse(202);
                 });
 
-            const transport = new LongPollingTransport(httpClient, undefined, logger, { logMessageContent: false, withCredentials: true, headers: {} });
+            const transport = new LongPollingTransport(httpClient, logger, { logMessageContent: false, withCredentials: true, headers: {} });
 
             await transport.connect("http://tempuri.org", TransferFormat.Text);
 
@@ -146,7 +147,7 @@ describe("LongPollingTransport", () => {
                     return new HttpResponse(202);
                 });
 
-            const transport = new LongPollingTransport(httpClient, undefined, logger, { logMessageContent: false, withCredentials: true, headers: {} });
+            const transport = new LongPollingTransport(httpClient, logger, { logMessageContent: false, withCredentials: true, headers: {} });
 
             await transport.connect("http://tempuri.org", TransferFormat.Text);
 
@@ -203,7 +204,7 @@ describe("LongPollingTransport", () => {
                     return new HttpResponse(202);
                 });
 
-            const transport = new LongPollingTransport(httpClient, undefined, logger, { logMessageContent: false, withCredentials: true, headers });
+            const transport = new LongPollingTransport(httpClient, logger, { logMessageContent: false, withCredentials: true, headers });
 
             await transport.connect("http://tempuri.org", TransferFormat.Text);
 
@@ -251,7 +252,7 @@ describe("LongPollingTransport", () => {
                     return new HttpResponse(202);
                 });
 
-            const transport = new LongPollingTransport(httpClient, undefined, logger,
+            const transport = new LongPollingTransport(httpClient, logger,
                 { logMessageContent: false, withCredentials: true, headers: {}, timeout: 123 });
 
             await transport.connect("http://tempuri.org", TransferFormat.Text);
@@ -276,9 +277,15 @@ describe("LongPollingTransport", () => {
             let firstAuthHeader = "";
             let secondAuthHeader = "";
             let deleteAuthHeader = "";
+            const accessTokenFactory = () => {
+                if (firstAuthHeader) {
+                    return "";
+                }
+                return "value";
+            };
             const pollingPromiseSource = new PromiseSource();
             const readyToStopPromiseSource = new PromiseSource();
-            const httpClient = new TestHttpClient()
+            const httpClient = new AccessTokenHttpClient(new TestHttpClient()
                 .on("GET", async (r) => {
                     if (firstPoll) {
                         firstPoll = false;
@@ -299,14 +306,9 @@ describe("LongPollingTransport", () => {
                 .on("DELETE", async (r) => {
                     deleteAuthHeader = r.headers!.Authorization;
                     return new HttpResponse(202);
-                });
+                }), undefined, accessTokenFactory);
 
-            const transport = new LongPollingTransport(httpClient, () => {
-                if (firstAuthHeader) {
-                    return "";
-                }
-                return "value";
-            }, logger, { logMessageContent: false, withCredentials: true, headers: {} });
+            const transport = new LongPollingTransport(httpClient, logger, { logMessageContent: false, withCredentials: true, headers: {} });
 
             await transport.connect("http://tempuri.org", TransferFormat.Text);
 
@@ -334,7 +336,7 @@ describe("LongPollingTransport", () => {
             let secondAuthHeader = "";
             let deleteAuthHeader = "";
             const pollingPromiseSource = new PromiseSource();
-            const httpClient = new TestHttpClient()
+            const httpClient = new AccessTokenHttpClient(new TestHttpClient()
                 .on("GET", async (r) => {
                     if (firstPoll) {
                         firstPoll = false;
@@ -349,9 +351,9 @@ describe("LongPollingTransport", () => {
                 .on("DELETE", async (r) => {
                     deleteAuthHeader = r.headers!.Authorization;
                     return new HttpResponse(202);
-                });
+                }), undefined, undefined);
 
-            const transport = new LongPollingTransport(httpClient, undefined, logger, { logMessageContent: false, withCredentials: true,
+            const transport = new LongPollingTransport(httpClient, logger, { logMessageContent: false, withCredentials: true,
                 headers: { Authorization: "Basic test" } });
 
             await transport.connect("http://tempuri.org", TransferFormat.Text);

--- a/src/SignalR/clients/ts/signalr/tests/ServerSentEventsTransport.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/ServerSentEventsTransport.test.ts
@@ -4,7 +4,7 @@
 import { MessageHeaders } from "../src/IHubProtocol";
 import { TransferFormat } from "../src/ITransport";
 
-import { HttpClient, HttpRequest } from "../src/HttpClient";
+import { HttpClient, HttpRequest, HttpResponse } from "../src/HttpClient";
 import { ILogger } from "../src/ILogger";
 import { ServerSentEventsTransport } from "../src/ServerSentEventsTransport";
 import { getUserAgentHeader } from "../src/Utils";
@@ -13,6 +13,7 @@ import { TestEventSource, TestMessageEvent } from "./TestEventSource";
 import { TestHttpClient } from "./TestHttpClient";
 import { registerUnhandledRejectionHandler } from "./Utils";
 import { IHttpConnectionOptions } from "signalr/src/IHttpConnectionOptions";
+import { AccessTokenHttpClient } from "../src/AccessTokenHttpClient";
 
 registerUnhandledRejectionHandler();
 
@@ -87,10 +88,10 @@ describe("ServerSentEventsTransport", () => {
     it("sets Authorization header on sends", async () => {
         await VerifyLogger.run(async (logger) => {
             let request: HttpRequest;
-            const httpClient = new TestHttpClient().on((r) => {
+            const httpClient = new AccessTokenHttpClient(new TestHttpClient().on((r) => {
                 request = r;
                 return "";
-            });
+            }), undefined, () => "secretToken");
 
             const sse = await createAndStartSSE(logger, "http://example.com", () => "secretToken", { httpClient });
 
@@ -98,6 +99,35 @@ describe("ServerSentEventsTransport", () => {
 
             expect(request!.headers!.Authorization).toBe("Bearer secretToken");
             expect(request!.url).toBe("http://example.com");
+        });
+    });
+
+    it("retries 401 requests on sends", async () => {
+        await VerifyLogger.run(async (logger) => {
+            let request: HttpRequest;
+            let requestCount = 0;
+            const httpClient = new AccessTokenHttpClient(new TestHttpClient().on((r) => {
+                requestCount++;
+                if (requestCount === 2) {
+                    return new HttpResponse(401);
+                }
+                request = r;
+                return "";
+            }), undefined, () => "secretToken" + requestCount);
+
+            // AccessTokenHttpClient assumes negotiate was called which would have called accessTokenFactory already
+            // It also assumes the request shouldn't be retried if the factory was called, so we need to make a "negotiate" call
+            // to test the retry behavior for send requests
+            await httpClient.post("");
+            expect(request!.headers!.Authorization).toBe("Bearer secretToken0");
+
+            const sse = await createAndStartSSE(logger, "http://example.com", () => "secretToken", { httpClient });
+
+            await sse.send("");
+
+            expect(request!.headers!.Authorization).toBe("Bearer secretToken2");
+            expect(request!.url).toBe("http://example.com");
+            expect(requestCount).toEqual(3);
         });
     });
 

--- a/src/SignalR/clients/ts/signalr/tests/ServerSentEventsTransport.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/ServerSentEventsTransport.test.ts
@@ -297,7 +297,12 @@ describe("ServerSentEventsTransport", () => {
 });
 
 async function createAndStartSSE(logger: ILogger, url?: string, accessTokenFactory?: (() => string | Promise<string>), options?: IHttpConnectionOptions): Promise<ServerSentEventsTransport> {
-    const sse = new ServerSentEventsTransport(options?.httpClient || new TestHttpClient(), accessTokenFactory, logger,
+    let token;
+    // SSE assumes (correctly) that negotiate will already create the token we want to use on connection startup, so simulate that here when creating the SSE transport
+    if (accessTokenFactory) {
+        token = await accessTokenFactory();
+    }
+    const sse = new ServerSentEventsTransport(options?.httpClient || new TestHttpClient(), token, logger,
         { logMessageContent: true, EventSource: TestEventSource, withCredentials: true, timeout: 10205, ...options });
 
     const connectPromise = sse.connect(url || "http://example.com", TransferFormat.Text);


### PR DESCRIPTION
Similar change as https://github.com/dotnet/aspnetcore/pull/42671

Change how AccessTokenFactory is called, once during startup, then only on auth failure.
Retry auth failures (once) when using LongPolling and SSE after getting (potentially) a new token