### PR TITLE
Don't throw TaskCanceledException in RateLimitingMiddleware

### DIFF
--- a/src/Middleware/RateLimiting/src/LeaseContext.cs
+++ b/src/Middleware/RateLimiting/src/LeaseContext.cs
@@ -7,12 +7,19 @@ namespace Microsoft.AspNetCore.RateLimiting;
 
 internal struct LeaseContext : IDisposable
 {
-    public bool? GlobalRejected { get; init; }
+    public RequestRejectionReason? RequestRejectionReason { get; init; }
 
-    public required RateLimitLease Lease { get; init; }
+    public RateLimitLease? Lease { get; init; }
 
     public void Dispose()
     {
-        Lease.Dispose();
+        Lease?.Dispose();
     }
+}
+
+internal enum RequestRejectionReason
+{
+    EndpointLimiter,
+    GlobalLimiter,
+    RequestCanceled
 }

--- a/src/Middleware/RateLimiting/src/RateLimitingMiddleware.cs
+++ b/src/Middleware/RateLimiting/src/RateLimitingMiddleware.cs
@@ -162,7 +162,7 @@ internal sealed partial class RateLimitingMiddleware
             // Don't throw if the request was canceled - instead log. 
             if (ex is OperationCanceledException && context.RequestAborted.IsCancellationRequested)
             {
-                RateLimiterLog.TaskCanceled(_logger);
+                RateLimiterLog.RequestCanceled(_logger);
                 return new LeaseContext() { RequestRejectionReason = RequestRejectionReason.RequestCanceled };
             }
             else
@@ -202,7 +202,7 @@ internal sealed partial class RateLimitingMiddleware
             // Don't throw if the request was canceled - instead log. 
             if (ex is OperationCanceledException && context.RequestAborted.IsCancellationRequested)
             {
-                RateLimiterLog.TaskCanceled(_logger);
+                RateLimiterLog.RequestCanceled(_logger);
                 return new LeaseContext() { RequestRejectionReason = RequestRejectionReason.RequestCanceled };
             }
             else
@@ -259,7 +259,7 @@ internal sealed partial class RateLimitingMiddleware
         [LoggerMessage(2, LogLevel.Debug, "This endpoint requires a rate limiting policy with name {PolicyName}, but no such policy exists.", EventName = "WarnMissingPolicy")]
         internal static partial void WarnMissingPolicy(ILogger logger, string policyName);
 
-        [LoggerMessage(3, LogLevel.Debug, "The request was canceled.", EventName = "TaskCanceled")]
-        internal static partial void TaskCanceled(ILogger logger);
+        [LoggerMessage(3, LogLevel.Debug, "The request was canceled.", EventName = "RequestCanceled")]
+        internal static partial void RequestCanceled(ILogger logger);
     }
 }

--- a/src/Middleware/RateLimiting/src/RateLimitingMiddleware.cs
+++ b/src/Middleware/RateLimiting/src/RateLimitingMiddleware.cs
@@ -78,12 +78,17 @@ internal sealed partial class RateLimitingMiddleware
     private async Task InvokeInternal(HttpContext context, EnableRateLimitingAttribute? enableRateLimitingAttribute)
     {
         using var leaseContext = await TryAcquireAsync(context);
-        if (leaseContext.Lease.IsAcquired)
+        if (leaseContext.Lease?.IsAcquired == true)
         {
             await _next(context);
         }
         else
         {
+            // If the request was canceled, do not call OnRejected, just return.
+            if (leaseContext.RequestRejectionReason == RequestRejectionReason.RequestCanceled)
+            {
+                return;
+            }
             var thisRequestOnRejected = _defaultOnRejected;
             RateLimiterLog.RequestRejectedLimitsExceeded(_logger);
             // OnRejected "wins" over DefaultRejectionStatusCode - we set DefaultRejectionStatusCode first,
@@ -91,7 +96,7 @@ internal sealed partial class RateLimitingMiddleware
             context.Response.StatusCode = _rejectionStatusCode;
 
             // If this request was rejected by the endpoint limiter, use its OnRejected if available.
-            if (leaseContext.GlobalRejected == false)
+            if (leaseContext.RequestRejectionReason == RequestRejectionReason.EndpointLimiter)
             {
                 DefaultRateLimiterPolicy? policy;
                 // Use custom policy OnRejected if available, else use OnRejected from the Options if available.
@@ -111,7 +116,8 @@ internal sealed partial class RateLimitingMiddleware
             }
             if (thisRequestOnRejected is not null)
             {
-                await thisRequestOnRejected(new OnRejectedContext() { HttpContext = context, Lease = leaseContext.Lease }, context.RequestAborted);
+                // leaseContext.Lease will only be null when the request was canceled.
+                await thisRequestOnRejected(new OnRejectedContext() { HttpContext = context, Lease = leaseContext.Lease! }, context.RequestAborted);
             }
         }
     }
@@ -139,21 +145,30 @@ internal sealed partial class RateLimitingMiddleware
                 globalLease = _globalLimiter.AttemptAcquire(context);
                 if (!globalLease.IsAcquired)
                 {
-                    return new LeaseContext() { GlobalRejected = true, Lease = globalLease };
+                    return new LeaseContext() { RequestRejectionReason = RequestRejectionReason.GlobalLimiter, Lease = globalLease };
                 }
             }
             endpointLease = _endpointLimiter.AttemptAcquire(context);
             if (!endpointLease.IsAcquired)
             {
                 globalLease?.Dispose();
-                return new LeaseContext() { GlobalRejected = false, Lease = endpointLease };
+                return new LeaseContext() { RequestRejectionReason = RequestRejectionReason.EndpointLimiter, Lease = endpointLease };
             }
         }
-        catch (Exception)
+        catch (Exception ex)
         {
             endpointLease?.Dispose();
             globalLease?.Dispose();
-            throw;
+            // Don't throw if the request was canceled - instead log. 
+            if (ex is OperationCanceledException && context.RequestAborted.IsCancellationRequested)
+            {
+                RateLimiterLog.TaskCanceled(_logger);
+                return new LeaseContext() { RequestRejectionReason = RequestRejectionReason.RequestCanceled };
+            }
+            else
+            {
+                throw;
+            }
         }
         return globalLease is null ? new LeaseContext() { Lease = endpointLease } : new LeaseContext() { Lease = new DefaultCombinedLease(globalLease, endpointLease) };
     }
@@ -170,21 +185,30 @@ internal sealed partial class RateLimitingMiddleware
                 globalLease = await _globalLimiter.AcquireAsync(context, cancellationToken: cancellationToken);
                 if (!globalLease.IsAcquired)
                 {
-                    return new LeaseContext() { GlobalRejected = true, Lease = globalLease };
+                    return new LeaseContext() { RequestRejectionReason = RequestRejectionReason.GlobalLimiter, Lease = globalLease };
                 }
             }
             endpointLease = await _endpointLimiter.AcquireAsync(context, cancellationToken: cancellationToken);
             if (!endpointLease.IsAcquired)
             {
                 globalLease?.Dispose();
-                return new LeaseContext() { GlobalRejected = false, Lease = endpointLease };
+                return new LeaseContext() { RequestRejectionReason = RequestRejectionReason.EndpointLimiter, Lease = endpointLease };
             }
         }
-        catch (Exception)
+        catch (Exception ex)
         {
             endpointLease?.Dispose();
             globalLease?.Dispose();
-            throw;
+            // Don't throw if the request was canceled - instead log. 
+            if (ex is OperationCanceledException && context.RequestAborted.IsCancellationRequested)
+            {
+                RateLimiterLog.TaskCanceled(_logger);
+                return new LeaseContext() { RequestRejectionReason = RequestRejectionReason.RequestCanceled };
+            }
+            else
+            {
+                throw;
+            }
         }
 
         return globalLease is null ? new LeaseContext() { Lease = endpointLease } : new LeaseContext() { Lease = new DefaultCombinedLease(globalLease, endpointLease) };
@@ -234,5 +258,8 @@ internal sealed partial class RateLimitingMiddleware
 
         [LoggerMessage(2, LogLevel.Debug, "This endpoint requires a rate limiting policy with name {PolicyName}, but no such policy exists.", EventName = "WarnMissingPolicy")]
         internal static partial void WarnMissingPolicy(ILogger logger, string policyName);
+
+        [LoggerMessage(3, LogLevel.Debug, "The request was canceled.", EventName = "TaskCanceled")]
+        internal static partial void TaskCanceled(ILogger logger);
     }
 }

--- a/src/Middleware/RateLimiting/src/RateLimitingMiddleware.cs
+++ b/src/Middleware/RateLimiting/src/RateLimitingMiddleware.cs
@@ -125,7 +125,7 @@ internal sealed partial class RateLimitingMiddleware
     private ValueTask<LeaseContext> TryAcquireAsync(HttpContext context)
     {
         var leaseContext = CombinedAcquire(context);
-        if (leaseContext.Lease.IsAcquired)
+        if (leaseContext.Lease?.IsAcquired == true)
         {
             return ValueTask.FromResult(leaseContext);
         }

--- a/src/Middleware/RateLimiting/src/RateLimitingMiddleware.cs
+++ b/src/Middleware/RateLimiting/src/RateLimitingMiddleware.cs
@@ -155,20 +155,11 @@ internal sealed partial class RateLimitingMiddleware
                 return new LeaseContext() { RequestRejectionReason = RequestRejectionReason.EndpointLimiter, Lease = endpointLease };
             }
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             endpointLease?.Dispose();
             globalLease?.Dispose();
-            // Don't throw if the request was canceled - instead log. 
-            if (ex is OperationCanceledException && context.RequestAborted.IsCancellationRequested)
-            {
-                RateLimiterLog.RequestCanceled(_logger);
-                return new LeaseContext() { RequestRejectionReason = RequestRejectionReason.RequestCanceled };
-            }
-            else
-            {
-                throw;
-            }
+            throw;
         }
         return globalLease is null ? new LeaseContext() { Lease = endpointLease } : new LeaseContext() { Lease = new DefaultCombinedLease(globalLease, endpointLease) };
     }


### PR DESCRIPTION
# Don't throw TaskCanceledException in RateLimitingMiddleware

Don't throw `TaskCanceledException` when the request gets canceled - instead log at the debug level & exit normally.

## Description

Today when a request is canceled, if that request was in the queue of a RateLimiter used by RateLimitingMiddleware, the middleware will throw the TaskCanceledException that it observes. Instead we should just log that info and exit gracefully.

Fixes #43473

## Customer Impact

Customers have reported that seeing a bunch of TaskCanceledExceptions when they refresh their site to be a bad experience.

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [x] Medium
- [ ] Low

Adds a new branch for returning from the middleware when the request is canceled - this scenario is different from the normal one of attempting to acquire a lease, so there could be some unforeseen bug.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props
