### PR TITLE
[release/7.0-rc1] Fix resolving method declaration in separate file

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
@@ -77,7 +77,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
                     var foundMethodReferenceBody = false;
                     if (!methodReference.Method.DeclaringSyntaxReferences.IsEmpty)
                     {
-                        var syntaxReference = methodReference.Method.DeclaringSyntaxReferences.SingleOrDefault();
+                        var syntaxReference = methodReference.Method.DeclaringSyntaxReferences.Single();
                         var syntaxNode = syntaxReference.GetSyntax(context.CancellationToken);
                         var methodOperation = syntaxNode.SyntaxTree == invocation.SemanticModel.SyntaxTree
                             ? invocation.SemanticModel.GetOperation(syntaxNode, context.CancellationToken)

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
@@ -77,8 +77,11 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
                     var foundMethodReferenceBody = false;
                     if (!methodReference.Method.DeclaringSyntaxReferences.IsEmpty)
                     {
-                        var syntaxReference = methodReference.Method.DeclaringSyntaxReferences[0];
-                        var methodOperation = invocation.SemanticModel.GetOperation(syntaxReference.GetSyntax(context.CancellationToken));
+                        var syntaxReference = methodReference.Method.DeclaringSyntaxReferences.SingleOrDefault();
+                        var syntaxNode = syntaxReference.GetSyntax(context.CancellationToken);
+                        var methodOperation = syntaxNode.SyntaxTree == invocation.SemanticModel.SyntaxTree
+                            ? invocation.SemanticModel.GetOperation(syntaxNode, context.CancellationToken)
+                            : null;
                         if (methodOperation is ILocalFunctionOperation { Body: not null } localFunction)
                         {
                             foundMethodReferenceBody = true;


### PR DESCRIPTION
## Description

Fixes unhandled exception in route handler analyzers.

Fixes https://github.com/dotnet/aspnetcore/issues/41794.

## Customer Impact

This change resolves an issue where ASP.NET Core analyzers threw unhandled exceptions for scenarios where customers defined route handler logic in files separate from where the `MapAction` invocations were made.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A



