### PR TITLE
Backport parts of 48a81a70597f

### DIFF
--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -40,7 +40,7 @@ jobs:
       displayName: Update submodules
     - script: ./restore.sh
       displayName: Run restore.sh
-    - script: npm install --prefix ./src/Components/test/E2ETest
+    - script: yarn install --frozen-lockfile --cwd ./src/Components/test/E2ETest
       displayName: NPM install
     - script: .dotnet/dotnet build ./src/Components/test/E2ETest -c $(BuildConfiguration) --no-restore
       displayName: Build

--- a/eng/targets/Npm.Common.targets
+++ b/eng/targets/Npm.Common.targets
@@ -42,7 +42,10 @@
   <Target Name="Restore">
     <Telemetry EventName="NETCORE_ENGINEERING_TELEMETRY" EventData="Category=Restore" />
     <Message Importance="High" Text="Running yarn install on $(MSBuildProjectFullPath)" />
-    <Yarn Command="install --mutex network $(InstallArgs)" StandardOutputImportance="High" StandardErrorImportance="High" IgnoreStandardErrorWarningFormat="$(IgnoreYarnWarnings)" />
+    <Yarn Command="install --mutex network $(InstallArgs) --frozen-lockfile"
+        StandardOutputImportance="High"
+        StandardErrorImportance="High"
+        IgnoreStandardErrorWarningFormat="$(IgnoreYarnWarnings)" />
   </Target>
 
   <Target Name="PrepareForBuild">

--- a/src/ProjectTemplates/test/Templates.Blazor.Tests/package.json
+++ b/src/ProjectTemplates/test/Templates.Blazor.Tests/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "selenium-standalone": "selenium-standalone",
-    "prepare": "selenium-standalone install --config ../../Shared/E2ETesting/selenium-config.json"
+    "prepare": "selenium-standalone install --config ../../../Shared/E2ETesting/selenium-config.json"
   },
   "author": "",
   "license": "MIT",

--- a/src/ProjectTemplates/test/Templates.Tests/package.json
+++ b/src/ProjectTemplates/test/Templates.Tests/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "selenium-standalone": "selenium-standalone",
-    "prepare": "selenium-standalone install --config ../../Shared/E2ETesting/selenium-config.json"
+    "prepare": "selenium-standalone install --config ../../../Shared/E2ETesting/selenium-config.json"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
- was "Exclusively use Azure (public) feeds (#43303)"
- Correct ref to selenium-config.json
  - fix what broke `yarn install` in these directories
- Use `yarn` in aspnetcore-components-e2e pipeline
  - also correct a missing `--frozen-lockfile`

Co-authored-by: MerlinBot