### PR TITLE
[7.0-rc1] Fix PopulateCertificatesFromStore on macOS to only return store certs 

### DIFF
--- a/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
+++ b/src/Shared/CertificateGeneration/MacOSCertificateManager.cs
@@ -375,7 +375,7 @@ internal sealed class MacOSCertificateManager : CertificateManager
 
     protected override void PopulateCertificatesFromStore(X509Store store, List<X509Certificate2> certificates)
     {
-        if (store.Name! == StoreName.My.ToString() && store.Location == store.Location && Directory.Exists(MacOSUserHttpsCertificateLocation))
+        if (store.Name! == StoreName.My.ToString() && store.Location == StoreLocation.CurrentUser && Directory.Exists(MacOSUserHttpsCertificateLocation))
         {
             var certsFromDisk = GetCertsFromDisk();
 
@@ -388,7 +388,10 @@ internal sealed class MacOSCertificateManager : CertificateManager
             // Certs created (or "upgraded") by .NET 7+.
             // .NET 7+ installs the certificate on disk as well as on the user keychain (for backwards
             // compatibility with pre-.NET 7).
-            var onDiskAndKeychain = certsFromDisk.Intersect(certsFromStore, ThumbprintComparer.Instance);
+            // Note that the actual certs we populate need to be the ones from the store location, and
+            // not the version from disk, since we may do other operations with these certs later (such
+            // as exporting) which would fail with crypto errors otherwise.
+            var onDiskAndKeychain = certsFromStore.Intersect(certsFromDisk, ThumbprintComparer.Instance);
 
             // The only times we can find a certificate on the keychain and a certificate on keychain+disk
             // are when the certificate on disk and keychain has expired and a pre-.NET 7 SDK has been


### PR DESCRIPTION
Some certificate export scenarios (exporting to a PEM file for instance) will lead us to try to export an RSA private key. Without this change, the first one of these exports works, and then subsequent ones fail with a vague crypto exception from `SecKeyCopyExternalRepresentation`.

The fix is simple; we have code in the certificate manager that takes the union of certificates in the new on-disk location and the store (keychain).

The code was previously doing:

```C#
var onDiskAndKeychain = certsFromDisk.Intersect(certsFromStore, ThumbprintComparer.Instance);
```

which meant that the actual certs returned were the ones loaded from disk (and also happened to be in the keychain), whereas what we _want_ to return is the certs from the keychain that also have on-disk versions. The reason why it works the first time is that the on-disk versions don't exist yet.

This change flips the Intersect call and adds a comment about all of this. While I was here I also noticed a typo on a nearby store location check so I fixed that too.


Fixes https://github.com/dotnet/aspnetcore/issues/43335