### PR TITLE
Stop setting content length 0 on 204s in MVC

### DIFF
--- a/src/Mvc/Mvc.Core/src/Formatters/HttpNoContentOutputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/HttpNoContentOutputFormatter.cs
@@ -34,7 +34,6 @@ public class HttpNoContentOutputFormatter : IOutputFormatter
     public Task WriteAsync(OutputFormatterWriteContext context)
     {
         var response = context.HttpContext.Response;
-        response.ContentLength = 0;
 
         if (response.StatusCode == StatusCodes.Status200OK)
         {

--- a/src/Mvc/Mvc.Core/test/Formatters/NoContentFormatterTests.cs
+++ b/src/Mvc/Mvc.Core/test/Formatters/NoContentFormatterTests.cs
@@ -131,6 +131,26 @@ public class NoContentFormatterTests
     }
 
     [Fact]
+    public async Task WriteAsync_DoesNotHaveContentLengthSet()
+    {
+        // Arrange
+        var context = new OutputFormatterWriteContext(
+            new DefaultHttpContext(),
+            new TestHttpResponseStreamWriterFactory().CreateWriter,
+            typeof(string),
+            @object: null);
+
+        var formatter = new HttpNoContentOutputFormatter();
+
+        // Act
+        await formatter.WriteAsync(context);
+
+        // Assert
+        // No Content responses shouldn't have a Content-Length.
+        Assert.Null(context.HttpContext.Response.ContentLength);
+    }
+
+    [Fact]
     public async Task WriteAsync_ContextStatusCodeSet_WritesSameStatusCode()
     {
         // Arrange


### PR DESCRIPTION
Fixes part of https://github.com/dotnet/aspnetcore/issues/43316

The HttpNoContentOutputFormatter in MVC was setting a 0 Content-Length for 204 No Content responses.

[RFC 9110 (and 7230 before it) says:](https://www.rfc-editor.org/rfc/rfc9110#section-8.6-8)

> A server MUST NOT send a Content-Length header field in any response with a status code of [1xx (Informational)](https://www.rfc-editor.org/rfc/rfc9110#status.1xx) or [204 (No Content)](https://www.rfc-editor.org/rfc/rfc9110#status.204). A server MUST NOT send a Content-Length header field in any [2xx (Successful)](https://www.rfc-editor.org/rfc/rfc9110#status.2xx) response to a CONNECT request ([Section 9.3.6](https://www.rfc-editor.org/rfc/rfc9110#CONNECT)).

