### PR TITLE
Code cleanup: Removing a superfluous switch block

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
@@ -146,13 +146,6 @@ internal sealed class HttpConnection : ITimeoutHandler
         {
             previousState = _protocolSelectionState;
             Debug.Assert(previousState != ProtocolSelectionState.Initializing, "The state should never be initializing");
-
-            switch (_protocolSelectionState)
-            {
-                case ProtocolSelectionState.Selected:
-                case ProtocolSelectionState.Aborted:
-                    break;
-            }
         }
 
         switch (previousState)

--- a/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
@@ -127,13 +127,6 @@ internal sealed class HttpConnection : ITimeoutHandler
         {
             previousState = _protocolSelectionState;
             Debug.Assert(previousState != ProtocolSelectionState.Initializing, "The state should never be initializing");
-
-            switch (_protocolSelectionState)
-            {
-                case ProtocolSelectionState.Selected:
-                case ProtocolSelectionState.Aborted:
-                    break;
-            }
         }
 
         switch (previousState)


### PR DESCRIPTION
#Removing a superfluous switch block

Removing a superfluous switch block in Kestrel/Core as part of a code cleanup

## Description

C# compiler (at compile time) already optimizes away these switch blocks.

Fixes #43328
