### PR TITLE
Copy invocation handler list in Java client

### DIFF
--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/CallbackMap.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/CallbackMap.java
@@ -38,10 +38,15 @@ class CallbackMap {
         }
     }
 
+    // Returns a copy of the handlers list so that modifications to the list don't cause issues with looping over the list
     public List<InvocationHandler> get(String key) {
         try {
             lock.lock();
-            return handlers.get(key);
+            List<InvocationHandler> handlers = this.handlers.get(key);
+            if (handlers == null) {
+                return null;
+            }
+            return new ArrayList<InvocationHandler>(handlers);
         } finally {
             lock.unlock();
         }
@@ -51,6 +56,18 @@ class CallbackMap {
         try {
             lock.lock();
             handlers.remove(key);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void remove(String key, InvocationHandler handler) {
+        try {
+            lock.lock();
+            List<InvocationHandler> handlers = this.handlers.get(key);
+            if (handlers != null) {
+                handlers.remove(handler);
+            }
         } finally {
             lock.unlock();
         }

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/CallbackMap.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/CallbackMap.java
@@ -31,22 +31,22 @@ class CallbackMap {
                     }
                 }
             }
+            methodHandlers = new ArrayList<>(methodHandlers);
             methodHandlers.add(handler);
+
+            // replace List in handlers map
+            handlers.remove(target);
+            handlers.put(target, methodHandlers);
             return handler;
         } finally {
             lock.unlock();
         }
     }
 
-    // Returns a copy of the handlers list so that modifications to the list don't cause issues with looping over the list
     public List<InvocationHandler> get(String key) {
         try {
             lock.lock();
-            List<InvocationHandler> handlers = this.handlers.get(key);
-            if (handlers == null) {
-                return null;
-            }
-            return new ArrayList<InvocationHandler>(handlers);
+            return this.handlers.get(key);
         } finally {
             lock.unlock();
         }
@@ -66,7 +66,12 @@ class CallbackMap {
             lock.lock();
             List<InvocationHandler> handlers = this.handlers.get(key);
             if (handlers != null) {
+                handlers = new ArrayList<>(handlers);
                 handlers.remove(handler);
+
+                // replace List in handlers map
+                this.handlers.remove(key);
+                this.handlers.put(key, handlers);
             }
         } finally {
             lock.unlock();

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/Subscription.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/Subscription.java
@@ -23,9 +23,6 @@ public class Subscription {
      * Removes the client method handler represented by this subscription.
      */
     public void unsubscribe() {
-        List<InvocationHandler> handler = this.handlers.get(target);
-        if (handler != null) {
-            handler.remove(this.handler);
-        }
+        this.handlers.remove(this.target, this.handler);
     }
 }


### PR DESCRIPTION
No one reported this even though it failed a few times...

Root cause was that we were removing an `.on` handler from the list while an invocation was currently looping over the list, which of course can cause issues. In our other clients we copy the list whenever we are about to loop over it, so doing the same in the Java client.