### PR TITLE
Strip Content-Length: 0 from responses that should not have a Content-Length

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -1153,7 +1153,17 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
         {
             if (!CanIncludeResponseContentLengthHeader())
             {
-                RejectInvalidHeaderForNonBodyResponse(appCompleted, HeaderNames.ContentLength);
+                if (responseHeaders.ContentLength.Value == 0)
+                {
+                    // If the response shouldn't include a Content-Length but it's 0
+                    // we'll just get rid of it without throwing an error, since it
+                    // is semantically equivalent to not having a Content-Length.
+                    responseHeaders.Remove(HeaderNames.ContentLength, out _);
+                }
+                else
+                {
+                    RejectInvalidHeaderForNonBodyResponse(appCompleted, HeaderNames.ContentLength);
+                }
             }
             else if (StatusCode == StatusCodes.Status205ResetContent && responseHeaders.ContentLength.Value != 0)
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -1158,7 +1158,7 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
                     // If the response shouldn't include a Content-Length but it's 0
                     // we'll just get rid of it without throwing an error, since it
                     // is semantically equivalent to not having a Content-Length.
-                    responseHeaders.Remove(HeaderNames.ContentLength, out _);
+                    responseHeaders.ContentLength = null;
                 }
                 else
                 {


### PR DESCRIPTION
We made a change (earlier in RC1, https://github.com/dotnet/aspnetcore/pull/43103) that tightened up Kestrel's Content-Length handling. Part of the change made it so that we throw if a `Content-Length` is set on responses that shouldn't have a `Content-Length` (1xx, 204 responses, or any 2xx responses to a CONNECT request).

This change keeps that behavior for _nonzero_ values of `Content-Length`. If the `Content-Length` is present but it's zero, we will now just remove it instead of throwing, since its absence is semantically equivalent.

We keep the existing behavior for 205's (the spec allows Content-Length 0 for those explicitly).

This is the remainder of the RC1 fix for https://github.com/dotnet/aspnetcore/issues/43316