### PR TITLE
[release/7.0] Hot reload: Acknowledge Blazor component parameter removal

### DIFF
--- a/src/Components/Components/test/ParameterViewTest.cs
+++ b/src/Components/Components/test/ParameterViewTest.cs
@@ -402,6 +402,172 @@ public partial class ParameterViewTest
             p => AssertParameter("attribute 3", attribute3Value, expectedIsCascading: false));
     }
 
+    [Fact]
+    public void HasRemovedDirectParameters_BothEmpty()
+    {
+        // Arrange
+        var oldParameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
+        {
+            RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(1),
+        }, 0);
+        var newParameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
+        {
+            RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(1),
+        }, 0);
+
+        // Act
+        var hasRemovedDirectParameters = newParameters.HasRemovedDirectParameters(oldParameters);
+
+        // Assert
+        Assert.False(hasRemovedDirectParameters);
+    }
+
+    [Fact]
+    public void HasRemovedDirectParameters_OldEmpty_NewNonEmpty()
+    {
+        // Arrange
+        var oldParameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
+        {
+            RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(1),
+        }, 0);
+        var newParameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
+        {
+            RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(2),
+            RenderTreeFrame.Attribute(1, "attribute 1", "value 1"),
+        }, 0);
+
+        // Act
+        var hasRemovedDirectParameters = newParameters.HasRemovedDirectParameters(oldParameters);
+
+        // Assert
+        Assert.False(hasRemovedDirectParameters);
+    }
+
+    [Fact]
+    public void HasRemovedDirectParameters_OldNonEmpty_NewEmpty()
+    {
+        // Arrange
+        var oldParameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
+        {
+            RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(2),
+            RenderTreeFrame.Attribute(1, "attribute 1", "value 1"),
+        }, 0);
+        var newParameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
+        {
+            RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(1),
+        }, 0);
+
+        // Act
+        var hasRemovedDirectParameters = newParameters.HasRemovedDirectParameters(oldParameters);
+
+        // Assert
+        Assert.True(hasRemovedDirectParameters);
+    }
+
+    [Fact]
+    public void HasRemovedDirectParameters_ParameterRemoved()
+    {
+        // Arrange
+        var oldParameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
+        {
+            RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(4),
+            RenderTreeFrame.Attribute(1, "attribute 1", "value 1"),
+            RenderTreeFrame.Attribute(2, "attribute 2", "value 2"),
+            RenderTreeFrame.Attribute(3, "attribute 3", "value 3"),
+        }, 0);
+        var newParameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
+        {
+            RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(3),
+            RenderTreeFrame.Attribute(1, "attribute 1", "value 1"),
+            RenderTreeFrame.Attribute(2, "attribute 3", "value 3"),
+        }, 0);
+
+        // Act
+        var hasRemovedDirectParameters = newParameters.HasRemovedDirectParameters(oldParameters);
+
+        // Assert
+        Assert.True(hasRemovedDirectParameters);
+    }
+
+    [Fact]
+    public void HasRemovedDirectParameters_ParameterReplaced()
+    {
+        // Arrange
+        var oldParameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
+        {
+            RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(4),
+            RenderTreeFrame.Attribute(1, "attribute 1", "value 1"),
+            RenderTreeFrame.Attribute(2, "attribute 2", "value 2"),
+            RenderTreeFrame.Attribute(3, "attribute 3", "value 3"),
+        }, 0);
+        var newParameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
+        {
+            RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(4),
+            RenderTreeFrame.Attribute(1, "attribute 2", "value 1"),
+            RenderTreeFrame.Attribute(2, "attribute replaced", "value 2"),
+            RenderTreeFrame.Attribute(3, "attribute 3", "value 3"),
+        }, 0);
+
+        // Act
+        var hasRemovedDirectParameters = newParameters.HasRemovedDirectParameters(oldParameters);
+
+        // Assert
+        Assert.True(hasRemovedDirectParameters);
+    }
+
+    [Fact]
+    public void HasRemovedDirectParameters_ParameterReplacedAndAdded()
+    {
+        // Arrange
+        var oldParameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
+        {
+            RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(4),
+            RenderTreeFrame.Attribute(1, "attribute 1", "value 1"),
+            RenderTreeFrame.Attribute(2, "attribute 2", "value 2"),
+            RenderTreeFrame.Attribute(3, "attribute 3", "value 3"),
+        }, 0);
+        var newParameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
+        {
+            RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(5),
+            RenderTreeFrame.Attribute(1, "attribute 2", "value 1"),
+            RenderTreeFrame.Attribute(2, "attribute replaced", "value 2"),
+            RenderTreeFrame.Attribute(3, "attribute 3", "value 3"),
+            RenderTreeFrame.Attribute(4, "attribute 4", "value 3"),
+        }, 0);
+
+        // Act
+        var hasRemovedDirectParameters = newParameters.HasRemovedDirectParameters(oldParameters);
+
+        // Assert
+        Assert.True(hasRemovedDirectParameters);
+    }
+
+    [Fact]
+    public void HasRemovedDirectParameters_ParametersSwapped()
+    {
+        // Arrange
+        var oldParameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
+        {
+            RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(4),
+            RenderTreeFrame.Attribute(1, "attribute 1", "value 1"),
+            RenderTreeFrame.Attribute(2, "attribute 2", "value 2"),
+            RenderTreeFrame.Attribute(3, "attribute 3", "value 3"),
+        }, 0);
+        var newParameters = new ParameterView(ParameterViewLifetime.Unbound, new[]
+        {
+            RenderTreeFrame.Element(0, "some element").WithElementSubtreeLength(4),
+            RenderTreeFrame.Attribute(1, "attribute 1", "value 1"),
+            RenderTreeFrame.Attribute(2, "attribute 3", "value 3"),
+            RenderTreeFrame.Attribute(3, "attribute 2", "value 2"),
+        }, 0);
+
+        // Act
+        var hasRemovedDirectParameters = newParameters.HasRemovedDirectParameters(oldParameters);
+
+        // Assert
+        Assert.False(hasRemovedDirectParameters);
+    }
+
     private Action<ParameterValue> AssertParameter(string expectedName, object expectedValue, bool expectedIsCascading)
     {
         return parameter =>


### PR DESCRIPTION
# [release/7.0] Hot reload: Acknowledge Blazor component parameter removal

If a parameter value was removed from a component during a hot reload edit, the component would retain the previously-supplied value. This PR fixes the issue by reinstantiating a component when a hot reload edit removes one of its parameters.

## Description

One approach to solving this bug could be to directly `default`-out all parameter properties before applying the new set of parameter values. The main problem with that is any custom construction logic initializing properties to their default values will be skipped. This can be fine in some cases, but even some of our E2E test pages would throw exceptions or break in other ways when _any_ hot reload change was applied using this approach.

Thus, with the changes in this PR, a component will get completely disposed and reinstantiated when a component parameter removal is detected during hot reload. This allows the component's construction logic to correctly reset parameter property values.

Fixes #31272

## Customer Impact

Certain types of code edits require the customer to either rebuild their project or refresh the webpage in order for the changes to be applied. Expanding the range of edits that a customer can make to their code without requiring manual refreshing/rebuilding makes Hot Reload a larger productivity booster. Supporting the live removal of Blazor component parameters is a step in that direction.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

This PR adds a single additional code path to the rendering logic, and it only applies for hot reload scenarios. New automated tests have been added for the logic determining when that new code path should be taken (i.e., detecting when component parameters have been removed).

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A
