### PR TITLE
WebTransport interfaces require preview features

### DIFF
--- a/src/Http/Http.Features/src/IHttpWebTransportFeature.cs
+++ b/src/Http/Http.Features/src/IHttpWebTransportFeature.cs
@@ -8,6 +8,7 @@ namespace Microsoft.AspNetCore.Http.Features;
 /// <summary>
 /// API for accepting and retrieving WebTransport sessions.
 /// </summary>
+[RequiresPreviewFeatures("WebTransport is a preview feature")]
 public interface IHttpWebTransportFeature
 {
     /// <summary>
@@ -20,6 +21,5 @@ public interface IHttpWebTransportFeature
     /// </summary>
     /// <param name="cancellationToken">The cancellation token to cancel waiting for the session.</param>
     /// <returns>An instance of a WebTransportSession which will be used to control the connection.</returns>
-    [RequiresPreviewFeatures("WebTransport is a preview feature")]
     ValueTask<IWebTransportSession> AcceptAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Http/Http.Features/src/IWebTransportSession.cs
+++ b/src/Http/Http.Features/src/IWebTransportSession.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
 using Microsoft.AspNetCore.Connections;
 
 namespace Microsoft.AspNetCore.Http.Features;
@@ -8,6 +9,7 @@ namespace Microsoft.AspNetCore.Http.Features;
 /// <summary>
 /// Controls the session and streams of a WebTransport session.
 /// </summary>
+[RequiresPreviewFeatures("WebTransport is a preview feature")]
 public interface IWebTransportSession
 {
     /// <summary>

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.Generated.cs
@@ -11,6 +11,8 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 
+#pragma warning disable CA2252 // WebTransport is a preview feature
+
 #nullable enable
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -1169,7 +1169,9 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
         }
     }
 
+#pragma warning disable CA2252 // WebTransport is a preview feature
     public override async ValueTask<IWebTransportSession> AcceptAsync(CancellationToken token)
+#pragma warning restore CA2252 // WebTransport is a preview feature
     {
         if (_isWebTransportSessionAccepted)
         {

--- a/src/Servers/Kestrel/Core/src/Internal/WebTransport/WebTransportSession.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/WebTransport/WebTransportSession.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.WebTransport;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.WebTransport;
 
+#pragma warning disable CA2252 // WebTransport is a preview feature
 internal sealed class WebTransportSession : IWebTransportSession
 {
     private static readonly IStreamDirectionFeature _outputStreamDirectionFeature = new DefaultStreamDirectionFeature(canRead: false, canWrite: true);
@@ -190,3 +191,4 @@ internal sealed class WebTransportSession : IWebTransportSession
         return success;
     }
 }
+#pragma warning restore CA2252 // WebTransport is a preview feature

--- a/src/Servers/Kestrel/Core/test/Http1/Http1HttpProtocolFeatureCollectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1HttpProtocolFeatureCollectionTests.cs
@@ -127,7 +127,9 @@ public class Http1HttpProtocolFeatureCollectionTests
         _collection[typeof(IHttpExtendedConnectFeature)] = CreateHttp1Connection();
         _collection[typeof(IHttpUpgradeFeature)] = CreateHttp1Connection();
         _collection[typeof(IPersistentStateFeature)] = CreateHttp1Connection();
+#pragma warning disable CA2252 // WebTransport is a preview feature
         _collection.Set<IHttpWebTransportFeature>(CreateHttp1Connection());
+#pragma warning restore CA2252 // WebTransport is a preview feature
 
         CompareGenericGetterToIndexer();
 
@@ -155,7 +157,9 @@ public class Http1HttpProtocolFeatureCollectionTests
         _collection.Set<IHttpExtendedConnectFeature>(CreateHttp1Connection());
         _collection.Set<IHttpUpgradeFeature>(CreateHttp1Connection());
         _collection.Set<IPersistentStateFeature>(CreateHttp1Connection());
+#pragma warning disable CA2252 // WebTransport is a preview feature
         _collection.Set<IHttpWebTransportFeature>(CreateHttp1Connection());
+#pragma warning restore CA2252 // WebTransport is a preview feature
 
         CompareGenericGetterToIndexer();
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/WebTransport/WebTransportHandshakeTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/WebTransport/WebTransportHandshakeTests.cs
@@ -27,11 +27,11 @@ public class WebTransportHandshakeTests : Http3TestBase
         {
             var success = true;
 
+#pragma warning disable CA2252 // WebTransport is a preview feature
             var webTransportFeature = context.Features.GetRequiredFeature<IHttpWebTransportFeature>();
 
             success &= webTransportFeature.IsWebTransportRequest;
 
-#pragma warning disable CA2252 // This API requires opting into preview features
             try
             {
                 var session = await webTransportFeature.AcceptAsync(CancellationToken.None).DefaultTimeout(); // todo session is null here

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/WebTransport/WebTransportTestUtilities.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/WebTransport/WebTransportTestUtilities.cs
@@ -22,13 +22,13 @@ internal class WebTransportTestUtilities
 
     public static async ValueTask<WebTransportSession> GenerateSession(Http3InMemory inMemory, TaskCompletionSource exitSessionTcs)
     {
+#pragma warning disable CA2252 // WebTransport is a preview feature
         var appCompletedTcs = new TaskCompletionSource<IWebTransportSession>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         await inMemory.InitializeConnectionAsync(async context =>
         {
             var webTransportFeature = context.Features.GetRequiredFeature<IHttpWebTransportFeature>();
 
-#pragma warning disable CA2252 // This API requires opting into preview features
             try
             {
                 var session = await webTransportFeature.AcceptAsync(CancellationToken.None).DefaultTimeout();
@@ -38,7 +38,7 @@ internal class WebTransportTestUtilities
             {
                 appCompletedTcs.SetException(exception);
             }
-#pragma warning restore CA2252
+#pragma warning restore CA2252 // WebTransport is a preview feature
 
             // wait for the test to tell us to kill the application
             await exitSessionTcs.Task;

--- a/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
+++ b/src/Servers/Kestrel/tools/CodeGenerator/HttpProtocolFeatureCollection.cs
@@ -88,7 +88,9 @@ public class HttpProtocolFeatureCollection
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Features.Authentication;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Features;";
+using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
+
+#pragma warning disable CA2252 // WebTransport is a preview feature";
 
         return FeatureCollectionGenerator.GenerateFile(
             namespaceName: "Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http",


### PR DESCRIPTION
AcceptAsync already had the `[RequiresPreviewFeatures]`. This just extends the treatment to the entire interface so we can make breaking changes to this API in a later release. We think we might expose a `MultiplexedConnectionContext` down the road.

Closes #42490