### PR TITLE
[release/7.0-rc1] HTTP/3 flaky test retries and logging

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionContextTests.cs
@@ -421,6 +421,8 @@ public class QuicConnectionContextTests : TestApplicationErrorLoggerLoggedTest
     public async Task StreamPool_StreamAbortedOnClientAndServer_NotPooled()
     {
         // Arrange
+        using var httpEventSource = new HttpEventSourceListener(LoggerFactory);
+
         await using var connectionListener = await QuicTestHelpers.CreateConnectionListenerFactory(LoggerFactory);
 
         var options = QuicTestHelpers.CreateClientConnectionOptions(connectionListener.EndPoint);

--- a/src/Servers/Kestrel/shared/test/ServerRetryHelper.cs
+++ b/src/Servers/Kestrel/shared/test/ServerRetryHelper.cs
@@ -7,6 +7,8 @@ namespace Microsoft.AspNetCore.Testing;
 
 public static class ServerRetryHelper
 {
+    private const int RetryCount = 15;
+
     /// <summary>
     /// Retry a func. Useful when a test needs an explicit port and you want to avoid port conflicts.
     /// </summary>
@@ -27,7 +29,7 @@ public static class ServerRetryHelper
             {
                 retryCount++;
 
-                if (retryCount >= 5)
+                if (retryCount >= RetryCount)
                 {
                     throw;
                 }

--- a/src/Servers/Kestrel/shared/test/ServerRetryHelper.cs
+++ b/src/Servers/Kestrel/shared/test/ServerRetryHelper.cs
@@ -1,28 +1,30 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
+using System.Net.Sockets;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Testing;
 
 public static class ServerRetryHelper
 {
-    private const int RetryCount = 15;
+    private const int RetryCount = 10;
 
     /// <summary>
     /// Retry a func. Useful when a test needs an explicit port and you want to avoid port conflicts.
     /// </summary>
     public static async Task BindPortsWithRetry(Func<int, Task> retryFunc, ILogger logger)
     {
+        var ports = GetFreePorts(RetryCount);
+
         var retryCount = 0;
         while (true)
         {
-            // Approx dynamic port range on Windows and Linux.
-            var randomPort = Random.Shared.Next(35000, 60000);
 
             try
             {
-                await retryFunc(randomPort);
+                await retryFunc(ports[retryCount]);
                 break;
             }
             catch (Exception ex)
@@ -39,5 +41,36 @@ public static class ServerRetryHelper
                 }
             }
         }
+    }
+
+    private static int[] GetFreePorts(int count)
+    {
+        var sockets = new List<Socket>();
+
+        for (var i = 0; i < count; i++)
+        {
+            // Find a port that's free by binding port 0.
+            // Note that this port should be free when the test runs, but:
+            // - Something else could steal it before the test uses it.
+            // - UDP port with the same number could be in use.
+            // For that reason, some retries should be available.
+            var ipEndPoint = new IPEndPoint(IPAddress.Loopback, 0);
+            var listenSocket = new Socket(ipEndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+
+            listenSocket.Bind(ipEndPoint);
+
+            sockets.Add(listenSocket);
+        }
+
+        // Ports are calculated upfront. Rebinding with port 0 could result the same port
+        // being returned for each retry.
+        var ports = sockets.Select(s => (IPEndPoint)s.LocalEndPoint).Select(ep => ep.Port).ToArray();
+
+        foreach (var socket in sockets)
+        {
+            socket.Dispose();
+        }
+
+        return ports;
     }
 }

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -228,6 +228,8 @@ public class Http3RequestTests : LoggedTest
     public async Task POST_ClientSendsOnlyHeaders_RequestReceivedOnServer(HttpProtocols protocol)
     {
         // Arrange
+        using var httpEventSource = new HttpEventSourceListener(LoggerFactory);
+
         var builder = CreateHostBuilder(context =>
         {
             return Task.CompletedTask;


### PR DESCRIPTION
Address various pipeline failures:

- [Pipelines - Run 20220818.34 (azure.com)](https://dev.azure.com/dnceng/public/_build/results?buildId=1952772&view=ms.vss-test-web.build-test-results-tab)
- [Pipelines - Run 20220818.38 (azure.com)](https://dev.azure.com/dnceng/public/_build/results?buildId=1952956&view=ms.vss-test-web.build-test-results-tab)
- [Pipelines - Run 20220817.3 (azure.com)](https://dev.azure.com/dnceng/public/_build/results?buildId=1950541&view=ms.vss-test-web.build-test-results-tab)
- [Pipelines - Run 20220818.2 (azure.com)](https://dev.azure.com/dnceng/public/_build/results?buildId=1951376&view=ms.vss-test-web.build-test-results-tab)
- [Pipelines - Run 20220818.3 (azure.com)](https://dev.azure.com/dnceng/public/_build/results?buildId=1952786&view=ms.vss-test-web.build-test-results-tab&runId=50232550&resultId=109657&paneView=debug)

More retries will hopefully remove one set of failures. More logging to find solutions for others in the future. System.Net.Quic team is still making changes, so it can be a source of instability.

Test only changes.