### PR TITLE
Triggering IConnectionLifetimeNotificationFeature on GoAway

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -967,7 +967,9 @@ internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHt
             throw new Http2ConnectionErrorException(CoreStrings.FormatHttp2ErrorStreamIdNotZero(_incomingFrame.Type), Http2ErrorCode.PROTOCOL_ERROR);
         }
 
+        // StopProcessingNextRequest must be called before RequestClose to ensure it's considered client initiated.
         StopProcessingNextRequest(serverInitiated: false);
+        _context.ConnectionFeatures.Get<IConnectionLifetimeNotificationFeature>()?.RequestClose();
 
         return Task.CompletedTask;
     }

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -1073,7 +1073,7 @@ internal class TestMultiplexedConnectionContext : MultiplexedConnectionContext, 
 
     public void RequestClose()
     {
-        throw new NotImplementedException();
+        ConnectionClosingCts.Cancel();
     }
 }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Globalization;
 using System.Net.Http;
 using System.Net.Http.HPack;
-using System.Net.Security;
 using System.Reflection;
 using System.Security.Authentication;
 using System.Text;
@@ -3852,6 +3851,19 @@ public class Http2ConnectionTests : Http2TestBase
 
         await SendGoAwayAsync();
 
+        await WaitForConnectionStopAsync(expectedLastStreamId: 0, ignoreNonGoAwayFrames: false);
+    }
+
+    [Fact]
+    public async Task GOAWAY_Received_ConnectionLifetimeNotification_Cancelled()
+    {
+        await InitializeConnectionAsync(_noopApplication, addKestrelFeatures: true);
+        var lifetime = _connection.ConnectionFeatures.Get<IConnectionLifetimeNotificationFeature>();
+        Assert.False(lifetime.ConnectionClosedRequested.IsCancellationRequested);
+
+        await SendGoAwayAsync();
+
+        Assert.True(lifetime.ConnectionClosedRequested.IsCancellationRequested);
         await WaitForConnectionStopAsync(expectedLastStreamId: 0, ignoreNonGoAwayFrames: false);
     }
 


### PR DESCRIPTION
Triggering Connection Lifetime Notification Feature's cancellation on GoAway

On GoAway frames triggering `IConnectionLifetimeNotificationFeature`'s cancellation for gRPC and SignalR to initiate teardown of long running requests.

## Description

For Kestrel h2 and h3 triggering `IConnectionLifetimeNotificationFeature` feature's *RequestClose()* method on GoAway frames, so that frameworks like SignalR or gRPC may proactively start closing long running request.
h3 control stream (which is the only stream that handles GoAway) also calls *StopProcessingNextRequest()* method otherwise `HttpConnection` (subscribed to `IConnectionLifetimeNotificationFeature`) would send GoAway's from server. h2 already does the same.

Adding new tests: `Http3InMemory` now implements *RequestClose()* method and `Http2TestBase` mimics sharing the same feature collection on ConnectionFeatures and by the Connection's Features properties.


Fixes #42057 