### PR TITLE
Remove the double dispatch on Windows for IO

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs
@@ -33,7 +33,7 @@ internal sealed partial class SocketConnection : TransportConnection
 
     internal SocketConnection(Socket socket,
                               MemoryPool<byte> memoryPool,
-                              PipeScheduler transportScheduler,
+                              PipeScheduler socketScheduler,
                               ILogger logger,
                               SocketSenderPool socketSenderPool,
                               PipeOptions inputOptions,
@@ -55,12 +55,7 @@ internal sealed partial class SocketConnection : TransportConnection
 
         ConnectionClosed = _connectionClosedTokenSource.Token;
 
-        // On *nix platforms, Sockets already dispatches to the ThreadPool.
-        // Yes, the IOQueues are still used for the PipeSchedulers. This is intentional.
-        // https://github.com/aspnet/KestrelHttpServer/issues/2573
-        var awaiterScheduler = OperatingSystem.IsWindows() ? transportScheduler : PipeScheduler.Inline;
-
-        _receiver = new SocketReceiver(awaiterScheduler);
+        _receiver = new SocketReceiver(socketScheduler);
 
         var pair = DuplexPipe.CreateConnectionPair(inputOptions, outputOptions);
 


### PR DESCRIPTION
- The windows IO thread pool was replaced with one that dispatches
to the thread pool. As a result, we remove the extra thread pool dispatch
that we originally had for windows because continuations for IO on windows ran on
the same thread that polls for IO.

See https://github.com/dotnet/runtime/pull/64834 for the thread pool changes.

~PS: I think we need to adjust this for the old non portable threadpool (there's a flag to go back to the old mode that we should probably respect here as well). This should be in .NET 7.~

TBD: Perf tests.