### PR TITLE
Skip component governance in public builds

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -57,10 +57,7 @@ parameters:
   condition: ''
   codeSign: false
   buildDirectory: $(System.DefaultWorkingDirectory)/eng/
-  ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    skipComponentGovernanceDetection: false
-  ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-    skipComponentGovernanceDetection: true
+  skipComponentGovernanceDetection: false
   isAzDOTestingJob: false
   enablePublishTestResults: ''
 
@@ -103,6 +100,8 @@ jobs:
     enableTelemetry: true
     helixRepo: dotnet/aspnetcore
     helixType: build.product/
+    ${{ if ne(variables['System.TeamProject'], 'internal') }}:
+      skipComponentGovernanceDetection: true
     workspace:
       clean: all
     # Map friendly OS names to the right queue

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -57,7 +57,10 @@ parameters:
   condition: ''
   codeSign: false
   buildDirectory: $(System.DefaultWorkingDirectory)/eng/
-  skipComponentGovernanceDetection: false
+  ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    skipComponentGovernanceDetection: false
+  ${{ if ne(variables['System.TeamProject'], 'internal') }}:
+    skipComponentGovernanceDetection: true
   isAzDOTestingJob: false
   enablePublishTestResults: ''
 


### PR DESCRIPTION
We only track internal builds for CG