### PR TITLE
Update Microsoft.Web.Xdt version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -290,6 +290,11 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7d981168a2a2ed7d2190776a08ece88665cba727</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Web.Xdt" Version="7.0.0-preview.22419.1">
+      <Uri>https://github.com/dotnet/xdt</Uri>
+      <Sha>6a23b4b92e39fdbd4c63672893b7dce394cc1400</Sha>
+      <SourceBuild RepoName="xdt" ManagedOnly="true" />
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <!-- Listed explicitly to workaround https://github.com/dotnet/cli/issues/10528 -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -223,7 +223,7 @@
     <MicrosoftOwinSecurityCookiesVersion>3.0.1</MicrosoftOwinSecurityCookiesVersion>
     <MicrosoftOwinTestingVersion>3.0.1</MicrosoftOwinTestingVersion>
     <MicrosoftWebAdministrationVersion>11.1.0</MicrosoftWebAdministrationVersion>
-    <MicrosoftWebXdtVersion>1.4.0</MicrosoftWebXdtVersion>
+    <MicrosoftWebXdtVersion>7.0.0-preview.22419.1</MicrosoftWebXdtVersion>
     <SystemIdentityModelTokensJwtVersion>6.21.0</SystemIdentityModelTokensJwtVersion>
     <NuGetPackagingVersion>6.2.0</NuGetPackagingVersion>
     <NuGetVersioningVersion>6.2.0</NuGetVersioningVersion>


### PR DESCRIPTION
# Update Microsoft.Web.Xdt version

## Description

Updates version of Microsoft.Web.Xdt package and add source-build dependency in Version.Details.xml.

Fixes https://github.com/dotnet/source-build/issues/2969
