### PR TITLE
[SignalR] Fix WebSocket client close when network disappears

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/UnitTests/WebSocketsTransportTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/WebSocketsTransportTests.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.WebSockets;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http.Connections.Client;
+using Microsoft.AspNetCore.Http.Connections.Client.Internal;
+using Microsoft.AspNetCore.SignalR.Tests;
+using Microsoft.AspNetCore.Testing;
+
+namespace Microsoft.AspNetCore.SignalR.Client.Tests;
+
+public class WebSocketsTransportTests : VerifiableLoggedTest
+{
+    // Tests that the transport can still be stopped if SendAsync and ReceiveAsync are hanging (ethernet unplugged for example)
+    [Fact]
+    public async Task StopCancelsSendAndReceive()
+    {
+        var options = new HttpConnectionOptions()
+        {
+            WebSocketFactory = (context, token) =>
+            {
+                return ValueTask.FromResult((WebSocket)new TestWebSocket());
+            },
+            CloseTimeout = TimeSpan.FromMilliseconds(1),
+        };
+
+        using (StartVerifiableLog())
+        {
+            var webSocketsTransport = new WebSocketsTransport(options, loggerFactory: LoggerFactory, () => Task.FromResult<string>(null), null);
+
+            await webSocketsTransport.StartAsync(
+                new Uri("http://fakeuri.org"), TransferFormat.Text).DefaultTimeout();
+
+            await webSocketsTransport.StopAsync().DefaultTimeout();
+
+            await webSocketsTransport.Running.DefaultTimeout();
+        }
+    }
+
+    internal class TestWebSocket : WebSocket
+    {
+        public Task ConnectAsync(Uri uri, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public override WebSocketCloseStatus? CloseStatus => null;
+
+        public override string CloseStatusDescription => string.Empty;
+
+        public override WebSocketState State => WebSocketState.Open;
+
+        public override string SubProtocol => string.Empty;
+
+        public override void Abort() { }
+
+        public override Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public override async Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+        {
+            await cancellationToken.WaitForCancellationAsync();
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        public override void Dispose() { }
+
+        public override async Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
+        {
+            await cancellationToken.WaitForCancellationAsync();
+            cancellationToken.ThrowIfCancellationRequested();
+            return new WebSocketReceiveResult(0, WebSocketMessageType.Text, true);
+        }
+
+        public override async Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
+        {
+            await cancellationToken.WaitForCancellationAsync();
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/43392

If the network goes away both `socket.ReceiveAsync` and `socket.SendAsync` can be running and stuck. When our shutdown logic runs we complete all the pipes and then wait for the send and receive loops to complete, but if the loops are stuck on the above methods then they may not complete for 10+ minutes.

This PR fixes that by always passing a `CancellationToken` to send and receive and when we are closing the connection we set the `CancellationTokenSource` to timeout after `CloseTimeout` so if a graceful close isn't possible, we can at least ungracefully close.