### PR TITLE
Unquarantine ClientCertificate_Required_NotSent_AcceptedViaCallback

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
@@ -104,7 +104,6 @@ public class QuicConnectionListenerTests : TestApplicationErrorLoggerLoggedTest
     [ConditionalFact]
     [MsQuicSupported]
     [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/42389")]
     public async Task ClientCertificate_Required_NotSent_AcceptedViaCallback()
     {
         using var httpEventSource = new HttpEventSourceListener(LoggerFactory);


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/42389