### PR TITLE
[SignalR] Fix bug when combining streaming and client results

### DIFF
--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -324,9 +324,9 @@ internal sealed partial class DefaultHubDispatcher<THub> : HubDispatcher<THub> w
                     if (hub.Clients is HubCallerClients hubCallerClients)
                     {
                         // Streaming invocations aren't involved with the semaphore.
-                        // Setting this to 0 avoids potential client result calls from the streaming hub method
+                        // Setting the semaphore released flag avoids potential client result calls from the streaming hub method
                         // releasing the semaphore which would cause a SemaphoreFullException.
-                        hubCallerClients.ShouldReleaseSemaphore = 0;
+                        hubCallerClients.TrySetSemaphoreReleased();
                     }
                 }
 
@@ -415,7 +415,7 @@ internal sealed partial class DefaultHubDispatcher<THub> : HubDispatcher<THub> w
             {
                 if (hub?.Clients is HubCallerClients hubCallerClients)
                 {
-                    wasSemaphoreReleased = Interlocked.CompareExchange(ref hubCallerClients.ShouldReleaseSemaphore, 0, 1) == 0;
+                    wasSemaphoreReleased = !hubCallerClients.TrySetSemaphoreReleased();
                 }
                 await CleanupInvocation(connection, hubMethodInvocationMessage, hubActivator, hub, scope);
             }

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -321,13 +321,11 @@ internal sealed partial class DefaultHubDispatcher<THub> : HubDispatcher<THub> w
 
                 if (isStreamCall || isStreamResponse)
                 {
-                    if (hub.Clients is HubCallerClients hubCallerClients)
-                    {
-                        // Streaming invocations aren't involved with the semaphore.
-                        // Setting the semaphore released flag avoids potential client result calls from the streaming hub method
-                        // releasing the semaphore which would cause a SemaphoreFullException.
-                        hubCallerClients.TrySetSemaphoreReleased();
-                    }
+                    Debug.Assert(hub.Clients is HubCallerClients);
+                    // Streaming invocations aren't involved with the semaphore.
+                    // Setting the semaphore released flag avoids potential client result calls from the streaming hub method
+                    // releasing the semaphore which would cause a SemaphoreFullException.
+                    ((HubCallerClients)hub.Clients).TrySetSemaphoreReleased();
                 }
 
                 if (isStreamResponse)

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -356,6 +356,18 @@ public class MethodHub : TestHub
             }
         });
     }
+
+    public async Task<int> GetClientResultWithStream(ChannelReader<int> channelReader)
+    {
+        var sum = await Clients.Caller.InvokeAsync<int>("Sum", 1, cancellationToken: default);
+        return sum;
+    }
+
+    public async IAsyncEnumerable<int> StreamWithClientResult()
+    {
+        var sum = await Clients.Caller.InvokeAsync<int>("Sum", 1, cancellationToken: default);
+        yield return sum;
+    }
 }
 
 internal class SelfRef


### PR DESCRIPTION
If you combined a streaming hub method with client results you would end up with the connection closing and a `SemaphoreFullException` on the server.

Probably not a super common scenario (especially because the feature is new 😆), but I could easily see developers ask the client for something before starting a stream, or once they finish reading from a stream they do some client result stuff.