### PR TITLE
[release/7.0] Improve port search retry logic

### DIFF
--- a/src/Servers/Kestrel/shared/test/ServerRetryHelper.cs
+++ b/src/Servers/Kestrel/shared/test/ServerRetryHelper.cs
@@ -13,9 +13,6 @@ public static class ServerRetryHelper
     /// <summary>
     /// Retry a func. Useful when a test needs an explicit port and you want to avoid port conflicts.
     /// </summary>
-    /// <summary>
-    /// Retry a func. Useful when a test needs an explicit port and you want to avoid port conflicts.
-    /// </summary>
     public static async Task BindPortsWithRetry(Func<int, Task> retryFunc, ILogger logger)
     {
         var retryCount = 0;

--- a/src/Servers/Kestrel/shared/test/ServerRetryHelper.cs
+++ b/src/Servers/Kestrel/shared/test/ServerRetryHelper.cs
@@ -17,7 +17,9 @@ public static class ServerRetryHelper
     public static async Task BindPortsWithRetry(Func<int, Task> retryFunc, ILogger logger)
     {
         var retryCount = 0;
-        var nextPortAttempt = 5000;
+
+        // Add a random number to starting port to reduce chance of conflicts because of multiple tests using this retry.
+        var nextPortAttempt = 5000 + Random.Shared.Next(500);
 
         while (true)
         {

--- a/src/Servers/Kestrel/shared/test/ServerRetryHelper.cs
+++ b/src/Servers/Kestrel/shared/test/ServerRetryHelper.cs
@@ -21,7 +21,7 @@ public static class ServerRetryHelper
 
         while (true)
         {
-            // Approx dynamic port range on Windows and Linux.
+            // Find a port that's available for TCP and UDP. Start with port 5000 and search upwards from there.
             var port = GetAvailablePort(nextPortAttempt, logger);
 
             try

--- a/src/Servers/Kestrel/shared/test/ServerRetryHelper.cs
+++ b/src/Servers/Kestrel/shared/test/ServerRetryHelper.cs
@@ -63,6 +63,8 @@ public static class ServerRetryHelper
         // Ignore active UDP listeners
         AddEndpoints(startingPort, unavailableEndpoints, properties.GetActiveUdpListeners());
 
+        logger.LogInformation($"Found {unavailableEndpoints.Count} unavailable endpoints.");
+
         for (var i = startingPort; i < ushort.MaxValue; i++)
         {
             var match = unavailableEndpoints.FirstOrDefault(ep => ep.Port == i);


### PR DESCRIPTION
Previous retry logic only looked at whether a TCP port was free then relied on retries incase the UDP port of the same number was taken.

Updated retry to use [IPGlobalProperties](https://docs.microsoft.com/en-us/dotnet/api/system.net.networkinformation.ipglobalproperties?view=net-6.0) which provides all the available connections and listeners for a logic machine. Use that to search for the next free port for both TCP and UDP.

Continue to have retries Just-In-Case there is a race between the test using the ports and something else on the machine using them.

---

# [release/7.0] Improve port search retry logic

Improve test retry logic when a test binds TCP and UDP on the same port. Designed to avoid flaky tests.

## Description

Contributes to fixing a number of flaky tests that were caused by failure attempting to start test server with TCP and UDP on the same port.

## Customer Impact

Test only change.

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Test only.

## Verification

- [ ] ~Manual (required)~ test only
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A