### PR TITLE
fix #43523 Content-Length and Transfer-Encoding conflicts

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1MessageBody.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO.Pipelines;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
@@ -157,6 +158,25 @@ internal abstract class Http1MessageBody : MessageBody
             if (transferCoding != TransferCoding.Chunked)
             {
                 KestrelBadHttpRequestException.Throw(RequestRejectionReason.FinalTransferCodingNotChunked, transferEncoding);
+            }
+
+            // https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
+            // A sender MUST NOT send a Content-Length header field in any message
+            // that contains a Transfer-Encoding header field.
+            // https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.3
+            // If a message is received with both a Transfer-Encoding and a
+            // Content-Length header field, the Transfer-Encoding overrides the
+            // Content-Length.  Such a message might indicate an attempt to
+            // perform request smuggling (Section 9.5) or response splitting
+            // (Section 9.4) and ought to be handled as an error.  A sender MUST
+            // remove the received Content-Length field prior to forwarding such
+            // a message downstream.
+            // We should remove the Content-Length request header in this case, for compatibility
+            // reasons, increase x-Content-Length so that the original Content-Length is still available.
+            if (headers.ContentLength.HasValue)
+            {
+                context.RequestHeaders.Add($"x-{HeaderNames.ContentLength}", context.RequestHeaders[HeaderNames.ContentLength]);
+                context.RequestHeaders.Remove(HeaderNames.ContentLength);
             }
 
             // TODO may push more into the wrapper rather than just calling into the message body

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1MessageBody.cs
@@ -173,7 +173,7 @@ internal abstract class Http1MessageBody : MessageBody
             // remove the received Content-Length field prior to forwarding such
             // a message downstream.
             // We should remove the Content-Length request header in this case, for compatibility
-            // reasons, increase x-Content-Length so that the original Content-Length is still available.
+            // reasons, include x-Content-Length so that the original Content-Length is still available.
             if (headers.ContentLength.HasValue)
             {
                 IHeaderDictionary headerDictionary = headers;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1MessageBody.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.IO.Pipelines;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Net.Http.Headers;
 
@@ -175,8 +176,9 @@ internal abstract class Http1MessageBody : MessageBody
             // reasons, increase x-Content-Length so that the original Content-Length is still available.
             if (headers.ContentLength.HasValue)
             {
-                context.RequestHeaders.Add($"x-{HeaderNames.ContentLength}", context.RequestHeaders[HeaderNames.ContentLength]);
-                context.RequestHeaders.Remove(HeaderNames.ContentLength);
+                IHeaderDictionary headerDictionary = headers;
+                headerDictionary.Add("X-Content-Length", headerDictionary[HeaderNames.ContentLength]);
+                headers.ContentLength = null;
             }
 
             // TODO may push more into the wrapper rather than just calling into the message body

--- a/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
@@ -1019,7 +1019,8 @@ public class Http1ConnectionTests : Http1ConnectionTestsBase
     public void ContentLengthShouldBeRemovedWhenBothTransferEncodingAndContentLengthRequestHeadersExist()
     {
         // Arrange
-        _http1Connection.RequestHeaders.Add(HeaderNames.ContentLength, "1024");
+        string contentLength = "1024";
+        _http1Connection.RequestHeaders.Add(HeaderNames.ContentLength, contentLength);
         _http1Connection.RequestHeaders.Add(HeaderNames.TransferEncoding, "chunked");
 
         // Act
@@ -1027,6 +1028,7 @@ public class Http1ConnectionTests : Http1ConnectionTestsBase
 
         // Assert
         Assert.True(_http1Connection.RequestHeaders.ContainsKey($"x-{HeaderNames.ContentLength}"));
+        Assert.Equal(contentLength, _http1Connection.RequestHeaders[$"x-{HeaderNames.ContentLength}"]);
         Assert.False(_http1Connection.RequestHeaders.ContainsKey(HeaderNames.ContentLength));
     }
 

--- a/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
@@ -1027,8 +1027,10 @@ public class Http1ConnectionTests : Http1ConnectionTestsBase
         Http1MessageBody.For(Kestrel.Core.Internal.Http.HttpVersion.Http11, (HttpRequestHeaders)_http1Connection.RequestHeaders, _http1Connection);
 
         // Assert
-        Assert.True(_http1Connection.RequestHeaders.ContainsKey($"x-{HeaderNames.ContentLength}"));
-        Assert.Equal(contentLength, _http1Connection.RequestHeaders[$"x-{HeaderNames.ContentLength}"]);
+        Assert.True(_http1Connection.RequestHeaders.ContainsKey("X-Content-Length"));
+        Assert.Equal(contentLength, _http1Connection.RequestHeaders["X-Content-Length"]);
+        Assert.True(_http1Connection.RequestHeaders.ContainsKey(HeaderNames.TransferEncoding));
+        Assert.Equal("chunked", _http1Connection.RequestHeaders[HeaderNames.TransferEncoding]);
         Assert.False(_http1Connection.RequestHeaders.ContainsKey(HeaderNames.ContentLength));
     }
 

--- a/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1ConnectionTests.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
 using Moq;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
@@ -1012,6 +1013,21 @@ public class Http1ConnectionTests : Http1ConnectionTestsBase
         _http1Connection.RequestHeaders.Host = "a=b";
         var ex = Assert.ThrowsAny<Http.BadHttpRequestException>(() => _http1Connection.EnsureHostHeaderExists());
         Assert.Equal(CoreStrings.FormatBadRequest_InvalidHostHeader_Detail("a=b"), ex.Message);
+    }
+
+    [Fact]
+    public void ContentLengthShouldBeRemovedWhenBothTransferEncodingAndContentLengthRequestHeadersExist()
+    {
+        // Arrange
+        _http1Connection.RequestHeaders.Add(HeaderNames.ContentLength, "1024");
+        _http1Connection.RequestHeaders.Add(HeaderNames.TransferEncoding, "chunked");
+
+        // Act
+        Http1MessageBody.For(Kestrel.Core.Internal.Http.HttpVersion.Http11, (HttpRequestHeaders)_http1Connection.RequestHeaders, _http1Connection);
+
+        // Assert
+        Assert.True(_http1Connection.RequestHeaders.ContainsKey($"x-{HeaderNames.ContentLength}"));
+        Assert.False(_http1Connection.RequestHeaders.ContainsKey(HeaderNames.ContentLength));
     }
 
     private bool TakeMessageHeaders(ReadOnlySequence<byte> readableBuffer, bool trailers, out SequencePosition consumed, out SequencePosition examined)


### PR DESCRIPTION
# fix #43523 Content-Length and Transfer-Encoding conflicts

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Fixes #43523 Content-Length and Transfer-Encoding conflicts