### PR TITLE
Workaround Xunit bug casting InlineData

### DIFF
--- a/src/Middleware/StaticFiles/test/UnitTests/RangeHelperTests.cs
+++ b/src/Middleware/StaticFiles/test/UnitTests/RangeHelperTests.cs
@@ -32,8 +32,8 @@ public class RangeHelperTests
     }
 
     [Theory]
-    [InlineData(0, null, 0, 2)]
-    [InlineData(0, 0, 0, 0)]
+    [InlineData(0L, null, 0L, 2L)]
+    [InlineData(0L, 0L, 0L, 0L)]
     public void NormalizeRange_ReturnsNormalizedRange(long? start, long? end, long? normalizedStart, long? normalizedEnd)
     {
         // Arrange & Act

--- a/src/Servers/Kestrel/Core/test/KestrelServerLimitsTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerLimitsTests.cs
@@ -214,7 +214,7 @@ public class KestrelServerLimitsTests
 
     [Theory]
     [InlineData(null)]
-    [InlineData(1u)]
+    [InlineData(1L)]
     [InlineData(long.MaxValue)]
     public void MaxConnectionsValid(long? value)
     {
@@ -238,8 +238,8 @@ public class KestrelServerLimitsTests
 
     [Theory]
     [InlineData(null)]
-    [InlineData(0)]
-    [InlineData(1)]
+    [InlineData(0L)]
+    [InlineData(1L)]
     [InlineData(long.MaxValue)]
     public void MaxUpgradedConnectionsValid(long? value)
     {
@@ -269,8 +269,8 @@ public class KestrelServerLimitsTests
 
     [Theory]
     [InlineData(null)]
-    [InlineData(0)]
-    [InlineData(1)]
+    [InlineData(0L)]
+    [InlineData(1L)]
     [InlineData(long.MaxValue)]
     public void MaxRequestBodySizeValid(long? value)
     {

--- a/src/Shared/ResultsTests/FileContentResultTestBase.cs
+++ b/src/Shared/ResultsTests/FileContentResultTestBase.cs
@@ -42,10 +42,10 @@ public abstract class FileContentResultTestBase
     }
 
     [Theory]
-    [InlineData(0, 4, "Hello", 5)]
-    [InlineData(6, 10, "World", 5)]
-    [InlineData(null, 5, "World", 5)]
-    [InlineData(6, null, "World", 5)]
+    [InlineData(0L, 4L, "Hello", 5L)]
+    [InlineData(6L, 10L, "World", 5L)]
+    [InlineData(null, 5L, "World", 5L)]
+    [InlineData(6L, null, "World", 5L)]
     public async Task WriteFileAsync_PreconditionStateShouldProcess_WritesRangeRequested(
         long? start,
         long? end,

--- a/src/Shared/ResultsTests/FileStreamResultTestBase.cs
+++ b/src/Shared/ResultsTests/FileStreamResultTestBase.cs
@@ -22,10 +22,10 @@ public abstract class FileStreamResultTestBase
         bool enableRangeProcessing = false);
 
     [Theory]
-    [InlineData(0, 4, "Hello", 5)]
-    [InlineData(6, 10, "World", 5)]
-    [InlineData(null, 5, "World", 5)]
-    [InlineData(6, null, "World", 5)]
+    [InlineData(0L, 4L, "Hello", 5L)]
+    [InlineData(6L, 10L, "World", 5L)]
+    [InlineData(null, 5L, "World", 5L)]
+    [InlineData(6L, null, "World", 5L)]
     public async Task WriteFileAsync_PreconditionStateShouldProcess_WritesRangeRequested(long? start, long? end, string expectedString, long contentLength)
     {
         // Arrange
@@ -326,7 +326,7 @@ public abstract class FileStreamResultTestBase
     }
 
     [Theory]
-    [InlineData(0)]
+    [InlineData(0L)]
     [InlineData(null)]
     public async Task WriteFileAsync_RangeRequested_FileLengthZeroOrNull(long? fileLength)
     {

--- a/src/Shared/ResultsTests/PhysicalFileResultTestBase.cs
+++ b/src/Shared/ResultsTests/PhysicalFileResultTestBase.cs
@@ -28,10 +28,10 @@ public abstract class PhysicalFileResultTestBase
         bool enableRangeProcessing = false);
 
     [Theory]
-    [InlineData(0, 3, 4)]
-    [InlineData(8, 13, 6)]
-    [InlineData(null, 5, 5)]
-    [InlineData(8, null, 26)]
+    [InlineData(0L, 3L, 4L)]
+    [InlineData(8L, 13L, 6L)]
+    [InlineData(null, 5L, 5L)]
+    [InlineData(8L, null, 26L)]
     public async Task WriteFileAsync_WritesRangeRequested(long? start, long? end, long contentLength)
     {
         // Arrange
@@ -284,10 +284,10 @@ public abstract class PhysicalFileResultTestBase
     }
 
     [Theory]
-    [InlineData(0, 3, 4)]
-    [InlineData(8, 13, 6)]
-    [InlineData(null, 3, 3)]
-    [InlineData(8, null, 26)]
+    [InlineData(0L, 3L, 4L)]
+    [InlineData(8L, 13L, 6L)]
+    [InlineData(null, 3L, 3L)]
+    [InlineData(8L, null, 26L)]
     public async Task ExecuteResultAsync_CallsSendFileAsyncWithRequestedRange_IfIHttpSendFilePresent(long? start, long? end, long contentLength)
     {
         // Arrange

--- a/src/Shared/ResultsTests/VirtualFileResultTestBase.cs
+++ b/src/Shared/ResultsTests/VirtualFileResultTestBase.cs
@@ -31,10 +31,10 @@ public abstract class VirtualFileResultTestBase
         bool enableRangeProcessing = false);
 
     [Theory]
-    [InlineData(0, 3, 4)]
-    [InlineData(8, 13, 6)]
-    [InlineData(null, 4, 4)]
-    [InlineData(8, null, 25)]
+    [InlineData(0L, 3L, 4L)]
+    [InlineData(8L, 13L, 6L)]
+    [InlineData(null, 4L, 4L)]
+    [InlineData(8L, null, 25L)]
     public async Task WriteFileAsync_WritesRangeRequested(
         long? start,
         long? end,
@@ -314,10 +314,10 @@ public abstract class VirtualFileResultTestBase
     }
 
     [Theory]
-    [InlineData(0, 3, 4)]
-    [InlineData(8, 13, 6)]
-    [InlineData(null, 3, 3)]
-    [InlineData(8, null, 25)]
+    [InlineData(0L, 3L, 4L)]
+    [InlineData(8L, 13L, 6L)]
+    [InlineData(null, 3L, 3L)]
+    [InlineData(8L, null, 25L)]
     public async Task ExecuteResultAsync_CallsSendFileAsyncWithRequestedRange_IfIHttpSendFilePresent(long? start, long? end, long contentLength)
     {
         // Arrange


### PR DESCRIPTION
See https://github.com/xunit/xunit/issues/2564
Workaround this issue by avoiding a cast between nullable numeric types.