### PR TITLE
docs: Remove syntax error in xml docs for `AuthenticationBuilder`

### DIFF
--- a/src/Security/Authentication/Core/src/AuthenticationBuilder.cs
+++ b/src/Security/Authentication/Core/src/AuthenticationBuilder.cs
@@ -68,7 +68,7 @@ public class AuthenticationBuilder
     /// <summary>
     /// Adds a <see cref="AuthenticationScheme"/> which can be used by <see cref="IAuthenticationService"/>.
     /// </summary>
-    /// <typeparam name="TOptions">The <see cref="AuthenticationSchemeOptions"/> type to configure the handler."/>.</typeparam>
+    /// <typeparam name="TOptions">The <see cref="AuthenticationSchemeOptions"/> type to configure the handler.</typeparam>
     /// <typeparam name="THandler">The <see cref="AuthenticationHandler{TOptions}"/> used to handle this scheme.</typeparam>
     /// <param name="authenticationScheme">The name of this scheme.</param>
     /// <param name="displayName">The display name of this scheme.</param>
@@ -82,7 +82,7 @@ public class AuthenticationBuilder
     /// <summary>
     /// Adds a <see cref="AuthenticationScheme"/> which can be used by <see cref="IAuthenticationService"/>.
     /// </summary>
-    /// <typeparam name="TOptions">The <see cref="AuthenticationSchemeOptions"/> type to configure the handler."/>.</typeparam>
+    /// <typeparam name="TOptions">The <see cref="AuthenticationSchemeOptions"/> type to configure the handler.</typeparam>
     /// <typeparam name="THandler">The <see cref="AuthenticationHandler{TOptions}"/> used to handle this scheme.</typeparam>
     /// <param name="authenticationScheme">The name of this scheme.</param>
     /// <param name="configureOptions">Used to configure the scheme options.</param>
@@ -96,7 +96,7 @@ public class AuthenticationBuilder
     /// Adds a <see cref="RemoteAuthenticationHandler{TOptions}"/> based <see cref="AuthenticationScheme"/> that supports remote authentication
     /// which can be used by <see cref="IAuthenticationService"/>.
     /// </summary>
-    /// <typeparam name="TOptions">The <see cref="RemoteAuthenticationOptions"/> type to configure the handler."/>.</typeparam>
+    /// <typeparam name="TOptions">The <see cref="RemoteAuthenticationOptions"/> type to configure the handler.</typeparam>
     /// <typeparam name="THandler">The <see cref="RemoteAuthenticationHandler{TOptions}"/> used to handle this scheme.</typeparam>
     /// <param name="authenticationScheme">The name of this scheme.</param>
     /// <param name="displayName">The display name of this scheme.</param>


### PR DESCRIPTION
Remove syntax error in xml docs for `AuthenticationBuilder`
