### PR TITLE
[Backport] [SignalR] Fix WebSocket client close when network disappears

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/UnitTests/WebSocketsTransportTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/WebSocketsTransportTests.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.WebSockets;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http.Connections.Client;
+using Microsoft.AspNetCore.Http.Connections.Client.Internal;
+using Microsoft.AspNetCore.SignalR.Tests;
+using Microsoft.AspNetCore.Testing;
+
+namespace Microsoft.AspNetCore.SignalR.Client.Tests;
+
+public class WebSocketsTransportTests : VerifiableLoggedTest
+{
+    // Tests that the transport can still be stopped if SendAsync and ReceiveAsync are hanging (ethernet unplugged for example)
+    [Fact]
+    public async Task StopCancelsSendAndReceive()
+    {
+        var options = new HttpConnectionOptions()
+        {
+            WebSocketFactory = (context, token) =>
+            {
+                return ValueTask.FromResult((WebSocket)new TestWebSocket());
+            },
+            CloseTimeout = TimeSpan.FromMilliseconds(1),
+        };
+
+        using (StartVerifiableLog())
+        {
+            var webSocketsTransport = new WebSocketsTransport(options, loggerFactory: LoggerFactory, () => Task.FromResult<string>(null));
+
+            await webSocketsTransport.StartAsync(
+                new Uri("http://fakeuri.org"), TransferFormat.Text).DefaultTimeout();
+
+            await webSocketsTransport.StopAsync().DefaultTimeout();
+
+            await webSocketsTransport.Running.DefaultTimeout();
+        }
+    }
+
+    internal class TestWebSocket : WebSocket
+    {
+        public Task ConnectAsync(Uri uri, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public override WebSocketCloseStatus? CloseStatus => null;
+
+        public override string CloseStatusDescription => string.Empty;
+
+        public override WebSocketState State => WebSocketState.Open;
+
+        public override string SubProtocol => string.Empty;
+
+        public override void Abort() { }
+
+        public override Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public override async Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+        {
+            await cancellationToken.WaitForCancellationAsync();
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+
+        public override void Dispose() { }
+
+        public override async Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
+        {
+            await cancellationToken.WaitForCancellationAsync();
+            cancellationToken.ThrowIfCancellationRequested();
+            return new WebSocketReceiveResult(0, WebSocketMessageType.Text, true);
+        }
+
+        public override async Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
+        {
+            await cancellationToken.WaitForCancellationAsync();
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+    }
+}


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/43518

# Fix WebSocket client close when network disappears

When the network silently disconnects (drop wifi, unplug ethernet, etc.) the WebSocket connection won't realize until many minutes later (TCP re-transmit etc., different per OS). One thing SignalR does to detect this is to use regular keep-alives between server and client and timeout if one wasn't received after 30 seconds by default.

However, there is an issue where we aren't properly triggering an ungraceful close of the WebSocket connection after those 30 seconds (and trying a graceful close). This change fixes that, and is also a likely candidate for backporting to 6.0 and maybe 3.1.

## Description

See summary I guess 😄 

Fixes #43392

## Customer Impact

Client connections may take over 10 minutes to detect that they have been disconnected before they can try to reconnect or be notified of disconnect. This is not great, especially since we've put effort into detecting these scenarios more quickly.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Change is to use cancellation tokens which aren't triggered until we are trying to close, so there should be no risk to normal app behavior. When we are trying to close, there could potentially be an extra log or 2 if the close becomes ungraceful, which isn't a big problem.

## Verification

- [ ] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [x] No
- [ ] N/A
