### PR TITLE
Use normal `$(_BuildArgs)` in internal jobs w/ binlogs

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -72,30 +72,32 @@ variables:
            /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
            /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
            /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-  # Do not log most Windows steps in official builds; this is the slowest job. Site extensions step always logs.
-  - name: WindowsArm64LogArgs
-    value: -ExcludeCIBinaryLog
-  - name: Windows64LogArgs
-    value: -ExcludeCIBinaryLog
-  - name: Windows86LogArgs
-    value: -ExcludeCIBinaryLog
-  - name: WindowsSignLogArgs
-    value: -ExcludeCIBinaryLog
-  - name: WindowsInstallersLogArgs
-    value: -ExcludeCIBinaryLog
-  - name: WindowsArm64InstallersLogArgs
-    value: -ExcludeCIBinaryLog
   # Variables for source indexing afterBuild step and job.
   - name: sourceIndexPackageVersion
     value: 1.0.1-20210614.1
   - name: sourceIndexPackageSource
     value: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   - group: source-dot-net stage1 variables
-- ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), eq(parameters.produceBinlogs, 'true')) }}:
+  - ${{ if ne(parameters.produceBinlogs, 'true') }}:
+    # Do not log most Windows steps in official builds; this is the slowest job. Site extensions step always logs.
+    - name: WindowsArm64LogArgs
+      value: -ExcludeCIBinaryLog
+    - name: Windows64LogArgs
+      value: -ExcludeCIBinaryLog
+    - name: Windows86LogArgs
+      value: -ExcludeCIBinaryLog
+    - name: WindowsSignLogArgs
+      value: -ExcludeCIBinaryLog
+    - name: WindowsInstallersLogArgs
+      value: -ExcludeCIBinaryLog
+    - name: WindowsArm64InstallersLogArgs
+      value: -ExcludeCIBinaryLog
+- ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
   - name: _BuildArgs
     value: '/p:SkipTestBuild=true /p:PostBuildSign=$(PostBuildSign)'
   - name: _PublishArgs
     value: ''
+- ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), eq(parameters.produceBinlogs, 'true')) }}:
   # Write binary logs for all main Windows build steps except the x86 one in public and PR builds.
   - name: WindowsArm64LogArgs
     value: /bl:artifacts/log/Release/Build.arm64.binlog


### PR DESCRIPTION
- give `$(*LogArgs)` variables slightly different conditions from `$(_BuildArgs)`, `$(_PublishArgs)`, &hellip;
  - that is, previous variable groupings were slightly off
- enabling binary logs previously broke manifest creation etc.