### PR TITLE
Move to newer xUnit packages

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -280,8 +280,8 @@
     <SystemReactiveLinqVersion>5.0.0</SystemReactiveLinqVersion>
     <SwashbuckleAspNetCoreVersion>6.4.0</SwashbuckleAspNetCoreVersion>
     <XunitAbstractionsVersion>2.0.3</XunitAbstractionsVersion>
-    <XunitAnalyzersVersion>0.10.0</XunitAnalyzersVersion>
-    <XunitVersion>2.4.1</XunitVersion>
+    <XunitAnalyzersVersion>1.0.0</XunitAnalyzersVersion>
+    <XunitVersion>2.4.2</XunitVersion>
     <XunitAssertVersion>$(XunitVersion)</XunitAssertVersion>
     <XunitExtensibilityCoreVersion>$(XunitVersion)</XunitExtensibilityCoreVersion>
     <XunitExtensibilityExecutionVersion>$(XunitVersion)</XunitExtensibilityExecutionVersion>

--- a/src/Http/Http.Extensions/test/HttpRequestJsonExtensionsTests.cs
+++ b/src/Http/Http.Extensions/test/HttpRequestJsonExtensionsTests.cs
@@ -70,6 +70,7 @@ public class HttpRequestJsonExtensionsTests
         var result = await context.Request.ReadFromJsonAsync<List<int>>(options);
 
         // Assert
+        Assert.NotNull(result);
         Assert.Collection(result,
             i => Assert.Equal(1, i),
             i => Assert.Equal(2, i));
@@ -87,6 +88,7 @@ public class HttpRequestJsonExtensionsTests
         var result = await context.Request.ReadFromJsonAsync<List<int>>();
 
         // Assert
+        Assert.NotNull(result);
         Assert.Collection(result,
             i => Assert.Equal(1, i),
             i => Assert.Equal(2, i));
@@ -200,6 +202,7 @@ public class HttpRequestJsonExtensionsTests
         var result = (List<int>?)await context.Request.ReadFromJsonAsync(typeof(List<int>), options);
 
         // Assert
+        Assert.NotNull(result);
         Assert.Collection(result,
             i => Assert.Equal(1, i),
             i => Assert.Equal(2, i));

--- a/src/Middleware/Diagnostics.EntityFrameworkCore/test/UnitTests/DatabaseErrorPageTest.cs
+++ b/src/Middleware/Diagnostics.EntityFrameworkCore/test/UnitTests/DatabaseErrorPageTest.cs
@@ -207,6 +207,7 @@ public class DatabaseErrorPageTest
 
         var content = await ExecutePage(options, model);
 
+        Assert.NotNull(options.MigrationsEndPointPath.Value); // guard
         Assert.Contains(options.MigrationsEndPointPath.Value, content);
     }
 

--- a/src/Middleware/Rewrite/test/ApacheModRewrite/ModRewriteMiddlewareTest.cs
+++ b/src/Middleware/Rewrite/test/ApacheModRewrite/ModRewriteMiddlewareTest.cs
@@ -349,7 +349,7 @@ public class ModRewriteMiddlewareTest
 
         var response = await server.CreateClient().GetAsync(input);
 
-        Assert.Equal(response.StatusCode, (HttpStatusCode)301);
+        Assert.Equal((HttpStatusCode)301, response.StatusCode);
         Assert.Equal(@"https://www.example.com/foo/", response.Headers.Location.AbsoluteUri);
     }
 

--- a/src/Middleware/StaticFiles/test/UnitTests/RangeHelperTests.cs
+++ b/src/Middleware/StaticFiles/test/UnitTests/RangeHelperTests.cs
@@ -32,8 +32,8 @@ public class RangeHelperTests
     }
 
     [Theory]
-    [InlineData(0, null, 0, 2)]
-    [InlineData(0, 0, 0, 0)]
+    [InlineData(0L, null, 0L, 2L)]
+    [InlineData(0L, 0L, 0L, 0L)]
     public void NormalizeRange_ReturnsNormalizedRange(long? start, long? end, long? normalizedStart, long? normalizedEnd)
     {
         // Arrange & Act

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -1137,8 +1137,9 @@ public class EndpointMetadataApiDescriptionProviderTest
             {
                 Assert.Equal("name", parameter.Name);
                 Assert.NotNull(parameter.RouteInfo);
-                Assert.Empty(parameter.RouteInfo!.Constraints);
-                Assert.True(parameter.RouteInfo!.IsOptional);
+                Assert.NotNull(parameter.RouteInfo.Constraints);
+                Assert.Empty(parameter.RouteInfo.Constraints);
+                Assert.True(parameter.RouteInfo.IsOptional);
                 Assert.Equal("default", parameter.RouteInfo!.DefaultValue);
             });
     }
@@ -1164,7 +1165,8 @@ public class EndpointMetadataApiDescriptionProviderTest
         var apiDescription = Assert.Single(context.Results);
         var parameter = Assert.Single(apiDescription.ParameterDescriptions);
         Assert.NotNull(parameter.RouteInfo);
-        Assert.Collection(parameter.RouteInfo!.Constraints,
+        Assert.NotNull(parameter.RouteInfo.Constraints);
+        Assert.Collection(parameter.RouteInfo.Constraints,
             constraint => Assert.IsType<MinLengthRouteConstraint>(constraint),
             constraint => Assert.IsType<GuidRouteConstraint>(constraint),
             constraint => Assert.IsType<MaxLengthRouteConstraint>(constraint));

--- a/src/Servers/Kestrel/Core/test/HttpParserTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpParserTests.cs
@@ -574,7 +574,7 @@ public class HttpParserTests : LoggedTest
             ParseRequestLine(parser, requestHandler, buffer, out var consumed, out var examined);
         });
 
-        Assert.Equal(badHttpRequestException.StatusCode, StatusCodes.Status400BadRequest);
+        Assert.Equal(StatusCodes.Status400BadRequest, badHttpRequestException.StatusCode);
         Assert.Equal(RequestRejectionReason.TlsOverHttpError, badHttpRequestException.Reason);
     }
 

--- a/src/Servers/Kestrel/Core/test/HttpRequestStreamTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpRequestStreamTests.cs
@@ -197,21 +197,21 @@ public class HttpRequestStreamTests
     }
 
     [Fact]
-    public void NullDestinationCausesCopyToAsyncToThrowArgumentNullException()
+    public async Task NullDestinationCausesCopyToAsyncToThrowArgumentNullException()
     {
         var pipeReader = new HttpRequestPipeReader();
         var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>(), pipeReader);
         pipeReader.StartAcceptingReads(null);
-        Assert.Throws<ArgumentNullException>(() => { stream.CopyToAsync(null); });
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => { await stream.CopyToAsync(null); });
     }
 
     [Fact]
-    public void ZeroBufferSizeCausesCopyToAsyncToThrowArgumentException()
+    public async Task ZeroBufferSizeCausesCopyToAsyncToThrowArgumentException()
     {
         var pipeReader = new HttpRequestPipeReader();
         var stream = new HttpRequestStream(Mock.Of<IHttpBodyControlFeature>(), new HttpRequestPipeReader());
         pipeReader.StartAcceptingReads(null);
         // This is technically a breaking change, to throw an ArgumentoutOfRangeException rather than an ArgumentException
-        Assert.Throws<ArgumentOutOfRangeException>(() => { stream.CopyToAsync(Mock.Of<Stream>(), 0); });
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => { await stream.CopyToAsync(Mock.Of<Stream>(), 0); });
     }
 }

--- a/src/Servers/Kestrel/Core/test/HttpResponseStreamTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpResponseStreamTests.cs
@@ -94,13 +94,13 @@ public class HttpResponseStreamTests
     }
 
     [Fact]
-    public void StopAcceptingWritesCausesWriteToThrowObjectDisposedException()
+    public async Task StopAcceptingWritesCausesWriteToThrowObjectDisposedException()
     {
         var pipeWriter = new HttpResponsePipeWriter(Mock.Of<IHttpResponseControl>());
         var stream = new HttpResponseStream(Mock.Of<IHttpBodyControlFeature>(), pipeWriter);
         pipeWriter.StartAcceptingWrites();
-        pipeWriter.StopAcceptingWritesAsync();
-        var ex = Assert.Throws<ObjectDisposedException>(() => { stream.WriteAsync(new byte[1], 0, 1); });
+        await pipeWriter.StopAcceptingWritesAsync();
+        var ex = await Assert.ThrowsAsync<ObjectDisposedException>(async () => { await stream.WriteAsync(new byte[1], 0, 1); });
         Assert.Contains(CoreStrings.WritingToResponseBodyAfterResponseCompleted, ex.Message);
     }
 

--- a/src/Servers/Kestrel/Core/test/KestrelServerLimitsTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerLimitsTests.cs
@@ -214,7 +214,7 @@ public class KestrelServerLimitsTests
 
     [Theory]
     [InlineData(null)]
-    [InlineData(1u)]
+    [InlineData(1L)]
     [InlineData(long.MaxValue)]
     public void MaxConnectionsValid(long? value)
     {
@@ -238,8 +238,8 @@ public class KestrelServerLimitsTests
 
     [Theory]
     [InlineData(null)]
-    [InlineData(0)]
-    [InlineData(1)]
+    [InlineData(0L)]
+    [InlineData(1L)]
     [InlineData(long.MaxValue)]
     public void MaxUpgradedConnectionsValid(long? value)
     {
@@ -269,8 +269,8 @@ public class KestrelServerLimitsTests
 
     [Theory]
     [InlineData(null)]
-    [InlineData(0)]
-    [InlineData(1)]
+    [InlineData(0L)]
+    [InlineData(1L)]
     [InlineData(long.MaxValue)]
     public void MaxRequestBodySizeValid(long? value)
     {

--- a/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/UnixDomainSocketsTests.cs
@@ -188,7 +188,7 @@ public class UnixDomainSocketsTest : TestApplicationErrorLoggerLoggedTest
                     Assert.False(httpStatusEnd == -1, $"Second space not found in '{httpResponse}'.");
 
                     var httpStatus = int.Parse(httpResponse.Substring(httpStatusStart, httpStatusEnd - httpStatusStart), CultureInfo.InvariantCulture);
-                    Assert.Equal(httpStatus, StatusCodes.Status200OK);
+                    Assert.Equal(StatusCodes.Status200OK, httpStatus);
 
                 }
                 await host.StopAsync().DefaultTimeout();

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/MaxRequestBodySizeTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/MaxRequestBodySizeTests.cs
@@ -212,7 +212,7 @@ public class MaxRequestBodySizeTests : LoggedTest
             var buffer = new byte[1];
 
             Assert.Equal(1, await context.Request.Body.ReadAsync(buffer, 0, 1));
-            Assert.Equal(buffer[0], (byte)'A');
+            Assert.Equal((byte)'A', buffer[0]);
             Assert.Equal(0, await context.Request.Body.ReadAsync(buffer, 0, 1));
 
             context.Response.ContentLength = 1;

--- a/src/Shared/ResultsTests/FileContentResultTestBase.cs
+++ b/src/Shared/ResultsTests/FileContentResultTestBase.cs
@@ -42,10 +42,10 @@ public abstract class FileContentResultTestBase
     }
 
     [Theory]
-    [InlineData(0, 4, "Hello", 5)]
-    [InlineData(6, 10, "World", 5)]
-    [InlineData(null, 5, "World", 5)]
-    [InlineData(6, null, "World", 5)]
+    [InlineData(0L, 4L, "Hello", 5L)]
+    [InlineData(6L, 10L, "World", 5L)]
+    [InlineData(null, 5L, "World", 5L)]
+    [InlineData(6L, null, "World", 5L)]
     public async Task WriteFileAsync_PreconditionStateShouldProcess_WritesRangeRequested(
         long? start,
         long? end,

--- a/src/Shared/ResultsTests/FileStreamResultTestBase.cs
+++ b/src/Shared/ResultsTests/FileStreamResultTestBase.cs
@@ -22,10 +22,10 @@ public abstract class FileStreamResultTestBase
         bool enableRangeProcessing = false);
 
     [Theory]
-    [InlineData(0, 4, "Hello", 5)]
-    [InlineData(6, 10, "World", 5)]
-    [InlineData(null, 5, "World", 5)]
-    [InlineData(6, null, "World", 5)]
+    [InlineData(0L, 4L, "Hello", 5L)]
+    [InlineData(6L, 10L, "World", 5L)]
+    [InlineData(null, 5L, "World", 5L)]
+    [InlineData(6L, null, "World", 5L)]
     public async Task WriteFileAsync_PreconditionStateShouldProcess_WritesRangeRequested(long? start, long? end, string expectedString, long contentLength)
     {
         // Arrange
@@ -326,7 +326,7 @@ public abstract class FileStreamResultTestBase
     }
 
     [Theory]
-    [InlineData(0)]
+    [InlineData(0L)]
     [InlineData(null)]
     public async Task WriteFileAsync_RangeRequested_FileLengthZeroOrNull(long? fileLength)
     {

--- a/src/Shared/ResultsTests/PhysicalFileResultTestBase.cs
+++ b/src/Shared/ResultsTests/PhysicalFileResultTestBase.cs
@@ -28,10 +28,10 @@ public abstract class PhysicalFileResultTestBase
         bool enableRangeProcessing = false);
 
     [Theory]
-    [InlineData(0, 3, 4)]
-    [InlineData(8, 13, 6)]
-    [InlineData(null, 5, 5)]
-    [InlineData(8, null, 26)]
+    [InlineData(0L, 3L, 4L)]
+    [InlineData(8L, 13L, 6L)]
+    [InlineData(null, 5L, 5L)]
+    [InlineData(8L, null, 26L)]
     public async Task WriteFileAsync_WritesRangeRequested(long? start, long? end, long contentLength)
     {
         // Arrange
@@ -284,10 +284,10 @@ public abstract class PhysicalFileResultTestBase
     }
 
     [Theory]
-    [InlineData(0, 3, 4)]
-    [InlineData(8, 13, 6)]
-    [InlineData(null, 3, 3)]
-    [InlineData(8, null, 26)]
+    [InlineData(0L, 3L, 4L)]
+    [InlineData(8L, 13L, 6L)]
+    [InlineData(null, 3L, 3L)]
+    [InlineData(8L, null, 26L)]
     public async Task ExecuteResultAsync_CallsSendFileAsyncWithRequestedRange_IfIHttpSendFilePresent(long? start, long? end, long contentLength)
     {
         // Arrange

--- a/src/Shared/ResultsTests/VirtualFileResultTestBase.cs
+++ b/src/Shared/ResultsTests/VirtualFileResultTestBase.cs
@@ -31,10 +31,10 @@ public abstract class VirtualFileResultTestBase
         bool enableRangeProcessing = false);
 
     [Theory]
-    [InlineData(0, 3, 4)]
-    [InlineData(8, 13, 6)]
-    [InlineData(null, 4, 4)]
-    [InlineData(8, null, 25)]
+    [InlineData(0L, 3L, 4L)]
+    [InlineData(8L, 13L, 6L)]
+    [InlineData(null, 4L, 4L)]
+    [InlineData(8L, null, 25L)]
     public async Task WriteFileAsync_WritesRangeRequested(
         long? start,
         long? end,
@@ -314,10 +314,10 @@ public abstract class VirtualFileResultTestBase
     }
 
     [Theory]
-    [InlineData(0, 3, 4)]
-    [InlineData(8, 13, 6)]
-    [InlineData(null, 3, 3)]
-    [InlineData(8, null, 25)]
+    [InlineData(0L, 3L, 4L)]
+    [InlineData(8L, 13L, 6L)]
+    [InlineData(null, 3L, 3L)]
+    [InlineData(8L, null, 25L)]
     public async Task ExecuteResultAsync_CallsSendFileAsyncWithRequestedRange_IfIHttpSendFilePresent(long? start, long? end, long contentLength)
     {
         // Arrange


### PR DESCRIPTION
- Get newer xUnit packages

  - move to `2.4.2` version of most xUnit packages
    - we were slightly behind Arcade SDK here and newer version has some fixes
    - _could_ reuse Arcade SDK's `$(XUnitVersion)`
      - that would require moving e.g. `$(XUnitAssertVersion)` to (say) CSharp.Common.props
      - VersionDefaults.props in SDK imports our Versions.props before setting its defaults
    - react to nullability errors due to new annotations in this version
  - move to XUnit.Abstractions `1.0.0`
    - react to issues new analyzer finds
- Workaround Xunit bug casting InlineData (#43570)
  - See https://github.com/xunit/xunit/issues/2564
  - Workaround this issue by avoiding a cast between nullable numeric types.