### PR TITLE
Pin language version in release branch

### DIFF
--- a/eng/targets/CSharp.Common.props
+++ b/eng/targets/CSharp.Common.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>10.0</LangVersion>
 
     <!-- Enables Strict mode for Roslyn compiler -->
     <Features>strict</Features>


### PR DESCRIPTION
We shouldn't be using new language features in a patch, keep that stuff in main!

Avoids potential breaking changes in newer language versions (e.g. `scoped` in 11.0)