### PR TITLE
Require preview features for most quic options

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/src/QuicTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/QuicTransportOptions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic;
@@ -16,21 +17,25 @@ public sealed class QuicTransportOptions
     /// <summary>
     /// The maximum number of concurrent bi-directional streams per connection.
     /// </summary>
+    [RequiresPreviewFeatures]
     public int MaxBidirectionalStreamCount { get; set; } = 100;
 
     /// <summary>
     /// The maximum number of concurrent inbound uni-directional streams per connection.
     /// </summary>
+    [RequiresPreviewFeatures]
     public int MaxUnidirectionalStreamCount { get; set; } = 10;
 
     /// <summary>
     /// The maximum read size.
     /// </summary>
+    [RequiresPreviewFeatures]
     public long? MaxReadBufferSize { get; set; } = 1024 * 1024;
 
     /// <summary>
     /// The maximum write size.
     /// </summary>
+    [RequiresPreviewFeatures]
     public long? MaxWriteBufferSize { get; set; } = 64 * 1024;
 
     /// <summary>


### PR DESCRIPTION
Marking some unfinished quic options as preview so we can continue working on them in .NET 8.

## Description

We don't expect to finish #32034 this release so I'm marking the affected APIs as preview. These are not commonly used, the impact should be minimal.

## Customer Impact

Customers using these options will get a suppressible warning.

## Regression?

- [ ] Yes
- [x] No

The entire quic feature was marked as preview in 6.0. That was removed early in 7.0, but we're going to mark some specific options as preview now.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Only introduces warnings.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
