### PR TITLE
[release/7.0] Set `MSBUILDLOGALLENVIRONMENTVARIABLES` in most CI jobs

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -155,6 +155,8 @@ jobs:
     - LC_ALL: 'en_US.UTF-8'
     - LANG: 'en_US.UTF-8'
     - LANGUAGE: 'en_US.UTF-8'
+    # Log environment variables in binary logs to ease debugging
+    - MSBUILDLOGALLENVIRONMENTVARIABLES: true
     steps:
     - ${{ if ne(parameters.agentOs, 'Windows') }}:
       - script: df -h


### PR DESCRIPTION
- should affect most of our pipelines though not a few post-build jobs
- as we saw in #43028, binary logs no longer include all environment variables by default
  - this change captures the environment variables not visibly referenced in our projects etc.
  - fix avoids a need to add the override later to debug an issue, at the cost of larger .binlog files