### PR TITLE
[SignalR] Handle wrong type from client result

### DIFF
--- a/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs
+++ b/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs
@@ -238,7 +238,15 @@ public sealed class JsonHubProtocol : IHubProtocol
                                 }
                                 else
                                 {
-                                    result = BindType(ref reader, input, returnType);
+                                    try
+                                    {
+                                        result = BindType(ref reader, input, returnType);
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        error = $"Error trying to deserialize result to {returnType.Name}. {ex.Message}";
+                                        hasResult = false;
+                                    }
                                 }
                             }
                         }
@@ -423,7 +431,15 @@ public sealed class JsonHubProtocol : IHubProtocol
                         }
                         else
                         {
-                            result = BindType(ref resultToken, input, returnType);
+                            try
+                            {
+                                result = BindType(ref resultToken, input, returnType);
+                            }
+                            catch (Exception ex)
+                            {
+                                error = $"Error trying to deserialize result to {returnType.Name}. {ex.Message}";
+                                hasResult = false;
+                            }
                         }
                     }
 

--- a/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocolWorker.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocolWorker.cs
@@ -162,6 +162,7 @@ internal abstract class MessagePackHubProtocolWorker
                 error = ReadString(ref reader, "error");
                 break;
             case NonVoidResult:
+                hasResult = true;
                 var itemType = ProtocolHelper.TryGetReturnType(binder, invocationId);
                 if (itemType is null)
                 {
@@ -175,10 +176,17 @@ internal abstract class MessagePackHubProtocolWorker
                     }
                     else
                     {
-                        result = DeserializeObject(ref reader, itemType, "argument");
+                        try
+                        {
+                            result = DeserializeObject(ref reader, itemType, "argument");
+                        }
+                        catch (Exception ex)
+                        {
+                            error = $"Error trying to deserialize result to {itemType.Name}. {ex.Message}";
+                            hasResult = false;
+                        }
                     }
                 }
-                hasResult = true;
                 break;
             case VoidResult:
                 hasResult = false;

--- a/src/SignalR/common/Protocols.NewtonsoftJson/src/Protocol/NewtonsoftJsonHubProtocol.cs
+++ b/src/SignalR/common/Protocols.NewtonsoftJson/src/Protocol/NewtonsoftJsonHubProtocol.cs
@@ -229,7 +229,15 @@ public class NewtonsoftJsonHubProtocol : IHubProtocol
                                             }
                                             else
                                             {
-                                                result = PayloadSerializer.Deserialize(reader, returnType);
+                                                try
+                                                {
+                                                    result = PayloadSerializer.Deserialize(reader, returnType);
+                                                }
+                                                catch (Exception ex)
+                                                {
+                                                    error = $"Error trying to deserialize result to {returnType.Name}. {ex.Message}";
+                                                    hasResult = false;
+                                                }
                                             }
                                         }
                                     }
@@ -417,7 +425,15 @@ public class NewtonsoftJsonHubProtocol : IHubProtocol
                             }
                             else
                             {
-                                result = resultToken.ToObject(returnType, PayloadSerializer);
+                                try
+                                {
+                                    result = resultToken.ToObject(returnType, PayloadSerializer);
+                                }
+                                catch (Exception ex)
+                                {
+                                    error = $"Error trying to deserialize result to {returnType.Name}. {ex.Message}";
+                                    hasResult = false;
+                                }
                             }
                         }
                     }

--- a/src/SignalR/common/SignalR.Common/test/Internal/Protocol/MessagePackHubProtocolTestBase.cs
+++ b/src/SignalR/common/SignalR.Common/test/Internal/Protocol/MessagePackHubProtocolTestBase.cs
@@ -307,8 +307,10 @@ public abstract class MessagePackHubProtocolTestBase
             new InvalidMessageData("CompletionResultKindOutOfRange", new byte[] { 0x94, 3, 0x80, 0xa3, (byte)'x', (byte)'y', (byte)'z', 42 }, "Invalid invocation result kind."),
             new InvalidMessageData("CompletionErrorMissing", new byte[] { 0x94, 3, 0x80, 0xa3, (byte)'x', (byte)'y', (byte)'z', 0x01 }, "Reading 'error' as String failed."),
             new InvalidMessageData("CompletionErrorInt", new byte[] { 0x95, 3, 0x80, 0xa3, (byte)'x', (byte)'y', (byte)'z', 0x01, 42 }, "Reading 'error' as String failed."),
-            new InvalidMessageData("CompletionResultMissing", new byte[] { 0x94, 3, 0x80, 0xa3, (byte)'x', (byte)'y', (byte)'z', 0x03 }, "Deserializing object of the `String` type for 'argument' failed."),
-            new InvalidMessageData("CompletionResultTypeMismatch", new byte[] { 0x95, 3, 0x80, 0xa3, (byte)'x', (byte)'y', (byte)'z', 0x03, 42 }, "Deserializing object of the `String` type for 'argument' failed."),
+
+            // These now result in CompletionMessages with the error field set
+            //new InvalidMessageData("CompletionResultMissing", new byte[] { 0x94, 3, 0x80, 0xa3, (byte)'x', (byte)'y', (byte)'z', 0x03 }, "Deserializing object of the `String` type for 'argument' failed."),
+            //new InvalidMessageData("CompletionResultTypeMismatch", new byte[] { 0x95, 3, 0x80, 0xa3, (byte)'x', (byte)'y', (byte)'z', 0x03, 42 }, "Deserializing object of the `String` type for 'argument' failed."),
         }.ToDictionary(t => t.Name);
 
     public static IEnumerable<object[]> BaseInvalidPayloadNames => BaseInvalidPayloads.Keys.Select(name => new object[] { name });

--- a/src/SignalR/common/SignalR.Common/test/Internal/Protocol/MessagePackHubProtocolTests.cs
+++ b/src/SignalR/common/SignalR.Common/test/Internal/Protocol/MessagePackHubProtocolTests.cs
@@ -256,6 +256,20 @@ public class MessagePackHubProtocolTests : MessagePackHubProtocolTestBase
         Assert.Equal("xyz", completion.InvocationId);
     }
 
+    [Fact]
+    public void WrongTypeForClientResultGivesErrorCompletionMessage()
+    {
+        var binder = new TestBinder(paramTypes: null, returnType: typeof(int));
+        var input = Frame(Convert.FromBase64String("lQOAo3h5egOmc3RyaW5n"));
+        var data = new ReadOnlySequence<byte>(input);
+        Assert.True(HubProtocol.TryParseMessage(ref data, binder, out var hubMessage));
+
+        var completion = Assert.IsType<CompletionMessage>(hubMessage);
+        Assert.Null(completion.Result);
+        Assert.StartsWith("Error trying to deserialize result to Int32.", completion.Error);
+        Assert.Equal("xyz", completion.InvocationId);
+    }
+
     public class ClientResultTestData
     {
         public string Name { get; }

--- a/src/SignalR/server/Specification.Tests/src/ScaleoutHubLifetimeManagerTests.cs
+++ b/src/SignalR/server/Specification.Tests/src/ScaleoutHubLifetimeManagerTests.cs
@@ -654,7 +654,7 @@ public abstract class ScaleoutHubLifetimeManagerTests<TBackplane> : HubLifetimeM
             await manager1.SetConnectionResultAsync(connection1.ConnectionId, CompletionMessage.WithResult(invocation.InvocationId, "wrong type")).DefaultTimeout();
 
             var ex = await Assert.ThrowsAsync<Exception>(() => resultTask).DefaultTimeout();
-            Assert.Equal("Client result wasn't deserializable to Int32.", ex.Message);
+            Assert.StartsWith("Error trying to deserialize result to Int32.", ex.Message);
         }
     }
 }

--- a/src/SignalR/server/Specification.Tests/src/ScaleoutHubLifetimeManagerTests.cs
+++ b/src/SignalR/server/Specification.Tests/src/ScaleoutHubLifetimeManagerTests.cs
@@ -626,4 +626,35 @@ public abstract class ScaleoutHubLifetimeManagerTests<TBackplane> : HubLifetimeM
         var ex = await Assert.ThrowsAsync<IOException>(() => manager1.InvokeConnectionAsync<int>("1234", "Result", new object[] { "test" }, cancellationToken: default)).DefaultTimeout();
         Assert.Equal("Connection '1234' does not exist.", ex.Message);
     }
+
+    /// <summary>
+    /// Specification test for SignalR HubLifetimeManager.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous completion of the test.</returns>
+    [Fact]
+    public async Task ClientReturnResultAcrossServersWithWrongReturnedTypeErrors()
+    {
+        var backplane = CreateBackplane();
+        var manager1 = CreateNewHubLifetimeManager(backplane);
+        var manager2 = CreateNewHubLifetimeManager(backplane);
+
+        using (var client1 = new TestClient())
+        {
+            var connection1 = HubConnectionContextUtils.Create(client1.Connection);
+
+            await manager1.OnConnectedAsync(connection1).DefaultTimeout();
+
+            // Server2 asks for a result from client1 on Server1
+            var resultTask = manager2.InvokeConnectionAsync<int>(connection1.ConnectionId, "Result", new object[] { "test" }, cancellationToken: default);
+            var invocation = Assert.IsType<InvocationMessage>(await client1.ReadAsync().DefaultTimeout());
+            Assert.NotNull(invocation.InvocationId);
+            Assert.Equal("test", invocation.Arguments[0]);
+
+            // Server1 gets the result from client1 and forwards to Server2
+            await manager1.SetConnectionResultAsync(connection1.ConnectionId, CompletionMessage.WithResult(invocation.InvocationId, "wrong type")).DefaultTimeout();
+
+            var ex = await Assert.ThrowsAsync<Exception>(() => resultTask).DefaultTimeout();
+            Assert.Equal("Client result wasn't deserializable to Int32.", ex.Message);
+        }
+    }
 }

--- a/src/SignalR/server/StackExchangeRedis/src/Internal/RedisLog.cs
+++ b/src/SignalR/server/StackExchangeRedis/src/Internal/RedisLog.cs
@@ -61,6 +61,9 @@ internal static partial class RedisLog
     [LoggerMessage(14, LogLevel.Error, "Error connecting to Redis.", EventName = "ErrorConnecting")]
     public static partial void ErrorConnecting(ILogger logger, Exception ex);
 
+    [LoggerMessage(15, LogLevel.Warning, "Error parsing client result with protocol {HubProtocol}.", EventName = "ErrorParsingResult")]
+    public static partial void ErrorParsingResult(ILogger logger, string hubProtocol, Exception? ex);
+
     // This isn't DefineMessage-based because it's just the simple TextWriter logging from ConnectionMultiplexer
     public static void ConnectionMultiplexerMessage(ILogger logger, string? message)
     {

--- a/src/SignalR/server/StackExchangeRedis/src/RedisHubLifetimeManager.cs
+++ b/src/SignalR/server/StackExchangeRedis/src/RedisHubLifetimeManager.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
@@ -695,13 +694,71 @@ public class RedisHubLifetimeManager<THub> : HubLifetimeManager<THub>, IDisposab
             }
 
             var ros = completion.CompletionMessage;
-            var parseSuccess = protocol.TryParseMessage(ref ros, _clientResultsManager, out var hubMessage);
-            Debug.Assert(parseSuccess);
+            HubMessage? hubMessage = null;
+            bool retryForError = false;
+            try
+            {
+                var parseSuccess = protocol.TryParseMessage(ref ros, _clientResultsManager, out hubMessage);
+                retryForError = !parseSuccess;
+            }
+            catch
+            {
+                // Client returned wrong type? Or just an error from the HubProtocol, let's try with RawResult as the type and see if that works
+                retryForError = true;
+            }
+
+            if (retryForError)
+            {
+                try
+                {
+                    ros = completion.CompletionMessage;
+                    // if this works then we know there was an error with the type the client returned, we'll replace the CompletionMessage below and provide an error to the application code
+                    if (!protocol.TryParseMessage(ref ros, FakeInvocationBinder.Instance, out hubMessage))
+                    {
+                        RedisLog.ErrorParsingResult(_logger, completion.ProtocolName, null);
+                        return;
+                    }
+                }
+                // Exceptions here would mean the HubProtocol implementation very likely has a bug, the other server has already deserialized the message (with RawResult) so it should be deserializable
+                // We don't know the InvocationId, we should let the application developer know and potentially surface the issue to the HubProtocol implementor
+                catch (Exception ex)
+                {
+                    RedisLog.ErrorParsingResult(_logger, completion.ProtocolName, ex);
+                    return;
+                }
+            }
 
             var invocationInfo = _clientResultsManager.RemoveInvocation(((CompletionMessage)hubMessage!).InvocationId!);
 
+            if (retryForError && invocationInfo is not null)
+            {
+                hubMessage = CompletionMessage.WithError(((CompletionMessage)hubMessage!).InvocationId!, $"Client result wasn't deserializable to {invocationInfo?.Type.Name}.");
+            }
+
             invocationInfo?.Completion(invocationInfo?.Tcs!, (CompletionMessage)hubMessage!);
         });
+    }
+
+    private class FakeInvocationBinder : IInvocationBinder
+    {
+        public static readonly FakeInvocationBinder Instance = new FakeInvocationBinder();
+
+        private FakeInvocationBinder() { }
+
+        public IReadOnlyList<Type> GetParameterTypes(string methodName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type GetReturnType(string invocationId)
+        {
+            return typeof(RawResult);
+        }
+
+        public Type GetStreamItemType(string streamId)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     private async Task EnsureRedisServerConnection()

--- a/src/SignalR/server/StackExchangeRedis/src/RedisHubLifetimeManager.cs
+++ b/src/SignalR/server/StackExchangeRedis/src/RedisHubLifetimeManager.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;


### PR DESCRIPTION
If a client result isn't deserializable for whatever reason (returned the wrong type, not supported by serialization system), the application code wouldn't get an error from their `InvokeAsync<T>(...)` call. This fixes that by trying our best to figure out what the client returned and propagating an error to the application code.