### PR TITLE
Update public pool names

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -78,7 +78,7 @@ jobs:
       vmImage: ubuntu-18.04
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Windows')) }}:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Svc-Public
+        name: NetCore-Svc-Public
         demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
         name: NetCore1ESPool-Svc-Internal


### PR DESCRIPTION
This change is required for builds to continue working in the new org, dev.azure.com/dnceng-public.