### PR TITLE
Update public pool names

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -94,7 +94,7 @@ jobs:
         vmImage: ubuntu-18.04
       ${{ if eq(parameters.agentOs, 'Windows') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCore1ESPool-Public
+          name: NetCore-Public
           demands: ImageOverride -equals 1es-windows-2019-open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: NetCore1ESPool-Svc-Internal


### PR DESCRIPTION
This change is required for builds to continue working in the new org, dev.azure.com/dnceng-public.