### PR TITLE
Update dotnet-getdocument to support minimal APIs

### DIFF
--- a/src/Tools/GetDocumentInsider/src/Commands/GetDocumentCommand.cs
+++ b/src/Tools/GetDocumentInsider/src/Commands/GetDocumentCommand.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-#if NETCOREAPP2_1
+#if NETCOREAPP2_1 || NET7_0_OR_GREATER
 using System.Runtime.Loader;
 #endif
 using Microsoft.Extensions.CommandLineUtils;
@@ -69,7 +69,7 @@ internal sealed class GetDocumentCommand : ProjectCommandBase
             }
         }
 
-#if NETCOREAPP2_1
+#if NETCOREAPP2_1 || NET7_0_OR_GREATER
         AssemblyLoadContext.Default.Resolving += (loadContext, assemblyName) =>
         {
             var name = assemblyName.Name;

--- a/src/Tools/GetDocumentInsider/src/Commands/GetDocumentCommand.cs
+++ b/src/Tools/GetDocumentInsider/src/Commands/GetDocumentCommand.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-#if NETCOREAPP2_1 || NET7_0_OR_GREATER
+#if NETCOREAPP
 using System.Runtime.Loader;
 #endif
 using Microsoft.Extensions.CommandLineUtils;
@@ -69,7 +69,7 @@ internal sealed class GetDocumentCommand : ProjectCommandBase
             }
         }
 
-#if NETCOREAPP2_1 || NET7_0_OR_GREATER
+#if NETCOREAPP
         AssemblyLoadContext.Default.Resolving += (loadContext, assemblyName) =>
         {
             var name = assemblyName.Name;

--- a/src/Tools/GetDocumentInsider/src/Commands/GetDocumentCommandWorker.cs
+++ b/src/Tools/GetDocumentInsider/src/Commands/GetDocumentCommandWorker.cs
@@ -75,7 +75,7 @@ internal sealed class GetDocumentCommandWorker
         // Register a TCS to be invoked when the entrypoint (aka Program.Main)
         // has finished running. For minimal APIs, this means that all app.X
         // calls about the host has been built have been executed.
-        var waitForStartTcs = new TaskCompletionSource<object>();
+        var waitForStartTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
         void OnEntryPointExit(Exception exception)
         {
             // If the entry point exited, we'll try to complete the wait
@@ -104,7 +104,7 @@ internal sealed class GetDocumentCommandWorker
                 HostFactoryResolver.CreateWebHostBuilder,
                 entryPointType));
 
-            return 4;
+            return 8;
         }
 
         try
@@ -120,10 +120,10 @@ internal sealed class GetDocumentCommandWorker
                     HostFactoryResolver.CreateWebHostBuilder,
                     entryPointType));
 
-                return 5;
+                return 9;
             }
 
-            // Wait for th application to start to ensure that all configurations
+            // Wait for the application to start to ensure that all configurations
             // on the WebApplicationBuilder have been processed.
             var applicationLifetime = services.GetRequiredService<IHostApplicationLifetime>();
             using (var registration = applicationLifetime.ApplicationStarted.Register(() => waitForStartTcs.TrySetResult(null)))
@@ -132,14 +132,14 @@ internal sealed class GetDocumentCommandWorker
                 var success = GetDocuments(services);
                 if (!success)
                 {
-                    return 6;
+                    return 10;
                 }
             }
         }
         catch (Exception ex)
         {
             _reporter.WriteError(ex.ToString());
-            return 7;
+            return 11;
         }
 #else
         try

--- a/src/Tools/GetDocumentInsider/src/Commands/GetDocumentCommandWorker.cs
+++ b/src/Tools/GetDocumentInsider/src/Commands/GetDocumentCommandWorker.cs
@@ -2,13 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Tools.Internal;
+#if NET7_0_OR_GREATER
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Http.Features;
+#endif
 
 namespace Microsoft.Extensions.ApiDescription.Tool.Commands;
 
@@ -53,6 +60,88 @@ internal sealed class GetDocumentCommandWorker
             return 3;
         }
 
+#if NET7_0_OR_GREATER
+        // Register no-op implementations of IServer and IHostLifetime
+        // to prevent the application server from actually launching after build.
+        void ConfigureHostBuilder(object hostBuilder)
+        {
+            ((IHostBuilder)hostBuilder).ConfigureServices((context, services) =>
+            {
+                services.AddSingleton<IServer, NoopServer>();
+                services.AddSingleton<IHostLifetime, NoopHostLifetime>();
+            });
+        }
+
+        // Register a TCS to be invoked when the entrypoint (aka Program.Main)
+        // has finished running. For minimal APIs, this means that all app.X
+        // calls about the host has been built have been executed.
+        var waitForStartTcs = new TaskCompletionSource<object>();
+        void OnEntryPointExit(Exception exception)
+        {
+            // If the entry point exited, we'll try to complete the wait
+            if (exception != null)
+            {
+                waitForStartTcs.TrySetException(exception);
+            }
+            else
+            {
+                waitForStartTcs.TrySetResult(null);
+            }
+        }
+
+        // Resolve the host factory, ensuring that we don't stop the
+        // application after the host has been built.
+        var factory = HostFactoryResolver.ResolveHostFactory(assembly,
+            stopApplication: false,
+            configureHostBuilder: ConfigureHostBuilder,
+            entrypointCompleted: OnEntryPointExit);
+
+        if (factory == null)
+        {
+            _reporter.WriteError(Resources.FormatMethodsNotFound(
+                HostFactoryResolver.BuildWebHost,
+                HostFactoryResolver.CreateHostBuilder,
+                HostFactoryResolver.CreateWebHostBuilder,
+                entryPointType));
+
+            return 4;
+        }
+
+        try
+        {
+            // Retrieve the service provider from the target host.
+            var services = ((IHost)factory(new[] { $"--{HostDefaults.ApplicationKey}={assemblyName}" })).Services;
+            if (services == null)
+            {
+                _reporter.WriteError(Resources.FormatServiceProviderNotFound(
+                    typeof(IServiceProvider),
+                    HostFactoryResolver.BuildWebHost,
+                    HostFactoryResolver.CreateHostBuilder,
+                    HostFactoryResolver.CreateWebHostBuilder,
+                    entryPointType));
+
+                return 5;
+            }
+
+            // Wait for th application to start to ensure that all configurations
+            // on the WebApplicationBuilder have been processed.
+            var applicationLifetime = services.GetRequiredService<IHostApplicationLifetime>();
+            using (var registration = applicationLifetime.ApplicationStarted.Register(() => waitForStartTcs.TrySetResult(null)))
+            {
+                waitForStartTcs.Task.Wait();
+                var success = GetDocuments(services);
+                if (!success)
+                {
+                    return 6;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _reporter.WriteError(ex.ToString());
+            return 7;
+        }
+#else
         try
         {
             var serviceFactory = HostFactoryResolver.ResolveServiceProviderFactory(assembly);
@@ -91,6 +180,7 @@ internal sealed class GetDocumentCommandWorker
             _reporter.WriteError(ex.ToString());
             return 7;
         }
+#endif
 
         return 0;
     }
@@ -303,4 +393,21 @@ internal sealed class GetDocumentCommandWorker
 
         return result;
     }
+
+#if NET7_0_OR_GREATER
+        private sealed class NoopHostLifetime : IHostLifetime
+        {
+            public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task WaitForStartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        }
+
+        private sealed class NoopServer : IServer
+        {
+            public IFeatureCollection Features { get; } = new FeatureCollection();
+            public void Dispose() { }
+            public Task StartAsync<TContext>(IHttpApplication<TContext> application, CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        }
+#endif
 }

--- a/src/Tools/GetDocumentInsider/src/GetDocument.Insider.csproj
+++ b/src/Tools/GetDocumentInsider/src/GetDocument.Insider.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <RootNamespace>Microsoft.Extensions.ApiDescription.Tool</RootNamespace>
-    <TargetFrameworks>netcoreapp2.1;$(DefaultNetFxTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;$(DefaultNetCoreTargetFramework);$(DefaultNetFxTargetFramework)</TargetFrameworks>
     <IsShippingPackage>false</IsShippingPackage>
     <Nullable>disable</Nullable>
     <NoWarn>$(NoWarn);nullable</NoWarn>
@@ -13,6 +13,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(DefaultNetFxTargetFramework)'">
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'">
+    <Reference Include="Microsoft.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/dotnet-getdocument/src/Commands/InvokeCommand.cs
+++ b/src/Tools/dotnet-getdocument/src/Commands/InvokeCommand.cs
@@ -79,9 +79,16 @@ internal sealed class InvokeCommand : HelpCommandBase
                             projectName,
                             targetFramework.Version));
                     }
+                    else if (targetFramework.Version > new Version(7, 0))
+                    {
+                        toolsDirectory = Path.Combine(thisPath, "net7.0");
+                    }
+                    else
+                    {
+                        toolsDirectory = Path.Combine(thisPath, "netcoreapp2.1");
+                    }
 
                     executable = DotNetMuxer.MuxerPathOrDefault();
-                    toolsDirectory = Path.Combine(thisPath, "netcoreapp2.1");
 
                     args.Add("exec");
                     args.Add("--depsFile");

--- a/src/Tools/dotnet-getdocument/src/Commands/InvokeCommand.cs
+++ b/src/Tools/dotnet-getdocument/src/Commands/InvokeCommand.cs
@@ -79,9 +79,9 @@ internal sealed class InvokeCommand : HelpCommandBase
                             projectName,
                             targetFramework.Version));
                     }
-                    else if (targetFramework.Version > new Version(7, 0))
+                    else if (targetFramework.Version >= new Version(7, 0))
                     {
-                        toolsDirectory = Path.Combine(thisPath, "net7.0");
+                        toolsDirectory = Path.Combine(thisPath, $"net{targetFramework.Version}");
                     }
                     else
                     {

--- a/src/Tools/dotnet-getdocument/src/dotnet-getdocument.csproj
+++ b/src/Tools/dotnet-getdocument/src/dotnet-getdocument.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <RootNamespace>Microsoft.Extensions.ApiDescription.Tool</RootNamespace>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;$(DefaultNetCoreTargetFramework)</TargetFrameworks>
     <UseAppHost>false</UseAppHost>
     <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>


### PR DESCRIPTION
## Description

This PR update the `dotnet getdocument` tool to react to changes in hosting that were shipped in .NET 6.

The hosting changes were incongruent with the strategy that the `getdocument` tool used to extract the active ServiceProvider from the application assembly. 

Fixes https://github.com/dotnet/aspnetcore/issues/43391

## Customer Impact

Without this change, OpenAPI document generation in the CLI and client generation in Visual Studio would fail to produce the necessary schemas and code for minimal API endpoints in user applications.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Low because:
- Change is limited to `getdocument` tool
- Change follows pattern used to react to hosting changes in other apps that examine host

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A
