### PR TITLE
[7.0-rc2] Allow spaces between the url and http version #43704

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -139,6 +139,14 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
         // Consume space
         offset++;
 
+        while ((uint)offset < (uint)requestLine.Length
+            && requestLine[offset] == ByteSpace)
+        {
+            // It's invalid to have multiple spaces between the url resource and version
+            // but some clients do it. Skip them.
+            offset++;
+        }
+
         // Version + CR is 9 bytes which should take us to .Length
         // LF should have been dropped prior to method call
         if ((uint)offset + 9 != (uint)requestLine.Length || requestLine[offset + 8] != ByteCR)

--- a/src/Servers/Kestrel/shared/test/HttpParsingData.cs
+++ b/src/Servers/Kestrel/shared/test/HttpParsingData.cs
@@ -76,7 +76,9 @@ public class HttpParsingData
             var httpVersions = new[]
             {
                     "HTTP/1.0",
-                    "HTTP/1.1"
+                    "HTTP/1.1",
+                    " HTTP/1.1",
+                    "   HTTP/1.1"
                 };
 
             return from method in methods
@@ -91,7 +93,7 @@ public class HttpParsingData
                            $"{path.Item1}",
                            $"{path.Item2}",
                            queryString,
-                           httpVersion
+                           httpVersion.Trim()
                        };
         }
     }
@@ -164,6 +166,12 @@ public class HttpParsingData
                     "GET / HTTP/1.1\n",
                     "GET / HTTP/1.0\rA\n",
                     "GET / HTTP/1.1\ra\n",
+                    "GET  / HTTP/1.1\r\n",
+                    "GET   / HTTP/1.1\r\n",
+                    "GET  /  HTTP/1.1\r\n",
+                    "GET   /   HTTP/1.1\r\n",
+                    "GET / HTTP/1.1 \r\n",
+                    "GET / HTTP/1.1  \r\n",
                     "GET / H\r\n",
                     "GET / HT\r\n",
                     "GET / HTT\r\n",
@@ -195,6 +203,12 @@ public class HttpParsingData
                     "CUSTOM / HTTP/1.1\n",
                     "CUSTOM / HTTP/1.0\rA\n",
                     "CUSTOM / HTTP/1.1\ra\n",
+                    "CUSTOM  / HTTP/1.1\r\n",
+                    "CUSTOM   / HTTP/1.1\r\n",
+                    "CUSTOM  /  HTTP/1.1\r\n",
+                    "CUSTOM   /   HTTP/1.1\r\n",
+                    "CUSTOM / HTTP/1.1 \r\n",
+                    "CUSTOM / HTTP/1.1  \r\n",
                     "CUSTOM / H\r\n",
                     "CUSTOM / HT\r\n",
                     "CUSTOM / HTT\r\n",


### PR DESCRIPTION
# Allow spaces between the url and http version

## Description

This is a change to allow requests that have extra spaces between the url and http version. E.g. "GET(sp)/(sp)(sp)HTTP/1.1\r\n". The spec only allows one space, but some clients send more than one and IIS/Http.Sys allow it.

Contributes to https://github.com/dotnet/aspnetcore/issues/43705

## Customer Impact

The customer regressed when moved to Kestrel. The customer doesn't expect to be able to update/replace the affected clients for 3+ years.

## Regression?

- [ ] Yes
- [ ] No
- [x] Umm...

Not a regression in Kestrel, but a compat break for customers moving from IIS/Http.Sys.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Constrained, unit testable.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
