### PR TITLE
Avoid client result invocation ID collisions

### DIFF
--- a/src/SignalR/common/Shared/ClientResultsManager.cs
+++ b/src/SignalR/common/Shared/ClientResultsManager.cs
@@ -42,6 +42,11 @@ internal sealed class ClientResultsManager : IInvocationBinder
     {
         var result = _pendingInvocations.TryAdd(invocationId, invocationInfo);
         Debug.Assert(result);
+        // Should have a 50% chance of happening once every 2.71 quintillion invocations (see UUID in Wikipedia)
+        if (!result)
+        {
+            invocationInfo.Complete(invocationInfo.Tcs, CompletionMessage.WithError(invocationId, "ID collision occurred when using client results. This is likely a bug in SignalR."));
+        }
     }
 
     public void TryCompleteResult(string connectionId, CompletionMessage message)

--- a/src/SignalR/server/Specification.Tests/src/ScaleoutHubLifetimeManagerTests.cs
+++ b/src/SignalR/server/Specification.Tests/src/ScaleoutHubLifetimeManagerTests.cs
@@ -588,25 +588,22 @@ public abstract class ScaleoutHubLifetimeManagerTests<TBackplane> : HubLifetimeM
         var manager1 = CreateNewHubLifetimeManager(backplane);
         var manager2 = CreateNewHubLifetimeManager(backplane);
 
-        using (var client1 = new TestClient())
-        using (var client2 = new TestClient())
+        using (var client = new TestClient())
         {
-            var connection1 = HubConnectionContextUtils.Create(client1.Connection);
-            var connection2 = HubConnectionContextUtils.Create(client2.Connection);
+            var connection = HubConnectionContextUtils.Create(client.Connection);
 
-            await manager1.OnConnectedAsync(connection1).DefaultTimeout();
-            await manager2.OnConnectedAsync(connection2).DefaultTimeout();
+            await manager1.OnConnectedAsync(connection).DefaultTimeout();
 
-            var invoke1 = manager1.InvokeConnectionAsync<int>(connection2.ConnectionId, "Result", new object[] { "test" }, cancellationToken: default);
-            var invocation2 = Assert.IsType<InvocationMessage>(await client2.ReadAsync().DefaultTimeout());
+            var invoke1 = manager1.InvokeConnectionAsync<int>(connection.ConnectionId, "Result", new object[] { "test" }, cancellationToken: default);
+            var invocation2 = Assert.IsType<InvocationMessage>(await client.ReadAsync().DefaultTimeout());
 
-            var invoke2 = manager2.InvokeConnectionAsync<int>(connection1.ConnectionId, "Result", new object[] { "test" }, cancellationToken: default);
-            var invocation1 = Assert.IsType<InvocationMessage>(await client1.ReadAsync().DefaultTimeout());
+            var invoke2 = manager2.InvokeConnectionAsync<int>(connection.ConnectionId, "Result", new object[] { "test" }, cancellationToken: default);
+            var invocation1 = Assert.IsType<InvocationMessage>(await client.ReadAsync().DefaultTimeout());
 
             Assert.NotEqual(invocation1.InvocationId, invocation2.InvocationId);
 
-            await manager1.SetConnectionResultAsync(connection2.ConnectionId, CompletionMessage.WithResult(invocation2.InvocationId, 2)).DefaultTimeout();
-            await manager2.SetConnectionResultAsync(connection1.ConnectionId, CompletionMessage.WithResult(invocation1.InvocationId, 5)).DefaultTimeout();
+            await manager1.SetConnectionResultAsync(connection.ConnectionId, CompletionMessage.WithResult(invocation2.InvocationId, 2)).DefaultTimeout();
+            await manager2.SetConnectionResultAsync(connection.ConnectionId, CompletionMessage.WithResult(invocation1.InvocationId, 5)).DefaultTimeout();
 
             var res = await invoke1.DefaultTimeout();
             Assert.Equal(2, res);

--- a/src/SignalR/server/StackExchangeRedis/src/Internal/RedisChannels.cs
+++ b/src/SignalR/server/StackExchangeRedis/src/Internal/RedisChannels.cs
@@ -23,12 +23,18 @@ internal sealed class RedisChannels
     /// </summary>
     public string GroupManagement { get; }
 
-    public RedisChannels(string prefix)
+    /// <summary>
+    /// Gets the name of the internal channel for receiving client results.
+    /// </summary>
+    public string ReturnResults { get; }
+
+    public RedisChannels(string prefix, string serverName)
     {
         _prefix = prefix;
 
         All = prefix + ":all";
         GroupManagement = prefix + ":internal:groups";
+        ReturnResults = _prefix + ":internal:return:" + serverName;
     }
 
     /// <summary>
@@ -70,16 +76,5 @@ internal sealed class RedisChannels
     public string Ack(string serverName)
     {
         return _prefix + ":internal:ack:" + serverName;
-    }
-
-    /// <summary>
-    /// Gets the name of the client return results channel for the specified server.
-    /// </summary>
-    /// <param name="serverName">The name of the server to get the client return results channel for.</param>
-    /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public string ReturnResults(string serverName)
-    {
-        return _prefix + ":internal:return:" + serverName;
     }
 }

--- a/src/SignalR/server/StackExchangeRedis/src/RedisHubLifetimeManager.cs
+++ b/src/SignalR/server/StackExchangeRedis/src/RedisHubLifetimeManager.cs
@@ -795,7 +795,8 @@ public class RedisHubLifetimeManager<THub> : HubLifetimeManager<THub>, IDisposab
         Debug.Assert(success);
         Debug.Assert(written == 24);
         // Trim the two '=='
-        return new string(base64.Slice(0, base64.Length - 2));
+        Debug.Assert(base64.EndsWith("=="));
+        return new string(base64[..^2]);
     }
 
     private sealed class LoggerTextWriter : TextWriter


### PR DESCRIPTION
Fixes bullet 7 of https://github.com/dotnet/aspnetcore/issues/5280

Stephen had an interesting idea:
> Couldn't we pass in a per-connection, `IInvocationBinder` that adds the connection id prefix back to the invocation id so the `IHubProtocol` doesn't need to be aware of it?

Unfortunately, we don't know the connection ID when `IHubProtocol` queries `IInvocationBinder` so the invocation id has to be the entire source of truth for the lookup.

After doing some local perf testing, the best approach I found was to just generate a GUID and base64 encode it for every invocation. There is only one allocation, the final string, and GUID generation is still fairly cheap, the most expensive part is likely getting the random bytes.

Other alternatives considered:
* generate a shorter random prefix at startup and append an incrementing ID every invoke. Then every 1000 or so invocations we generate a new random prefix and reset the ID to 0 (so the full invocation ID doesn't grow too big). Sadly, I couldn't figure out how to do this lock free, or even lock free until it needed to reset. So this approach becomes very slow in a multi-threaded environment.
* generate a shorter random prefix at startup and append an incrementing ID every invoke. If a collision occurs, reply to the original server that it collided and original server will try to use a new ID, repeat. This approach would require more noise over the backplane and complexities with coding.
* Use some form of randomness and then just throw if a collision occurs. Collisions should be rare and application code likely already is handling exceptions because of timeouts, connection closing, connection throwing error for a result, etc.