### PR TITLE
Unquarantine ClientAbortingConnectionImmediatelyIsNotLoggedHigherThanDebug 

### DIFF
--- a/src/Servers/Kestrel/test/FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/ResponseTests.cs
@@ -417,7 +417,6 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
 
     [Theory]
     [MemberData(nameof(ConnectionMiddlewareData))]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/41850")]
     public async Task ClientAbortingConnectionImmediatelyIsNotLoggedHigherThanDebug(ListenOptions listenOptions)
     {
         // Attempt multiple connections to be extra sure the resets are consistently logged appropriately.


### PR DESCRIPTION
For https://github.com/dotnet/aspnetcore/issues/41850

![image](https://user-images.githubusercontent.com/6537861/188206985-ce9293d4-8cf6-4984-9c52-0399787602d4.png)