### PR TITLE
Add Error Logging for the Blazor DebugProxyLauncher

### DIFF
--- a/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
+++ b/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
@@ -164,7 +164,7 @@ internal static class DebugProxyLauncher
                 if (!errorEncountered)
                 {
                     taskCompletionSource.TrySetException(new InvalidOperationException(
-                        "No output has been recevied from the application."));
+                        "No output has been received from the application."));
                 }
                 return;
             }

--- a/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
+++ b/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
@@ -164,7 +164,7 @@ internal static class DebugProxyLauncher
                 if (!errorEncountered)
                 {
                     taskCompletionSource.TrySetException(new InvalidOperationException(
-                        "No output has been received from the application."));
+                        "Expected output has not been received from the application."));
                 }
                 return;
             }

--- a/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
+++ b/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
@@ -139,12 +139,12 @@ internal static class DebugProxyLauncher
     private static void CompleteTaskWhenServerIsReady(Process aspNetProcess, TaskCompletionSource<string> taskCompletionSource)
     {
         string? capturedUrl = null;
-        bool errorEncountered = false;
-
-        aspNetProcess.OutputDataReceived += OnOutputDataReceived;
-        aspNetProcess.BeginErrorReadLine();
+        var errorEncountered = false;
 
         aspNetProcess.ErrorDataReceived += OnErrorDataReceived;
+        aspNetProcess.BeginErrorReadLine();
+
+        aspNetProcess.OutputDataReceived += OnOutputDataReceived;
         aspNetProcess.BeginOutputReadLine();
 
         void OnErrorDataReceived(object sender, DataReceivedEventArgs eventArgs)


### PR DESCRIPTION
# Add Error Logging for the Blazor DebugProxyLauncher

Adds error logging (from STDERR) in case the debug proxy failed to launch. These errors are now visible in the Visual Studio `Debug` Output window.

## Description

The output panel of VS will now show any exceptions encountered when launching the debug proxy. Previously this was only visible if the application was started via the command line.

Fixes #42614

## Customer Impact

In an earlier release, we ran into https://github.com/dotnet/runtime/issues/70841, however identifying and debugging that issue proved to be tricky as we weren't getting the error output in VS. This PR remedies that by ensuring the STDERR output stream is captured in the VS Debug output window.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Just adding additional logging for the error case.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
