### PR TITLE
[release/7.0] Remove tagged keys as entries are evicted

### DIFF
--- a/src/Middleware/OutputCaching/src/Memory/MemoryOutputCacheStore.cs
+++ b/src/Middleware/OutputCaching/src/Memory/MemoryOutputCacheStore.cs
@@ -32,7 +32,7 @@ internal sealed class MemoryOutputCacheStore : IOutputCacheStore
             {
                 if (keys != null && keys.Count > 0)
                 {
-                    // If MemoryCache changed to run eviction callbacks run inline in Remove, iterating over keys could throw
+                    // If MemoryCache changed to run eviction callbacks inline in Remove, iterating over keys could throw
                     // To prevent allocating a copy of the keys we check if the eviction callback ran,
                     // and if it did we restart the loop.
 

--- a/src/Middleware/OutputCaching/src/Memory/MemoryOutputCacheStore.cs
+++ b/src/Middleware/OutputCaching/src/Memory/MemoryOutputCacheStore.cs
@@ -126,7 +126,6 @@ internal sealed class MemoryOutputCacheStore : IOutputCacheStore
                             if (tagged.Count == 0)
                             {
                                 _taggedEntries.Remove(tag);
-                                break;
                             }
                         }
                     }

--- a/src/Middleware/OutputCaching/src/Memory/MemoryOutputCacheStore.cs
+++ b/src/Middleware/OutputCaching/src/Memory/MemoryOutputCacheStore.cs
@@ -83,12 +83,10 @@ internal sealed class MemoryOutputCacheStore : IOutputCacheStore
             {
                 foreach (var tag in tags)
                 {
-                    if (String.IsNullOrEmpty(tag))
+                    if (tag is null)
                     {
-                        throw new ArgumentException(Resources.TagCannotBeNullOrEmpty);
+                        throw new ArgumentException(Resources.TagCannotBeNull);
                     }
-
-                    ArgumentNullException.ThrowIfNull(tag);
 
                     if (!_taggedEntries.TryGetValue(tag, out var keys))
                     {

--- a/src/Middleware/OutputCaching/src/Memory/MemoryOutputCacheStore.cs
+++ b/src/Middleware/OutputCaching/src/Memory/MemoryOutputCacheStore.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -108,14 +109,12 @@ internal sealed class MemoryOutputCacheStore : IOutputCacheStore
         {
             var tags = state as string[];
 
-            if (tags == null || tags.Length == 0)
-            {
-                return;
-            }
+            Debug.Assert(tags != null);
+            Debug.Assert(tags.Length > 0);
 
             lock (_tagsLock)
             {
-                foreach (var tag in tags)
+                foreach (var tag in tags!)
                 {
                     if (_taggedEntries.TryGetValue(tag, out var tagged) && tagged != null)
                     {
@@ -127,6 +126,7 @@ internal sealed class MemoryOutputCacheStore : IOutputCacheStore
                             if (tagged.Count == 0)
                             {
                                 _taggedEntries.Remove(tag);
+                                break;
                             }
                         }
                     }

--- a/src/Middleware/OutputCaching/src/Resources.resx
+++ b/src/Middleware/OutputCaching/src/Resources.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="TagCannotBeNullOrEmpty" xml:space="preserve">
-    <value>Tag value cannot be null or empty.</value>
+  <data name="TagCannotBeNull" xml:space="preserve">
+    <value>A tag value cannot be null.</value>
   </data>
 </root>

--- a/src/Middleware/OutputCaching/src/Resources.resx
+++ b/src/Middleware/OutputCaching/src/Resources.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Policy_InvalidType" xml:space="preserve">
-    <value>The type '{0}' is not a valid output policy.</value>
+  <data name="TagCannotBeNullOrEmpty" xml:space="preserve">
+    <value>Tag value cannot be null or empty.</value>
   </data>
 </root>

--- a/src/Middleware/OutputCaching/test/MemoryOutputCacheStoreTests.cs
+++ b/src/Middleware/OutputCaching/test/MemoryOutputCacheStoreTests.cs
@@ -74,12 +74,16 @@ public class MemoryOutputCacheStoreTests
         HashSet<string> tag1s;
 
         // Wait for the hashset to be removed as it happens on a separate thread
-        var timeout = Task.Delay(1000);
-        while (store.TaggedEntries.TryGetValue("tag1", out tag1s) && !timeout.IsCompleted) { }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        while (store.TaggedEntries.TryGetValue("tag1", out tag1s) && !cts.IsCancellationRequested)
+        {
+            await Task.Yield();
+        }
 
         Assert.Null(result);
         Assert.Null(tag1s);
-        Assert.False(timeout.IsCompleted);
     }
 
     [Fact]
@@ -176,11 +180,19 @@ public class MemoryOutputCacheStoreTests
         HashSet<string> tag1s, tag2s;
 
         // Wait for the hashset to be removed as it happens on a separate thread
-        var timeout = Task.Delay(2000);
-        while (store.TaggedEntries.TryGetValue("tag1", out tag1s) && !timeout.IsCompleted) { }
-        while (store.TaggedEntries.TryGetValue("tag2", out tag2s) && tag2s.Count != 1 && !timeout.IsCompleted) { }
 
-        Assert.False(timeout.IsCompleted);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        while (store.TaggedEntries.TryGetValue("tag1", out tag1s) && !cts.IsCancellationRequested)
+        {
+            await Task.Yield();
+        }
+
+        while (store.TaggedEntries.TryGetValue("tag2", out tag2s) && tag2s.Count != 1 && !cts.IsCancellationRequested)
+        {
+            await Task.Yield();
+        }
+
         Assert.Null(tag1s);
         Assert.Single(tag2s);
     }

--- a/src/Middleware/OutputCaching/test/MemoryOutputCacheStoreTests.cs
+++ b/src/Middleware/OutputCaching/test/MemoryOutputCacheStoreTests.cs
@@ -172,7 +172,7 @@ public class MemoryOutputCacheStoreTests
 
         // Wait for the hashset to be removed as it happens on a separate thread
         var timeout = Task.Delay(1000);
-        while (store.TaggedEntries.TryGetValue("tag1", out _) && !timeout.IsCompleted) ;
+        while (store.TaggedEntries.TryGetValue("tag1", out _) && !timeout.IsCompleted) { }
 
         Assert.False(timeout.IsCompleted);
         Assert.Single(tag2s);

--- a/src/Middleware/OutputCaching/test/MemoryOutputCacheStoreTests.cs
+++ b/src/Middleware/OutputCaching/test/MemoryOutputCacheStoreTests.cs
@@ -197,6 +197,18 @@ public class MemoryOutputCacheStoreTests
         Assert.Single(tag2s);
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task Store_Throws_OnInvalidTag(string tag)
+    {
+        var store = new MemoryOutputCacheStore(new MemoryCache(new MemoryCacheOptions()));
+        var value = "abc"u8.ToArray();
+        var key = "abc";
+
+        await Assert.ThrowsAsync<ArgumentException>(async () => await store.SetAsync(key, value, new string[] { tag }, TimeSpan.FromMinutes(1), default));
+    }
+
     private class TestMemoryOptionsClock : Extensions.Internal.ISystemClock
     {
         public DateTimeOffset UtcNow { get; set; }

--- a/src/Middleware/OutputCaching/test/MemoryOutputCacheStoreTests.cs
+++ b/src/Middleware/OutputCaching/test/MemoryOutputCacheStoreTests.cs
@@ -199,7 +199,6 @@ public class MemoryOutputCacheStoreTests
 
     [Theory]
     [InlineData(null)]
-    [InlineData("")]
     public async Task Store_Throws_OnInvalidTag(string tag)
     {
         var store = new MemoryOutputCacheStore(new MemoryCache(new MemoryCacheOptions()));

--- a/src/Middleware/OutputCaching/test/OutputCacheMiddlewareTests.cs
+++ b/src/Middleware/OutputCaching/test/OutputCacheMiddlewareTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.OutputCaching.Memory;
@@ -743,14 +742,13 @@ public class OutputCacheMiddlewareTests
             })));
         var context = TestUtils.CreateTestContext();
         middleware.TryGetRequestPolicies(context.HttpContext, out var policies);
+        middleware.ShimResponseStream(context);
 
         await context.HttpContext.Response.WriteAsync(new string('0', 101));
 
         context.CachedResponse = new OutputCacheEntry() { Headers = new HeaderDictionary() };
         context.CacheKey = "BaseKey";
-        context.CachedResponseValidFor = TimeSpan.FromSeconds(100);
-
-        middleware.ShimResponseStream(context);
+        context.CachedResponseValidFor = TimeSpan.FromSeconds(10);
 
         await middleware.FinalizeCacheBodyAsync(context);
 

--- a/src/Middleware/OutputCaching/test/OutputCacheMiddlewareTests.cs
+++ b/src/Middleware/OutputCaching/test/OutputCacheMiddlewareTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.OutputCaching.Memory;
@@ -742,13 +743,14 @@ public class OutputCacheMiddlewareTests
             })));
         var context = TestUtils.CreateTestContext();
         middleware.TryGetRequestPolicies(context.HttpContext, out var policies);
-        middleware.ShimResponseStream(context);
 
         await context.HttpContext.Response.WriteAsync(new string('0', 101));
 
         context.CachedResponse = new OutputCacheEntry() { Headers = new HeaderDictionary() };
         context.CacheKey = "BaseKey";
-        context.CachedResponseValidFor = TimeSpan.FromSeconds(10);
+        context.CachedResponseValidFor = TimeSpan.FromSeconds(100);
+
+        middleware.ShimResponseStream(context);
 
         await middleware.FinalizeCacheBodyAsync(context);
 


### PR DESCRIPTION
## Description:
 
When output cache entries are evicted, their keys are not removed from the tagged collections. This fixes it by using a post eviction callback.

## Customer Impact

Non-breaking. Fixes potential memory leak.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A
