### PR TITLE
Don't cache Endpoints if a source throws

### DIFF
--- a/src/Http/Routing/src/CompositeEndpointDataSource.cs
+++ b/src/Http/Routing/src/CompositeEndpointDataSource.cs
@@ -242,8 +242,7 @@ public sealed class CompositeEndpointDataSource : EndpointDataSource, IDisposabl
     [MemberNotNull(nameof(_consumerChangeToken))]
     private void CreateChangeTokenUnsynchronized(bool collectionChanged)
     {
-        _cts = new CancellationTokenSource();
-        _consumerChangeToken = new CancellationChangeToken(_cts.Token);
+        var cts = new CancellationTokenSource();
 
         if (collectionChanged)
         {
@@ -255,17 +254,24 @@ public sealed class CompositeEndpointDataSource : EndpointDataSource, IDisposabl
                     () => HandleChange(collectionChanged: false)));
             }
         }
+
+        _cts = cts;
+        _consumerChangeToken = new CancellationChangeToken(cts.Token);
     }
 
     [MemberNotNull(nameof(_endpoints))]
     private void CreateEndpointsUnsynchronized()
     {
-        _endpoints = new List<Endpoint>();
+        var endpoints = new List<Endpoint>();
 
         foreach (var dataSource in _dataSources)
         {
-            _endpoints.AddRange(dataSource.Endpoints);
+            endpoints.AddRange(dataSource.Endpoints);
         }
+
+        // Only cache _endpoints after everything succeeds without throwing.
+        // We don't want to create a negative cache which would cause 404s when there should be 500s.
+        _endpoints = endpoints;
     }
 
     // Use private variable '_endpoints' to avoid initialization


### PR DESCRIPTION
## Description

Don't cache Endpoints in CompositeEndpointDataSource if a child EndpointDataSource source throws. CompositeEndpointDataSource is almost always the root EndpointDataSource, so this affects most apps.

Fixes #43693

## Customer Impact

Without this fix, you do not see endpoint generation errors after the first request. You should see something like:

<img width="606" alt="Developer exception page" src="https://user-images.githubusercontent.com/54385/188253294-4b58cb05-2ea7-4b48-b23a-73b19452e7da.png">

But instead get 404s after the first failed request:

<img width="606" alt="404 HTTP status page" src="https://user-images.githubusercontent.com/54385/188253265-c4b3c2ee-5b89-4e3a-86d5-900bcfc50fd5.png">

We should be consistently throwing exceptions to outer middleware like the one responsible for the developer exception page and producing 500s instead of 404s.

## Regression?

- [x] Yes
- [ ] No

This is a regression introduced in 7.0-preview6 by #42195. 

## Risk

- [ ] High
- [ ] Medium
- [x] Low

This is merely waiting to cache a list later after we know nothing threw while generating the list's elements.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

@Pilchie