### PR TITLE
[release/7.0] Fix auth exception stopping QUIC connection listener

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
@@ -186,7 +186,7 @@ internal sealed class QuicConnectionListener : IMultiplexedConnectionListener, I
                 // If the client rejects the connection because of an invalid cert then AcceptConnectionAsync throws.
                 // An error thrown inside ConnectionOptionsCallback can also throw from AcceptConnectionAsync.
                 // These are recoverable errors and we don't want to stop accepting connections.
-                QuicLog.ConnectionListenerConnectionFailed(_log, ex);
+                QuicLog.ConnectionListenerAcceptConnectionFailed(_log, ex);
             }
         }
 

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
@@ -6,7 +6,6 @@ using System.Net;
 using System.Net.Quic;
 using System.Net.Security;
 using System.Runtime.CompilerServices;
-using System.Security.Authentication;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
@@ -76,10 +75,7 @@ internal sealed class QuicConnectionListener : IMultiplexedConnectionListener, I
                 var serverAuthenticationOptions = await _tlsConnectionCallbackOptions.OnConnection(context, cancellationToken);
 
                 // If the callback didn't set protocols then use the listener's list of protocols.
-                if (serverAuthenticationOptions.ApplicationProtocols == null)
-                {
-                    serverAuthenticationOptions.ApplicationProtocols = _tlsConnectionCallbackOptions.ApplicationProtocols;
-                }
+                serverAuthenticationOptions.ApplicationProtocols ??= _tlsConnectionCallbackOptions.ApplicationProtocols;
 
                 // If the SslServerAuthenticationOptions doesn't have a cert or protocols then the
                 // QUIC connection will fail and the client receives an unhelpful message.
@@ -193,10 +189,7 @@ internal sealed class QuicConnectionListener : IMultiplexedConnectionListener, I
         return null;
     }
 
-    public async ValueTask UnbindAsync(CancellationToken cancellationToken = default)
-    {
-        await DisposeAsync();
-    }
+    public ValueTask UnbindAsync(CancellationToken cancellationToken = default) => DisposeAsync();
 
     public async ValueTask DisposeAsync()
     {

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
@@ -178,7 +178,7 @@ internal sealed class QuicConnectionListener : IMultiplexedConnectionListener, I
             {
                 // If the client rejects the connection because of an invalid cert then AcceptAsync throws.
                 // This is a recoverable error and we don't want to stop accepting connections because of this.
-                QuicLog.ConnectionListenerAcceptConnectionFailed(_log, ex);
+                QuicLog.ConnectionListenerHandshakeFailed(_log, ex);
             }
         }
 

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicLog.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicLog.cs
@@ -232,6 +232,9 @@ internal static partial class QuicLog
         }
     }
 
+    [LoggerMessage(24, LogLevel.Debug, "QUIC listener accept connection failed.", EventName = "ConnectionListenerAcceptConnectionFailed")]
+    public static partial void ConnectionListenerAcceptConnectionFailed(ILogger logger, Exception exception);
+
     private static StreamType GetStreamType(QuicStreamContext streamContext) =>
         streamContext.CanRead && streamContext.CanWrite
             ? StreamType.Bidirectional

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicLog.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicLog.cs
@@ -232,8 +232,8 @@ internal static partial class QuicLog
         }
     }
 
-    [LoggerMessage(24, LogLevel.Debug, "QUIC listener accept connection failed.", EventName = "ConnectionListenerAcceptConnectionFailed")]
-    public static partial void ConnectionListenerAcceptConnectionFailed(ILogger logger, Exception exception);
+    [LoggerMessage(24, LogLevel.Debug, "QUIC listener connection handshake failed.", EventName = "ConnectionListenerHandshakeFailed")]
+    public static partial void ConnectionListenerHandshakeFailed(ILogger logger, Exception exception);
 
     private static StreamType GetStreamType(QuicStreamContext streamContext) =>
         streamContext.CanRead && streamContext.CanWrite

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicLog.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicLog.cs
@@ -232,8 +232,8 @@ internal static partial class QuicLog
         }
     }
 
-    [LoggerMessage(24, LogLevel.Debug, "QUIC listener connection handshake failed.", EventName = "ConnectionListenerHandshakeFailed")]
-    public static partial void ConnectionListenerHandshakeFailed(ILogger logger, Exception exception);
+    [LoggerMessage(24, LogLevel.Debug, "QUIC listener connection failed.", EventName = "ConnectionListenerConnectionFailed")]
+    public static partial void ConnectionListenerConnectionFailed(ILogger logger, Exception exception);
 
     private static StreamType GetStreamType(QuicStreamContext streamContext) =>
         streamContext.CanRead && streamContext.CanWrite

--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicLog.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicLog.cs
@@ -232,8 +232,8 @@ internal static partial class QuicLog
         }
     }
 
-    [LoggerMessage(24, LogLevel.Debug, "QUIC listener connection failed.", EventName = "ConnectionListenerConnectionFailed")]
-    public static partial void ConnectionListenerConnectionFailed(ILogger logger, Exception exception);
+    [LoggerMessage(24, LogLevel.Debug, "QUIC listener connection failed.", EventName = "ConnectionListenerAcceptConnectionFailed")]
+    public static partial void ConnectionListenerAcceptConnectionFailed(ILogger logger, Exception exception);
 
     private static StreamType GetStreamType(QuicStreamContext streamContext) =>
         streamContext.CanRead && streamContext.CanWrite

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
@@ -78,7 +78,7 @@ public class QuicConnectionListenerTests : TestApplicationErrorLoggerLoggedTest
         await serverConnection1.DisposeAsync().AsTask().DefaultTimeout();
 
         // Act & Assert 2
-        var serverFailureLogTask = WaitForLogMessage(m => m.EventId.Name == "ConnectionListenerConnectionFailed");
+        var serverFailureLogTask = WaitForLogMessage(m => m.EventId.Name == "ConnectionListenerAcceptConnectionFailed");
 
         Logger.LogInformation("Client creating unsuccessful connection 2");
         var acceptTask2 = connectionListener.AcceptAndAddFeatureAsync().DefaultTimeout();

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicConnectionListenerTests.cs
@@ -78,7 +78,7 @@ public class QuicConnectionListenerTests : TestApplicationErrorLoggerLoggedTest
         await serverConnection1.DisposeAsync().AsTask().DefaultTimeout();
 
         // Act & Assert 2
-        var serverFailureLogTask = WaitForLogMessage(m => m.EventId.Name == "ConnectionListenerAcceptConnectionFailed");
+        var serverFailureLogTask = WaitForLogMessage(m => m.EventId.Name == "ConnectionListenerHandshakeFailed");
 
         Logger.LogInformation("Client creating unsuccessful connection 2");
         var acceptTask2 = connectionListener.AcceptAndAddFeatureAsync().DefaultTimeout();
@@ -89,7 +89,8 @@ public class QuicConnectionListenerTests : TestApplicationErrorLoggerLoggedTest
         }, "The remote certificate is invalid because of errors in the certificate chain: RemoteCertificateChainErrors");
 
         Assert.False(acceptTask2.IsCompleted, "Accept doesn't return for failed client connection.");
-        await serverFailureLogTask.DefaultTimeout();
+        var serverFailureLog = await serverFailureLogTask.DefaultTimeout();
+        Assert.NotNull(serverFailureLog.Exception);
 
         // Act & Assert 3
         Logger.LogInformation("Client creating successful connection 3");

--- a/src/Servers/Kestrel/Transport.Quic/test/QuicTestHelpers.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/QuicTestHelpers.cs
@@ -116,9 +116,9 @@ internal static class QuicTestHelpers
         return true;
     }
 
-    public static QuicClientConnectionOptions CreateClientConnectionOptions(EndPoint remoteEndPoint)
+    public static QuicClientConnectionOptions CreateClientConnectionOptions(EndPoint remoteEndPoint, bool? ignoreInvalidCertificate = null)
     {
-        return new QuicClientConnectionOptions
+        var options = new QuicClientConnectionOptions
         {
             MaxInboundBidirectionalStreams = 200,
             MaxInboundUnidirectionalStreams = 200,
@@ -128,12 +128,16 @@ internal static class QuicTestHelpers
                 ApplicationProtocols = new List<SslApplicationProtocol>
                 {
                     SslApplicationProtocol.Http3
-                },
-                RemoteCertificateValidationCallback = RemoteCertificateValidationCallback
+                }
             },
             DefaultStreamErrorCode = 0,
             DefaultCloseErrorCode = 0,
         };
+        if (ignoreInvalidCertificate ?? true)
+        {
+            options.ClientAuthenticationOptions.RemoteCertificateValidationCallback = RemoteCertificateValidationCallback;
+        }
+        return options;
     }
 
     public static async Task<QuicStreamContext> CreateAndCompleteBidirectionalStreamGracefully(QuicConnection clientConnection, MultiplexedConnectionContext serverConnection, ILogger logger)


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/43723

## Description

If an HTTP/3 connection request from a client fails because of an auth issue, e.g. client rejects an invalid server certificate, then the connection listener accept loop stops. This prevents future connections.

## Customer Impact

Without this fix, a client can create a request that causes to Kestrel to stop accepting HTTP/3 connections.

## Regression?

- [ ] Yes
- [ ] No

Maybe. There might have been changes in System.Net.Quic to throw this error. [The XML docs on QuicListener.AcceptConnectionAsync](https://github.com/dotnet/runtime/blob/8582c5cbcf03d6c0d1d3f0d11e622b8b0168f50f/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs#L154-L158) have mixed signals about whether this exception should be thrown.

@dotnet/ncl could you confirm that this is expected behavior?

## Risk

- [ ] High
- [ ] Medium
- [x] Low

~This fixes this particular error, but I worry about if there are other exceptions that are thrown out of listener accept that would stop the connection accept loop. I'd like to get some advice on @dotnet/ncl on how best to use `QuicListener.AcceptConnectionAsync`.~

~We should keep listening if `AuthenticationException` is thrown. Is there a list of `QuicError` values for which we should continue listening? Or the inverse, what `QuicError` values should stop the accept loop?~

I think we have certainty from the NCL team on how best to use the QUIC connection listener.

## Verification

- [ ] Manual (required)
- [x] Automated

I'm unsure if it is possible to test this error in a browser manually. A browser HTTP/3 connection only works when the server offers a valid TLS cert; this failure only happens when the TLS cert is invalid.

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

@Pilchie