### PR TITLE
[release/7.0]: Throw if a by ref type is returned to avoid making invalid IL

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -972,7 +972,7 @@ public static partial class RequestDelegateFactory
             else
             {
                 // TODO: Handle custom awaitables
-                throw new NotSupportedException($"Unsupported return type: {returnType}");
+                throw new NotSupportedException($"Unsupported return type: {TypeNameHelper.GetTypeDisplayName(returnType)}");
             }
         }
         else if (typeof(IResult).IsAssignableFrom(returnType))
@@ -987,6 +987,11 @@ public static partial class RequestDelegateFactory
         else if (returnType == typeof(string))
         {
             return Expression.Call(StringResultWriteResponseAsyncMethod, HttpContextExpr, methodCall);
+        }
+        else if (returnType.IsByRefLike)
+        {
+            // Unsupported
+            throw new NotSupportedException($"Unsupported return type: {TypeNameHelper.GetTypeDisplayName(returnType)}");
         }
         else if (returnType.IsValueType)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/41920

## Description

Minimal APIs can generate invalid IL when returning by ref types. This change detects them and throws an error.

## Customer Impact

Tiny, the error message doesn't talk about generating in valid IL. T

## Regression?

- [ ] Yes
- [x] No

Not really, the error message looks much worse scary in .NET 7 (look like corruption in the runtime).

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Very low risk, we're just fixing the error message.

## Verification

- [ ] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

@Pilchie