### PR TITLE
Fixed summary for FileStream property.

### DIFF
--- a/src/Http/Http.Results/src/FileStreamHttpResult.cs
+++ b/src/Http/Http.Results/src/FileStreamHttpResult.cs
@@ -108,7 +108,7 @@ public sealed class FileStreamHttpResult : IResult, IFileHttpResult, IContentTyp
     public long? FileLength { get; internal set; }
 
     /// <summary>
-    /// Gets or sets the stream with the file that will be sent back as the response.
+    /// Gets the stream with the file that will be sent back as the response.
     /// </summary>
     public Stream FileStream { get; }
 


### PR DESCRIPTION
# {PR title}

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

I corrected a summary of the FileStream property in the FileStreamHttpResult.cs class.  Original summary stated that the property could be set and get but the property only defines a getter.

Fixes #43744
