### PR TITLE
Remove aspnetcore submodule workaround

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -733,7 +733,7 @@ stages:
     parameters:
       platform:
         name: 'Managed'
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33-20210222183538-031e7d2'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8-20220809204800-17a4aab'
         buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks'
         skipPublishValidation: true
         timeoutInMinutes: 120

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -733,7 +733,7 @@ stages:
     parameters:
       platform:
         name: 'Managed'
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-20210714125435-9b5bbc2'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-33-20210222183538-031e7d2'
         buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks'
         skipPublishValidation: true
         timeoutInMinutes: 120

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <GitHubRepositoryName>aspnetcore</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
-    <CloneSubmodulesToInnerSourceBuildRepo>false</CloneSubmodulesToInnerSourceBuildRepo>
   </PropertyGroup>
 
   <Target Name="PrepareGlobalJsonForSourceBuild"
@@ -12,19 +11,6 @@
     <Exec
       Command="./eng/scripts/prepare-sourcebuild-globaljson.sh"
       WorkingDirectory="$(InnerSourceBuildRepoRoot)" />
-  </Target>
-
-  <!--
-    Init submodules - temporarary workaround for https://github.com/dotnet/sourcelink/pull/653
-  -->
-  <Target Name="InitSubmodules"
-          DependsOnTargets="PrepareInnerSourceBuildRepoRoot"
-          BeforeTargets="RunInnerSourceBuildCommand">
-
-    <Exec
-      Command="git submodule update --init --recursive"
-      WorkingDirectory="$(InnerSourceBuildRepoRoot)"
-      EnvironmentVariables="@(InnerBuildEnv)" />
   </Target>
 
   <!--


### PR DESCRIPTION
# Remove aspnetcore submodule workaround

Remove aspnetcore submodule workaround, used for source-build leg in this repo.

## Description

We have been using a patch for source-build tarball creation. This PR moves the patch into the repo itself.

The fix has been attempted before but it failed internal build, due to the way submodules were restored in Source-Build (Managed) build. That issue was caused by the old version of Git (v1.8x) in current source-build containers (CentOS 7) and the use of 'git stash create' which requires user identity to be set - this requirement was removed in Git versions v2.1x. An example of that failure: https://dev.azure.com/dnceng/internal/_build/results?buildId=1979701&view=logs&s=ff05ad62-bb9a-53b6-ce9f-72f329a63e7c&j=42c44170-37b9-56ec-05f4-844efa8f4b88

I am now updating the container to centos-stream8, which has a newer Git (v2.1x) and does not experience the 'git stash create' issue anymore, see my validation build, "Source-Build (managed)" stage: https://dev.azure.com/dnceng/internal/_build/results?buildId=1984984&view=results

Fixes: https://github.com/dotnet/source-build/issues/2972
