### PR TITLE
[release/7.0] Fix NavigationLock prerendering

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/NavigationLockPrerenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/NavigationLockPrerenderingTest.cs
@@ -34,7 +34,7 @@ public class NavigationLockPrerenderingTest : ServerTestBase<BasicTestAppServerS
         Browser.Click(By.Id("internal-navigation-link"));
         Browser.Equal("Prevented navigations: 1", () => Browser.FindElement(By.Id("num-prevented-navigations")).Text);
 
-        // Assert that external navigations are blocked.
+        // Assert that external navigations are blocked
         Browser.Navigate().GoToUrl("about:blank");
         Browser.SwitchTo().Alert().Dismiss();
         Browser.Equal("Prevented navigations: 1", () => Browser.FindElement(By.Id("num-prevented-navigations")).Text);

--- a/src/Components/test/E2ETest/ServerExecutionTests/NavigationLockPrerenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/NavigationLockPrerenderingTest.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
+using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
+using Microsoft.AspNetCore.E2ETesting;
+using OpenQA.Selenium;
+using TestServer;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests;
+
+public class NavigationLockPrerenderingTest : ServerTestBase<BasicTestAppServerSiteFixture<LockedNavigationStartup>>
+{
+    public NavigationLockPrerenderingTest(
+        BrowserFixture browserFixture,
+        BasicTestAppServerSiteFixture<LockedNavigationStartup> serverFixture,
+        ITestOutputHelper output)
+        : base(browserFixture, serverFixture, output)
+    {
+    }
+
+    [Fact]
+    public void NavigationIsLockedAfterPrerendering()
+    {
+        Navigate("/locked-navigation");
+
+        // Assert that the component rendered successfully
+        Browser.Equal("Prevented navigations: 0", () => Browser.FindElement(By.Id("num-prevented-navigations")).Text);
+
+        BeginInteractivity();
+
+        // Assert that internal navigations are blocked
+        Browser.Click(By.Id("internal-navigation-link"));
+        Browser.Equal("Prevented navigations: 1", () => Browser.FindElement(By.Id("num-prevented-navigations")).Text);
+
+        // Assert that external navigations are blocked.
+        Browser.Navigate().GoToUrl("about:blank");
+        Browser.SwitchTo().Alert().Dismiss();
+        Browser.Equal("Prevented navigations: 1", () => Browser.FindElement(By.Id("num-prevented-navigations")).Text);
+    }
+
+    private void BeginInteractivity()
+    {
+        Browser.Exists(By.Id("load-boot-script")).Click();
+
+        var javascript = (IJavaScriptExecutor)Browser;
+        Browser.True(() => (bool)javascript.ExecuteScript("return window['__aspnetcore__testing__blazor__started__'] === true;"));
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/LockNavigationOnPageLoad.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/LockNavigationOnPageLoad.razor
@@ -1,0 +1,28 @@
+﻿@using Microsoft.AspNetCore.Components.Routing
+
+@inject INavigationInterception NavigationInterception
+
+<a id="internal-navigation-link" href="should-never-get-here">Internal navigation</a>
+
+<span id="num-prevented-navigations">Prevented navigations: @_numPreventedNavigations</span>
+
+<NavigationLock OnBeforeInternalNavigation="HandleBeforeInternalNavigationAsync" ConfirmExternalNavigation />
+
+@code {
+    private int _numPreventedNavigations = 0;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await NavigationInterception.EnableNavigationInterceptionAsync();
+        }
+    }
+
+    private Task HandleBeforeInternalNavigationAsync(LocationChangingContext context)
+    {
+        _numPreventedNavigations++;
+        context.PreventNavigation();
+        return Task.CompletedTask;
+    }
+}

--- a/src/Components/test/testassets/TestServer/LockedNavigationStartup.cs
+++ b/src/Components/test/testassets/TestServer/LockedNavigationStartup.cs
@@ -43,5 +43,4 @@ public class LockedNavigationStartup
             });
         });
     }
-
 }

--- a/src/Components/test/testassets/TestServer/LockedNavigationStartup.cs
+++ b/src/Components/test/testassets/TestServer/LockedNavigationStartup.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Microsoft.AspNetCore.Authentication.Cookies;
+
+namespace TestServer;
+
+public class LockedNavigationStartup
+{
+    // This method gets called by the runtime. Use this method to add services to the container.
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddMvc();
+        services.AddServerSideBlazor();
+        services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme).AddCookie();
+    }
+
+    // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    {
+        var enUs = new CultureInfo("en-US");
+        CultureInfo.DefaultThreadCurrentCulture = enUs;
+        CultureInfo.DefaultThreadCurrentUICulture = enUs;
+
+        if (env.IsDevelopment())
+        {
+            app.UseDeveloperExceptionPage();
+        }
+
+        app.Map("/locked-navigation", app =>
+        {
+            app.UseStaticFiles();
+
+            app.UseAuthentication();
+
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapRazorPages();
+                endpoints.MapFallbackToPage("/LockedNavigationHost");
+                endpoints.MapBlazorHub();
+            });
+        });
+    }
+
+}

--- a/src/Components/test/testassets/TestServer/Pages/LockedNavigationHost.cshtml
+++ b/src/Components/test/testassets/TestServer/Pages/LockedNavigationHost.cshtml
@@ -1,0 +1,33 @@
+﻿@page "/locked-navigation"
+@using BasicTestApp.RouterTest
+
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Locked navigation</title>
+    <base href="~/" />
+</head>
+<body>
+    <app><component type="typeof(LockNavigationOnPageLoad)" render-mode="ServerPrerendered" /></app>
+
+    @*
+        So that E2E tests can make assertions about both the prerendered and
+        interactive states, we only load the .js file when told to.
+    *@
+    <hr />
+
+    <button id="load-boot-script" onclick="start()">Load boot script</button>
+
+    <script src="_framework/blazor.server.js" autostart="false"></script>
+
+    <script>
+        function start() {
+            Blazor.start({
+                logLevel: 1 // LogLevel.Debug
+            }).then(function () {
+                window['__aspnetcore__testing__blazor__started__'] = true;
+            });
+        }
+    </script>
+</body>
+</html>

--- a/src/Components/test/testassets/TestServer/Program.cs
+++ b/src/Components/test/testassets/TestServer/Program.cs
@@ -20,6 +20,7 @@ public class Program
             ["CORS (WASM)"] = (BuildWebHost<CorsStartup>(CreateAdditionalArgs(args)), "/subdir"),
             ["Prerendering (Server-side)"] = (BuildWebHost<PrerenderedStartup>(CreateAdditionalArgs(args)), "/prerendered"),
             ["Deferred component content (Server-side)"] = (BuildWebHost<DeferredComponentContentStartup>(CreateAdditionalArgs(args)), "/deferred-component-content"),
+            ["Locked navigation (Server-side)"] = (BuildWebHost<LockedNavigationStartup>(CreateAdditionalArgs(args)), "/locked-navigation"),
             ["Client-side with fallback"] = (BuildWebHost<StartupWithMapFallbackToClientSideBlazor>(CreateAdditionalArgs(args)), "/fallback"),
             ["Multiple components (Server-side)"] = (BuildWebHost<MultipleComponents>(CreateAdditionalArgs(args)), "/multiple-components"),
             ["Save state"] = (BuildWebHost<SaveState>(CreateAdditionalArgs(args)), "/save-state"),


### PR DESCRIPTION
# Fix `NavigationLock` prerendering

Fixes a bug that caused `<NavigationLock />` to throw an exception during prerendering if its `ConfirmExternalNavigation` parameter is set to `true`.

## Description

This bug was caused by `<NavigationLock />` attempting to perform JS interop calls during prerendering. This fix moves these JS interop calls to the `OnAfterRenderAsync()` method, which does not get called during prerendering. This PR also adds an E2E test verifying that `<NavigationLock />` works correctly when prerendering is enabled.

Fixes #43724

## Customer Impact

The ability to cancel navigation events is a feature that the community has shown [significant interest](https://github.com/dotnet/aspnetcore/issues/14962) in. With it finally landing in .NET 7, we want this feature to be supported in as many scenarios as possible. The bug that this PR fixes would in many cases force customers to choose between enabling prerendering and using the `<NavigationLock />` component.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

We have extensive existing test coverage. New automated tests have been added for the scenario that this PR fixes.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A