### PR TITLE
Enable fast publishing

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -41,14 +41,8 @@ variables:
   value: true
 - name: _TeamName
   value:  AspNetCore
-- name: _DotNetPublishToBlobFeed
-  value: true
 - name: _PublishUsingPipelines
   value: true
-- name: _DotNetArtifactsCategory
-  value: .NETCORE
-- name: _DotNetValidationArtifactsCategory
-  value: .NETCORE
 - name: PostBuildSign
   value: true
 - name: _UseHelixOpenQueues
@@ -67,11 +61,7 @@ variables:
   - name: _PublishArgs
     value: /p:Publish=true
            /p:GenerateChecksums=true
-           /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-           /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-           /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
            /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
-           /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
   # Variables for source indexing afterBuild step and job.
   - name: sourceIndexPackageVersion
     value: 1.0.1-20210614.1
@@ -782,6 +772,7 @@ stages:
           demands: ImageOverride -equals Build.Server.Amd64.VS2019
         publishUsingPipelines: ${{ variables._PublishUsingPipelines }}
         enablePublishBuildArtifacts: true # publish artifacts/log files
+        publishAssetsImmediately: true # Don't use a separate stage for darc publishing.
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(parameters.testSourceIndexing, 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
       - job: SourceIndexUpload
         displayName: Upload indexable solution
@@ -852,3 +843,4 @@ stages:
       enableSigningValidation: false
       enableNugetValidation: false
       publishInstallersAndChecksums: true
+      publishAssetsImmediately: true


### PR DESCRIPTION
Eliminates the "Publish Using Darc" stage altogether, moving the call to publishing at the end of the Publish To Build Asset Registry job.

This eliminates 10ish minutes of overhead.

Also remove a bunch of unused variables.