### PR TITLE
Fix ProjectTemplate test failure logs on helix

### DIFF
--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -37,7 +37,11 @@ public class Project : IDisposable
             }
 
             var testLogFolder = typeof(Project).Assembly.GetCustomAttribute<TestFrameworkFileLoggerAttribute>()?.BaseDirectory;
-            return string.IsNullOrEmpty(testLogFolder) ? GetAssemblyMetadata("ArtifactsLogDir") : testLogFolder;
+            if (string.IsNullOrEmpty(testLogFolder))
+            {
+                throw new InvalidOperationException($"No test log folder specified via {nameof(TestFrameworkFileLoggerAttribute)}.");
+            }
+            return testLogFolder;
         }
     }
 

--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -30,14 +30,14 @@ public class Project : IDisposable
     {
         get
         {
-            var testLogFolder = typeof(Project).Assembly.GetCustomAttribute<TestFrameworkFileLoggerAttribute>()?.BaseDirectory;
-            if (!string.IsNullOrEmpty(testLogFolder))
+            var helixWorkItemUploadRoot = Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT");
+            if (!string.IsNullOrEmpty(helixWorkItemUploadRoot))
             {
-                return testLogFolder;
+                return helixWorkItemUploadRoot;
             }
 
-            var helixWorkItemUploadRoot = Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT");
-            return string.IsNullOrEmpty(helixWorkItemUploadRoot) ? GetAssemblyMetadata("ArtifactsLogDir") : helixWorkItemUploadRoot;
+            var testLogFolder = typeof(Project).Assembly.GetCustomAttribute<TestFrameworkFileLoggerAttribute>()?.BaseDirectory;
+            return string.IsNullOrEmpty(testLogFolder) ? GetAssemblyMetadata("ArtifactsLogDir") : testLogFolder;
         }
     }
 


### PR DESCRIPTION
Binlogs aren't being uploaded on failure like expected. I believe this is because https://github.com/dotnet/aspnetcore/pull/37447 changed the directory ProjectTemplate tests write the binlog to, to artifacts/log, which likely isn't going to work correctly on Helix.