### PR TITLE
feat: use the value of the variable directly

### DIFF
--- a/src/Caching/SqlServer/src/DatabaseOperations.cs
+++ b/src/Caching/SqlServer/src/DatabaseOperations.cs
@@ -98,12 +98,10 @@ internal sealed class DatabaseOperations : IDatabaseOperations
 
     public void DeleteExpiredCacheItems()
     {
-        var utcNow = SystemClock.UtcNow;
-
         using (var connection = new SqlConnection(ConnectionString))
         using (var command = new SqlCommand(SqlQueries.DeleteExpiredCacheItems, connection))
         {
-            command.Parameters.AddWithValue("UtcNow", SqlDbType.DateTimeOffset, utcNow);
+            command.Parameters.AddWithValue("UtcNow", SqlDbType.DateTimeOffset, SystemClock.UtcNow);
 
             connection.Open();
 
@@ -115,7 +113,7 @@ internal sealed class DatabaseOperations : IDatabaseOperations
     {
         var utcNow = SystemClock.UtcNow;
 
-        var absoluteExpiration = DatabaseOperations.GetAbsoluteExpiration(utcNow, options);
+        var absoluteExpiration = DatabaseOperations.GetAbsoluteExpiration(SystemClock.UtcNow, options);
         DatabaseOperations.ValidateOptions(options.SlidingExpiration, absoluteExpiration);
 
         using (var connection = new SqlConnection(ConnectionString))
@@ -191,8 +189,6 @@ internal sealed class DatabaseOperations : IDatabaseOperations
 
     private byte[]? GetCacheItem(string key, bool includeValue)
     {
-        var utcNow = SystemClock.UtcNow;
-
         string query;
         if (includeValue)
         {
@@ -209,7 +205,7 @@ internal sealed class DatabaseOperations : IDatabaseOperations
         {
             command.Parameters
                 .AddCacheItemId(key)
-                .AddWithValue("UtcNow", SqlDbType.DateTimeOffset, utcNow);
+                .AddWithValue("UtcNow", SqlDbType.DateTimeOffset, SystemClock.UtcNow);
 
             connection.Open();
 
@@ -237,8 +233,6 @@ internal sealed class DatabaseOperations : IDatabaseOperations
     {
         token.ThrowIfCancellationRequested();
 
-        var utcNow = SystemClock.UtcNow;
-
         string query;
         if (includeValue)
         {
@@ -255,7 +249,7 @@ internal sealed class DatabaseOperations : IDatabaseOperations
         {
             command.Parameters
                 .AddCacheItemId(key)
-                .AddWithValue("UtcNow", SqlDbType.DateTimeOffset, utcNow);
+                .AddWithValue("UtcNow", SqlDbType.DateTimeOffset, SystemClock.UtcNow);
 
             await connection.OpenAsync(token).ConfigureAwait(false);
 


### PR DESCRIPTION
# Use value of Utc directly

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

The value of Utc can be used directly.

