### PR TITLE
Default install Playwright to false

### DIFF
--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -11,6 +11,7 @@
   <PropertyGroup>
     <_TestingArchitecture>x64</_TestingArchitecture>
     <_TestingArchitecture Condition=" '$(IsArm64HelixQueue)' == 'true' ">arm64</_TestingArchitecture>
+    <TestDependsOnPlaywright Condition="'$(TestDependsOnPlaywright)' == ''">false</TestDependsOnPlaywright>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TestDependsOnPlaywright)' == 'true'">


### PR DESCRIPTION
Noticed that every helix test run was installing playwright which is super unnecessary. This is because for some reason System.CommandLine treats anything other than "false" as true when using `parseResult.ValueForOption<bool>("--playwright");`, and since we were passing `string.Empty` it defaulted to true.