### PR TITLE
[7.0] Disable body streams for H2 CONNECT requests 

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -716,4 +716,7 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="Http3ErrorControlStreamClosed" xml:space="preserve">
     <value>A control stream used by the connection was closed or reset.</value>
   </data>
+  <data name="ConnectResponseCanNotHaveBody" xml:space="preserve">
+    <value>'CONNECT' requests with a 2XX success status code cannot have a response body.</value>
+  </data>
 </root>

--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -686,8 +686,8 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="AcceptCannotBeCalledMultipleTimes" xml:space="preserve">
     <value>IHttpExtendedConnectFeature.AcceptAsync was already called and can only be called once per request.</value>
   </data>
-  <data name="ConnectStatusMustBe200" xml:space="preserve">
-    <value>The response status code for a Extended CONNECT request must be 200.</value>
+  <data name="ConnectStatusMustBe2XX" xml:space="preserve">
+    <value>The response status code for a Extended CONNECT request must be 2XX.</value>
   </data>
   <data name="AttemptedToReadHeaderOnAbortedStream" xml:space="preserve">
     <value>Attempted to read header on aborted stream.</value>
@@ -717,6 +717,6 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
     <value>A control stream used by the connection was closed or reset.</value>
   </data>
   <data name="ConnectResponseCanNotHaveBody" xml:space="preserve">
-    <value>'CONNECT' requests with a 2XX success status code cannot have a response body.</value>
+    <value>Responses to 'CONNECT' requests with the success status code '{StatusCode}' cannot have a response body. Use the 'IHttpExtendedConnectFeature' to accept and write to the 'CONNECT' stream.</value>
   </data>
 </root>

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -300,9 +300,9 @@ internal partial class HttpProtocol
             throw new InvalidOperationException(CoreStrings.AcceptCannotBeCalledMultipleTimes);
         }
 
-        if (StatusCode != StatusCodes.Status200OK)
+        if (StatusCode < StatusCodes.Status200OK || StatusCodes.Status300MultipleChoices <= StatusCode)
         {
-            throw new InvalidOperationException(CoreStrings.ConnectStatusMustBe200);
+            throw new InvalidOperationException(CoreStrings.ConnectStatusMustBe2XX);
         }
 
         IsExtendedConnectAccepted = true;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.FeatureCollection.cs
@@ -309,7 +309,7 @@ internal partial class HttpProtocol
 
         await FlushAsync();
 
-        return _bodyControl!.Upgrade();
+        return _bodyControl!.AcceptConnect();
     }
 
     void IHttpRequestLifetimeFeature.Abort()

--- a/src/Servers/Kestrel/Core/src/Internal/Http/MessageBody.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/MessageBody.cs
@@ -39,6 +39,8 @@ internal abstract class MessageBody
 
     public bool ExtendedConnect { get; protected set; }
 
+    public HttpProtocol Context => _context;
+
     public virtual bool IsEmpty => false;
 
     protected KestrelTrace Log => _context.ServiceContext.Log;

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/BodyControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/BodyControl.cs
@@ -11,12 +11,16 @@ internal sealed class BodyControl
 {
     private static readonly ThrowingWasUpgradedWriteOnlyStream _throwingResponseStream
         = new ThrowingWasUpgradedWriteOnlyStream();
+    private static readonly ThrowingPipeWriter _throwingUpgradedPipeWriter = new(CoreStrings.ResponseStreamWasUpgraded);
     private readonly HttpResponseStream _response;
     private readonly HttpResponsePipeWriter _responseWriter;
     private readonly HttpRequestPipeReader _requestReader;
     private readonly HttpRequestStream _request;
     private readonly HttpRequestPipeReader _emptyRequestReader;
     private readonly WrappingStream _upgradeableResponse;
+    private readonly WrappingPipeWriter _upgradeablePipeWriter;
+    private readonly StatusCheckPipeWriter _connectPipeWriter;
+    private readonly StatusCheckWriteStream _connectResponse;
     private readonly HttpRequestStream _emptyRequest;
     private readonly Stream _upgradeStream;
 
@@ -30,7 +34,10 @@ internal sealed class BodyControl
         _responseWriter = new HttpResponsePipeWriter(responseControl);
         _response = new HttpResponseStream(bodyControl, _responseWriter);
         _upgradeableResponse = new WrappingStream(_response);
+        _upgradeablePipeWriter = new WrappingPipeWriter(_responseWriter);
         _upgradeStream = new HttpUpgradeStream(_request, _response);
+        _connectPipeWriter = new(_responseWriter);
+        _connectResponse = new(_response);
     }
 
     public bool CanHaveBody { get; private set; }
@@ -39,7 +46,13 @@ internal sealed class BodyControl
     {
         // causes writes to context.Response.Body to throw
         _upgradeableResponse.SetInnerStream(_throwingResponseStream);
+        _upgradeablePipeWriter.SetInnerPipe(_throwingUpgradedPipeWriter);
         // _upgradeStream always uses _response
+        return _upgradeStream;
+    }
+
+    public Stream AcceptConnect()
+    {
         return _upgradeStream;
     }
 
@@ -54,8 +67,17 @@ internal sealed class BodyControl
         {
             // until Upgrade() is called, context.Response.Body should use the normal output stream
             _upgradeableResponse.SetInnerStream(_response);
+            _upgradeablePipeWriter.SetInnerPipe(_responseWriter);
             // upgradeable requests should never have a request body
-            return (_emptyRequest, _upgradeableResponse, _emptyRequestReader, _responseWriter);
+            return (_emptyRequest, _upgradeableResponse, _emptyRequestReader, _upgradeablePipeWriter);
+        }
+        else if (body.ExtendedConnect)
+        {
+            // CONNECT requests do not have a request or response body until after accepted,
+            // unless it's a 300+ response.
+            _connectResponse.SetRequest(body.Context);
+            _connectPipeWriter.SetRequest(body.Context);
+            return (_emptyRequest, _connectResponse, _emptyRequestReader, _connectPipeWriter);
         }
         else
         {

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/StatusCheckPipeWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/StatusCheckPipeWriter.cs
@@ -33,7 +33,7 @@ internal sealed class StatusCheckPipeWriter : PipeWriter
         Debug.Assert(_context != null);
         if (_context.StatusCode < 300)
         {
-            throw new InvalidOperationException(CoreStrings.ConnectResponseCanNotHaveBody);
+            throw new InvalidOperationException(CoreStrings.FormatConnectResponseCanNotHaveBody(_context.StatusCode));
         }
     }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/StatusCheckPipeWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/StatusCheckPipeWriter.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.IO.Pipelines;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+
+// Throws if the Http Status code is less than 300.
+// For use with CONNECT responses that can't have a response body for 2xx.
+internal sealed class StatusCheckPipeWriter : PipeWriter
+{
+    private readonly PipeWriter _inner;
+    private HttpProtocol? _context;
+
+    public StatusCheckPipeWriter(PipeWriter inner)
+    {
+        _inner = inner;
+    }
+
+    public void SetRequest(HttpProtocol context)
+    {
+        _context = context;
+    }
+
+    public override bool CanGetUnflushedBytes => _inner.CanGetUnflushedBytes;
+
+    public override long UnflushedBytes => _inner.UnflushedBytes;
+
+    private void CheckStatus()
+    {
+        Debug.Assert(_context != null);
+        if (_context.StatusCode < 300)
+        {
+            throw new InvalidOperationException(CoreStrings.ConnectResponseCanNotHaveBody);
+        }
+    }
+
+    public override void Advance(int bytes)
+    {
+        CheckStatus();
+        _inner.Advance(bytes);
+    }
+
+    public override void CancelPendingFlush()
+    {
+        CheckStatus();
+        _inner.CancelPendingFlush();
+    }
+
+    public override void Complete(Exception? exception = null)
+    {
+        CheckStatus();
+        _inner.Complete(exception);
+    }
+
+    public override ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default)
+    {
+        CheckStatus();
+        return _inner.FlushAsync(cancellationToken);
+    }
+
+    public override Memory<byte> GetMemory(int sizeHint = 0)
+    {
+        CheckStatus();
+        return _inner.GetMemory(sizeHint);
+    }
+
+    public override Span<byte> GetSpan(int sizeHint = 0)
+    {
+        CheckStatus();
+        return _inner.GetSpan(sizeHint);
+    }
+
+    public override Stream AsStream(bool leaveOpen = false)
+    {
+        CheckStatus();
+        return _inner.AsStream(leaveOpen);
+    }
+
+    public override ValueTask CompleteAsync(Exception? exception = null)
+    {
+        CheckStatus();
+        return _inner.CompleteAsync(exception);
+    }
+
+    public override ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
+    {
+        CheckStatus();
+        return _inner.WriteAsync(source, cancellationToken);
+    }
+}

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/StatusCheckWriteStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/StatusCheckWriteStream.cs
@@ -27,7 +27,7 @@ internal sealed class StatusCheckWriteStream : WriteOnlyStream
         Debug.Assert(_context != null);
         if (_context.StatusCode < 300)
         {
-            throw new InvalidOperationException(CoreStrings.ConnectResponseCanNotHaveBody);
+            throw new InvalidOperationException(CoreStrings.FormatConnectResponseCanNotHaveBody(_context.StatusCode));
         }
     }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/StatusCheckWriteStream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/StatusCheckWriteStream.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+
+// Used for CONNECT responses that can't have a body for 2XX responses.
+internal sealed class StatusCheckWriteStream : WriteOnlyStream
+{
+    private readonly Stream _inner;
+    private HttpProtocol? _context;
+
+    public StatusCheckWriteStream(Stream inner)
+    {
+        _inner = inner;
+    }
+
+    public void SetRequest(HttpProtocol context)
+    {
+        _context = context;
+    }
+
+    private void CheckStatus()
+    {
+        Debug.Assert(_context != null);
+        if (_context.StatusCode < 300)
+        {
+            throw new InvalidOperationException(CoreStrings.ConnectResponseCanNotHaveBody);
+        }
+    }
+
+    public override bool CanSeek => _inner.CanSeek;
+
+    public override bool CanWrite => _inner.CanWrite;
+
+    public override bool CanTimeout => _inner.CanTimeout;
+
+    public override long Length => _inner.Length;
+
+    public override long Position
+    {
+        get => _inner.Position;
+        set => _inner.Position = value;
+    }
+
+    public override int WriteTimeout
+    {
+        get => _inner.WriteTimeout;
+        set => _inner.WriteTimeout = value;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void SetLength(long value)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void Flush()
+    {
+        CheckStatus();
+        _inner.Flush();
+    }
+
+    public override Task FlushAsync(CancellationToken cancellationToken)
+    {
+        CheckStatus();
+        return _inner.FlushAsync(cancellationToken);
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        CheckStatus();
+        _inner.Write(buffer, offset, count);
+    }
+
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        CheckStatus();
+        return _inner.WriteAsync(buffer, offset, count, cancellationToken);
+    }
+
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
+    {
+        CheckStatus();
+        return _inner.WriteAsync(source, cancellationToken);
+    }
+
+    public override void WriteByte(byte value)
+    {
+        CheckStatus();
+        _inner.WriteByte(value);
+    }
+
+    public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
+    {
+        CheckStatus();
+        return _inner.BeginWrite(buffer, offset, count, callback, state);
+    }
+
+    public override void EndWrite(IAsyncResult asyncResult)
+        => _inner.EndWrite(asyncResult);
+
+    public override void Close()
+    {
+        CheckStatus();
+        _inner.Close();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _inner.Dispose();
+        }
+    }
+}

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/ThrowingPipeWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/ThrowingPipeWriter.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Pipelines;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+
+internal sealed class ThrowingPipeWriter : PipeWriter
+{
+    private readonly string _message;
+
+    public ThrowingPipeWriter(string message)
+    {
+        _message = message;
+    }
+
+    public override void Advance(int bytes) => throw new InvalidOperationException(_message);
+
+    public override void CancelPendingFlush() => throw new InvalidOperationException(_message);
+
+    public override void Complete(Exception? exception = null) => throw new InvalidOperationException(_message);
+
+    public override ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default) => throw new InvalidOperationException(_message);
+
+    public override Memory<byte> GetMemory(int sizeHint = 0) => throw new InvalidOperationException(_message);
+
+    public override Span<byte> GetSpan(int sizeHint = 0) => throw new InvalidOperationException(_message);
+}

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/WrappingPipeWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/WrappingPipeWriter.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Pipelines;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+
+internal sealed class WrappingPipeWriter : PipeWriter
+{
+    private PipeWriter _inner;
+
+    public WrappingPipeWriter(PipeWriter inner)
+    {
+        _inner = inner;
+    }
+
+    public void SetInnerPipe(PipeWriter inner)
+    {
+        _inner = inner;
+    }
+
+    public override bool CanGetUnflushedBytes => _inner.CanGetUnflushedBytes;
+
+    public override long UnflushedBytes => _inner.UnflushedBytes;
+
+    public override void Advance(int bytes)
+    {
+        _inner.Advance(bytes);
+    }
+
+    public override void CancelPendingFlush()
+    {
+        _inner.CancelPendingFlush();
+    }
+
+    public override void Complete(Exception? exception = null)
+    {
+        _inner.Complete(exception);
+    }
+
+    public override ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default)
+    {
+        return _inner.FlushAsync(cancellationToken);
+    }
+
+    public override Memory<byte> GetMemory(int sizeHint = 0)
+    {
+        return _inner.GetMemory(sizeHint);
+    }
+
+    public override Span<byte> GetSpan(int sizeHint = 0)
+    {
+        return _inner.GetSpan(sizeHint);
+    }
+
+    public override Stream AsStream(bool leaveOpen = false)
+    {
+        return _inner.AsStream(leaveOpen);
+    }
+
+    public override ValueTask CompleteAsync(Exception? exception = null)
+    {
+        return _inner.CompleteAsync(exception);
+    }
+
+    public override ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
+    {
+        return _inner.WriteAsync(source, cancellationToken);
+    }
+}

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -1166,7 +1166,7 @@ public class Http2TestBase : TestApplicationErrorLoggerLoggedTest, IDisposable, 
         }
     }
 
-    internal async Task<Http2FrameWithPayload> ReceiveFrameAsync(uint maxFrameSize = Http2PeerSettings.DefaultMaxFrameSize)
+    internal async Task<Http2FrameWithPayload> ReceiveFrameAsync(uint maxFrameSize = uint.MaxValue)
     {
         var frame = new Http2FrameWithPayload();
 
@@ -1208,7 +1208,7 @@ public class Http2TestBase : TestApplicationErrorLoggerLoggedTest, IDisposable, 
 
     internal async Task<Http2FrameWithPayload> ExpectAsync(Http2FrameType type, int withLength, byte withFlags, int withStreamId)
     {
-        var frame = await ReceiveFrameAsync((uint)withLength);
+        var frame = await ReceiveFrameAsync();
 
         Assert.Equal(type, frame.Type);
         Assert.Equal(withStreamId, frame.StreamId);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2WebSocketTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2WebSocketTests.cs
@@ -171,6 +171,7 @@ public class Http2WebSocketTests : Http2TestBase
 
             Assert.Equal(0, await context.Request.Body.ReadAsync(new byte[1]));
 
+            context.Response.StatusCode = StatusCodes.Status201Created; // Any 2XX should work
             var stream = await connectFeature.AcceptAsync();
             Assert.Equal(0, await stream.ReadAsync(new byte[1]));
             await stream.WriteAsync(new byte[] { 0x01 });
@@ -203,7 +204,7 @@ public class Http2WebSocketTests : Http2TestBase
         await SendDataAsync(1, Array.Empty<byte>(), endStream: true);
 
         var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
-            withLength: 32,
+            withLength: 36,
             withFlags: (byte)Http2HeadersFrameFlags.END_HEADERS,
             withStreamId: 1);
 
@@ -211,7 +212,7 @@ public class Http2WebSocketTests : Http2TestBase
 
         Assert.Equal(2, _decodedHeaders.Count);
         Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
-        Assert.Equal("200", _decodedHeaders[InternalHeaderNames.Status]);
+        Assert.Equal("201", _decodedHeaders[InternalHeaderNames.Status]);
 
         var dataFrame = await ExpectAsync(Http2FrameType.DATA,
             withLength: 1,
@@ -246,7 +247,7 @@ public class Http2WebSocketTests : Http2TestBase
 
         Assert.Equal(2, _decodedHeaders.Count);
         Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
-        Assert.Equal("200", _decodedHeaders[InternalHeaderNames.Status]);
+        Assert.Equal("201", _decodedHeaders[InternalHeaderNames.Status]);
 
         dataFrame = await ExpectAsync(Http2FrameType.DATA,
             withLength: 1,

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2WebSocketTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2WebSocketTests.cs
@@ -439,18 +439,18 @@ public class Http2WebSocketTests : Http2TestBase
             // We could throw, but no-oping is adequate.
             Assert.Equal(0, await context.Request.Body.ReadAsync(new byte[1]));
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => context.Response.Body.WriteAsync(new byte[1] { 0x00 }).AsTask());
-            Assert.Equal(CoreStrings.ConnectResponseCanNotHaveBody, ex.Message);
+            Assert.Equal(CoreStrings.FormatConnectResponseCanNotHaveBody(200), ex.Message);
             ex = await Assert.ThrowsAsync<InvalidOperationException>(() => context.Response.BodyWriter.WriteAsync(new byte[1] { 0x00 }).AsTask());
-            Assert.Equal(CoreStrings.ConnectResponseCanNotHaveBody, ex.Message);
+            Assert.Equal(CoreStrings.FormatConnectResponseCanNotHaveBody(200), ex.Message);
 
             var stream = await connectFeature.AcceptAsync();
 
             // The body streams still shouldn't work after Accept
             Assert.Equal(0, await context.Request.Body.ReadAsync(new byte[1]));
             ex = await Assert.ThrowsAsync<InvalidOperationException>(() => context.Response.Body.WriteAsync(new byte[1] { 0x00 }).AsTask());
-            Assert.Equal(CoreStrings.ConnectResponseCanNotHaveBody, ex.Message);
+            Assert.Equal(CoreStrings.FormatConnectResponseCanNotHaveBody(200), ex.Message);
             ex = await Assert.ThrowsAsync<InvalidOperationException>(() => context.Response.BodyWriter.WriteAsync(new byte[1] { 0x00 }).AsTask());
-            Assert.Equal(CoreStrings.ConnectResponseCanNotHaveBody, ex.Message);
+            Assert.Equal(CoreStrings.FormatConnectResponseCanNotHaveBody(200), ex.Message);
 
             // The connect stream should work
             Assert.Equal(1, await stream.ReadAsync(new byte[1]));

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2WebSocketTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2WebSocketTests.cs
@@ -1,19 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
-using System.Net.Http;
-using System.Net.Http.HPack;
-using System.Runtime.ExceptionServices;
-using System.Text;
-using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Testing;
-using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
 using Moq;
 
@@ -65,8 +57,7 @@ public class Http2WebSocketTests : Http2TestBase
             new KeyValuePair<string, string>(HeaderNames.SecWebSocketVersion, "13"),
             new KeyValuePair<string, string>(HeaderNames.Origin, "http://www.example.com"),
         };
-        await SendHeadersAsync(1, Http2HeadersFrameFlags.END_HEADERS, headers);
-        await SendDataAsync(1, Array.Empty<byte>(), endStream: true);
+        await SendHeadersAsync(1, Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM, headers);
 
         var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
             withLength: 32,
@@ -429,6 +420,136 @@ public class Http2WebSocketTests : Http2TestBase
             withFlags: (byte)Http2DataFrameFlags.NONE,
             withStreamId: 1);
         Assert.Equal(0x01, dataFrame.Payload.Span[0]);
+
+        dataFrame = await ExpectAsync(Http2FrameType.DATA,
+            withLength: 0,
+            withFlags: (byte)Http2DataFrameFlags.END_STREAM,
+            withStreamId: 1);
+
+        await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+    }
+
+    [Fact]
+    public async Task ExtendedCONNECTMethod_DoesNotProvideUsableBodyStreams()
+    {
+        await InitializeConnectionAsync(async context =>
+        {
+            var connectFeature = context.Features.Get<IHttpExtendedConnectFeature>();
+            // We could throw, but no-oping is adequate.
+            Assert.Equal(0, await context.Request.Body.ReadAsync(new byte[1]));
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => context.Response.Body.WriteAsync(new byte[1] { 0x00 }).AsTask());
+            Assert.Equal(CoreStrings.ConnectResponseCanNotHaveBody, ex.Message);
+            ex = await Assert.ThrowsAsync<InvalidOperationException>(() => context.Response.BodyWriter.WriteAsync(new byte[1] { 0x00 }).AsTask());
+            Assert.Equal(CoreStrings.ConnectResponseCanNotHaveBody, ex.Message);
+
+            var stream = await connectFeature.AcceptAsync();
+
+            // The body streams still shouldn't work after Accept
+            Assert.Equal(0, await context.Request.Body.ReadAsync(new byte[1]));
+            ex = await Assert.ThrowsAsync<InvalidOperationException>(() => context.Response.Body.WriteAsync(new byte[1] { 0x00 }).AsTask());
+            Assert.Equal(CoreStrings.ConnectResponseCanNotHaveBody, ex.Message);
+            ex = await Assert.ThrowsAsync<InvalidOperationException>(() => context.Response.BodyWriter.WriteAsync(new byte[1] { 0x00 }).AsTask());
+            Assert.Equal(CoreStrings.ConnectResponseCanNotHaveBody, ex.Message);
+
+            // The connect stream should work
+            Assert.Equal(1, await stream.ReadAsync(new byte[1]));
+            await stream.WriteAsync(new byte[] { 0x01 });
+        });
+
+        var headers = new[]
+        {
+            new KeyValuePair<string, string>(InternalHeaderNames.Method, "CONNECT"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Protocol, "websocket"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Path, "/chat"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Authority, "server.example.com"),
+            new KeyValuePair<string, string>(HeaderNames.WebSocketSubProtocols, "chat, superchat"),
+            new KeyValuePair<string, string>(HeaderNames.SecWebSocketExtensions, "permessage-deflate"),
+            new KeyValuePair<string, string>(HeaderNames.SecWebSocketVersion, "13"),
+            new KeyValuePair<string, string>(HeaderNames.Origin, "http://www.example.com"),
+        };
+        await SendHeadersAsync(1, Http2HeadersFrameFlags.END_HEADERS, headers);
+
+        await SendDataAsync(1, new byte[10241], endStream: true);
+
+        var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+            withLength: 32,
+            withFlags: (byte)Http2HeadersFrameFlags.END_HEADERS,
+            withStreamId: 1);
+
+        _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+        Assert.Equal(2, _decodedHeaders.Count);
+        Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal("200", _decodedHeaders[InternalHeaderNames.Status]);
+
+        var dataFrame = await ExpectAsync(Http2FrameType.DATA,
+            withLength: 1,
+            withFlags: (byte)Http2DataFrameFlags.NONE,
+            withStreamId: 1);
+        Assert.Equal(0x01, dataFrame.Payload.Span[0]);
+
+        dataFrame = await ExpectAsync(Http2FrameType.DATA,
+            withLength: 0,
+            withFlags: (byte)Http2DataFrameFlags.END_STREAM,
+            withStreamId: 1);
+
+        await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+    }
+
+    [Fact]
+    public async Task ExtendedCONNECTMethod_CanHaveNon200ResponseWithBody()
+    {
+        await InitializeConnectionAsync(async context =>
+        {
+            var connectFeature = context.Features.Get<IHttpExtendedConnectFeature>();
+            Assert.True(connectFeature.IsExtendedConnect);
+
+            context.Response.StatusCode = Http.StatusCodes.Status418ImATeapot;
+            context.Response.ContentLength = 2;
+            await context.Response.Body.WriteAsync(new byte[1] { 0x01 });
+            await context.Response.BodyWriter.WriteAsync(new byte[1] { 0x02 });
+        });
+
+        var headers = new[]
+        {
+            new KeyValuePair<string, string>(InternalHeaderNames.Method, "CONNECT"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Protocol, "websocket"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Path, "/chat"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Authority, "server.example.com"),
+            new KeyValuePair<string, string>(HeaderNames.WebSocketSubProtocols, "chat, superchat"),
+            new KeyValuePair<string, string>(HeaderNames.SecWebSocketExtensions, "permessage-deflate"),
+            new KeyValuePair<string, string>(HeaderNames.SecWebSocketVersion, "13"),
+            new KeyValuePair<string, string>(HeaderNames.Origin, "http://www.example.com"),
+        };
+        await SendHeadersAsync(1, Http2HeadersFrameFlags.END_HEADERS, headers);
+
+        await SendDataAsync(1, new byte[10241], endStream: true);
+
+        var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+            withLength: 40,
+            withFlags: (byte)Http2HeadersFrameFlags.END_HEADERS,
+            withStreamId: 1);
+
+        _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+        Assert.Equal(3, _decodedHeaders.Count);
+        Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal("418", _decodedHeaders[InternalHeaderNames.Status]);
+        Assert.Equal("2", _decodedHeaders[HeaderNames.ContentLength]);
+
+        var dataFrame = await ExpectAsync(Http2FrameType.DATA,
+            withLength: 1,
+            withFlags: (byte)Http2DataFrameFlags.NONE,
+            withStreamId: 1);
+        Assert.Equal(0x01, dataFrame.Payload.Span[0]);
+
+        dataFrame = await ExpectAsync(Http2FrameType.DATA,
+            withLength: 1,
+            withFlags: (byte)Http2DataFrameFlags.NONE,
+            withStreamId: 1);
+        Assert.Equal(0x02, dataFrame.Payload.Span[0]);
 
         dataFrame = await ExpectAsync(Http2FrameType.DATA,
             withLength: 0,

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/UpgradeTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/UpgradeTests.cs
@@ -31,6 +31,9 @@ public class UpgradeTests : LoggedTest
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => context.Response.Body.WriteAsync(new byte[1], 0, 1));
             Assert.Equal(CoreStrings.ResponseStreamWasUpgraded, ex.Message);
 
+            await Assert.ThrowsAsync<InvalidOperationException>(() => context.Response.BodyWriter.WriteAsync(new byte[1]).AsTask());
+            Assert.Equal(CoreStrings.ResponseStreamWasUpgraded, ex.Message);
+
             using (var writer = new StreamWriter(stream))
             {
                 await writer.WriteLineAsync("New protocol data");


### PR DESCRIPTION
Disallow reading the request body or writing to the response body for H2 CONNECT requests.

## Description

HTTP/2 CONNECT requests use a new protocol implemented in 7.0 to enable WebSockets over HTTP/2. When the request is presented to the application the normal request and response body streams and pipe reader/writers let you interact with it as a normal request. Since CONNECT requests aren't supposed to have a normal request or response body this may cause someone to accidently break the request if they weren't paying attention to the CONNECT. E.g. buffering all the data, or responding with HTML.

Responses with a status code of 300+ are allowed to have a body (e.g. for errors), so we need to check the status code when writing.

I noticed that Upgrades only disabled the Stream, not the PipeWriter, so I did something similar there.

Fixes #43697

## Customer Impact

This helps apps avoid accidentally mishandling a CONNECT request.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

New feature area.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A