### PR TITLE
[release/7.0] HTTP/3: Improve handling of connection timeout

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionContext.cs
@@ -76,7 +76,7 @@ internal partial class QuicConnectionContext : TransportMultiplexedConnection
         lock (_shutdownLock)
         {
             // Check if connection has already been already aborted.
-            if (_abortReason != null)
+            if (_abortReason != null || _closeTask != null)
             {
                 return;
             }
@@ -147,12 +147,26 @@ internal partial class QuicConnectionContext : TransportMultiplexedConnection
         {
             lock (_shutdownLock)
             {
-                // This error should only happen when shutdown has been initiated by the server.
+                // OperationAborted should only happen when shutdown has been initiated by the server.
                 // If there is no abort reason and we have this error then the connection is in an
                 // unexpected state. Abort connection and throw reason error.
                 if (_abortReason == null)
                 {
                     Abort(new ConnectionAbortedException("Unexpected error when accepting stream.", ex));
+                }
+
+                _abortReason!.Throw();
+            }
+        }
+        catch (QuicException ex) when (ex.QuicError == QuicError.ConnectionTimeout)
+        {
+            lock (_shutdownLock)
+            {
+                // ConnectionTimeout can happen when the client app is shutdown without aborting the connection.
+                // For example, a console app makes a HTTP/3 request with HttpClient and then exits without disposing the client.
+                if (_abortReason == null)
+                {
+                    Abort(new ConnectionAbortedException("The connection timed out waiting for a response from the peer.", ex));
                 }
 
                 _abortReason!.Throw();


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/43727

## Description:
 
An HTTP/3 client can make a request to the server and then be shut down without closing the connection. The connection eventually times out on the server. This error trips a debug assert as an unexpected error.

An example of this happening is a console app sending a HTTP/3 request with HttpClient, then the console process is terminated. The server believes the connection is alive until the timeout is reached, at which point this error is thrown.

PR adds a catch for this error type and explicitly aborts the connection with a friendly error message.

## Customer Impact

* Messy Kestrel server logs
* Customers who build Kestrel as debug might trigger assert

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Improved error handling when a connection is already dead.

## Verification

- [x] Manual (required) - Tested with HttpClient in console app
- [ ] Automated - Not possible to easily automate testing because it requires the client app to be terminated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A