### PR TITLE
[release/7.0] Improve error message for ByRef parameter exception

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -647,18 +647,18 @@ public static partial class RequestDelegateFactory
 
         if (parameter.ParameterType.IsByRef)
         {
-            var attribute = string.Empty;
+            var attribute = "ref";
 
             if (parameter.Attributes.HasFlag(ParameterAttributes.In))
             {
-                attribute = "in ";
+                attribute = "in";
             }
             else if (parameter.Attributes.HasFlag(ParameterAttributes.Out))
             {
-                attribute = "out ";
+                attribute = "out";
             }
 
-            throw new NotSupportedException($"The by reference parameter '{attribute}{TypeNameHelper.GetTypeDisplayName(parameter.ParameterType, fullName: false)} {parameter.Name}' is not supported.");
+            throw new NotSupportedException($"The by reference parameter '{attribute} {TypeNameHelper.GetTypeDisplayName(parameter.ParameterType, fullName: false)} {parameter.Name}' is not supported.");
         }
 
         var parameterCustomAttributes = parameter.GetCustomAttributes();

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -645,6 +645,22 @@ public static partial class RequestDelegateFactory
             throw new InvalidOperationException($"Encountered a parameter of type '{parameter.ParameterType}' without a name. Parameters must have a name.");
         }
 
+        if (parameter.ParameterType.IsByRef)
+        {
+            var attribute = string.Empty;
+
+            if (parameter.Attributes.HasFlag(ParameterAttributes.In))
+            {
+                attribute = "in ";
+            }
+            else if (parameter.Attributes.HasFlag(ParameterAttributes.Out))
+            {
+                attribute = "out ";
+            }
+
+            throw new NotSupportedException($"The by reference parameter '{attribute}{TypeNameHelper.GetTypeDisplayName(parameter.ParameterType, fullName: false)} {parameter.Name}' is not supported.");
+        }
+
         var parameterCustomAttributes = parameter.GetCustomAttributes();
 
         if (parameterCustomAttributes.OfType<IFromRouteMetadata>().FirstOrDefault() is { } routeAttribute)

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -2634,6 +2634,22 @@ public class RequestDelegateFactoryTests : LoggedTest
         }
     }
 
+    [Fact]
+    public void BuildRequestDelegateThrowsNotSupportedExceptionForByRefParameters()
+    {
+        void OutMethod(out string foo) { foo = ""; }
+        void InMethod(in string foo) { }
+        void RefMethod(ref string foo) { }
+
+        var outParamException = Assert.Throws<NotSupportedException>(() => RequestDelegateFactory.Create(OutMethod));
+        var inParamException = Assert.Throws<NotSupportedException>(() => RequestDelegateFactory.Create(InMethod));
+        var refParamException = Assert.Throws<NotSupportedException>(() => RequestDelegateFactory.Create(RefMethod));
+
+        Assert.Equal($"The by reference parameter 'out {typeof(string).Name}& foo' is not supported.", outParamException.Message);
+        Assert.Equal($"The by reference parameter 'in {typeof(string).Name}& foo' is not supported.", inParamException.Message);
+        Assert.Equal($"The by reference parameter '{typeof(string).Name}& foo' is not supported.", refParamException.Message);
+    }
+
     [Theory]
     [MemberData(nameof(ImplicitFromServiceActions))]
     public async Task RequestDelegateRequiresServiceForAllImplicitFromServiceParameters(Delegate action)

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -2649,7 +2649,7 @@ public class RequestDelegateFactoryTests : LoggedTest
 
         Assert.Equal($"The by reference parameter 'out {typeName} foo' is not supported.", outParamException.Message);
         Assert.Equal($"The by reference parameter 'in {typeName} foo' is not supported.", inParamException.Message);
-        Assert.Equal($"The by reference parameter '{typeName} foo' is not supported.", refParamException.Message);
+        Assert.Equal($"The by reference parameter 'ref  {typeName} foo' is not supported.", refParamException.Message);
     }
 
     [Theory]

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -2649,7 +2649,7 @@ public class RequestDelegateFactoryTests : LoggedTest
 
         Assert.Equal($"The by reference parameter 'out {typeName} foo' is not supported.", outParamException.Message);
         Assert.Equal($"The by reference parameter 'in {typeName} foo' is not supported.", inParamException.Message);
-        Assert.Equal($"The by reference parameter 'ref  {typeName} foo' is not supported.", refParamException.Message);
+        Assert.Equal($"The by reference parameter 'ref {typeName} foo' is not supported.", refParamException.Message);
     }
 
     [Theory]

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -2645,9 +2645,11 @@ public class RequestDelegateFactoryTests : LoggedTest
         var inParamException = Assert.Throws<NotSupportedException>(() => RequestDelegateFactory.Create(InMethod));
         var refParamException = Assert.Throws<NotSupportedException>(() => RequestDelegateFactory.Create(RefMethod));
 
-        Assert.Equal($"The by reference parameter 'out {typeof(string).Name}& foo' is not supported.", outParamException.Message);
-        Assert.Equal($"The by reference parameter 'in {typeof(string).Name}& foo' is not supported.", inParamException.Message);
-        Assert.Equal($"The by reference parameter '{typeof(string).Name}& foo' is not supported.", refParamException.Message);
+        var typeName = typeof(string).MakeByRefType().Name;
+
+        Assert.Equal($"The by reference parameter 'out {typeName} foo' is not supported.", outParamException.Message);
+        Assert.Equal($"The by reference parameter 'in {typeName} foo' is not supported.", inParamException.Message);
+        Assert.Equal($"The by reference parameter '{typeName} foo' is not supported.", refParamException.Message);
     }
 
     [Theory]

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelMetadata.cs
@@ -545,6 +545,13 @@ public abstract class ModelMetadata : IEquatable<ModelMetadata?>, IModelMetadata
 
     internal static Func<ParameterExpression, Expression, Expression>? FindTryParseMethod(Type modelType)
     {
+        if (modelType.IsByRef)
+        {
+            // ByRef is no supported in this case and
+            // will be reported later for the user.
+            return null;
+        }
+
         modelType = Nullable.GetUnderlyingType(modelType) ?? modelType;
         return ParameterBindingMethodCache.FindTryParseMethod(modelType);
     }

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Metadata/DefaultModelMetadataTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Metadata/DefaultModelMetadataTest.cs
@@ -391,6 +391,27 @@ public class DefaultModelMetadataTest
 
     [Theory]
     [InlineData(typeof(string))]
+    [InlineData(typeof(int))]
+    public void IsParseableType_ReturnsFalse_ForByRefTypes(Type modelType)
+    {
+        // Arrange
+        var provider = new EmptyModelMetadataProvider();
+        var detailsProvider = new EmptyCompositeMetadataDetailsProvider();
+
+        var key = ModelMetadataIdentity.ForType(modelType.MakeByRefType());
+        var cache = new DefaultMetadataDetails(key, new ModelAttributes(Array.Empty<object>(), null, null));
+
+        var metadata = new DefaultModelMetadata(provider, detailsProvider, cache);
+
+        // Act
+        var isParseableType = metadata.IsParseableType;
+
+        // Assert
+        Assert.False(isParseableType);
+    }
+
+    [Theory]
+    [InlineData(typeof(string))]
     [InlineData(typeof(IDisposable))]
     [InlineData(typeof(Nullable<int>))]
     public void IsRequired_ReturnsFalse_ForNullableTypes(Type modelType)


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/43256

## Description

The mechanism to detect Try/Parse method fails when a `ByRef` type with a very obscure message.

```
System.TypeLoadException: Could not load type 'System.Char&' from assembly 'System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e'.
   at System.RuntimeTypeHandle.MakeByRef()
   at System.RuntimeType.MakeByRefType()
   at Microsoft.AspNetCore.Http.ParameterBindingMethodCache.<FindTryParseMethod>g__Finder|15_0(Type type)
```

This change detects if it is a by ref type and:

- Minimal APIs: throws a better error
- MVC: avoid the obscure exception and keep the .NET 6 behavior.

## Customer Impact

Minimal APIs is a very small impact, since it is just an improved error message. In MVC we are avoiding the obscure error and reporting as same as we have in .NET 6.

## Regression?

- [ ] Yes
- [x] No

Not really, the error message is very obscure and does not explain what is wrong.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Very low risk, we're just fixing the error message.

## Verification

- [X] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A