### PR TITLE
[release/7.0] Fix Blazor RemoteAuthenticatorView processing the same action multiple times

### DIFF
--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/RemoteAuthenticatorViewCore.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/RemoteAuthenticatorViewCore.cs
@@ -17,6 +17,7 @@ public partial class RemoteAuthenticatorViewCore<[DynamicallyAccessedMembers(Jso
 {
     private RemoteAuthenticationApplicationPathsOptions _applicationPaths;
     private string _action;
+    private string _lastHandledAction;
     private InteractiveRequestOptions _cachedRequest;
 
     private static readonly NavigationOptions AuthenticationNavigationOptions =
@@ -152,6 +153,13 @@ public partial class RemoteAuthenticatorViewCore<[DynamicallyAccessedMembers(Jso
     /// <inheritdoc />
     protected override async Task OnParametersSetAsync()
     {
+        if (_lastHandledAction == Action)
+        {
+            // Avoid processing the same action more than once.
+            return;
+        }
+
+        _lastHandledAction = Action;
         Log.ProcessingAuthenticatorAction(Logger, Action);
         switch (Action)
         {


### PR DESCRIPTION
# Fix Blazor `RemoteAuthenticatorView` processing the same action multiple times

Fixes an issue where the `<RemoteAuthenticatorView/>` component would sometimes fire the login callback more than once.

## Description

The previous logic processed the current authentication action each time the component was re-rendered. Depending on the authentication service used, this could result in the login callback firing more than once. This PR fixes the problem by caching the last processed action and disabling authentication processing until the action changes.

Fixes #39507

## Customer Impact

It causes difficulty for customers to write their own logic in a way that accounts for login callbacks firing more than once. In addition, other expensive authentication actions may get invoked unnecessarily behind the scenes, which can degrade the experience of the customer's app. Multiple customers have reported being affected by this issue, so fixing it has a relatively high impact.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The fix for this issue is simple, and we have extensive existing test coverage. New tests have been added validating the fix.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A