### PR TITLE
Fix `Path` and `Exception` content in the Problem Details Json

### DIFF
--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddlewareImpl.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddlewareImpl.cs
@@ -179,17 +179,10 @@ internal class DeveloperExceptionPageMiddlewareImpl
                 Status = httpContext.Response.StatusCode
             };
 
-            var exceptionDetails = _exceptionDetailsProvider.GetDetails(errorContext.Exception);
             problemDetails.Extensions["exception"] = new
             {
-                Details = exceptionDetails.Select(d => new
-                {
-                    Message = d.ErrorMessage ?? d.Error?.Message,
-                    Type = TypeNameHelper.GetTypeDisplayName(d.Error),
-                    StackFrames = d.StackFrames,
-                }),
+                Details = errorContext.Exception.ToString(),
                 Headers = httpContext.Request.Headers,
-                Error = errorContext.Exception.ToString(),
                 Path = httpContext.Request.Path.ToString(),
                 Endpoint = httpContext.GetEndpoint()?.ToString(),
                 RouteValues = httpContext.Features.Get<IRouteValuesFeature>()?.RouteValues,

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddlewareImpl.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddlewareImpl.cs
@@ -190,7 +190,7 @@ internal class DeveloperExceptionPageMiddlewareImpl
                 }),
                 Headers = httpContext.Request.Headers,
                 Error = errorContext.Exception.ToString(),
-                Path = httpContext.Request.Path,
+                Path = httpContext.Request.Path.ToString(),
                 Endpoint = httpContext.GetEndpoint()?.ToString(),
                 RouteValues = httpContext.Features.Get<IRouteValuesFeature>()?.RouteValues,
             };


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/43816

## Description

`Developer Exception Middleware` generates a Problem Details with `Request Path` as `object`. This change update it to a `string`.

## Customer Impact

In Preview 7, the `Developer Exception Middleware` was updated to generate a Problem Details, all exception information including the `Request Path`.

``` json
"path": {
    "value": "/throw",
    "hasValue": true
}
```

With this change the `Problem Details` json payload will contains `Path` as `string` instead of `object`.

``` json
"path":  "/throw"
```

## Regression?

- [ ] Yes
- [x] No

It is actually a bug fix.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Very low risk, we're just fixing the generated Problem Details content introduced in .NET 7 Preview 7.

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
