### PR TITLE
Empty template tweaks

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/Client/MainLayout.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/Client/MainLayout.razor
@@ -1,3 +1,5 @@
 ﻿@inherits LayoutComponentBase
 
-<main> @Body </main>
+<main>
+    @Body
+</main>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/Client/wwwroot/css/app.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/Client/wwwroot/css/app.css
@@ -1,3 +1,7 @@
+h1:focus {
+    outline: none;
+}
+
 #blazor-error-ui {
     background: lightyellow;
     bottom: 0;


### PR DESCRIPTION
# Blazor WebAssembly empty template tweaks

The new Blazor WebAssembly empty template has a couple of minor, easily fixable issues.

## Description

1. The indentation inside `MainLayout.razor` is nonstandard
2. We're missing the usual `h1:focus` CSS rule, so when the page first loads, there's a strange black box around everything

Fixes #43869

## Customer Impact

Without these changes, the new project's output looks strange when first loaded in a browser. The fix in this PR just adds the same `h1:focus` CSS rule we use in all the other Blazor projects.

Similarly, the `MainLayout.razor` file has nonstandard layout without this PR.

## Regression?

- [ ] Yes
- [x] No - **the empty template is a new feature in 7.0**

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Spectacularly low risk, as it's only a minor CSS tweak to bring this template more in line with the standard one that's been well proven already.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
