### PR TITLE
[Backport] [SignalR] Avoid unobserved tasks in the .NET client

### DIFF
--- a/eng/targets/CSharp.Common.targets
+++ b/eng/targets/CSharp.Common.targets
@@ -116,7 +116,7 @@
      -->
     <When Condition=" ('$(Nullable)' == 'annotations' OR '$(Nullable)' == 'enable') AND
         '$(SuppressNullableAttributesImport)' != 'true' AND
-        (('$(TargetFrameworkIdentifier)' == '.NETStandard' AND $([MSBuild]::VersionLessThanOrEquals('$(TargetFrameworkVersion)', '2.0'))) OR '$(TargetFrameworkIdentifier)' == '.NETFramework')">
+        (('$(TargetFrameworkIdentifier)' == '.NETStandard' AND $([MSBuild]::VersionLessThanOrEquals('$(TargetFrameworkVersion)', '2.1'))) OR '$(TargetFrameworkIdentifier)' == '.NETFramework')">
       <PropertyGroup>
         <DefineConstants>$(DefineConstants),INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>
         <NoWarn>$(NoWarn);nullable</NoWarn>

--- a/src/Shared/Nullable/NullableAttributes.cs
+++ b/src/Shared/Nullable/NullableAttributes.cs
@@ -5,6 +5,8 @@
 
 namespace System.Diagnostics.CodeAnalysis
 {
+// Attributes added in netstandard2.1
+#if !NETSTANDARD2_1_OR_GREATER
     /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
 #if INTERNAL_NULLABLE_ATTRIBUTES
@@ -126,7 +128,10 @@ namespace System.Diagnostics.CodeAnalysis
         /// <summary>Gets the condition parameter value.</summary>
         public bool ParameterValue { get; }
     }
+#endif
 
+// Attributes added in 5.0
+#if NETSTANDARD || NETFRAMEWORK
     /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
 #if INTERNAL_NULLABLE_ATTRIBUTES
@@ -193,4 +198,5 @@ namespace System.Diagnostics.CodeAnalysis
         /// <summary>Gets field or property member names.</summary>
         public string[] Members { get; }
     }
+#endif
 }

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.Log.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.Log.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.SignalR.Client
 {
     public partial class HubConnection
     {
-        private static class Log
+        private static partial class Log
         {
             private static readonly LogDefineOptions SkipEnabledCheckLogOptions = new() { SkipEnabledCheck = true };
 
@@ -253,6 +253,11 @@ namespace Microsoft.AspNetCore.SignalR.Client
 
             private static readonly Action<ILogger, string, Exception?> _erroredStream =
                 LoggerMessage.Define<string>(LogLevel.Trace, new EventId(84, "ErroredStream"), "Client threw an error for stream '{StreamId}'.");
+
+            [LoggerMessage(87, LogLevel.Trace, "Completion message for stream '{StreamId}' was not sent because the connection is closed.", EventName = "CompletingStreamNotSent")]
+            public static partial void CompletingStreamNotSent(ILogger logger, string streamId);
+
+            // EventId 88 used in 7.0+
 
             public static void PreparingNonBlockingInvocation(ILogger logger, string target, int count)
             {


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/43545

# Avoid unobserved tasks in the .NET client

## Description

When using SignalR to stream data to the server your connection can abruptly disconnect for a variety of reasons (which aren't important here). If this happens the client will try to send a stream completion message to the server which would throw on the client side, but be an unobserved exception.

Fixes #43389

## Customer Impact

Unobserved exceptions can crash certain applications (wpf for example). This change avoids the unobserved exception which avoids potentially crashing client applications.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The change is effectively inlining some code and slightly modifying it so we can avoid throwing an exception which was previously unobserved. Now we are just avoiding throwing the exception.

## Verification

- [ ] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A