### PR TITLE
Explains that AddJsonOptions will use web defaults

### DIFF
--- a/src/Http/Http.Extensions/src/HttpJsonServiceExtensions.cs
+++ b/src/Http/Http.Extensions/src/HttpJsonServiceExtensions.cs
@@ -18,7 +18,7 @@ public static class HttpJsonServiceExtensions
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection" /> to configure options on.</param>
     /// <param name="configureOptions">The <see cref="Action{JsonOptions}"/> to configure the
-    /// <see cref="JsonOptions"/>, uses default values from <c>JsonSerializerDefaults.Web</c>.
+    /// <see cref="JsonOptions"/>, uses default values from <c>JsonSerializerDefaults.Web</c>.</param>
     /// <returns>The modified <see cref="IServiceCollection"/>.</returns>
     public static IServiceCollection ConfigureHttpJsonOptions(this IServiceCollection services, Action<JsonOptions> configureOptions)
     {

--- a/src/Http/Http.Extensions/src/HttpJsonServiceExtensions.cs
+++ b/src/Http/Http.Extensions/src/HttpJsonServiceExtensions.cs
@@ -14,7 +14,7 @@ public static class HttpJsonServiceExtensions
     /// Configures options used for reading and writing JSON when using
     /// <see cref="O:Microsoft.AspNetCore.Http.HttpRequestJsonExtensions.ReadFromJsonAsync" />
     /// and <see cref="O:Microsoft.AspNetCore.Http.HttpResponseJsonExtensions.WriteAsJsonAsync" />.
-    /// <see cref="JsonOptions"/> uses default values from <c>JsonSerializerDefaults.Web</c>
+    /// <see cref="JsonOptions"/> uses default values from <c>JsonSerializerDefaults.Web</c>.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection" /> to configure options on.</param>
     /// <param name="configureOptions">The <see cref="Action{JsonOptions}"/> to configure the

--- a/src/Http/Http.Extensions/src/HttpJsonServiceExtensions.cs
+++ b/src/Http/Http.Extensions/src/HttpJsonServiceExtensions.cs
@@ -14,10 +14,11 @@ public static class HttpJsonServiceExtensions
     /// Configures options used for reading and writing JSON when using
     /// <see cref="O:Microsoft.AspNetCore.Http.HttpRequestJsonExtensions.ReadFromJsonAsync" />
     /// and <see cref="O:Microsoft.AspNetCore.Http.HttpResponseJsonExtensions.WriteAsJsonAsync" />.
+    /// <see cref="JsonOptions"/> uses default values from <c>JsonSerializerDefaults.Web</c>
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection" /> to configure options on.</param>
     /// <param name="configureOptions">The <see cref="Action{JsonOptions}"/> to configure the
-    /// <see cref="JsonOptions"/>.</param>
+    /// <see cref="JsonOptions"/>, uses default values from <c>JsonSerializerDefaults.Web</c>.
     /// <returns>The modified <see cref="IServiceCollection"/>.</returns>
     public static IServiceCollection ConfigureHttpJsonOptions(this IServiceCollection services, Action<JsonOptions> configureOptions)
     {

--- a/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreMvcBuilderExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreMvcBuilderExtensions.cs
@@ -43,7 +43,7 @@ public static class MvcCoreMvcBuilderExtensions
 
     /// <summary>
     /// Configures <see cref="JsonOptions"/> for the specified <paramref name="builder"/>.
-    /// Uses default values from <c>JsonSerializerDefaults.Web</c>
+    /// Uses default values from <c>JsonSerializerDefaults.Web</c>.
     /// </summary>
     /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
     /// <param name="configure">An <see cref="Action"/> to configure the <see cref="JsonOptions"/>.</param>

--- a/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreMvcBuilderExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreMvcBuilderExtensions.cs
@@ -43,6 +43,7 @@ public static class MvcCoreMvcBuilderExtensions
 
     /// <summary>
     /// Configures <see cref="JsonOptions"/> for the specified <paramref name="builder"/>.
+    /// Uses default values from <c>JsonSerializerDefaults.Web</c>
     /// </summary>
     /// <param name="builder">The <see cref="IMvcBuilder"/>.</param>
     /// <param name="configure">An <see cref="Action"/> to configure the <see cref="JsonOptions"/>.</param>


### PR DESCRIPTION
# Explains that AddJsonOptions will use web defaults

## Description

I was confused when I had to explicitly set `PropertyNameCaseInsensitive = false` when the default value for `JsonSerializerOptions.PropertyNameCaseInsensitive` is `false`. Upon looking at the code I can see it is initialised with the `JsonSerializerDefaults.Web` defaults which sets `PropertyNameCaseInsensitive = true`.

Just adding this to the documentation so it's clearer about what will happen.

