### PR TITLE
[Blazor] [WebView] Avoid Base64 encoding because Json Serializer should do that

### DIFF
--- a/src/Components/WebView/WebView/src/IpcSender.cs
+++ b/src/Components/WebView/WebView/src/IpcSender.cs
@@ -29,7 +29,12 @@ internal sealed class IpcSender
         {
             renderBatchWriter.Write(in renderBatch);
         }
-        var message = IpcCommon.Serialize(IpcCommon.OutgoingMessageType.RenderBatch, batchId, Convert.ToBase64String(arrayBuilder.Buffer, 0, arrayBuilder.Count));
+
+        var data = arrayBuilder.Buffer.AsSpan(0, arrayBuilder.Count).ToArray();
+        var message = IpcCommon.Serialize(IpcCommon.OutgoingMessageType.RenderBatch,
+            batchId,
+            data);
+
         DispatchMessageWithErrorHandling(message);
     }
 


### PR DESCRIPTION
# [Blazor] [WebView] Avoid Base64 encoding because Json Serializer should do that

Currently WebView is converting the payload to Base64 and handing over it to the internal Json serializer. In case the payload is quite large, the serialization takes a large amount of time, because the serializer is handling the string value as "normal" and tries to escape the content of the string. This PR is handing over a byte[] to the serializer, so the serializer converters it to Base64 without further check.

Fixes #43867 
