### PR TITLE
Use same language set for .wxl and .json files (#43888)

### DIFF
--- a/eng/common/generate-locproject.ps1
+++ b/eng/common/generate-locproject.ps1
@@ -91,6 +91,7 @@ $locJson = @{
             )
         },
         @{
+            LanguageSet = $LanguageSet
             CloneLanguageSet = "WiX_CloneLanguages"
             LssFiles = @( "wxl_loc.lss" )
             LocItems = @(
@@ -110,7 +111,6 @@ $locJson = @{
                             SourceFile = $sourceFile
                             CopyOption = "LangIDOnPath"
                             OutputPath = $outputPath
-                            Languages = "cs-CZ;de-DE;es-ES;fr-FR;it-IT;ja-JP;ko-KR;pl-PL;pt-BR;ru-RU;tr-TR;zh-CN;zh-TW"
                         }
                     }
                 }


### PR DESCRIPTION
- translation infrastructure works better when `Projects` elements use same languages
  - previous use of two+two codes were an unnecessary complication and cover the same languages
- `WiX_CloneLanguages` already updated on loc side to use the default two-letter language codes