### PR TITLE
Fix double dispatch on linux

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketSenderPool.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketSenderPool.cs
@@ -20,6 +20,8 @@ internal sealed class SocketSenderPool : IDisposable
         _scheduler = scheduler;
     }
 
+    public PipeScheduler Scheduler => _scheduler;
+
     public SocketSender Rent()
     {
         if (_queue.TryDequeue(out var sender))

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionContextFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionContextFactory.cs
@@ -48,7 +48,7 @@ public sealed class SocketConnectionContextFactory : IDisposable
         var maxWriteBufferSize = _options.MaxWriteBufferSize ?? 0;
         var applicationScheduler = options.UnsafePreferInlineScheduling ? PipeScheduler.Inline : PipeScheduler.ThreadPool;
 
-        // Socket callbacks run on the threads polling for IO if we're using the old thread windows thread pool
+        // Socket callbacks run on the threads polling for IO if we're using the old Windows thread pool
         var dispatchSocketCallbacks = OperatingSystem.IsWindows() &&
                                       (Environment.GetEnvironmentVariable("DOTNET_ThreadPool_UsePortableThreadPoolForIO") == "0" ||
                                       Environment.GetEnvironmentVariable("COMPlus_ThreadPool_UsePortableThreadPoolForIO") == "0");


### PR DESCRIPTION
- Fixing a regression introduced into linux sockets workloads when removing double dispatching on windows. We only want to dispatch by default if we're running on the old windows IO threadpool.

New version of https://github.com/dotnet/aspnetcore/pull/43849