### PR TITLE
Retry Tests

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -21,9 +21,6 @@
     {"testName": {"contains": "MvcTemplate_IdentityWeb_SingleOrg_BuildsAndPublishes"}},
     {"testName": {"contains": "WebApiTemplateCSharp_IdentityWeb_IndividualB2C_BuildsAndPublishes"}},
     {"testName": {"contains": "WebApiTemplateCSharp_IdentityWeb_SingleOrg_BuildsAndPublishes"}},
-    
-    
-    
     {"testAssembly": {"contains": "IIS"}},
     {"failureMessage": {"contains":"(Site is started but no worker process found)"}},
     {"failureMessage": {"contains": "network disconnected"}}

--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -16,6 +16,14 @@
     {"testName": {"contains": "BidirectionalStream_ServerReadsDataAndCompletes_GracefullyClosed"}},
     {"testName": {"contains": "POST_ServerAbort_ClientReceivesAbort"}},
     {"testName": {"contains": "POST_ServerAbortAfterWrite_ClientReceivesAbort"}},
+    {"testName": {"contains": "BlazorWasmHostedTemplate_IndividualAuth_NoHttps_Works_WithOutLocalDB"}},
+    {"testName": {"contains": "MvcTemplate_IdentityWeb_SingleOrg_NoHttps_BuildsAndPublishes"}},
+    {"testName": {"contains": "MvcTemplate_IdentityWeb_SingleOrg_BuildsAndPublishes"}},
+    {"testName": {"contains": "WebApiTemplateCSharp_IdentityWeb_IndividualB2C_BuildsAndPublishes"}},
+    {"testName": {"contains": "WebApiTemplateCSharp_IdentityWeb_SingleOrg_BuildsAndPublishes"}},
+    
+    
+    
     {"testAssembly": {"contains": "IIS"}},
     {"failureMessage": {"contains":"(Site is started but no worker process found)"}},
     {"failureMessage": {"contains": "network disconnected"}}


### PR DESCRIPTION
BlazorWasmHostedTemplate_IndividualAuth_NoHttps_Works_WithOutLocalDB: https://dev.azure.com/dnceng-public/public/_build/results?buildId=11288&view=ms.vss-test-web.build-test-results-tab&runId=221798&resultId=124695&paneView=debug

```
Project  failed to publish. Exit code 1.
/datadisks/disk1/work/A1A708EE/p/dotnet-cli/dotnet publish --no-restore -c Release /bl
StdErr:
StdOut: MSBuild version 17.4.0-preview-22451-06+2db11c256 for .NET
/datadisks/disk1/work/A1A708EE/p/dotnet-cli/sdk/7.0.100-rc.2.22457.6/MSBuild.dll -maxcpucount -property:_IsPublishing=true -property:Configuration=Release -target:Publish -verbosity:m /bl ./AspNet.Fqcnlmbwe5nj.Server.csproj
/datadisks/disk1/work/A1A708EE/p/dotnet-cli/sdk/7.0.100-rc.2.22457.6/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(219,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/datadisks/disk1/work/A1A708EE/w/A3B508F0/e/Templates/BaseFolder/AspNet.Fqcnlmbwe5nj/Server/AspNet.Fqcnlmbwe5nj.Server.csproj]
/datadisks/disk1/work/A1A708EE/p/dotnet-cli/sdk/7.0.100-rc.2.22457.6/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(219,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/datadisks/disk1/work/A1A708EE/w/A3B508F0/e/Templates/BaseFolder/AspNet.Fqcnlmbwe5nj/Shared/AspNet.Fqcnlmbwe5nj.Shared.csproj]
AspNet.Fqcnlmbwe5nj.Shared -> /datadisks/disk1/work/A1A708EE/w/A3B508F0/e/Templates/BaseFolder/AspNet.Fqcnlmbwe5nj/Shared/bin/Release/net7.0/AspNet.Fqcnlmbwe5nj.Shared.dll
AspNet.Fqcnlmbwe5nj.Client -> /datadisks/disk1/work/A1A708EE/w/A3B508F0/e/Templates/BaseFolder/AspNet.Fqcnlmbwe5nj/Client/bin/Release/net7.0/AspNet.Fqcnlmbwe5nj.Client.dll
AspNet.Fqcnlmbwe5nj.Client (Blazor output) -> /datadisks/disk1/work/A1A708EE/w/A3B508F0/e/Templates/BaseFolder/AspNet.Fqcnlmbwe5nj/Client/bin/Release/net7.0/wwwroot
AspNet.Fqcnlmbwe5nj.Server -> /datadisks/disk1/work/A1A708EE/w/A3B508F0/e/Templates/BaseFolder/AspNet.Fqcnlmbwe5nj/Server/bin/Release/net7.0/AspNet.Fqcnlmbwe5nj.Server.dll
Optimizing assemblies for size may change the behavior of the app. Be sure to test after publishing. See: https://aka.ms/dotnet-illink
Compressing Blazor WebAssembly publish artifacts. This may take a while...
AspNet.Fqcnlmbwe5nj.Server -> /datadisks/disk1/work/A1A708EE/w/A3B508F0/e/Templates/BaseFolder/AspNet.Fqcnlmbwe5nj/Server/bin/Release/net7.0/publish/

Expected: True
Actual:   False
```

MvcTemplate_IdentityWeb_SingleOrg_NoHttps_BuildsAndPublishes: https://dev.azure.com/dnceng-public/public/_build/results?buildId=11381&view=ms.vss-test-web.build-test-results-tab&runId=223828&resultId=121563&paneView=debug

```
Project new mvc  --auth SingleOrg --use-program-main --called-api-url "https://graph.microsoft.com" --called-api-scopes user.readwrite --no-https failed to publish. Exit code 1.
/private/tmp/helix/working/AFB709CC/p/dotnet-cli/dotnet publish --no-restore -c Release /bl
StdErr:
StdOut: MSBuild version 17.4.0-preview-22451-06+2db11c256 for .NET
/private/tmp/helix/working/AFB709CC/p/dotnet-cli/sdk/7.0.100-rc.2.22457.6/MSBuild.dll -maxcpucount -property:_IsPublishing=true -property:Configuration=Release -target:Publish -verbosity:m /bl ./AspNet.zlsah5a1w4no.csproj
/private/tmp/helix/working/AFB709CC/p/dotnet-cli/sdk/7.0.100-rc.2.22457.6/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(219,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/private/tmp/helix/working/AFB709CC/w/B21709A2/e/Templates/BaseFolder/AspNet.zlsah5a1w4no/AspNet.zlsah5a1w4no.csproj]
AspNet.zlsah5a1w4no -> /private/tmp/helix/working/AFB709CC/w/B21709A2/e/Templates/BaseFolder/AspNet.zlsah5a1w4no/bin/Release/net7.0/AspNet.zlsah5a1w4no.dll

Expected: True
Actual:   False
```

MvcTemplate_IdentityWeb_SingleOrg_BuildsAndPublishes: https://dev.azure.com/dnceng-public/public/_build/results?buildId=11599&view=ms.vss-test-web.build-test-results-tab&runId=230462&resultId=121564&paneView=debug

```
Project new mvc  --auth SingleOrg --calls-graph failed to publish. Exit code 1.
/datadisks/disk1/work/9D6F08B6/p/dotnet-cli/dotnet publish --no-restore -c Release /bl
StdErr:
StdOut: MSBuild version 17.4.0-preview-22451-06+2db11c256 for .NET
/datadisks/disk1/work/9D6F08B6/p/dotnet-cli/sdk/7.0.100-rc.2.22457.6/MSBuild.dll -maxcpucount -property:_IsPublishing=true -property:Configuration=Release -target:Publish -verbosity:m /bl ./AspNet.hl4yomwfnes0.csproj
/datadisks/disk1/work/9D6F08B6/p/dotnet-cli/sdk/7.0.100-rc.2.22457.6/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(219,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/datadisks/disk1/work/9D6F08B6/w/B6190A3D/e/Templates/BaseFolder/AspNet.hl4yomwfnes0/AspNet.hl4yomwfnes0.csproj]
AspNet.hl4yomwfnes0 -> /datadisks/disk1/work/9D6F08B6/w/B6190A3D/e/Templates/BaseFolder/AspNet.hl4yomwfnes0/bin/Release/net7.0/AspNet.hl4yomwfnes0.dll
AspNet.hl4yomwfnes0 -> /datadisks/disk1/work/9D6F08B6/w/B6190A3D/e/Templates/BaseFolder/AspNet.hl4yomwfnes0/bin/Release/net7.0/publish/

Expected: True
Actual:   False
```


WebApiTemplateCSharp_IdentityWeb_IndividualB2C_BuildsAndPublishes: https://dev.azure.com/dnceng-public/public/_build/results?buildId=11907&view=ms.vss-test-web.build-test-results-tab&runId=238280&resultId=121588&paneView=debug

```
Project new webapi  --auth IndividualB2C --use-minimal-apis failed to publish. Exit code 1.
/private/tmp/helix/working/AD6F0958/p/dotnet-cli/dotnet publish --no-restore -c Release /bl
StdErr:
StdOut: MSBuild version 17.4.0-preview-22451-06+2db11c256 for .NET
/private/tmp/helix/working/AD6F0958/p/dotnet-cli/sdk/7.0.100-rc.2.22457.6/MSBuild.dll -maxcpucount -property:_IsPublishing=true -property:Configuration=Release -target:Publish -verbosity:m /bl ./AspNet.lwob5jnd4xdw.csproj
/private/tmp/helix/working/AD6F0958/p/dotnet-cli/sdk/7.0.100-rc.2.22457.6/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(219,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/private/tmp/helix/working/AD6F0958/w/97DA0916/e/Templates/BaseFolder/AspNet.lwob5jnd4xdw/AspNet.lwob5jnd4xdw.csproj]
AspNet.lwob5jnd4xdw -> /private/tmp/helix/working/AD6F0958/w/97DA0916/e/Templates/BaseFolder/AspNet.lwob5jnd4xdw/bin/Release/net7.0/AspNet.lwob5jnd4xdw.dll
AspNet.lwob5jnd4xdw -> /private/tmp/helix/working/AD6F0958/w/97DA0916/e/Templates/BaseFolder/AspNet.lwob5jnd4xdw/bin/Release/net7.0/publish/

Expected: True
Actual:   False
```

WebApiTemplateCSharp_IdentityWeb_SingleOrg_BuildsAndPublishes: https://dev.azure.com/dnceng-public/public/_build/results?buildId=12886&view=ms.vss-test-web.build-test-results-tab&runId=254464&resultId=121586&paneView=debug

```
Project new webapi  --auth SingleOrg --calls-graph failed to build. Exit code 1.
/private/tmp/helix/working/BE520A33/p/dotnet-cli/dotnet build --no-restore -c Debug /bl
StdErr:
StdOut: MSBuild version 17.4.0-preview-22451-06+2db11c256 for .NET
/private/tmp/helix/working/BE520A33/p/dotnet-cli/sdk/7.0.100-rc.2.22457.6/MSBuild.dll -consoleloggerparameters:Summary -maxcpucount -property:Configuration=Debug -verbosity:m /bl ./AspNet.tuny5gtl4h3v.csproj
/private/tmp/helix/working/BE520A33/p/dotnet-cli/sdk/7.0.100-rc.2.22457.6/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(219,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/private/tmp/helix/working/BE520A33/w/B32F0972/e/Templates/BaseFolder/AspNet.tuny5gtl4h3v/AspNet.tuny5gtl4h3v.csproj]
AspNet.tuny5gtl4h3v -> /private/tmp/helix/working/BE520A33/w/B32F0972/e/Templates/BaseFolder/AspNet.tuny5gtl4h3v/bin/Debug/net7.0/AspNet.tuny5gtl4h3v.dll

Expected: True
Actual:   False
```
