### PR TITLE
[7.0] Close connections on client cert failures 

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
@@ -4,6 +4,7 @@
 using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
@@ -13,6 +14,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 internal sealed class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicationProtocolFeature, ITlsHandshakeFeature
 {
     private readonly SslStream _sslStream;
+    private readonly ConnectionContext _context;
     private X509Certificate2? _clientCert;
     private ReadOnlyMemory<byte>? _applicationProtocol;
     private SslProtocols? _protocol;
@@ -24,14 +26,19 @@ internal sealed class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicat
     private int? _keyExchangeStrength;
     private Task<X509Certificate2?>? _clientCertTask;
 
-    public TlsConnectionFeature(SslStream sslStream)
+    public TlsConnectionFeature(SslStream sslStream, ConnectionContext context)
     {
         if (sslStream is null)
         {
             throw new ArgumentNullException(nameof(sslStream));
         }
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
 
         _sslStream = sslStream;
+        _context = context;
     }
 
     internal bool AllowDelayedClientCertificateNegotation { get; set; }
@@ -122,7 +129,19 @@ internal sealed class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicat
 
     private async Task<X509Certificate2?> GetClientCertificateAsyncCore(CancellationToken cancellationToken)
     {
-        await _sslStream.NegotiateClientCertificateAsync(cancellationToken);
+        try
+        {
+            await _sslStream.NegotiateClientCertificateAsync(cancellationToken);
+        }
+        catch (Exception)
+        {
+            // We can't tell which exceptions are fatal or recoverable. Consider them all fatal
+            // and close the connection to avoid over-caching. This allows recovery by starting
+            // a new connection https://github.com/dotnet/aspnetcore/issues/41369
+            _context.Features.Get<IConnectionLifetimeNotificationFeature>()?.RequestClose();
+            throw;
+        }
+
         return ClientCertificate;
     }
 

--- a/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
@@ -133,11 +133,12 @@ internal sealed class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicat
         {
             await _sslStream.NegotiateClientCertificateAsync(cancellationToken);
         }
-        catch (Exception)
+        catch
         {
             // We can't tell which exceptions are fatal or recoverable. Consider them all fatal
-            // and close the connection to avoid over-caching. This allows recovery by starting
-            // a new connection https://github.com/dotnet/aspnetcore/issues/41369
+            // and close the connection to avoid over-caching and affecting future requests on this connection.
+            // This allows recovery by starting a new connection. The close is graceful to allow the server to
+            // send an error response like 401. https://github.com/dotnet/aspnetcore/issues/41369
             _context.Features.Get<IConnectionLifetimeNotificationFeature>()?.RequestClose();
             throw;
         }

--- a/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
@@ -135,8 +135,8 @@ internal sealed class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicat
         }
         catch
         {
-            // We can't tell which exceptions are fatal or recoverable. Consider them all fatal
-            // and close the connection to avoid over-caching and affecting future requests on this connection.
+            // We can't tell which exceptions are fatal or recoverable. Consider them all recoverable only given a new connection
+            // and close the connection gracefully to avoid over-caching and affecting future requests on this connection.
             // This allows recovery by starting a new connection. The close is graceful to allow the server to
             // send an error response like 401. https://github.com/dotnet/aspnetcore/issues/41369
             _context.Features.Get<IConnectionLifetimeNotificationFeature>()?.RequestClose();

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -141,7 +141,7 @@ internal sealed class HttpsConnectionMiddleware
             context.Features.Get<IMemoryPoolFeature>()?.MemoryPool ?? MemoryPool<byte>.Shared);
         var sslStream = sslDuplexPipe.Stream;
 
-        var feature = new Core.Internal.TlsConnectionFeature(sslStream);
+        var feature = new Core.Internal.TlsConnectionFeature(sslStream, context);
         // Set the mode if options were used. If the callback is used it will set the mode later.
         feature.AllowDelayedClientCertificateNegotation =
             _options?.ClientCertificateMode == ClientCertificateMode.DelayCertificate;


### PR DESCRIPTION
Mark the connection for closure if an error occurs while requesting the client certificate.

## Description

Requesting a client certificate after an HTTP request has arrived requires renegotiating the TLS session. Kestrel caches the result for the lifetime of the connection because the operation shouldn't be performed more than once. Renegotiation requires that the TCP connection be clear of request data. If a client cert is requested for a POST request with a large body it will fail because there is still request data in the pipe. However, that failure is recoverable if the data gets drained later, but subsequent requests could be stuck with the cached error.

Because Kestrel doesn't know which errors are recoverable, it should treat all renegotiation errors as non-recoverable by gracefully closing the connection.

I was also able to clean up some adjacent tests for issues that had already been fixed elsewhere.

Fixes #41369

## Customer Impact

This came from an internal partner. It required significant investigation to understand why requests on a given connection were failing. They are able to work around it in 6.0 using the same RequestClose API, but asked us to make this the default behavior to avoid such investigations in the future.

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

This matches the workaround being used.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
