### PR TITLE
Changing to use the non-generic WriteAsJsonAsync

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -62,9 +62,7 @@ public static partial class RequestDelegateFactory
     private static readonly PropertyInfo HeaderIndexerProperty = typeof(IHeaderDictionary).GetProperty("Item")!;
     private static readonly PropertyInfo FormFilesIndexerProperty = typeof(IFormFileCollection).GetProperty("Item")!;
 
-    // Call WriteAsJsonAsync<object?>() to serialize the runtime return type rather than the declared return type.
-    // https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-polymorphism
-    private static readonly MethodInfo JsonResultWriteResponseAsyncMethod = GetMethodInfo<Func<HttpResponse, object?, Task>>((response, value) => HttpResponseJsonExtensions.WriteAsJsonAsync<object?>(response, value, default));
+    private static readonly MethodInfo JsonResultWriteResponseAsyncMethod = typeof(RequestDelegateFactory).GetMethod(nameof(WriteJsonResponse), BindingFlags.NonPublic | BindingFlags.Static)!;
 
     private static readonly MethodInfo LogParameterBindingFailedMethod = GetMethodInfo<Action<HttpContext, string, string, string, bool>>((httpContext, parameterType, parameterName, sourceValue, shouldThrow) =>
         Log.ParameterBindingFailed(httpContext, parameterType, parameterName, sourceValue, shouldThrow));
@@ -1045,11 +1043,11 @@ public static partial class RequestDelegateFactory
         else if (returnType.IsValueType)
         {
             var box = Expression.TypeAs(methodCall, typeof(object));
-            return Expression.Call(JsonResultWriteResponseAsyncMethod, HttpResponseExpr, box, Expression.Constant(CancellationToken.None));
+            return Expression.Call(JsonResultWriteResponseAsyncMethod, HttpResponseExpr, box);
         }
         else
         {
-            return Expression.Call(JsonResultWriteResponseAsyncMethod, HttpResponseExpr, methodCall, Expression.Constant(CancellationToken.None));
+            return Expression.Call(JsonResultWriteResponseAsyncMethod, HttpResponseExpr, methodCall);
         }
     }
 
@@ -1995,8 +1993,7 @@ public static partial class RequestDelegateFactory
         else
         {
             // Otherwise, we JSON serialize when we reach the terminal state
-            // Call WriteAsJsonAsync<object?>() to serialize the runtime return type rather than the declared return type.
-            return httpContext.Response.WriteAsJsonAsync<object?>(obj);
+            return WriteJsonResponse(httpContext.Response, obj);
         }
     }
 
@@ -2006,14 +2003,12 @@ public static partial class RequestDelegateFactory
 
         static async Task ExecuteAwaited(Task<T> task, HttpContext httpContext)
         {
-            // Call WriteAsJsonAsync<object?>() to serialize the runtime return type rather than the declared return type.
-            await httpContext.Response.WriteAsJsonAsync<object?>(await task);
+            await WriteJsonResponse(httpContext.Response, await task);
         }
 
         if (task.IsCompletedSuccessfully)
         {
-            // Call WriteAsJsonAsync<object?>() to serialize the runtime return type rather than the declared return type.
-            return httpContext.Response.WriteAsJsonAsync<object?>(task.GetAwaiter().GetResult());
+            return WriteJsonResponse(httpContext.Response, task.GetAwaiter().GetResult());
         }
 
         return ExecuteAwaited(task, httpContext);
@@ -2096,14 +2091,12 @@ public static partial class RequestDelegateFactory
     {
         static async Task ExecuteAwaited(ValueTask<T> task, HttpContext httpContext)
         {
-            // Call WriteAsJsonAsync<object?>() to serialize the runtime return type rather than the declared return type.
-            await httpContext.Response.WriteAsJsonAsync<object?>(await task);
+            await WriteJsonResponse(httpContext.Response, await task);
         }
 
         if (task.IsCompletedSuccessfully)
         {
-            // Call WriteAsJsonAsync<object?>() to serialize the runtime return type rather than the declared return type.
-            return httpContext.Response.WriteAsJsonAsync<object?>(task.GetAwaiter().GetResult());
+            return WriteJsonResponse(httpContext.Response, task.GetAwaiter().GetResult());
         }
 
         return ExecuteAwaited(task, httpContext);
@@ -2152,6 +2145,21 @@ public static partial class RequestDelegateFactory
     {
         await EnsureRequestResultNotNull(result).ExecuteAsync(httpContext);
     }
+
+    private static Task WriteJsonResponse(HttpResponse response, object? value)
+    {
+        if (value == null)
+        {
+            return HttpResponseJsonExtensions.WriteAsJsonAsync(response, value, default);
+        }
+
+        // Call WriteAsJsonAsync() with the runtime type to serialize the runtime type rather than the declared type
+        // and avoid source generators issues.
+        // https://github.com/dotnet/aspnetcore/issues/43894
+        // https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-polymorphism
+        return HttpResponseJsonExtensions.WriteAsJsonAsync(response, value, value.GetType(), default);
+    }
+
     private static class RequestDelegateFactoryConstants
     {
         public const string RouteAttribute = "Route (Attribute)";

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -2193,7 +2193,7 @@ public static partial class RequestDelegateFactory
         // and avoid source generators issues.
         // https://github.com/dotnet/aspnetcore/issues/43894
         // https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-polymorphism
-        return HttpResponseJsonExtensions.WriteAsJsonAsync(response, value, value?.GetType() ?? typeof(object), default);
+        return HttpResponseJsonExtensions.WriteAsJsonAsync(response, value, value is null ? typeof(object) : value.GetType(), default);
 
     }
 

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -2189,16 +2189,11 @@ public static partial class RequestDelegateFactory
 
     private static Task WriteJsonResponse(HttpResponse response, object? value)
     {
-        if (value == null)
-        {
-            return HttpResponseJsonExtensions.WriteAsJsonAsync(response, value, default);
-        }
-
         // Call WriteAsJsonAsync() with the runtime type to serialize the runtime type rather than the declared type
         // and avoid source generators issues.
         // https://github.com/dotnet/aspnetcore/issues/43894
         // https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-polymorphism
-        return HttpResponseJsonExtensions.WriteAsJsonAsync(response, value, value.GetType(), default);
+        return HttpResponseJsonExtensions.WriteAsJsonAsync(response, value, value?.GetType() ?? typeof(object), default);
 
     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -35,7 +35,7 @@ using Moq;
 
 namespace Microsoft.AspNetCore.Routing.Internal;
 
-public class RequestDelegateFactoryTests : LoggedTest
+public partial class RequestDelegateFactoryTests : LoggedTest
 {
     public static IEnumerable<object[]> NoResult
     {
@@ -3012,6 +3012,46 @@ public class RequestDelegateFactoryTests : LoggedTest
         Assert.NotNull(deserializedResponseBody);
         Assert.Equal("Write even more tests!", deserializedResponseBody!.Name);
         Assert.Equal("With type hierarchies!", deserializedResponseBody!.Child);
+    }
+
+    public static IEnumerable<object[]> JsonContextActions
+    {
+        get
+        {
+            return ComplexResult.Concat(ChildResult);
+        }
+    }
+
+    [JsonSerializable(typeof(Todo))]
+    [JsonSerializable(typeof(TodoChild))]
+    private partial class TestJsonContext : JsonSerializerContext
+    { }
+
+    [Theory]
+    [MemberData(nameof(JsonContextActions))]
+    public async Task RequestDelegateWritesAsJsonResponseBody_WithJsonSerializerContext(Delegate @delegate)
+    {
+        var httpContext = CreateHttpContext();
+        httpContext.RequestServices = new ServiceCollection()
+            .AddSingleton(LoggerFactory)
+            .ConfigureHttpJsonOptions(o => o.SerializerOptions.AddContext<TestJsonContext>())
+            .BuildServiceProvider();
+
+        var responseBodyStream = new MemoryStream();
+        httpContext.Response.Body = responseBodyStream;
+
+        var factoryResult = RequestDelegateFactory.Create(@delegate);
+        var requestDelegate = factoryResult.RequestDelegate;
+
+        await requestDelegate(httpContext);
+
+        var deserializedResponseBody = JsonSerializer.Deserialize<Todo>(responseBodyStream.ToArray(), new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(deserializedResponseBody);
+        Assert.Equal("Write even more tests!", deserializedResponseBody!.Name);
     }
 
     public static IEnumerable<object[]> CustomResults

--- a/src/Http/Http.Results/src/HttpResultsHelper.cs
+++ b/src/Http/Http.Results/src/HttpResultsHelper.cs
@@ -28,11 +28,10 @@ internal static partial class HttpResultsHelper
         }
 
         var declaredType = typeof(T);
-
-        Log.WritingResultAsJson(logger, declaredType.Name);
-
         if (declaredType.IsValueType)
         {
+            Log.WritingResultAsJson(logger, declaredType.Name);
+
             // In this case the polymorphism is not
             // relevant and we don't need to box.
             return httpContext.Response.WriteAsJsonAsync(
@@ -41,8 +40,17 @@ internal static partial class HttpResultsHelper
                         contentType: contentType);
         }
 
-        return httpContext.Response.WriteAsJsonAsync<object?>(
+        var runtimeType = value.GetType();
+
+        Log.WritingResultAsJson(logger, runtimeType.Name);
+
+        // Call WriteAsJsonAsync() with the runtime type to serialize the runtime type rather than the declared type
+        // and avoid source generators issues.
+        // https://github.com/dotnet/aspnetcore/issues/43894
+        // https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-polymorphism
+        return httpContext.Response.WriteAsJsonAsync(
             value,
+            runtimeType,
             options: jsonSerializerOptions,
             contentType: contentType);
     }

--- a/src/Http/Http.Results/test/HttpResultsHelperTests.cs
+++ b/src/Http/Http.Results/test/HttpResultsHelperTests.cs
@@ -1,0 +1,153 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.AspNetCore.Http.HttpResults;
+
+public partial class HttpResultsHelperTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task WriteResultAsJsonAsync_Works_ForValueTypes(bool useJsonContext)
+    {
+        // Arrange
+        var value = new TodoStruct()
+        {
+            Id = 1,
+            IsComplete = true,
+            Name = "Write even more tests!",
+        };
+        var responseBodyStream = new MemoryStream();
+        var httpContext = CreateHttpContext(responseBodyStream, useJsonContext);
+
+        // Act
+        await HttpResultsHelper.WriteResultAsJsonAsync(httpContext, NullLogger.Instance, value);
+
+        // Assert
+        var body = JsonSerializer.Deserialize<TodoStruct>(responseBodyStream.ToArray(), new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.Equal("Write even more tests!", body!.Name);
+        Assert.True(body!.IsComplete);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task WriteResultAsJsonAsync_Works_ForReferenceTypes(bool useJsonContext)
+    {
+        // Arrange
+        var value = new Todo()
+        {
+            Id = 1,
+            IsComplete = true,
+            Name = "Write even more tests!",
+        };
+        var responseBodyStream = new MemoryStream();
+        var httpContext = CreateHttpContext(responseBodyStream, useJsonContext);
+
+        // Act
+        await HttpResultsHelper.WriteResultAsJsonAsync(httpContext, NullLogger.Instance, value);
+
+        // Assert
+        var body = JsonSerializer.Deserialize<Todo>(responseBodyStream.ToArray(), new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(body);
+        Assert.Equal("Write even more tests!", body!.Name);
+        Assert.True(body!.IsComplete);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task WriteResultAsJsonAsync_Works_ForChildTypes(bool useJsonContext)
+    {
+        // Arrange
+        var value = new TodoChild()
+        {
+            Id = 1,
+            IsComplete = true,
+            Name = "Write even more tests!",
+            Child = "With type hierarchies!"
+        };
+        var responseBodyStream = new MemoryStream();
+        var httpContext = CreateHttpContext(responseBodyStream, useJsonContext);
+
+        // Act
+        await HttpResultsHelper.WriteResultAsJsonAsync(httpContext, NullLogger.Instance, value);
+
+        // Assert
+        var body = JsonSerializer.Deserialize<TodoChild>(responseBodyStream.ToArray(), new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(body);
+        Assert.Equal("Write even more tests!", body!.Name);
+        Assert.True(body!.IsComplete);
+        Assert.Equal("With type hierarchies!", body!.Child);
+    }
+
+    private static DefaultHttpContext CreateHttpContext(Stream stream, bool useJsonContext = false)
+        => new()
+        {
+            RequestServices = CreateServices(useJsonContext),
+            Response =
+            {
+                Body = stream,
+            },
+        };
+
+    private static IServiceProvider CreateServices(bool useJsonContext = false)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory, NullLoggerFactory>();
+
+        if (useJsonContext)
+        {
+            services.ConfigureHttpJsonOptions(o => o.SerializerOptions.AddContext<TestJsonContext>());
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    [JsonSerializable(typeof(Todo))]
+    [JsonSerializable(typeof(TodoChild))]
+    [JsonSerializable(typeof(TodoStruct))]
+    private partial class TestJsonContext : JsonSerializerContext
+    { }
+
+    private class Todo
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "Todo";
+        public bool IsComplete { get; set; }
+    }
+
+    private struct TodoStruct
+    {
+        public TodoStruct()
+        {
+        }
+
+        public int Id { get; set; }
+        public string Name { get; set; } = "Todo";
+        public bool IsComplete { get; set; }
+    }
+
+    private class TodoChild : Todo
+    {
+        public string Child { get; set; }
+    }
+}


### PR DESCRIPTION
Fixes #43894

## Description

After changes in how the S.T.J, incorporated in RC1, we are no longer able to use JSON source generators with Minimal APIs without adding `[JsonSerializable(typeof(object))]` to the configured `JsonSerializerContext`. 

https://github.com/dotnet/docs/issues/30755
https://github.com/dotnet/docs/issues/30758

It is happening because we were calling `HttpResponseJsonExtensions.WriteAsJsonAsync<object?>` to keep the polymorphic behavior reported here [#41724 (comment)](https://github.com/dotnet/aspnetcore/issues/41724#issuecomment-1142735823).

In this change we are using the non-generic `HttpResponseJsonExtensions.WriteAsJsonAsync` method and providing the `runtime type` to the JSON Serializer.

## Customer Impact

There is no functional impact compared with what we have behavior the S.T.J changes other than make it works with JSON Source Generators.

## Regression?

- [ ] Yes
- [x] No

It is a bug, the polymorphism behavior will be kept but now Minimal will works with JSON Source Generators .

## Risk

- [ ] High
- [X] Medium
- [ ] Low

## Verification

- [X] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A


cc @eiriktsarpalis @dotnet/area-system-text-json 