### PR TITLE
[release/7.0] Infer response metadata in RequestDelegateFactory

### DIFF
--- a/src/Http/Http.Extensions/src/Microsoft.AspNetCore.Http.Extensions.csproj
+++ b/src/Http/Http.Extensions/src/Microsoft.AspNetCore.Http.Extensions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>ASP.NET Core common extension methods for HTTP abstractions, HTTP headers, HTTP request/response, and session state.</Description>
@@ -17,6 +17,7 @@
     <Compile Include="$(SharedSourceRoot)EndpointMetadataPopulator.cs" LinkBase="Shared"/>
     <Compile Include="$(SharedSourceRoot)PropertyAsParameterInfo.cs" LinkBase="Shared"/>
     <Compile Include="..\..\Shared\StreamCopyOperationInternal.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)ApiExplorerTypes\*.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)RoutingMetadata\AcceptsMetadata.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)TypeNameHelper\TypeNameHelper.cs" LinkBase="Shared"/>
     <Compile Include="$(SharedSourceRoot)ProblemDetails\ProblemDetailsDefaults.cs" LinkBase="Shared" />

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -1812,17 +1812,6 @@ public static partial class RequestDelegateFactory
         return Expression.Convert(boundValueExpr, parameter.ParameterType);
     }
 
-    private static void AddInferredProducesResponseTypeMetadata(RequestDelegateFactoryContext factoryContext, Type type, string[] contentTypes)
-    {
-        if (factoryContext.MetadataAlreadyInferred)
-        {
-            return;
-        }
-
-        // Type cannot be null, and contentTypes is either [ "application/json" ] or [ "text/plain" ] both of which are valid.
-        factoryContext.EndpointBuilder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(type, statusCode: 200, contentTypes));
-    }
-
     private static void AddInferredAcceptsMetadata(RequestDelegateFactoryContext factoryContext, Type type, string[] contentTypes)
     {
         if (factoryContext.MetadataAlreadyInferred)

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -379,7 +379,7 @@ public static partial class RequestDelegateFactory
 
         if (!factoryContext.MetadataAlreadyInferred)
         {
-            PopulateBuiltInResponseTypeMetadata(methodInfo.ReturnType, factoryContext.Parameters, factoryContext.EndpointBuilder);
+            PopulateBuiltInResponseTypeMetadata(methodInfo.ReturnType, factoryContext.EndpointBuilder);
 
             // Add metadata provided by the delegate return type and parameter types next, this will be more specific than inferred metadata from above
             EndpointMetadataPopulator.PopulateMetadata(methodInfo, factoryContext.EndpointBuilder, factoryContext.Parameters);
@@ -928,7 +928,7 @@ public static partial class RequestDelegateFactory
         return Expression.Block(localVariables, checkParamAndCallMethod);
     }
 
-    private static void PopulateBuiltInResponseTypeMetadata(Type returnType, IEnumerable<ParameterInfo> parameters, EndpointBuilder builder)
+    private static void PopulateBuiltInResponseTypeMetadata(Type returnType, EndpointBuilder builder)
     {
         if (returnType.IsByRefLike)
         {
@@ -957,15 +957,6 @@ public static partial class RequestDelegateFactory
         if (returnType == typeof(void) || typeof(IResult).IsAssignableFrom(returnType))
         {
             return;
-        }
-
-        // Skip methods that have HttpContext or HttpResponse parameters that might change the status code from 200.
-        foreach (var parameter in parameters)
-        {
-            if (parameter.ParameterType == typeof(HttpContext) || parameter.ParameterType == typeof(HttpResponse))
-            {
-                return;
-            }
         }
 
         if (returnType == typeof(string))

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -110,8 +110,9 @@ public static partial class RequestDelegateFactory
     private static readonly MemberExpression FilterContextHttpContextStatusCodeExpr = Expression.Property(FilterContextHttpContextResponseExpr, typeof(HttpResponse).GetProperty(nameof(HttpResponse.StatusCode))!);
     private static readonly ParameterExpression InvokedFilterContextExpr = Expression.Parameter(typeof(EndpointFilterInvocationContext), "filterContext");
 
-    private static readonly string[] DefaultAcceptsContentType = new[] { "application/json" };
+    private static readonly string[] DefaultAcceptsAndProducesContentType = new[] { JsonConstants.JsonContentType };
     private static readonly string[] FormFileContentType = new[] { "multipart/form-data" };
+    private static readonly string[] PlaintextContentType = new[] { "text/plain" };
 
     /// <summary>
     /// Returns metadata inferred automatically for the <see cref="RequestDelegate"/> created by <see cref="Create(Delegate, RequestDelegateFactoryOptions?, RequestDelegateMetadataResult?)"/>.
@@ -378,10 +379,10 @@ public static partial class RequestDelegateFactory
 
         if (!factoryContext.MetadataAlreadyInferred)
         {
+            PopulateBuiltInResponseTypeMetadata(methodInfo.ReturnType, factoryContext.Parameters, factoryContext.EndpointBuilder);
+
             // Add metadata provided by the delegate return type and parameter types next, this will be more specific than inferred metadata from above
-            EndpointMetadataPopulator.PopulateMetadata(methodInfo,
-                factoryContext.EndpointBuilder,
-                factoryContext.Parameters);
+            EndpointMetadataPopulator.PopulateMetadata(methodInfo, factoryContext.EndpointBuilder, factoryContext.Parameters);
         }
 
         return args;
@@ -927,6 +928,56 @@ public static partial class RequestDelegateFactory
         return Expression.Block(localVariables, checkParamAndCallMethod);
     }
 
+    private static void PopulateBuiltInResponseTypeMetadata(Type returnType, IEnumerable<ParameterInfo> parameters, EndpointBuilder builder)
+    {
+        if (returnType.IsByRefLike)
+        {
+            throw GetUnsupportedReturnTypeException(returnType);
+        }
+
+        if (returnType == typeof(Task) || returnType == typeof(ValueTask))
+        {
+            returnType = typeof(void);
+        }
+        else if (AwaitableInfo.IsTypeAwaitable(returnType, out _))
+        {
+            var genericTypeDefinition = returnType.IsGenericType ? returnType.GetGenericTypeDefinition() : null;
+
+            if (genericTypeDefinition == typeof(Task<>) || genericTypeDefinition == typeof(ValueTask<>))
+            {
+                returnType = returnType.GetGenericArguments()[0];
+            }
+            else
+            {
+                throw GetUnsupportedReturnTypeException(returnType);
+            }
+        }
+
+        // Skip void returns and IResults. IResults might implement IEndpointMetadataProvider but otherwise we don't know what it might do.
+        if (returnType == typeof(void) || typeof(IResult).IsAssignableFrom(returnType))
+        {
+            return;
+        }
+
+        // Skip methods that have HttpContext or HttpResponse parameters that might change the status code from 200.
+        foreach (var parameter in parameters)
+        {
+            if (parameter.ParameterType == typeof(HttpContext) || parameter.ParameterType == typeof(HttpResponse))
+            {
+                return;
+            }
+        }
+
+        if (returnType == typeof(string))
+        {
+            builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(type: null, statusCode: 200, PlaintextContentType));
+        }
+        else
+        {
+            builder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(returnType, statusCode: 200, DefaultAcceptsAndProducesContentType));
+        }
+    }
+
     private static Expression AddResponseWritingToMethodCall(Expression methodCall, Type returnType)
     {
         // Exact request delegate match
@@ -1021,7 +1072,7 @@ public static partial class RequestDelegateFactory
             else
             {
                 // TODO: Handle custom awaitables
-                throw new NotSupportedException($"Unsupported return type: {TypeNameHelper.GetTypeDisplayName(returnType)}");
+                throw GetUnsupportedReturnTypeException(returnType);
             }
         }
         else if (typeof(IResult).IsAssignableFrom(returnType))
@@ -1039,8 +1090,7 @@ public static partial class RequestDelegateFactory
         }
         else if (returnType.IsByRefLike)
         {
-            // Unsupported
-            throw new NotSupportedException($"Unsupported return type: {TypeNameHelper.GetTypeDisplayName(returnType)}");
+            throw GetUnsupportedReturnTypeException(returnType);
         }
         else if (returnType.IsValueType)
         {
@@ -1771,6 +1821,17 @@ public static partial class RequestDelegateFactory
         return Expression.Convert(boundValueExpr, parameter.ParameterType);
     }
 
+    private static void AddInferredProducesResponseTypeMetadata(RequestDelegateFactoryContext factoryContext, Type type, string[] contentTypes)
+    {
+        if (factoryContext.MetadataAlreadyInferred)
+        {
+            return;
+        }
+
+        // Type cannot be null, and contentTypes is either [ "application/json" ] or [ "text/plain" ] both of which are valid.
+        factoryContext.EndpointBuilder.Metadata.Add(ProducesResponseTypeMetadata.CreateUnvalidated(type, statusCode: 200, contentTypes));
+    }
+
     private static void AddInferredAcceptsMetadata(RequestDelegateFactoryContext factoryContext, Type type, string[] contentTypes)
     {
         if (factoryContext.MetadataAlreadyInferred)
@@ -1849,7 +1910,7 @@ public static partial class RequestDelegateFactory
 
         factoryContext.JsonRequestBodyParameter = parameter;
         factoryContext.AllowEmptyRequestBody = allowEmpty || isOptional;
-        AddInferredAcceptsMetadata(factoryContext, parameter.ParameterType, DefaultAcceptsContentType);
+        AddInferredAcceptsMetadata(factoryContext, parameter.ParameterType, DefaultAcceptsAndProducesContentType);
 
         if (!factoryContext.AllowEmptyRequestBody)
         {
@@ -2152,6 +2213,12 @@ public static partial class RequestDelegateFactory
     {
         await EnsureRequestResultNotNull(result).ExecuteAsync(httpContext);
     }
+
+    private static NotSupportedException GetUnsupportedReturnTypeException(Type returnType)
+    {
+        return new NotSupportedException($"Unsupported return type: {TypeNameHelper.GetTypeDisplayName(returnType)}");
+    }
+
     private static class RequestDelegateFactoryConstants
     {
         public const string RouteAttribute = "Route (Attribute)";

--- a/src/OpenApi/src/OpenApiGenerator.cs
+++ b/src/OpenApi/src/OpenApiGenerator.cs
@@ -193,6 +193,8 @@ internal sealed class OpenApiGenerator
         foreach (var annotation in eligibileAnnotations)
         {
             var statusCode = annotation.Key.ToString(CultureInfo.InvariantCulture);
+
+            // TODO: Use the discarded response Type for schema generation
             var (_, contentTypes) = annotation.Value;
             var responseContent = new Dictionary<string, OpenApiMediaType>();
 

--- a/src/OpenApi/test/OpenApiRouteHandlerBuilderExtensionTests.cs
+++ b/src/OpenApi/test/OpenApiRouteHandlerBuilderExtensionTests.cs
@@ -136,8 +136,16 @@ public class OpenApiRouteHandlerBuilderExtensionTests
         var groupDataSource = Assert.Single(builder.DataSources);
         var endpoint = Assert.Single(groupDataSource.Endpoints);
         var operation = endpoint.Metadata.GetMetadata<OpenApiOperation>();
+
         Assert.NotNull(operation);
-        Assert.Equal("201", operation.Responses.Keys.SingleOrDefault());
+        Assert.Equal(2, operation.Responses.Count);
+
+        var defaultOperation = operation.Responses["200"];
+        Assert.True(defaultOperation.Content.ContainsKey("text/plain"));
+
+        var annotatedOperation = operation.Responses["201"];
+        // Produces doesn't special case string??
+        Assert.True(annotatedOperation.Content.ContainsKey("application/json"));
     }
 
     [Fact]

--- a/src/Shared/ApiExplorerTypes/ProducesResponseTypeMetadata.cs
+++ b/src/Shared/ApiExplorerTypes/ProducesResponseTypeMetadata.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Linq;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.Net.Http.Headers;
@@ -20,11 +19,11 @@ internal sealed class ProducesResponseTypeMetadata : IProducesResponseTypeMetada
     /// </summary>
     /// <param name="statusCode">The HTTP response status code.</param>
     public ProducesResponseTypeMetadata(int statusCode)
-        : this(typeof(void), statusCode)
+        : this(type: null, statusCode, Enumerable.Empty<string>())
     {
-        IsResponseTypeSetByDefault = true;
     }
 
+    // Only for internal use where validation is unnecessary.
     /// <summary>
     /// Initializes an instance of <see cref="ProducesResponseTypeMetadata"/>.
     /// </summary>
@@ -34,7 +33,6 @@ internal sealed class ProducesResponseTypeMetadata : IProducesResponseTypeMetada
     {
         Type = type ?? throw new ArgumentNullException(nameof(type));
         StatusCode = statusCode;
-        IsResponseTypeSetByDefault = false;
         _contentTypes = Enumerable.Empty<string>();
     }
 
@@ -54,7 +52,6 @@ internal sealed class ProducesResponseTypeMetadata : IProducesResponseTypeMetada
 
         Type = type ?? throw new ArgumentNullException(nameof(type));
         StatusCode = statusCode;
-        IsResponseTypeSetByDefault = false;
 
         MediaTypeHeaderValue.Parse(contentType);
         for (var i = 0; i < additionalContentTypes.Length; i++)
@@ -65,29 +62,28 @@ internal sealed class ProducesResponseTypeMetadata : IProducesResponseTypeMetada
         _contentTypes = GetContentTypes(contentType, additionalContentTypes);
     }
 
+    // Only for internal use where validation is unnecessary.
+    private ProducesResponseTypeMetadata(Type? type, int statusCode, IEnumerable<string> contentTypes)
+    {
+
+        Type = type;
+        StatusCode = statusCode;
+        _contentTypes = contentTypes;
+    }
+
     /// <summary>
     /// Gets or sets the type of the value returned by an action.
     /// </summary>
-    public Type Type { get; set; }
+    public Type? Type { get; set; }
 
     /// <summary>
     /// Gets or sets the HTTP status code of the response.
     /// </summary>
     public int StatusCode { get; set; }
 
-    /// <summary>
-    /// Used to distinguish a `Type` set by default in the constructor versus
-    /// one provided by the user.
-    ///
-    /// When <see langword="false"/>, then <see cref="Type"/> is set by user.
-    ///
-    /// When <see langword="true"/>, then <see cref="Type"/> is set by by
-    /// default in the constructor
-    /// </summary>
-    /// <value></value>
-    internal bool IsResponseTypeSetByDefault { get; }
-
     public IEnumerable<string> ContentTypes => _contentTypes;
+
+    internal static ProducesResponseTypeMetadata CreateUnvalidated(Type? type, int statusCode, IEnumerable<string> contentTypes) => new(type, statusCode, contentTypes);
 
     private static List<string> GetContentTypes(string contentType, string[] additionalContentTypes)
     {


### PR DESCRIPTION
RequestDelegateFactory should infer metadata about the response bodies it produces similar to the way it infers metadata about the request bodies it consumes.

## Description

RequestDelegateFactory already infers [IAcceptsMetadata](https://github.com/dotnet/aspnetcore/blob/8f0d440d4251ae479966b65c7b331841adb70aa6/src/Http/Http.Extensions/src/RequestDelegateFactory.cs#L1725) when it's reading JSON request bodies or multipart form data, so it's peculiar that it does not infer [IProducesResponseTypeMetadata](https://github.com/dotnet/aspnetcore/blob/8f0d440d4251ae479966b65c7b331841adb70aa6/src/Http/Http.Abstractions/src/Metadata/IProducesResponseTypeMetadata.cs) when our [TypedResults do](https://github.com/dotnet/aspnetcore/blob/8f0d440d4251ae479966b65c7b331841adb70aa6/src/Http/Http.Results/src/OkOfT.cs#L64).

With this PR, RequestDelegateFactory now infers and adds "application/json" and "text/plain" ProducesResponseTypeMetadata with the appropriate return Type (for POCOs, not for `string`).

Fixes #43675

## Customer Impact

@DamianEdwards [mentioned](https://github.com/dotnet/aspnetcore/issues/43675#issuecomment-1244492489):

> So I just hit a scenario where this might help. I was attempting to get JWT bearer auth and the new problem details service support to work in an app, such that that Swagger UI enables logging in and making requests from the browser.
> 
> ```csharp
> var examples = app.MapGroup("/").WithTags("Examples");
> 
> // Describe that all APIs can return errors as JSON or plain text
> examples.WithMetadata(new ProducesResponseTypeAttribute(typeof(ProblemDetails), 401, "application/problem+json", "text/plain"));
> examples.WithMetadata(new ProducesResponseTypeAttribute(typeof(ProblemDetails), 403, "application/problem+json", "text/plain"));
> 
> examples.MapGet("/secret", (ClaimsPrincipal user) => "shhh").RequireAuthorization();
> 
> app.Run();
> ```

> This results in the API being described as **only** returning 401 or 403, as the inferred response (200: text/plain) is omitted due to the explicit metadata in the group. This PR makes it so RDF now infers the 200 "text\plain" response as well.

## Regression?

- [ ] Yes
- [x] No

This is a brand-new scenario though.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

This mostly impacts the new `WithOpenApi()` and `MapGroup()` features.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

@DamianEdwards @captainsafia @Pilchie 