### PR TITLE
[release/2.1] Remove most non-Windows build job support

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -312,10 +312,11 @@ jobs:
     steps:
     - checkout: self
       clean: true
-    - task: NodeTool@0
-      displayName: Install Node 10.x
+    - task: NuGetCommand@2
+      displayName: 'Clear NuGet caches'
       inputs:
-        versionSpec: 10.x
+        command: custom
+        arguments: 'locals all -clear'
     - task: DownloadBuildArtifacts@0
       displayName: Download Windows SharedFx artifacts
       inputs:
@@ -338,6 +339,9 @@ jobs:
         PB_RESTORESOURCE: $(PB_RestoreSource)
         PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
       displayName: Build SharedFX Installers
+    - powershell: eng\scripts\KillProcesses.ps1
+      displayName: Kill processes
+      condition: always()
     - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
       - task: PublishBuildArtifacts@1
         displayName: Upload artifacts

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -145,6 +145,7 @@ jobs:
     - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
       - task: PublishBuildArtifacts@1
         displayName: Upload artifacts
+        condition: always()
         continueOnError: true
         inputs:
           pathtoPublish: artifacts/
@@ -153,6 +154,7 @@ jobs:
           parallel: true
       - task: PublishBuildArtifacts@1
         displayName: Upload dependencies.g.props
+        condition: always()
         continueOnError: true
         inputs:
           pathtoPublish: .deps/dependencies.g.props
@@ -230,6 +232,7 @@ jobs:
     - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
       - task: PublishBuildArtifacts@1
         displayName: Upload artifacts
+        condition: always()
         continueOnError: true
         inputs:
           pathtoPublish: artifacts/
@@ -287,6 +290,7 @@ jobs:
     - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
       - task: PublishBuildArtifacts@1
         displayName: Upload artifacts
+        condition: always()
         continueOnError: true
         inputs:
           pathtoPublish: artifacts/
@@ -296,8 +300,7 @@ jobs:
 
   - job: SharedFX_Installers
     displayName: Build SharedFX Installers
-    dependsOn:
-      - Windows_SharedFx
+    dependsOn: Windows_SharedFx
     timeoutInMinutes: 90
     workspace:
       clean: all
@@ -345,6 +348,7 @@ jobs:
     - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
       - task: PublishBuildArtifacts@1
         displayName: Upload artifacts
+        condition: always()
         continueOnError: true
         inputs:
           pathtoPublish: artifacts/
@@ -468,6 +472,7 @@ jobs:
     - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
       - task: PublishBuildArtifacts@1
         displayName: Upload logs
+        condition: always()
         continueOnError: true
         inputs:
           pathtoPublish: artifacts/logs

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -37,7 +37,6 @@ jobs:
   parameters:
     jobName: Windows_Build
     jobDisplayName: "Build and test: Windows"
-    agentOs: Windows
     buildArgs: $(BuildNumberArg)
     codeSign: true
     beforeBuild:
@@ -303,7 +302,8 @@ jobs:
     workspace:
       clean: all
     pool:
-      vmImage: ubuntu-18.04
+      name: NetCore1ESPool-Svc-Internal
+      demands: ImageOverride -equals Build.Server.Amd64.VS2019
     variables:
       LC_ALL: 'en_US.UTF-8'
       LANG: 'en_US.UTF-8'
@@ -327,7 +327,7 @@ jobs:
         sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/
         contents: '**'
         targetFolder: $(Build.SourcesDirectory)/.deps/Signed/
-    - script: ./$(BuildDirectory)/build.sh
+    - script: .\build.cmd
               -ci
               $(BuildNumberArg)
               /t:BuildInstallers
@@ -338,8 +338,6 @@ jobs:
         PB_RESTORESOURCE: $(PB_RestoreSource)
         PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
       displayName: Build SharedFX Installers
-    - bash: docker system prune -af
-      displayName: Docker prune
     - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
       - task: PublishBuildArtifacts@1
         displayName: Upload artifacts

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -1,5 +1,5 @@
 # default-build.yml
-# Description: Defines a build phase for invoking build.sh/cmd
+# Description: Defines a build phase for invoking build.cmd
 # Parameters:
 #   jobName: string
 #       The name of the job. Defaults to the name of the OS. No spaces allowed
@@ -8,14 +8,14 @@
 #   poolName: string
 #       The name of the Azure DevOps agent pool to use.
 #   agentOs: string
-#       Used in templates to define variables which are OS specific. Typically from the set { Windows, Linux, MacOS }
+#       Used in templates to define variables which are OS specific. Typically 'Windows'.
 #   buildArgs: string
-#       Additional arguments to pass to the build.sh/cmd script.
+#       Additional arguments to pass to the build.cmd script.
 #       Note: -ci is always passed
 #   beforeBuild: [steps]
-#       Additional steps to run before build.sh/cmd
+#       Additional steps to run before build.cmd
 #   afterBuild: [steps]
-#       Additional steps to run after build.sh/cmd
+#       Additional steps to run after build.cmd
 #   artifacts:
 #      publish: boolean
 #           Should artifacts be published
@@ -32,7 +32,7 @@
 #   codeSign: boolean
 #       This build definition is enabled for code signing. (Only applies to Windows)
 #   buildDirectory: string
-#       Specifies what directory to run build.sh/cmd
+#       Specifies what directory to run build.cmd
 
 #
 # See https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema for details
@@ -70,12 +70,10 @@ jobs:
   # Map friendly OS names to the right queue
   # See https://github.com/dotnet/arcade/blob/master/Documentation/ChoosingAMachinePool.md
   pool:
+    # poolName parameter is currently always empty.
     ${{ if ne(parameters.poolName, '') }}:
       name: ${{ parameters.poolName }}
-    ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'MacOS')) }}:
-      vmImage: macOS-11
-    ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Linux')) }}:
-      vmImage: ubuntu-18.04
+    # Setting AgentOS to anything but Windows will likely fail the build.
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Windows')) }}:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: NetCore-Svc-Public
@@ -143,21 +141,6 @@ jobs:
         PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
       displayName: Run build.cmd
     - powershell: eng\scripts\KillProcesses.ps1
-      displayName: Kill processes
-      condition: always()
-  - ${{ if ne(parameters.agentOs, 'Windows') }}:
-    - script: ./$(BuildDirectory)/build.sh
-              -ci
-              -p:Configuration=$(BuildConfiguration)
-              $(BuildScriptArgs)
-              $(BinlogArg)
-      env:
-        PB_PackageVersionPropsUrl: $(PB_PackageVersionPropsUrl)
-        PB_AssetRootUrl: $(PB_AssetRootUrl)
-        PB_RestoreSource: $(PB_RestoreSource)
-        PB_PublishBlobFeedKey: $(PB_PublishBlobFeedKey)
-      displayName: Run build.sh
-    - script: eng/scripts/KillProcesses.sh
       displayName: Kill processes
       condition: always()
   - ${{ if ne(parameters.variables.PB_SKIPTESTS, 'true') }}:

--- a/build/SharedFx.props
+++ b/build/SharedFx.props
@@ -1,7 +1,8 @@
 <Project>
   <PropertyGroup>
     <!-- directories -->
-    <_WorkRoot>$(RepositoryRoot).w\$(SharedFxRID)\</_WorkRoot>
+    <_WorkRoot Condition=" '$(SharedFxRID)' == '' ">$(RepositoryRoot).w\</_WorkRoot>
+    <_WorkRoot Condition=" '$(SharedFxRID)' != '' ">$(RepositoryRoot).w\$(SharedFxRID)\</_WorkRoot>
     <_WorkLayoutDir>$(_WorkRoot).l\</_WorkLayoutDir>
     <_WorkOutputDir>$(_WorkRoot).o\</_WorkOutputDir>
     <_MetapackageSrcRoot>$(RepositoryRoot)src\Packages\</_MetapackageSrcRoot>

--- a/build/SharedFxInstaller.targets
+++ b/build/SharedFxInstaller.targets
@@ -4,14 +4,6 @@
   <Target Name="_EnsureInstallerPrerequisites">
     <MakeDir Directories="$(_InstallersOutputDir)" />
 
-    <!-- Check Docker server OS -->
-    <Exec Command="docker version -f &quot;{{.Server.Os}}&quot;" StandardOutputImportance="Normal" ConsoleToMSBuild="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="DockerHostOS" />
-    </Exec>
-
-    <Error
-      Text="Docker host must be using Linux containers."
-      Condition="'$(DockerHostOS)' != 'linux'"/>
     <Error
       Text="Expected archive missing at $(SharedFxIntermediateArchiveFilePrefix)-%(WindowsSharedFxRIDs.Identity).zip."
       Condition="'@(WindowsSharedFxRIDs)' != '' AND !Exists('$(SharedFxIntermediateArchiveFilePrefix)-%(WindowsSharedFxRIDs.Identity).zip')" />


### PR DESCRIPTION
- [release/2.1] Remove most non-Windows build job support
  - jobs w/ a few explicit settings _may_ run fine but are otherwise unsupported
    - scripts and so on remain but nothing in our YAML
  - move the last non-Windows job to Windows
    - no need for `docker` in `Build SharedFX Installers` job
- !fixup! Make `SharedFX_Installers` job more like the others
- always publish artifacts
  - log files were lost in failed jobs
- !fixup! Remove double backslash in `$(_WorkRoot)`
  - caused problems building SharedFx installers on Windows



