### PR TITLE
[Blazor wasm] Use provided loadBootResource function to override how config is loaded

### DIFF
--- a/src/Components/Web.JS/src/Boot.WebAssembly.ts
+++ b/src/Components/Web.JS/src/Boot.WebAssembly.ts
@@ -136,7 +136,7 @@ async function boot(options?: Partial<WebAssemblyStartOptions>): Promise<void> {
 
   const [resourceLoader] = await Promise.all([
     WebAssemblyResourceLoader.initAsync(bootConfigResult.bootConfig, candidateOptions || {}),
-    WebAssemblyConfigLoader.initAsync(bootConfigResult),
+    WebAssemblyConfigLoader.initAsync(bootConfigResult, candidateOptions || {}),
   ]);
 
   try {

--- a/src/Components/Web.JS/src/Platform/WebAssemblyConfigLoader.ts
+++ b/src/Components/Web.JS/src/Platform/WebAssemblyConfigLoader.ts
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { BootConfigResult } from './BootConfig';
+import { WebAssemblyStartOptions } from './WebAssemblyStartOptions';
 import { System_String, System_Object } from './Platform';
 import { Blazor } from '../GlobalExports';
 import { BINDING } from './Mono/MonoPlatform';
 
 export class WebAssemblyConfigLoader {
-  static async initAsync(bootConfigResult: BootConfigResult): Promise<void> {
+  static async initAsync(bootConfigResult: BootConfigResult, startOptions: Partial<WebAssemblyStartOptions>): Promise<void> {
     Blazor._internal.getApplicationEnvironment = () => BINDING.js_string_to_mono_string(bootConfigResult.applicationEnvironment);
 
     const configFiles = await Promise.all((bootConfigResult.bootConfig.config || [])
@@ -21,6 +22,18 @@ export class WebAssemblyConfigLoader {
     };
 
     async function getConfigBytes(file: string): Promise<Uint8Array> {
+      // Allow developers to override how the config is loaded
+      if (startOptions.loadBootResource) {
+        const customLoadResult = startOptions.loadBootResource('config', file, file, '');
+        if (customLoadResult instanceof Promise) {
+          // They are supplying an entire custom response, so just use that
+          return new Uint8Array(await (await customLoadResult).arrayBuffer());
+        } else if (typeof customLoadResult === 'string') {
+          // They are supplying a custom URL, so use that with the default fetch behavior
+          file = customLoadResult;
+        }
+      }
+
       const response = await fetch(file, {
         method: 'GET',
         credentials: 'include',

--- a/src/Components/Web.JS/src/Platform/WebAssemblyConfigLoader.ts
+++ b/src/Components/Web.JS/src/Platform/WebAssemblyConfigLoader.ts
@@ -24,7 +24,7 @@ export class WebAssemblyConfigLoader {
     async function getConfigBytes(file: string): Promise<Uint8Array> {
       // Allow developers to override how the config is loaded
       if (startOptions.loadBootResource) {
-        const customLoadResult = startOptions.loadBootResource('config', file, file, '');
+        const customLoadResult = startOptions.loadBootResource('configuration', file, file, '');
         if (customLoadResult instanceof Promise) {
           // They are supplying an entire custom response, so just use that
           return new Uint8Array(await (await customLoadResult).arrayBuffer());

--- a/src/Components/Web.JS/src/Platform/WebAssemblyStartOptions.ts
+++ b/src/Components/Web.JS/src/Platform/WebAssemblyStartOptions.ts
@@ -27,4 +27,4 @@ export interface WebAssemblyStartOptions {
 // This type doesn't have to align with anything in BootConfig.
 // Instead, this represents the public API through which certain aspects
 // of boot resource loading can be customized.
-export type WebAssemblyBootResourceType = 'assembly' | 'pdb' | 'dotnetjs' | 'dotnetwasm' | 'globalization' | 'manifest' | 'config';
+export type WebAssemblyBootResourceType = 'assembly' | 'pdb' | 'dotnetjs' | 'dotnetwasm' | 'globalization' | 'manifest' | 'configuration';

--- a/src/Components/Web.JS/src/Platform/WebAssemblyStartOptions.ts
+++ b/src/Components/Web.JS/src/Platform/WebAssemblyStartOptions.ts
@@ -27,4 +27,4 @@ export interface WebAssemblyStartOptions {
 // This type doesn't have to align with anything in BootConfig.
 // Instead, this represents the public API through which certain aspects
 // of boot resource loading can be customized.
-export type WebAssemblyBootResourceType = 'assembly' | 'pdb' | 'dotnetjs' | 'dotnetwasm' | 'globalization' | 'manifest';
+export type WebAssemblyBootResourceType = 'assembly' | 'pdb' | 'dotnetjs' | 'dotnetwasm' | 'globalization' | 'manifest' | 'config';


### PR DESCRIPTION
# [Blazor wasm] Use provided loadBootResource function to override how the config is loaded

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Use "loadBootResource" function to override how the config is loaded.

## Description
PR updates `WebAssemblyConfigLoader.initAsync` to use provided `loadBootResource` function from `startOptions` to override how the config is loaded in runtime. Allows loading config from a custom source, such as an external CDN. Providing similar behavior to loading of other boot resources.

I couldn't find any existing tests that cover current `loadBootResource` behavior for other resources. So, I didn't include any new tests. Though I see that `JsInitializersTest.cs` might be a good place for that? Let me know if these tests are expected and I will work on this too.  

Fixes #43700.