### PR TITLE
Update facebook OAuth API version to 14, google to v3

### DIFF
--- a/src/Security/Authentication/Facebook/src/FacebookDefaults.cs
+++ b/src/Security/Authentication/Facebook/src/FacebookDefaults.cs
@@ -24,15 +24,15 @@ public static class FacebookDefaults
     /// <remarks>
     /// For more details about this endpoint, see <see href="https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow#login"/>.
     /// </remarks>
-    public static readonly string AuthorizationEndpoint = "https://www.facebook.com/v11.0/dialog/oauth";
+    public static readonly string AuthorizationEndpoint = "https://www.facebook.com/v14.0/dialog/oauth";
 
     /// <summary>
     /// The OAuth endpoint used to retrieve access tokens.
     /// </summary>
-    public static readonly string TokenEndpoint = "https://graph.facebook.com/v11.0/oauth/access_token";
+    public static readonly string TokenEndpoint = "https://graph.facebook.com/v14.0/oauth/access_token";
 
     /// <summary>
     /// The Facebook Graph API endpoint that is used to gather additional user information.
     /// </summary>
-    public static readonly string UserInformationEndpoint = "https://graph.facebook.com/v11.0/me";
+    public static readonly string UserInformationEndpoint = "https://graph.facebook.com/v14.0/me";
 }

--- a/src/Security/Authentication/Google/src/GoogleDefaults.cs
+++ b/src/Security/Authentication/Google/src/GoogleDefaults.cs
@@ -34,8 +34,5 @@ public static class GoogleDefaults
     /// <summary>
     /// The Google endpoint that is used to gather additional user information.
     /// </summary>
-    /// <remarks>
-    /// For more details about this endpoint, see <see href="https://developers.google.com/apis-explorer/#search/oauth2/oauth2/v2/"/>.
-    /// </remarks>
-    public static readonly string UserInformationEndpoint = "https://www.googleapis.com/oauth2/v2/userinfo";
+    public static readonly string UserInformationEndpoint = "https://www.googleapis.com/oauth2/v3/userinfo";
 }

--- a/src/Security/Authentication/Google/src/GoogleOptions.cs
+++ b/src/Security/Authentication/Google/src/GoogleOptions.cs
@@ -25,7 +25,8 @@ public class GoogleOptions : OAuthOptions
         Scope.Add("profile");
         Scope.Add("email");
 
-        ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "id");
+        ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "id"); // v2
+        ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "sub"); // v3
         ClaimActions.MapJsonKey(ClaimTypes.Name, "name");
         ClaimActions.MapJsonKey(ClaimTypes.GivenName, "given_name");
         ClaimActions.MapJsonKey(ClaimTypes.Surname, "family_name");

--- a/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountDefaults.cs
+++ b/src/Security/Authentication/MicrosoftAccount/src/MicrosoftAccountDefaults.cs
@@ -22,7 +22,7 @@ public static class MicrosoftAccountDefaults
     /// The default endpoint used to perform Microsoft account authentication.
     /// </summary>
     /// <remarks>
-    /// For more details about this endpoint, see <see href="https://developer.microsoft.com/en-us/graph/docs/concepts/auth_v2_user"/>.
+    /// For more details about this endpoint, see <see href="https://docs.microsoft.com/en-us/graph/auth-v2-user"/>.
     /// </remarks>
     public static readonly string AuthorizationEndpoint = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize";
 

--- a/src/Security/Authentication/test/FacebookTests.cs
+++ b/src/Security/Authentication/test/FacebookTests.cs
@@ -229,7 +229,7 @@ public class FacebookTests : RemoteAuthenticationTests<FacebookOptions>
         var transaction = await server.SendAsync("http://example.com/base/login");
         Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
         var location = transaction.Response.Headers.Location.AbsoluteUri;
-        Assert.Contains("https://www.facebook.com/v11.0/dialog/oauth", location);
+        Assert.Contains("https://www.facebook.com/v14.0/dialog/oauth", location);
         Assert.Contains("response_type=code", location);
         Assert.Contains("client_id=", location);
         Assert.Contains("redirect_uri=" + UrlEncoder.Default.Encode("http://example.com/base/signin-facebook"), location);
@@ -262,7 +262,7 @@ public class FacebookTests : RemoteAuthenticationTests<FacebookOptions>
         var transaction = await server.SendAsync("http://example.com/login");
         Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
         var location = transaction.Response.Headers.Location.AbsoluteUri;
-        Assert.Contains("https://www.facebook.com/v11.0/dialog/oauth", location);
+        Assert.Contains("https://www.facebook.com/v14.0/dialog/oauth", location);
         Assert.Contains("response_type=code", location);
         Assert.Contains("client_id=", location);
         Assert.Contains("redirect_uri=" + UrlEncoder.Default.Encode("http://example.com/signin-facebook"), location);
@@ -297,7 +297,7 @@ public class FacebookTests : RemoteAuthenticationTests<FacebookOptions>
         var transaction = await server.SendAsync("http://example.com/challenge");
         Assert.Equal(HttpStatusCode.Redirect, transaction.Response.StatusCode);
         var location = transaction.Response.Headers.Location.AbsoluteUri;
-        Assert.Contains("https://www.facebook.com/v11.0/dialog/oauth", location);
+        Assert.Contains("https://www.facebook.com/v14.0/dialog/oauth", location);
         Assert.Contains("response_type=code", location);
         Assert.Contains("client_id=", location);
         Assert.Contains("redirect_uri=", location);

--- a/src/Security/Authentication/test/GoogleTests.cs
+++ b/src/Security/Authentication/test/GoogleTests.cs
@@ -1026,11 +1026,11 @@ public class GoogleTests : RemoteAuthenticationTests<GoogleOptions>
                         refresh_token = "Test Refresh Token"
                     });
                 }
-                else if (req.RequestUri.GetComponents(UriComponents.SchemeAndServer | UriComponents.Path, UriFormat.UriEscaped) == "https://www.googleapis.com/oauth2/v2/userinfo")
+                else if (req.RequestUri.GetComponents(UriComponents.SchemeAndServer | UriComponents.Path, UriFormat.UriEscaped) == "https://www.googleapis.com/oauth2/v3/userinfo")
                 {
                     return ReturnJsonResponse(new
                     {
-                        id = "Test User ID",
+                        sub = "Test User ID",
                         name = "Test Name",
                         given_name = "Test Given Name",
                         family_name = "Test Family Name",


### PR DESCRIPTION
Contributes to #4684

This is our annual review and update of the OAuth endpoint values. Only facebook had a documented version change, but it doesn't seem to impact behavior so I'm not going to try updating 7.0, just main.

Google has one undocumented version change from v2 to v3 for the userinfo endpoint, where the id claim changed to sub to closer align with OpenIdConnect.
  