### PR TITLE
Improve file fallback routing behavior when using ConsumesAttribute

### DIFF
--- a/src/Middleware/StaticFiles/src/StaticFilesEndpointRouteBuilderExtensions.cs
+++ b/src/Middleware/StaticFiles/src/StaticFilesEndpointRouteBuilderExtensions.cs
@@ -13,6 +13,9 @@ namespace Microsoft.AspNetCore.Builder;
 /// </summary>
 public static class StaticFilesEndpointRouteBuilderExtensions
 {
+    // See: https://github.com/dotnet/aspnetcore/issues/41060
+    private static readonly string[] _supportedHttpMethods = new[] { HttpMethods.Get };
+
     /// <summary>
     /// Adds a specialized <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that will match
     /// requests for non-filenames with the lowest possible priority. The request will be routed to a
@@ -42,17 +45,12 @@ public static class StaticFilesEndpointRouteBuilderExtensions
         this IEndpointRouteBuilder endpoints,
         string filePath)
     {
-        if (endpoints == null)
-        {
-            throw new ArgumentNullException(nameof(endpoints));
-        }
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ArgumentNullException.ThrowIfNull(filePath);
 
-        if (filePath == null)
-        {
-            throw new ArgumentNullException(nameof(filePath));
-        }
-
-        return endpoints.MapFallback(CreateRequestDelegate(endpoints, filePath));
+        return endpoints
+            .MapFallback(CreateRequestDelegate(endpoints, filePath))
+            .WithMetadata(new HttpMethodMetadata(_supportedHttpMethods));
     }
 
     /// <summary>
@@ -83,17 +81,12 @@ public static class StaticFilesEndpointRouteBuilderExtensions
         string filePath,
         StaticFileOptions options)
     {
-        if (endpoints == null)
-        {
-            throw new ArgumentNullException(nameof(endpoints));
-        }
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ArgumentNullException.ThrowIfNull(filePath);
 
-        if (filePath == null)
-        {
-            throw new ArgumentNullException(nameof(filePath));
-        }
-
-        return endpoints.MapFallback(CreateRequestDelegate(endpoints, filePath, options));
+        return endpoints
+            .MapFallback(CreateRequestDelegate(endpoints, filePath, options))
+            .WithMetadata(new HttpMethodMetadata(_supportedHttpMethods));
     }
 
     /// <summary>
@@ -130,22 +123,13 @@ public static class StaticFilesEndpointRouteBuilderExtensions
         [StringSyntax("Route")] string pattern,
         string filePath)
     {
-        if (endpoints == null)
-        {
-            throw new ArgumentNullException(nameof(endpoints));
-        }
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ArgumentNullException.ThrowIfNull(pattern);
+        ArgumentNullException.ThrowIfNull(filePath);
 
-        if (pattern == null)
-        {
-            throw new ArgumentNullException(nameof(filePath));
-        }
-
-        if (filePath == null)
-        {
-            throw new ArgumentNullException(nameof(filePath));
-        }
-
-        return endpoints.MapFallback(pattern, CreateRequestDelegate(endpoints, filePath));
+        return endpoints
+            .MapFallback(pattern, CreateRequestDelegate(endpoints, filePath))
+            .WithMetadata(new HttpMethodMetadata(_supportedHttpMethods));
     }
 
     /// <summary>
@@ -181,22 +165,13 @@ public static class StaticFilesEndpointRouteBuilderExtensions
         string filePath,
         StaticFileOptions options)
     {
-        if (endpoints == null)
-        {
-            throw new ArgumentNullException(nameof(endpoints));
-        }
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ArgumentNullException.ThrowIfNull(pattern);
+        ArgumentNullException.ThrowIfNull(filePath);
 
-        if (pattern == null)
-        {
-            throw new ArgumentNullException(nameof(filePath));
-        }
-
-        if (filePath == null)
-        {
-            throw new ArgumentNullException(nameof(filePath));
-        }
-
-        return endpoints.MapFallback(pattern, CreateRequestDelegate(endpoints, filePath, options));
+        return endpoints
+            .MapFallback(pattern, CreateRequestDelegate(endpoints, filePath, options))
+            .WithMetadata(new HttpMethodMetadata(_supportedHttpMethods));
     }
 
     private static RequestDelegate CreateRequestDelegate(

--- a/src/Middleware/StaticFiles/src/StaticFilesEndpointRouteBuilderExtensions.cs
+++ b/src/Middleware/StaticFiles/src/StaticFilesEndpointRouteBuilderExtensions.cs
@@ -13,8 +13,11 @@ namespace Microsoft.AspNetCore.Builder;
 /// </summary>
 public static class StaticFilesEndpointRouteBuilderExtensions
 {
+    // By explicitly stating the supported HTTP methods for static files,
+    // we limit the types of situations where the fallback to file is matched
+    // after an endpoint is discarded, for example, due to a mismatched content type.
     // See: https://github.com/dotnet/aspnetcore/issues/41060
-    private static readonly string[] _supportedHttpMethods = new[] { HttpMethods.Get };
+    private static readonly string[] _supportedHttpMethods = new[] { HttpMethods.Get, HttpMethods.Head };
 
     /// <summary>
     /// Adds a specialized <see cref="RouteEndpoint"/> to the <see cref="IEndpointRouteBuilder"/> that will match

--- a/src/Mvc/test/Mvc.FunctionalTests/RoutingFallbackTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RoutingFallbackTest.cs
@@ -1,9 +1,12 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
 using System.Net.Http;
+using System.Text;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
 
@@ -102,7 +105,7 @@ public class RoutingFallbackTest : IClassFixture<MvcTestFixture<RoutingWebSite.S
     public async Task Fallback_CanFallbackToPage()
     {
         // Arrange
-        var url = "http://localhost/Foo";
+        var url = "http://localhost/FallbackToPage/Foo/Bar";
         var request = new HttpRequestMessage(HttpMethod.Get, url);
 
         // Act
@@ -112,5 +115,22 @@ public class RoutingFallbackTest : IClassFixture<MvcTestFixture<RoutingWebSite.S
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal("Hello from fallback page: /FallbackPage", content);
+    }
+
+    [Fact]
+    public async Task Fallback_DoesNotFallbackToFile_WhenContentTypeDoesNotMatchConsumesAttribute()
+    {
+        // Arrange
+        var url = "http://localhost/ConsumesAttribute/Json";
+        var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = new StringContent("some plaintext", Encoding.UTF8, "text/plain"),
+        };
+
+        // Act
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.UnsupportedMediaType, response.StatusCode);
     }
 }

--- a/src/Mvc/test/WebSites/RoutingWebSite/Controllers/ConsumesAttributeController.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/Controllers/ConsumesAttributeController.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace Mvc.RoutingWebSite.Controllers;
+
+[Route("ConsumesAttribute/[action]")]
+public class ConsumesAttributeController : Controller
+{
+    [HttpPost]
+    [Consumes("application/json")]
+    public IActionResult Json([FromBody] string json)
+    {
+        return Content($"Received json \"{json}\"");
+    }
+}

--- a/src/Mvc/test/WebSites/RoutingWebSite/StartupForFallback.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/StartupForFallback.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+
 namespace RoutingWebSite;
 
 // For by tests for fallback routing to pages/controllers
@@ -12,6 +15,9 @@ public class StartupForFallback
             .AddMvc()
             .AddNewtonsoftJson();
 
+        services.AddScoped<TestResponseGenerator>();
+        services.AddSingleton<IActionContextAccessor, ActionContextAccessor>();
+
         // Used by some controllers defined in this project.
         services.Configure<RouteOptions>(options => options.ConstraintMap["slugify"] = typeof(SlugifyParameterTransformer));
     }
@@ -22,7 +28,8 @@ public class StartupForFallback
         app.UseEndpoints(endpoints =>
         {
             endpoints.MapFallbackToAreaController("admin/{*path:nonfile}", "Index", "Fallback", "Admin");
-            endpoints.MapFallbackToPage("/FallbackPage");
+            endpoints.MapFallbackToPage("FallbackToPage/{*path:nonfile}", "/FallbackPage");
+            endpoints.MapFallbackToFile("notfound.html");
 
             endpoints.MapControllerRoute("admin", "link_generation/{area}/{controller}/{action}/{id?}");
         });


### PR DESCRIPTION
# Improve file fallback routing behavior when using `ConsumesAttribute`

Prevents the configured fallback file from matching routes that were discarded due to a mismatch between the request body content type and the content type specified via a `ConsumesAttribute` on a controller action.

## Description

This fix works by only allowing the fallback file to be returned when making a GET request. As such, the fix specifically improves the behavior for non-GET controller actions.

Fixes #41060

## Customer Impact

Some customers have had their applications affected by this issue when migrating from .NET 5 to .NET 6. This fix reduces the magnitude of the breaking change in routing logic introduced in .NET 6, so customers are less likely to have their apps be negatively affected.

## Regression?

- [X] Yes
- [ ] No

Regressed from .NET 5.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

This is a narrowly scoped change, and it's unlikely customers are relying on file fallback routing matching non-GET requests.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A