### PR TITLE
[release/7.0] Continue using typeof(void) for empty TypedResults

### DIFF
--- a/src/Http/Http.Results/test/AcceptedAtRouteResultTests.cs
+++ b/src/Http/Http.Results/test/AcceptedAtRouteResultTests.cs
@@ -85,6 +85,7 @@ public class AcceptedAtRouteResultTests
         // Assert
         var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
         Assert.Equal(StatusCodes.Status202Accepted, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/AcceptedResultTests.cs
+++ b/src/Http/Http.Results/test/AcceptedResultTests.cs
@@ -41,7 +41,9 @@ public class AcceptedResultTests
         PopulateMetadata<Accepted>(((Delegate)MyApi).GetMethodInfo(), builder);
 
         // Assert
-        Assert.Contains(builder.Metadata, m => m is ProducesResponseTypeMetadata { StatusCode: StatusCodes.Status202Accepted });
+        var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
+        Assert.Equal(StatusCodes.Status202Accepted, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/BadRequestResultTests.cs
+++ b/src/Http/Http.Results/test/BadRequestResultTests.cs
@@ -56,6 +56,7 @@ public class BadRequestResultTests
         // Assert
         var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
         Assert.Equal(StatusCodes.Status400BadRequest, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/ConflictResultTests.cs
+++ b/src/Http/Http.Results/test/ConflictResultTests.cs
@@ -57,6 +57,7 @@ public class ConflictResultTests
         // Assert
         var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
         Assert.Equal(StatusCodes.Status409Conflict, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/CreatedAtRouteResultTests.cs
+++ b/src/Http/Http.Results/test/CreatedAtRouteResultTests.cs
@@ -81,6 +81,7 @@ public partial class CreatedAtRouteResultTests
         // Assert
         var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
         Assert.Equal(StatusCodes.Status201Created, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/CreatedResultTests.cs
+++ b/src/Http/Http.Results/test/CreatedResultTests.cs
@@ -74,6 +74,7 @@ public class CreatedResultTests
         // Assert
         var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
         Assert.Equal(StatusCodes.Status201Created, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/NoContentResultTests.cs
+++ b/src/Http/Http.Results/test/NoContentResultTests.cs
@@ -53,6 +53,7 @@ public class NoContentResultTests
         // Assert
         var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
         Assert.Equal(StatusCodes.Status204NoContent, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/NotFoundResultTests.cs
+++ b/src/Http/Http.Results/test/NotFoundResultTests.cs
@@ -52,6 +52,7 @@ public class NotFoundResultTests
         // Assert
         var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
         Assert.Equal(StatusCodes.Status404NotFound, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/OkResultTests.cs
+++ b/src/Http/Http.Results/test/OkResultTests.cs
@@ -56,6 +56,7 @@ public class OkResultTests
         // Assert
         var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
         Assert.Equal(StatusCodes.Status200OK, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/UnprocessableEntityResultTests.cs
+++ b/src/Http/Http.Results/test/UnprocessableEntityResultTests.cs
@@ -56,6 +56,7 @@ public class UnprocessableEntityResultTests
         // Assert
         var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
         Assert.Equal(StatusCodes.Status422UnprocessableEntity, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
     }
 
     [Fact]

--- a/src/Shared/ApiExplorerTypes/ProducesResponseTypeMetadata.cs
+++ b/src/Shared/ApiExplorerTypes/ProducesResponseTypeMetadata.cs
@@ -19,7 +19,7 @@ internal sealed class ProducesResponseTypeMetadata : IProducesResponseTypeMetada
     /// </summary>
     /// <param name="statusCode">The HTTP response status code.</param>
     public ProducesResponseTypeMetadata(int statusCode)
-        : this(type: null, statusCode, Enumerable.Empty<string>())
+        : this(typeof(void), statusCode, Enumerable.Empty<string>())
     {
     }
 


### PR DESCRIPTION
This is fixing a minor regression from a few hours ago. This only has in impact if you're using the new `TypedResults` with MVC Controllers to populate your ApiExplorer model for things like Swashbuckle.

In #43961, I updated the internal `ProducesResponseTypeMetadata` type to accept a `null` `Type` to match the interface. I think `null` is still correct for "text/plain" strings returned directly from minimal route handlers. However, I went too far with that change and modified a constructor that our existing `TypedResults` were already using to start using `null` instead of `typeof(void)` even though these are slightly different.

https://github.com/dotnet/aspnetcore/blob/0bb3d6897e3cae58517217b628c08e585d0bede6/src/Http/Http.Results/src/Ok.cs#L53

`OpenApiGenerator` and `EndpointMetadataApiDescriptionProvider` handle `typeof(void)` and `null` the same, so this has no real impact when minimal route handlers return `TypedResults`.

https://github.com/dotnet/aspnetcore/blob/0bb3d6897e3cae58517217b628c08e585d0bede6/src/OpenApi/src/OpenApiGenerator.cs#L138-L140

https://github.com/dotnet/aspnetcore/blob/0bb3d6897e3cae58517217b628c08e585d0bede6/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs#L360-L363

However, for some reason, `ApiResponseTypeProvider` does treat these differently and excludes all results with a `null` type but not a `void` type.

https://github.com/dotnet/aspnetcore/blob/0bb3d6897e3cae58517217b628c08e585d0bede6/src/Mvc/Mvc.ApiExplorer/src/ApiResponseTypeProvider.cs#L208-L211

I don't really understand why `ApiResponseTypeProvider` treats these differently while the others don't, but it's been that way for 4 years. I'm more comfortable reverting the unnecessary change I made a couple hours ago. Semantically this makes more sense too. `typeof(void)` means there's no response content and `null` means there is content but no schema beyond the Content-Type (e.g. "text/plain").

@Pilchie