### PR TITLE
`IsCharWhitespace` for HTML5 spec without char[].IndexOf

### DIFF
--- a/src/Mvc/Mvc.Razor/src/TagHelpers/UrlResolutionTagHelper.cs
+++ b/src/Mvc/Mvc.Razor/src/TagHelpers/UrlResolutionTagHelper.cs
@@ -323,7 +323,10 @@ public class UrlResolutionTagHelper : TagHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsCharWhitespace(char ch)
     {
-        if (ch > 32) return false;
+        if (ch > 32)
+        {
+            return false;
+        }
 
         // Valid whitespace characters defined by the HTML5 spec.
         const long BitMask =

--- a/src/Mvc/Mvc.TagHelpers/src/GlobbingUrlBuilder.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/GlobbingUrlBuilder.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.FileProviders;
@@ -15,9 +16,6 @@ namespace Microsoft.AspNetCore.Mvc.TagHelpers;
 /// </summary>
 public class GlobbingUrlBuilder
 {
-    // Valid whitespace characters defined by the HTML5 spec.
-    private static readonly char[] ValidAttributeWhitespaceChars =
-        new[] { '\t', '\n', '\u000C', '\r', ' ' };
     private static readonly PathComparer DefaultPathComparer = new PathComparer();
     private static readonly char[] PatternSeparator = new[] { ',' };
     private static readonly char[] PathSeparator = new[] { '/' };
@@ -301,10 +299,22 @@ public class GlobbingUrlBuilder
         return value.Value;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsWhiteSpace(string value, int index)
     {
         var ch = value[index];
-        return ValidAttributeWhitespaceChars.AsSpan().IndexOf(ch) != -1;
+
+        if (ch > 32) return false;
+
+        // Valid whitespace characters defined by the HTML5 spec.
+        const long BitMask =
+            (1L << '\t')    //  9
+          | (1L << '\n')    // 10
+          | (1L << '\f')    // 12
+          | (1L << '\r')    // 13
+          | (1L << ' ');    // 32
+
+        return (BitMask & (1L << ch)) != 0;
     }
 
     private static StringSegment Trim(StringSegment value)

--- a/src/Mvc/Mvc.TagHelpers/src/GlobbingUrlBuilder.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/GlobbingUrlBuilder.cs
@@ -304,7 +304,10 @@ public class GlobbingUrlBuilder
     {
         var ch = value[index];
 
-        if (ch > 32) return false;
+        if (ch > 32)
+        {
+            return false;
+        }
 
         // Valid whitespace characters defined by the HTML5 spec.
         const long BitMask =


### PR DESCRIPTION
In MVC's tag-helpers for the check `IsCharWhitespace` a `static readonly char[]` with the allowed chars was used and then the `IndexOf(ch)` to see if the given char is in that set or not.
For the five allowed chars this operation is quite costly, and the call to `IndexOf` can't be inlined as it's too big.

As kind of direct lookup we can construct a bit-mask from the allowed chars, then check if the given char is in that bit-mask.
Results in speedup ~10x (for this isolated operation in the benchmark).
Moreover the code becomes very tiny, so it can be inlined -- though the JIT needs some help with that decision.

<details>
  <summary>Benchmark code</summary>

```c#
using System.Runtime.CompilerServices;
using BenchmarkDotNet.Attributes;

Bench bench = new();
Console.WriteLine(bench.Default());
Console.WriteLine(bench.BitMask());
Console.WriteLine(bench.BitMaskInlined());

#if !DEBUG
BenchmarkDotNet.Running.BenchmarkRunner.Run<Bench>();
#endif

[DisassemblyDiagnoser]
public class Bench
{
    private static readonly char[] ValidAttributeWhitespaceChars =
        new[] { '\t', '\n', '\u000C', '\r', ' ' };

    [Benchmark(Baseline = true, OperationsPerInvoke = char.MaxValue - char.MinValue)]
    public int Default()
    {
        int count = 0;

        for (int i = char.MinValue; i <= char.MaxValue; ++i)
        {
            if (IsCharWhitespace((char)i))
            {
                count++;
            }
        }

        return count;
    }

    [Benchmark(OperationsPerInvoke = char.MaxValue - char.MinValue)]
    public int BitMask()
    {
        int count = 0;

        for (int i = char.MinValue; i <= char.MaxValue; ++i)
        {
            if (IsCharWhitespaceBitMask((char)i))
            {
                count++;
            }
        }

        return count;
    }

    [Benchmark(OperationsPerInvoke = char.MaxValue - char.MinValue)]
    public int BitMaskInlined()
    {
        int count = 0;

        for (int i = char.MinValue; i <= char.MaxValue; ++i)
        {
            if (IsCharWhitespaceBitMaskInlined((char)i))
            {
                count++;
            }
        }

        return count;
    }

    private static bool IsCharWhitespace(char ch)
    {
        return ValidAttributeWhitespaceChars.AsSpan().IndexOf(ch) != -1;
    }

    private static bool IsCharWhitespaceBitMask(char ch)
    {
        if (ch > 32) return false;

        // Valid whitespace characters defined by the HTML5 spec.
        const long BitMask =
            (1L << '\t')    // 9
          | (1L << '\n')    // 10
          | (1L << '\f')    // 12
          | (1L << '\r')    // 13
          | (1L << ' ');    // 32

        return (BitMask & (1L << ch)) != 0;
    }

    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    private static bool IsCharWhitespaceBitMaskInlined(char ch)
    {
        if (ch > 32) return false;

        // Valid whitespace characters defined by the HTML5 spec.
        const long BitMask =
            (1L << '\t')    // 9
          | (1L << '\n')    // 10
          | (1L << '\f')    // 12
          | (1L << '\r')    // 13
          | (1L << ' ');    // 32

        return (BitMask & (1L << ch)) != 0;
    }
}
```
</details>

```
|         Method |      Mean |     Error |    StdDev | Ratio | Code Size |
|--------------- |----------:|----------:|----------:|------:|----------:|
|        Default | 6.0844 ns | 0.1193 ns | 0.1374 ns |  1.00 |     107 B |
|        BitMask | 2.1983 ns | 0.0435 ns | 0.0714 ns |  0.37 |      85 B |
| BitMaskInlined | 0.6276 ns | 0.0125 ns | 0.0162 ns |  0.10 |      51 B |
```
(.NET SDK=7.0.100-rc.2.22426.5)

Method `BitMaskInlined` is used in this PR.