### PR TITLE
[6.0] Allow zero byte reads on the test server response body 

### DIFF
--- a/src/Hosting/TestHost/src/ResponseBodyReaderStream.cs
+++ b/src/Hosting/TestHost/src/ResponseBodyReaderStream.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.TestHost
 
         public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            VerifyBuffer(buffer, offset, count);
+            ValidateBufferArguments(buffer, offset, count);
             CheckAborted();
 
             if (_readerComplete)
@@ -99,22 +99,6 @@ namespace Microsoft.AspNetCore.TestHost
             readableBuffer.CopyTo(new Span<byte>(buffer, offset, count));
             _pipe.Reader.AdvanceTo(readableBuffer.End);
             return (int)actual;
-        }
-
-        private static void VerifyBuffer(byte[] buffer, int offset, int count)
-        {
-            if (buffer == null)
-            {
-                throw new ArgumentNullException(nameof(buffer));
-            }
-            if (offset < 0 || offset > buffer.Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(offset), offset, string.Empty);
-            }
-            if (count <= 0 || count > buffer.Length - offset)
-            {
-                throw new ArgumentOutOfRangeException(nameof(count), count, string.Empty);
-            }
         }
 
         internal void Cancel()


### PR DESCRIPTION
YARP adopted the zero-byte-read pattern to reduce memory usage on long lived connections. However, we've found several existing streams in the framework that do not support that pattern. 

## Description

In-memory web app testing using TestServer is a pattern we recommend to make tests more reliable. Customers can set up YARP to proxy to an in-memory TestServer instance to test multiple applications together. However, when YARP adopted the zero-byte-read pattern, TestServer didn't support that and the scenario broke.

There is no known workaround for 6.0. The issue was partially fixed in 7.0 via new Stream Memory overloads.

Fixes #41692

## Customer Impact

YARP customers are currently blocked from testing by proxying to in-memory apps via TestServer.

## Regression?

- [x] Yes
- [ ] No

This worked with YARP 1.0 before zero-byte-reads were adopted in 1.1.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

This is a testing component.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A