### PR TITLE
Only add MethodInfo to route handler endpoints

### DIFF
--- a/src/Http/Routing/src/RouteEndpointDataSource.cs
+++ b/src/Http/Routing/src/RouteEndpointDataSource.cs
@@ -168,8 +168,12 @@ internal sealed class RouteEndpointDataSource : EndpointDataSource
         {
             DisplayName = displayName,
             ApplicationServices = _applicationServices,
-            Metadata = { handler.Method },
         };
+
+        if (isRouteHandler)
+        {
+            builder.Metadata.Add(handler.Method);
+        }
 
         if (entry.HttpMethods is not null)
         {

--- a/src/Http/Routing/test/UnitTests/Builder/RequestDelegateEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/RequestDelegateEndpointRouteBuilderExtensionsTest.cs
@@ -190,10 +190,9 @@ public class RequestDelegateEndpointRouteBuilderExtensionsTest
         // Assert
         var endpointBuilder1 = GetRouteEndpointBuilder(builder);
         Assert.Equal("/", endpointBuilder1.RoutePattern.RawText);
-        Assert.Equal(3, endpointBuilder1.Metadata.Count);
-        Assert.Equal(((RequestDelegate)Handle).Method, endpointBuilder1.Metadata[0]);
-        Assert.IsType<Attribute1>(endpointBuilder1.Metadata[1]);
-        Assert.IsType<Attribute2>(endpointBuilder1.Metadata[2]);
+        Assert.Equal(2, endpointBuilder1.Metadata.Count);
+        Assert.IsType<Attribute1>(endpointBuilder1.Metadata[0]);
+        Assert.IsType<Attribute2>(endpointBuilder1.Metadata[1]);
     }
 
     [Fact]
@@ -228,11 +227,10 @@ public class RequestDelegateEndpointRouteBuilderExtensionsTest
 
         // As with the Delegate Map method overloads for route handlers, the attributes on the RequestDelegate
         // can override the HttpMethodMetadata. Extension methods could already do this.
-        Assert.Equal(4, endpoint.Metadata.Count);
-        Assert.Equal(((RequestDelegate)HandleHttpMetdata).Method, endpoint.Metadata[0]);
-        Assert.Equal("METHOD", GetMethod(endpoint.Metadata[1]));
-        Assert.Equal("ATTRIBUTE", GetMethod(endpoint.Metadata[2]));
-        Assert.Equal("BUILDER", GetMethod(endpoint.Metadata[3]));
+        Assert.Equal(3, endpoint.Metadata.Count);
+        Assert.Equal("METHOD", GetMethod(endpoint.Metadata[0]));
+        Assert.Equal("ATTRIBUTE", GetMethod(endpoint.Metadata[1]));
+        Assert.Equal("BUILDER", GetMethod(endpoint.Metadata[2]));
 
         Assert.Equal("BUILDER", endpoint.Metadata.GetMetadata<IHttpMethodMetadata>()?.HttpMethods.Single());
 


### PR DESCRIPTION
## Description

This PR resolves a regression to OpenAPI-generation behavior due to a change in the `RouteEndpointDataSource` that was introduced in RC1. See [this comment](https://github.com/dotnet/aspnetcore/issues/44005#issuecomment-1248717069) for more einfo.

Fixes https://github.com/dotnet/aspnetcore/issues/44005

## Customer Impact

This PR resolves a regression in which endpoints that customers would expect to be hidden from OpenAPI generation were visible 

## Regression?

- [X] Yes
- [ ] No

This is a regression from .NET 6 and .NET 7 Preview 7 behavior.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The risk is low because we are reverting to known behavior (as of .NET 6).

## Verification

- [X] Manual (required): on user code from bug report
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A