### PR TITLE
Get template error codes from the right processes

### DIFF
--- a/src/ProjectTemplates/Shared/BlazorTemplateTest.cs
+++ b/src/ProjectTemplates/Shared/BlazorTemplateTest.cs
@@ -52,8 +52,7 @@ public abstract class BlazorTemplateTest : LoggedTest
             project.TargetFramework = targetFramework;
         }
 
-        var createResult = await project.RunDotNetNewAsync(ProjectType, auth: auth, args: args, errorOnRestoreError: false);
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
+        await project.RunDotNetNewAsync(ProjectType, auth: auth, args: args, errorOnRestoreError: false);
 
         if (serverProject || auth is null)
         {
@@ -78,8 +77,7 @@ public abstract class BlazorTemplateTest : LoggedTest
                 targetProject = GetSubProject(project, "Server", $"{project.ProjectName}.Server");
             }
 
-            var publishResult = await targetProject.RunDotNetPublishAsync(noRestore: false);
-            Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", targetProject, publishResult));
+            await targetProject.RunDotNetPublishAsync(noRestore: false);
         }
 
         return project;

--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -61,7 +61,7 @@ public class Project : IDisposable
     public ITestOutputHelper Output { get; set; }
     public IMessageSink DiagnosticsMessageSink { get; set; }
 
-    internal async Task<ProcessResult> RunDotNetNewAsync(
+    internal async Task RunDotNetNewAsync(
         string templateName,
         string auth = null,
         string language = null,
@@ -126,10 +126,10 @@ public class Project : IDisposable
             result.ExitCode = -1;
         }
 
-        return result;
+        Assert.True(0 == result.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", this, result));
     }
 
-    internal async Task<ProcessResult> RunDotNetPublishAsync(IDictionary<string, string> packageOptions = null, string additionalArgs = null, bool noRestore = true)
+    internal async Task RunDotNetPublishAsync(IDictionary<string, string> packageOptions = null, string additionalArgs = null, bool noRestore = true)
     {
         Output.WriteLine("Publishing ASP.NET Core application...");
 
@@ -150,10 +150,11 @@ public class Project : IDisposable
         }
 
         CaptureBinLogOnFailure(execution);
-        return result;
+
+        Assert.True(0 == result.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", this, result));
     }
 
-    internal async Task<ProcessResult> RunDotNetBuildAsync(IDictionary<string, string> packageOptions = null, string additionalArgs = null, bool errorOnBuildWarning = true)
+    internal async Task RunDotNetBuildAsync(IDictionary<string, string> packageOptions = null, string additionalArgs = null, bool errorOnBuildWarning = true)
     {
         Output.WriteLine("Building ASP.NET Core application...");
 
@@ -172,7 +173,8 @@ public class Project : IDisposable
         }
 
         CaptureBinLogOnFailure(execution);
-        return result;
+
+        Assert.True(0 == result.ExitCode, ErrorMessages.GetFailedProcessMessage("build", this, result));
     }
 
     internal AspNetProcess StartBuiltProjectAsync(bool hasListeningUri = true, ILogger logger = null)
@@ -206,7 +208,7 @@ public class Project : IDisposable
         return new AspNetProcess(DevCert, Output, TemplatePublishDir, projectDll, environment, published: true, hasListeningUri: hasListeningUri, usePublishedAppHost: usePublishedAppHost);
     }
 
-    internal async Task<ProcessResult> RunDotNetEfCreateMigrationAsync(string migrationName)
+    internal async Task RunDotNetEfCreateMigrationAsync(string migrationName)
     {
         var args = $"--verbose --no-build migrations add {migrationName}";
 
@@ -222,10 +224,11 @@ public class Project : IDisposable
 
         using var result = ProcessEx.Run(Output, TemplateOutputDir, command, args);
         await result.Exited;
-        return new ProcessResult(result);
+        var processResult = new ProcessResult(result);
+        Assert.True(0 == processResult.ExitCode, ErrorMessages.GetFailedProcessMessage("run EF migrations", this, processResult));
     }
 
-    internal async Task<ProcessResult> RunDotNetEfUpdateDatabaseAsync()
+    internal async Task RunDotNetEfUpdateDatabaseAsync()
     {
         var args = "--verbose --no-build database update";
 
@@ -241,7 +244,8 @@ public class Project : IDisposable
 
         using var result = ProcessEx.Run(Output, TemplateOutputDir, command, args);
         await result.Exited;
-        return new ProcessResult(result);
+        var processResult = new ProcessResult(result);
+        Assert.True(0 == processResult.ExitCode, ErrorMessages.GetFailedProcessMessage("update database", this, processResult));
     }
 
     // If this fails, you should generate new migrations via migrations/updateMigrations.cmd
@@ -289,7 +293,7 @@ public class Project : IDisposable
         }
     }
 
-    public async Task<Project> VerifyLaunchSettings(string[] expectedLaunchProfileNames)
+    public async Task VerifyLaunchSettings(string[] expectedLaunchProfileNames)
     {
         var launchSettingsFiles = Directory.EnumerateFiles(TemplateOutputDir, "launchSettings.json", SearchOption.AllDirectories);
 
@@ -342,8 +346,6 @@ public class Project : IDisposable
                 }
             }
         }
-
-        return this;
     }
 
     public string ReadFile(string path)
@@ -352,7 +354,7 @@ public class Project : IDisposable
         return File.ReadAllText(Path.Combine(TemplateOutputDir, path));
     }
 
-    internal async Task<ProcessEx> RunDotNetNewRawAsync(string arguments)
+    internal async Task RunDotNetNewRawAsync(string arguments)
     {
         var result = ProcessEx.Run(
             Output,
@@ -362,7 +364,7 @@ public class Project : IDisposable
                 $" --debug:disable-sdk-templates --debug:custom-hive \"{TemplatePackageInstaller.CustomHivePath}\"" +
                 $" -o {TemplateOutputDir}");
         await result.Exited;
-        return result;
+        Assert.True(result.ExitCode == 0, result.GetFormattedOutput());
     }
 
     public void Dispose()

--- a/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorTemplateTest.cs
@@ -35,8 +35,7 @@ public abstract class BlazorTemplateTest : BrowserTestBase
             project.TargetFramework = targetFramework;
         }
 
-        var createResult = await project.RunDotNetNewAsync(ProjectType, auth: auth, args: args);
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
+        await project.RunDotNetNewAsync(ProjectType, auth: auth, args: args);
 
         if (!onlyCreate)
         {
@@ -46,15 +45,13 @@ public abstract class BlazorTemplateTest : BrowserTestBase
                 targetProject = GetSubProject(project, "Server", $"{project.ProjectName}.Server");
             }
 
-            var publishResult = await targetProject.RunDotNetPublishAsync(noRestore: false);
-            Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", targetProject, publishResult));
+            await targetProject.RunDotNetPublishAsync(noRestore: false);
 
             // Run dotnet build after publish. The reason is that one uses Config = Debug and the other uses Config = Release
             // The output from publish will go into bin/Release/netcoreappX.Y/publish and won't be affected by calling build
             // later, while the opposite is not true.
 
-            var buildResult = await targetProject.RunDotNetBuildAsync();
-            Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", targetProject, buildResult));
+            await targetProject.RunDotNetBuildAsync();
         }
 
         return project;

--- a/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWasmTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWasmTemplateTest.cs
@@ -248,24 +248,20 @@ public class BlazorWasmTemplateTest : BlazorTemplateTest
         var appSettingsPath = Path.Combine(serverProject.TemplateOutputDir, "appsettings.json");
         File.WriteAllText(appSettingsPath, replacedSection);
 
-        var publishResult = await serverProject.RunDotNetPublishAsync();
-        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", serverProject, publishResult));
+        await serverProject.RunDotNetPublishAsync();
 
         // Run dotnet build after publish. The reason is that one uses Config = Debug and the other uses Config = Release
         // The output from publish will go into bin/Release/netcoreappX.Y/publish and won't be affected by calling build
         // later, while the opposite is not true.
 
-        var buildResult = await serverProject.RunDotNetBuildAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", serverProject, buildResult));
+        await serverProject.RunDotNetBuildAsync();
 
-        var migrationsResult = await serverProject.RunDotNetEfCreateMigrationAsync("blazorwasm");
-        Assert.True(0 == migrationsResult.ExitCode, ErrorMessages.GetFailedProcessMessage("run EF migrations", serverProject, migrationsResult));
+        await serverProject.RunDotNetEfCreateMigrationAsync("blazorwasm");
         serverProject.AssertEmptyMigration("blazorwasm");
 
         if (useLocalDb)
         {
-            var dbUpdateResult = await serverProject.RunDotNetEfUpdateDatabaseAsync();
-            Assert.True(0 == dbUpdateResult.ExitCode, ErrorMessages.GetFailedProcessMessage("update database", serverProject, dbUpdateResult));
+            await serverProject.RunDotNetEfUpdateDatabaseAsync();
         }
 
         return project;

--- a/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Auth.Tests/BlazorWasmTemplateAuthTest.cs
+++ b/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Auth.Tests/BlazorWasmTemplateAuthTest.cs
@@ -95,18 +95,15 @@ public class BlazorWasmTemplateAuthTest : BlazorTemplateTest
         var appSettingsPath = Path.Combine(serverProject.TemplateOutputDir, "appsettings.json");
         File.WriteAllText(appSettingsPath, replacedSection);
 
-        var publishResult = await serverProject.RunDotNetPublishAsync();
-        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", serverProject, publishResult));
+        await serverProject.RunDotNetPublishAsync();
 
         // Run dotnet build after publish. The reason is that one uses Config = Debug and the other uses Config = Release
         // The output from publish will go into bin/Release/netcoreappX.Y/publish and won't be affected by calling build
         // later, while the opposite is not true.
 
-        var buildResult = await serverProject.RunDotNetBuildAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", serverProject, buildResult));
+        await serverProject.RunDotNetBuildAsync();
 
-        var migrationsResult = await serverProject.RunDotNetEfCreateMigrationAsync("blazorwasm");
-        Assert.True(0 == migrationsResult.ExitCode, ErrorMessages.GetFailedProcessMessage("run EF migrations", serverProject, migrationsResult));
+        await serverProject.RunDotNetEfCreateMigrationAsync("blazorwasm");
         serverProject.AssertEmptyMigration("blazorwasm");
 
         return project;

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/MvcTemplateTest.cs
@@ -55,8 +55,7 @@ public class MvcTemplateTest : LoggedTest
     {
         var project = await ProjectFactory.CreateProject(Output);
 
-        var createResult = await project.RunDotNetNewAsync("mvc", language: languageOverride, args: args);
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
+        await project.RunDotNetNewAsync("mvc", language: languageOverride, args: args);
 
         var noHttps = args?.Contains(ArgConstants.NoHttps) ?? false;
         var expectedLaunchProfileNames = noHttps
@@ -78,15 +77,13 @@ public class MvcTemplateTest : LoggedTest
             return;
         }
 
-        var publishResult = await project.RunDotNetPublishAsync();
-        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
+        await project.RunDotNetPublishAsync();
 
         // Run dotnet build after publish. The reason is that one uses Config = Debug and the other uses Config = Release
         // The output from publish will go into bin/Release/netcoreappX.Y/publish and won't be affected by calling build
         // later, while the opposite is not true.
 
-        var buildResult = await project.RunDotNetBuildAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
+        await project.RunDotNetBuildAsync();
 
         IEnumerable<string> menuLinks = new List<string> {
                 PageUrls.HomeUrl,
@@ -157,8 +154,7 @@ public class MvcTemplateTest : LoggedTest
             : noHttps
                 ? new[] { ArgConstants.NoHttps }
                 : null;
-        var createResult = await project.RunDotNetNewAsync("mvc", auth: "Individual", useLocalDB: useLocalDB, args: args);
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
+        await project.RunDotNetNewAsync("mvc", auth: "Individual", useLocalDB: useLocalDB, args: args);
 
         var expectedLaunchProfileNames = noHttps
             ? new[] { "http", "IIS Express" }
@@ -171,18 +167,15 @@ public class MvcTemplateTest : LoggedTest
             Assert.Contains(".db", projectFileContents);
         }
 
-        var publishResult = await project.RunDotNetPublishAsync();
-        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
+        await project.RunDotNetPublishAsync();
 
         // Run dotnet build after publish. The reason is that one uses Config = Debug and the other uses Config = Release
         // The output from publish will go into bin/Release/netcoreappX.Y/publish and won't be affected by calling build
         // later, while the opposite is not true.
 
-        var buildResult = await project.RunDotNetBuildAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
+        await project.RunDotNetBuildAsync();
 
-        var migrationsResult = await project.RunDotNetEfCreateMigrationAsync("mvc");
-        Assert.True(0 == migrationsResult.ExitCode, ErrorMessages.GetFailedProcessMessage("run EF migrations", project, migrationsResult));
+        await project.RunDotNetEfCreateMigrationAsync("mvc");
         project.AssertEmptyMigration("mvc");
 
         // Note: if any links are updated here, RazorPagesTemplateTest.cs should be updated as well
@@ -284,11 +277,9 @@ public class MvcTemplateTest : LoggedTest
         var project = await ProjectFactory.CreateProject(Output);
         project.RuntimeIdentifier = runtimeIdentifer;
 
-        var createResult = await project.RunDotNetNewAsync("mvc");
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
+        await project.RunDotNetNewAsync("mvc");
 
-        var publishResult = await project.RunDotNetPublishAsync(additionalArgs: $"/p:PublishSingleFile=true -r {runtimeIdentifer} --self-contained", noRestore: false);
-        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
+        await project.RunDotNetPublishAsync(additionalArgs: $"/p:PublishSingleFile=true -r {runtimeIdentifer} --self-contained", noRestore: false);
 
         var menuLinks = new[]
         {
@@ -361,20 +352,17 @@ public class MvcTemplateTest : LoggedTest
     {
         var project = await ProjectFactory.CreateProject(Output);
 
-        var createResult = await project.RunDotNetNewAsync("mvc", auth: auth, args: args);
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
+        await project.RunDotNetNewAsync("mvc", auth: auth, args: args);
 
         // Identity Web auth requires https and thus ignores the --no-https option if passed so there should never be an 'http' profile
         var expectedLaunchProfileNames = new[] { "https", "IIS Express" };
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
         // Verify building in debug works
-        var buildResult = await project.RunDotNetBuildAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
+        await project.RunDotNetBuildAsync();
 
         // Publish builds in "release" configuration. Running publish should ensure we can compile in release and that we can publish without issues.
-        var publishResult = await project.RunDotNetPublishAsync();
-        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
+        await project.RunDotNetPublishAsync();
 
         return project;
     }

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/MvcTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/MvcTemplateTest.cs
@@ -373,8 +373,8 @@ public class MvcTemplateTest : LoggedTest
         Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
 
         // Publish builds in "release" configuration. Running publish should ensure we can compile in release and that we can publish without issues.
-        buildResult = await project.RunDotNetPublishAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, buildResult));
+        var publishResult = await project.RunDotNetPublishAsync();
+        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
 
         return project;
     }

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/RazorPagesTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/RazorPagesTemplateTest.cs
@@ -67,14 +67,14 @@ public class RazorPagesTemplateTest : LoggedTest
         Assert.DoesNotContain("Microsoft.Extensions.SecretManager.Tools", projectFileContents);
 
         var publishResult = await project.RunDotNetPublishAsync();
-        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, createResult));
+        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
 
         // Run dotnet build after publish. The reason is that one uses Config = Debug and the other uses Config = Release
         // The output from publish will go into bin/Release/netcoreappX.Y/publish and won't be affected by calling build
         // later, while the opposite is not true.
 
         var buildResult = await project.RunDotNetBuildAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, createResult));
+        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
 
         var pages = new List<Page>
             {
@@ -309,8 +309,8 @@ public class RazorPagesTemplateTest : LoggedTest
         Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
 
         // Publish builds in "release" configuration. Running publish should ensure we can compile in release and that we can publish without issues.
-        buildResult = await project.RunDotNetPublishAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, buildResult));
+        var publishResult = await project.RunDotNetPublishAsync();
+        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
 
         return project;
     }

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/RazorPagesTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/RazorPagesTemplateTest.cs
@@ -51,8 +51,7 @@ public class RazorPagesTemplateTest : LoggedTest
             : noHttps
                 ? new[] { ArgConstants.NoHttps }
                 : null;
-        var createResult = await project.RunDotNetNewAsync("razor", args: args);
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("razor", project, createResult));
+        await project.RunDotNetNewAsync("razor", args: args);
 
         var expectedLaunchProfileNames = noHttps
             ? new[] { "http", "IIS Express" }
@@ -66,15 +65,13 @@ public class RazorPagesTemplateTest : LoggedTest
         Assert.DoesNotContain("Microsoft.EntityFrameworkCore.Tools.DotNet", projectFileContents);
         Assert.DoesNotContain("Microsoft.Extensions.SecretManager.Tools", projectFileContents);
 
-        var publishResult = await project.RunDotNetPublishAsync();
-        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
+        await project.RunDotNetPublishAsync();
 
         // Run dotnet build after publish. The reason is that one uses Config = Debug and the other uses Config = Release
         // The output from publish will go into bin/Release/netcoreappX.Y/publish and won't be affected by calling build
         // later, while the opposite is not true.
 
-        var buildResult = await project.RunDotNetBuildAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
+        await project.RunDotNetBuildAsync();
 
         var pages = new List<Page>
             {
@@ -147,8 +144,7 @@ public class RazorPagesTemplateTest : LoggedTest
             : noHttps
                 ? new[] { ArgConstants.NoHttps }
                 : null;
-        var createResult = await project.RunDotNetNewAsync("razor", auth: "Individual", useLocalDB: useLocalDB, args: args);
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
+        await project.RunDotNetNewAsync("razor", auth: "Individual", useLocalDB: useLocalDB, args: args);
 
         // Individual auth supports no https OK
         var expectedLaunchProfileNames = noHttps
@@ -162,18 +158,15 @@ public class RazorPagesTemplateTest : LoggedTest
             Assert.Contains(".db", projectFileContents);
         }
 
-        var publishResult = await project.RunDotNetPublishAsync();
-        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
+        await project.RunDotNetPublishAsync();
 
         // Run dotnet build after publish. The reason is that one uses Config = Debug and the other uses Config = Release
         // The output from publish will go into bin/Release/netcoreappX.Y/publish and won't be affected by calling build
         // later, while the opposite is not true.
 
-        var buildResult = await project.RunDotNetBuildAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
+        await project.RunDotNetBuildAsync();
 
-        var migrationsResult = await project.RunDotNetEfCreateMigrationAsync("razorpages");
-        Assert.True(0 == migrationsResult.ExitCode, ErrorMessages.GetFailedProcessMessage("run EF migrations", project, migrationsResult));
+        await project.RunDotNetEfCreateMigrationAsync("razorpages");
         project.AssertEmptyMigration("razorpages");
 
         // Note: if any links are updated here, MvcTemplateTest.cs should be updated as well
@@ -297,20 +290,17 @@ public class RazorPagesTemplateTest : LoggedTest
     {
         var project = await ProjectFactory.CreateProject(Output);
 
-        var createResult = await project.RunDotNetNewAsync("razor", auth: auth, args: args);
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
+        await project.RunDotNetNewAsync("razor", auth: auth, args: args);
 
         // Identity Web auth requires https and thus ignores the --no-https option if passed so there should never be an 'http' profile
         var expectedLaunchProfileNames = new[] { "https", "IIS Express" };
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
         // Verify building in debug works
-        var buildResult = await project.RunDotNetBuildAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
+        await project.RunDotNetBuildAsync();
 
         // Publish builds in "release" configuration. Running publish should ensure we can compile in release and that we can publish without issues.
-        var publishResult = await project.RunDotNetPublishAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
+        await project.RunDotNetPublishAsync();
 
         return project;
     }

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/WebApiTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/WebApiTemplateTest.cs
@@ -165,11 +165,9 @@ public class WebApiTemplateTest : LoggedTest
             : useMinimalApis
                 ? new[] { ArgConstants.UseMinimalApis, ArgConstants.NoOpenApi }
                 : new[] { ArgConstants.NoOpenApi };
-        var createResult = await project.RunDotNetNewAsync("webapi", args: args);
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
+        await project.RunDotNetNewAsync("webapi", args: args);
 
-        var buildResult = await project.RunDotNetBuildAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
+        await project.RunDotNetBuildAsync();
 
         using var aspNetProcess = project.StartBuiltProjectAsync();
         Assert.False(
@@ -196,8 +194,7 @@ public class WebApiTemplateTest : LoggedTest
             : useMinimalApis
                 ? new[] { ArgConstants.UseMinimalApis, ArgConstants.NoOpenApi, ArgConstants.NoHttps }
                 : new[] { ArgConstants.NoOpenApi, ArgConstants.NoHttps };
-        var createResult = await project.RunDotNetNewAsync("webapi", args: args);
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
+        await project.RunDotNetNewAsync("webapi", args: args);
 
         var noHttps = args.Contains(ArgConstants.NoHttps);
         var expectedLaunchProfileNames = noHttps
@@ -205,8 +202,7 @@ public class WebApiTemplateTest : LoggedTest
             : new[] { "http", "https", "IIS Express" };
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
-        var buildResult = await project.RunDotNetBuildAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
+        await project.RunDotNetBuildAsync();
 
         using var aspNetProcess = project.StartBuiltProjectAsync();
         Assert.False(
@@ -220,8 +216,7 @@ public class WebApiTemplateTest : LoggedTest
     {
         var project = await FactoryFixture.CreateProject(Output);
 
-        var createResult = await project.RunDotNetNewAsync("webapi", language: languageOverride, auth: auth, args: args);
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
+        await project.RunDotNetNewAsync("webapi", language: languageOverride, auth: auth, args: args);
 
         // External auth mechanisms require https to work and thus don't honor the --no-https flag
         var requiresHttps = string.Equals(auth, "IndividualB2C", StringComparison.OrdinalIgnoreCase)
@@ -240,15 +235,13 @@ public class WebApiTemplateTest : LoggedTest
             return project;
         }
 
-        var publishResult = await project.RunDotNetPublishAsync();
-        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
+        await project.RunDotNetPublishAsync();
 
         // Run dotnet build after publish. The reason is that one uses Config = Debug and the other uses Config = Release
         // The output from publish will go into bin/Release/netcoreappX.Y/publish and won't be affected by calling build
         // later, while the opposite is not true.
 
-        var buildResult = await project.RunDotNetBuildAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
+        await project.RunDotNetBuildAsync();
 
         return project;
     }

--- a/src/ProjectTemplates/test/Templates.Tests/BaselineTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/BaselineTest.cs
@@ -73,8 +73,7 @@ public class BaselineTest : LoggedTest
     public async Task Template_Produces_The_Right_Set_Of_FilesAsync(string arguments, string[] expectedFiles)
     {
         Project = await ProjectFactory.CreateProject(Output);
-        var createResult = await Project.RunDotNetNewRawAsync(arguments);
-        Assert.True(createResult.ExitCode == 0, createResult.GetFormattedOutput());
+        await Project.RunDotNetNewRawAsync(arguments);
 
         foreach (var file in expectedFiles)
         {

--- a/src/ProjectTemplates/test/Templates.Tests/EmptyWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/EmptyWebTemplateTest.cs
@@ -75,8 +75,7 @@ public class EmptyWebTemplateTest : LoggedTest
     {
         var project = await ProjectFactory.CreateProject(Output);
 
-        var createResult = await project.RunDotNetNewAsync("web", args: args, language: languageOverride);
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
+        await project.RunDotNetNewAsync("web", args: args, language: languageOverride);
 
         var noHttps = args?.Contains(ArgConstants.NoHttps) ?? false;
         var expectedLaunchProfileNames = noHttps
@@ -90,15 +89,13 @@ public class EmptyWebTemplateTest : LoggedTest
             return;
         }
 
-        var publishResult = await project.RunDotNetPublishAsync();
-        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
+        await project.RunDotNetPublishAsync();
 
         // Run dotnet build after publish. The reason is that one uses Config = Debug and the other uses Config = Release
         // The output from publish will go into bin/Release/netcoreappX.Y/publish and won't be affected by calling build
         // later, while the opposite is not true.
 
-        var buildResult = await project.RunDotNetBuildAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
+        await project.RunDotNetBuildAsync();
 
         using (var aspNetProcess = project.StartBuiltProjectAsync())
         {

--- a/src/ProjectTemplates/test/Templates.Tests/GrpcTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/GrpcTemplateTest.cs
@@ -45,17 +45,14 @@ public class GrpcTemplateTest : LoggedTest
         var project = await ProjectFactory.CreateProject(Output);
 
         var args = useProgramMain ? new[] { ArgConstants.UseProgramMain } : null;
-        var createResult = await project.RunDotNetNewAsync("grpc", args: args);
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
+        await project.RunDotNetNewAsync("grpc", args: args);
 
         var expectedLaunchProfileNames = new[] { "http", "https" };
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
-        var publishResult = await project.RunDotNetPublishAsync();
-        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
+        await project.RunDotNetPublishAsync();
 
-        var buildResult = await project.RunDotNetBuildAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
+        await project.RunDotNetBuildAsync();
 
         var isOsx = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         var isWindowsOld = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.OSVersion.Version < new Version(6, 2);

--- a/src/ProjectTemplates/test/Templates.Tests/IdentityUIPackageTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/IdentityUIPackageTest.cs
@@ -105,24 +105,20 @@ public class IdentityUIPackageTest : LoggedTest
         var project = await ProjectFactory.CreateProject(Output);
         var useLocalDB = false;
 
-        var createResult = await project.RunDotNetNewAsync("razor", auth: "Individual", useLocalDB: useLocalDB, environmentVariables: packageOptions);
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
+        await project.RunDotNetNewAsync("razor", auth: "Individual", useLocalDB: useLocalDB, environmentVariables: packageOptions);
 
         var projectFileContents = ReadFile(project.TemplateOutputDir, $"{project.ProjectName}.csproj");
         Assert.Contains(".db", projectFileContents);
 
-        var publishResult = await project.RunDotNetPublishAsync(packageOptions: packageOptions);
-        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
+        await project.RunDotNetPublishAsync(packageOptions: packageOptions);
 
         // Run dotnet build after publish. The reason is that one uses Config = Debug and the other uses Config = Release
         // The output from publish will go into bin/Release/netcoreappX.Y/publish and won't be affected by calling build
         // later, while the opposite is not true.
 
-        var buildResult = await project.RunDotNetBuildAsync(packageOptions: packageOptions);
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
+        await project.RunDotNetBuildAsync(packageOptions: packageOptions);
 
-        var migrationsResult = await project.RunDotNetEfCreateMigrationAsync("razorpages");
-        Assert.True(0 == migrationsResult.ExitCode, ErrorMessages.GetFailedProcessMessage("run EF migrations", project, migrationsResult));
+        await project.RunDotNetEfCreateMigrationAsync("razorpages");
         project.AssertEmptyMigration("razorpages");
 
         var versionValidator = "Bootstrap v5.1.0";

--- a/src/ProjectTemplates/test/Templates.Tests/ItemTemplateTests/BlazorServerTests.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/ItemTemplateTests/BlazorServerTests.cs
@@ -27,8 +27,7 @@ public class BlazorServerTest
     {
         Project = await ProjectFactory.CreateProject(Output);
 
-        var createResult = await Project.RunDotNetNewAsync("razorcomponent --name Different");
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create", Project, createResult));
+        await Project.RunDotNetNewAsync("razorcomponent --name Different");
 
         Project.AssertFileExists("Different.razor", shouldExist: true);
         Assert.Contains("<h3>Different</h3>", Project.ReadFile("Different.razor"));

--- a/src/ProjectTemplates/test/Templates.Tests/RazorClassLibraryTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/RazorClassLibraryTemplateTest.cs
@@ -35,18 +35,15 @@ public class RazorClassLibraryTemplateTest : LoggedTest
     {
         var project = await ProjectFactory.CreateProject(Output);
 
-        var createResult = await project.RunDotNetNewAsync("razorclasslib", args: new[] { "--support-pages-and-views", "true" });
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
+        await project.RunDotNetNewAsync("razorclasslib", args: new[] { "--support-pages-and-views", "true" });
 
-        var publishResult = await project.RunDotNetPublishAsync();
-        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
+        await project.RunDotNetPublishAsync();
 
         // Run dotnet build after publish. The reason is that one uses Config = Debug and the other uses Config = Release
         // The output from publish will go into bin/Release/netcoreappX.Y/publish and won't be affected by calling build
         // later, while the opposite is not true.
 
-        var buildResult = await project.RunDotNetBuildAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
+        await project.RunDotNetBuildAsync();
     }
 
     [ConditionalFact]
@@ -55,17 +52,14 @@ public class RazorClassLibraryTemplateTest : LoggedTest
     {
         var project = await ProjectFactory.CreateProject(Output);
 
-        var createResult = await project.RunDotNetNewAsync("razorclasslib");
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
+        await project.RunDotNetNewAsync("razorclasslib");
 
-        var publishResult = await project.RunDotNetPublishAsync();
-        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
+        await project.RunDotNetPublishAsync();
 
         // Run dotnet build after publish. The reason is that one uses Config = Debug and the other uses Config = Release
         // The output from publish will go into bin/Release/netcoreappX.Y/publish and won't be affected by calling build
         // later, while the opposite is not true.
 
-        var buildResult = await project.RunDotNetBuildAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
+        await project.RunDotNetBuildAsync();
     }
 }

--- a/src/ProjectTemplates/test/Templates.Tests/SpaTemplatesTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/SpaTemplatesTest.cs
@@ -43,17 +43,14 @@ public class SpaTemplatesTest : LoggedTest
     {
         var project = await ProjectFactory.CreateProject(Output);
         var args = new[] { "--NoSpaFrontEnd", "true" };
-        var createResult = await project.RunDotNetNewAsync(template, auth: auth, args: args);
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage(template, project, createResult));
+        await project.RunDotNetNewAsync(template, auth: auth, args: args);
 
-        var publishResult = await project.RunDotNetPublishAsync();
-        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
+        await project.RunDotNetPublishAsync();
 
         // Run dotnet build after publish. The reason is that one uses Config = Debug and the other uses Config = Release
         // The output from publish will go into bin/Release/netcoreappX.Y/publish and won't be affected by calling build
         // later, while the opposite is not true.
 
-        var buildResult = await project.RunDotNetBuildAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
+        await project.RunDotNetBuildAsync();
     }
 }

--- a/src/ProjectTemplates/test/Templates.Tests/WorkerTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/WorkerTemplateTest.cs
@@ -38,18 +38,15 @@ public class WorkerTemplateTest : LoggedTest
     {
         var project = await ProjectFactory.CreateProject(Output);
 
-        var createResult = await project.RunDotNetNewAsync("worker", language: language, args: args);
-        Assert.True(0 == createResult.ExitCode, ErrorMessages.GetFailedProcessMessage("create/restore", project, createResult));
+        await project.RunDotNetNewAsync("worker", language: language, args: args);
 
-        var publishResult = await project.RunDotNetPublishAsync();
-        Assert.True(0 == publishResult.ExitCode, ErrorMessages.GetFailedProcessMessage("publish", project, publishResult));
+        await project.RunDotNetPublishAsync();
 
         // Run dotnet build after publish. The reason is that one uses Config = Debug and the other uses Config = Release
         // The output from publish will go into bin/Release/netcoreappX.Y/publish and won't be affected by calling build
         // later, while the opposite is not true.
 
-        var buildResult = await project.RunDotNetBuildAsync();
-        Assert.True(0 == buildResult.ExitCode, ErrorMessages.GetFailedProcessMessage("build", project, buildResult));
+        await project.RunDotNetBuildAsync();
 
         using (var aspNetProcess = project.StartBuiltProjectAsync(hasListeningUri: false))
         {


### PR DESCRIPTION
I noticed while investigating template test logs that some logs were reporting the error code from the wrong process. This causes confusing logs like `Xunit.Sdk.TrueException: Project new razor  --no-https failed to publish. Exit code 0.`, the actual exit code is lost.