### PR TITLE
Vectorized HttpCharacters

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
@@ -89,8 +88,6 @@ internal sealed class KestrelServerImpl : IServer
         Features.Set<IServerAddressesFeature>(_serverAddresses);
 
         _transportManager = new TransportManager(_transportFactory, _multiplexedTransportFactory, ServiceContext);
-
-        HttpCharacters.Initialize();
     }
 
     private static ServiceContext CreateServiceContext(IOptions<KestrelServerOptions> options, ILoggerFactory loggerFactory, DiagnosticSource? diagnosticSource)

--- a/src/Shared/ServerInfrastructure/HttpCharacters.cs
+++ b/src/Shared/ServerInfrastructure/HttpCharacters.cs
@@ -1,201 +1,82 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
 
 namespace Microsoft.AspNetCore.Http;
 
-internal static class HttpCharacters
+[SkipLocalsInit]
+internal static unsafe partial class HttpCharacters
 {
-    private const int _tableSize = 128;
-    private static readonly bool[] _alphaNumeric = InitializeAlphaNumeric();
-    private static readonly bool[] _authority = InitializeAuthority();
-    private static readonly bool[] _token = InitializeToken();
-    private static readonly bool[] _host = InitializeHost();
-    private static readonly bool[] _fieldValue = InitializeFieldValue();
+    private static partial ReadOnlySpan<bool> LookupAuthority();
+    private static partial ReadOnlySpan<bool> LookupToken();
+    private static partial ReadOnlySpan<bool> LookupHost();
+    private static partial ReadOnlySpan<bool> LookupFieldValue();
 
-    internal static void Initialize()
+    private static partial Vector128<sbyte> BitMaskLookupAuthority();
+    private static partial Vector128<sbyte> BitMaskLookupToken();
+    private static partial Vector128<sbyte> BitMaskLookupHost();
+    private static partial Vector128<sbyte> BitMaskLookupFieldValue();
+
+    public static bool ContainsInvalidAuthorityChar(ReadOnlySpan<byte> s)
     {
-        // Access _alphaNumeric to initialize static fields
-        var _ = _alphaNumeric;
+        var index = Vector128.IsHardwareAccelerated && s.Length >= Vector128<byte>.Count
+            ? IndexOfInvalidCharVectorized(s, BitMaskLookupAuthority())
+            : IndexOfInvalidCharScalar(s, LookupAuthority());
+
+        return index >= 0;
     }
 
-    private static bool[] InitializeAlphaNumeric()
+    public static int IndexOfInvalidHostChar(ReadOnlySpan<char> s)
     {
-        // ALPHA and DIGIT https://tools.ietf.org/html/rfc5234#appendix-B.1
-        var alphaNumeric = new bool[_tableSize];
-        for (var c = '0'; c <= '9'; c++)
-        {
-            alphaNumeric[c] = true;
-        }
-        for (var c = 'A'; c <= 'Z'; c++)
-        {
-            alphaNumeric[c] = true;
-        }
-        for (var c = 'a'; c <= 'z'; c++)
-        {
-            alphaNumeric[c] = true;
-        }
-        return alphaNumeric;
+        return Vector128.IsHardwareAccelerated && s.Length >= Vector128<short>.Count
+            ? IndexOfInvalidCharVectorized(s, BitMaskLookupHost())
+            : IndexOfInvalidCharScalar(s, LookupHost());
     }
 
-    private static bool[] InitializeAuthority()
+    public static int IndexOfInvalidTokenChar(ReadOnlySpan<char> s)
     {
-        // Authority https://tools.ietf.org/html/rfc3986#section-3.2
-        // Examples:
-        // microsoft.com
-        // hostname:8080
-        // [::]:8080
-        // [fe80::]
-        // 127.0.0.1
-        // user@host.com
-        // user:password@host.com
-        var authority = new bool[_tableSize];
-        Array.Copy(_alphaNumeric, authority, _tableSize);
-        authority[':'] = true;
-        authority['.'] = true;
-        authority['-'] = true;
-        authority['['] = true;
-        authority[']'] = true;
-        authority['@'] = true;
-        return authority;
+        return Vector128.IsHardwareAccelerated && s.Length >= Vector128<short>.Count
+            ? IndexOfInvalidCharVectorized(s, BitMaskLookupToken())
+            : IndexOfInvalidCharScalar(s, LookupToken());
     }
 
-    private static bool[] InitializeToken()
+    public static int IndexOfInvalidTokenChar(ReadOnlySpan<byte> s)
     {
-        // tchar https://tools.ietf.org/html/rfc7230#appendix-B
-        var token = new bool[_tableSize];
-        Array.Copy(_alphaNumeric, token, _tableSize);
-        token['!'] = true;
-        token['#'] = true;
-        token['$'] = true;
-        token['%'] = true;
-        token['&'] = true;
-        token['\''] = true;
-        token['*'] = true;
-        token['+'] = true;
-        token['-'] = true;
-        token['.'] = true;
-        token['^'] = true;
-        token['_'] = true;
-        token['`'] = true;
-        token['|'] = true;
-        token['~'] = true;
-        return token;
-    }
-
-    private static bool[] InitializeHost()
-    {
-        // Matches Http.Sys
-        // Matches RFC 3986 except "*" / "+" / "," / ";" / "=" and "%" HEXDIG HEXDIG which are not allowed by Http.Sys
-        var host = new bool[_tableSize];
-        Array.Copy(_alphaNumeric, host, _tableSize);
-        host['!'] = true;
-        host['$'] = true;
-        host['&'] = true;
-        host['\''] = true;
-        host['('] = true;
-        host[')'] = true;
-        host['-'] = true;
-        host['.'] = true;
-        host['_'] = true;
-        host['~'] = true;
-        return host;
-    }
-
-    private static bool[] InitializeFieldValue()
-    {
-        // field-value https://tools.ietf.org/html/rfc7230#section-3.2
-        var fieldValue = new bool[_tableSize];
-
-        fieldValue[0x9] = true; // HTAB
-
-        for (var c = 0x20; c <= 0x7e; c++) // VCHAR and SP
-        {
-            fieldValue[c] = true;
-        }
-        return fieldValue;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ContainsInvalidAuthorityChar(Span<byte> s)
-    {
-        var authority = _authority;
-
-        for (var i = 0; i < s.Length; i++)
-        {
-            var c = s[i];
-            if (c >= (uint)authority.Length || !authority[c])
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int IndexOfInvalidHostChar(string s)
-    {
-        var host = _host;
-
-        for (var i = 0; i < s.Length; i++)
-        {
-            var c = s[i];
-            if (c >= (uint)host.Length || !host[c])
-            {
-                return i;
-            }
-        }
-
-        return -1;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int IndexOfInvalidTokenChar(string s)
-    {
-        var token = _token;
-
-        for (var i = 0; i < s.Length; i++)
-        {
-            var c = s[i];
-            if (c >= (uint)token.Length || !token[c])
-            {
-                return i;
-            }
-        }
-
-        return -1;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int IndexOfInvalidTokenChar(ReadOnlySpan<byte> span)
-    {
-        var token = _token;
-
-        for (var i = 0; i < span.Length; i++)
-        {
-            var c = span[i];
-            if (c >= (uint)token.Length || !token[c])
-            {
-                return i;
-            }
-        }
-
-        return -1;
+        return Vector128.IsHardwareAccelerated && s.Length >= Vector128<byte>.Count
+            ? IndexOfInvalidCharVectorized(s, BitMaskLookupToken())
+            : IndexOfInvalidCharScalar(s, LookupToken());
     }
 
     // Follows field-value rules in https://tools.ietf.org/html/rfc7230#section-3.2
     // Disallows characters > 0x7E.
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int IndexOfInvalidFieldValueChar(string s)
+    public static int IndexOfInvalidFieldValueChar(ReadOnlySpan<char> s)
     {
-        var fieldValue = _fieldValue;
+        return Vector128.IsHardwareAccelerated && s.Length >= Vector128<short>.Count
+            ? IndexOfInvalidCharVectorized(s, BitMaskLookupFieldValue())
+            : IndexOfInvalidCharScalar(s, LookupFieldValue());
+    }
 
-        for (var i = 0; i < s.Length; i++)
+    // Follows field-value rules for chars <= 0x7F. Allows extended characters > 0x7F.
+    public static int IndexOfInvalidFieldValueCharExtended(ReadOnlySpan<char> s)
+    {
+        return Vector128.IsHardwareAccelerated && s.Length >= Vector128<short>.Count
+            ? IndexOfInvalidCharExtendedVectorized(s, BitMaskLookupFieldValue())
+            : IndexOfInvalidCharExtendedScalar(s, LookupFieldValue());
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int IndexOfInvalidCharScalar(ReadOnlySpan<byte> value, ReadOnlySpan<bool> lookup)
+    {
+        for (var i = 0; i < value.Length; ++i)
         {
-            var c = s[i];
-            if (c >= (uint)fieldValue.Length || !fieldValue[c])
+            var b = value[i];
+
+            if (b >= lookup.Length || !lookup[b])
             {
                 return i;
             }
@@ -204,21 +85,392 @@ internal static class HttpCharacters
         return -1;
     }
 
-    // Follows field-value rules for chars <= 0x7F. Allows extended characters > 0x7F.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int IndexOfInvalidFieldValueCharExtended(string s)
+    private static int IndexOfInvalidCharScalar(ReadOnlySpan<char> value, ReadOnlySpan<bool> lookup)
     {
-        var fieldValue = _fieldValue;
-
-        for (var i = 0; i < s.Length; i++)
+        for (var i = 0; i < value.Length; ++i)
         {
-            var c = s[i];
-            if (c < (uint)fieldValue.Length && !fieldValue[c])
+            var c = value[i];
+
+            if (c >= lookup.Length || !lookup[c])
             {
                 return i;
             }
         }
 
         return -1;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int IndexOfInvalidCharExtendedScalar(ReadOnlySpan<char> value, ReadOnlySpan<bool> lookup)
+    {
+        for (var i = 0; i < value.Length; ++i)
+        {
+            var c = value[i];
+
+            if (c < (uint)lookup.Length && !lookup[c])
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static int IndexOfInvalidCharVectorized(ReadOnlySpan<byte> value, Vector128<sbyte> bitMaskLookup)
+    {
+        Debug.Assert(Vector128.IsHardwareAccelerated);
+        Debug.Assert(value.Length >= Vector128<sbyte>.Count);
+
+        // To check if a bit in a bitmask from the Bitmask is set, in a sequential code
+        // we would do ((1 << bitIndex) & bitmask) != 0
+        // As there is no hardware instrinic for such a shift, we use a lookup that
+        // stores the shifted bitpositions.
+        // So (1 << bitIndex) becomes BitPosLook[bitIndex], which is simd-friendly.
+        //
+        // A bitmask from the Bitmask (see below) is created only for values 0..7 (one byte),
+        // so to avoid a explicit check for values outside 0..7, i.e.
+        // high nibbles 8..F, we use a bitpos that always results in escaping.
+        var bitPosLookup = Vector128.Create(
+            0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80,     // high-nibble 0..7
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF      // high-nibble 8..F
+        ).AsSByte();
+
+        var nibbleMaskSByte = Vector128.Create((sbyte)0xF);
+        var zeroMaskSByte = Vector128<sbyte>.Zero;
+
+        var idx = (nuint)0;
+        var end = (nuint)(uint)(value.Length - Vector128<sbyte>.Count);
+        uint mask;
+        ref var ptr = ref MemoryMarshal.GetReference(value);
+
+        while (idx <= end)
+        {
+            var values = Vector128.LoadUnsafe(ref ptr, idx).AsSByte();
+
+            mask = CreateEscapingMask(values, bitMaskLookup, bitPosLookup, nibbleMaskSByte, zeroMaskSByte);
+            if (mask != 0)
+            {
+                goto Found;
+            }
+
+            idx += (uint)Vector128<sbyte>.Count;
+        }
+
+        // Here we know that < 16 bytes are remaining. We shift the space around to process
+        // another full vector.
+        var remaining = (uint)value.Length - idx;
+        if ((nint)remaining > 0)
+        {
+            remaining -= (uint)Vector128<sbyte>.Count;
+
+            var values = Vector128.LoadUnsafe(ref ptr, idx + remaining).AsSByte();
+
+            mask = CreateEscapingMask(values, bitMaskLookup, bitPosLookup, nibbleMaskSByte, zeroMaskSByte);
+            if (mask != 0)
+            {
+                idx += remaining;
+                goto Found;
+            }
+        }
+
+        goto NotFound;
+
+    Found:
+        idx += GetIndexOfFirstNeedToEscape(mask);
+        return (int)idx;
+
+    NotFound:
+        return -1;
+    }
+
+    private static int IndexOfInvalidCharVectorized(ReadOnlySpan<char> value, Vector128<sbyte> bitMaskLookup)
+    {
+        Debug.Assert(Vector128.IsHardwareAccelerated);
+        Debug.Assert(value.Length >= Vector128<short>.Count);
+
+        // See comment above for description.
+        var bitPosLookup = Vector128.Create(
+            0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80,     // high-nibble 0..7
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF      // high-nibble 8..F
+        ).AsSByte();
+
+        var nibbleMaskSByte = Vector128.Create((sbyte)0xF);
+        var zeroMaskSByte = Vector128<sbyte>.Zero;
+
+        var idx = (nuint)0;
+        uint mask;
+        ref var ptr = ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(value));
+
+        if (value.Length >= 2 * Vector128<short>.Count)
+        {
+            var end = (uint)(value.Length - 2 * Vector128<short>.Count);
+
+            do
+            {
+                var source0 = Vector128.LoadUnsafe(ref ptr, idx);
+                var source1 = Vector128.LoadUnsafe(ref ptr, idx + 8);
+                var values = NarrowWithSaturation(source0, source1);
+
+                mask = CreateEscapingMask(values, bitMaskLookup, bitPosLookup, nibbleMaskSByte, zeroMaskSByte);
+                if (mask != 0)
+                {
+                    goto Found;
+                }
+
+                idx += 2 * (uint)Vector128<short>.Count;
+            }
+            while (idx <= end);
+        }
+
+        // Here we know that 8 to 15 chars are remaining. Process the first 8 chars.
+        if (idx <= (uint)(value.Length - Vector128<short>.Count))
+        {
+            var source = Vector128.LoadUnsafe(ref ptr, idx);
+            var values = NarrowWithSaturation(source, source);
+
+            mask = CreateEscapingMask(values, bitMaskLookup, bitPosLookup, nibbleMaskSByte, zeroMaskSByte);
+            if (mask != 0)
+            {
+                goto Found;
+            }
+
+            idx += (uint)Vector128<short>.Count;
+        }
+
+        // Here we know that < 8 chars are remaining. We shift the space around to process
+        // another full vector.
+        var remaining = (uint)value.Length - idx;
+        if ((nint)remaining > 0)
+        {
+            remaining -= (uint)Vector128<short>.Count;
+
+            var source = Vector128.LoadUnsafe(ref ptr, idx + remaining);
+            var values = NarrowWithSaturation(source, source);
+
+            mask = CreateEscapingMask(values, bitMaskLookup, bitPosLookup, nibbleMaskSByte, zeroMaskSByte);
+            if (mask != 0)
+            {
+                idx += remaining;
+                goto Found;
+            }
+        }
+
+        goto NotFound;
+
+    Found:
+        idx += GetIndexOfFirstNeedToEscape(mask);
+        return (int)idx;
+
+    NotFound:
+        return -1;
+    }
+
+    private static int IndexOfInvalidCharExtendedVectorized(ReadOnlySpan<char> value, Vector128<sbyte> bitMaskLookup)
+    {
+        Debug.Assert(Vector128.IsHardwareAccelerated);
+        Debug.Assert(value.Length >= Vector128<short>.Count);
+
+        // See comment above for description.
+        var bitPosLookup = Vector128.Create(
+            0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80,     // high-nibble 0..7
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF      // high-nibble 8..F
+        ).AsSByte();
+
+        var nibbleMaskSByte = Vector128.Create((sbyte)0xF);
+        var zeroMaskSByte = Vector128<sbyte>.Zero;
+        var nonAsciiMaskShort = Vector128.Create((ushort)0xFF80).AsInt16();
+
+        var idx = (nuint)0;
+        var end = (uint)(value.Length - Vector128<short>.Count);
+        uint mask;
+        ref var ptr = ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(value));
+
+        // Perf: don't unroll here, as it won't inline anymore due too excessive use of vector-registers.
+        while (idx <= end)
+        {
+            var source = Vector128.LoadUnsafe(ref ptr, idx);
+            var values = Vector128.Narrow(source, source);
+            var asciiMask = CreateAsciiMask(nonAsciiMaskShort, zeroMaskSByte, source);
+
+            mask = CreateEscapingMaskExtended(values, bitMaskLookup, bitPosLookup, nibbleMaskSByte, zeroMaskSByte, asciiMask);
+            if (mask != 0)
+            {
+                goto Found;
+            }
+
+            idx += (uint)Vector128<short>.Count;
+        }
+
+        // Here we know that < 8 chars are remaining. We shift the space around to process
+        // another full vector.
+        var remaining = (uint)value.Length - idx;
+        if ((nint)remaining > 0)
+        {
+            remaining -= (uint)Vector128<short>.Count;
+
+            var source = Vector128.LoadUnsafe(ref ptr, idx + remaining);
+            var values = Vector128.Narrow(source, source);
+            var asciiMask = CreateAsciiMask(nonAsciiMaskShort, zeroMaskSByte, source);
+
+            mask = CreateEscapingMaskExtended(values, bitMaskLookup, bitPosLookup, nibbleMaskSByte, zeroMaskSByte, asciiMask);
+            if (mask != 0)
+            {
+                idx += remaining;
+                goto Found;
+            }
+        }
+
+        goto NotFound;
+
+    Found:
+        idx += GetIndexOfFirstNeedToEscape(mask);
+        return (int)idx;
+
+    NotFound:
+        return -1;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static Vector128<sbyte> CreateAsciiMask(Vector128<short> nonAsciiMask, Vector128<sbyte> zero, Vector128<short> values)
+        {
+            var masked = values & nonAsciiMask;
+            var ascii = Vector128.Equals(masked, zero.AsInt16());
+            return Vector128.Narrow(ascii, ascii);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static uint CreateEscapingMaskExtended(
+            Vector128<sbyte> values,
+            Vector128<sbyte> bitMaskLookup,
+            Vector128<sbyte> bitPosLookup,
+            Vector128<sbyte> nibbleMaskSByte,
+            Vector128<sbyte> nullMaskSByte,
+            Vector128<sbyte> asciiMask)
+        {
+            Debug.Assert(Vector128.IsHardwareAccelerated);
+
+            var highNibbles = Vector128.ShiftRightLogical(values.AsInt32(), 4).AsSByte();
+            var lowNibbles = values & nibbleMaskSByte;
+
+            var bitMask = Shuffle(bitMaskLookup, lowNibbles);
+            var bitPositions = Shuffle(bitPosLookup, highNibbles);
+
+            var mask = bitPositions & bitMask;
+
+            var comparison = Vector128.Equals(mask, nullMaskSByte);
+            comparison = Vector128.Equals(comparison, nullMaskSByte);
+            comparison &= asciiMask;
+
+            return comparison.ExtractMostSignificantBits();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static uint GetIndexOfFirstNeedToEscape(uint mask)
+    {
+        // Found at least one byte that needs to be escaped, figure out the index of
+        // the first one found that needs to be escaped within the 16 bytes.
+        Debug.Assert(mask > 0 && mask <= 65_535);
+        var tzc = uint.TrailingZeroCount(mask);
+        Debug.Assert(tzc < 16);
+
+        return tzc;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static uint CreateEscapingMask(
+        Vector128<sbyte> values,
+        Vector128<sbyte> bitMaskLookup,
+        Vector128<sbyte> bitPosLookup,
+        Vector128<sbyte> nibbleMaskSByte,
+        Vector128<sbyte> nullMaskSByte)
+    {
+        // To check if an input byte needs to be escaped or not, we use a bitmask-lookup.
+        // Therefore we split the input byte into the low- and high-nibble, which will get
+        // the row-/column-index in the bit-mask.
+        // The bitmask-lookup looks like:
+        //                                     high-nibble
+        // low-nibble  0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+        //         0   1   1   0   0   0   0   1   0   1   1   1   1   1   1   1   1
+        //         1   1   1   0   0   0   0   0   0   1   1   1   1   1   1   1   1
+        //         2   1   1   1   0   0   0   0   0   1   1   1   1   1   1   1   1
+        //         3   1   1   0   0   0   0   0   0   1   1   1   1   1   1   1   1
+        //         4   1   1   0   0   0   0   0   0   1   1   1   1   1   1   1   1
+        //         5   1   1   0   0   0   0   0   0   1   1   1   1   1   1   1   1
+        //         6   1   1   1   0   0   0   0   0   1   1   1   1   1   1   1   1
+        //         7   1   1   1   0   0   0   0   0   1   1   1   1   1   1   1   1
+        //         8   1   1   0   0   0   0   0   0   1   1   1   1   1   1   1   1
+        //         9   1   1   0   0   0   0   0   0   1   1   1   1   1   1   1   1
+        //         A   1   1   0   0   0   0   0   0   1   1   1   1   1   1   1   1
+        //         B   1   1   1   0   0   0   0   0   1   1   1   1   1   1   1   1
+        //         C   1   1   0   1   0   1   0   0   1   1   1   1   1   1   1   1
+        //         D   1   1   0   0   0   0   0   0   1   1   1   1   1   1   1   1
+        //         E   1   1   0   1   0   0   0   0   1   1   1   1   1   1   1   1
+        //         F   1   1   0   0   0   0   0   1   1   1   1   1   1   1   1   1
+        //
+        // where 1 denotes the neeed for escaping, while 0 means no escaping needed.
+        // For high-nibbles in the range 8..F every input needs to be escaped, so we
+        // can omit them in the bit-mask, thus only high-nibbles in the range 0..7 need
+        // to be considered, hence the entries in the bit-mask can be of type byte.
+        //
+        // In the bitmask-lookup for each row (= low-nibble) a bit-mask for the
+        // high-nibbles (= columns) is created.
+
+        Debug.Assert(Vector128.IsHardwareAccelerated);
+
+        // Perf: the shift needs to be done as Int32, as there exists a hw-instruction and no sw-emulation needs to be done.
+        // Cf. https://github.com/dotnet/runtime/issues/75770
+        var highNibbles = Vector128.ShiftRightLogical(values.AsInt32(), 4).AsSByte() & nibbleMaskSByte;
+        var lowNibbles = values & nibbleMaskSByte;
+
+        var bitMask = Shuffle(bitMaskLookup, lowNibbles);
+        var bitPositions = Shuffle(bitPosLookup, highNibbles);
+
+        var mask = bitPositions & bitMask;
+
+        // There's no not-equal instruction, so we double compare to zero to achieve the same.
+        var comparison = Vector128.Equals(nullMaskSByte, mask);
+        comparison = Vector128.Equals(nullMaskSByte, comparison);
+
+        return comparison.ExtractMostSignificantBits();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector128<sbyte> NarrowWithSaturation(Vector128<short> v0, Vector128<short> v1)
+    {
+        Debug.Assert(Vector128.IsHardwareAccelerated);
+
+        // TODO: https://github.com/dotnet/runtime/issues/75724
+
+        if (Sse2.IsSupported)
+        {
+            return Sse2.PackSignedSaturate(v0, v1);
+        }
+        else
+        {
+            // This is not the exact algorithm for saturation, but for the use-case
+            // here it's does what it should do. I.e. eliminate non-ASCII chars in the
+            // results.
+
+            var v0HighNibbles = Vector128.ShiftRightLogical(v0, 8);
+            var v1HighNibbles = Vector128.ShiftRightLogical(v1, 8);
+
+            var ascii0 = Vector128.Equals(Vector128<short>.Zero, v0HighNibbles);
+            var ascii1 = Vector128.Equals(Vector128<short>.Zero, v1HighNibbles);
+
+            v0 &= ascii0;
+            v1 &= ascii1;
+
+            return Vector128.Narrow(v0, v1);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector128<sbyte> Shuffle(Vector128<sbyte> vector, Vector128<sbyte> indices)
+    {
+        // Perf: Ssse3.Shuffle produces better code
+        return Sse3.IsSupported
+            ? Ssse3.Shuffle(vector, indices)
+            : Vector128.Shuffle(vector, indices);
     }
 }

--- a/src/Shared/ServerInfrastructure/HttpCharacters.generated.cs
+++ b/src/Shared/ServerInfrastructure/HttpCharacters.generated.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+namespace Microsoft.AspNetCore.Http;
+
+[CompilerGenerated]
+internal static partial class HttpCharacters
+{
+    private static class Constants
+    {
+        public static ReadOnlySpan<bool> LookupAuthority => new bool[] { false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, true, false, true, true, true, true, true, true, true, true, true, true, true, false, false, false, false, false, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, true, false, false, false, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, false, false, false, false };
+        public static ReadOnlySpan<bool> LookupToken => new bool[] { false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, false, true, true, true, true, true, false, false, true, true, false, true, true, false, true, true, true, true, true, true, true, true, true, true, false, false, false, false, false, false, false, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, false, false, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, true, false, true, false };
+        public static ReadOnlySpan<bool> LookupHost => new bool[] { false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, false, false, true, false, true, true, true, true, false, false, false, true, true, false, true, true, true, true, true, true, true, true, true, true, false, false, false, false, false, false, false, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, false, false, false, true, false, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, false, false, true, false };
+        public static ReadOnlySpan<bool> LookupFieldValue => new bool[] { false, false, false, false, false, false, false, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false };
+    }
+
+    // Due to a JIT limitation we need to slice these constants (see comments above) in order
+    // to "unlink" the span, and allow proper hoisting out of the loop.
+    // This is tracked in https://github.com/dotnet/runtime/issues/12241
+
+    private static partial ReadOnlySpan<bool> LookupAuthority() => Constants.LookupAuthority.Slice(0);
+    private static partial ReadOnlySpan<bool> LookupToken() => Constants.LookupToken.Slice(0);
+    private static partial ReadOnlySpan<bool> LookupHost() => Constants.LookupHost.Slice(0);
+    private static partial ReadOnlySpan<bool> LookupFieldValue() => Constants.LookupFieldValue.Slice(0);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] private static partial Vector128<sbyte> BitMaskLookupAuthority() => Vector128.Create(0x47, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x8F, 0xAF, 0x8B, 0xAB, 0xAF).AsSByte();
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] private static partial Vector128<sbyte> BitMaskLookupToken() => Vector128.Create(0x17, 0x03, 0x07, 0x03, 0x03, 0x03, 0x03, 0x03, 0x07, 0x07, 0x0B, 0xAB, 0x2F, 0xAB, 0x0B, 0x8F).AsSByte();
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] private static partial Vector128<sbyte> BitMaskLookupHost() => Vector128.Create(0x57, 0x03, 0x07, 0x07, 0x03, 0x07, 0x03, 0x03, 0x03, 0x03, 0x0F, 0xAF, 0xAF, 0xAB, 0x2B, 0x8F).AsSByte();
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] private static partial Vector128<sbyte> BitMaskLookupFieldValue() => Vector128.Create(0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x02, 0x03, 0x03, 0x03, 0x03, 0x03, 0x83).AsSByte();
+}


### PR DESCRIPTION
⚠️ There are some open questions from my side -- thus it's a draft PR

**Note**: after I created this PR I got pushed towards https://github.com/dotnet/runtime/issues/68328, with which I think this can be solved in a more general runtime-like way. I don't know the outcome from that issue (yet), so please lets hold on with this PR in the meantime. Should we close it instead and eventually re-open if the mentioned issue doesn't fit?
At least the the "extended" case a special handling is needed -- so if the issue has a usable solution, this PR can be trimmed down if the "extended" case is worth it (which I doubt, as it's seldom?).

--- 

As outlined in https://github.com/dotnet/aspnetcore/pull/33776#discussion_r656939393 these methods are vectorized now.

Vectorization is not a plain win, there are trade-offs due to a bit more overhead. In the numbers belows this can be seen quite good. There seems to be a pattern were perf regresses:
* very short inputs
* if a invalid char is at the very beginning

In these cases a scalar-loop is faster, as it has less work to do in comparison to vectorized code.
But the longer the input, the farther away from the beginning the invalid char is or if there's no invalid char at all, vectorization shows nice improvements.

I expect that in real-life most of the input is valid, thus no invalid char is found, as well as inputs are long enough for vectorization to show it's goodness.
If my assumption is wrong, at least for specific method, we could disable vectorizaiton on these.

```
|     Method |                           Categories | Length | InvalidCharPos |        Mean | Ratio |
|----------- |------------------------------------- |------- |--------------- |------------:|------:|
|    Default |         ContainsInvalidAuthorityChar |      7 |           None |   5.8321 ns |  1.00 |
| Vectorized |         ContainsInvalidAuthorityChar |      7 |           None |   5.5462 ns |  0.95 |
|            |                                      |        |                |             |       |
|    Default |         ContainsInvalidAuthorityChar |      7 |          Start |   0.6175 ns |  1.00 |
| Vectorized |         ContainsInvalidAuthorityChar |      7 |          Start |   1.4070 ns |  2.30 |
|            |                                      |        |                |             |       |
|    Default |         ContainsInvalidAuthorityChar |      7 |            End |   5.5931 ns |  1.00 |
| Vectorized |         ContainsInvalidAuthorityChar |      7 |            End |   5.4145 ns |  0.97 |
|            |                                      |        |                |             |       |
|    Default |         ContainsInvalidAuthorityChar |     15 |           None |  10.9659 ns |  1.00 |
| Vectorized |         ContainsInvalidAuthorityChar |     15 |           None |  11.0064 ns |  1.00 |
|            |                                      |        |                |             |       |
|    Default |         ContainsInvalidAuthorityChar |     15 |          Start |   0.6444 ns |  1.00 |
| Vectorized |         ContainsInvalidAuthorityChar |     15 |          Start |   1.2530 ns |  1.94 |
|            |                                      |        |                |             |       |
|    Default |         ContainsInvalidAuthorityChar |     15 |            End |  10.6669 ns |  1.00 |
| Vectorized |         ContainsInvalidAuthorityChar |     15 |            End |  10.7583 ns |  1.01 |
|            |                                      |        |                |             |       |
|    Default |         ContainsInvalidAuthorityChar |    113 |           None |  87.7130 ns |  1.00 |
| Vectorized |         ContainsInvalidAuthorityChar |    113 |           None |  13.7753 ns |  0.16 |
|            |                                      |        |                |             |       |
|    Default |         ContainsInvalidAuthorityChar |    113 |          Start |   0.6885 ns |  1.00 |
| Vectorized |         ContainsInvalidAuthorityChar |    113 |          Start |   3.1128 ns |  4.57 |
|            |                                      |        |                |             |       |
|    Default |         ContainsInvalidAuthorityChar |    113 |            End |  89.8752 ns |  1.00 |
| Vectorized |         ContainsInvalidAuthorityChar |    113 |            End |  13.2677 ns |  0.15 |
|            |                                      |        |                |             |       |
|    Default |         IndexOfInvalidFieldValueChar |      7 |           None |   5.0010 ns |  1.00 |
| Vectorized |         IndexOfInvalidFieldValueChar |      7 |           None |   6.4814 ns |  1.30 |
|            |                                      |        |                |             |       |
|    Default |         IndexOfInvalidFieldValueChar |      7 |          Start |   0.5463 ns |  1.00 |
| Vectorized |         IndexOfInvalidFieldValueChar |      7 |          Start |   1.0296 ns |  1.88 |
|            |                                      |        |                |             |       |
|    Default |         IndexOfInvalidFieldValueChar |      7 |            End |   4.9472 ns |  1.00 |
| Vectorized |         IndexOfInvalidFieldValueChar |      7 |            End |   6.1276 ns |  1.24 |
|            |                                      |        |                |             |       |
|    Default |         IndexOfInvalidFieldValueChar |     15 |           None |  10.0493 ns |  1.00 |
| Vectorized |         IndexOfInvalidFieldValueChar |     15 |           None |   5.2853 ns |  0.53 |
|            |                                      |        |                |             |       |
|    Default |         IndexOfInvalidFieldValueChar |     15 |          Start |   0.5595 ns |  1.00 |
| Vectorized |         IndexOfInvalidFieldValueChar |     15 |          Start |   3.7454 ns |  6.78 |
|            |                                      |        |                |             |       |
|    Default |         IndexOfInvalidFieldValueChar |     15 |            End |  12.8468 ns |  1.00 |
| Vectorized |         IndexOfInvalidFieldValueChar |     15 |            End |   7.2468 ns |  0.58 |
|            |                                      |        |                |             |       |
|    Default |         IndexOfInvalidFieldValueChar |    113 |           None |  92.7111 ns |  1.00 |
| Vectorized |         IndexOfInvalidFieldValueChar |    113 |           None |  15.7101 ns |  0.17 |
|            |                                      |        |                |             |       |
|    Default |         IndexOfInvalidFieldValueChar |    113 |          Start |   0.5651 ns |  1.00 |
| Vectorized |         IndexOfInvalidFieldValueChar |    113 |          Start |   3.8203 ns |  6.84 |
|            |                                      |        |                |             |       |
|    Default |         IndexOfInvalidFieldValueChar |    113 |            End | 100.5039 ns |  1.00 |
| Vectorized |         IndexOfInvalidFieldValueChar |    113 |            End |  16.9102 ns |  0.17 |
|            |                                      |        |                |             |       |
|    Default | IndexOfInvalidFieldValueCharExtended |      7 |           None |   6.1985 ns |  1.00 |
| Vectorized | IndexOfInvalidFieldValueCharExtended |      7 |           None |   6.9981 ns |  1.13 |
|            |                                      |        |                |             |       |
|    Default | IndexOfInvalidFieldValueCharExtended |      7 |          Start |   0.4000 ns |  1.00 |
| Vectorized | IndexOfInvalidFieldValueCharExtended |      7 |          Start |   1.4511 ns |  3.61 |
|            |                                      |        |                |             |       |
|    Default | IndexOfInvalidFieldValueCharExtended |      7 |            End |   5.9051 ns |  1.00 |
| Vectorized | IndexOfInvalidFieldValueCharExtended |      7 |            End |   7.8430 ns |  1.32 |
|            |                                      |        |                |             |       |
|    Default | IndexOfInvalidFieldValueCharExtended |     15 |           None |  12.6932 ns |  1.00 |
| Vectorized | IndexOfInvalidFieldValueCharExtended |     15 |           None |   6.3665 ns |  0.51 |
|            |                                      |        |                |             |       |
|    Default | IndexOfInvalidFieldValueCharExtended |     15 |          Start |   0.6317 ns |  1.00 |
| Vectorized | IndexOfInvalidFieldValueCharExtended |     15 |          Start |   4.1039 ns |  6.57 |
|            |                                      |        |                |             |       |
|    Default | IndexOfInvalidFieldValueCharExtended |     15 |            End |  11.2936 ns |  1.00 |
| Vectorized | IndexOfInvalidFieldValueCharExtended |     15 |            End |   6.2646 ns |  0.56 |
|            |                                      |        |                |             |       |
|    Default | IndexOfInvalidFieldValueCharExtended |    113 |           None |  88.2136 ns |  1.00 |
| Vectorized | IndexOfInvalidFieldValueCharExtended |    113 |           None |  31.7663 ns |  0.36 |
|            |                                      |        |                |             |       |
|    Default | IndexOfInvalidFieldValueCharExtended |    113 |          Start |   0.6923 ns |  1.00 |
| Vectorized | IndexOfInvalidFieldValueCharExtended |    113 |          Start |   3.7021 ns |  5.51 |
|            |                                      |        |                |             |       |
|    Default | IndexOfInvalidFieldValueCharExtended |    113 |            End |  91.9725 ns |  1.00 |
| Vectorized | IndexOfInvalidFieldValueCharExtended |    113 |            End |  32.3834 ns |  0.35 |
|            |                                      |        |                |             |       |
|    Default |               IndexOfInvalidHostChar |      7 |           None |   5.5270 ns |  1.00 |
| Vectorized |               IndexOfInvalidHostChar |      7 |           None |   6.8330 ns |  1.23 |
|            |                                      |        |                |             |       |
|    Default |               IndexOfInvalidHostChar |      7 |          Start |   0.5591 ns |  1.00 |
| Vectorized |               IndexOfInvalidHostChar |      7 |          Start |   1.1605 ns |  2.08 |
|            |                                      |        |                |             |       |
|    Default |               IndexOfInvalidHostChar |      7 |            End |   5.1811 ns |  1.00 |
| Vectorized |               IndexOfInvalidHostChar |      7 |            End |   6.6147 ns |  1.28 |
|            |                                      |        |                |             |       |
|    Default |               IndexOfInvalidHostChar |     15 |           None |  10.9923 ns |  1.00 |
| Vectorized |               IndexOfInvalidHostChar |     15 |           None |   4.9088 ns |  0.45 |
|            |                                      |        |                |             |       |
|    Default |               IndexOfInvalidHostChar |     15 |          Start |   0.5255 ns |  1.00 |
| Vectorized |               IndexOfInvalidHostChar |     15 |          Start |   3.3160 ns |  6.36 |
|            |                                      |        |                |             |       |
|    Default |               IndexOfInvalidHostChar |     15 |            End |  10.0873 ns |  1.00 |
| Vectorized |               IndexOfInvalidHostChar |     15 |            End |   5.8072 ns |  0.58 |
|            |                                      |        |                |             |       |
|    Default |               IndexOfInvalidHostChar |    113 |           None |  99.1043 ns |  1.00 |
| Vectorized |               IndexOfInvalidHostChar |    113 |           None |  15.6849 ns |  0.16 |
|            |                                      |        |                |             |       |
|    Default |               IndexOfInvalidHostChar |    113 |          Start |   0.3126 ns |  1.00 |
| Vectorized |               IndexOfInvalidHostChar |    113 |          Start |   3.4211 ns | 11.04 |
|            |                                      |        |                |             |       |
|    Default |               IndexOfInvalidHostChar |    113 |            End |  91.7623 ns |  1.00 |
| Vectorized |               IndexOfInvalidHostChar |    113 |            End |  14.9058 ns |  0.16 |
|            |                                      |        |                |             |       |
|    Default |        IndexOfInvalidTokenChar_Bytes |      7 |           None |   6.4794 ns |  1.00 |
| Vectorized |        IndexOfInvalidTokenChar_Bytes |      7 |           None |   5.5825 ns |  0.87 |
|            |                                      |        |                |             |       |
|    Default |        IndexOfInvalidTokenChar_Bytes |      7 |          Start |   0.5898 ns |  1.00 |
| Vectorized |        IndexOfInvalidTokenChar_Bytes |      7 |          Start |   1.1259 ns |  1.90 |
|            |                                      |        |                |             |       |
|    Default |        IndexOfInvalidTokenChar_Bytes |      7 |            End |   6.0219 ns |  1.00 |
| Vectorized |        IndexOfInvalidTokenChar_Bytes |      7 |            End |   5.2224 ns |  0.87 |
|            |                                      |        |                |             |       |
|    Default |        IndexOfInvalidTokenChar_Bytes |     15 |           None |  12.3160 ns |  1.00 |
| Vectorized |        IndexOfInvalidTokenChar_Bytes |     15 |           None |  11.1012 ns |  0.91 |
|            |                                      |        |                |             |       |
|    Default |        IndexOfInvalidTokenChar_Bytes |     15 |          Start |   0.7251 ns |  1.00 |
| Vectorized |        IndexOfInvalidTokenChar_Bytes |     15 |          Start |   1.0208 ns |  1.40 |
|            |                                      |        |                |             |       |
|    Default |        IndexOfInvalidTokenChar_Bytes |     15 |            End |  11.9562 ns |  1.00 |
| Vectorized |        IndexOfInvalidTokenChar_Bytes |     15 |            End |  11.0921 ns |  0.93 |
|            |                                      |        |                |             |       |
|    Default |        IndexOfInvalidTokenChar_Bytes |    113 |           None |  93.1642 ns |  1.00 |
| Vectorized |        IndexOfInvalidTokenChar_Bytes |    113 |           None |  12.9503 ns |  0.14 |
|            |                                      |        |                |             |       |
|    Default |        IndexOfInvalidTokenChar_Bytes |    113 |          Start |   0.6146 ns |  1.00 |
| Vectorized |        IndexOfInvalidTokenChar_Bytes |    113 |          Start |   2.9311 ns |  4.80 |
|            |                                      |        |                |             |       |
|    Default |        IndexOfInvalidTokenChar_Bytes |    113 |            End |  95.4803 ns |  1.00 |
| Vectorized |        IndexOfInvalidTokenChar_Bytes |    113 |            End |  13.4628 ns |  0.14 |
|            |                                      |        |                |             |       |
|    Default |       IndexOfInvalidTokenChar_String |      7 |           None |   6.0107 ns |  1.00 |
| Vectorized |       IndexOfInvalidTokenChar_String |      7 |           None |   7.4539 ns |  1.24 |
|            |                                      |        |                |             |       |
|    Default |       IndexOfInvalidTokenChar_String |      7 |          Start |   0.6448 ns |  1.00 |
| Vectorized |       IndexOfInvalidTokenChar_String |      7 |          Start |   1.0052 ns |  1.61 |
|            |                                      |        |                |             |       |
|    Default |       IndexOfInvalidTokenChar_String |      7 |            End |   5.4034 ns |  1.00 |
| Vectorized |       IndexOfInvalidTokenChar_String |      7 |            End |   6.7783 ns |  1.25 |
|            |                                      |        |                |             |       |
|    Default |       IndexOfInvalidTokenChar_String |     15 |           None |  10.7808 ns |  1.00 |
| Vectorized |       IndexOfInvalidTokenChar_String |     15 |           None |   4.6405 ns |  0.43 |
|            |                                      |        |                |             |       |
|    Default |       IndexOfInvalidTokenChar_String |     15 |          Start |   0.4462 ns |  1.00 |
| Vectorized |       IndexOfInvalidTokenChar_String |     15 |          Start |   3.2645 ns |  7.42 |
|            |                                      |        |                |             |       |
|    Default |       IndexOfInvalidTokenChar_String |     15 |            End |  10.3272 ns |  1.00 |
| Vectorized |       IndexOfInvalidTokenChar_String |     15 |            End |   4.9606 ns |  0.48 |
|            |                                      |        |                |             |       |
|    Default |       IndexOfInvalidTokenChar_String |    113 |           None |  88.7606 ns |  1.00 |
| Vectorized |       IndexOfInvalidTokenChar_String |    113 |           None |  14.8116 ns |  0.17 |
|            |                                      |        |                |             |       |
|    Default |       IndexOfInvalidTokenChar_String |    113 |          Start |   0.4781 ns |  1.00 |
| Vectorized |       IndexOfInvalidTokenChar_String |    113 |          Start |   3.1777 ns |  6.71 |
|            |                                      |        |                |             |       |
|    Default |       IndexOfInvalidTokenChar_String |    113 |            End |  93.7237 ns |  1.00 |
| Vectorized |       IndexOfInvalidTokenChar_String |    113 |            End |  14.8531 ns |  0.16 |
```

---

For a description how the approach works, please see comments in code.