### PR TITLE
Fix the name of the maestro-bot user.

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -2499,7 +2499,7 @@
                 {
                   "name": "isActivitySender",
                   "parameters": {
-                    "user": "dotnet-maestro-bot "
+                    "user": "dotnet-maestro-bot"
                   }
                 }
               ]


### PR DESCRIPTION
This bug was causing all the PRs sent by the `dotnet-maestro-bot` to be labeled as `community-contribution`:
<img width="802" alt="image" src="https://user-images.githubusercontent.com/34246760/190921501-b8767eb6-c747-430b-a27c-5f1e833dbca8.png">
