### PR TITLE
[release/7.0] Change gRPC JSON to only accept top-level field as request body

### DIFF
--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonSettings.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonSettings.cs
@@ -10,6 +10,7 @@ public sealed class GrpcJsonSettings
 {
     /// <summary>
     /// Gets or sets a value that indicates whether fields with default values are ignored during serialization.
+    /// This setting only affects fields which don't support "presence", such as singular non-optional proto3 primitive fields.
     /// Default value is false.
     /// </summary>
     public bool IgnoreDefaultValues { get; set; }

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonSettings.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonSettings.cs
@@ -9,10 +9,8 @@ namespace Microsoft.AspNetCore.Grpc.JsonTranscoding;
 public sealed class GrpcJsonSettings
 {
     /// <summary>
-    /// Whether fields which would otherwise not be included in the formatted data
-    /// should be formatted even when the value is not present, or has the default value.
-    /// This option only affects fields which don't support "presence" (e.g.
-    /// singular non-optional proto3 primitive fields).
+    /// Gets or sets a value that indicates whether fields with default values are ignored during serialization.
+    /// Default value is false.
     /// </summary>
     public bool IgnoreDefaultValues { get; set; }
 
@@ -23,7 +21,7 @@ public sealed class GrpcJsonSettings
     public bool WriteEnumsAsIntegers { get; set; }
 
     /// <summary>
-    /// Gets or sets a value that indicates whether <see cref="Int64"/> and <see cref="UInt64"/> values are written as strings instead of numbers.
+    /// Gets or sets a value that indicates whether <see cref="long"/> and <see cref="ulong"/> values are written as strings instead of numbers.
     /// Default value is false.
     /// </summary>
     public bool WriteInt64sAsStrings { get; set; }

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Binding/JsonTranscodingProviderServiceBinder.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Binding/JsonTranscodingProviderServiceBinder.cs
@@ -246,7 +246,7 @@ internal sealed partial class JsonTranscodingProviderServiceBinder<TService> : S
         {
             if (responseBody.Contains('.', StringComparison.Ordinal))
             {
-                throw new InvalidOperationException($"The response body field '{responseBody}' references a nested field. The field must be on the top-level response message.");
+                throw new InvalidOperationException($"The response body field '{responseBody}' references a nested field. The response body field name must be on the top-level response message.");
             }
             responseBodyDescriptor = methodDescriptor.OutputType.FindFieldByName(responseBody);
             if (responseBodyDescriptor == null)

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Binding/JsonTranscodingProviderServiceBinder.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Binding/JsonTranscodingProviderServiceBinder.cs
@@ -244,6 +244,10 @@ internal sealed partial class JsonTranscodingProviderServiceBinder<TService> : S
         FieldDescriptor? responseBodyDescriptor = null;
         if (!string.IsNullOrEmpty(responseBody))
         {
+            if (responseBody.Contains('.', StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"The response body field '{responseBody}' references a nested field. The field must be on the top-level response message.");
+            }
             responseBodyDescriptor = methodDescriptor.OutputType.FindFieldByName(responseBody);
             if (responseBodyDescriptor == null)
             {
@@ -255,7 +259,7 @@ internal sealed partial class JsonTranscodingProviderServiceBinder<TService> : S
             responseBodyDescriptor,
             bodyDescriptor?.Descriptor,
             bodyDescriptor?.IsDescriptorRepeated ?? false,
-            bodyDescriptor?.FieldDescriptors,
+            bodyDescriptor?.FieldDescriptor,
             routeParameterDescriptors,
             routeAdapter);
         return descriptorInfo;

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/CallHandlers/CallHandlerDescriptorInfo.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/CallHandlers/CallHandlerDescriptorInfo.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Google.Protobuf.Reflection;
 using Grpc.Shared;
 
@@ -15,30 +14,25 @@ internal sealed class CallHandlerDescriptorInfo
         FieldDescriptor? responseBodyDescriptor,
         MessageDescriptor? bodyDescriptor,
         bool bodyDescriptorRepeated,
-        List<FieldDescriptor>? bodyFieldDescriptors,
+        FieldDescriptor? bodyFieldDescriptor,
         Dictionary<string, RouteParameter> routeParameterDescriptors,
         JsonTranscodingRouteAdapter routeAdapter)
     {
         ResponseBodyDescriptor = responseBodyDescriptor;
         BodyDescriptor = bodyDescriptor;
         BodyDescriptorRepeated = bodyDescriptorRepeated;
-        BodyFieldDescriptors = bodyFieldDescriptors;
+        BodyFieldDescriptor = bodyFieldDescriptor;
         RouteParameterDescriptors = routeParameterDescriptors;
         RouteAdapter = routeAdapter;
-        if (BodyFieldDescriptors != null)
-        {
-            BodyFieldDescriptorsPath = string.Join('.', BodyFieldDescriptors.Select(d => d.Name));
-        }
         PathDescriptorsCache = new ConcurrentDictionary<string, List<FieldDescriptor>?>();
     }
 
     public FieldDescriptor? ResponseBodyDescriptor { get; }
     public MessageDescriptor? BodyDescriptor { get; }
-    [MemberNotNullWhen(true, nameof(BodyFieldDescriptors), nameof(BodyFieldDescriptorsPath))]
+    [MemberNotNullWhen(true, nameof(BodyFieldDescriptor))]
     public bool BodyDescriptorRepeated { get; }
-    public List<FieldDescriptor>? BodyFieldDescriptors { get; }
+    public FieldDescriptor? BodyFieldDescriptor { get; }
     public Dictionary<string, RouteParameter> RouteParameterDescriptors { get; }
     public JsonTranscodingRouteAdapter RouteAdapter { get; }
     public ConcurrentDictionary<string, List<FieldDescriptor>?> PathDescriptorsCache { get; }
-    public string? BodyFieldDescriptorsPath { get; }
 }

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonRequestHelpers.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonRequestHelpers.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
 using System.Diagnostics;
-using System.Linq;
 using System.Text;
 using System.Text.Json;
 using Google.Api;
@@ -201,7 +199,7 @@ internal static class JsonRequestHelpers
 
                             // TODO: JsonSerializer currently doesn't support deserializing values onto an existing object or collection.
                             // Either update this to use new functionality in JsonSerializer or improve work-around perf.
-                            type = JsonConverterHelper.GetFieldType(serverCallContext.DescriptorInfo.BodyFieldDescriptors.Last());
+                            type = JsonConverterHelper.GetFieldType(serverCallContext.DescriptorInfo.BodyFieldDescriptor);
                             type = type.GetGenericArguments()[0];
                             type = typeof(List<>).MakeGenericType(type);
 
@@ -231,10 +229,13 @@ internal static class JsonRequestHelpers
                     }
                 }
 
-                if (serverCallContext.DescriptorInfo.BodyFieldDescriptors != null)
+                if (serverCallContext.DescriptorInfo.BodyFieldDescriptor != null)
                 {
                     requestMessage = (IMessage)Activator.CreateInstance<TRequest>();
-                    ServiceDescriptorHelpers.RecursiveSetValue(requestMessage, serverCallContext.DescriptorInfo.BodyFieldDescriptors, bodyContent); // TODO - check nullability
+
+                    // The spec says that request body must be on the top-level message.
+                    // Recursive request body isn't supported.
+                    ServiceDescriptorHelpers.SetValue(requestMessage, serverCallContext.DescriptorInfo.BodyFieldDescriptor, bodyContent);
                 }
                 else
                 {
@@ -355,7 +356,8 @@ internal static class JsonRequestHelpers
 
             if (serverCallContext.DescriptorInfo.ResponseBodyDescriptor != null)
             {
-                // TODO: Support recursive response body?
+                // The spec says that response body must be on the top-level message.
+                // Recursive response body isn't supported.
                 responseBody = serverCallContext.DescriptorInfo.ResponseBodyDescriptor.Accessor.GetValue((IMessage)message);
                 responseType = JsonConverterHelper.GetFieldType(serverCallContext.DescriptorInfo.ResponseBodyDescriptor);
             }
@@ -381,17 +383,24 @@ internal static class JsonRequestHelpers
     {
         if (serverCallContext.DescriptorInfo.BodyDescriptor != null)
         {
-            if (serverCallContext.DescriptorInfo.BodyFieldDescriptors == null || serverCallContext.DescriptorInfo.BodyFieldDescriptors.Count == 0)
+            var bodyFieldName = serverCallContext.DescriptorInfo.BodyFieldDescriptor?.Name;
+
+            // Null field name indicates "*" which means the entire message is bound to the body.
+            if (bodyFieldName == null)
             {
                 return false;
             }
 
-            if (variable == serverCallContext.DescriptorInfo.BodyFieldDescriptorsPath)
+            // Exact match
+            if (variable == bodyFieldName)
             {
                 return false;
             }
 
-            if (variable.StartsWith(serverCallContext.DescriptorInfo.BodyFieldDescriptorsPath!, StringComparison.Ordinal))
+            // Nested field of field name.
+            if (bodyFieldName.Length + 1 < variable.Length &&
+                variable.StartsWith(bodyFieldName, StringComparison.Ordinal) &&
+                variable[bodyFieldName.Length] == '.')
             {
                 return false;
             }

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/GrpcJsonTranscodingDescriptionProvider.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/GrpcJsonTranscodingDescriptionProvider.cs
@@ -137,7 +137,7 @@ internal sealed class GrpcJsonTranscodingDescriptionProvider : IApiDescriptionPr
             });
         }
 
-        var queryParameters = ServiceDescriptorHelpers.ResolveQueryParameterDescriptors(routeParameters, methodDescriptor, bodyDescriptor?.Descriptor, bodyDescriptor?.FieldDescriptors);
+        var queryParameters = ServiceDescriptorHelpers.ResolveQueryParameterDescriptors(routeParameters, methodDescriptor, bodyDescriptor?.Descriptor, bodyDescriptor?.FieldDescriptor);
         foreach (var queryDescription in queryParameters)
         {
             var fieldType = MessageDescriptorHelpers.ResolveFieldType(queryDescription.Value);

--- a/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
@@ -172,60 +172,7 @@ internal static class ServiceDescriptorHelpers
 
             if (isLast)
             {
-                if (field.IsRepeated)
-                {
-                    var list = (IList)field.Accessor.GetValue(currentValue);
-                    if (values is StringValues stringValues)
-                    {
-                        foreach (var value in stringValues)
-                        {
-                            list.Add(ConvertValue(value, field));
-                        }
-                    }
-                    else if (values is IList listValues)
-                    {
-                        foreach (var value in listValues)
-                        {
-                            list.Add(ConvertValue(value, field));
-                        }
-                    }
-                    else
-                    {
-                        list.Add(ConvertValue(values, field));
-                    }
-                }
-                else
-                {
-                    if (values is StringValues stringValues)
-                    {
-                        if (stringValues.Count == 1)
-                        {
-                            field.Accessor.SetValue(currentValue, ConvertValue(stringValues[0], field));
-                        }
-                        else
-                        {
-                            throw new InvalidOperationException("Can't set multiple values onto a non-repeating field.");
-                        }
-                    }
-                    else if (values is IMessage message)
-                    {
-                        if (IsWrapperType(message.Descriptor))
-                        {
-                            const int WrapperValueFieldNumber = Int32Value.ValueFieldNumber;
-
-                            var wrappedValue = message.Descriptor.Fields[WrapperValueFieldNumber].Accessor.GetValue(message);
-                            field.Accessor.SetValue(currentValue, wrappedValue);
-                        }
-                        else
-                        {
-                            field.Accessor.SetValue(currentValue, message);
-                        }
-                    }
-                    else
-                    {
-                        field.Accessor.SetValue(currentValue, ConvertValue(values, field));
-                    }
-                }
+                SetValue(currentValue, field, values);
             }
             else
             {
@@ -238,6 +185,64 @@ internal static class ServiceDescriptorHelpers
                 }
 
                 currentValue = fieldMessage;
+            }
+        }
+    }
+
+    public static void SetValue(IMessage message, FieldDescriptor field, object? values)
+    {
+        if (field.IsRepeated)
+        {
+            var list = (IList)field.Accessor.GetValue(message);
+            if (values is StringValues stringValues)
+            {
+                foreach (var value in stringValues)
+                {
+                    list.Add(ConvertValue(value, field));
+                }
+            }
+            else if (values is IList listValues)
+            {
+                foreach (var value in listValues)
+                {
+                    list.Add(ConvertValue(value, field));
+                }
+            }
+            else
+            {
+                list.Add(ConvertValue(values, field));
+            }
+        }
+        else
+        {
+            if (values is StringValues stringValues)
+            {
+                if (stringValues.Count == 1)
+                {
+                    field.Accessor.SetValue(message, ConvertValue(stringValues[0], field));
+                }
+                else
+                {
+                    throw new InvalidOperationException("Can't set multiple values onto a non-repeating field.");
+                }
+            }
+            else if (values is IMessage messageValue)
+            {
+                if (IsWrapperType(messageValue.Descriptor))
+                {
+                    const int WrapperValueFieldNumber = Int32Value.ValueFieldNumber;
+
+                    var wrappedValue = messageValue.Descriptor.Fields[WrapperValueFieldNumber].Accessor.GetValue(messageValue);
+                    field.Accessor.SetValue(message, wrappedValue);
+                }
+                else
+                {
+                    field.Accessor.SetValue(message, messageValue);
+                }
+            }
+            else
+            {
+                field.Accessor.SetValue(message, ConvertValue(values, field));
             }
         }
     }
@@ -312,24 +317,28 @@ internal static class ServiceDescriptorHelpers
         {
             if (!string.Equals(body, "*", StringComparison.Ordinal))
             {
-                var bodyFieldPath = body.Split('.');
-                if (!TryResolveDescriptors(methodDescriptor.InputType, bodyFieldPath, out var bodyFieldDescriptors))
+                if (body.Contains('.', StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException($"The body field '{body}' references a nested field. The field must be on the top-level request message.");
+                }
+                var responseBodyDescriptor = methodDescriptor.InputType.FindFieldByName(body);
+                if (responseBodyDescriptor == null)
                 {
                     throw new InvalidOperationException($"Couldn't find matching field for body '{body}' on {methodDescriptor.InputType.Name}.");
                 }
-                var leafDescriptor = bodyFieldDescriptors.Last();
-                var propertyName = FormatUnderscoreName(leafDescriptor.Name, pascalCase: true, preservePeriod: false);
-                var propertyInfo = leafDescriptor.ContainingType.ClrType.GetProperty(propertyName);
 
-                if (leafDescriptor.IsRepeated)
+                var propertyName = FormatUnderscoreName(responseBodyDescriptor.Name, pascalCase: true, preservePeriod: false);
+                var propertyInfo = responseBodyDescriptor.ContainingType.ClrType.GetProperty(propertyName);
+
+                if (responseBodyDescriptor.IsRepeated)
                 {
                     // A repeating field isn't a message type. The JSON parser will parse using the containing
                     // type to get the repeating collection.
-                    return new BodyDescriptorInfo(leafDescriptor.ContainingType, bodyFieldDescriptors, IsDescriptorRepeated: true, propertyInfo);
+                    return new BodyDescriptorInfo(responseBodyDescriptor.ContainingType, responseBodyDescriptor, IsDescriptorRepeated: true, propertyInfo);
                 }
                 else
                 {
-                    return new BodyDescriptorInfo(leafDescriptor.MessageType, bodyFieldDescriptors, IsDescriptorRepeated: false, propertyInfo);
+                    return new BodyDescriptorInfo(responseBodyDescriptor.MessageType, responseBodyDescriptor, IsDescriptorRepeated: false, propertyInfo);
                 }
             }
             else
@@ -341,7 +350,7 @@ internal static class ServiceDescriptorHelpers
                     requestParameter = methodInfo.GetParameters().SingleOrDefault(p => p.Name == "request");
                 }
 
-                return new BodyDescriptorInfo(methodDescriptor.InputType, FieldDescriptors: null, IsDescriptorRepeated: false, ParameterInfo: requestParameter);
+                return new BodyDescriptorInfo(methodDescriptor.InputType, FieldDescriptor: null, IsDescriptorRepeated: false, ParameterInfo: requestParameter);
             }
         }
 
@@ -440,7 +449,7 @@ internal static class ServiceDescriptorHelpers
 
     public sealed record BodyDescriptorInfo(
         MessageDescriptor Descriptor,
-        List<FieldDescriptor>? FieldDescriptors,
+        FieldDescriptor? FieldDescriptor,
         bool IsDescriptorRepeated,
         PropertyInfo? PropertyInfo = null,
         ParameterInfo? ParameterInfo = null);

--- a/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
@@ -319,7 +319,7 @@ internal static class ServiceDescriptorHelpers
             {
                 if (body.Contains('.', StringComparison.Ordinal))
                 {
-                    throw new InvalidOperationException($"The body field '{body}' references a nested field. The field must be on the top-level request message.");
+                    throw new InvalidOperationException($"The body field '{body}' references a nested field. The body field name must be on the top-level request message.");
                 }
                 var responseBodyDescriptor = methodDescriptor.InputType.FindFieldByName(body);
                 if (responseBodyDescriptor == null)
@@ -361,7 +361,7 @@ internal static class ServiceDescriptorHelpers
         Dictionary<string, RouteParameter> routeParameters,
         MethodDescriptor methodDescriptor,
         MessageDescriptor? bodyDescriptor,
-        List<FieldDescriptor>? bodyFieldDescriptors)
+        FieldDescriptor? bodyFieldDescriptor)
     {
         var existingParameters = new List<FieldDescriptor>();
 
@@ -375,13 +375,10 @@ internal static class ServiceDescriptorHelpers
 
         if (bodyDescriptor != null)
         {
-            if (bodyFieldDescriptors != null)
+            if (bodyFieldDescriptor != null)
             {
                 // Body with field name.
-                // The body field descriptors collection contains all the descriptors in the path.
-                // We only care about the final place the body is set and so add only the last
-                // descriptor to the existing parameters collection.
-                existingParameters.Add(bodyFieldDescriptors.Last());
+                existingParameters.Add(bodyFieldDescriptor);
             }
             else
             {

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/Infrastructure/TestHelpers.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/Infrastructure/TestHelpers.cs
@@ -62,13 +62,13 @@ internal static class TestHelpers
         Dictionary<string, RouteParameter>? routeParameterDescriptors = null,
         MessageDescriptor? bodyDescriptor = null,
         bool? bodyDescriptorRepeated = null,
-        List<FieldDescriptor>? bodyFieldDescriptors = null)
+        FieldDescriptor? bodyFieldDescriptor = null)
     {
         return new CallHandlerDescriptorInfo(
             responseBodyDescriptor,
             bodyDescriptor,
             bodyDescriptorRepeated ?? false,
-            bodyFieldDescriptors,
+            bodyFieldDescriptor,
             routeParameterDescriptors ?? new Dictionary<string, RouteParameter>(),
             JsonTranscodingRouteAdapter.Parse(HttpRoutePattern.Parse("/")));
     }

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Infrastructure/TestHelpers.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Infrastructure/TestHelpers.cs
@@ -63,13 +63,13 @@ internal static class TestHelpers
         Dictionary<string, RouteParameter>? routeParameterDescriptors = null,
         MessageDescriptor? bodyDescriptor = null,
         bool? bodyDescriptorRepeated = null,
-        List<FieldDescriptor>? bodyFieldDescriptors = null)
+        FieldDescriptor? bodyFieldDescriptor = null)
     {
         return new CallHandlerDescriptorInfo(
             responseBodyDescriptor,
             bodyDescriptor,
             bodyDescriptorRepeated ?? false,
-            bodyFieldDescriptors,
+            bodyFieldDescriptor,
             routeParameterDescriptors ?? new Dictionary<string, RouteParameter>(),
             JsonTranscodingRouteAdapter.Parse(HttpRoutePattern.Parse("/")));
     }

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/JsonTranscodingServiceMethodProviderTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/JsonTranscodingServiceMethodProviderTests.cs
@@ -161,7 +161,7 @@ public class JsonTranscodingServiceMethodProviderTests
         // Assert
         Assert.Equal("Error binding gRPC service 'JsonTranscodingInvalidNestedResponseBodyGreeterService'.", ex.Message);
         Assert.Equal("Error binding BadResponseBody on JsonTranscodingInvalidNestedResponseBodyGreeterService to HTTP API.", ex.InnerException!.InnerException!.Message);
-        Assert.Equal("The response body field 'sub.subfield' references a nested field. The field must be on the top-level response message.", ex.InnerException!.InnerException!.InnerException!.Message);
+        Assert.Equal("The response body field 'sub.subfield' references a nested field. The response body field name must be on the top-level response message.", ex.InnerException!.InnerException!.InnerException!.Message);
     }
 
     [Fact]
@@ -185,7 +185,7 @@ public class JsonTranscodingServiceMethodProviderTests
         // Assert
         Assert.Equal("Error binding gRPC service 'JsonTranscodingInvalidNestedBodyGreeterService'.", ex.Message);
         Assert.Equal("Error binding BadBody on JsonTranscodingInvalidNestedBodyGreeterService to HTTP API.", ex.InnerException!.InnerException!.Message);
-        Assert.Equal("The body field 'sub.subfield' references a nested field. The field must be on the top-level request message.", ex.InnerException!.InnerException!.InnerException!.Message);
+        Assert.Equal("The body field 'sub.subfield' references a nested field. The body field name must be on the top-level request message.", ex.InnerException!.InnerException!.InnerException!.Message);
     }
 
     [Fact]

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/JsonTranscodingServiceMethodProviderTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/JsonTranscodingServiceMethodProviderTests.cs
@@ -153,6 +153,18 @@ public class JsonTranscodingServiceMethodProviderTests
     }
 
     [Fact]
+    public void AddMethod_BadResponseBody_Nested_ThrowError()
+    {
+        // Arrange & Act
+        var ex = Assert.Throws<InvalidOperationException>(() => MapEndpoints<JsonTranscodingInvalidNestedResponseBodyGreeterService>());
+
+        // Assert
+        Assert.Equal("Error binding gRPC service 'JsonTranscodingInvalidNestedResponseBodyGreeterService'.", ex.Message);
+        Assert.Equal("Error binding BadResponseBody on JsonTranscodingInvalidNestedResponseBodyGreeterService to HTTP API.", ex.InnerException!.InnerException!.Message);
+        Assert.Equal("The response body field 'sub.subfield' references a nested field. The field must be on the top-level response message.", ex.InnerException!.InnerException!.InnerException!.Message);
+    }
+
+    [Fact]
     public void AddMethod_BadBody_ThrowError()
     {
         // Arrange & Act

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/JsonTranscodingServiceMethodProviderTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/JsonTranscodingServiceMethodProviderTests.cs
@@ -165,6 +165,18 @@ public class JsonTranscodingServiceMethodProviderTests
     }
 
     [Fact]
+    public void AddMethod_BadBody_Nested_ThrowError()
+    {
+        // Arrange & Act
+        var ex = Assert.Throws<InvalidOperationException>(() => MapEndpoints<JsonTranscodingInvalidNestedBodyGreeterService>());
+
+        // Assert
+        Assert.Equal("Error binding gRPC service 'JsonTranscodingInvalidNestedBodyGreeterService'.", ex.Message);
+        Assert.Equal("Error binding BadBody on JsonTranscodingInvalidNestedBodyGreeterService to HTTP API.", ex.InnerException!.InnerException!.Message);
+        Assert.Equal("The body field 'sub.subfield' references a nested field. The field must be on the top-level request message.", ex.InnerException!.InnerException!.InnerException!.Message);
+    }
+
+    [Fact]
     public void AddMethod_BadPattern_ThrowError()
     {
         // Arrange & Act

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/httpbody.proto
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/httpbody.proto
@@ -21,11 +21,6 @@ message HttpBodySubField {
   google.api.HttpBody sub = 2;
 }
 
-message NestedHttpBodySubField {
-  string name = 1;
-  HttpBodySubField sub = 2;
-}
-
 message HelloWorldRequest {
   string name = 1;
 }

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/transcoding.proto
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/transcoding.proto
@@ -76,11 +76,29 @@ service JsonTranscodingInvalidResponseBodyGreeter {
   }
 }
 
+service JsonTranscodingInvalidNestedResponseBodyGreeter {
+  rpc BadResponseBody (HelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      get: "/v1/greeter/{name}"
+      response_body: "sub.subfield"
+    };
+  }
+}
+
 service JsonTranscodingInvalidBodyGreeter {
   rpc BadBody (HelloRequest) returns (HelloReply) {
     option (google.api.http) = {
       get: "/v1/greeter/{name}"
       body: "NoMatch"
+    };
+  }
+}
+
+service JsonTranscodingInvalidNestedBodyGreeter {
+  rpc BadBody (HelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      get: "/v1/greeter/{name}"
+      body: "sub.subfield"
     };
   }
 }
@@ -181,13 +199,19 @@ message HelloRequest {
   google.protobuf.NullValue null_value = 20;
   google.protobuf.FieldMask field_mask_value = 21;
   string field_name = 22 [json_name="json_customized_name"];
+  google.protobuf.FloatValue float_value = 23;
 }
 
 message HelloReply {
+  message SubMessage {
+    string subfield = 1;
+    repeated string subfields = 2;
+  }
   string message = 1;
   repeated string values = 2;
   google.protobuf.StringValue nullable_message = 3;
   google.protobuf.Any any_message = 4;
+  SubMessage sub = 5;
 }
 
 message NullValueContainer {

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/TestObjects/Services/JsonTranscodingInvalidNestedBodyGreeterService.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/TestObjects/Services/JsonTranscodingInvalidNestedBodyGreeterService.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Transcoding;
+
+namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.TestObjects;
+
+public class JsonTranscodingInvalidNestedBodyGreeterService : JsonTranscodingInvalidNestedBodyGreeter.JsonTranscodingInvalidNestedBodyGreeterBase
+{
+}

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/TestObjects/Services/JsonTranscodingInvalidNestedBodyGreeterService.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/TestObjects/Services/JsonTranscodingInvalidNestedBodyGreeterService.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Transcoding;

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/TestObjects/Services/JsonTranscodingInvalidNestedResponseBodyGreeterService.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/TestObjects/Services/JsonTranscodingInvalidNestedResponseBodyGreeterService.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Transcoding;
+
+namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.TestObjects;
+
+public class JsonTranscodingInvalidNestedResponseBodyGreeterService : JsonTranscodingInvalidNestedResponseBodyGreeter.JsonTranscodingInvalidNestedResponseBodyGreeterBase
+{
+}


### PR DESCRIPTION
## Description

gRPC JSON transcoding has a `body` field on the annotation added to gRPC methods. It specifies where the request body is deserialized to.

```protobuf
service JsonTranscodingInvalidNestedBodyGreeter {
  rpc BadBody (HelloRequest) returns (HelloReply) {
    option (google.api.http) = {
      get: "/v1/greeter/{name}"
      body: "sub.subfield" // <- THIS GUY
    };
  }
}
```

Currently, we accept a path to a nested field, which is a period-separated path of field names, e.g. `address.city`. The HttpRule spec (unofficial spec for transcoding) says `body` must be a top-level field. A path isn't allow.

See https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc/google.api#google.api.HttpRule

![image](https://user-images.githubusercontent.com/303201/191013390-c6227490-8a0c-4379-b474-ec8d2ca3938e.png)

This PR changes transcoding only to accept a top-level field and provides a friendly error message if a nested field is specified:

> The body field 'sub.subfield' references a nested field. The body field name must be on the top-level request message.

## Customer Impact

Currently, the ASP.NET Core transcoding implementation doesn't follow the spec. Could cause confusion when customers are migrating to or from ASP.NET Core transcoding.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The changes lock down what request body binding accepts and makes the implementation simpler.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

