### PR TITLE
Fix DetectMisplacedLambdaAttribute analyzer and tests

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -160,7 +160,7 @@
         <DotNetProjects Include="
                           $(RepoRoot)src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj;
                           $(RepoRoot)src\Framework\App.Ref.Internal\src\Microsoft.AspNetCore.App.Ref.Internal.csproj;
-                          $(RepoRoot)src\Framework\AspNetCoreAnalyzers\**\*.csproj;
+                          $(RepoRoot)src\Framework\AspNetCoreAnalyzers\test\Microsoft.AspNetCore.App.Analyzers.Test.csproj;
                           $(RepoRoot)src\Framework\test\Microsoft.AspNetCore.App.UnitTests.csproj;
                           $(RepoRoot)src\Caching\**\*.*proj;
                           $(RepoRoot)src\DefaultBuilder\**\*.*proj;

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -160,6 +160,7 @@
         <DotNetProjects Include="
                           $(RepoRoot)src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj;
                           $(RepoRoot)src\Framework\App.Ref.Internal\src\Microsoft.AspNetCore.App.Ref.Internal.csproj;
+                          $(RepoRoot)src\Framework\AspNetCoreAnalyzers\**\*.csproj;
                           $(RepoRoot)src\Framework\test\Microsoft.AspNetCore.App.UnitTests.csproj;
                           $(RepoRoot)src\Caching\**\*.*proj;
                           $(RepoRoot)src\DefaultBuilder\**\*.*proj;

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectMisplacedLambdaAttribute.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectMisplacedLambdaAttribute.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -22,23 +23,17 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
         //    Hello();
         //    return "foo";
         // }
-        IMethodSymbol? methodSymbol = null;
 
-        // () => Hello() has a single child which is a BlockOperation so we check to see if
-        // expression associated with that operation is an invocation expression
-        if (lambda.ChildOperations.FirstOrDefault().Syntax is InvocationExpressionSyntax innerInvocation)
+        // All lambdas have a single child which is a BlockOperation. We search ChildOperations for
+        // the invocation expression.
+        if (lambda.ChildOperations.Count != 1 || lambda.ChildOperations.FirstOrDefault() is not IBlockOperation blockOperation)
         {
-            methodSymbol = lambda.Symbol;
-        }
-
-        if (lambda.ChildOperations.FirstOrDefault().ChildOperations.FirstOrDefault() is IReturnOperation returnOperation
-            && returnOperation.ReturnedValue is IInvocationOperation returnedInvocation)
-        {
-            methodSymbol = returnedInvocation.TargetMethod;
+            Debug.Fail("Expected a single top-level BlockOperation for all lambdas.");
+            return;
         }
 
         // If no method definition was found for the lambda, then abort.
-        if (methodSymbol is null)
+        if (GetReturnedInvocation(blockOperation) is not IMethodSymbol methodSymbol)
         {
             return;
         }
@@ -72,6 +67,39 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
             }
 
             return false;
+        }
+
+        static IMethodSymbol? GetReturnedInvocation(IBlockOperation blockOperation)
+        {
+            foreach (var op in blockOperation.ChildOperations.Reverse())
+            {
+                if (op is IReturnOperation returnStatement)
+                {
+                    if (returnStatement.ReturnedValue is IInvocationOperation invocationReturn)
+                    {
+                        return invocationReturn.TargetMethod;
+                    }
+
+                    // Sometimes expression backed lambdas include an IReturnOperation with a null ReturnedValue
+                    // right after the IExpressionStatementOperation whose Operation is the real ReturnedValue,
+                    // so we keep looking backwards rather than returning null immediately.
+                }
+                else if (op is IExpressionStatementOperation expression)
+                {
+                    if (expression.Operation is IInvocationOperation invocationExpression)
+                    {
+                        return invocationExpression.TargetMethod;
+                    }
+
+                    return null;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/Framework/AspNetCoreAnalyzers/test/Verifiers/CSharpWebApplicationBuilderCodeFixVerifier.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/Verifiers/CSharpWebApplicationBuilderCodeFixVerifier.cs
@@ -68,6 +68,7 @@ public static class CSharpWebApplicationBuilderCodeFixVerifier
                 TrimAssemblyExtension(typeof(Microsoft.Extensions.Hosting.HostingHostBuilderExtensions).Assembly.Location),
                 TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Builder.ConfigureHostBuilder).Assembly.Location),
                 TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Builder.ConfigureWebHostBuilder).Assembly.Location),
+                TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Builder.EndpointRoutingApplicationBuilderExtensions).Assembly.Location),
                 TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Hosting.HostingAbstractionsWebHostBuilderExtensions).Assembly.Location),
                 TrimAssemblyExtension(typeof(Microsoft.Extensions.Logging.ILoggingBuilder).Assembly.Location),
                 TrimAssemblyExtension(typeof(Microsoft.Extensions.Logging.ConsoleLoggerExtensions).Assembly.Location),


### PR DESCRIPTION
## Description

Before this change, we had a whole suite of analyzers that were not being tested on the CI.

I just happened to be looking at these analyzers because we started working on new out-of-band analyzers for the hackathon. When running the tests locally, I discovered failing tests because of a false positive in our `DetectMisplacedLambdaAttribute` logic. That's when I realized these tests must not be running on the CI.

## Customer Impact

Customers haven't noticed this. Below, the `[Authorize]` attribute is in the correct location, but we improperly warn anyway.

![Inline false positive warning](https://user-images.githubusercontent.com/54385/191338083-e765681a-a7a9-4f2a-8839-e8d687c22e03.png)

But we've noticed that the false positive warning does not always show up in the error list. It appears to be due to the race condition fixed by https://github.com/dotnet/roslyn/issues/6322. We think this might be why no customers have reported this issue. The false positive happens to be in a fairly specific case where an attribute is added to a lambda that then immediately invokes another method.

![Build output and error list](https://user-images.githubusercontent.com/54385/191338804-992e5fb8-41aa-4af2-b6ad-8c25180f20c1.png)

## Regression?

- [x] Yes
- [ ] No

Tests haven't been running on the CI, so the regression likely happened sometime between preview1 when the analyzer was first released and now.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

I think it would be higher risk to continue running no tests for these analyzers in our `release/7.0` branch.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A