### PR TITLE
Update the SDK to 8.0.100-alpha.1.22469.4

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "7.0.100-rc.2.22462.1"
+    "version": "8.0.100-alpha.1.22469.4"
   },
   "tools": {
-    "dotnet": "7.0.100-rc.2.22462.1",
+    "dotnet": "8.0.100-alpha.1.22469.4",
     "runtimes": {
       "dotnet/x86": [
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"

--- a/src/Servers/HttpSys/test/FunctionalTests/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.csproj
+++ b/src/Servers/HttpSys/test/FunctionalTests/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests.csproj
@@ -5,7 +5,7 @@
     <TestGroupName>HttpSys.FunctionalTests</TestGroupName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Required for System.Net.Quic which has a preview API in .NET 7 -->
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Servers/Kestrel/Transport.Quic/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests.csproj
+++ b/src/Servers/Kestrel/Transport.Quic/test/Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests.csproj
@@ -5,7 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <!-- Required for System.Net.Quic which has a preview API in .NET 7 -->
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I'm seeing errors like the following locally, but that project does have `<EnablePreviewFeatures>true</EnablePreviewFeatures>`, 
```
D:\github\aspnetcore\src\Servers\Kestrel\Transport.Quic\test\QuicConnectionContextTests.cs(60,50): error CA2252: Using
'ConnectAsync' requires opting into preview features. See https://aka.ms/dotnet-warnings/preview-features for more info
rmation. [D:\github\aspnetcore\src\Servers\Kestrel\Transport.Quic\test\Microsoft.AspNetCore.Server.Kestrel.Transport.Qu
ic.Tests.csproj]
```

We'll need to track that down if it repos on the CI.