### PR TITLE
Updating the SDK, hopefully fixing template tests

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "7.0.100-rc.2.22462.1"
+    "version": "7.0.100-rc.1.22375.2"
   },
   "tools": {
-    "dotnet": "7.0.100-rc.2.22462.1",
+    "dotnet": "7.0.100-rc.1.22375.2",
     "runtimes": {
       "dotnet/x86": [
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "7.0.100-rc.1.22375.2"
+    "version": "7.0.100-rtm.22471.17"
   },
   "tools": {
-    "dotnet": "7.0.100-rc.1.22375.2",
+    "dotnet": "7.0.100-rtm.22471.17",
     "runtimes": {
       "dotnet/x86": [
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"

--- a/src/ProjectTemplates/Shared/TemplatePackageInstaller.cs
+++ b/src/ProjectTemplates/Shared/TemplatePackageInstaller.cs
@@ -141,7 +141,7 @@ internal static class TemplatePackageInstaller
         {
             var proc = await RunDotNetNew(output, $"\"{templateName}\"");
 
-            if (!proc.Error.Contains("No templates found matching:"))
+            if (!proc.Error.Contains("No templates or subcommands found matching:"))
             {
                 throw new InvalidOperationException($"Failed to uninstall previous templates. The template '{templateName}' could still be found.");
             }

--- a/src/ProjectTemplates/Shared/TemplatePackageInstaller.cs
+++ b/src/ProjectTemplates/Shared/TemplatePackageInstaller.cs
@@ -141,7 +141,7 @@ internal static class TemplatePackageInstaller
         {
             var proc = await RunDotNetNew(output, $"\"{templateName}\"");
 
-            if (!proc.Error.Contains("No templates or subcommands found matching:"))
+            if (!proc.Error.Contains("No templates found matching:"))
             {
                 throw new InvalidOperationException($"Failed to uninstall previous templates. The template '{templateName}' could still be found.");
             }


### PR DESCRIPTION
Rolling back SDK version to `7.0.100-rc.1.22375.2` as suggested at https://github.com/dotnet/aspnetcore/pull/44069#pullrequestreview-1112960681. This is to work around the build issues we've had since updating to a newer SDK.

**Update** No, that SDK version doesn't work, as it leads to [this deterministic error](https://github.com/dotnet/aspnetcore/pull/44087#issuecomment-1255082455). I'm now trying to update to the latest 7.0 SDK. The current status is that the template tests are passing locally with that SDK, so let's see if they also pass in CI.