### PR TITLE
Use perfect-hash in HttpUriScheme.GetKnownMethod(string) instead of trie

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
@@ -238,6 +238,9 @@ internal static partial class HttpUtilities
         // or return HttpMethod.Custom if not found.
         // 
         // Further info and how to call gperf see https://github.com/dotnet/aspnetcore/pull/44096
+        //
+        // Code here could be removed if Roslyn improvements from
+        // https://github.com/dotnet/roslyn/issues/56374 are added.
 
         const int MinWordLength = 3;
         const int MaxWordLength = 7;

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
@@ -229,8 +229,7 @@ internal static partial class HttpUtilities
     /// <returns><see cref="HttpMethod"/></returns>
     public static HttpMethod GetKnownMethod(string? value)
     {
-        // TODO: fix that comment
-        // For a description for that approach see https://github.com/dotnet/aspnetcore/pull/[0-9]+
+        // For a description for that approach see https://github.com/dotnet/aspnetcore/pull/44096
 
         const int MinWordLength = 3;
         const int MaxWordLength = 7;

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs
@@ -243,22 +243,28 @@ internal static partial class HttpUtilities
         const int MaxWordLength = 7;
         const int MaxHashValue = 12;
 
-        if (value is null || ((uint)(value.Length - MinWordLength) > (MaxWordLength - MinWordLength)))
+        if (string.IsNullOrEmpty(value))
         {
             return HttpMethod.None;
         }
 
-        var methodsLookup = Methods();
+        if (((uint)(value.Length - MinWordLength) <= (MaxWordLength - MinWordLength)))
+        {
+            var methodsLookup = Methods();
 
-        Debug.Assert(WordListForPerfectHashOfMethods.Length == (MaxHashValue + 1) && methodsLookup.Length == (MaxHashValue + 1));
+            Debug.Assert(WordListForPerfectHashOfMethods.Length == (MaxHashValue + 1) && methodsLookup.Length == (MaxHashValue + 1));
 
-        var index = PerfectHash(value);
+            var index = PerfectHash(value);
 
-        return index < (uint)WordListForPerfectHashOfMethods.Length
-            && WordListForPerfectHashOfMethods[index] == value
-            && index < (uint)methodsLookup.Length
-            ? (HttpMethod)methodsLookup[(int)index]
-            : HttpMethod.Custom;
+            if (index < (uint)WordListForPerfectHashOfMethods.Length
+                && WordListForPerfectHashOfMethods[index] == value
+                && index < (uint)methodsLookup.Length)
+            {
+                return (HttpMethod)methodsLookup[(int)index];
+            }
+        }
+
+        return HttpMethod.Custom;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static uint PerfectHash(ReadOnlySpan<char> str)


### PR DESCRIPTION
## Description

In `HttpUtilities.GetKnownMethod(string value)` a [trie based approach](https://github.com/dotnet/aspnetcore/blob/ce2db7ea0b161fc5eb35710fca6feeafeeac37bc/src/Servers/Kestrel/Core/src/Internal/Infrastructure/HttpUtilities.cs#L248-L298) is used.

Recently I stumbled accross [Fast parsing HTTP verbs](http://0x80.pl/notesen/2022-01-29-http-verb-parse.html) from [Wojciech Muła](https://github.com/WojciechMula) and gave it a try.
The approach uses [gperf -- Perfect Hash Function Generator](https://www.gnu.org/software/gperf/manual/gperf.html) to generate a _perfect hash function_ which computes / looks up a key which can be used to get the known HTTP-method.

## Benchmark results

```
|  Method |  Method |     Mean | Ratio |
|-------- |-------- |---------:|------:|
| Default | CONNECT | 4.788 ns |  1.00 |
|      PR | CONNECT | 1.889 ns |  0.39 |
|         |         |          |       |
| Default |  DELETE | 4.293 ns |  1.00 |
|      PR |  DELETE | 2.009 ns |  0.47 |
|         |         |          |       |
| Default |     GET | 3.526 ns |  1.00 |
|      PR |     GET | 1.935 ns |  0.55 |
|         |         |          |       |
| Default |    HEAD | 3.983 ns |  1.00 |
|      PR |    HEAD | 1.979 ns |  0.51 |
|         |         |          |       |
| Default | OPTIONS | 4.789 ns |  1.00 |
|      PR | OPTIONS | 1.960 ns |  0.40 |
|         |         |          |       |
| Default |   PATCH | 4.778 ns |  1.00 |
|      PR |   PATCH | 2.206 ns |  0.46 |
|         |         |          |       |
| Default |    POST | 4.584 ns |  1.00 |
|      PR |    POST | 1.873 ns |  0.41 |
|         |         |          |       |
| Default |     PRI | 7.030 ns |  1.00 |
|      PR |     PRI | 4.799 ns |  0.68 |
|         |         |          |       |
| Default |     PUT | 4.156 ns |  1.00 |
|      PR |     PUT | 1.916 ns |  0.46 |
|         |         |          |       |
| Default |   TRACE | 4.372 ns |  1.00 |
|      PR |   TRACE | 1.951 ns |  0.45 |
```

(I ran the benchmark several times to verify that the numbers are correct. I didn't believe in the first runs :wink: ... it's less code, traded with lookups)

### Additional notes for gperf

As the lookup table isn't intuitive here the steps needed to create it.

Version of gperf: 3.1

File `knownverbs.txt`:
```
CONNECT
DELETE
GET
HEAD
OPTIONS
PATCH
POST
PUT
TRACE
```

Command to run the generator:
```bash
gperf --output-file=knownverbs.c knownverbs.txt
```

This generator spits out C-code, which got ported to C# afterwards.

_Note_: there are plenty more tools for creating perfect-hashes, but this one is by far the easiest to use.

Question: gperf is _GNU General Public License_. Here only the output of that tool is used. To my understanding using this here doesn't violate GPL, but please confirm.

<details>
  <summary>Generated C-code</summary>

```c
/* ANSI-C code produced by gperf version 3.1 */
/* Command-line: gperf --output-file=knownverbs.c knownverbs.txt  */
/* Computed positions: -k'1' */

#if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
      && ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
      && (')' == 41) && ('*' == 42) && ('+' == 43) && (',' == 44) \
      && ('-' == 45) && ('.' == 46) && ('/' == 47) && ('0' == 48) \
      && ('1' == 49) && ('2' == 50) && ('3' == 51) && ('4' == 52) \
      && ('5' == 53) && ('6' == 54) && ('7' == 55) && ('8' == 56) \
      && ('9' == 57) && (':' == 58) && (';' == 59) && ('<' == 60) \
      && ('=' == 61) && ('>' == 62) && ('?' == 63) && ('A' == 65) \
      && ('B' == 66) && ('C' == 67) && ('D' == 68) && ('E' == 69) \
      && ('F' == 70) && ('G' == 71) && ('H' == 72) && ('I' == 73) \
      && ('J' == 74) && ('K' == 75) && ('L' == 76) && ('M' == 77) \
      && ('N' == 78) && ('O' == 79) && ('P' == 80) && ('Q' == 81) \
      && ('R' == 82) && ('S' == 83) && ('T' == 84) && ('U' == 85) \
      && ('V' == 86) && ('W' == 87) && ('X' == 88) && ('Y' == 89) \
      && ('Z' == 90) && ('[' == 91) && ('\\' == 92) && (']' == 93) \
      && ('^' == 94) && ('_' == 95) && ('a' == 97) && ('b' == 98) \
      && ('c' == 99) && ('d' == 100) && ('e' == 101) && ('f' == 102) \
      && ('g' == 103) && ('h' == 104) && ('i' == 105) && ('j' == 106) \
      && ('k' == 107) && ('l' == 108) && ('m' == 109) && ('n' == 110) \
      && ('o' == 111) && ('p' == 112) && ('q' == 113) && ('r' == 114) \
      && ('s' == 115) && ('t' == 116) && ('u' == 117) && ('v' == 118) \
      && ('w' == 119) && ('x' == 120) && ('y' == 121) && ('z' == 122) \
      && ('{' == 123) && ('|' == 124) && ('}' == 125) && ('~' == 126))
/* The character set is not based on ISO-646.  */
#error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gperf@gnu.org>."
#endif


#define TOTAL_KEYWORDS 9
#define MIN_WORD_LENGTH 3
#define MAX_WORD_LENGTH 7
#define MIN_HASH_VALUE 3
#define MAX_HASH_VALUE 12
/* maximum key range = 10, duplicates = 0 */

#ifdef __GNUC__
__inline
#else
#ifdef __cplusplus
inline
#endif
#endif
static unsigned int
hash (register const char *str, register size_t len)
{
  static unsigned char asso_values[] =
    {
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13,  5,  0, 13,
      13,  0,  0, 13, 13, 13, 13, 13, 13,  0,
       5, 13, 13, 13,  0, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
      13, 13, 13, 13, 13, 13
    };
  return len + asso_values[(unsigned char)str[0]];
}

const char *
in_word_set (register const char *str, register size_t len)
{
  static const char * wordlist[] =
    {
      "", "", "",
      "GET",
      "HEAD",
      "TRACE",
      "DELETE",
      "OPTIONS",
      "PUT",
      "POST",
      "PATCH",
      "",
      "CONNECT"
    };

  if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
    {
      register unsigned int key = hash (str, len);

      if (key <= MAX_HASH_VALUE)
        {
          register const char *s = wordlist[key];

          if (*str == *s && !strcmp (str + 1, s + 1))
            return s;
        }
    }
  return 0;
}
```
</details>
