### PR TITLE
Implement OwinEnvironment.CopyTo and add Tests - Fixes #44082

### DIFF
--- a/src/Http/Owin/src/OwinEnvironment.cs
+++ b/src/Http/Owin/src/OwinEnvironment.cs
@@ -267,24 +267,10 @@ public class OwinEnvironment : IDictionary<string, object>
             throw new ArgumentException("Not enough available space in array", nameof(array));
         }
 
-        // Simpler code and easier to read, but causes an allocation of the enumerator/iterator - is the trade off okay?
-        //foreach (var entryPair in this)
-        //{
-        //    array[arrayIndex++] = entryPair;
-        //}
-
-        // Same code as the iterator GetEnumerator but directly pushed the results into the array
-        foreach (var entryPair in _entries)
+        // Causes an allocation of the enumerator/iterator but is easier to maintain
+        foreach (var entryPair in this)
         {
-            object value;
-            if (entryPair.Value.TryGet(_context, out value))
-            {
-                array[arrayIndex++] = new KeyValuePair<string, object>(entryPair.Key, value);
-            }
-        }
-        foreach (var entryPair in _context.Items)
-        {
-            array[arrayIndex++] = new KeyValuePair<string, object>(Convert.ToString(entryPair.Key, CultureInfo.InvariantCulture), entryPair.Value);
+            array[arrayIndex++] = entryPair;
         }
     }
 

--- a/src/Http/Owin/src/OwinEnvironment.cs
+++ b/src/Http/Owin/src/OwinEnvironment.cs
@@ -254,7 +254,38 @@ public class OwinEnvironment : IDictionary<string, object>
 
     void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
     {
-        throw new NotImplementedException();
+        if (array is null)
+        {
+            throw new ArgumentNullException(nameof(array));
+        }
+        if (arrayIndex < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+        }
+        if (arrayIndex + _entries.Count + _context.Items.Count > array.Length)
+        {
+            throw new ArgumentException("Not enough available space in array", nameof(array));
+        }
+
+        // Simpler code and easier to read, but causes an allocation of the enumerator/iterator - is the trade off okay?
+        //foreach (var entryPair in this)
+        //{
+        //    array[arrayIndex++] = entryPair;
+        //}
+
+        // Same code as the iterator GetEnumerator but directly pushed the results into the array
+        foreach (var entryPair in _entries)
+        {
+            object value;
+            if (entryPair.Value.TryGet(_context, out value))
+            {
+                array[arrayIndex++] = new KeyValuePair<string, object>(entryPair.Key, value);
+            }
+        }
+        foreach (var entryPair in _context.Items)
+        {
+            array[arrayIndex++] = new KeyValuePair<string, object>(Convert.ToString(entryPair.Key, CultureInfo.InvariantCulture), entryPair.Value);
+        }
     }
 
     int ICollection<KeyValuePair<string, object>>.Count

--- a/src/Http/Owin/test/OwinEnvironmentTests.cs
+++ b/src/Http/Owin/test/OwinEnvironmentTests.cs
@@ -134,6 +134,31 @@ public class OwinEnvironmentTests
         Assert.NotNull(((IEnumerable)owinEnvironment).GetEnumerator());
     }
 
+    [Fact]
+    public void OwinEnvironmentImplementsCopyTo()
+    {
+        var owinEnvironment = new OwinEnvironment(CreateContext());
+        var collection = (ICollection<KeyValuePair<string, object>>)owinEnvironment;
+
+        var length = collection.Count;
+        var kvp = new KeyValuePair<string, object>[length];
+
+        collection.CopyTo(kvp, 0);
+
+        Assert.Throws<ArgumentNullException>(() => collection.CopyTo(null, 0)); // array is null
+        Assert.Throws<ArgumentOutOfRangeException>(() => collection.CopyTo(kvp, -1));   // arrayIndex is less than 0
+        Assert.Throws<ArgumentException>(() => collection.CopyTo(kvp, 1));  // The number of elements in the source ICollection<T> is greater than the available space from arrayIndex to the end of the destination array.
+    }
+
+    [Fact]
+    public void OwinEnvironmentSupportsLinq()
+    {
+        var owinEnvironment = new OwinEnvironment(CreateContext());
+
+        var orderedEnvironment = owinEnvironment.OrderBy(kv => kv.Key).ToList();
+        Assert.NotNull(orderedEnvironment);
+    }
+
     private HttpContext CreateContext()
     {
         var context = new DefaultHttpContext();


### PR DESCRIPTION
# Implement OwinEnvironment.CopyTo and add Tests - Fixes #44082

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Add an implementation of `ICollection<KeyValuePair<string, object>>.CopyTo` to `OwinEnvironment`

## Description

OwinEnvironment has a `throw new NotImplementedException();` for this method which caused an issue with some Linq methods. This caused an issue when trying to use the `Microsoft.Owin.Diagnostics` package's `UseErrorPage` for example.

The implementation copies the code from `GetEnumerator`, and includes the appropriate exceptions per https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.icollection-1.copyto?view=net-6.0
There is a 'simpler' implementation which just delegates the main implementation of getting the `KeyValuePair`s, but this would result in allocating the enumerator/iterator which seems like a waste of memory.

There are tests 
- `OwinEnvironmentImplementsCopyTo` - Check that the function works for a valid target array and that all the error conditions throw an exception.
- `OwinEnvironmentSupportsLinq` - Check that `OwinEnvironment` supports the Linq method `OrderBy` which is how the issue was originally discovered.

Fixes #44082
