### PR TITLE
refactor: use grep -E/-F instead of fgrep/egrep

### DIFF
--- a/src/SignalR/clients/java/signalr/gradlew
+++ b/src/SignalR/clients/java/signalr/gradlew
@@ -146,8 +146,8 @@ if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     # Now convert the arguments - kludge to limit ourselves to /bin/sh
     i=0
     for arg in "$@" ; do
-        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
-        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
+        CHECK=`echo "$arg"|grep -E -c "$OURCYGPATTERN" -`
+        CHECK2=`echo "$arg"|grep -E -c "^-"`                                 ### Determine if an option
 
         if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
             eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`


### PR DESCRIPTION
# refactor: use grep -E/-F instead of fgrep/egrep

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

`egrep` and `fgrep` are obsolescent now. This PR updates  all `egrep` and `fgrep` commands to `grep -E` and `grep -F`.

Running egrep/fgrep command with grep v3.8 will output the following warning to stderr:

```
egrep: warning: egrep is obsolescent; using grep -E
```

see also:

- https://www.phoronix.com/news/GNU-Grep-3.8-Stop-egrep-fgrep
- https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00001.html

Fixes #44106
