### PR TITLE
[release/7.0] Fix item template `groupIdentity` and `identity` values

### DIFF
--- a/src/ProjectTemplates/Web.Client.ItemTemplates/content/Less/.template.config/template.json
+++ b/src/ProjectTemplates/Web.Client.ItemTemplates/content/Less/.template.config/template.json
@@ -7,7 +7,7 @@
   "description": "LESS is a language that compiles into CSS",
   "groupIdentity": "Microsoft.DotNet.Web.ClientItems.Less",
   "precedence": "100",
-  "identity": "Microsoft.DotNet.Web.ClientItems.Less",
+  "identity": "Microsoft.DotNet.Web.ClientItems.Less.7.0",
   "shortName": "less",
   "sourceName": "styleSheet1",
   "tags": {

--- a/src/ProjectTemplates/Web.Client.ItemTemplates/content/Scss/.template.config/template.json
+++ b/src/ProjectTemplates/Web.Client.ItemTemplates/content/Scss/.template.config/template.json
@@ -7,7 +7,7 @@
   "description": "SCSS is a language that compiles into CSS",
   "groupIdentity": "Microsoft.DotNet.Web.ClientItems.Scss",
   "precedence": "100",
-  "identity": "Microsoft.DotNet.Web.ClientItems.Scss",
+  "identity": "Microsoft.DotNet.Web.ClientItems.Scss.7.0",
   "shortName": "scss",
   "sourceName": "styleSheet1",
   "tags": {

--- a/src/ProjectTemplates/Web.Client.ItemTemplates/content/TypeScript/.template.config/template.json
+++ b/src/ProjectTemplates/Web.Client.ItemTemplates/content/TypeScript/.template.config/template.json
@@ -7,7 +7,7 @@
   "description": "A blank TypeScript source file",
   "groupIdentity": "Microsoft.DotNet.Web.ClientItems.TypeScript",
   "precedence": "100",
-  "identity": "Microsoft.DotNet.Web.ClientItems.TypeScript",
+  "identity": "Microsoft.DotNet.Web.ClientItems.TypeScript.7.0",
   "shortName": "tsfile",
   "sourceName": "file1",
   "tags": {

--- a/src/ProjectTemplates/Web.ItemTemplates/content/Protobuf/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/Protobuf/.template.config/template.json
@@ -12,9 +12,9 @@
     "language": "",
     "type": "item"
   },
-  "groupIdentity": "Microsoft.Web.Grpc.Protobuf.6.0",
+  "groupIdentity": "Microsoft.Web.Grpc.Protobuf",
   "precedence": "600",
-  "identity": "Microsoft.Web.Grpc.Protobuf",
+  "identity": "Microsoft.Web.Grpc.Protobuf.7.0",
   "shortname": "proto",
   "sourceName": "protobuf",
   "primaryOutputs": [

--- a/src/ProjectTemplates/Web.ItemTemplates/content/RazorComponent/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/RazorComponent/.template.config/template.json
@@ -14,7 +14,7 @@
   },
   "groupIdentity": "Microsoft.AspNetCore.Components.RazorComponent",
   "precedence": "600",
-  "identity": "Microsoft.AspNetCore.Components.RazorComponent.6.0",
+  "identity": "Microsoft.AspNetCore.Components.RazorComponent.7.0",
   "shortname": "razorcomponent",
   "sourceName": "Component1",
   "primaryOutputs": [

--- a/src/ProjectTemplates/Web.ItemTemplates/content/RazorPage/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/RazorPage/.template.config/template.json
@@ -11,7 +11,7 @@
   },
   "groupIdentity": "Microsoft.AspNetCore.Mvc.RazorPage",
   "precedence": "600",
-  "identity": "Microsoft.AspNetCore.Mvc.RazorPage.6.0",
+  "identity": "Microsoft.AspNetCore.Mvc.RazorPage.7.0",
   "shortName": "page",
   "sourceName": "Index",
   "primaryOutputs": [

--- a/src/ProjectTemplates/Web.ItemTemplates/content/ViewImports/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/ViewImports/.template.config/template.json
@@ -11,7 +11,7 @@
   },
   "groupIdentity": "Microsoft.AspNetCore.Mvc.ViewImports",
   "precedence": "600",
-  "identity": "Microsoft.AspNetCore.Mvc.ViewImports.6.0",
+  "identity": "Microsoft.AspNetCore.Mvc.ViewImports.7.0",
   "shortName": "viewimports",
   "sourceName": "ignoreme",
   "primaryOutputs": [

--- a/src/ProjectTemplates/Web.ItemTemplates/content/ViewStart/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/ViewStart/.template.config/template.json
@@ -11,7 +11,7 @@
   },
   "groupIdentity": "Microsoft.AspNetCore.Mvc.ViewStart",
   "precedence": "600",
-  "identity": "Microsoft.AspNetCore.Mvc.ViewStart.6.0",
+  "identity": "Microsoft.AspNetCore.Mvc.ViewStart.7.0",
   "shortName": "viewstart",
   "sourceName": "ignoreme",
   "primaryOutputs": [


### PR DESCRIPTION
# [release/7.0] Fix item template `groupIdentity` and `identity` values

## Description

- give these templates release-specific `identity`s; some matched what we had in 6.0.x
- in `protobuf` template, start from 44483c367545 i.e. fix its `groupIdentity`
  - then, update the `identity` to use `.7.0` instead of `.6.0`

Fixes - #44095

## Customer Impact

Without this fix, customer would see duplicates in `dotnet new --list`.

`identity` uniqueness is essentially defence-in-depth, ensuring the latest content is shown to users.

## Regression?

- [x] Yes
- [ ] No

Regression from having only 6.0.x and earlier templates installed. Problem arises because 7.0.x `protobuf` template does not have the same `groupIdentity` as in previous releases.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Small changes to template metadata that are similar to 44483c367545 and what we did w/ `identity` in previous releases.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A