### PR TITLE
[release/7.0] Update spa-templates to ref new 7.0 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 [submodule "src/submodules/spa-templates"]
 	path = src/submodules/spa-templates
 	url = https://github.com/dotnet/spa-templates.git
-	branch = main
+	branch = release/7.0


### PR DESCRIPTION
# [release/7.0] Update spa-templates to ref new 7.0 branch

## Description

- just created release/7.0 in dotnet/spa-templates
  - use it here to enable main in spa-templates to get new branding
- also use latest commit from spa-templates

Contains a fix for [[C&AI Translation Feedback] - ASP.NET Core incomplete German translation](https://dev.azure.com/ceapex/CEINTL/_workitems/edit/710128). #43956 brings in fixes for the templates in dotnat/aspnetcore for that bug too (more on that when that loc handback PR is in main and ready for backporting).

## Customer Impact

Without this fix, customer would see `Target net7.0` instead of `Ziel net7.0` when in a German locale and using one of the templates from Microsoft.DotNet.Web.Spa.ProjectTemplates.7.0.

## Regression?

- [ ] Yes
- [x] No

Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0 only had translations for the name and description of the two templates from dotnet/spa-templates. This change here completes filling that gap.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

One-word changes in existing language-specific files 😃

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A