### PR TITLE
Fix up packaging for Extensions.ApiDescription.Server

### DIFF
--- a/src/Tools/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.csproj
+++ b/src/Tools/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <!-- Included primarily to ensure dotnet-getdocument and GetDocument.Insider can be referenced. -->
-    <TargetFrameworks>netcoreapp2.1;$(DefaultNetFxTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;$(DefaultNetCoreTargetFramework);$(DefaultNetFxTargetFramework)</TargetFrameworks>
 
     <Description>MSBuild tasks and targets for build-time Swagger and OpenApi document generation</Description>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
@@ -19,7 +19,7 @@
       because publish output matches what was built.
     -->
     <Reference Include="dotnet-getdocument"
-      Condition=" '$(TargetFramework)' == 'netcoreapp2.1' "
+      Condition=" '$(TargetFramework)' != '$(DefaultNetFxTargetFramework)' "
       Targets="Publish"
       Private="false"
       ReferenceOutputAssembly="false"
@@ -28,7 +28,7 @@
       Private="false"
       ReferenceOutputAssembly="false"
       SkipGetTargetFrameworkProperties="true">
-        <Targets Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">Publish</Targets>
+        <Targets Condition=" '$(TargetFramework)' != '$(DefaultNetFxTargetFramework)' ">Publish</Targets>
     </Reference>
   </ItemGroup>
 

--- a/src/Tools/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.nuspec
+++ b/src/Tools/Extensions.ApiDescription.Server/src/Microsoft.Extensions.ApiDescription.Server.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.8">
     $CommonMetadataElements$
@@ -12,5 +12,6 @@
     <file src="$artifactsBinDir$\GetDocument.Insider\$configuration$\net462\*.*" target="tools\net462" />
     <file src="$artifactsBinDir$\GetDocument.Insider\x86\$configuration$\net462\*.*" target="tools\net462-x86" />
     <file src="$artifactsBinDir$\GetDocument.Insider\$configuration$\netcoreapp2.1\publish\*.*" target="tools\netcoreapp2.1" />
+    <file src="$artifactsBinDir$\GetDocument.Insider\$configuration$\net7.0\publish\*.*" target="tools\net7.0" />
   </files>
 </package>

--- a/src/Tools/GetDocumentInsider/src/GetDocument.Insider.csproj
+++ b/src/Tools/GetDocumentInsider/src/GetDocument.Insider.csproj
@@ -16,7 +16,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'">
-    <Reference Include="Microsoft.AspNetCore" />
+    <Reference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" />
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

This change fixes up the package of dependencies for the `dotnet-getdocument` tool to enable changes that were made to support minimal APIs in .NET 7.

- Publish `GetDocument.Insider` dependency  for all .NET Core TFMs
- Use targeted referenced to shared runtime dependencies in `GetDocument.Insider`
- Add .NET 7 outputs to `ApiDescription.Server` package.

Fixes https://github.com/dotnet/aspnetcore/issues/44119

## Customer Impact

Without this bug fix, customers are not able to leverage client generation for ASP.NET apps in Visual Studio for .NET 7 applications. There are no accessible workarounds for this bug.

## Regression?

- [X] Yes
- [ ] No

Regression from .NET 7 RC 1. The bug is present in .NET 7 RC 2 and this PR is targeting .NET 7 RC2. 

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Change is localized to `Extensions.ApiDescription.Server`.

## Verification

- [X] Manual (required)

Manual validation was completed by adding a reference to the local package output directory `aspnetcore\artifacts\packages\Debug\Shipping` and using the `7.0.0-dev` version of the `Microsoft.Extensions.ApiDescription.Server` package in a sample project.

```xml
<Project Sdk="Microsoft.NET.Sdk.Web">

  <PropertyGroup>
    <TargetFramework>net7.0</TargetFramework>
    <Nullable>enable</Nullable>
    <ImplicitUsings>enable</ImplicitUsings>
    <OpenApiGenerateDocumentsOnBuild>true</OpenApiGenerateDocumentsOnBuild>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
    <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="7.0.0-dev" PrivateAssets="all" />
    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.0-*" PrivateAssets="all" />
  </ItemGroup>

</Project>

```

- [ ] Automated

## Packaging changes reviewed?

- [X] Yes
- [ ] No
- [ ] N/A