### PR TITLE
Add comment to WebAssembly empty template about scoped CSS. Fixes #43975

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/Client/wwwroot/index.html
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/Client/wwwroot/index.html
@@ -8,6 +8,14 @@
     <!--#if PWA -->
     <link href="manifest.json" rel="manifest" />
     <!--#endif -->
+    
+    <!--#if Hosted -->
+    <!-- If you add any scoped CSS files, uncomment the following to load them
+    <link href="EmptyComponentsWebAssembly_CSharp.Client.styles.css" rel="stylesheet" /> -->
+    <!--#else -->
+    <!-- If you add any scoped CSS files, uncomment the following to load them
+    <link href="EmptyComponentsWebAssembly_CSharp.styles.css" rel="stylesheet" /> -->
+    <!--#endif -->
 </head>
 
 <body>


### PR DESCRIPTION
# Add comment to WebAssembly empty template about scoped CSS

Adds a comment showing how to reference scoped CSS.

## Description

The new "empty" Blazor WebAssembly template doesn't contain any scoped CSS by default, and hence doesn't reference the scoped CSS bundle because there isn't one. When a developer later adds scoped CSS, they need to reference the bundle which is difficult to figure out how to do. This comment gives them the code they need.

Fixes #43975

## Customer Impact

Without this change, it's very difficult to work out how to make scoped CSS work. You have to figure out the correct form of the generated filename based on your project name.

## Regression?

- [ ] Yes
- [x] No (empty template is new in 7.0)

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Just adding a comment to a template.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A