### PR TITLE
[release/7.0] Update Roslyn Versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -206,9 +206,9 @@
     -->
     <Analyzer_MicrosoftCodeAnalysisCSharpVersion>3.3.1</Analyzer_MicrosoftCodeAnalysisCSharpVersion>
     <Analyzer_MicrosoftCodeAnalysisCSharpWorkspacesVersion>3.3.1</Analyzer_MicrosoftCodeAnalysisCSharpWorkspacesVersion>
-    <MicrosoftCodeAnalysisCommonVersion>4.2.0-2.22128.1</MicrosoftCodeAnalysisCommonVersion>
-    <MicrosoftCodeAnalysisCSharpVersion>4.2.0-2.22128.1</MicrosoftCodeAnalysisCSharpVersion>
-    <MicrosoftCodeAnalysisCSharpWorkspacesVersion>4.2.0-2.22128.1</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
+    <MicrosoftCodeAnalysisCommonVersion>4.4.0-3.22472.13</MicrosoftCodeAnalysisCommonVersion>
+    <MicrosoftCodeAnalysisCSharpVersion>4.4.0-3.22472.13</MicrosoftCodeAnalysisCSharpVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesVersion>4.4.0-3.22472.13</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>3.3.3</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <MicrosoftCodeAnalysisCSharpAnalyzerTestingXUnitVersion>1.1.2-beta1.22276.1</MicrosoftCodeAnalysisCSharpAnalyzerTestingXUnitVersion>
     <MicrosoftCodeAnalysisCSharpCodeFixTestingXUnitVersion>1.1.2-beta1.22276.1</MicrosoftCodeAnalysisCSharpCodeFixTestingXUnitVersion>


### PR DESCRIPTION
# Update Roslyn Versions

Summary of the changes

Update the Roslyn version referenced by Razor to `4.4.0-3.22472.13`.

## Description

This is a routine change we complete every release to update the Roslyn version used by the [Razor Runtime Compilation NuGet package](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Razor). This PR uses the Roslyn version [provided](https://github.com/dotnet/aspnetcore/pull/44072#discussion_r978887076) by @jaredpar. 

The Razor Runtime Compilation NuGet package needs to reference a version of Roslyn that ships as a NuGet package. However, as Roslyn doesn't follow the runtime ship schedule, ASP.NET Core manually updates this package version.

Fixes: https://github.com/dotnet/aspnetcore/issues/39387

## Customer Impact

This change ensures the version of Roslyn used by the Razor Runtime Compilation NuGet package is synchronized with the version of Roslyn used by the Razor Compiler (which ships as part of the SDK). Without synchronized Roslyn versions, we could have undefined behavior in our published packages.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Routine version bump.

## Verification

- [x] Manual (required)
- [x] Automated

Due to the nature of this update, [CI validation is sufficient](https://github.com/dotnet/aspnetcore/pull/44148#issuecomment-1258202249).

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

References:
- https://github.com/dotnet/aspnetcore/pull/28125
- https://github.com/dotnet/aspnetcore/pull/37764
- https://github.com/dotnet/aspnetcore/pull/44072
