### PR TITLE
Add loc comments and fix Windows installer bug

### DIFF
--- a/.azure/pipelines/localization.yml
+++ b/.azure/pipelines/localization.yml
@@ -20,9 +20,10 @@ variables:
   value: AspNetCore
 
 jobs:
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.Reason'], 'Manual'))) }}:
   - template: /eng/common/templates/job/onelocbuild.yml
     parameters:
+      CreatePr: ${{ ne(variables['Build.Reason'], 'Manual') }}
       LclPackageId: 'LCL-JUNO-PROD-ASPNETCORE'
       LclSource: lclFilesFromPackage
       MirrorRepo: aspnetcore

--- a/src/Installers/Windows/SharedFrameworkBundle/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/thm.wxl
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[BundleNameFull] Setup</String>
-  <String Id="Title">[BundleNameShort]</String>
-  <String Id="SubTitle">[BundleNameSub]</String>
+  <String Id="Caption"><!--_locComment_text="{Locked='[BundleNameFull]'}"-->[BundleNameFull] Setup</String>
+  <String Id="Title"><!--_locComment_text="{Locked}"-->[BundleNameShort]</String>
+  <String Id="SubTitle"><!--_locComment_text="{Locked}"-->[BundleNameSub]</String>
   <String Id="InstallHeader">Welcome</String>
-  <String Id="InstallMessage">Setup will install [WixBundleName] on your computer. Click install to continue, options to set the install directory or Close to exit.</String>
-  <String Id="InstallVersion">Version [WixBundleVersion]</String>
+  <String Id="InstallMessage"><!--_locComment_text="{Locked='[WixBundleName]'}"-->Setup will install [WixBundleName] on your computer. Click install to continue, options to set the install directory or Close to exit.</String>
+  <String Id="InstallVersion"><!--_locComment_text="{Locked='[WixBundleVersion]'}"-->Version [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
   <String Id="HelpHeader">Setup Help</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]directory[\[] - installs, repairs, uninstalls or
    creates a complete local copy of the bundle in directory. Install is the default.
 
 /passive | /quiet -  displays minimal UI with no prompts or displays no UI and
@@ -18,7 +18,7 @@
 /norestart   - suppress any attempts to restart. By default UI will prompt before restart.
 /log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
   <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallLicenseLinkText">[WixBundleName] &lt;a href="#"&gt;license terms&lt;/a&gt;.</String>
+  <String Id="InstallLicenseLinkText"><!--_locComment_text="{Locked='[WixBundleName]'}"-->[WixBundleName] &lt;a href="#"&gt;license terms&lt;/a&gt;.</String>
   <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
   <String Id="InstallOptionsButton">&amp;Options</String>
   <String Id="InstallInstallButton">&amp;Install</String>
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">&amp;Close</String>
   <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
   <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation Successfully Completed</String> 
-  <String Id="SuccessHeader">Setup Successful</String>	
+  <String Id="SuccessInstallHeader">Installation Successfully Completed</String>
+  <String Id="SuccessHeader">Setup Successful</String>
   <String Id="SuccessLaunchButton">&amp;Launch</String>
   <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
   <String Id="SuccessRestartButton">&amp;Restart</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">Setup Failed</String>
   <String Id="FailureInstallHeader">Setup Failed</String>
   <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String> 
+  <String Id="FailureRepairHeader">Repair Failed</String>
   <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
   <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
   <String Id="FailureRestartButton">&amp;Restart</String>
@@ -59,6 +59,6 @@
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
 
-  <String Id="Welcome">Welcome to the [WixBundleName] Setup.</String>
-  <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
+  <String Id="Welcome"><!--_locComment_text="{Locked='[WixBundleName]'}"-->Welcome to the [WixBundleName] Setup.</String>
+  <String Id="EulaPrivacy"><!--_locComment_text="{Locked='[WixBundleName]'}"-->[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/thm.wxl
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption"><!--_locComment_text="{Locked='[WixBundleName]'"-->[WixBundleName] Setup</String>
+  <String Id="Caption"><!--_locComment_text="{Locked='[WixBundleName]'}"-->[WixBundleName] Setup</String>
   <String Id="Title"><!--_locComment_text="{Locked}"-->[BundleNameShort]</String>
   <String Id="SubTitle"><!--_locComment_text="{Locked}"-->[BundleNameSub]</String>
   <String Id="InstallHeader">Welcome</String>
-  <String Id="InstallMessage"><!--_locComment_text="{Locked='[WixBundleName]'"-->Setup will install [WixBundleName] on your computer. Click install to continue, options to set the install directory or Close to exit.</String>
-  <String Id="InstallVersion"><!--_locComment_text="{Locked='[WixBundleVersion]'"-->Version [WixBundleVersion]</String>
+  <String Id="InstallMessage"><!--_locComment_text="{Locked='[WixBundleName]'}"-->Setup will install [WixBundleName] on your computer. Click install to continue, options to set the install directory or Close to exit.</String>
+  <String Id="InstallVersion"><!--_locComment_text="{Locked='[WixBundleVersion]'}"-->Version [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
   <String Id="HelpHeader">Setup Help</String>
@@ -18,7 +18,7 @@
 /norestart   - suppress any attempts to restart. By default UI will prompt before restart.
 /log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
   <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallLicenseLinkText"><!--_locComment_text="{Locked='[WixBundleName]'"-->[WixBundleName] &lt;a href="#"&gt;license terms&lt;/a&gt;.</String>
+  <String Id="InstallLicenseLinkText"><!--_locComment_text="{Locked='[WixBundleName]'}"-->[WixBundleName] &lt;a href="#"&gt;license terms&lt;/a&gt;.</String>
   <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
   <String Id="InstallOptionsButton">&amp;Options</String>
   <String Id="InstallInstallButton">&amp;Install</String>
@@ -60,10 +60,10 @@
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
 
   <!-- Custom UI strings -->
-  <String Id="Welcome"><!--_locComment_text="{Locked='[WixBundleName]'"-->Welcome to the [WixBundleName] Setup.</String>
+  <String Id="Welcome"><!--_locComment_text="{Locked='[WixBundleName]'}"-->Welcome to the [WixBundleName] Setup.</String>
   <String Id="InstallResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
   <String Id="InstallNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
-  <String Id="EulaPrivacy"><!--_locComment_text="{Locked='[WixBundleName]'"-->[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
+  <String Id="EulaPrivacy"><!--_locComment_text="{Locked='[WixBundleName]'}"-->[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
   <String Id="ModifyResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
   <String Id="ModifyNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/thm.wxl
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] Setup</String>
-  <String Id="Title">[BundleNameShort]</String>
-  <String Id="SubTitle">[BundleNameSub]</String>
+  <String Id="Caption"><!--_locComment_text="{Locked='[WixBundleName]'"-->[WixBundleName] Setup</String>
+  <String Id="Title"><!--_locComment_text="{Locked}"-->[BundleNameShort]</String>
+  <String Id="SubTitle"><!--_locComment_text="{Locked}"-->[BundleNameSub]</String>
   <String Id="InstallHeader">Welcome</String>
-  <String Id="InstallMessage">Setup will install [WixBundleName] on your computer. Click install to continue, options to set the install directory or Close to exit.</String>
-  <String Id="InstallVersion">Version [WixBundleVersion]</String>
+  <String Id="InstallMessage"><!--_locComment_text="{Locked='[WixBundleName]'"-->Setup will install [WixBundleName] on your computer. Click install to continue, options to set the install directory or Close to exit.</String>
+  <String Id="InstallVersion"><!--_locComment_text="{Locked='[WixBundleVersion]'"-->Version [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
   <String Id="HelpHeader">Setup Help</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]directory[\]] - installs, repairs, uninstalls or
    creates a complete local copy of the bundle in directory. Install is the default.
 
 /passive | /quiet -  displays minimal UI with no prompts or displays no UI and
@@ -18,7 +18,7 @@
 /norestart   - suppress any attempts to restart. By default UI will prompt before restart.
 /log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
   <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallLicenseLinkText">[WixBundleName] &lt;a href="#"&gt;license terms&lt;/a&gt;.</String>
+  <String Id="InstallLicenseLinkText"><!--_locComment_text="{Locked='[WixBundleName]'"-->[WixBundleName] &lt;a href="#"&gt;license terms&lt;/a&gt;.</String>
   <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
   <String Id="InstallOptionsButton">&amp;Options</String>
   <String Id="InstallInstallButton">&amp;Install</String>
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">&amp;Close</String>
   <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
   <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation Successfully Completed</String> 
-  <String Id="SuccessHeader">Setup Successful</String>	
+  <String Id="SuccessInstallHeader">Installation Successfully Completed</String>
+  <String Id="SuccessHeader">Setup Successful</String>
   <String Id="SuccessLaunchButton">&amp;Launch</String>
   <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
   <String Id="SuccessRestartButton">&amp;Restart</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">Setup Failed</String>
   <String Id="FailureInstallHeader">Setup Failed</String>
   <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String> 
+  <String Id="FailureRepairHeader">Repair Failed</String>
   <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
   <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
   <String Id="FailureRestartButton">&amp;Restart</String>
@@ -60,10 +60,10 @@
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
 
   <!-- Custom UI strings -->
-  <String Id="Welcome">Welcome to the [WixBundleName] Setup.</String>
+  <String Id="Welcome"><!--_locComment_text="{Locked='[WixBundleName]'"-->Welcome to the [WixBundleName] Setup.</String>
   <String Id="InstallResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
   <String Id="InstallNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
-  <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
+  <String Id="EulaPrivacy"><!--_locComment_text="{Locked='[WixBundleName]'"-->[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
   <String Id="ModifyResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
   <String Id="ModifyNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
 </WixLocalization>


### PR DESCRIPTION
- #44167, escape square brackets in `[directory]`
- add loc comments to lock WiX substitutions