### PR TITLE
[release/6.0] Use Ubuntu 20.04 a bit more

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -101,10 +101,10 @@ jobs:
         ${{ if or(eq(parameters.useHostedUbuntu, false), and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'Manual', 'PullRequest', 'Schedule'))) }}:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCore-Svc-Public
-            demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+            demands: ImageOverride -equals Build.Ubuntu.2004.Amd64.Open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: NetCore1ESPool-Svc-Internal
-            demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+            demands: ImageOverride -equals Build.Ubuntu.2004.Amd64
       ${{ if eq(parameters.agentOs, 'Windows') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: NetCore-Svc-Public


### PR DESCRIPTION
- make version consistent w/ AzDO hosted image
- images now available (dotnet/arcade#10833 gap filled)