### PR TITLE
Read HTTP_PORTS and HTTPS_PORTS into IServerAddresses 

### DIFF
--- a/src/Hosting/Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Hosting/Abstractions/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 #nullable enable
-static readonly Microsoft.AspNetCore.Hosting.WebHostDefaults.HttpPortKey -> string!
-static readonly Microsoft.AspNetCore.Hosting.WebHostDefaults.HttpsPortKey -> string!
+static readonly Microsoft.AspNetCore.Hosting.WebHostDefaults.HttpPortsKey -> string!
+static readonly Microsoft.AspNetCore.Hosting.WebHostDefaults.HttpsPortsKey -> string!

--- a/src/Hosting/Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Hosting/Abstractions/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static readonly Microsoft.AspNetCore.Hosting.WebHostDefaults.HttpPortKey -> string!
+static readonly Microsoft.AspNetCore.Hosting.WebHostDefaults.HttpsPortKey -> string!

--- a/src/Hosting/Abstractions/src/WebHostDefaults.cs
+++ b/src/Hosting/Abstractions/src/WebHostDefaults.cs
@@ -54,6 +54,16 @@ public static class WebHostDefaults
     public static readonly string ServerUrlsKey = "urls";
 
     /// <summary>
+    /// The configuration key associated with the "http_port" configuration.
+    /// </summary>
+    public static readonly string HttpPortKey = "http_port";
+
+    /// <summary>
+    /// The configuration key associated with the "https_port" configuration.
+    /// </summary>
+    public static readonly string HttpsPortKey = "https_port";
+
+    /// <summary>
     /// The configuration key associated with the "ContentRoot" configuration.
     /// </summary>
     public static readonly string ContentRootKey = "contentRoot";

--- a/src/Hosting/Abstractions/src/WebHostDefaults.cs
+++ b/src/Hosting/Abstractions/src/WebHostDefaults.cs
@@ -54,14 +54,14 @@ public static class WebHostDefaults
     public static readonly string ServerUrlsKey = "urls";
 
     /// <summary>
-    /// The configuration key associated with the "http_port" configuration.
+    /// The configuration key associated with the "http_ports" configuration.
     /// </summary>
-    public static readonly string HttpPortKey = "http_port";
+    public static readonly string HttpPortsKey = "http_ports";
 
     /// <summary>
-    /// The configuration key associated with the "https_port" configuration.
+    /// The configuration key associated with the "https_ports" configuration.
     /// </summary>
-    public static readonly string HttpsPortKey = "https_port";
+    public static readonly string HttpsPortsKey = "https_ports";
 
     /// <summary>
     /// The configuration key associated with the "ContentRoot" configuration.

--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostService.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostService.cs
@@ -73,6 +73,8 @@ internal sealed partial class GenericWebHostService : IHostedService
                 urls = Options.WebHostOptions.ServerUrls;
             }
 
+            var httpPorts = Configuration[WebHostDefaults.HttpPortsKey] ?? string.Empty;
+            var httpsPorts = Configuration[WebHostDefaults.HttpsPortsKey] ?? string.Empty;
             if (string.IsNullOrEmpty(urls))
             {
                 // HTTP_PORTS and HTTPS_PORTS, these are lower priority than Urls.
@@ -83,9 +85,13 @@ internal sealed partial class GenericWebHostService : IHostedService
                         .Select(port => $"{scheme}://*:{port}"));
                 }
 
-                var httpUrls = ExpandPorts(Configuration[WebHostDefaults.HttpPortsKey] ?? string.Empty, Uri.UriSchemeHttp);
-                var httpsUrls = ExpandPorts(Configuration[WebHostDefaults.HttpsPortsKey] ?? string.Empty, Uri.UriSchemeHttps);
+                var httpUrls = ExpandPorts(httpPorts, Uri.UriSchemeHttp);
+                var httpsUrls = ExpandPorts(httpsPorts, Uri.UriSchemeHttps);
                 urls = $"{httpUrls};{httpsUrls}";
+            }
+            else if (!string.IsNullOrEmpty(httpPorts) || !string.IsNullOrEmpty(httpsPorts))
+            {
+                Logger.PortsOverridenByUrls(httpPorts, httpsPorts, urls);
             }
 
             if (!string.IsNullOrEmpty(urls))

--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostService.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostService.cs
@@ -73,6 +73,18 @@ internal sealed partial class GenericWebHostService : IHostedService
                 urls = Options.WebHostOptions.ServerUrls;
             }
 
+            if (string.IsNullOrEmpty(urls))
+            {
+                // HTTP_PORTS and HTTPS_PORTS, these are lower priority than Urls.
+                var httpPorts = Configuration[WebHostDefaults.HttpPortKey];
+                var httpUrls = httpPorts?.Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                    .Select(port => $"http://*:{port}").Aggregate((s1, s2) => string.Concat(s1, ";", s2));
+                var httpsPorts = Configuration[WebHostDefaults.HttpsPortKey];
+                var httpsUrls = httpsPorts?.Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                    .Select(port => $"https://*:{port}").Aggregate((s1, s2) => string.Concat(s1, ";", s2));
+                urls = string.Join(';', httpUrls, httpsUrls);
+            }
+
             if (!string.IsNullOrEmpty(urls))
             {
                 // We support reading "preferHostingUrls" from app configuration

--- a/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingLoggerExtensions.cs
@@ -42,5 +42,12 @@ internal static class HostingLoggerExtensions
             message: message,
             exception: exception);
     }
+
+    public static void PortsOverridenByUrls(this ILogger logger, string httpPorts, string httpsPorts, string urls)
+    {
+        logger.LogWarning(eventId: LoggerEventIds.PortsOverridenByUrls,
+            message: "Overriding HTTP_PORTS '{http}' and HTTPS_PORTS '{https}'. Binding to values defined by URLS instead '{urls}'.",
+            httpPorts, httpsPorts, urls);
+    }
 }
 

--- a/src/Hosting/Hosting/src/Internal/LoggerEventIds.cs
+++ b/src/Hosting/Hosting/src/Internal/LoggerEventIds.cs
@@ -19,4 +19,5 @@ internal static class LoggerEventIds
     public const int ServerShutdownException = 12;
     public const int HostingStartupAssemblyLoaded = 13;
     public const int ServerListeningOnAddresses = 14;
+    public const int PortsOverridenByUrls = 15;
 }

--- a/src/Hosting/Hosting/test/GenericWebHostBuilderTests.cs
+++ b/src/Hosting/Hosting/test/GenericWebHostBuilderTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http.Features;
@@ -85,6 +86,46 @@ public class GenericWebHostBuilderTests
         host.Start();
 
         Assert.Equal("TEST_URL", server.Addresses.Single());
+    }
+
+    [Theory]
+    [InlineData(null, null, null, "")]
+    [InlineData("", "", "", "")]
+    [InlineData("http://urls", "", "", "http://urls")]
+    [InlineData("http://urls", "5000", "", "http://urls")]
+    [InlineData("http://urls", "", "5001", "http://urls")]
+    [InlineData("http://urls", "5000", "5001", "http://urls")]
+    [InlineData("", "5000", "", "http://*:5000")]
+    [InlineData("", "5000;5002;5004", "", "http://*:5000;http://*:5002;http://*:5004")]
+    [InlineData("", "", "5001", "https://*:5001")]
+    [InlineData("", "", "5001;5003;5005", "https://*:5001;https://*:5003;https://*:5005")]
+    [InlineData("", "5000", "5001", "http://*:5000;https://*:5001")]
+    [InlineData("", "5000;5002", "5001;5003", "http://*:5000;http://*:5002;https://*:5001;https://*:5003")]
+    public void ReadsUrlsOrPorts(string urls, string httpPort, string httpsPort, string expected)
+    {
+        var server = new TestServer();
+
+        using var host = new HostBuilder()
+            .ConfigureHostConfiguration(config =>
+            {
+                config.AddInMemoryCollection(new[]
+                {
+                    new KeyValuePair<string, string>("urls", urls),
+                    new KeyValuePair<string, string>("http_port", httpPort),
+                    new KeyValuePair<string, string>("https_port", httpsPort),
+                });
+            })
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                    .UseServer(server)
+                    .Configure(_ => { });
+            })
+            .Build();
+
+        host.Start();
+
+        Assert.Equal(expected, string.Join(';', server.Addresses));
     }
 
     private class TestServer : IServer, IServerAddressesFeature

--- a/src/Hosting/Hosting/test/GenericWebHostBuilderTests.cs
+++ b/src/Hosting/Hosting/test/GenericWebHostBuilderTests.cs
@@ -101,7 +101,7 @@ public class GenericWebHostBuilderTests
     [InlineData("", "", "5001;5003;5005", "https://*:5001;https://*:5003;https://*:5005")]
     [InlineData("", "5000", "5001", "http://*:5000;https://*:5001")]
     [InlineData("", "5000;5002", "5001;5003", "http://*:5000;http://*:5002;https://*:5001;https://*:5003")]
-    public void ReadsUrlsOrPorts(string urls, string httpPort, string httpsPort, string expected)
+    public void ReadsUrlsOrPorts(string urls, string httpPorts, string httpsPorts, string expected)
     {
         var server = new TestServer();
 
@@ -111,8 +111,8 @@ public class GenericWebHostBuilderTests
                 config.AddInMemoryCollection(new[]
                 {
                     new KeyValuePair<string, string>("urls", urls),
-                    new KeyValuePair<string, string>("http_port", httpPort),
-                    new KeyValuePair<string, string>("https_port", httpsPort),
+                    new KeyValuePair<string, string>("http_ports", httpPorts),
+                    new KeyValuePair<string, string>("https_ports", httpsPorts),
                 });
             })
             .ConfigureWebHost(webHostBuilder =>


### PR DESCRIPTION
Fixes #43135

Container images want to be able to specify ports rather than urls. We want to avoid overloading the definition for ASPNETCORE_URLS, so this adds support for ASPNETCORE_HTTP_PORTS and ASPNETCORE_HTTPS_PORTS. URLS still takes priority, these new variables will be ignored if URLS is set.

Each is a list of semi-colon delimited values that will be mapped to `http(s)://*:{port}` respectively.

This will cause Kestrel to bind to all public IPs with IPv4 and IPv6 for the given ports.

This would also work with Http.Sys though we have a warning there not to use wildcards.
https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/httpsys?view=aspnetcore-6.0#configure-windows-server

This is only implemented for generic web host and newer, not legacy webhost.