### PR TITLE
Update docker tag to latest schema

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -527,7 +527,7 @@ stages:
       jobName: Linux_musl_x64_build
       jobDisplayName: "Build: Linux Musl x64"
       agentOs: Linux
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode-20210910135833-c401c85
+      container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode-latest
       buildArgs:
         --arch x64
         --os-name linux-musl
@@ -562,7 +562,7 @@ stages:
       jobDisplayName: "Build: Linux Musl ARM"
       agentOs: Linux
       useHostedUbuntu: false
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm-alpine-20211022152824-78f7860
+      container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm-alpine-latest
       buildArgs:
         --arch arm
         --os-name linux-musl
@@ -596,7 +596,7 @@ stages:
       jobDisplayName: "Build: Linux Musl ARM64"
       agentOs: Linux
       useHostedUbuntu: false
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-alpine-20211022152824-538077f
+      container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-alpine-latest
       buildArgs:
         --arch arm64
         --os-name linux-musl
@@ -725,7 +725,7 @@ stages:
     parameters:
       platform:
         name: 'Managed'
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8-20220809204800-17a4aab'
+        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8-latest'
         buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks'
         skipPublishValidation: true
         jobProperties:

--- a/eng/docker/rhel.Dockerfile
+++ b/eng/docker/rhel.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile that creates a container suitable to build dotnet-cli
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-rpmpkg-20220505130359-d0fa36f
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-rpmpkg-latest
 
 # Setup User to match Host User, and give superuser permissions
 ARG USER

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -1,11 +1,11 @@
 <Project>
   <!-- This file is shared between Helix.proj and .csproj files. -->
   <PropertyGroup>
-    <HelixQueueAlpine314>(Alpine.314.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-helix-amd64-20210910135833-1848e19</HelixQueueAlpine314>
-    <HelixQueueDebian11>(Debian.11.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64-20211001171307-0ece9b3</HelixQueueDebian11>
-    <HelixQueueFedora34>(Fedora.34.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-helix-20210924174119-4f64125</HelixQueueFedora34>
-    <HelixQueueMariner>(Mariner)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix-20210528192219-92bf620</HelixQueueMariner>
-    <HelixQueueArmDebian11>(Debian.11.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-arm64v8-20211001171229-97d8652</HelixQueueArmDebian11>
+    <HelixQueueAlpine314>(Alpine.314.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-helix-amd64-latest</HelixQueueAlpine314>
+    <HelixQueueDebian11>(Debian.11.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64-latest</HelixQueueDebian11>
+    <HelixQueueFedora34>(Fedora.34.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-helix-latest</HelixQueueFedora34>
+    <HelixQueueMariner>(Mariner)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix-latest</HelixQueueMariner>
+    <HelixQueueArmDebian11>(Debian.11.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-arm64v8-latest</HelixQueueArmDebian11>
 
     <!-- Do not attempt to override global property. -->
     <RunQuarantinedTests Condition=" '$(RunQuarantinedTests)' == '' ">false</RunQuarantinedTests>

--- a/src/Installers/Rpm/Directory.Build.targets
+++ b/src/Installers/Rpm/Directory.Build.targets
@@ -85,7 +85,7 @@
       <FpmArgs Include="&quot;$(PackageContentRoot)=$(RpmPackageInstallRoot)&quot;" />
     </ItemGroup>
 
-    <Exec Command="scl enable rh-ruby25 'fpm @(FpmArgs,' ')'" />
+    <Exec Command="scl enable rh-ruby26 'fpm @(FpmArgs,' ')'" />
 
     <Copy SourceFiles="$(TargetPath)"
           DestinationFiles="$(CblMariner1TargetPath)"


### PR DESCRIPTION
# Update docker tag to latest schema

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

This change moves all of the docker images to the -latest tag as part of https://github.com/dotnet/dnceng/issues/1294.

Also updates the ruby exec command as the image changed in install ruby26

Fixes https://github.com/dotnet/dnceng/issues/1294
