### PR TITLE
Fix printing signing key in user-jwts tool

### DIFF
--- a/src/Tools/dotnet-user-jwts/src/Commands/KeyCommand.cs
+++ b/src/Tools/dotnet-user-jwts/src/Commands/KeyCommand.cs
@@ -82,7 +82,7 @@ internal sealed class KeyCommand
             return 0;
         }
 
-        reporter.Output(Resources.FormatKeyCommand_Confirmed(signingKeyMaterial));
+        reporter.Output(Resources.FormatKeyCommand_Confirmed(Convert.ToBase64String(signingKeyMaterial)));
         return 0;
     }
 }

--- a/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
+++ b/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
@@ -495,6 +495,31 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     }
 
     [Fact]
+    public void Key_CanPrintWithBase64()
+    {
+        var projectPath = _fixture.CreateProject();
+        var project = Path.Combine(projectPath, "TestProject.csproj");
+
+        var app = new Program(_console);
+        app.Run(new[] { "create", "--project", project, "--issuer", "test-issuer", "--scheme", "test-scheme" });
+        app.Run(new[] { "create", "--project", project, "--issuer", "test-issuer", "--scheme", "test-scheme-2" });
+        app.Run(new[] { "create", "--project", project, "--issuer", "test-issuer-2", "--scheme", "test-scheme" });
+        app.Run(new[] { "create", "--project", project, "--issuer", "test-issuer-2", "--scheme", "test-scheme-3" });
+
+        Assert.Contains("New JWT saved", _console.GetOutput());
+        _console.ClearOutput();
+
+        app.Run(new[] { "key", "--project", project, "--scheme", "test-scheme", "--issuer", "test-issuer" });
+        var printMatches = Regex.Matches(_console.GetOutput(), "Signing Key: '(.*?)'");
+        var key = printMatches.SingleOrDefault().Groups[1].Value;
+        _console.ClearOutput();
+
+        var buffer = new Span<byte>(new byte[key.Length]);
+        Assert.True(Convert.TryFromBase64String(key, buffer, out var bytesParsed));
+        Assert.Equal(32, bytesParsed);
+    }
+
+    [Fact]
     public void Create_CanHandleNoProjectOptionProvided()
     {
         var projectPath = _fixture.CreateProject();


### PR DESCRIPTION
## Description

Resolves a bug where signing keys are not printed correctly when users use the `dotnet user-jwts key` command.

```diff
$ dotnet user-jwts key
- Signing Key: 'System.Byte[]'
+ Signing Key: '+hVynppyxkvsnKlbNrXj7JUIFtoK/np7+xJANzzdgBI='
```

## Customer Impact

Without this bug fix, the `dotnet user-jwts key` doesn't provide the correct information to users looking to examine the signing key currently used for their local development JWTs.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

*Low* risk because fix is localized to user-jwts tool and only affects output printing.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A