### PR TITLE
[7.0] Fix ANCM hosting bundle conditions for older OS

### DIFF
--- a/src/Installers/Windows/WindowsHostingBundle/ANCM.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/ANCM.wxs
@@ -11,7 +11,7 @@
                         Compressed="yes"
                         Vital="yes"
                         Visible="no"
-                        InstallCondition="(NativeMachine=&quot;$(var.NativeMachine_x86)&quot;) AND (IISCoreWebEngineInstalled_x86=1) AND (IISW3SVCInstalled_x86=1) AND (NOT OPT_NO_ANCM OR OPT_NO_ANCM=&quot;0&quot;)">
+                        InstallCondition="NOT VersionNT64 AND (VersionNT &gt;= v6.1) AND (IISCoreWebEngineInstalled_x86=1) AND (IISW3SVCInstalled_x86=1) AND (NOT OPT_NO_ANCM OR OPT_NO_ANCM=&quot;0&quot;)">
                 <MsiProperty Name="OPT_NO_SHARED_CONFIG_CHECK" Value="[OPT_NO_SHARED_CONFIG_CHECK]" />
             </MsiPackage>
 
@@ -21,7 +21,7 @@
                         Compressed="yes"
                         Vital="yes"
                         Visible="no"
-                        InstallCondition="(NativeMachine=&quot;$(var.NativeMachine_x64)&quot;) AND (IISCoreWebEngineInstalled_x64=1) AND (IISW3SVCInstalled_x64=1) AND (NOT OPT_NO_ANCM OR OPT_NO_ANCM=&quot;0&quot;)">
+                        InstallCondition="VersionNT64 AND (VersionNT64 &gt;= v6.1) AND NOT (NativeMachine=&quot;$(var.NativeMachine_arm64)&quot;) AND (IISCoreWebEngineInstalled_x64=1) AND (IISW3SVCInstalled_x64=1) AND (NOT OPT_NO_ANCM OR OPT_NO_ANCM=&quot;0&quot;)">
                 <MsiProperty Name="OPT_NO_SHARED_CONFIG_CHECK" Value="[OPT_NO_SHARED_CONFIG_CHECK]" />
             </MsiPackage>
             

--- a/src/Installers/Windows/WindowsHostingBundle/DotNetCore.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/DotNetCore.wxs
@@ -40,7 +40,7 @@
                         Name="$(var.DotNetRedistLtsInstallerx64)"
                         Compressed="yes"
                         Vital="yes"
-                        InstallCondition="(NativeMachine=&quot;$(var.NativeMachine_x64)&quot;) AND (NOT OPT_NO_RUNTIME OR OPT_NO_RUNTIME=&quot;0&quot;)"
+                        InstallCondition="VersionNT64 AND NOT (NativeMachine=&quot;$(var.NativeMachine_arm64)&quot;) AND (NOT OPT_NO_RUNTIME OR OPT_NO_RUNTIME=&quot;0&quot;)"
                         InstallCommand="/quiet /norestart"
                         RepairCommand="/quiet /repair"
                         UninstallCommand="/quiet /uninstall"

--- a/src/Installers/Windows/WindowsHostingBundle/DotNetCore.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/DotNetCore.wxs
@@ -3,13 +3,13 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
     <Fragment>
         <util:ProductSearch Id="DotNetRedistLtsProductSearch_x86"
-                            Condition="(NativeMachine=&quot;$(var.NativeMachine_x86)&quot;)"
+                            Condition="NOT VersionNT64"
                             ProductCode="$(var.DotNetRedistLtsInstallerProductCodex86)"
                             Result="version"
                             Variable="DotNetRedistLtsProductVersion_x86" />
 
         <util:ProductSearch Id="DotNetRedistLtsProductSearch_x64"
-                            Condition="(NativeMachine=&quot;$(var.NativeMachine_x64)&quot;)"
+                            Condition="VersionNT64 AND NOT (NativeMachine=&quot;$(var.NativeMachine_arm64)&quot;)"
                             ProductCode="$(var.DotNetRedistLtsInstallerProductCodex64)"
                             Result="version"
                             Variable="DotNetRedistLtsProductVersion_x64" />

--- a/src/Installers/Windows/WindowsHostingBundle/SharedFramework.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/SharedFramework.wxs
@@ -3,13 +3,13 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
     <Fragment>
         <util:ProductSearch Id="SharedFxRedistProductSearch_x86"
-                            Condition="(NativeMachine=&quot;$(var.NativeMachine_x86)&quot;)"
+                            Condition="NOT VersionNT64"
                             ProductCode="$(var.SharedFxInstallerProductCodex86)"
                             Result="version"
                             Variable="SharedFxRedistProductVersion_x86" />
 
         <util:ProductSearch Id="SharedFxRedistProductSearch_x64"
-                            Condition="(NativeMachine=&quot;$(var.NativeMachine_x64)&quot;)"
+                            Condition="VersionNT64 AND NOT (NativeMachine=&quot;$(var.NativeMachine_arm64)&quot;)"
                             ProductCode="$(var.SharedFxInstallerProductCodex64)"
                             Result="version"
                             Variable="SharedFxRedistProductVersion_x64" />
@@ -40,7 +40,7 @@
                         Name="$(var.SharedFxRedistInstallerx64)"
                         Compressed="yes"
                         Vital="yes"
-                        InstallCondition="(NativeMachine=&quot;$(var.NativeMachine_x64)&quot;) AND (NOT OPT_NO_SHAREDFX OR OPT_NO_SHAREDFX=&quot;0&quot;)"
+                        InstallCondition="VersionNT64 AND NOT (NativeMachine=&quot;$(var.NativeMachine_arm64)&quot;) AND (NOT OPT_NO_SHAREDFX OR OPT_NO_SHAREDFX=&quot;0&quot;)"
                         InstallCommand="/quiet /norestart"
                         RepairCommand="/quiet /repair"
                         UninstallCommand="/quiet /uninstall"


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/44113

Reverts most install conditions back to the way they were before arm64 was added in https://github.com/dotnet/aspnetcore/pull/40709 to handle older OS's which do not support NativeMachine, but keeps using NativeMachine for arm64 install condition

## Customer Impact

Without this bug fix, the windows hosting bundle only installs the x86 components for ASP.NET Core for older versions that don't support NativeMachine in wix (i.e. Windows Server 2016).

## Regression?

- [X] Yes
- [ ] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

## Verification

- [X] Manual (required)

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A