### PR TITLE
Upgrade Microsoft.OpenApi dependency to 1.4.3

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -290,7 +290,7 @@
     <XUnitRunnerVisualStudioVersion>2.4.3</XUnitRunnerVisualStudioVersion>
     <MicrosoftDataSqlClientVersion>4.0.1</MicrosoftDataSqlClientVersion>
     <MicrosoftAspNetCoreAppVersion>6.0.0-preview.3.21167.1</MicrosoftAspNetCoreAppVersion>
-    <MicrosoftOpenApiVersion>1.2.3</MicrosoftOpenApiVersion>
+    <MicrosoftOpenApiVersion>1.4.3</MicrosoftOpenApiVersion>
     <!-- dotnet tool versions (see also auto-updated DotnetEfVersion property). -->
     <DotnetDumpVersion>6.0.322601</DotnetDumpVersion>
     <DotnetServeVersion>1.10.93</DotnetServeVersion>

--- a/src/OpenApi/test/OpenApiRouteHandlerBuilderExtensionTests.cs
+++ b/src/OpenApi/test/OpenApiRouteHandlerBuilderExtensionTests.cs
@@ -72,9 +72,9 @@ public class OpenApiRouteHandlerBuilderExtensionTests
         var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(serviceProvider));
         string GetString(string id) => "Foo";
         _ = builder.MapDelete("/{id}", GetString)
-            .WithOpenApi(generatedOperation => {
-                generatedOperation.Parameters[0].Schema = new() { Type = "number" };
-                return generatedOperation;
+            .WithOpenApi(operation => new(operation)
+            {
+                Parameters = new List<OpenApiParameter>() { new() { Schema = new() { Type = "number" } } }
             });
 
         var dataSource = GetBuilderEndpointDataSource(builder);
@@ -161,15 +161,13 @@ public class OpenApiRouteHandlerBuilderExtensionTests
         var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(serviceProvider));
         string GetString() => "Foo";
         var myGroup = builder.MapGroup("/group");
-        myGroup.WithOpenApi(o =>
+        myGroup.WithOpenApi(o => new(o)
         {
-            o.Summary = "Set from outer group";
-            return o;
+            Summary = "Set from outer group"
         });
-        myGroup.MapDelete("/a", GetString).WithOpenApi(o =>
+        myGroup.MapDelete("/a", GetString).WithOpenApi(o => new(o)
         {
-            o.Summary = "Set from endpoint";
-            return o;
+            Summary = "Set from endpoint"
         });
 
         // The RotueGroupBuilder adds a single EndpointDataSource.
@@ -195,10 +193,9 @@ public class OpenApiRouteHandlerBuilderExtensionTests
 
         static void WithLocalSummary(RouteHandlerBuilder builder)
         {
-            builder.WithOpenApi(operation =>
+            builder.WithOpenApi(operation => new(operation)
             {
-                operation.Summary = $"| Local Summary | 200 Status Response Content-Type: {operation.Responses["200"].Content.Keys.Single()}";
-                return operation;
+                Summary = $"| Local Summary | 200 Status Response Content-Type: {operation.Responses["200"].Content.Keys.Single()}"
             });
         }
 
@@ -210,19 +207,17 @@ public class OpenApiRouteHandlerBuilderExtensionTests
         WithLocalSummary(outerGroup.MapDelete("/outer-a", GetString));
 
         // The order WithOpenApi() is relative to the MapDelete() methods does not matter.
-        outerGroup.WithOpenApi(operation =>
+        outerGroup.WithOpenApi(operation => new(operation)
         {
-            operation.Summary = $"Outer Group Summary {operation.Summary}";
-            return operation;
+            Summary = $"Outer Group Summary {operation.Summary}"
         });
 
         WithLocalSummary(outerGroup.MapDelete("/outer-b", GetString));
         WithLocalSummary(innerGroup.MapDelete("/inner-a", GetString));
 
-        innerGroup.WithOpenApi(operation =>
+        innerGroup.WithOpenApi(operation => new(operation)
         {
-            operation.Summary = $"| Inner Group Summary {operation.Summary}";
-            return operation;
+            Summary = $"| Inner Group Summary {operation.Summary}"
         });
 
         WithLocalSummary(innerGroup.MapDelete("/inner-b", GetString));


### PR DESCRIPTION
## Description

This PR upgrades our `Microssoft.OpenApi` dependency to 1.4.3 to capture bug fixes and features.

## Customer Impact

Users will have access to bug fixes for the copy-constructors on their `OpenApiOperation` definitions and improvements to the accuracy of the generated OpenAPI document.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Impact is isolated to `Microsoft.AspNetCore.OpenApi` package. 

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A