### PR TITLE
[release/7.0] Remove VS nupkg push

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -265,16 +265,6 @@ stages:
                 $(WindowsArm64InstallersLogArgs)
         displayName: Build ARM64 Installers
 
-      # A few files must also go to the VS package feed.
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables.PostBuildSign, 'true')) }}:
-        - task: NuGetCommand@2
-          displayName: Push Visual Studio packages
-          inputs:
-            command: push
-            packagesToPush: 'artifacts/packages/**/VS.Redist.Common.AspNetCore.*.nupkg'
-            nuGetFeedType: external
-            publishFeedCredentials: 'DevDiv - VS package feed'
-
       artifacts:
       - name: Windows_Logs
         path: artifacts/log/


### PR DESCRIPTION
Signing happens at the end of the build now, even with in-build signing. The staging pipeline pushes the nupkgs. This step is not necessary, and pushes unsigned nupkgs.