### PR TITLE
Add code cleanup rules (+perf)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -232,6 +232,15 @@ dotnet_diagnostic.IDE0011.severity = warning
 # IDE0020: Use pattern matching to avoid is check followed by a cast (with variable)
 dotnet_diagnostic.IDE0020.severity = warning
 
+# IDE0029: Use coalesce expression (non-nullable types)
+dotnet_diagnostic.IDE0029.severity = warning
+
+# IDE0030: Use coalesce expression (nullable types)
+dotnet_diagnostic.IDE0030.severity = warning
+
+# IDE0031: Use null propagation
+dotnet_diagnostic.IDE0031.severity = warning
+
 # IDE0035: Remove unreachable code
 dotnet_diagnostic.IDE0035.severity = warning
 
@@ -331,6 +340,12 @@ dotnet_diagnostic.CA2249.severity = suggestion
 dotnet_diagnostic.IDE0005.severity = suggestion
 # IDE0020: Use pattern matching to avoid is check followed by a cast (with variable)
 dotnet_diagnostic.IDE0020.severity = suggestion
+# IDE0029: Use coalesce expression (non-nullable types)
+dotnet_diagnostic.IDE0029.severity = suggestion
+# IDE0030: Use coalesce expression (nullable types)
+dotnet_diagnostic.IDE0030.severity = suggestion
+# IDE0031: Use null propagation
+dotnet_diagnostic.IDE0031.severity = suggestion
 # IDE0038: Use pattern matching to avoid is check followed by a cast (without variable)
 dotnet_diagnostic.IDE0038.severity = suggestion
 # IDE0044: Make field readonly

--- a/.editorconfig
+++ b/.editorconfig
@@ -229,12 +229,18 @@ dotnet_diagnostic.IDE0005.severity = warning
 # IDE0011: Curly braces to surround blocks of code
 dotnet_diagnostic.IDE0011.severity = warning
 
+# IDE0020: Use pattern matching to avoid is check followed by a cast (with variable)
+dotnet_diagnostic.IDE0020.severity = warning
+
 # IDE0035: Remove unreachable code
 dotnet_diagnostic.IDE0035.severity = warning
 
 # IDE0036: Order modifiers
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
 dotnet_diagnostic.IDE0036.severity = warning
+
+# IDE0038: Use pattern matching to avoid is check followed by a cast (without variable)
+dotnet_diagnostic.IDE0038.severity = warning
 
 # IDE0043: Format string contains invalid placeholder
 dotnet_diagnostic.IDE0043.severity = warning
@@ -265,11 +271,14 @@ file_header_template = Licensed to the .NET Foundation under one or more agreeme
 # IDE0161: Convert to file-scoped namespace
 dotnet_diagnostic.IDE0161.severity = warning
 
+# IDE0200: Lambda expression can be removed
+dotnet_diagnostic.IDE0200.severity = warning
+
 # IDE2000: Disallow multiple blank lines
 dotnet_style_allow_multiple_blank_lines_experimental = false
 dotnet_diagnostic.IDE2000.severity = warning
 
-[{eng/tools/**.cs,**/{test,testassets,samples,Samples,perf,scripts}/**.cs}]
+[{eng/tools/**.cs,**/{test,testassets,samples,Samples,perf,scripts,stress}/**.cs}]
 # CA1018: Mark attributes with AttributeUsageAttribute
 dotnet_diagnostic.CA1018.severity = suggestion
 # CA1507: Use nameof to express symbol names
@@ -320,6 +329,10 @@ dotnet_diagnostic.CA2012.severity = suggestion
 dotnet_diagnostic.CA2249.severity = suggestion
 # IDE0005: Remove unnecessary usings
 dotnet_diagnostic.IDE0005.severity = suggestion
+# IDE0020: Use pattern matching to avoid is check followed by a cast (with variable)
+dotnet_diagnostic.IDE0020.severity = suggestion
+# IDE0038: Use pattern matching to avoid is check followed by a cast (without variable)
+dotnet_diagnostic.IDE0038.severity = suggestion
 # IDE0044: Make field readonly
 dotnet_diagnostic.IDE0044.severity = suggestion
 # IDE0051: Remove unused private members
@@ -330,6 +343,8 @@ dotnet_diagnostic.IDE0059.severity = suggestion
 dotnet_diagnostic.IDE0060.severity = suggestion
 # IDE0062: Make local function static
 dotnet_diagnostic.IDE0062.severity = suggestion
+# IDE0200: Lambda expression can be removed
+dotnet_diagnostic.IDE0200.severity = suggestion
 
 # CA2016: Forward the 'CancellationToken' parameter to methods that take one
 dotnet_diagnostic.CA2016.severity = suggestion

--- a/src/Components/Authorization/src/AuthorizeRouteView.cs
+++ b/src/Components/Authorization/src/AuthorizeRouteView.cs
@@ -38,7 +38,7 @@ public sealed class AuthorizeRouteView : RouteView
         // Cache the rendering delegates so that we only construct new closure instances
         // when they are actually used (e.g., we never prepare a RenderFragment bound to
         // the NotAuthorized content except when you are displaying that particular state)
-        RenderFragment renderBaseRouteViewDelegate = builder => base.Render(builder);
+        RenderFragment renderBaseRouteViewDelegate = base.Render;
         _renderAuthorizedDelegate = authenticateState => renderBaseRouteViewDelegate;
         _renderNotAuthorizedDelegate = authenticationState => builder => RenderNotAuthorizedInDefaultLayout(builder, authenticationState);
         _renderAuthorizingDelegate = RenderAuthorizingInDefaultLayout;

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -586,7 +586,7 @@ internal partial class CircuitHost : IAsyncDisposable
         // Dispatch any buffered renders we accumulated during a disconnect.
         // Note that while the rendering is async, we cannot await it here. The Task returned by ProcessBufferedRenderBatches relies on
         // OnRenderCompletedAsync to be invoked to complete, and SignalR does not allow concurrent hub method invocations.
-        _ = Renderer.Dispatcher.InvokeAsync(() => Renderer.ProcessBufferedRenderBatches());
+        _ = Renderer.Dispatcher.InvokeAsync(Renderer.ProcessBufferedRenderBatches);
     }
 
     private void AssertInitialized()

--- a/src/Components/Server/src/Circuits/RemoteRenderer.cs
+++ b/src/Components/Server/src/Circuits/RemoteRenderer.cs
@@ -175,7 +175,7 @@ internal partial class RemoteRenderer : WebRenderer
         // All the batches are sent in order based on the fact that SignalR
         // provides ordering for the underlying messages and that the batches
         // are always in order.
-        return Task.WhenAll(_unacknowledgedRenderBatches.Select(b => WriteBatchBytesAsync(b)));
+        return Task.WhenAll(_unacknowledgedRenderBatches.Select(WriteBatchBytesAsync));
     }
 
     private async Task WriteBatchBytesAsync(UnacknowledgedRenderBatch pending)

--- a/src/Components/Web/src/JSComponents/JSComponentInterop.cs
+++ b/src/Components/Web/src/JSComponents/JSComponentInterop.cs
@@ -29,7 +29,7 @@ public class JSComponentInterop
     {
         if (HotReloadManager.Default.MetadataUpdateSupported)
         {
-            HotReloadManager.Default.OnDeltaApplied += () => ParameterTypeCaches.Clear();
+            HotReloadManager.Default.OnDeltaApplied += ParameterTypeCaches.Clear;
         }
     }
 

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostConfiguration.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostConfiguration.cs
@@ -158,7 +158,7 @@ public class WebAssemblyHostConfiguration : IConfiguration, IConfigurationRoot, 
         // provider has reloaded data. This will invoke the RaiseChanged
         // method which maps changes in individual providers to the change
         // token on the WebAssemblyHostConfiguration object.
-        _changeTokenRegistrations.Add(ChangeToken.OnChange(() => provider.GetReloadToken(), () => RaiseChanged()));
+        _changeTokenRegistrations.Add(ChangeToken.OnChange(provider.GetReloadToken, RaiseChanged));
 
         // We keep a list of providers in this class so that we can map
         // set and get methods on this class to the set and get methods

--- a/src/Components/WebAssembly/WebAssembly/src/HotReload/WebAssemblyHotReload.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/HotReload/WebAssemblyHotReload.cs
@@ -26,7 +26,10 @@ public static class WebAssemblyHotReload
 
     internal static async Task InitializeAsync()
     {
+        // Analyzer has a bug where it doesn't handle ConditionalAttribute: https://github.com/dotnet/roslyn/issues/63464
+#pragma warning disable IDE0200 // Remove unnecessary lambda expression
         _hotReloadAgent = new HotReloadAgent(m => Debug.WriteLine(m));
+#pragma warning restore IDE0200 // Remove unnecessary lambda expression
 
         if (Environment.GetEnvironmentVariable("__ASPNETCORE_BROWSER_TOOLS") == "true")
         {

--- a/src/FileProviders/Manifest.MSBuildTask/src/Manifest.cs
+++ b/src/FileProviders/Manifest.MSBuildTask/src/Manifest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
@@ -46,7 +46,7 @@ public class Manifest
         var root = new XElement(ElementNames.Root,
             new XElement(ElementNames.ManifestVersion, "1.0"),
             new XElement(ElementNames.FileSystem,
-            Root.Children.Select(e => BuildNode(e))));
+            Root.Children.Select(BuildNode)));
 
         document.Add(root);
 
@@ -64,7 +64,7 @@ public class Manifest
         else
         {
             var directory = new XElement(ElementNames.Directory, new XAttribute(ElementNames.Name, entry.Name));
-            directory.Add(entry.Children.Select(c => BuildNode(c)));
+            directory.Add(entry.Children.Select(BuildNode));
             return directory;
         }
     }

--- a/src/Hosting/Server.IntegrationTesting/src/Deployers/RemoteWindowsDeployer/RemoteWindowsDeployer.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Deployers/RemoteWindowsDeployer/RemoteWindowsDeployer.cs
@@ -19,7 +19,7 @@ public class RemoteWindowsDeployer : ApplicationDeployer
     private string _deployedFolderPathInFileShare;
     private readonly RemoteWindowsDeploymentParameters _deploymentParameters;
     private bool _isDisposed;
-    private static readonly Lazy<Scripts> _scripts = new Lazy<Scripts>(() => CopyEmbeddedScriptFilesToDisk());
+    private static readonly Lazy<Scripts> _scripts = new Lazy<Scripts>(CopyEmbeddedScriptFilesToDisk);
 
     public RemoteWindowsDeployer(RemoteWindowsDeploymentParameters deploymentParameters, ILoggerFactory loggerFactory)
         : base(deploymentParameters, loggerFactory)

--- a/src/Http/Http.Abstractions/src/Internal/ParsingHelpers.cs
+++ b/src/Http/Http.Abstractions/src/Internal/ParsingHelpers.cs
@@ -63,7 +63,7 @@ internal static class ParsingHelpers
         }
         else
         {
-            headers[key] = string.Join(",", value.Select((s) => QuoteIfNeeded(s)));
+            headers[key] = string.Join(",", value.Select(QuoteIfNeeded));
         }
     }
 
@@ -135,7 +135,7 @@ internal static class ParsingHelpers
         }
         else
         {
-            headers[key] = existing + "," + string.Join(",", values.Select(value => QuoteIfNeeded(value)));
+            headers[key] = existing + "," + string.Join(",", values.Select(QuoteIfNeeded));
         }
     }
 

--- a/src/Http/Routing/src/EndpointNameAddressScheme.cs
+++ b/src/Http/Routing/src/EndpointNameAddressScheme.cs
@@ -70,7 +70,7 @@ internal sealed class EndpointNameAddressScheme : IEndpointAddressScheme<string>
 
         // OK we need to report some duplicates.
         var duplicates = endpoints
-            .GroupBy(e => GetEndpointName(e))
+            .GroupBy(GetEndpointName)
             .Where(g => g.Key != null && g.Count() > 1);
 
         var builder = new StringBuilder();

--- a/src/Http/Routing/src/Matching/DfaMatcherFactory.cs
+++ b/src/Http/Routing/src/Matching/DfaMatcherFactory.cs
@@ -32,9 +32,6 @@ internal sealed class DfaMatcherFactory : MatcherFactory
         // when the services are disposed.
         var lifetime = _services.GetRequiredService<DataSourceDependentMatcher.Lifetime>();
 
-        return new DataSourceDependentMatcher(dataSource, lifetime, () =>
-        {
-            return _services.GetRequiredService<DfaMatcherBuilder>();
-        });
+        return new DataSourceDependentMatcher(dataSource, lifetime, _services.GetRequiredService<DfaMatcherBuilder>);
     }
 }

--- a/src/Http/Routing/src/Matching/HostMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/HostMatcherPolicy.cs
@@ -210,7 +210,7 @@ public sealed class HostMatcherPolicy : MatcherPolicy, IEndpointComparerPolicy, 
         for (var i = 0; i < endpoints.Count; i++)
         {
             var endpoint = endpoints[i];
-            var hosts = endpoint.Metadata.GetMetadata<IHostMetadata>()?.Hosts.Select(h => CreateEdgeKey(h)).ToArray();
+            var hosts = endpoint.Metadata.GetMetadata<IHostMetadata>()?.Hosts.Select(CreateEdgeKey).ToArray();
             if (hosts == null || hosts.Length == 0)
             {
                 hosts = new[] { EdgeKey.WildcardEdgeKey };
@@ -232,7 +232,7 @@ public sealed class HostMatcherPolicy : MatcherPolicy, IEndpointComparerPolicy, 
         {
             var endpoint = endpoints[i];
 
-            var endpointKeys = endpoint.Metadata.GetMetadata<IHostMetadata>()?.Hosts.Select(h => CreateEdgeKey(h)).ToArray() ?? Array.Empty<EdgeKey>();
+            var endpointKeys = endpoint.Metadata.GetMetadata<IHostMetadata>()?.Hosts.Select(CreateEdgeKey).ToArray() ?? Array.Empty<EdgeKey>();
             if (endpointKeys.Length == 0)
             {
                 // OK this means that this endpoint matches *all* hosts.

--- a/src/Http/Routing/src/Matching/ILEmitTrieJumpTable.cs
+++ b/src/Http/Routing/src/Matching/ILEmitTrieJumpTable.cs
@@ -68,10 +68,7 @@ internal sealed class ILEmitTrieJumpTable : JumpTable
     internal async Task InitializeILDelegateAsync()
     {
         // Offload the creation of the IL delegate to the thread pool.
-        await Task.Run(() =>
-        {
-            InitializeILDelegate();
-        });
+        await Task.Run(InitializeILDelegate);
     }
 
     // Internal for testing

--- a/src/Identity/UI/src/IdentityDefaultUIConfigureOptions.cs
+++ b/src/Identity/UI/src/IdentityDefaultUIConfigureOptions.cs
@@ -34,7 +34,7 @@ internal sealed class IdentityDefaultUIConfigureOptions<TUser> :
         options.Conventions.AddAreaFolderApplicationModelConvention(
             IdentityUIDefaultAreaName,
             "/",
-            pam => convention.Apply(pam));
+            convention.Apply);
         options.Conventions.AddAreaFolderApplicationModelConvention(
             IdentityUIDefaultAreaName,
             "/Account/Manage",

--- a/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReferenceOfT.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/DotNetObjectReferenceOfT.cs
@@ -88,10 +88,7 @@ public sealed class DotNetObjectReference<[DynamicallyAccessedMembers(JSInvokabl
         {
             Disposed = true;
 
-            if (_jsRuntime != null)
-            {
-                _jsRuntime.ReleaseObjectReference(_objectId);
-            }
+            _jsRuntime?.ReleaseObjectReference(_objectId);
         }
     }
 

--- a/src/Mvc/Mvc.Core/src/Infrastructure/ControllerActionInvoker.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ControllerActionInvoker.cs
@@ -504,10 +504,7 @@ internal partial class ControllerActionInvoker : ResourceInvoker, IActionInvoker
             return;
         }
 
-        if (context.ExceptionDispatchInfo != null)
-        {
-            context.ExceptionDispatchInfo.Throw();
-        }
+        context.ExceptionDispatchInfo?.Throw();
 
         if (context.Exception != null)
         {

--- a/src/Mvc/Mvc.Core/src/Infrastructure/ResourceInvoker.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ResourceInvoker.cs
@@ -1447,10 +1447,7 @@ internal abstract partial class ResourceInvoker
             return;
         }
 
-        if (context.ExceptionDispatchInfo != null)
-        {
-            context.ExceptionDispatchInfo.Throw();
-        }
+        context.ExceptionDispatchInfo?.Throw();
 
         if (context.Exception != null)
         {
@@ -1470,10 +1467,7 @@ internal abstract partial class ResourceInvoker
             return;
         }
 
-        if (context.ExceptionDispatchInfo != null)
-        {
-            context.ExceptionDispatchInfo.Throw();
-        }
+        context.ExceptionDispatchInfo?.Throw();
 
         if (context.Exception != null)
         {
@@ -1493,10 +1487,7 @@ internal abstract partial class ResourceInvoker
             return;
         }
 
-        if (context.ExceptionDispatchInfo != null)
-        {
-            context.ExceptionDispatchInfo.Throw();
-        }
+        context.ExceptionDispatchInfo?.Throw();
 
         if (context.Exception != null)
         {

--- a/src/Mvc/Mvc.Core/src/Routing/ActionEndpointDataSourceBase.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/ActionEndpointDataSourceBase.cs
@@ -79,7 +79,7 @@ internal abstract class ActionEndpointDataSourceBase : EndpointDataSource, IDisp
         if (_actions is ActionDescriptorCollectionProvider collectionProviderWithChangeToken)
         {
             _disposable = ChangeToken.OnChange(
-                () => collectionProviderWithChangeToken.GetChangeToken(),
+                collectionProviderWithChangeToken.GetChangeToken,
                 UpdateEndpoints);
         }
     }

--- a/src/Mvc/Mvc.Core/src/Routing/DynamicControllerEndpointSelectorCache.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/DynamicControllerEndpointSelectorCache.cs
@@ -26,7 +26,7 @@ internal class DynamicControllerEndpointSelectorCache
     public DynamicControllerEndpointSelector GetEndpointSelector(Endpoint endpoint)
     {
         var dataSourceId = endpoint.Metadata.GetMetadata<ControllerEndpointDataSourceIdMetadata>()!;
-        return _endpointSelectorCache.GetOrAdd(dataSourceId.Id, key => EnsureDataSource(key));
+        return _endpointSelectorCache.GetOrAdd(dataSourceId.Id, EnsureDataSource);
     }
 
     private DynamicControllerEndpointSelector EnsureDataSource(int key)

--- a/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
+++ b/src/Mvc/Mvc.DataAnnotations/src/DataAnnotationsMetadataProvider.cs
@@ -124,7 +124,7 @@ internal sealed class DataAnnotationsMetadataProvider :
             }
             else
             {
-                displayMetadata.Description = () => displayAttribute.GetDescription();
+                displayMetadata.Description = displayAttribute.GetDescription;
             }
         }
 
@@ -146,7 +146,7 @@ internal sealed class DataAnnotationsMetadataProvider :
             }
             else
             {
-                displayMetadata.DisplayName = () => displayAttribute.GetName();
+                displayMetadata.DisplayName = displayAttribute.GetName;
             }
         }
         else if (displayNameAttribute != null)
@@ -274,7 +274,7 @@ internal sealed class DataAnnotationsMetadataProvider :
             }
             else
             {
-                displayMetadata.Placeholder = () => displayAttribute.GetPrompt();
+                displayMetadata.Placeholder = displayAttribute.GetPrompt;
             }
         }
 

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RazorRuntimeCompilationHostingStartup.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/RazorRuntimeCompilationHostingStartup.cs
@@ -11,6 +11,6 @@ internal sealed class RazorRuntimeCompilationHostingStartup : IHostingStartup
     public void Configure(IWebHostBuilder builder)
     {
         // Add Razor services
-        builder.ConfigureServices(services => RazorRuntimeCompilationMvcCoreBuilderExtensions.AddServices(services));
+        builder.ConfigureServices(RazorRuntimeCompilationMvcCoreBuilderExtensions.AddServices);
     }
 }

--- a/src/Mvc/Mvc.Razor/src/RazorPageActivator.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorPageActivator.cs
@@ -39,7 +39,7 @@ public class RazorPageActivator : IRazorPageActivator
 
         _propertyAccessors = new RazorPagePropertyActivator.PropertyValueAccessors
         {
-            UrlHelperAccessor = context => urlHelperFactory.GetUrlHelper(context),
+            UrlHelperAccessor = urlHelperFactory.GetUrlHelper,
             JsonHelperAccessor = context => jsonHelper,
             DiagnosticSourceAccessor = context => diagnosticSource,
             HtmlEncoderAccessor = context => htmlEncoder,

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/DefaultPageFactoryProvider.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/DefaultPageFactoryProvider.cs
@@ -31,7 +31,7 @@ internal sealed class DefaultPageFactoryProvider : IPageFactoryProvider
         _modelMetadataProvider = metadataProvider;
         _propertyAccessors = new RazorPagePropertyActivator.PropertyValueAccessors
         {
-            UrlHelperAccessor = context => urlHelperFactory.GetUrlHelper(context),
+            UrlHelperAccessor = urlHelperFactory.GetUrlHelper,
             JsonHelperAccessor = context => jsonHelper,
             DiagnosticSourceAccessor = context => diagnosticListener,
             HtmlEncoderAccessor = context => htmlEncoder,

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/DynamicPageEndpointSelectorCache.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/DynamicPageEndpointSelectorCache.cs
@@ -33,7 +33,7 @@ internal class DynamicPageEndpointSelectorCache
 
         var dataSourceId = endpoint.Metadata.GetMetadata<PageEndpointDataSourceIdMetadata>();
         Debug.Assert(dataSourceId is not null);
-        return _endpointSelectorCache.GetOrAdd(dataSourceId.Id, key => EnsureDataSource(key));
+        return _endpointSelectorCache.GetOrAdd(dataSourceId.Id, EnsureDataSource);
     }
 
     private DynamicPageEndpointSelector EnsureDataSource(int key)

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionInvoker.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageActionInvoker.cs
@@ -703,10 +703,7 @@ internal sealed class PageActionInvoker : ResourceInvoker, IActionInvoker
             return;
         }
 
-        if (context.ExceptionDispatchInfo != null)
-        {
-            context.ExceptionDispatchInfo.Throw();
-        }
+        context.ExceptionDispatchInfo?.Throw();
 
         if (context.Exception != null)
         {

--- a/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageResultExecutor.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Infrastructure/PageResultExecutor.cs
@@ -104,9 +104,6 @@ public class PageResultExecutor : ViewExecutor
     private static void OnExecuting(PageContext pageContext)
     {
         var viewDataValuesProvider = pageContext.HttpContext.Features.Get<IViewDataValuesProviderFeature>();
-        if (viewDataValuesProvider != null)
-        {
-            viewDataValuesProvider.ProvideViewDataValues(pageContext.ViewData);
-        }
+        viewDataValuesProvider?.ProvideViewDataValues(pageContext.ViewData);
     }
 }

--- a/src/Mvc/Mvc.ViewFeatures/src/AttributeDictionary.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/AttributeDictionary.cs
@@ -154,10 +154,7 @@ public class AttributeDictionary : IDictionary<string, string?>, IReadOnlyDictio
     /// <inheritdoc />
     public void Clear()
     {
-        if (_items != null)
-        {
-            _items.Clear();
-        }
+        _items?.Clear();
     }
 
     /// <inheritdoc />

--- a/src/Mvc/Mvc.ViewFeatures/src/ExpressionHelper.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/ExpressionHelper.cs
@@ -135,10 +135,7 @@ internal static class ExpressionHelper
         if (segmentCount == 0)
         {
             Debug.Assert(!doNotCache);
-            if (expressionTextCache != null)
-            {
-                expressionTextCache.TryAdd(expression, string.Empty);
-            }
+            expressionTextCache?.TryAdd(expression, string.Empty);
 
             return string.Empty;
         }

--- a/src/Mvc/Mvc.ViewFeatures/src/RemoteAttributeBase.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/RemoteAttributeBase.cs
@@ -62,7 +62,7 @@ public abstract class RemoteAttributeBase : ValidationAttribute, IClientModelVal
         {
             _additionalFields = value ?? string.Empty;
             _additionalFieldsSplit = SplitAndTrimPropertyNames(value)
-                .Select(field => FormatPropertyForClientValidation(field))
+                .Select(FormatPropertyForClientValidation)
                 .ToArray();
         }
     }

--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/TagBuilder.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/TagBuilder.cs
@@ -404,10 +404,7 @@ public class TagBuilder : IHtmlContent
                 writer.Write(tagBuilder.TagName);
                 tagBuilder.AppendAttributes(writer, encoder);
                 writer.Write(">");
-                if (tagBuilder._innerHtml != null)
-                {
-                    tagBuilder._innerHtml.WriteTo(writer, encoder);
-                }
+                tagBuilder._innerHtml?.WriteTo(writer, encoder);
                 writer.Write("</");
                 writer.Write(tagBuilder.TagName);
                 writer.Write(">");

--- a/src/Mvc/Mvc.ViewFeatures/src/ViewComponentResultExecutor.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/ViewComponentResultExecutor.cs
@@ -162,10 +162,7 @@ public partial class ViewComponentResultExecutor : IActionResultExecutor<ViewCom
     private static void OnExecuting(ViewContext viewContext)
     {
         var viewDataValuesProvider = viewContext.HttpContext.Features.Get<IViewDataValuesProviderFeature>();
-        if (viewDataValuesProvider != null)
-        {
-            viewDataValuesProvider.ProvideViewDataValues(viewContext.ViewData);
-        }
+        viewDataValuesProvider?.ProvideViewDataValues(viewContext.ViewData);
     }
 
     private static Task<IHtmlContent> GetViewComponentResult(IViewComponentHelper viewComponentHelper, ILogger logger, ViewComponentResult result)

--- a/src/Mvc/Mvc.ViewFeatures/src/ViewExecutor.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/ViewExecutor.cs
@@ -265,9 +265,6 @@ public class ViewExecutor
     private static void OnExecuting(ViewContext viewContext)
     {
         var viewDataValuesProvider = viewContext.HttpContext.Features.Get<IViewDataValuesProviderFeature>();
-        if (viewDataValuesProvider != null)
-        {
-            viewDataValuesProvider.ProvideViewDataValues(viewContext.ViewData);
-        }
+        viewDataValuesProvider?.ProvideViewDataValues(viewContext.ViewData);
     }
 }

--- a/src/Mvc/shared/Mvc.Core.TestCommon/CommonResourceInvokerTest.cs
+++ b/src/Mvc/shared/Mvc.Core.TestCommon/CommonResourceInvokerTest.cs
@@ -482,7 +482,7 @@ public abstract class CommonResourceInvokerTest
         var invoker = CreateInvoker(filter.Object, exception: Exception);
 
         // Act
-        await Assert.ThrowsAsync(Exception.GetType(), async () => await invoker.InvokeAsync());
+        await Assert.ThrowsAsync(Exception.GetType(), invoker.InvokeAsync);
 
         // Assert
         filter.Verify(f => f.OnException(It.IsAny<ExceptionContext>()), Times.Once());
@@ -945,7 +945,7 @@ public abstract class CommonResourceInvokerTest
 
         // Act & Assert
         await ExceptionAssert.ThrowsAsync<InvalidOperationException>(
-            async () => await invoker.InvokeAsync(),
+            invoker.InvokeAsync,
             message);
     }
 
@@ -972,7 +972,7 @@ public abstract class CommonResourceInvokerTest
         var invoker = CreateInvoker(filter.Object);
 
         // Act
-        await Assert.ThrowsAsync(exception.GetType(), async () => await invoker.InvokeAsync());
+        await Assert.ThrowsAsync(exception.GetType(), invoker.InvokeAsync);
 
         // Assert
         result.Verify(r => r.ExecuteResultAsync(It.IsAny<ActionContext>()), Times.Once());

--- a/src/Security/Authentication/Certificate/src/CertificateAuthenticationHandler.cs
+++ b/src/Security/Authentication/Certificate/src/CertificateAuthenticationHandler.cs
@@ -87,10 +87,7 @@ internal sealed class CertificateAuthenticationHandler : AuthenticationHandler<C
                 }
             }
 
-            if (_cache != null)
-            {
-                _cache.Put(Context, clientCertificate, result);
-            }
+            _cache?.Put(Context, clientCertificate, result);
             return result;
         }
         catch (Exception ex)

--- a/src/Servers/Connections.Abstractions/src/ConnectionBuilderExtensions.cs
+++ b/src/Servers/Connections.Abstractions/src/ConnectionBuilderExtensions.cs
@@ -24,7 +24,7 @@ public static class ConnectionBuilderExtensions
         var handler = ActivatorUtilities.GetServiceOrCreateInstance<TConnectionHandler>(connectionBuilder.ApplicationServices);
 
         // This is a terminal middleware, so there's no need to use the 'next' parameter
-        return connectionBuilder.Run(connection => handler.OnConnectedAsync(connection));
+        return connectionBuilder.Run(handler.OnConnectedAsync);
     }
 
     /// <summary>

--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -149,10 +149,7 @@ public class HttpSysOptions
                 throw new ArgumentOutOfRangeException(nameof(value), value, "The value must be greater than zero.");
             }
 
-            if (_requestQueue != null)
-            {
-                _requestQueue.SetLengthLimit(_requestQueueLength);
-            }
+            _requestQueue?.SetLengthLimit(_requestQueueLength);
             // Only store it if it succeeds or hasn't started yet
             _requestQueueLength = value;
         }
@@ -210,10 +207,7 @@ public class HttpSysOptions
                 throw new ArgumentOutOfRangeException(nameof(value), value, message);
             }
 
-            if (_requestQueue != null)
-            {
-                _requestQueue.SetRejectionVerbosity(value);
-            }
+            _requestQueue?.SetRejectionVerbosity(value);
             // Only store it if it succeeds or hasn't started yet
             _rejectionVebosityLevel = value;
         }

--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -382,10 +382,7 @@ internal sealed partial class Request
         }
         catch (Exception)
         {
-            if (certLoader != null)
-            {
-                certLoader.Dispose();
-            }
+            certLoader?.Dispose();
             throw;
         }
         return _clientCert;

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestStreamAsyncResult.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestStreamAsyncResult.cs
@@ -150,10 +150,7 @@ internal sealed unsafe class RequestStreamAsyncResult : IAsyncResult, IDisposabl
     {
         if (disposing)
         {
-            if (_overlapped != null)
-            {
-                _overlapped.Dispose();
-            }
+            _overlapped?.Dispose();
             _cancellationRegistration.Dispose();
         }
     }

--- a/src/Servers/HttpSys/src/RequestProcessing/ResponseStreamAsyncResult.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/ResponseStreamAsyncResult.cs
@@ -316,14 +316,8 @@ internal sealed unsafe partial class ResponseStreamAsyncResult : IAsyncResult, I
 
     public void Dispose()
     {
-        if (_overlapped != null)
-        {
-            _overlapped.Dispose();
-        }
-        if (_fileStream != null)
-        {
-            _fileStream.Dispose();
-        }
+        _overlapped?.Dispose();
+        _fileStream?.Dispose();
         _cancellationRegistration.Dispose();
     }
 }

--- a/src/Servers/HttpSys/src/UrlPrefixCollection.cs
+++ b/src/Servers/HttpSys/src/UrlPrefixCollection.cs
@@ -67,10 +67,7 @@ public class UrlPrefixCollection : ICollection<UrlPrefix>
         lock (_prefixes)
         {
             var id = _nextId++;
-            if (_urlGroup != null)
-            {
-                _urlGroup.RegisterPrefix(item.FullPrefix, id);
-            }
+            _urlGroup?.RegisterPrefix(item.FullPrefix, id);
             _prefixes.Add(id, item);
         }
     }
@@ -157,10 +154,7 @@ public class UrlPrefixCollection : ICollection<UrlPrefix>
                 if (pair.Value.Equals(item))
                 {
                     id = pair.Key;
-                    if (_urlGroup != null)
-                    {
-                        _urlGroup.UnregisterPrefix(pair.Value.FullPrefix);
-                    }
+                    _urlGroup?.UnregisterPrefix(pair.Value.FullPrefix);
                 }
             }
             if (id.HasValue)

--- a/src/Servers/IIS/IISIntegration/src/IISMiddleware.cs
+++ b/src/Servers/IIS/IISIntegration/src/IISMiddleware.cs
@@ -116,7 +116,7 @@ public class IISMiddleware
             string.Equals(ANCMShutdownEventHeaderValue, httpContext.Request.Headers[MSAspNetCoreEvent], StringComparison.OrdinalIgnoreCase))
         {
             // Execute shutdown task on background thread without waiting for completion
-            var shutdownTask = Task.Run(() => _applicationLifetime.StopApplication());
+            var shutdownTask = Task.Run(_applicationLifetime.StopApplication);
             httpContext.Response.StatusCode = StatusCodes.Status202Accepted;
             return Task.CompletedTask;
         }

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeploymentParameters.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeploymentParameters.cs
@@ -28,9 +28,8 @@ public class IISDeploymentParameters : DeploymentParameters
     public IISDeploymentParameters(DeploymentParameters parameters)
         : base(parameters)
     {
-        if (parameters is IISDeploymentParameters)
+        if (parameters is IISDeploymentParameters tempParameters)
         {
-            var tempParameters = (IISDeploymentParameters)parameters;
             WebConfigActionList = tempParameters.WebConfigActionList;
             ServerConfigActionList = tempParameters.ServerConfigActionList;
             WebConfigBasedEnvironmentVariables = tempParameters.WebConfigBasedEnvironmentVariables;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -787,10 +787,7 @@ internal class Http1OutputProducer : IHttpOutputProducer, IDisposable
 
         public void Return()
         {
-            if (_memoryOwner != null)
-            {
-                _memoryOwner.Dispose();
-            }
+            _memoryOwner?.Dispose();
         }
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TransportConnectionManager.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TransportConnectionManager.cs
@@ -94,7 +94,7 @@ internal sealed class TransportConnectionManager
         }
 
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        token.Register(() => tcs.SetResult());
+        token.Register(tcs.SetResult);
         return tcs.Task;
     }
 }

--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -95,7 +95,7 @@ internal abstract class CertificateManager
                 var now = DateTimeOffset.Now;
                 var validCertificates = matchingCertificates
                     .Where(c => IsValidCertificate(c, now, requireExportable))
-                    .OrderByDescending(c => GetCertificateVersion(c))
+                    .OrderByDescending(GetCertificateVersion)
                     .ToArray();
 
                 if (Log.IsEnabled())

--- a/src/Shared/Dictionary/AdaptiveCapacityDictionary.cs
+++ b/src/Shared/Dictionary/AdaptiveCapacityDictionary.cs
@@ -244,10 +244,7 @@ internal sealed class AdaptiveCapacityDictionary<TKey, TValue> : IDictionary<TKe
     /// <inheritdoc />
     public void Clear()
     {
-        if (_dictionaryStorage != null)
-        {
-            _dictionaryStorage.Clear();
-        }
+        _dictionaryStorage?.Clear();
 
         if (_count == 0)
         {

--- a/src/Shared/Process/ProcessEx.cs
+++ b/src/Shared/Process/ProcessEx.cs
@@ -167,10 +167,7 @@ internal sealed class ProcessEx : IDisposable
             }
         }
 
-        if (_stdoutLines != null)
-        {
-            _stdoutLines.Add(e.Data);
-        }
+        _stdoutLines?.Add(e.Data);
     }
 
     private void OnProcessExited(object sender, EventArgs e)

--- a/src/Shared/PropertyAsParameterInfo.cs
+++ b/src/Shared/PropertyAsParameterInfo.cs
@@ -45,10 +45,10 @@ internal sealed class PropertyAsParameterInfo : ParameterInfo
     public override bool HasDefaultValue
         => _constructionParameterInfo is not null && _constructionParameterInfo.HasDefaultValue;
     public override object? DefaultValue
-        => _constructionParameterInfo is not null ? _constructionParameterInfo.DefaultValue : null;
+        => _constructionParameterInfo?.DefaultValue;
     public override int MetadataToken => _underlyingProperty.MetadataToken;
     public override object? RawDefaultValue
-        => _constructionParameterInfo is not null ? _constructionParameterInfo.RawDefaultValue : null;
+        => _constructionParameterInfo?.RawDefaultValue;
 
     /// <summary>
     /// Unwraps all parameters that contains <see cref="AsParametersAttribute"/> and
@@ -120,9 +120,9 @@ internal sealed class PropertyAsParameterInfo : ParameterInfo
                     }
                 }
             }
-            else if (flattenedParameters is not null)
+            else
             {
-                flattenedParameters.Add(parameters[i]);
+                flattenedParameters?.Add(parameters[i]);
             }
         }
 

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
@@ -34,8 +34,8 @@ internal sealed partial class HttpConnectionManager
         _disconnectTimeoutTicks = (long)(connectionOptions.Value.DisconnectTimeout ?? ConnectionOptionsSetup.DefaultDisconectTimeout).TotalMilliseconds;
 
         // Register these last as the callbacks could run immediately
-        appLifetime.ApplicationStarted.Register(() => Start());
-        appLifetime.ApplicationStopping.Register(() => CloseConnections());
+        appLifetime.ApplicationStarted.Register(Start);
+        appLifetime.ApplicationStopping.Register(CloseConnections);
     }
 
     public void Start()

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -729,9 +729,6 @@ public partial class HubConnectionContext
         _closedRequestedRegistration?.Dispose();
 
         // Use _streamTracker to avoid lazy init from StreamTracker getter if it doesn't exist
-        if (_streamTracker != null)
-        {
-            _streamTracker.CompleteAll(new OperationCanceledException("The underlying connection was closed."));
-        }
+        _streamTracker?.CompleteAll(new OperationCanceledException("The underlying connection was closed."));
     }
 }

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcherLog.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcherLog.cs
@@ -27,7 +27,7 @@ internal static partial class DefaultHubDispatcherLog
     {
         if (logger.IsEnabled(LogLevel.Trace))
         {
-            var resultType = objectMethodExecutor.AsyncResultType == null ? objectMethodExecutor.MethodReturnType : objectMethodExecutor.AsyncResultType;
+            var resultType = objectMethodExecutor.AsyncResultType ?? objectMethodExecutor.MethodReturnType;
             StreamingResult(logger, invocationId, resultType.FullName);
         }
     }
@@ -39,7 +39,7 @@ internal static partial class DefaultHubDispatcherLog
     {
         if (logger.IsEnabled(LogLevel.Trace))
         {
-            var resultType = objectMethodExecutor.AsyncResultType == null ? objectMethodExecutor.MethodReturnType : objectMethodExecutor.AsyncResultType;
+            var resultType = objectMethodExecutor.AsyncResultType ?? objectMethodExecutor.MethodReturnType;
             SendingResult(logger, invocationId, resultType.FullName);
         }
     }

--- a/src/SignalR/server/Core/src/Internal/HubReflectionHelper.cs
+++ b/src/SignalR/server/Core/src/Internal/HubReflectionHelper.cs
@@ -15,7 +15,7 @@ internal static class HubReflectionHelper
         var methods = hubType.GetMethods(BindingFlags.Public | BindingFlags.Instance);
         var allInterfaceMethods = _excludeInterfaces.SelectMany(i => GetInterfaceMethods(hubType, i));
 
-        return methods.Except(allInterfaceMethods).Where(m => IsHubMethod(m));
+        return methods.Except(allInterfaceMethods).Where(IsHubMethod);
     }
 
     private static IEnumerable<MethodInfo> GetInterfaceMethods(Type type, Type iface)

--- a/src/SignalR/server/Core/src/Internal/TypedClientBuilder.cs
+++ b/src/SignalR/server/Core/src/Internal/TypedClientBuilder.cs
@@ -12,7 +12,7 @@ internal static class TypedClientBuilder<T>
     private const string ClientModuleName = "Microsoft.AspNetCore.SignalR.TypedClientBuilder";
 
     // There is one static instance of _builder per T
-    private static readonly Lazy<Func<IClientProxy, T>> _builder = new Lazy<Func<IClientProxy, T>>(() => GenerateClientBuilder());
+    private static readonly Lazy<Func<IClientProxy, T>> _builder = new Lazy<Func<IClientProxy, T>>(GenerateClientBuilder);
 
     private static readonly PropertyInfo CancellationTokenNoneProperty = typeof(CancellationToken).GetProperty("None", BindingFlags.Public | BindingFlags.Static)!;
 

--- a/src/Testing/src/xunit/EnvironmentVariableSkipConditionAttribute.cs
+++ b/src/Testing/src/xunit/EnvironmentVariableSkipConditionAttribute.cs
@@ -78,7 +78,7 @@ public class EnvironmentVariableSkipConditionAttribute : Attribute, ITestConditi
     {
         get
         {
-            var value = _currentValue == null ? "(null)" : _currentValue;
+            var value = _currentValue ?? "(null)";
             return $"Test skipped on environment variable with name '{_variableName}' and value '{value}' " +
                 $"for the '{nameof(RunOnMatch)}' value of '{RunOnMatch}'.";
         }

--- a/src/Tools/GetDocumentInsider/src/Commands/GetDocumentCommand.cs
+++ b/src/Tools/GetDocumentInsider/src/Commands/GetDocumentCommand.cs
@@ -53,7 +53,7 @@ internal sealed class GetDocumentCommand : ProjectCommandBase
         var packagedAssemblies = Directory
             .EnumerateFiles(toolsDirectory, "*.dll")
             .Except(new[] { Path.GetFullPath(thisAssembly.Location) })
-            .ToDictionary(path => Path.GetFileNameWithoutExtension(path), path => new AssemblyInfo(path));
+            .ToDictionary(Path.GetFileNameWithoutExtension, path => new AssemblyInfo(path));
 
         // Explicitly load all assemblies we need first to preserve target project as much as possible. This
         // executable is always run in the target project's context (either through location or .deps.json file).

--- a/src/Tools/Microsoft.dotnet-openapi/src/Internal/OpenapiDependencyAttribute.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/src/Internal/OpenapiDependencyAttribute.cs
@@ -15,7 +15,7 @@ internal sealed class OpenApiDependencyAttribute : Attribute
     {
         Name = name;
         Version = version;
-        CodeGenerators = codeGenerators.Split(';', StringSplitOptions.RemoveEmptyEntries).Select(c => Enum.Parse<CodeGenerator>(c)).ToArray();
+        CodeGenerators = codeGenerators.Split(';', StringSplitOptions.RemoveEmptyEntries).Select(Enum.Parse<CodeGenerator>).ToArray();
     }
 
     public string Name { get; set; }

--- a/src/Tools/dotnet-dev-certs/src/Program.cs
+++ b/src/Tools/dotnet-dev-certs/src/Program.cs
@@ -297,7 +297,7 @@ internal sealed class Program
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                var trustedCertificates = certificates.Where(c => certificateManager.IsTrusted(c)).ToList();
+                var trustedCertificates = certificates.Where(certificateManager.IsTrusted).ToList();
                 if (!trustedCertificates.Any())
                 {
                     reporter.Output($@"The following certificates were found, but none of them is trusted: {CertificateManager.ToCertificateDescription(certificates)}");

--- a/src/WebEncoders/src/EncoderServiceCollectionExtensions.cs
+++ b/src/WebEncoders/src/EncoderServiceCollectionExtensions.cs
@@ -32,11 +32,11 @@ public static class EncoderServiceCollectionExtensions
         // Register the default encoders
         // We want to call the 'Default' property getters lazily since they perform static caching
         services.TryAddSingleton(
-            CreateFactory(() => HtmlEncoder.Default, settings => HtmlEncoder.Create(settings)));
+            CreateFactory(() => HtmlEncoder.Default, HtmlEncoder.Create));
         services.TryAddSingleton(
-            CreateFactory(() => JavaScriptEncoder.Default, settings => JavaScriptEncoder.Create(settings)));
+            CreateFactory(() => JavaScriptEncoder.Default, JavaScriptEncoder.Create));
         services.TryAddSingleton(
-            CreateFactory(() => UrlEncoder.Default, settings => UrlEncoder.Create(settings)));
+            CreateFactory(() => UrlEncoder.Default, UrlEncoder.Create));
 
         return services;
     }


### PR DESCRIPTION
[IDE0020: Use pattern matching to avoid is check followed by a cast (with variable)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0020-ide0038)
[IDE0029: Use coalesce expression (non-nullable types)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0029-ide0030)
[IDE0030: Use coalesce expression (nullable types)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0029-ide0030)
[IDE0031: Use null propagation](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0031)
[IDE0038: Use pattern matching to avoid is check followed by a cast (without variable)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0020-ide0038)
[IDE0200: Lambda expression can be removed](https://github.com/dotnet/roslyn/blob/main/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryLambdaExpression/CSharpRemoveUnnecessaryLambdaExpressionDiagnosticAnalyzer.cs)

These rules all can result in improved performance, details explained in https://devblogs.microsoft.com/dotnet/performance_improvements_in_net_7/
Additionally, it's often cleaner looking code.