### PR TITLE
Fix route parameter completion provider including names that are already used

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternCompletionProvider.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternCompletionProvider.cs
@@ -233,7 +233,11 @@ public class RoutePatternCompletionProvider : CompletionProvider
             var resolvedParameterSymbols = RoutePatternParametersDetector.ResolvedParameters(context.MethodSymbol, context.WellKnownTypes);
             foreach (var parameterSymbol in resolvedParameterSymbols)
             {
-                context.AddIfMissing(parameterSymbol.Name, suffix: null, description: null, WellKnownTags.Parameter, parentOpt: parentOpt);
+                // Don't suggest parameter name if it already exists in the route.
+                if (!context.Tree.RouteParameters.ContainsKey(parameterSymbol.Name))
+                {
+                    context.AddIfMissing(parameterSymbol.Name, suffix: null, description: null, WellKnownTags.Parameter, parentOpt: parentOpt);
+                }
             }
         }
     }

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternCompletionProviderTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternCompletionProviderTests.cs
@@ -494,6 +494,62 @@ class Program
     }
 
     [Fact]
+    public async Task Insertion_ParameterOpenBrace_ParameterInUse_NoResults()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+
+class Program
+{
+    static void Main()
+    {
+        MapCustomThing(null, @""{id}/{$$"", (string id) => "");
+    }
+
+    static void MapCustomThing(IEndpointRouteBuilder endpoints, [StringSyntax(""Route"")] string pattern, Delegate delegate)
+    {
+    }
+}
+");
+
+        // Assert
+        Assert.Empty(result.Completions.ItemsList);
+    }
+
+    [Fact]
+    public async Task Insertion_ParameterOpenBrace_OtherParameters_ReturnDelegateParameterItem()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+
+class Program
+{
+    static void Main()
+    {
+        MapCustomThing(null, @""{id}/{$$"", (string id, string id2) => "");
+    }
+
+    static void MapCustomThing(IEndpointRouteBuilder endpoints, [StringSyntax(""Route"")] string pattern, Delegate delegate)
+    {
+    }
+}
+");
+
+        // Assert
+        Assert.Collection(
+            result.Completions.ItemsList,
+            i => Assert.Equal("id2", i.DisplayText));
+    }
+
+    [Fact]
     public async Task Insertion_ParameterOpenBrace_ControllerAction_HasParameter_ReturnActionParameterItem()
     {
         // Arrange & Act

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternCompletionProviderTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternCompletionProviderTests.cs
@@ -521,6 +521,33 @@ class Program
     }
 
     [Fact]
+    public async Task Insertion_ParameterOpenBrace_ParameterInUse_DifferentCase_NoResults()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+
+class Program
+{
+    static void Main()
+    {
+        MapCustomThing(null, @""{ID}/{$$"", (string id) => "");
+    }
+
+    static void MapCustomThing(IEndpointRouteBuilder endpoints, [StringSyntax(""Route"")] string pattern, Delegate delegate)
+    {
+    }
+}
+");
+
+        // Assert
+        Assert.Empty(result.Completions.ItemsList);
+    }
+
+    [Fact]
     public async Task Insertion_ParameterOpenBrace_OtherParameters_ReturnDelegateParameterItem()
     {
         // Arrange & Act


### PR DESCRIPTION
Completion provider offers names from lambda expression or action method. This PR stops the completion provider from suggesting names that are already in the route.