### PR TITLE
Add option to use system culture in RequestLocalizationOptions

### DIFF
--- a/src/Middleware/Localization/src/PublicAPI.Shipped.txt
+++ b/src/Middleware/Localization/src/PublicAPI.Shipped.txt
@@ -53,7 +53,6 @@ Microsoft.AspNetCore.Builder.RequestLocalizationOptions.FallBackToParentUICultur
 Microsoft.AspNetCore.Builder.RequestLocalizationOptions.RequestCultureProviders.get -> System.Collections.Generic.IList<Microsoft.AspNetCore.Localization.IRequestCultureProvider!>!
 Microsoft.AspNetCore.Builder.RequestLocalizationOptions.RequestCultureProviders.set -> void
 Microsoft.AspNetCore.Builder.RequestLocalizationOptions.RequestLocalizationOptions() -> void
-Microsoft.AspNetCore.Builder.RequestLocalizationOptions.RequestLocalizationOptions(bool useUserOverride) -> void
 Microsoft.AspNetCore.Builder.RequestLocalizationOptions.SetDefaultCulture(string! defaultCulture) -> Microsoft.AspNetCore.Builder.RequestLocalizationOptions!
 Microsoft.AspNetCore.Builder.RequestLocalizationOptions.SupportedCultures.get -> System.Collections.Generic.IList<System.Globalization.CultureInfo!>?
 Microsoft.AspNetCore.Builder.RequestLocalizationOptions.SupportedCultures.set -> void

--- a/src/Middleware/Localization/src/PublicAPI.Shipped.txt
+++ b/src/Middleware/Localization/src/PublicAPI.Shipped.txt
@@ -53,6 +53,7 @@ Microsoft.AspNetCore.Builder.RequestLocalizationOptions.FallBackToParentUICultur
 Microsoft.AspNetCore.Builder.RequestLocalizationOptions.RequestCultureProviders.get -> System.Collections.Generic.IList<Microsoft.AspNetCore.Localization.IRequestCultureProvider!>!
 Microsoft.AspNetCore.Builder.RequestLocalizationOptions.RequestCultureProviders.set -> void
 Microsoft.AspNetCore.Builder.RequestLocalizationOptions.RequestLocalizationOptions() -> void
+Microsoft.AspNetCore.Builder.RequestLocalizationOptions.RequestLocalizationOptions(bool useUserOverride) -> void
 Microsoft.AspNetCore.Builder.RequestLocalizationOptions.SetDefaultCulture(string! defaultCulture) -> Microsoft.AspNetCore.Builder.RequestLocalizationOptions!
 Microsoft.AspNetCore.Builder.RequestLocalizationOptions.SupportedCultures.get -> System.Collections.Generic.IList<System.Globalization.CultureInfo!>?
 Microsoft.AspNetCore.Builder.RequestLocalizationOptions.SupportedCultures.set -> void

--- a/src/Middleware/Localization/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/Localization/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Builder.RequestLocalizationOptions.CultureInfoUseUserOverride.get -> bool
+Microsoft.AspNetCore.Builder.RequestLocalizationOptions.CultureInfoUseUserOverride.set -> void

--- a/src/Middleware/Localization/src/RequestLocalizationOptions.cs
+++ b/src/Middleware/Localization/src/RequestLocalizationOptions.cs
@@ -28,7 +28,7 @@ public class RequestLocalizationOptions
     }
 
     /// <summary>
-    /// Gets or sets whether to use use user-selected culture or default system culture. Defaults to <c>true</c>.
+    /// Configures <see cref="CultureInfo.UseUserOverride "/>. Defaults to <c>true</c>.
     /// </summary>
     public bool CultureInfoUseUserOverride { get; set; } = true;
 

--- a/src/Middleware/Localization/src/RequestLocalizationOptions.cs
+++ b/src/Middleware/Localization/src/RequestLocalizationOptions.cs
@@ -11,26 +11,14 @@ namespace Microsoft.AspNetCore.Builder;
 /// </summary>
 public class RequestLocalizationOptions
 {
-    private readonly bool _useUserOverride;
-
     private RequestCulture _defaultRequestCulture =
         new RequestCulture(CultureInfo.CurrentCulture, CultureInfo.CurrentUICulture);
 
     /// <summary>
     /// Creates a new <see cref="RequestLocalizationOptions"/> with default values.
     /// </summary>
-    public RequestLocalizationOptions() : this(useUserOverride: true)
+    public RequestLocalizationOptions()
     {
-
-    }
-
-    /// <summary>
-    /// Creates a new <see cref="RequestLocalizationOptions"/> with default values and ability to specify the culture settings.
-    /// <param name="useUserOverride">Whether to use user-selected culture or default system culture.</param>
-    /// </summary>
-    public RequestLocalizationOptions(bool useUserOverride)
-    {
-        _useUserOverride = useUserOverride;
         RequestCultureProviders = new List<IRequestCultureProvider>
         {
             new QueryStringRequestCultureProvider { Options = this },
@@ -38,6 +26,11 @@ public class RequestLocalizationOptions
             new AcceptLanguageHeaderRequestCultureProvider { Options = this }
         };
     }
+
+    /// <summary>
+    /// Gets or sets whether to use use user-selected culture or default system culture. Defaults to <c>true</c>.
+    /// </summary>
+    public bool CultureInfoUseUserOverride { get; set; } = true;
 
     /// <summary>
     /// Gets or sets the default culture to use for requests when a supported culture could not be determined by
@@ -136,7 +129,7 @@ public class RequestLocalizationOptions
 
         foreach (var culture in cultures)
         {
-            supportedCultures.Add(new CultureInfo(culture, useUserOverride: _useUserOverride));
+            supportedCultures.Add(new CultureInfo(culture, useUserOverride: CultureInfoUseUserOverride));
         }
 
         SupportedCultures = supportedCultures;
@@ -154,7 +147,7 @@ public class RequestLocalizationOptions
         var supportedUICultures = new List<CultureInfo>(uiCultures.Length);
         foreach (var culture in uiCultures)
         {
-            supportedUICultures.Add(new CultureInfo(culture, useUserOverride: _useUserOverride));
+            supportedUICultures.Add(new CultureInfo(culture, useUserOverride: CultureInfoUseUserOverride));
         }
 
         SupportedUICultures = supportedUICultures;
@@ -170,7 +163,7 @@ public class RequestLocalizationOptions
     /// <returns>The <see cref="RequestLocalizationOptions"/>.</returns>
     public RequestLocalizationOptions SetDefaultCulture(string defaultCulture)
     {
-        DefaultRequestCulture = new RequestCulture(new CultureInfo(defaultCulture, useUserOverride: _useUserOverride));
+        DefaultRequestCulture = new RequestCulture(new CultureInfo(defaultCulture, useUserOverride: CultureInfoUseUserOverride));
 
         return this;
     }

--- a/src/Middleware/Localization/src/RequestLocalizationOptions.cs
+++ b/src/Middleware/Localization/src/RequestLocalizationOptions.cs
@@ -11,14 +11,18 @@ namespace Microsoft.AspNetCore.Builder;
 /// </summary>
 public class RequestLocalizationOptions
 {
+    private readonly bool _useUserOverride;
+
     private RequestCulture _defaultRequestCulture =
         new RequestCulture(CultureInfo.CurrentCulture, CultureInfo.CurrentUICulture);
 
     /// <summary>
     /// Creates a new <see cref="RequestLocalizationOptions"/> with default values.
+    /// <param name="useUserOverride">Whether to use user-selected culture or default system culture. Defaults to <c>false</c>.</param>
     /// </summary>
-    public RequestLocalizationOptions()
+    public RequestLocalizationOptions(bool useUserOverride = false)
     {
+        _useUserOverride = useUserOverride;
         RequestCultureProviders = new List<IRequestCultureProvider>
             {
                 new QueryStringRequestCultureProvider { Options = this },
@@ -124,10 +128,11 @@ public class RequestLocalizationOptions
 
         foreach (var culture in cultures)
         {
-            supportedCultures.Add(new CultureInfo(culture));
+            supportedCultures.Add(new CultureInfo(culture, useUserOverride: _useUserOverride));
         }
 
         SupportedCultures = supportedCultures;
+
         return this;
     }
 
@@ -141,10 +146,11 @@ public class RequestLocalizationOptions
         var supportedUICultures = new List<CultureInfo>(uiCultures.Length);
         foreach (var culture in uiCultures)
         {
-            supportedUICultures.Add(new CultureInfo(culture));
+            supportedUICultures.Add(new CultureInfo(culture, useUserOverride: _useUserOverride));
         }
 
         SupportedUICultures = supportedUICultures;
+
         return this;
     }
 
@@ -156,7 +162,8 @@ public class RequestLocalizationOptions
     /// <returns>The <see cref="RequestLocalizationOptions"/>.</returns>
     public RequestLocalizationOptions SetDefaultCulture(string defaultCulture)
     {
-        DefaultRequestCulture = new RequestCulture(defaultCulture);
+        DefaultRequestCulture = new RequestCulture(new CultureInfo(defaultCulture, useUserOverride: _useUserOverride));
+
         return this;
     }
 }

--- a/src/Middleware/Localization/src/RequestLocalizationOptions.cs
+++ b/src/Middleware/Localization/src/RequestLocalizationOptions.cs
@@ -18,17 +18,25 @@ public class RequestLocalizationOptions
 
     /// <summary>
     /// Creates a new <see cref="RequestLocalizationOptions"/> with default values.
-    /// <param name="useUserOverride">Whether to use user-selected culture or default system culture. Defaults to <c>true</c>.</param>
     /// </summary>
-    public RequestLocalizationOptions(bool useUserOverride = true)
+    public RequestLocalizationOptions() : this(useUserOverride: true)
+    {
+
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="RequestLocalizationOptions"/> with default values and ability to specify the culture settings.
+    /// <param name="useUserOverride">Whether to use user-selected culture or default system culture.</param>
+    /// </summary>
+    public RequestLocalizationOptions(bool useUserOverride)
     {
         _useUserOverride = useUserOverride;
         RequestCultureProviders = new List<IRequestCultureProvider>
-            {
-                new QueryStringRequestCultureProvider { Options = this },
-                new CookieRequestCultureProvider { Options = this },
-                new AcceptLanguageHeaderRequestCultureProvider { Options = this }
-            };
+        {
+            new QueryStringRequestCultureProvider { Options = this },
+            new CookieRequestCultureProvider { Options = this },
+            new AcceptLanguageHeaderRequestCultureProvider { Options = this }
+        };
     }
 
     /// <summary>

--- a/src/Middleware/Localization/src/RequestLocalizationOptions.cs
+++ b/src/Middleware/Localization/src/RequestLocalizationOptions.cs
@@ -18,9 +18,9 @@ public class RequestLocalizationOptions
 
     /// <summary>
     /// Creates a new <see cref="RequestLocalizationOptions"/> with default values.
-    /// <param name="useUserOverride">Whether to use user-selected culture or default system culture. Defaults to <c>false</c>.</param>
+    /// <param name="useUserOverride">Whether to use user-selected culture or default system culture. Defaults to <c>true</c>.</param>
     /// </summary>
-    public RequestLocalizationOptions(bool useUserOverride = false)
+    public RequestLocalizationOptions(bool useUserOverride = true)
     {
         _useUserOverride = useUserOverride;
         RequestCultureProviders = new List<IRequestCultureProvider>


### PR DESCRIPTION
Fixes #44286

We faced an issue in OrchardCore, the current culture based on the user-selected culture all the time because `CultureInfo` called the default constructor with `useUserOverride

It would be nice if we can fix this behavior by adding a simple parameter to `RequestLocalizationOptions` that allow us to use whether to select user-selected culture or default system culture

/cc @DamianEdwards