### PR TITLE
Update static file docs and log if WebRootPath is not found 

### DIFF
--- a/src/Hosting/Abstractions/src/IWebHostEnvironment.cs
+++ b/src/Hosting/Abstractions/src/IWebHostEnvironment.cs
@@ -13,11 +13,13 @@ public interface IWebHostEnvironment : IHostEnvironment
 {
     /// <summary>
     /// Gets or sets the absolute path to the directory that contains the web-servable application content files.
+    /// This defaults to the 'wwwroot' subfolder.
     /// </summary>
     string WebRootPath { get; set; }
 
     /// <summary>
     /// Gets or sets an <see cref="IFileProvider"/> pointing at <see cref="WebRootPath"/>.
+    /// This defaults to referencing files from the 'wwwroot' subfolder.
     /// </summary>
     IFileProvider WebRootFileProvider { get; set; }
 }

--- a/src/Middleware/Middleware.slnf
+++ b/src/Middleware/Middleware.slnf
@@ -114,6 +114,7 @@
       "src\\Middleware\\WebSockets\\test\\UnitTests\\Microsoft.AspNetCore.WebSockets.Tests.csproj",
       "src\\Middleware\\perf\\Microbenchmarks\\Microsoft.AspNetCore.WebSockets.Microbenchmarks.csproj",
       "src\\Middleware\\perf\\ResponseCaching.Microbenchmarks\\Microsoft.AspNetCore.ResponseCaching.Microbenchmarks.csproj",
+      "src\\ObjectPool\\src\\Microsoft.Extensions.ObjectPool.csproj",
       "src\\Security\\Authorization\\Core\\src\\Microsoft.AspNetCore.Authorization.csproj",
       "src\\Servers\\Connections.Abstractions\\src\\Microsoft.AspNetCore.Connections.Abstractions.csproj",
       "src\\Servers\\HttpSys\\src\\Microsoft.AspNetCore.Server.HttpSys.csproj",
@@ -122,7 +123,9 @@
       "src\\Servers\\IIS\\IntegrationTesting.IIS\\src\\Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj",
       "src\\Servers\\Kestrel\\Core\\src\\Microsoft.AspNetCore.Server.Kestrel.Core.csproj",
       "src\\Servers\\Kestrel\\Kestrel\\src\\Microsoft.AspNetCore.Server.Kestrel.csproj",
-      "src\\Servers\\Kestrel\\Transport.Sockets\\src\\Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.csproj"
+      "src\\Servers\\Kestrel\\Transport.Quic\\src\\Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.csproj",
+      "src\\Servers\\Kestrel\\Transport.Sockets\\src\\Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.csproj",
+      "src\\WebEncoders\\src\\Microsoft.Extensions.WebEncoders.csproj"
     ]
   }
 }

--- a/src/Middleware/StaticFiles/src/DefaultFilesExtensions.cs
+++ b/src/Middleware/StaticFiles/src/DefaultFilesExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.Options;
@@ -17,6 +18,8 @@ public static class DefaultFilesExtensions
     /// </summary>
     /// <param name="app"></param>
     /// <returns></returns>
+    /// <remarks>This defaults to serving files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// which defaults to the 'wwwroot' subfolder.</remarks>
     public static IApplicationBuilder UseDefaultFiles(this IApplicationBuilder app)
     {
         if (app == null)
@@ -33,6 +36,8 @@ public static class DefaultFilesExtensions
     /// <param name="app"></param>
     /// <param name="requestPath">The relative request path.</param>
     /// <returns></returns>
+    /// <remarks>This defaults to serving files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// which defaults to the 'wwwroot' subfolder.</remarks>
     public static IApplicationBuilder UseDefaultFiles(this IApplicationBuilder app, string requestPath)
     {
         if (app == null)

--- a/src/Middleware/StaticFiles/src/DefaultFilesExtensions.cs
+++ b/src/Middleware/StaticFiles/src/DefaultFilesExtensions.cs
@@ -18,8 +18,10 @@ public static class DefaultFilesExtensions
     /// </summary>
     /// <param name="app"></param>
     /// <returns></returns>
-    /// <remarks>This defaults to serving files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
-    /// which defaults to the 'wwwroot' subfolder.</remarks>
+    /// <remarks>
+    /// Files are served from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// or <see cref="IWebHostEnvironment.WebRootFileProvider"/> which defaults to the 'wwwroot' subfolder.
+    /// </remarks>
     public static IApplicationBuilder UseDefaultFiles(this IApplicationBuilder app)
     {
         if (app == null)
@@ -36,8 +38,10 @@ public static class DefaultFilesExtensions
     /// <param name="app"></param>
     /// <param name="requestPath">The relative request path.</param>
     /// <returns></returns>
-    /// <remarks>This defaults to serving files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
-    /// which defaults to the 'wwwroot' subfolder.</remarks>
+    /// <remarks>
+    /// Files are served from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// or <see cref="IWebHostEnvironment.WebRootFileProvider"/> which defaults to the 'wwwroot' subfolder.
+    /// </remarks>
     public static IApplicationBuilder UseDefaultFiles(this IApplicationBuilder app, string requestPath)
     {
         if (app == null)

--- a/src/Middleware/StaticFiles/src/DirectoryBrowserExtensions.cs
+++ b/src/Middleware/StaticFiles/src/DirectoryBrowserExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.Options;
@@ -17,6 +18,8 @@ public static class DirectoryBrowserExtensions
     /// </summary>
     /// <param name="app"></param>
     /// <returns></returns>
+    /// <remarks>This defaults to browsing files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// which defaults to the 'wwwroot' subfolder.</remarks>
     public static IApplicationBuilder UseDirectoryBrowser(this IApplicationBuilder app)
     {
         if (app == null)
@@ -33,6 +36,8 @@ public static class DirectoryBrowserExtensions
     /// <param name="app"></param>
     /// <param name="requestPath">The relative request path.</param>
     /// <returns></returns>
+    /// <remarks>This defaults to browsing files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// which defaults to the 'wwwroot' subfolder.</remarks>
     public static IApplicationBuilder UseDirectoryBrowser(this IApplicationBuilder app, string requestPath)
     {
         if (app == null)

--- a/src/Middleware/StaticFiles/src/DirectoryBrowserExtensions.cs
+++ b/src/Middleware/StaticFiles/src/DirectoryBrowserExtensions.cs
@@ -18,8 +18,10 @@ public static class DirectoryBrowserExtensions
     /// </summary>
     /// <param name="app"></param>
     /// <returns></returns>
-    /// <remarks>This defaults to browsing files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
-    /// which defaults to the 'wwwroot' subfolder.</remarks>
+    /// <remarks>
+    /// Files are served from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// or <see cref="IWebHostEnvironment.WebRootFileProvider"/> which defaults to the 'wwwroot' subfolder.
+    /// </remarks>
     public static IApplicationBuilder UseDirectoryBrowser(this IApplicationBuilder app)
     {
         if (app == null)
@@ -36,8 +38,10 @@ public static class DirectoryBrowserExtensions
     /// <param name="app"></param>
     /// <param name="requestPath">The relative request path.</param>
     /// <returns></returns>
-    /// <remarks>This defaults to browsing files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
-    /// which defaults to the 'wwwroot' subfolder.</remarks>
+    /// <remarks>
+    /// Files are served from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// or <see cref="IWebHostEnvironment.WebRootFileProvider"/> which defaults to the 'wwwroot' subfolder.
+    /// </remarks>
     public static IApplicationBuilder UseDirectoryBrowser(this IApplicationBuilder app, string requestPath)
     {
         if (app == null)

--- a/src/Middleware/StaticFiles/src/FileServerExtensions.cs
+++ b/src/Middleware/StaticFiles/src/FileServerExtensions.cs
@@ -17,8 +17,10 @@ public static class FileServerExtensions
     /// </summary>
     /// <param name="app"></param>
     /// <returns></returns>
-    /// <remarks>This defaults to serving files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
-    /// which defaults to the 'wwwroot' subfolder.</remarks>
+    /// <remarks>
+    /// Files are served from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// or <see cref="IWebHostEnvironment.WebRootFileProvider"/> which defaults to the 'wwwroot' subfolder.
+    /// </remarks>
     public static IApplicationBuilder UseFileServer(this IApplicationBuilder app)
     {
         if (app == null)

--- a/src/Middleware/StaticFiles/src/FileServerExtensions.cs
+++ b/src/Middleware/StaticFiles/src/FileServerExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Builder;
@@ -16,6 +17,8 @@ public static class FileServerExtensions
     /// </summary>
     /// <param name="app"></param>
     /// <returns></returns>
+    /// <remarks>This defaults to serving files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// which defaults to the 'wwwroot' subfolder.</remarks>
     public static IApplicationBuilder UseFileServer(this IApplicationBuilder app)
     {
         if (app == null)
@@ -32,6 +35,8 @@ public static class FileServerExtensions
     /// <param name="app"></param>
     /// <param name="enableDirectoryBrowsing">Should directory browsing be enabled?</param>
     /// <returns></returns>
+    /// <remarks>This defaults to serving files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// which defaults to the 'wwwroot' subfolder.</remarks>
     public static IApplicationBuilder UseFileServer(this IApplicationBuilder app, bool enableDirectoryBrowsing)
     {
         if (app == null)
@@ -51,6 +56,8 @@ public static class FileServerExtensions
     /// <param name="app"></param>
     /// <param name="requestPath">The relative request path.</param>
     /// <returns></returns>
+    /// <remarks>This defaults to serving files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// which defaults to the 'wwwroot' subfolder.</remarks>
     public static IApplicationBuilder UseFileServer(this IApplicationBuilder app, string requestPath)
     {
         if (app == null)

--- a/src/Middleware/StaticFiles/src/FileServerExtensions.cs
+++ b/src/Middleware/StaticFiles/src/FileServerExtensions.cs
@@ -35,8 +35,10 @@ public static class FileServerExtensions
     /// <param name="app"></param>
     /// <param name="enableDirectoryBrowsing">Should directory browsing be enabled?</param>
     /// <returns></returns>
-    /// <remarks>This defaults to serving files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
-    /// which defaults to the 'wwwroot' subfolder.</remarks>
+    /// <remarks>
+    /// Files are served from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// or <see cref="IWebHostEnvironment.WebRootFileProvider"/> which defaults to the 'wwwroot' subfolder.
+    /// </remarks>
     public static IApplicationBuilder UseFileServer(this IApplicationBuilder app, bool enableDirectoryBrowsing)
     {
         if (app == null)
@@ -56,8 +58,10 @@ public static class FileServerExtensions
     /// <param name="app"></param>
     /// <param name="requestPath">The relative request path.</param>
     /// <returns></returns>
-    /// <remarks>This defaults to serving files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
-    /// which defaults to the 'wwwroot' subfolder.</remarks>
+    /// <remarks>
+    /// Files are served from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// or <see cref="IWebHostEnvironment.WebRootFileProvider"/> which defaults to the 'wwwroot' subfolder.
+    /// </remarks>
     public static IApplicationBuilder UseFileServer(this IApplicationBuilder app, string requestPath)
     {
         if (app == null)

--- a/src/Middleware/StaticFiles/src/Infrastructure/SharedOptionsBase.cs
+++ b/src/Middleware/StaticFiles/src/Infrastructure/SharedOptionsBase.cs
@@ -44,8 +44,10 @@ public abstract class SharedOptionsBase
     /// <summary>
     /// The file system used to locate resources
     /// </summary>
-    /// <remarks>This defaults to serving files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
-    /// which defaults to the 'wwwroot' subfolder.</remarks>
+    /// <remarks>
+    /// Files are served from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// or <see cref="IWebHostEnvironment.WebRootFileProvider"/> which defaults to the 'wwwroot' subfolder.
+    /// </remarks>
     public IFileProvider? FileProvider
     {
         get { return SharedOptions.FileProvider; }

--- a/src/Middleware/StaticFiles/src/Infrastructure/SharedOptionsBase.cs
+++ b/src/Middleware/StaticFiles/src/Infrastructure/SharedOptionsBase.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.FileProviders;
 
@@ -32,6 +33,7 @@ public abstract class SharedOptionsBase
 
     /// <summary>
     /// The relative request path that maps to static resources.
+    /// This defaults to the site root '/'.
     /// </summary>
     public PathString RequestPath
     {
@@ -42,6 +44,8 @@ public abstract class SharedOptionsBase
     /// <summary>
     /// The file system used to locate resources
     /// </summary>
+    /// <remarks>This defaults to serving files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// which defaults to the 'wwwroot' subfolder.</remarks>
     public IFileProvider? FileProvider
     {
         get { return SharedOptions.FileProvider; }

--- a/src/Middleware/StaticFiles/src/LoggerExtensions.cs
+++ b/src/Middleware/StaticFiles/src/LoggerExtensions.cs
@@ -58,4 +58,8 @@ internal static partial class LoggerExtensions
 
     [LoggerMessage(14, LogLevel.Debug, "The file transmission was cancelled", EventName = "WriteCancelled")]
     public static partial void WriteCancelled(this ILogger logger, Exception ex);
+
+    [LoggerMessage(16, LogLevel.Warning,
+        "The WebRootPath was not found: {webRootPath}. Static files may be unavailable.", EventName = "WebRootPathNotFound")]
+    public static partial void WebRootPathNotFound(this ILogger logger, string webRootPath);
 }

--- a/src/Middleware/StaticFiles/src/LoggerExtensions.cs
+++ b/src/Middleware/StaticFiles/src/LoggerExtensions.cs
@@ -60,6 +60,6 @@ internal static partial class LoggerExtensions
     public static partial void WriteCancelled(this ILogger logger, Exception ex);
 
     [LoggerMessage(16, LogLevel.Warning,
-        "The WebRootPath was not found: {webRootPath}. Static files may be unavailable.", EventName = "WebRootPathNotFound")]
+        "The WebRootPath was not found: {WebRootPath}. Static files may be unavailable.", EventName = "WebRootPathNotFound")]
     public static partial void WebRootPathNotFound(this ILogger logger, string webRootPath);
 }

--- a/src/Middleware/StaticFiles/src/StaticFileExtensions.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileExtensions.cs
@@ -18,8 +18,10 @@ public static class StaticFileExtensions
     /// </summary>
     /// <param name="app"></param>
     /// <returns></returns>
-    /// <remarks>This defaults to serving files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
-    /// which defaults to the 'wwwroot' subfolder.</remarks>
+    /// <remarks>
+    /// Files are served from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// or <see cref="IWebHostEnvironment.WebRootFileProvider"/> which defaults to the 'wwwroot' subfolder.
+    /// </remarks>
     public static IApplicationBuilder UseStaticFiles(this IApplicationBuilder app)
     {
         if (app == null)
@@ -36,8 +38,10 @@ public static class StaticFileExtensions
     /// <param name="app"></param>
     /// <param name="requestPath">The relative request path.</param>
     /// <returns></returns>
-    /// <remarks>This defaults to serving files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
-    /// which defaults to the 'wwwroot' subfolder.</remarks>
+    /// <remarks>
+    /// Files are served from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// or <see cref="IWebHostEnvironment.WebRootFileProvider"/> which defaults to the 'wwwroot' subfolder.
+    /// </remarks>
     public static IApplicationBuilder UseStaticFiles(this IApplicationBuilder app, string requestPath)
     {
         if (app == null)

--- a/src/Middleware/StaticFiles/src/StaticFileExtensions.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.Options;
@@ -17,6 +18,8 @@ public static class StaticFileExtensions
     /// </summary>
     /// <param name="app"></param>
     /// <returns></returns>
+    /// <remarks>This defaults to serving files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// which defaults to the 'wwwroot' subfolder.</remarks>
     public static IApplicationBuilder UseStaticFiles(this IApplicationBuilder app)
     {
         if (app == null)
@@ -33,6 +36,8 @@ public static class StaticFileExtensions
     /// <param name="app"></param>
     /// <param name="requestPath">The relative request path.</param>
     /// <returns></returns>
+    /// <remarks>This defaults to serving files from the path specified in <see cref="IWebHostEnvironment.WebRootPath"/>
+    /// which defaults to the 'wwwroot' subfolder.</remarks>
     public static IApplicationBuilder UseStaticFiles(this IApplicationBuilder app, string requestPath)
     {
         if (app == null)

--- a/src/Middleware/StaticFiles/src/StaticFileMiddleware.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileMiddleware.cs
@@ -57,6 +57,12 @@ public class StaticFileMiddleware
         _fileProvider = _options.FileProvider ?? Helpers.ResolveFileProvider(hostingEnv);
         _matchUrl = _options.RequestPath;
         _logger = loggerFactory.CreateLogger<StaticFileMiddleware>();
+
+        // See HostingEnvironmentExtensions.Initialize
+        if (_fileProvider is NullFileProvider && _fileProvider == hostingEnv.WebRootFileProvider)
+        {
+            _logger.WebRootPathNotFound(Path.GetFullPath(Path.Combine(hostingEnv.ContentRootPath, hostingEnv.WebRootPath ?? "wwwroot")));
+        }
     }
 
     /// <summary>

--- a/src/Middleware/StaticFiles/test/UnitTests/StaticFileMiddlewareTests.cs
+++ b/src/Middleware/StaticFiles/test/UnitTests/StaticFileMiddlewareTests.cs
@@ -17,12 +17,13 @@ using Moq;
 
 namespace Microsoft.AspNetCore.StaticFiles;
 
-public class StaticFileMiddlewareTests
+public class StaticFileMiddlewareTests : LoggedTest
 {
     [Fact]
     public async Task ReturnsNotFoundWithoutWwwroot()
     {
         using var host = new HostBuilder()
+            .ConfigureServices(AddTestLogging)
             .ConfigureWebHost(webHostBuilder =>
             {
                 webHostBuilder
@@ -38,6 +39,9 @@ public class StaticFileMiddlewareTests
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         Assert.Null(response.Headers.ETag);
+
+        Assert.Contains(TestSink.Writes, w => w.Message.Contains("The WebRootPath was not found")
+            && w.Message.Contains("Static files may be unavailable."));
     }
 
     [ConditionalFact]
@@ -52,6 +56,7 @@ public class StaticFileMiddlewareTests
         try
         {
             using var host = new HostBuilder()
+            .ConfigureServices(AddTestLogging)
             .ConfigureWebHost(webHostBuilder =>
             {
                 webHostBuilder
@@ -83,6 +88,7 @@ public class StaticFileMiddlewareTests
             .ThrowsAsync(new FileNotFoundException());
         mockSendFile.Setup(m => m.Stream).Returns(Stream.Null);
         using var host = new HostBuilder()
+            .ConfigureServices(AddTestLogging)
             .ConfigureWebHost(webHostBuilder =>
             {
                 webHostBuilder


### PR DESCRIPTION
Fixes #38481

AspNetCore only serves static files from the wwwroot subfolder by default. This is different from ASP.NET Framework that served from the root directory by default.

Currently there's no warning or error if the wwwroot directory does not exist.

This adds xml docs to clarify the default, and logs warning if the wwwroot directory is missing and you have a StaticFile middleware.