### PR TITLE
Add warning on FallbackHref property

### DIFF
--- a/src/Mvc/Mvc.TagHelpers/src/LinkTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/LinkTagHelper.cs
@@ -147,6 +147,9 @@ public class LinkTagHelper : UrlResolutionTagHelper
 
     /// <summary>
     /// The URL of a CSS stylesheet to fallback to in the case the primary one fails.
+    /// Using this option will inject inline JavaScript into the page to detect if
+    /// the primary failed to load. This option will not work in applications using
+    /// a strict Content-Security-Policy, in line with security best practice.
     /// </summary>
     [HtmlAttributeName(FallbackHrefAttributeName)]
     public string FallbackHref { get; set; }


### PR DESCRIPTION
# Add warning on FallbackHref property in LinkTagHelper



A more sensible implementation could inject a `<script>` element with a `self` `src` (with content dynamically generated by the framework); or at the very least allow the user to provide a `nonce` attribute. In the absence of either of these approaches, developers should be made aware of how this functionality is implemented as it has ramifications for any CSP which does not whitelist an `unsafe-inline` `script-src`.