### PR TITLE
Fix typo link in aspnetcore docs readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ The table below outlines the different docs in this folder and what they are hel
 | [How references are resolved](ReferenceResolution.md)       | Overview of dependency reference setup in the repo         | Anyone looking to understand how package references are configured in the repo |
 | [Servicing changes](Servicing.md) | Documentation on how to submit servicing PRs to previous releases       | Anyone to submit patches or backports to prior releases, contains the "Shiproom Template"  |
 | [Shared framework](SharedFramework.md)         | Overview of the ASP.NET Core Shared framework | Anyone looking to understand the policies in place for managing the code of the shared framework         |
-| Submodules           | Documentation on working with submodules in Git     |   Anyone working with submodules in the repo     |
+| [Submodules](Submodules.md)           | Documentation on working with submodules in Git     |   Anyone working with submodules in the repo     |
 | [Triage process](TriageProcess.md)| Overview of the issue triage process used in the repo     | Anyone looking to understand the triage process on the repo  |
 | [Updating Major Version & TFM](UpdatingMajorVersionAndTFM.md)| Instructions for updating the repo branding & TFM in preparation for a new major release     | Repo developers who want to know more about our branding & release process  |
 | [Assembly trimming guide](Trimming.md)| Guidance on adding trimming support to an ASP.NET Core assembly     | Repo developers who want to help add support for trimming to ASP.NET Core  |


### PR DESCRIPTION
Fix Submodules typo link in aspnetcore docs readme

# Fix Submodules typo link in aspnetcore docs readme

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Fix Submodules typo link in [aspnetcore docs readme](https://github.com/dotnet/aspnetcore/tree/main/docs)

![image](https://user-images.githubusercontent.com/29026887/193428618-3ac33736-0c77-4454-adca-46b3f42a8c86.png)

