### PR TITLE
Use string.StartsWith(char) and string.EndsWith(char) where applicable

### DIFF
--- a/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/BasicTestAppAuthenticationWebDriverExtensions.cs
+++ b/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/BasicTestAppAuthenticationWebDriverExtensions.cs
@@ -10,7 +10,7 @@ internal static class BasicTestAppAuthenticationWebDriverExtensions
 {
     public static void SignInAs(this IWebDriver browser, Uri baseUri, string usernameOrNull, string rolesOrNull, bool useSeparateTab = false)
     {
-        var basePath = baseUri.LocalPath.EndsWith("/", StringComparison.Ordinal) ? baseUri.LocalPath : baseUri.LocalPath + "/";
+        var basePath = baseUri.LocalPath.EndsWith('/') ? baseUri.LocalPath : baseUri.LocalPath + "/";
         var authenticationPageUrl = $"{basePath}Authentication";
         var baseRelativeUri = usernameOrNull == null
             ? $"{authenticationPageUrl}?signout=true"

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonTranscodingRouteAdapter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonTranscodingRouteAdapter.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 /// For example, consider a multi-segment parameter route:
 /// - Before: /v1/{book.name=shelves/*/books/*}
 /// - After: /v1/shelves/{__Complex_book.name_2}/books/{__Complex_book.name_4}
-/// 
+///
 /// It is rewritten so that any * or ** segments become ASP.NET Core route parameters. These parameter
 /// names are never used by the user, and instead they're reconstructed into the final value by the
 /// adapter and then added to the HttpRequest.RouteValues collection.
@@ -178,7 +178,7 @@ internal sealed class JsonTranscodingRouteAdapter
         {
             return SegmentType.CatchAll;
         }
-        else if (segment.StartsWith("*", StringComparison.Ordinal))
+        else if (segment.StartsWith('*'))
         {
             return SegmentType.Any;
         }

--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -400,7 +400,7 @@ public class ContentDispositionHeaderValue
         {
             string? result;
             // filename*=utf-8'lang'%7FMyString
-            if (parameter.EndsWith("*", StringComparison.Ordinal))
+            if (parameter.EndsWith('*'))
             {
                 if (TryDecode5987(nameParameter.Value, out result))
                 {

--- a/src/Http/Http.Abstractions/src/Extensions/MapExtensions.cs
+++ b/src/Http/Http.Abstractions/src/Extensions/MapExtensions.cs
@@ -58,7 +58,7 @@ public static class MapExtensions
             throw new ArgumentNullException(nameof(configuration));
         }
 
-        if (pathMatch.HasValue && pathMatch.Value!.EndsWith("/", StringComparison.Ordinal))
+        if (pathMatch.HasValue && pathMatch.Value!.EndsWith('/'))
         {
             throw new ArgumentException("The path must not end with a '/'", nameof(pathMatch));
         }

--- a/src/Http/Http.Results/src/VirtualFileHttpResult.cs
+++ b/src/Http/Http.Results/src/VirtualFileHttpResult.cs
@@ -152,7 +152,7 @@ public sealed class VirtualFileHttpResult : IResult, IFileHttpResult, IContentTy
     internal IFileInfo GetFileInformation(IFileProvider fileProvider)
     {
         var normalizedPath = FileName;
-        if (normalizedPath.StartsWith("~", StringComparison.Ordinal))
+        if (normalizedPath.StartsWith('~'))
         {
             normalizedPath = normalizedPath.Substring(1);
         }

--- a/src/Http/Routing.Abstractions/src/VirtualPathData.cs
+++ b/src/Http/Routing.Abstractions/src/VirtualPathData.cs
@@ -86,7 +86,7 @@ public class VirtualPathData
             return string.Empty;
         }
 
-        if (!path.StartsWith("/", StringComparison.Ordinal))
+        if (!path.StartsWith('/'))
         {
             return "/" + path;
         }

--- a/src/Http/Routing/src/ParameterPolicyActivator.cs
+++ b/src/Http/Routing/src/ParameterPolicyActivator.cs
@@ -35,7 +35,7 @@ internal static class ParameterPolicyActivator
 
         string argumentString;
         var indexOfFirstOpenParens = inlineParameterPolicy.IndexOf('(');
-        if (indexOfFirstOpenParens >= 0 && inlineParameterPolicy.EndsWith(")", StringComparison.Ordinal))
+        if (indexOfFirstOpenParens >= 0 && inlineParameterPolicy.EndsWith(')'))
         {
             parameterPolicyKey = inlineParameterPolicy.Substring(0, indexOfFirstOpenParens);
             argumentString = inlineParameterPolicy.Substring(

--- a/src/Http/Routing/src/Patterns/RoutePatternParser.cs
+++ b/src/Http/Routing/src/Patterns/RoutePatternParser.cs
@@ -220,7 +220,7 @@ internal static class RoutePatternParser
         var templatePart = RouteParameterParser.ParseRouteParameter(decoded);
 
         // See #475 - this is here because InlineRouteParameterParser can't return errors
-        if (decoded.StartsWith("*", StringComparison.Ordinal) && decoded.EndsWith("?", StringComparison.Ordinal))
+        if (decoded.StartsWith('*') && decoded.EndsWith('?'))
         {
             context.Error = Resources.TemplateRoute_CatchAllCannotBeOptional;
             return false;
@@ -466,11 +466,11 @@ internal static class RoutePatternParser
         {
             return routePattern.Substring(2);
         }
-        else if (routePattern.StartsWith("/", StringComparison.Ordinal))
+        else if (routePattern.StartsWith('/'))
         {
             return routePattern.Substring(1);
         }
-        else if (routePattern.StartsWith("~", StringComparison.Ordinal))
+        else if (routePattern.StartsWith('~'))
         {
             throw new RoutePatternException(routePattern, Resources.TemplateRoute_InvalidRouteTemplate);
         }

--- a/src/Http/Routing/src/RouteCollection.cs
+++ b/src/Http/Routing/src/RouteCollection.cs
@@ -176,7 +176,7 @@ public class RouteCollection : IRouteCollection
                 queryString = queryString.ToLowerInvariant();
             }
 
-            if (_options.AppendTrailingSlash && !urlWithoutQueryString.EndsWith("/", StringComparison.Ordinal))
+            if (_options.AppendTrailingSlash && !urlWithoutQueryString.EndsWith('/'))
             {
                 urlWithoutQueryString += "/";
             }

--- a/src/Middleware/StaticFiles/src/Infrastructure/SharedOptions.cs
+++ b/src/Middleware/StaticFiles/src/Infrastructure/SharedOptions.cs
@@ -29,7 +29,7 @@ public class SharedOptions
         get { return _requestPath; }
         set
         {
-            if (value.HasValue && value.Value!.EndsWith("/", StringComparison.Ordinal))
+            if (value.HasValue && value.Value!.EndsWith('/'))
             {
                 throw new ArgumentException("Request path must not end in a slash");
             }

--- a/src/Mvc/Mvc.Core/src/ApplicationModels/AttributeRouteModel.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationModels/AttributeRouteModel.cs
@@ -160,7 +160,7 @@ public class AttributeRouteModel
     {
         return template != null &&
             (template.StartsWith("~/", StringComparison.Ordinal) ||
-            template.StartsWith("/", StringComparison.Ordinal));
+            template.StartsWith('/'));
     }
 
     private static string? ChooseName(
@@ -192,7 +192,7 @@ public class AttributeRouteModel
             return right;
         }
 
-        if (left!.EndsWith("/", StringComparison.Ordinal))
+        if (left!.EndsWith('/'))
         {
             return left + right;
         }
@@ -225,7 +225,7 @@ public class AttributeRouteModel
         }
 
         var startIndex = 0;
-        if (result.StartsWith("/", StringComparison.Ordinal))
+        if (result.StartsWith('/'))
         {
             startIndex = 1;
         }
@@ -241,7 +241,7 @@ public class AttributeRouteModel
         }
 
         var subStringLength = result.Length - startIndex;
-        if (result.EndsWith("/", StringComparison.Ordinal))
+        if (result.EndsWith('/'))
         {
             subStringLength--;
         }

--- a/src/Mvc/Mvc.Core/src/Formatters/FormatterMappings.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/FormatterMappings.cs
@@ -114,7 +114,7 @@ public class FormatterMappings
             throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(format));
         }
 
-        if (format.StartsWith(".", StringComparison.Ordinal))
+        if (format.StartsWith('.'))
         {
             if (format == ".")
             {

--- a/src/Mvc/Mvc.Core/src/Infrastructure/VirtualFileResultExecutor.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/VirtualFileResultExecutor.cs
@@ -128,7 +128,7 @@ public partial class VirtualFileResultExecutor : FileResultExecutorBase, IAction
         }
 
         var normalizedPath = result.FileName;
-        if (normalizedPath.StartsWith("~", StringComparison.Ordinal))
+        if (normalizedPath.StartsWith('~'))
         {
             normalizedPath = normalizedPath.Substring(1);
         }

--- a/src/Mvc/Mvc.Core/src/Routing/UrlHelperBase.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/UrlHelperBase.cs
@@ -443,12 +443,12 @@ public abstract class UrlHelperBase : IUrlHelper
             {
                 builder.Append(pathBase.Value);
 
-                if (pathBase.Value.EndsWith("/", StringComparison.Ordinal))
+                if (pathBase.Value.EndsWith('/'))
                 {
                     builder.Length--;
                 }
 
-                if (!virtualPath.StartsWith("/", StringComparison.Ordinal))
+                if (!virtualPath.StartsWith('/'))
                 {
                     builder.Append('/');
                 }
@@ -483,7 +483,7 @@ public abstract class UrlHelperBase : IUrlHelper
                 url = "/";
                 return true;
             }
-            else if (virtualPath.StartsWith("/", StringComparison.Ordinal))
+            else if (virtualPath.StartsWith('/'))
             {
                 url = virtualPath;
                 return true;

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/FileProviderRazorProjectFileSystem.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/FileProviderRazorProjectFileSystem.cs
@@ -78,8 +78,8 @@ internal sealed class FileProviderRazorProjectFileSystem : RazorProjectFileSyste
 
     private static string JoinPath(string path1, string path2)
     {
-        var hasTrailingSlash = path1.EndsWith("/", StringComparison.Ordinal);
-        var hasLeadingSlash = path2.StartsWith("/", StringComparison.Ordinal);
+        var hasTrailingSlash = path1.EndsWith('/');
+        var hasLeadingSlash = path2.StartsWith('/');
         if (hasLeadingSlash && hasTrailingSlash)
         {
             return string.Concat(path1, path2.AsSpan(1));

--- a/src/Mvc/Mvc.RazorPages/src/ApplicationModels/PageRouteModelFactory.cs
+++ b/src/Mvc/Mvc.RazorPages/src/ApplicationModels/PageRouteModelFactory.cs
@@ -86,7 +86,7 @@ internal sealed partial class PageRouteModelFactory
         const string AreaPagesRoot = "/Pages/";
 
         result = default;
-        Debug.Assert(relativePath.StartsWith("/", StringComparison.Ordinal));
+        Debug.Assert(relativePath.StartsWith('/'));
         // Parse the area root directory.
         var areaRootEndIndex = relativePath.IndexOf('/', startIndex: 1);
         if (areaRootEndIndex == -1 ||
@@ -139,7 +139,7 @@ internal sealed partial class PageRouteModelFactory
         // Result = /Products/List/Categories
         Debug.Assert(!string.IsNullOrEmpty(areaName));
         Debug.Assert(!string.IsNullOrEmpty(viewEnginePath));
-        Debug.Assert(viewEnginePath.StartsWith("/", StringComparison.Ordinal));
+        Debug.Assert(viewEnginePath.StartsWith('/'));
 
         return string.Create(1 + areaName.Length + viewEnginePath.Length, (areaName, viewEnginePath), (span, tuple) =>
         {
@@ -172,8 +172,8 @@ internal sealed partial class PageRouteModelFactory
 
     private static string NormalizeDirectory(string directory)
     {
-        Debug.Assert(directory.StartsWith("/", StringComparison.Ordinal));
-        if (directory.Length > 1 && !directory.EndsWith("/", StringComparison.Ordinal))
+        Debug.Assert(directory.StartsWith('/'));
+        if (directory.Length > 1 && !directory.EndsWith('/'))
         {
             return directory + "/";
         }

--- a/src/Mvc/Mvc.RazorPages/src/DependencyInjection/RazorPagesRazorViewEngineOptionsSetup.cs
+++ b/src/Mvc/Mvc.RazorPages/src/DependencyInjection/RazorPagesRazorViewEngineOptionsSetup.cs
@@ -65,11 +65,11 @@ internal sealed class RazorPagesRazorViewEngineOptionsSetup : IConfigureOptions<
 
     private static string CombinePath(string path1, string path2)
     {
-        if (path1.EndsWith("/", StringComparison.Ordinal) || path2.StartsWith("/", StringComparison.Ordinal))
+        if (path1.EndsWith('/') || path2.StartsWith('/'))
         {
             return path1 + path2;
         }
-        else if (path1.EndsWith("/", StringComparison.Ordinal) && path2.StartsWith("/", StringComparison.Ordinal))
+        else if (path1.EndsWith('/') && path2.StartsWith('/'))
         {
             return string.Concat(path1, path2.AsSpan(1));
         }

--- a/src/Mvc/Mvc.ViewFeatures/src/NameAndIdProvider.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/NameAndIdProvider.cs
@@ -176,7 +176,7 @@ internal static class NameAndIdProvider
 
         previousNameAndId.HtmlFieldPrefix = htmlFieldPrefix;
         previousNameAndId.Expression = expression;
-        if (expression.StartsWith("[", StringComparison.Ordinal))
+        if (expression.StartsWith('['))
         {
             // The expression might represent an indexer access, in which case  with a 'dot' would be invalid.
             previousNameAndId.OutputFullName = htmlFieldPrefix + expression;

--- a/src/Mvc/Mvc.ViewFeatures/src/TemplateInfo.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/TemplateInfo.cs
@@ -97,7 +97,7 @@ public class TemplateInfo
             return partialFieldName;
         }
 
-        if (partialFieldName.StartsWith("[", StringComparison.Ordinal))
+        if (partialFieldName.StartsWith('['))
         {
             // The partialFieldName might represent an indexer access, in which case combining
             // with a 'dot' would be invalid.

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -1290,7 +1290,7 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
             return uri;
         }
 
-        if (!uri.StartsWith("/", StringComparison.Ordinal))
+        if (!uri.StartsWith('/'))
         {
             return uri;
         }

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectPostConfigureOptions.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectPostConfigureOptions.cs
@@ -87,7 +87,7 @@ public class OpenIdConnectPostConfigureOptions : IPostConfigureOptions<OpenIdCon
                 if (string.IsNullOrEmpty(options.MetadataAddress) && !string.IsNullOrEmpty(options.Authority))
                 {
                     options.MetadataAddress = options.Authority;
-                    if (!options.MetadataAddress.EndsWith("/", StringComparison.Ordinal))
+                    if (!options.MetadataAddress.EndsWith('/'))
                     {
                         options.MetadataAddress += "/";
                     }

--- a/src/Security/Authentication/WsFederation/src/WsFederationHandler.cs
+++ b/src/Security/Authentication/WsFederation/src/WsFederationHandler.cs
@@ -418,7 +418,7 @@ public class WsFederationHandler : RemoteAuthenticationHandler<WsFederationOptio
             return uri;
         }
 
-        if (!uri.StartsWith("/", StringComparison.Ordinal))
+        if (!uri.StartsWith('/'))
         {
             return uri;
         }

--- a/src/Servers/HttpSys/src/UrlPrefix.cs
+++ b/src/Servers/HttpSys/src/UrlPrefix.cs
@@ -88,7 +88,7 @@ public class UrlPrefix
         {
             path = "/";
         }
-        else if (!path.EndsWith("/", StringComparison.Ordinal))
+        else if (!path.EndsWith('/'))
         {
             path += "/";
         }


### PR DESCRIPTION
Use string.StartsWith(char) and string.EndsWith(char) where possible as the method is slightly faster. I haven't changed projects targeting netstandard2.0 as this method doesn't exist on this target.