### PR TITLE
Optimize some string.Substring usages

### DIFF
--- a/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/EnableAuthenticator.cshtml.cs
+++ b/src/Security/samples/Identity.ExternalClaims/Pages/Account/Manage/EnableAuthenticator.cshtml.cs
@@ -119,12 +119,12 @@ public class EnableAuthenticatorModel : PageModel
         int currentPosition = 0;
         while (currentPosition + 4 < unformattedKey.Length)
         {
-            result.Append(unformattedKey.Substring(currentPosition, 4)).Append(" ");
+            result.Append(unformattedKey.AsSpan(currentPosition, 4)).Append(' ');
             currentPosition += 4;
         }
         if (currentPosition < unformattedKey.Length)
         {
-            result.Append(unformattedKey.Substring(currentPosition));
+            result.Append(unformattedKey.AsSpan(currentPosition));
         }
 
         return result.ToString().ToLowerInvariant();

--- a/src/Servers/HttpSys/src/UrlPrefix.cs
+++ b/src/Servers/HttpSys/src/UrlPrefix.cs
@@ -127,11 +127,11 @@ public class UrlPrefix
         }
 
         scheme = whole.Substring(0, schemeDelimiterEnd);
-        var portString = whole.Substring(hostDelimiterEnd, pathDelimiterStart - hostDelimiterEnd); // The leading ":" is included
+        var portString = whole.AsSpan(hostDelimiterEnd, pathDelimiterStart - hostDelimiterEnd); // The leading ":" is included
         int portValue;
-        if (!string.IsNullOrEmpty(portString))
+        if (!portString.IsEmpty)
         {
-            var portValueString = portString.Substring(1); // Trim the leading ":"
+            var portValueString = portString.Slice(1); // Trim the leading ":"
             if (int.TryParse(portValueString, NumberStyles.Integer, CultureInfo.InvariantCulture, out portValue))
             {
                 host = whole.Substring(hostDelimiterStart, hostDelimiterEnd - hostDelimiterStart);


### PR DESCRIPTION
In https://github.com/dotnet/aspnetcore/pull/44273#issuecomment-1263308332, @gfoidl suggested to review other `Substring` usages in the repository.

I've identified 3 main patterns:
- `string.Substring(start, end).Trim()` -> `string.AsSpan(start, end).Trim().ToString()`
- `StringBuilder.Append(str.Substring(start, end))` -> `StringBuilder.Append(str.AsSpan(start, end))`
- A case where we can use `ReadOnlySpan<char>` directly without using a `string`

I'm not sure the first pattern is a good replacement. When `Trim` removes whitespaces, there is a perf and allocation improvements. But when value is already trimmed, the new pattern is slightly slower on my machine. So, you may want to keep the `Substring.Trim` pattern if the value is unlikely to contain whitespace. => Tell me if I must revert these changes

|               Method |          Str |      Mean |     Error |    StdDev | Ratio | RatioSD |   Gen0 | Allocated | Alloc Ratio |
|--------------------- |------------- |----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
|       Substring_Trim |      TrimStart   | 13.817 ns | 0.0912 ns | 0.0762 ns |  1.00 |    0.00 | 0.0038 |      64 B |        1.00 |
| AsSpan_Trim_ToString |      TrimStart   | 10.395 ns | 0.0859 ns | 0.0804 ns |  0.75 |    0.01 | 0.0019 |      32 B |        0.50 |
|                      |              |           |           |           |       |         |        |           |             |
|       Substring_Trim |       NoTrim   |  7.305 ns | 0.1279 ns | 0.1068 ns |  1.00 |    0.00 | 0.0019 |      32 B |        1.00 |
| AsSpan_Trim_ToString |       NoTrim   |  9.767 ns | 0.1530 ns | 0.1431 ns |  1.34 |    0.03 | 0.0019 |      32 B |        1.00 |
|                      |              |           |           |           |       |         |        |           |             |
|       Substring_Trim | TrimBoth          | 14.383 ns | 0.0993 ns | 0.0929 ns |  1.00 |    0.00 | 0.0033 |      56 B |        1.00 |
| AsSpan_Trim_ToString | TrimBoth          | 10.955 ns | 0.1231 ns | 0.1151 ns |  0.76 |    0.01 | 0.0014 |      24 B |        0.43 |