### PR TITLE
Add <title> to empty wasm template index.html

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/Client/wwwroot/index.html
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/Client/wwwroot/index.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="utf-8" />
+    <title>ComponentsWebAssembly-CSharp</title>
     <base href="/" />
     <link href="css/app.css" rel="stylesheet" />
     <!--#if PWA -->

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/Client/wwwroot/index.html
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/Client/wwwroot/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8" />
-    <title>ComponentsWebAssembly-CSharp</title>
+    <title>EmptyComponentsWebAssembly-CSharp</title>
     <base href="/" />
     <link href="css/app.css" rel="stylesheet" />
     <!--#if PWA -->


### PR DESCRIPTION
# Add <title> to empty wasm template index.html

Add <title> to empty wasm template index.html

## Description

The new Blazor WebAssembly "empty" project template lacks a `<title>`, but (1) everyone wants a title, and (2) the `<title>` element is required by the HTML spec - we can't omit it without the document being invalid. This PR adds it.

Fixes #44335

## Customer Impact

Without fixing this, newly-created projects don't conform to the HTML spec by default. And it's just strange.

## Regression?

- [ ] Yes
- [x] No - the empty wasm template is new in 7.0

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

It's just adding a `<title>` element to a plain-text HTML file, equivalently to how it already appears in the non-empty template.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
