### PR TITLE
Document 2F un-escape behavior for HttpRequest.Path

### DIFF
--- a/src/Http/Http.Abstractions/src/HttpRequest.cs
+++ b/src/Http/Http.Abstractions/src/HttpRequest.cs
@@ -47,9 +47,14 @@ public abstract class HttpRequest
     public abstract PathString PathBase { get; set; }
 
     /// <summary>
-    /// Gets or sets the request path from RequestPath.
+    /// Gets or sets the portion of the request path that identifies the requested resource.
+    /// <para>
+    /// The value may be <see cref="PathString.Empty"/> if <see cref="PathBase"/> contains the full path,
+    /// or for 'OPTIONS *' requests.
+    /// The path is fully decoded by the server except for '%2F', which would decode to '/' and
+    /// change the meaning of the path segments. '%2F' can only be replaced after splitting the path into segments.
+    /// </para>
     /// </summary>
-    /// <returns>The request path from RequestPath.</returns>
     public abstract PathString Path { get; set; }
 
     /// <summary>

--- a/src/Http/Http.Features/src/IHttpRequestFeature.cs
+++ b/src/Http/Http.Features/src/IHttpRequestFeature.cs
@@ -40,8 +40,10 @@ public interface IHttpRequestFeature
     /// <summary>
     /// Gets or sets the portion of the request path that identifies the requested resource.
     /// <para>
-    /// The value is un-escaped. The value may be <see cref="string.Empty"/> if <see cref="PathBase"/> contains the
-    /// full path.
+    /// The value may be <see cref="string.Empty"/> if <see cref="PathBase"/> contains the full path,
+    /// or for 'OPTIONS *' requests.
+    /// The path is fully decoded by the server except for '%2F', which would decode to '/' and
+    /// change the meaning of the path segments. '%2F' can only be replaced after splitting the path into segments.
     /// </para>
     /// </summary>
     string Path { get; set; }


### PR DESCRIPTION
Contributes to #30655.

This was a poor design decision but not one we can fix in the current APIs. Documenting the weird behavior for now, and considering new path segment based APIs for the future.