### PR TITLE
Update comment to say which element is targeted

### DIFF
--- a/src/Mvc/Mvc.TagHelpers/src/ValidationMessageTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/ValidationMessageTagHelper.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 namespace Microsoft.AspNetCore.Mvc.TagHelpers;
 
 /// <summary>
-/// <see cref="ITagHelper"/> implementation targeting any HTML element with an <c>asp-validation-for</c>
+/// <see cref="ITagHelper"/> implementation targeting &lt;span&gt; elements with an <c>asp-validation-for</c>
 /// attribute.
 /// </summary>
 [HtmlTargetElement("span", Attributes = ValidationForAttributeName)]

--- a/src/Mvc/Mvc.TagHelpers/src/ValidationSummaryTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/ValidationSummaryTagHelper.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 namespace Microsoft.AspNetCore.Mvc.TagHelpers;
 
 /// <summary>
-/// <see cref="ITagHelper"/> implementation targeting any HTML element with an <c>asp-validation-summary</c>
+/// <see cref="ITagHelper"/> implementation targeting &lt;div&gt; elements with an <c>asp-validation-summary</c>
 /// attribute.
 /// </summary>
 [HtmlTargetElement("div", Attributes = ValidationSummaryAttributeName)]


### PR DESCRIPTION
These comments were changed in bfdeda797df054a4ae8a6fa9250e65f07cd63a1e but are inaccurate which can lead to confusion if you're going based on IntelliSense and not looking deeper into the documentation or source.
