### PR TITLE
Fix components-e2e pipeline

### DIFF
--- a/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/BasicTestAppAuthenticationWebDriverExtensions.cs
+++ b/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/BasicTestAppAuthenticationWebDriverExtensions.cs
@@ -20,13 +20,11 @@ internal static class BasicTestAppAuthenticationWebDriverExtensions
         {
             // Some tests need to change the authentication state without discarding the
             // original page, but this adds several seconds of delay
-            var javascript = (IJavaScriptExecutor)browser;
             var originalWindow = browser.CurrentWindowHandle;
-            javascript.ExecuteScript("window.open()");
-            browser.SwitchTo().Window(browser.WindowHandles.Last());
+            browser.SwitchTo().NewWindow(WindowType.Tab);
             browser.Navigate(baseUri, baseRelativeUri, noReload: false);
             browser.Exists(By.CssSelector("h1#authentication"));
-            javascript.ExecuteScript("window.close()");
+            browser.Close();
             browser.SwitchTo().Window(originalWindow);
         }
         else

--- a/src/Shared/E2ETesting/selenium-config.json
+++ b/src/Shared/E2ETesting/selenium-config.json
@@ -1,7 +1,7 @@
 {
   "drivers": {
     "chrome": {
-      "version" : "103.0.5060.134"
+      "version" : "106.0.5249.21"
     }
   },
   "ignoreExtraDrivers": true


### PR DESCRIPTION
# Fix components-e2e pipeline

The cause of the issue appears to be how we were opening/switching tabs to sign in during the auth tests. There seems to be some flakiness in `IWebDriver.WindowHandles` (possibly a selenium bug). This PR simplifies our approach and avoids using `WindowHandles`.

I also updated the ChromeDriver version, since that hasn't been done in a while.

Fixes #44385
