### PR TITLE
Standard stream argument validation

### DIFF
--- a/src/Components/Shared/src/ArrayBuilderMemoryStream.cs
+++ b/src/Components/Shared/src/ArrayBuilderMemoryStream.cs
@@ -57,7 +57,7 @@ internal sealed class ArrayBuilderMemoryStream : Stream
     /// <inheritdoc />
     public override void Write(byte[] buffer, int offset, int count)
     {
-        ValidateArguments(buffer, offset, count);
+        ValidateBufferArguments(buffer, offset, count);
 
         ArrayBuilder.Append(buffer, offset, count);
     }
@@ -76,7 +76,7 @@ internal sealed class ArrayBuilderMemoryStream : Stream
     /// <inheritdoc />
     public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
     {
-        ValidateArguments(buffer, offset, count);
+        ValidateBufferArguments(buffer, offset, count);
 
         ArrayBuilder.Append(buffer, offset, count);
         return Task.CompletedTask;
@@ -102,30 +102,6 @@ internal sealed class ArrayBuilderMemoryStream : Stream
 
     /// <inheritdoc />
     public override ValueTask DisposeAsync() => default;
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void ValidateArguments(byte[] buffer, int offset, int count)
-    {
-        if (buffer == null)
-        {
-            ThrowHelper.ThrowArgumentNullException(nameof(buffer));
-        }
-
-        if (offset < 0)
-        {
-            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(offset));
-        }
-
-        if (count < 0)
-        {
-            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(count));
-        }
-
-        if (buffer.Length - offset < count)
-        {
-            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(offset));
-        }
-    }
 
     private static class ThrowHelper
     {

--- a/src/Hosting/TestHost/src/ResponseBodyReaderStream.cs
+++ b/src/Hosting/TestHost/src/ResponseBodyReaderStream.cs
@@ -68,8 +68,6 @@ internal sealed class ResponseBodyReaderStream : Stream
 
     public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
     {
-        VerifyBuffer(buffer, offset, count);
-
         return ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
     }
 
@@ -103,22 +101,6 @@ internal sealed class ResponseBodyReaderStream : Stream
         readableBuffer.CopyTo(buffer.Span);
         _pipe.Reader.AdvanceTo(readableBuffer.End);
         return (int)actual;
-    }
-
-    private static void VerifyBuffer(byte[] buffer, int offset, int count)
-    {
-        if (buffer == null)
-        {
-            throw new ArgumentNullException(nameof(buffer));
-        }
-        if (offset < 0 || offset > buffer.Length)
-        {
-            throw new ArgumentOutOfRangeException(nameof(offset), offset, string.Empty);
-        }
-        if (count <= 0 || count > buffer.Length - offset)
-        {
-            throw new ArgumentOutOfRangeException(nameof(count), count, string.Empty);
-        }
     }
 
     internal void Cancel()

--- a/src/Http/WebUtilities/src/BufferedReadStream.cs
+++ b/src/Http/WebUtilities/src/BufferedReadStream.cs
@@ -204,7 +204,7 @@ public class BufferedReadStream : Stream
     /// <inheritdoc/>
     public override int Read(byte[] buffer, int offset, int count)
     {
-        ValidateBuffer(buffer, offset, count);
+        ValidateBufferArguments(buffer, offset, count);
 
         // Drain buffer
         if (_bufferCount > 0)
@@ -222,7 +222,6 @@ public class BufferedReadStream : Stream
     /// <inheritdoc/>
     public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
     {
-        ValidateBuffer(buffer, offset, count);
         return ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
     }
 
@@ -420,15 +419,5 @@ public class BufferedReadStream : Stream
     private void CheckDisposed()
     {
         ObjectDisposedException.ThrowIf(_disposed, nameof(BufferedReadStream));
-    }
-
-    private static void ValidateBuffer(byte[] buffer, int offset, int count)
-    {
-        // Delegate most of our validation.
-        _ = new ArraySegment<byte>(buffer, offset, count);
-        if (count == 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(count), "The value must be greater than zero.");
-        }
     }
 }

--- a/src/Http/WebUtilities/src/FileBufferingWriteStream.cs
+++ b/src/Http/WebUtilities/src/FileBufferingWriteStream.cs
@@ -108,7 +108,7 @@ public sealed class FileBufferingWriteStream : Stream
     /// <inheritdoc />
     public override void Write(byte[] buffer, int offset, int count)
     {
-        ThrowArgumentException(buffer, offset, count);
+        ValidateBufferArguments(buffer, offset, count);
         ThrowIfDisposed();
 
         if (_bufferLimit.HasValue && _bufferLimit - Length < count)
@@ -141,7 +141,6 @@ public sealed class FileBufferingWriteStream : Stream
     /// <inheritdoc />
     public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
     {
-        ThrowArgumentException(buffer, offset, count);
         await WriteAsync(buffer.AsMemory(offset, count), cancellationToken);
     }
 
@@ -284,25 +283,5 @@ public sealed class FileBufferingWriteStream : Stream
     private void ThrowIfDisposed()
     {
         ObjectDisposedException.ThrowIf(Disposed, nameof(FileBufferingWriteStream));
-    }
-
-    private static void ThrowArgumentException(byte[] buffer, int offset, int count)
-    {
-        ArgumentNullException.ThrowIfNull(buffer);
-
-        if (offset < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(offset));
-        }
-
-        if (count < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(count));
-        }
-
-        if (buffer.Length - offset < count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(offset));
-        }
     }
 }

--- a/src/Middleware/OutputCaching/src/Streams/SegmentWriteStream.cs
+++ b/src/Middleware/OutputCaching/src/Streams/SegmentWriteStream.cs
@@ -122,20 +122,7 @@ internal sealed class SegmentWriteStream : Stream
 
     public override void Write(byte[] buffer, int offset, int count)
     {
-        ArgumentNullException.ThrowIfNull(buffer);
-
-        if (offset < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(offset), offset, "Non-negative number required.");
-        }
-        if (count < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(count), count, "Non-negative number required.");
-        }
-        if (count > buffer.Length - offset)
-        {
-            throw new ArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
-        }
+        ValidateBufferArguments(buffer, offset, count);
         if (!CanWrite)
         {
             throw new ObjectDisposedException("The stream has been closed for writing.");

--- a/src/Middleware/ResponseCaching/src/Streams/SegmentWriteStream.cs
+++ b/src/Middleware/ResponseCaching/src/Streams/SegmentWriteStream.cs
@@ -122,22 +122,7 @@ internal sealed class SegmentWriteStream : Stream
 
     public override void Write(byte[] buffer, int offset, int count)
     {
-        if (buffer == null)
-        {
-            throw new ArgumentNullException(nameof(buffer));
-        }
-        if (offset < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(offset), offset, "Non-negative number required.");
-        }
-        if (count < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(count), count, "Non-negative number required.");
-        }
-        if (count > buffer.Length - offset)
-        {
-            throw new ArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
-        }
+        ValidateBufferArguments(buffer, offset, count);
         if (!CanWrite)
         {
             throw new ObjectDisposedException("The stream has been closed for writing.");

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestStream.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestStream.cs
@@ -94,19 +94,6 @@ internal sealed partial class RequestStream : Stream
         _requestContext.Abort();
     }
 
-    private static void ValidateReadBuffer(byte[] buffer, int offset, int size)
-    {
-        ArgumentNullException.ThrowIfNull(buffer);
-        if ((uint)offset > (uint)buffer.Length)
-        {
-            throw new ArgumentOutOfRangeException(nameof(offset), offset, string.Empty);
-        }
-        if ((uint)size > (uint)(buffer.Length - offset))
-        {
-            throw new ArgumentOutOfRangeException(nameof(size), size, string.Empty);
-        }
-    }
-
     public override unsafe int Read([In, Out] byte[] buffer, int offset, int size)
     {
         if (!RequestContext.AllowSynchronousIO)
@@ -114,7 +101,7 @@ internal sealed partial class RequestStream : Stream
             throw new InvalidOperationException("Synchronous IO APIs are disabled, see AllowSynchronousIO.");
         }
 
-        ValidateReadBuffer(buffer, offset, size);
+        ValidateBufferArguments(buffer, offset, size);
         CheckSizeLimit();
         if (_closed)
         {
@@ -200,7 +187,7 @@ internal sealed partial class RequestStream : Stream
 
     public override unsafe Task<int> ReadAsync(byte[] buffer, int offset, int size, CancellationToken cancellationToken)
     {
-        ValidateReadBuffer(buffer, offset, size);
+        ValidateBufferArguments(buffer, offset, size);
         CheckSizeLimit();
         if (_closed)
         {

--- a/src/Servers/HttpSys/test/FunctionalTests/RequestBodyTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/RequestBodyTests.cs
@@ -127,10 +127,10 @@ public class RequestBodyTests
             byte[] input = new byte[100];
             Assert.Throws<ArgumentNullException>("buffer", () => httpContext.Request.Body.Read(null, 0, 1));
             Assert.Throws<ArgumentOutOfRangeException>("offset", () => httpContext.Request.Body.Read(input, -1, 1));
-            Assert.Throws<ArgumentOutOfRangeException>("offset", () => httpContext.Request.Body.Read(input, input.Length + 1, 1));
-            Assert.Throws<ArgumentOutOfRangeException>("size", () => httpContext.Request.Body.Read(input, 10, -1));
-            Assert.Throws<ArgumentOutOfRangeException>("size", () => httpContext.Request.Body.Read(input, 1, input.Length));
-            Assert.Throws<ArgumentOutOfRangeException>("size", () => httpContext.Request.Body.Read(input, 0, input.Length + 1));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => httpContext.Request.Body.Read(input, input.Length + 1, 1));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => httpContext.Request.Body.Read(input, 10, -1));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => httpContext.Request.Body.Read(input, 1, input.Length));
+            Assert.Throws<ArgumentOutOfRangeException>("count", () => httpContext.Request.Body.Read(input, 0, input.Length + 1));
             return Task.FromResult(0);
         }))
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/41692

This is forward port of the TestServer patch from 6.0: https://github.com/dotnet/aspnetcore/pull/44020. This fix enabled zero-byte reads which is a pattern used by YARP.

I also looked for other streams that had this issue and changed them to use the standard validation method not available from the base Stream class. In a few places we rely directly on the validation done by AsMemory.