### PR TITLE
Remove CookieNameEncoding

### DIFF
--- a/src/Http/Http/src/Internal/RequestCookieCollection.cs
+++ b/src/Http/Http/src/Internal/RequestCookieCollection.cs
@@ -59,9 +59,6 @@ internal sealed class RequestCookieCollection : IRequestCookieCollection
     }
 
     public static RequestCookieCollection Parse(StringValues values)
-       => ParseInternal(values, AppContext.TryGetSwitch(ResponseCookies.EnableCookieNameEncoding, out var enabled) && enabled);
-
-    internal static RequestCookieCollection ParseInternal(StringValues values, bool enableCookieNameEncoding)
     {
         if (values.Count == 0)
         {
@@ -72,7 +69,7 @@ internal sealed class RequestCookieCollection : IRequestCookieCollection
         var collection = new RequestCookieCollection();
         var store = collection.Store!;
 
-        if (CookieHeaderParserShared.TryParseValues(values, store, enableCookieNameEncoding, supportsMultipleValues: true))
+        if (CookieHeaderParserShared.TryParseValues(values, store, supportsMultipleValues: true))
         {
             if (store.Count == 0)
             {

--- a/src/Http/Http/src/Internal/ResponseCookies.cs
+++ b/src/Http/Http/src/Internal/ResponseCookies.cs
@@ -14,9 +14,6 @@ namespace Microsoft.AspNetCore.Http;
 /// </summary>
 internal sealed partial class ResponseCookies : IResponseCookies
 {
-    internal const string EnableCookieNameEncoding = "Microsoft.AspNetCore.Http.EnableCookieNameEncoding";
-    internal bool _enableCookieNameEncoding = AppContext.TryGetSwitch(EnableCookieNameEncoding, out var enabled) && enabled;
-
     private readonly IFeatureCollection _features;
     private ILogger? _logger;
 
@@ -34,9 +31,7 @@ internal sealed partial class ResponseCookies : IResponseCookies
     /// <inheritdoc />
     public void Append(string key, string value)
     {
-        var setCookieHeaderValue = new SetCookieHeaderValue(
-            _enableCookieNameEncoding ? Uri.EscapeDataString(key) : key,
-            Uri.EscapeDataString(value))
+        var setCookieHeaderValue = new SetCookieHeaderValue(key, Uri.EscapeDataString(value))
         {
             Path = "/"
         };
@@ -68,10 +63,7 @@ internal sealed partial class ResponseCookies : IResponseCookies
             }
         }
 
-        var cookie = options.CreateCookieHeader(
-            _enableCookieNameEncoding ? Uri.EscapeDataString(key) : key,
-            Uri.EscapeDataString(value)).ToString();
-
+        var cookie = options.CreateCookieHeader(key, Uri.EscapeDataString(value)).ToString();
         Headers.SetCookie = StringValues.Concat(Headers.SetCookie, cookie);
     }
 
@@ -107,8 +99,7 @@ internal sealed partial class ResponseCookies : IResponseCookies
 
         foreach (var keyValuePair in keyValuePairs)
         {
-            var key = _enableCookieNameEncoding ? Uri.EscapeDataString(keyValuePair.Key) : keyValuePair.Key;
-            cookies[position] = string.Concat(key, "=", Uri.EscapeDataString(keyValuePair.Value), cookieSuffix);
+            cookies[position] = string.Concat(keyValuePair.Key, "=", Uri.EscapeDataString(keyValuePair.Value), cookieSuffix);
             position++;
         }
 
@@ -131,7 +122,7 @@ internal sealed partial class ResponseCookies : IResponseCookies
             throw new ArgumentNullException(nameof(options));
         }
 
-        var encodedKeyPlusEquals = (_enableCookieNameEncoding ? Uri.EscapeDataString(key) : key) + "=";
+        var encodedKeyPlusEquals = key + "=";
         var domainHasValue = !string.IsNullOrEmpty(options.Domain);
         var pathHasValue = !string.IsNullOrEmpty(options.Path);
 

--- a/src/Http/Http/test/RequestCookiesCollectionTests.cs
+++ b/src/Http/Http/test/RequestCookiesCollectionTests.cs
@@ -22,21 +22,6 @@ public class RequestCookiesCollectionTests
         Assert.Equal(expectedValue, cookies[expectedKey]);
     }
 
-    [Theory]
-    [InlineData("key=value", "key", "value")]
-    [InlineData("key%2C=%21value", "key,", "!value")]
-    [InlineData("ke%23y%2C=val%5Eue", "ke#y,", "val^ue")]
-    [InlineData("base64=QUI%2BREU%2FRw%3D%3D", "base64", "QUI+REU/Rw==")]
-    [InlineData("base64=QUI+REU/Rw==", "base64", "QUI+REU/Rw==")]
-    public void AppContextSwitchUnEscapesKeysAndValues(string input, string expectedKey, string expectedValue)
-    {
-        var cookies = RequestCookieCollection.ParseInternal(new StringValues(input), enableCookieNameEncoding: true);
-
-        Assert.Equal(1, cookies.Count);
-        Assert.Equal(expectedKey, cookies.Keys.Single());
-        Assert.Equal(expectedValue, cookies[expectedKey]);
-    }
-
     [Fact]
     public void ParseManyCookies()
     {

--- a/src/Http/Http/test/ResponseCookiesTest.cs
+++ b/src/Http/Http/test/ResponseCookiesTest.cs
@@ -269,23 +269,4 @@ public class ResponseCookiesTest
 
         Assert.Throws<ArgumentException>(() => cookies.Append(key, "1"));
     }
-
-    [Theory]
-    [InlineData("key", "value", "key=value")]
-    [InlineData("key,", "!value", "key%2C=%21value")]
-    [InlineData("ke#y,", "val^ue", "ke%23y%2C=val%5Eue")]
-    [InlineData("base64", "QUI+REU/Rw==", "base64=QUI%2BREU%2FRw%3D%3D")]
-    public void AppContextSwitchEscapesKeysAndValuesBeforeSettingCookie(string key, string value, string expected)
-    {
-        var headers = (IHeaderDictionary)new HeaderDictionary();
-        var features = MakeFeatures(headers);
-        var cookies = new ResponseCookies(features);
-        cookies._enableCookieNameEncoding = true;
-
-        cookies.Append(key, value);
-
-        var cookieHeaderValues = headers.SetCookie;
-        Assert.Single(cookieHeaderValues);
-        Assert.StartsWith(expected, cookieHeaderValues[0]);
-    }
 }

--- a/src/Http/Shared/CookieHeaderParserShared.cs
+++ b/src/Http/Shared/CookieHeaderParserShared.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Net.Http.Headers;
 
 internal static class CookieHeaderParserShared
 {
-    public static bool TryParseValues(StringValues values, IDictionary<string, string> store, bool enableCookieNameEncoding, bool supportsMultipleValues)
+    public static bool TryParseValues(StringValues values, IDictionary<string, string> store, bool supportsMultipleValues)
     {
         // If a parser returns an empty list, it means there was no value, but that's valid (e.g. "Accept: "). The caller
         // can ignore the value.
@@ -29,8 +29,7 @@ internal static class CookieHeaderParserShared
                 if (TryParseValue(value, ref index, supportsMultipleValues, out var parsedName, out var parsedValue))
                 {
                     // The entry may not contain an actual value, like " , "
-                    var name = enableCookieNameEncoding ? Uri.UnescapeDataString(parsedName.Value.Value!) : parsedName.Value.Value!;
-                    store[name] = Uri.UnescapeDataString(parsedValue.Value.Value!);
+                    store[parsedName.Value.Value!] = Uri.UnescapeDataString(parsedValue.Value.Value!);
                     hasFoundValue = true;
                 }
                 else


### PR DESCRIPTION
This AppCompat switch was added a few releases ago as a temporary measure. We want to remove it for .NET 8.

Fixes #44396