### PR TITLE
Fix invalid redirection after 2FA sign-in (#44395)

### DIFF
--- a/src/Identity/Core/src/IdentityCookiesBuilderExtensions.cs
+++ b/src/Identity/Core/src/IdentityCookiesBuilderExtensions.cs
@@ -100,6 +100,10 @@ public static class IdentityCookieAuthenticationBuilderExtensions
         builder.AddCookie(IdentityConstants.TwoFactorUserIdScheme, o =>
         {
             o.Cookie.Name = IdentityConstants.TwoFactorUserIdScheme;
+            o.Events = new CookieAuthenticationEvents
+            {
+                OnRedirectToReturnUrl = _ => Task.CompletedTask
+            };
             o.ExpireTimeSpan = TimeSpan.FromMinutes(5);
         });
         return new OptionsBuilder<CookieAuthenticationOptions>(builder.Services, IdentityConstants.TwoFactorUserIdScheme);

--- a/src/Identity/Core/src/IdentityServiceCollectionExtensions.cs
+++ b/src/Identity/Core/src/IdentityServiceCollectionExtensions.cs
@@ -72,6 +72,10 @@ public static class IdentityServiceCollectionExtensions
         .AddCookie(IdentityConstants.TwoFactorUserIdScheme, o =>
         {
             o.Cookie.Name = IdentityConstants.TwoFactorUserIdScheme;
+            o.Events = new CookieAuthenticationEvents
+            {
+                OnRedirectToReturnUrl = _ => Task.CompletedTask
+            };
             o.ExpireTimeSpan = TimeSpan.FromMinutes(5);
         });
 


### PR DESCRIPTION
# Fix invalid redirection after 2FA sign-in (#44395)

This PR adds new default event handler for 2FA sign-in standard algorithm.

## Description

There is a redundant user redirection when error ocurs during 2FA after `IdentityResult.RequiresTwoFactor` result for _/Account/Login_ (or other default) page.

Fixes #44395
