### PR TITLE
Always run inline for socket callbacks

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionContextFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionContextFactory.cs
@@ -42,14 +42,6 @@ public sealed class SocketConnectionContextFactory : IDisposable
         var maxWriteBufferSize = _options.MaxWriteBufferSize ?? 0;
         var applicationScheduler = options.UnsafePreferInlineScheduling ? PipeScheduler.Inline : PipeScheduler.ThreadPool;
 
-        // Socket callbacks run on the threads polling for IO if we're using the old Windows thread pool
-        var dispatchSocketCallbacks = OperatingSystem.IsWindows() &&
-                                      (Environment.GetEnvironmentVariable("DOTNET_ThreadPool_UsePortableThreadPoolForIO") == "0" ||
-                                      Environment.GetEnvironmentVariable("COMPlus_ThreadPool_UsePortableThreadPoolForIO") == "0");
-
-        PipeScheduler SelectSocketsScheduler(PipeScheduler dispatchingScheduler) =>
-            dispatchSocketCallbacks ? dispatchingScheduler : PipeScheduler.Inline;
-
         if (_settingsCount > 0)
         {
             _settings = new QueueSettings[_settingsCount];
@@ -58,14 +50,13 @@ public sealed class SocketConnectionContextFactory : IDisposable
             {
                 var memoryPool = _options.MemoryPoolFactory();
                 var transportScheduler = options.UnsafePreferInlineScheduling ? PipeScheduler.Inline : new IOQueue();
-                var socketsScheduler = SelectSocketsScheduler(transportScheduler);
 
                 _settings[i] = new QueueSettings()
                 {
                     Scheduler = transportScheduler,
                     InputOptions = new PipeOptions(memoryPool, applicationScheduler, transportScheduler, maxReadBufferSize, maxReadBufferSize / 2, useSynchronizationContext: false),
                     OutputOptions = new PipeOptions(memoryPool, transportScheduler, applicationScheduler, maxWriteBufferSize, maxWriteBufferSize / 2, useSynchronizationContext: false),
-                    SocketSenderPool = new SocketSenderPool(socketsScheduler),
+                    SocketSenderPool = new SocketSenderPool(PipeScheduler.Inline),
                     MemoryPool = memoryPool,
                 };
             }
@@ -74,7 +65,6 @@ public sealed class SocketConnectionContextFactory : IDisposable
         {
             var memoryPool = _options.MemoryPoolFactory();
             var transportScheduler = options.UnsafePreferInlineScheduling ? PipeScheduler.Inline : PipeScheduler.ThreadPool;
-            var socketsScheduler = SelectSocketsScheduler(transportScheduler);
 
             _settings = new QueueSettings[]
             {
@@ -83,7 +73,7 @@ public sealed class SocketConnectionContextFactory : IDisposable
                     Scheduler = transportScheduler,
                     InputOptions = new PipeOptions(memoryPool, applicationScheduler, transportScheduler, maxReadBufferSize, maxReadBufferSize / 2, useSynchronizationContext: false),
                     OutputOptions = new PipeOptions(memoryPool, transportScheduler, applicationScheduler, maxWriteBufferSize, maxWriteBufferSize / 2, useSynchronizationContext: false),
-                    SocketSenderPool = new SocketSenderPool(socketsScheduler),
+                    SocketSenderPool = new SocketSenderPool(PipeScheduler.Inline),
                     MemoryPool = memoryPool,
                 }
             };


### PR DESCRIPTION
- .NET 8 removed the windows native threadpool fallback for socket IO completions. Remove the checks for flags that no longer exist.
