### PR TITLE
update contributing guidelines to state that Squash is preferred

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,12 @@ If you don't know what a pull request is read this article: <https://help.github
 
 Your pull request will now go through extensive checks by the subject matter experts on our team. Please be patient; we have hundreds of pull requests across all of our repositories. Update your pull request according to feedback until it is approved by one of the ASP.NET team members. After that, one of our team members may adjust the branch you merge into based on the expected release schedule.
 
+## Merging pull requests
+
+When your pull request has had all feedback addressed, it has been signed off by one or more reviewers with commit access, and all checks are green, we will commit it.
+
+We commit pull requests as a single Squash commit unless there are special circumstances. This creates a simpler history than a Merge or Rebase commit. "Special circumstances" are rare, and typically mean that there are a series of cleanly separated changes that will be too hard to understand if squashed together, or for some reason we want to preserve the ability to bisect them.
+
 ## Code of conduct
 
 See [CODE-OF-CONDUCT.md](./CODE-OF-CONDUCT.md)


### PR DESCRIPTION
I understand from @captainsafia that this is de-facto policy.

BTW, we may want to require admin elevation for merge and rebase into main. dotnet/runtime does this and it has caused little or no trouble.
