### PR TITLE
Update project template precedence values

### DIFF
--- a/src/ProjectTemplates/Web.Client.ItemTemplates/content/Less/.template.config/template.json
+++ b/src/ProjectTemplates/Web.Client.ItemTemplates/content/Less/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "LESS is a language that compiles into CSS",
   "groupIdentity": "Microsoft.DotNet.Web.ClientItems.Less",
-  "precedence": "100",
+  "precedence": "700",
   "identity": "Microsoft.DotNet.Web.ClientItems.Less.7.0",
   "shortName": "less",
   "sourceName": "styleSheet1",

--- a/src/ProjectTemplates/Web.Client.ItemTemplates/content/Scss/.template.config/template.json
+++ b/src/ProjectTemplates/Web.Client.ItemTemplates/content/Scss/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "SCSS is a language that compiles into CSS",
   "groupIdentity": "Microsoft.DotNet.Web.ClientItems.Scss",
-  "precedence": "100",
+  "precedence": "700",
   "identity": "Microsoft.DotNet.Web.ClientItems.Scss.7.0",
   "shortName": "scss",
   "sourceName": "styleSheet1",

--- a/src/ProjectTemplates/Web.Client.ItemTemplates/content/TypeScript/.template.config/template.json
+++ b/src/ProjectTemplates/Web.Client.ItemTemplates/content/TypeScript/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A blank TypeScript source file",
   "groupIdentity": "Microsoft.DotNet.Web.ClientItems.TypeScript",
-  "precedence": "100",
+  "precedence": "700",
   "identity": "Microsoft.DotNet.Web.ClientItems.TypeScript.7.0",
   "shortName": "tsfile",
   "sourceName": "file1",

--- a/src/ProjectTemplates/Web.ItemTemplates/content/Protobuf/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/Protobuf/.template.config/template.json
@@ -13,7 +13,7 @@
     "type": "item"
   },
   "groupIdentity": "Microsoft.Web.Grpc.Protobuf",
-  "precedence": "600",
+  "precedence": "700",
   "identity": "Microsoft.Web.Grpc.Protobuf.7.0",
   "shortname": "proto",
   "sourceName": "protobuf",

--- a/src/ProjectTemplates/Web.ItemTemplates/content/RazorComponent/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/RazorComponent/.template.config/template.json
@@ -13,7 +13,7 @@
     "type": "item"
   },
   "groupIdentity": "Microsoft.AspNetCore.Components.RazorComponent",
-  "precedence": "600",
+  "precedence": "700",
   "identity": "Microsoft.AspNetCore.Components.RazorComponent.7.0",
   "shortname": "razorcomponent",
   "sourceName": "Component1",

--- a/src/ProjectTemplates/Web.ItemTemplates/content/RazorPage/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/RazorPage/.template.config/template.json
@@ -10,7 +10,7 @@
     "type": "item"
   },
   "groupIdentity": "Microsoft.AspNetCore.Mvc.RazorPage",
-  "precedence": "600",
+  "precedence": "700",
   "identity": "Microsoft.AspNetCore.Mvc.RazorPage.7.0",
   "shortName": "page",
   "sourceName": "Index",

--- a/src/ProjectTemplates/Web.ItemTemplates/content/ViewImports/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/ViewImports/.template.config/template.json
@@ -10,7 +10,7 @@
     "type": "item"
   },
   "groupIdentity": "Microsoft.AspNetCore.Mvc.ViewImports",
-  "precedence": "600",
+  "precedence": "700",
   "identity": "Microsoft.AspNetCore.Mvc.ViewImports.7.0",
   "shortName": "viewimports",
   "sourceName": "ignoreme",

--- a/src/ProjectTemplates/Web.ItemTemplates/content/ViewStart/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ItemTemplates/content/ViewStart/.template.config/template.json
@@ -10,7 +10,7 @@
     "type": "item"
   },
   "groupIdentity": "Microsoft.AspNetCore.Mvc.ViewStart",
-  "precedence": "600",
+  "precedence": "700",
   "identity": "Microsoft.AspNetCore.Mvc.ViewStart.7.0",
   "shortName": "viewstart",
   "sourceName": "ignoreme",


### PR DESCRIPTION
# Update project template precedence values

When .NET 6 and .NET 7 are installed side-by-side, some item templates cannot be created via `dotnet new`. This PR fixes the issue by giving the 7.0 templates higher precedence.

## Description

Attempting to run `dotnet new` using one of the affected project templates (e.g. "page") results in the following error:

```
Unable to resolve the template, the following installed templates are conflicting:
Identity                                Template Name  Short Name  Language  Precedence  Author     Package
--------------------------------------  -------------  ----------  --------  ----------  ---------  -------
Microsoft.AspNetCore.Mvc.RazorPage.6.0  Razor Page     page        C#        600         Microsoft
Microsoft.AspNetCore.Mvc.RazorPage.7.0  Razor Page     page        C#        600         Microsoft

Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.
```

The fix is to update the "precedence" values for each template to correlate with the major version (e.g. `700` for .NET 7).

## Customer Impact

Without this fix, customers would not be able to use `dotnet new` with any of the templates defined in `Web.ItemTemplates` or `Web.Client.ItemTemplates` if .NET 6 and .NET 7 are installed side-by-side.

## Regression?

- [ ] Yes
- [X] No

This is a new bug that occurs when .NET 6 and .NET 7 are installed side-by-side.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

This PR changes a single value for each affected template configuration. We've already updated the precedence values for other templates and haven't seen any problems arise from that change.

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A