### PR TITLE
Don't package Microsoft.Aspnetcore.Ratelimiting

### DIFF
--- a/eng/SharedFramework.Local.props
+++ b/eng/SharedFramework.Local.props
@@ -18,7 +18,6 @@
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.Extensions.Identity.Stores" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Connections.Abstractions" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Authorization" />
-    <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.RateLimiting" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Http.Connections.Common" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.SignalR.Protocols.Json" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.SignalR.Common" />
@@ -79,6 +78,7 @@
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Localization.Routing" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Localization" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.OutputCaching" />
+    <AspNetCoreAppReference Include="Microsoft.AspNetCore.RateLimiting" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.RequestDecompression" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.ResponseCaching.Abstractions" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.ResponseCaching" />

--- a/src/Middleware/RateLimiting/src/Microsoft.AspNetCore.RateLimiting.csproj
+++ b/src/Middleware/RateLimiting/src/Microsoft.AspNetCore.RateLimiting.csproj
@@ -7,6 +7,7 @@
     <PackageTags>aspnetcore</PackageTags>
     <IsTrimmable>true</IsTrimmable>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Don't package Microsoft.Aspnetcore.Ratelimiting

Only ship Microsoft.Aspnetcore.Ratelimiting in the Shared Framework

## Description

Turns off the package build for Microsoft.Aspnetcore.Ratelimiting so that it only ships via the Shared Framework

## Customer Impact

Eliminates confusion over how to ingest Microsoft.Aspnetcore.Ratelimiting

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

People consuming this via a package would already have needed to use our SharedFx as well, so they shouldn't be broken by this.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props