### PR TITLE
Fix logging of certificate chain errors.

### DIFF
--- a/src/Security/Authentication/Certificate/src/CertificateAuthenticationHandler.cs
+++ b/src/Security/Authentication/Certificate/src/CertificateAuthenticationHandler.cs
@@ -152,7 +152,7 @@ internal sealed class CertificateAuthenticationHandler : AuthenticationHandler<C
             {
                 chainErrors.Add($"{validationFailure.Status} {validationFailure.StatusInformation}");
             }
-            Logger.CertificateFailedValidation(clientCertificate.Subject, chainErrors);
+            Logger.CertificateFailedValidation(clientCertificate.Subject, string.Join(",", chainErrors));
             return AuthenticateResults.InvalidClientCertificate;
         }
 

--- a/src/Security/Authentication/Certificate/src/CertificateAuthenticationHandler.cs
+++ b/src/Security/Authentication/Certificate/src/CertificateAuthenticationHandler.cs
@@ -152,7 +152,7 @@ internal sealed class CertificateAuthenticationHandler : AuthenticationHandler<C
             {
                 chainErrors.Add($"{validationFailure.Status} {validationFailure.StatusInformation}");
             }
-            Logger.CertificateFailedValidation(clientCertificate.Subject, string.Join(",", chainErrors));
+            Logger.CertificateFailedValidation(clientCertificate.Subject, chainErrors);
             return AuthenticateResults.InvalidClientCertificate;
         }
 

--- a/src/Security/Authentication/Certificate/src/LoggingExtensions.cs
+++ b/src/Security/Authentication/Certificate/src/LoggingExtensions.cs
@@ -15,5 +15,5 @@ internal static partial class LoggingExtensions
     public static partial void CertificateRejected(this ILogger logger, string certificateType, string subject);
 
     [LoggerMessage(2, LogLevel.Warning, "Certificate validation failed, subject was {Subject}. {ChainErrors}", EventName = "CertificateFailedValidation")]
-    public static partial void CertificateFailedValidation(this ILogger logger, string subject, string chainErrors);
+    public static partial void CertificateFailedValidation(this ILogger logger, string subject, IList<string> chainErrors);
 }

--- a/src/Security/Authentication/Certificate/src/LoggingExtensions.cs
+++ b/src/Security/Authentication/Certificate/src/LoggingExtensions.cs
@@ -15,5 +15,5 @@ internal static partial class LoggingExtensions
     public static partial void CertificateRejected(this ILogger logger, string certificateType, string subject);
 
     [LoggerMessage(2, LogLevel.Warning, "Certificate validation failed, subject was {Subject}. {ChainErrors}", EventName = "CertificateFailedValidation")]
-    public static partial void CertificateFailedValidation(this ILogger logger, string subject, IEnumerable<string> chainErrors);
+    public static partial void CertificateFailedValidation(this ILogger logger, string subject, string chainErrors);
 }


### PR DESCRIPTION
Use comma-separated list to format the logged string.

# Fix logging of certificate chain errors.

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Without this the log just says: "System.Collections.Generic.List1[System.String]".

Fixes #44484
