### PR TITLE
Skip template update check in template tests

### DIFF
--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -73,7 +73,7 @@ public class Project : IDisposable
         IDictionary<string, string> environmentVariables = null)
     {
         var hiveArg = $" --debug:disable-sdk-templates --debug:custom-hive \"{TemplatePackageInstaller.CustomHivePath}\"";
-        var argString = $"new {templateName} {hiveArg}";
+        var argString = $"new {templateName} {hiveArg} --no-update-check";
         environmentVariables ??= new Dictionary<string, string>();
         if (!string.IsNullOrEmpty(auth))
         {
@@ -361,7 +361,7 @@ public class Project : IDisposable
             AppContext.BaseDirectory,
             DotNetMuxer.MuxerPathOrDefault(),
             arguments +
-                $" --debug:disable-sdk-templates --debug:custom-hive \"{TemplatePackageInstaller.CustomHivePath}\"" +
+                $" --debug:disable-sdk-templates --debug:custom-hive \"{TemplatePackageInstaller.CustomHivePath}\" --no-update-check" +
                 $" -o {TemplateOutputDir}");
         await result.Exited;
         Assert.True(result.ExitCode == 0, result.GetFormattedOutput());

--- a/src/ProjectTemplates/Shared/TemplatePackageInstaller.cs
+++ b/src/ProjectTemplates/Shared/TemplatePackageInstaller.cs
@@ -74,7 +74,7 @@ internal static class TemplatePackageInstaller
             DotNetMuxer.MuxerPathOrDefault(),
             //--debug:disable-sdk-templates means, don't include C:\Program Files\dotnet\templates, aka. what comes with SDK, so we don't need to uninstall
             //--debug:custom-hive means, don't install templates on CI/developer machine, instead create new temporary instance
-            $"new {arguments} --debug:disable-sdk-templates --debug:custom-hive \"{CustomHivePath}\"");
+            $"new {arguments} --debug:disable-sdk-templates --debug:custom-hive \"{CustomHivePath}\" --no-update-check");
 
         await proc.Exited;
 


### PR DESCRIPTION
Given the logs:
```
[0.001s] [TestLifetime] [Information] Starting test WebApiTemplateCSharp_IdentityWeb_IndividualB2C_BuildsAndPublishes-IndividualB2C-System.String[] at 2022-10-11T00:23:27
[0.001s] [Templates.Mvc.Test.WebApiTemplateTest] [Information] ==> /datadisks/disk1/work/ACD0099B/p/dotnet-cli/dotnet new webapi  --debug:disable-sdk-templates --debug:custom-hive "/datadisks/disk1/work/ACD0099B/w/B91609B1/e/Hives/.templateEngine" --auth IndividualB2C --use-minimal-apis --called-api-url "https://graph.microsoft.com" --called-api-scopes user.readwrite -o /datadisks/disk1/work/ACD0099B/w/B91609B1/e/Templates/BaseFolder/AspNet.bolkl2k0oc2y [/datadisks/disk1/work/ACD0099B/w/B91609B1/e/]
[0.581s] [Templates.Mvc.Test.WebApiTemplateTest] [Information] The template "ASP.NET Core Web API" was created successfully.
[0.581s] [Templates.Mvc.Test.WebApiTemplateTest] [Information] 
[0.581s] [Templates.Mvc.Test.WebApiTemplateTest] [Information] Processing post-creation actions...
[0.581s] [Templates.Mvc.Test.WebApiTemplateTest] [Information] Restoring /datadisks/disk1/work/ACD0099B/w/B91609B1/e/Templates/BaseFolder/AspNet.bolkl2k0oc2y/AspNet.bolkl2k0oc2y.csproj:
[1.023s] [Templates.Mvc.Test.WebApiTemplateTest] [Information]   Determining projects to restore...
[1.489s] [Templates.Mvc.Test.WebApiTemplateTest] [Information]   Restored /datadisks/disk1/work/ACD0099B/w/B91609B1/e/Templates/BaseFolder/AspNet.bolkl2k0oc2y/AspNet.bolkl2k0oc2y.csproj (in 220 ms).
[1.503s] [Templates.Mvc.Test.WebApiTemplateTest] [Information] Restore succeeded.
[1.503s] [Templates.Mvc.Test.WebApiTemplateTest] [Information] 
[37.725s] [Templates.Mvc.Test.WebApiTemplateTest] [Information] 
[37.743s] [Templates.Mvc.Test.WebApiTemplateTest] [Information] Process exited.
```
We can see that the new line followed by the restore comes from
https://github.com/dotnet/sdk/blob/bba11ce80a3168e099d172f37d771878ed36cb5c/src/Cli/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs#L88-L89
Once that completes, there is another new line at https://github.com/dotnet/sdk/blob/bba11ce80a3168e099d172f37d771878ed36cb5c/src/Cli/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs#L170
The timestamps show us that something took a long time **after** the restore action took place and **before** the second new line.

Tracking down where the second new line (that took 30+ seconds) came from, leads to https://github.com/dotnet/sdk/blob/bba11ce80a3168e099d172f37d771878ed36cb5c/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs#L179.
We can see immediately before this new line there are 3 tasks running, one of which is the template creation + restore. One of the tasks is checking for newer templates so it can recommend updating, this task is skippable via `--no-update-check`. ~~Since there is no logging to see which task is taking forever, I'm going to guess it's the update check, and since we don't care about the update check in tests I'm proposing skipping it.~~ Looks like that guess was wrong 😢 