### PR TITLE
Increase timeouts for template tests

### DIFF
--- a/src/ProjectTemplates/test/Templates.Blazor.Server.Tests/Templates.Blazor.Server.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Blazor.Server.Tests/Templates.Blazor.Server.Tests.csproj
@@ -18,6 +18,7 @@
     <TestTemplateCreationFolder>TestTemplates\</TestTemplateCreationFolder>
     <RestoreFolderName>Server</RestoreFolderName>
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
+    <HelixTimeout>01:00:00</HelixTimeout>
     <SkipHelixQueues>
       $(HelixQueueArmDebian11);
     </SkipHelixQueues>

--- a/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Auth.Tests/Templates.Blazor.WebAssembly.Auth.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Auth.Tests/Templates.Blazor.WebAssembly.Auth.Tests.csproj
@@ -18,6 +18,7 @@
     <TestTemplateCreationFolder>TestTemplates\</TestTemplateCreationFolder>
     <RestoreFolderName>WebAssembly</RestoreFolderName>
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
+    <HelixTimeout>01:00:00</HelixTimeout>
     <SkipHelixQueues>
       $(HelixQueueArmDebian11);
     </SkipHelixQueues>

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
@@ -18,6 +18,7 @@
     <TestTemplateCreationFolder>TestTemplates\</TestTemplateCreationFolder>
     <RestoreFolderName>Mvc</RestoreFolderName>
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
+    <HelixTimeout>01:00:00</HelixTimeout>
     <SkipHelixQueues>
       $(HelixQueueArmDebian11);
     </SkipHelixQueues>

--- a/src/ProjectTemplates/test/Templates.Tests/Templates.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Tests/Templates.Tests.csproj
@@ -18,6 +18,7 @@
     <TestTemplateCreationFolder>TestTemplates\</TestTemplateCreationFolder>
     <RestoreFolderName>Other</RestoreFolderName>
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
+    <HelixTimeout>01:00:00</HelixTimeout>
     <SkipHelixQueues>
       $(HelixQueueArmDebian11);
     </SkipHelixQueues>


### PR DESCRIPTION
Some template tests are now hitting the 40 minute timeout, possibly due to increased restore times. This PR increases the timeout to see if that resolves the issue.
