### PR TITLE
Override Send in TestHost.ClientHandler

### DIFF
--- a/src/Hosting/TestHost/src/ClientHandler.cs
+++ b/src/Hosting/TestHost/src/ClientHandler.cs
@@ -48,10 +48,24 @@ public class ClientHandler : HttpMessageHandler
 
     /// <summary>
     /// This adapts HttpRequestMessages to ASP.NET Core requests, dispatches them through the pipeline, and returns the
-    /// associated HttpResponseMessage.
+    /// associated HttpResponseMessage synchronously.
     /// </summary>
-    /// <param name="request"></param>
-    /// <param name="cancellationToken"></param>
+    /// <param name="request">The <see cref="HttpRequestMessage"/>.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+    /// <returns></returns>
+    protected override HttpResponseMessage Send(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        return SendAsync(request, cancellationToken).GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// This adapts HttpRequestMessages to ASP.NET Core requests, dispatches them through the pipeline, and returns the
+    /// associated HttpResponseMessage asynchronously.
+    /// </summary>
+    /// <param name="request">The <see cref="HttpRequestMessage"/>.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
     /// <returns></returns>
     protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request,

--- a/src/Hosting/TestHost/src/ClientHandler.cs
+++ b/src/Hosting/TestHost/src/ClientHandler.cs
@@ -47,26 +47,30 @@ public class ClientHandler : HttpMessageHandler
     internal bool PreserveExecutionContext { get; set; }
 
     /// <summary>
-    /// This adapts HttpRequestMessages to ASP.NET Core requests, dispatches them through the pipeline, and returns the
-    /// associated HttpResponseMessage synchronously.
+    /// This synchronous method is not supported due to the risk of threadpool exhaustion when running multiple tests in parallel. 
     /// </summary>
     /// <param name="request">The <see cref="HttpRequestMessage"/>.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-    /// <returns></returns>
+    /// <exception cref="NotSupportedException">Thrown unconditionally.</exception>
+    /// <remarks>
+    /// Use the asynchronous version of this method, <see cref="SendAsync(HttpRequestMessage, CancellationToken)"/>, instead.
+    /// </remarks>
     protected override HttpResponseMessage Send(
         HttpRequestMessage request,
         CancellationToken cancellationToken)
     {
-        return SendAsync(request, cancellationToken).GetAwaiter().GetResult();
+        throw new NotSupportedException(
+            "This synchronous method is not supported due to the risk of threadpool exhaustion " +
+            "when running multiple tests in parallel. Use the asynchronous version of this method instead.");
     }
 
     /// <summary>
     /// This adapts HttpRequestMessages to ASP.NET Core requests, dispatches them through the pipeline, and returns the
-    /// associated HttpResponseMessage asynchronously.
+    /// associated HttpResponseMessage.
     /// </summary>
     /// <param name="request">The <see cref="HttpRequestMessage"/>.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-    /// <returns></returns>
+    /// <returns>A <see cref="Task{TResult}"/> returning the <see cref="HttpResponseMessage"/>.</returns>
     protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request,
         CancellationToken cancellationToken)

--- a/src/Hosting/TestHost/test/ClientHandlerTests.cs
+++ b/src/Hosting/TestHost/test/ClientHandlerTests.cs
@@ -332,26 +332,16 @@ public class ClientHandlerTests
     }
 
     [Fact]
-    public void ResponseStart()
+    public void Send_ThrowsNotSupportedException()
     {
-        bool? preHasStarted = null;
-        bool? postHasStarted = null;
-        var handler = new ClientHandler(PathString.Empty, new DummyApplication(async context =>
-        {
-            preHasStarted = context.Response.HasStarted;
-
-            await context.Response.StartAsync();
-
-            postHasStarted = context.Response.HasStarted;
-        }));
+        var handler = new ClientHandler(
+            PathString.Empty,
+            new DummyApplication(context => { return Task.CompletedTask; }));
 
         var invoker = new HttpMessageInvoker(handler);
         var message = new HttpRequestMessage(HttpMethod.Post, "https://example.com/");
 
-        var response = invoker.Send(message, CancellationToken.None);
-
-        Assert.False(preHasStarted);
-        Assert.True(postHasStarted);
+        Assert.Throws<NotSupportedException>(() => invoker.Send(message, CancellationToken.None));
     }
 
     [Fact]

--- a/src/Hosting/TestHost/test/ClientHandlerTests.cs
+++ b/src/Hosting/TestHost/test/ClientHandlerTests.cs
@@ -332,6 +332,29 @@ public class ClientHandlerTests
     }
 
     [Fact]
+    public void ResponseStart()
+    {
+        bool? preHasStarted = null;
+        bool? postHasStarted = null;
+        var handler = new ClientHandler(PathString.Empty, new DummyApplication(async context =>
+        {
+            preHasStarted = context.Response.HasStarted;
+
+            await context.Response.StartAsync();
+
+            postHasStarted = context.Response.HasStarted;
+        }));
+
+        var invoker = new HttpMessageInvoker(handler);
+        var message = new HttpRequestMessage(HttpMethod.Post, "https://example.com/");
+
+        var response = invoker.Send(message, CancellationToken.None);
+
+        Assert.False(preHasStarted);
+        Assert.True(postHasStarted);
+    }
+
+    [Fact]
     public async Task ResubmitRequestWorks()
     {
         int requestCount = 1;


### PR DESCRIPTION
### Override Send in Microsoft.AspNetCore.TestHost.ClientHandler

Overrides `ClientHandler.Send` to throw `NotSupportedException" with the following message:
> This synchronous method is not supported due to the risk of threadpool exhaustion when running multiple tests in parallel. Use the asynchronous version of this method instead.

Fixes #44464