### PR TITLE
Remove temporary allocations from Identity

### DIFF
--- a/src/Identity/Extensions.Core/src/AuthenticatorTokenProvider.cs
+++ b/src/Identity/Extensions.Core/src/AuthenticatorTokenProvider.cs
@@ -68,9 +68,9 @@ public class AuthenticatorTokenProvider<TUser> : IUserTwoFactorTokenProvider<TUs
         for (int i = -2; i <= 2; i++)
         {
 #if NET6_0_OR_GREATER
-            var expectedCode = Rfc6238AuthenticationService.ComputeTotp(keyBytes, (ulong)(timestep + i), modifier: null);
+            var expectedCode = Rfc6238AuthenticationService.ComputeTotp(keyBytes, (ulong)(timestep + i), modifierBytes: null);
 #else
-            var expectedCode = Rfc6238AuthenticationService.ComputeTotp(hash, (ulong)(timestep + i), modifier: null);
+            var expectedCode = Rfc6238AuthenticationService.ComputeTotp(hash, (ulong)(timestep + i), modifierBytes: null);
 #endif
             if (expectedCode == code)
             {

--- a/src/Identity/Extensions.Core/src/Base32.cs
+++ b/src/Identity/Extensions.Core/src/Base32.cs
@@ -13,7 +13,7 @@ internal static class Base32
     private const string _base32Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 
 #if NET6_0_OR_GREATER
-    public static string ToBase32WithSecureBytes()
+    public static string GenerateBase32()
     {
         const int length = 20;
         return string.Create(((length + 4) / 5) * 8, 0, static (buffer, _) =>

--- a/src/Identity/Extensions.Core/src/Base32.cs
+++ b/src/Identity/Extensions.Core/src/Base32.cs
@@ -16,6 +16,12 @@ internal static class Base32
     public static string GenerateBase32()
     {
         const int length = 20;
+        // base32 takes 5 bytes and converts them into 8 characters, which would be (byte length / 5) * 8
+        // except that it also pads ('=') for the last processed chunk if it's less than 5 bytes.
+        // So in order to handle the padding we add 1 less than the chunk size to our byte length
+        // which will either be removed due to integer division truncation if the length was already a multiple of 5
+        // or it will increase the divided length by 1 meaning that a 1-4 byte length chunk will be 1 instead of 0
+        // so the padding is now included in our string length calculation
         return string.Create(((length + 4) / 5) * 8, 0, static (buffer, _) =>
         {
             Span<byte> bytes = stackalloc byte[length];

--- a/src/Identity/Extensions.Core/src/IdentityResult.cs
+++ b/src/Identity/Extensions.Core/src/IdentityResult.cs
@@ -49,6 +49,16 @@ public class IdentityResult
         return result;
     }
 
+    internal static IdentityResult Failed(List<IdentityError>? errors)
+    {
+        var result = new IdentityResult { Succeeded = false };
+        if (errors != null)
+        {
+            result._errors.AddRange(errors);
+        }
+        return result;
+    }
+
     /// <summary>
     /// Converts the value of the current <see cref="IdentityResult"/> object to its equivalent string representation.
     /// </summary>

--- a/src/Identity/Extensions.Core/src/PasswordHasher.cs
+++ b/src/Identity/Extensions.Core/src/PasswordHasher.cs
@@ -35,13 +35,15 @@ public class PasswordHasher<TUser> : IPasswordHasher<TUser> where TUser : class
     private readonly int _iterCount;
     private readonly RandomNumberGenerator _rng;
 
+    private static readonly PasswordHasherOptions DefaultOptions = new PasswordHasherOptions();
+
     /// <summary>
     /// Creates a new instance of <see cref="PasswordHasher{TUser}"/>.
     /// </summary>
     /// <param name="optionsAccessor">The options for this instance.</param>
     public PasswordHasher(IOptions<PasswordHasherOptions>? optionsAccessor = null)
     {
-        var options = optionsAccessor?.Value ?? new PasswordHasherOptions();
+        var options = optionsAccessor?.Value ?? DefaultOptions;
 
         _compatibilityMode = options.CompatibilityMode;
         switch (_compatibilityMode)

--- a/src/Identity/Extensions.Core/src/PasswordValidator.cs
+++ b/src/Identity/Extensions.Core/src/PasswordValidator.cs
@@ -46,36 +46,42 @@ public class PasswordValidator<TUser> : IPasswordValidator<TUser> where TUser : 
         {
             throw new ArgumentNullException(nameof(manager));
         }
-        var errors = new List<IdentityError>();
+        List<IdentityError>? errors = null;
         var options = manager.Options.Password;
         if (string.IsNullOrWhiteSpace(password) || password.Length < options.RequiredLength)
         {
+            errors ??= new List<IdentityError>();
             errors.Add(Describer.PasswordTooShort(options.RequiredLength));
         }
         if (options.RequireNonAlphanumeric && password.All(IsLetterOrDigit))
         {
+            errors ??= new List<IdentityError>();
             errors.Add(Describer.PasswordRequiresNonAlphanumeric());
         }
         if (options.RequireDigit && !password.Any(IsDigit))
         {
+            errors ??= new List<IdentityError>();
             errors.Add(Describer.PasswordRequiresDigit());
         }
         if (options.RequireLowercase && !password.Any(IsLower))
         {
+            errors ??= new List<IdentityError>();
             errors.Add(Describer.PasswordRequiresLower());
         }
         if (options.RequireUppercase && !password.Any(IsUpper))
         {
+            errors ??= new List<IdentityError>();
             errors.Add(Describer.PasswordRequiresUpper());
         }
         if (options.RequiredUniqueChars >= 1 && password.Distinct().Count() < options.RequiredUniqueChars)
         {
+            errors ??= new List<IdentityError>();
             errors.Add(Describer.PasswordRequiresUniqueChars(options.RequiredUniqueChars));
         }
         return
-            Task.FromResult(errors.Count == 0
-                ? IdentityResult.Success
-                : IdentityResult.Failed(errors.ToArray()));
+            Task.FromResult(errors?.Count > 0
+                ? IdentityResult.Failed(errors)
+                : IdentityResult.Success);
     }
 
     /// <summary>

--- a/src/Identity/Extensions.Core/src/Rfc6238AuthenticationService.cs
+++ b/src/Identity/Extensions.Core/src/Rfc6238AuthenticationService.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using System.Net;
@@ -15,7 +17,6 @@ internal static class Rfc6238AuthenticationService
     private static readonly Encoding _encoding = new UTF8Encoding(false, true);
 #if NETSTANDARD2_0 || NETFRAMEWORK
     private static readonly DateTime _unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-    private static readonly RandomNumberGenerator _rng = RandomNumberGenerator.Create();
 #endif
 
     internal static int ComputeTotp(

--- a/src/Identity/Extensions.Core/src/UserManager.cs
+++ b/src/Identity/Extensions.Core/src/UserManager.cs
@@ -2509,7 +2509,7 @@ public class UserManager<TUser> : IDisposable where TUser : class
         _rng.GetBytes(bytes);
         return Base32.ToBase32(bytes);
 #else
-        return Base32.ToBase32WithSecureBytes();
+        return Base32.GenerateBase32();
 #endif
     }
 

--- a/src/Identity/Extensions.Core/src/UserManager.cs
+++ b/src/Identity/Extensions.Core/src/UserManager.cs
@@ -2278,6 +2278,22 @@ public class UserManager<TUser> : IDisposable where TUser : class
     /// <returns></returns>
     protected virtual string CreateTwoFactorRecoveryCode()
     {
+#if NET6_0_OR_GREATER
+        return string.Create(11, 0, static (buffer, _) =>
+        {
+            buffer[10] = GetRandomRecoveryCodeChar();
+            buffer[9] = GetRandomRecoveryCodeChar();
+            buffer[8] = GetRandomRecoveryCodeChar();
+            buffer[7] = GetRandomRecoveryCodeChar();
+            buffer[6] = GetRandomRecoveryCodeChar();
+            buffer[5] = '-';
+            buffer[4] = GetRandomRecoveryCodeChar();
+            buffer[3] = GetRandomRecoveryCodeChar();
+            buffer[2] = GetRandomRecoveryCodeChar();
+            buffer[1] = GetRandomRecoveryCodeChar();
+            buffer[0] = GetRandomRecoveryCodeChar();
+        });
+#else
         var recoveryCode = new StringBuilder(11);
         recoveryCode.Append(GetRandomRecoveryCodeChar());
         recoveryCode.Append(GetRandomRecoveryCodeChar());
@@ -2291,6 +2307,7 @@ public class UserManager<TUser> : IDisposable where TUser : class
         recoveryCode.Append(GetRandomRecoveryCodeChar());
         recoveryCode.Append(GetRandomRecoveryCodeChar());
         return recoveryCode.ToString();
+#endif
     }
 
     // We don't want to use any confusing characters like 0/O 1/I/L/l
@@ -2487,13 +2504,13 @@ public class UserManager<TUser> : IDisposable where TUser : class
 
     private static string NewSecurityStamp()
     {
-        byte[] bytes = new byte[20];
 #if NETSTANDARD2_0 || NETFRAMEWORK
+        byte[] bytes = new byte[20];
         _rng.GetBytes(bytes);
-#else
-        RandomNumberGenerator.Fill(bytes);
-#endif
         return Base32.ToBase32(bytes);
+#else
+        return Base32.ToBase32WithSecureBytes();
+#endif
     }
 
     // IUserLoginStore methods
@@ -2550,19 +2567,20 @@ public class UserManager<TUser> : IDisposable where TUser : class
                 throw new InvalidOperationException(Resources.NullSecurityStamp);
             }
         }
-        var errors = new List<IdentityError>();
+        List<IdentityError>? errors = null;
         foreach (var v in UserValidators)
         {
             var result = await v.ValidateAsync(this, user).ConfigureAwait(false);
             if (!result.Succeeded)
             {
+                errors ??= new List<IdentityError>();
                 errors.AddRange(result.Errors);
             }
         }
-        if (errors.Count > 0)
+        if (errors?.Count > 0)
         {
             Logger.LogDebug(LoggerEventIds.UserValidationFailed, "User validation failed: {errors}.", string.Join(";", errors.Select(e => e.Code)));
-            return IdentityResult.Failed(errors.ToArray());
+            return IdentityResult.Failed(errors);
         }
         return IdentityResult.Success;
     }
@@ -2576,7 +2594,7 @@ public class UserManager<TUser> : IDisposable where TUser : class
     /// <returns>A <see cref="IdentityResult"/> representing whether validation was successful.</returns>
     protected async Task<IdentityResult> ValidatePasswordAsync(TUser user, string? password)
     {
-        var errors = new List<IdentityError>();
+        List<IdentityError>? errors = null;
         var isValid = true;
         foreach (var v in PasswordValidators)
         {
@@ -2585,6 +2603,7 @@ public class UserManager<TUser> : IDisposable where TUser : class
             {
                 if (result.Errors.Any())
                 {
+                    errors ??= new List<IdentityError>();
                     errors.AddRange(result.Errors);
                 }
 
@@ -2593,8 +2612,8 @@ public class UserManager<TUser> : IDisposable where TUser : class
         }
         if (!isValid)
         {
-            Logger.LogDebug(LoggerEventIds.PasswordValidationFailed, "User password validation failed: {errors}.", string.Join(";", errors.Select(e => e.Code)));
-            return IdentityResult.Failed(errors.ToArray());
+            Logger.LogDebug(LoggerEventIds.PasswordValidationFailed, "User password validation failed: {errors}.", string.Join(";", errors?.Select(e => e.Code) ?? Array.Empty<string>()));
+            return IdentityResult.Failed(errors);
         }
         return IdentityResult.Success;
     }

--- a/src/Identity/test/Identity.FunctionalTests/Pages/Account/Manage/EnableAuthenticator.cs
+++ b/src/Identity/test/Identity.FunctionalTests/Pages/Account/Manage/EnableAuthenticator.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
@@ -48,7 +48,7 @@ internal class EnableAuthenticator : DefaultUIPage
         var keyBytes = Base32.FromBase32(key);
         var unixTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
         var timestep = Convert.ToInt64(unixTimestamp / 30);
-        var topt = Rfc6238AuthenticationService.ComputeTotp(keyBytes, (ulong)timestep, modifier: null);
+        var topt = Rfc6238AuthenticationService.ComputeTotp(keyBytes, (ulong)timestep, modifierBytes: null);
         return topt.ToString("D6", CultureInfo.InvariantCulture);
     }
 }

--- a/src/Identity/test/Identity.Test/Base32Test.cs
+++ b/src/Identity/test/Identity.Test/Base32Test.cs
@@ -26,6 +26,13 @@ public class Base32Test
         Assert.Equal<byte>(data, Base32.FromBase32(Base32.ToBase32(data)));
     }
 
+    [Fact]
+    public void SecureToBase32IsValid()
+    {
+        var output = Base32.FromBase32(Base32.ToBase32WithSecureBytes());
+        Assert.Equal(20, output.Length);
+    }
+
     private static readonly RandomNumberGenerator _rng = RandomNumberGenerator.Create();
 
     private static byte[] GetRandomByteArray(int length)

--- a/src/Identity/test/Identity.Test/Base32Test.cs
+++ b/src/Identity/test/Identity.Test/Base32Test.cs
@@ -27,9 +27,9 @@ public class Base32Test
     }
 
     [Fact]
-    public void SecureToBase32IsValid()
+    public void GenerateBase32IsValid()
     {
-        var output = Base32.FromBase32(Base32.ToBase32WithSecureBytes());
+        var output = Base32.FromBase32(Base32.GenerateBase32());
         Assert.Equal(20, output.Length);
     }
 


### PR DESCRIPTION
Noticed some unnecessary temporary allocations in the Identity code + modernized some of it to use `Span` based APIs to remove more allocations.

There is room for improvement (e.g. PasswordHasher), but it would require a lot more refactoring of code.