### PR TITLE
Fix documentation for .AddIdentityResources()

### DIFF
--- a/src/Identity/ApiAuthorization.IdentityServer/src/IdentityServerBuilderConfigurationExtensions.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/IdentityServerBuilderConfigurationExtensions.cs
@@ -132,7 +132,7 @@ public static class IdentityServerBuilderConfigurationExtensions
 
     /// <summary>
     /// Adds identity resources from the default configuration to the server using the key
-    /// IdentityServer:Resources
+    /// IdentityServer:Identity
     /// </summary>
     /// <param name="builder">The <see cref="IIdentityServerBuilder"/>.</param>
     /// <returns>The <see cref="IIdentityServerBuilder"/>.</returns>


### PR DESCRIPTION
# Fix documentation for `.AddIdentityResources()`

## Description

Package: `Microsoft.AspNetCore.ApiAuthorization.IdentityServer`
Namespace: `Microsoft.Extensions.DependencyInjection`

The `IIdentityServerBuilder.AddIdentityResources(...)` documentation says that identity resources are loaded from configuration using the key "**IdentityServer:Resources**". However, the overload for `AddIdentityResources(...)` actually uses the key "**IdentityServer:Identity**". This PR updates the documentation to reflect that.

(No bug created for this, as it did not fit any of the issue categories.)