### PR TITLE
Improve MapGroup link generation test

### DIFF
--- a/src/Mvc/test/Mvc.FunctionalTests/RoutingGroupsTest.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RoutingGroupsTest.cs
@@ -46,8 +46,9 @@ public class RoutingGroupsTests : IClassFixture<MvcTestFixture<StartupForGroups>
 
         var document = await response.GetHtmlDocumentAsync();
         var editLink = document.RequiredQuerySelector("#editlink");
+        var contactLink = document.RequiredQuerySelector("#contactlink");
         Assert.Equal("/pages/Edit/10", editLink.GetAttribute("href"));
-        // TODO: Investigate why the #contactlink to the controller is empty.
+        Assert.Equal("/controllers/contoso/Home/Contact", contactLink.GetAttribute("href"));
     }
 
     private record RouteInfo(string RouteName, IDictionary<string, string> RouteValues, string Link);

--- a/src/Mvc/test/Mvc.FunctionalTests/RoutingTestsBase.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RoutingTestsBase.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
@@ -1554,7 +1554,7 @@ public abstract class RoutingTestsBase<TStartup> : IClassFixture<MvcTestFixture<
         Assert.Equal("/Edit/10", editLink.GetAttribute("href"));
 
         var contactLink = document.RequiredQuerySelector("#contactlink");
-        Assert.Equal("/Home/Contact", contactLink.GetAttribute("href"));
+        Assert.Equal("/Home/Contact?org=contoso", contactLink.GetAttribute("href"));
     }
 
     [Fact]

--- a/src/Mvc/test/WebSites/RoutingWebSite/Pages/PageWithLinks.cshtml
+++ b/src/Mvc/test/WebSites/RoutingWebSite/Pages/PageWithLinks.cshtml
@@ -5,4 +5,4 @@
 
 <a id="editlink" asp-page="/Edit" asp-route-id="10">Edit</a>
 <br />
-<a id="contactlink" asp-action="Contact" asp-controller="Home">Contact</a>
+<a id="contactlink" asp-action="Contact" asp-controller="Home" asp-route-org="contoso">Contact</a>

--- a/src/Mvc/test/WebSites/RoutingWebSite/StartupForGroups.cs
+++ b/src/Mvc/test/WebSites/RoutingWebSite/StartupForGroups.cs
@@ -29,7 +29,7 @@ public class StartupForGroups
             pagesGroup.MapRazorPages();
 
             var controllerGroup = endpoints.MapGroup("/controllers/{org}");
-            controllerGroup.MapControllers();
+            controllerGroup.MapControllerRoute(name: "default", pattern: "{controller}/{action}/{id?}");
         });
     }
 }


### PR DESCRIPTION
Turns out you need to call `MapControllerRoute` instead of `MapControllers` for the endpoint-routing-based link generation to work. I was also missing `asp-route-org="contoso"` in the razor page.

Fixes #41430
