### PR TITLE
Add more granular tests for HeaderUtilities.TryParseQualityDouble

### DIFF
--- a/src/Http/Headers/test/HeaderUtilitiesTest.cs
+++ b/src/Http/Headers/test/HeaderUtilitiesTest.cs
@@ -326,15 +326,15 @@ public class HeaderUtilitiesTest
     [InlineData("", 0)]
     [InlineData("1", 1)]
     [InlineData("0.1", 3)]
-    public void TryParseQualityDouble_WithStartIndexOutOfRange_ReturnsFalse(string inputString, int startIndex)
+    public void TryParseQualityDouble_StartIndexIsOutOfRange_ReturnsFalse(string inputString, int startIndex)
         => VerifyTryParseQualityDoubleFailure(inputString, startIndex);
 
     [Theory]
-    [MemberData(nameof(InvalidLeadingCharacterData))]
-    public void TryParseQualityDouble_HasInvalidLeadingChar_ReturnsFalse(string inputString, int startIndex)
+    [MemberData(nameof(InvalidStartingCharacterData))]
+    public void TryParseQualityDouble_HasInvalidStartingCharacter_ReturnsFalse(string inputString, int startIndex)
         => VerifyTryParseQualityDoubleFailure(inputString, startIndex);
 
-    public static TheoryData<string, int> InvalidLeadingCharacterData() => new()
+    public static TheoryData<string, int> InvalidStartingCharacterData() => new()
     {
         { ".123", 0 },
         { "q=.123", 2 },
@@ -362,13 +362,13 @@ public class HeaderUtilitiesTest
     [Theory]
     [InlineData("0.123456789", 0)]
     [InlineData("q=0.123456789", 2)]
-    public void TryParseQualityDouble_ExceedsQualityValueMaxCharCount_ReturnsFalse(string inputString, int startIndex)
+    public void TryParseQualityDouble_ExceedsQualityValueMaxCharacterCount_ReturnsFalse(string inputString, int startIndex)
         => VerifyTryParseQualityDoubleFailure(inputString, startIndex);
 
     [Theory]
     [InlineData("1.000000001", 0)]
     [InlineData("q=1.000000001", 2)]
-    public void TryParseQualityDouble_QualityExceedsOne_ReturnsFalse(string inputString, int startIndex)
+    public void TryParseQualityDouble_ParsedQualityIsGreaterThanOne_ReturnsFalse(string inputString, int startIndex)
         => VerifyTryParseQualityDoubleFailure(inputString, startIndex);
 
     private static void VerifyTryParseQualityDoubleFailure(string inputString, int startIndex)

--- a/src/Http/Headers/test/HeaderUtilitiesTest.cs
+++ b/src/Http/Headers/test/HeaderUtilitiesTest.cs
@@ -312,9 +312,7 @@ public class HeaderUtilitiesTest
     [InlineData("text;q=0.12345678", 0.12345678d, 10)]
     [InlineData("text;q=0.98765432", 0.98765432d, 10)]
     public void TryParseQualityDouble_WithDecimalPart_ReturnsCorrectQuality(
-        string inputString,
-        double expectedQuality,
-        int expectedLength)
+        string inputString, double expectedQuality, int expectedLength)
         => VerifyTryParseQualityDoubleSuccess(inputString, 7, expectedQuality, expectedLength);
 
     [Theory]

--- a/src/Http/Headers/test/HeaderUtilitiesTest.cs
+++ b/src/Http/Headers/test/HeaderUtilitiesTest.cs
@@ -331,10 +331,8 @@ public class HeaderUtilitiesTest
     [InlineData("text;q=0.12345678,*;q=1", 0.12345678d, 10)]
     [InlineData("text;q=0.98765432,*;q=1", 0.98765432d, 10)]
     public void TryParseQualityDouble_WithDecimalPart_WithSubsequentCharacters_ReturnsCorrectQuality(
-    string inputString,
-    double expectedQuality,
-    int expectedLength)
-    => VerifyTryParseQualityDoubleSuccess(inputString, 7, expectedQuality, expectedLength);
+        string inputString, double expectedQuality, int expectedLength)
+        => VerifyTryParseQualityDoubleSuccess(inputString, 7, expectedQuality, expectedLength);
 
     private static void VerifyTryParseQualityDoubleSuccess(string inputString, int startIndex, double expectedQuality, int expectedLength)
     {


### PR DESCRIPTION
## Add more granular tests for HeaderUtilities.TryParseQualityDouble

Adds more unit tests for `HeaderUtilities.TryParseQualityDouble`.

### Test cases added so far: 

- **Valid Input:**
    - Quality value has a decimal part (w/ and w/o subsequent characters)
    - Quality value does not have a decimal part (w/ and w/o subsequent characters)
- **Invalid Input:**
    - Start index exceeds length of input
    - Invalid starting character
    - Multiple digits before dot
    - Exceeds max character count for quality values
    - Parsed quality exceeds one

Fixes #2710
