### PR TITLE
[release/7.0] Backport loc fixes

### DIFF
--- a/src/Installers/Windows/SharedFrameworkBundle/1028/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1028/thm.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption">[BundleNameFull] 安裝程式</String>
   <String Id="Title">[BundleNameShort]</String>
@@ -8,8 +8,8 @@
   <String Id="InstallVersion">版本 [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">您確定要取消嗎?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">前一版</String>
-  <String Id="HelpHeader">安裝程式說明</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - 在目錄中安裝、修復、解除安裝或
+  <String Id="HelpHeader">安裝說明</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]目錄[\]] - 在目錄中安裝、修復、解除安裝或
    建立搭售方案的完整本機複本。預設為安裝。
 
 /passive | /quiet -  顯示最少 UI 且不含提示，或者不顯示 UI，也
@@ -38,16 +38,16 @@
   <String Id="ModifyCloseButton">關閉(&amp;C)</String>
   <String Id="SuccessRepairHeader">修復已成功完成</String>
   <String Id="SuccessUninstallHeader">解除安裝已成功完成</String>
-  <String Id="SuccessInstallHeader">安裝已成功完成</String> 
-  <String Id="SuccessHeader">設定成功</String>	
+  <String Id="SuccessInstallHeader">安裝已成功完成</String>
+  <String Id="SuccessHeader">設定成功</String>
   <String Id="SuccessLaunchButton">啟動(&amp;L)</String>
   <String Id="SuccessRestartText">必須重新啟動電腦，才能使用此軟體。</String>
   <String Id="SuccessRestartButton">重新啟動(&amp;R)</String>
   <String Id="SuccessCloseButton">關閉(&amp;C)</String>
-  <String Id="FailureHeader">設定失敗</String>
-  <String Id="FailureInstallHeader">安裝程式失敗</String>
+  <String Id="FailureHeader">安裝失敗</String>
+  <String Id="FailureInstallHeader">設定失敗</String>
   <String Id="FailureUninstallHeader">解除安裝失敗</String>
-  <String Id="FailureRepairHeader">修復失敗</String> 
+  <String Id="FailureRepairHeader">修復失敗</String>
   <String Id="FailureHyperlinkLogText">有一個或多個問題導致安裝程式失敗。請解決問題，然後重試一次安裝。如需詳細資訊，請參閱&lt;a href="#"&gt;記錄檔&lt;/a&gt;。</String>
   <String Id="FailureRestartText">必須重新啟動電腦，才能完成軟體的復原。</String>
   <String Id="FailureRestartButton">重新啟動(&amp;R)</String>

--- a/src/Installers/Windows/SharedFrameworkBundle/1029/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1029/thm.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption">Instalační program pro [BundleNameFull]</String>
   <String Id="Title">[BundleNameShort]</String>
@@ -8,8 +8,8 @@
   <String Id="InstallVersion">Verze [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Opravdu chcete akci zrušit?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Předchozí verze</String>
-  <String Id="HelpHeader">Nápověda k instalaci</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [adresář] – Nainstaluje, opraví, odinstaluje nebo
+  <String Id="HelpHeader">Nápověda nastavení</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]adresář[\]] – Nainstaluje, opraví, odinstaluje nebo
    vytvoří úplnou místní kopii svazku v adresáři. Výchozí možností je instalace.
 
 /passive | /quiet –  Zobrazí minimální uživatelské rozhraní bez výzev nebo nezobrazí žádné uživatelské rozhraní a
@@ -19,7 +19,7 @@
 /log log.txt – Uloží protokol do konkrétního souboru. Ve výchozím nastavení bude soubor protokolu vytvořen v adresáři %TEMP%.</String>
   <String Id="HelpCloseButton">&amp;Zavřít</String>
   <String Id="InstallLicenseLinkText">&lt;a href="#"&gt;Licenční podmínky&lt;/a&gt; pro [WixBundleName]</String>
-  <String Id="InstallAcceptCheckbox">Souhl&amp;asím s licenčními podmínkami.</String>
+  <String Id="InstallAcceptCheckbox">Souhl&amp;asím s licenčními podmínkami</String>
   <String Id="InstallOptionsButton">M&amp;ožnosti</String>
   <String Id="InstallInstallButton">&amp;Instalovat</String>
   <String Id="InstallCloseButton">&amp;Zavřít</String>
@@ -29,30 +29,30 @@
   <String Id="OptionsOkButton">&amp;OK</String>
   <String Id="OptionsCancelButton">&amp;Storno</String>
   <String Id="ProgressHeader">Průběh instalace</String>
-  <String Id="ProgressLabel">Zpracování:</String>
-  <String Id="OverallProgressPackageText">Inicializuje se...</String>
+  <String Id="ProgressLabel">Probíhá zpracování:</String>
+  <String Id="OverallProgressPackageText">Inicializace...</String>
   <String Id="ProgressCancelButton">&amp;Storno</String>
   <String Id="ModifyHeader">Změnit instalaci</String>
   <String Id="ModifyRepairButton">Op&amp;ravit</String>
   <String Id="ModifyUninstallButton">O&amp;dinstalovat</String>
   <String Id="ModifyCloseButton">&amp;Zavřít</String>
-  <String Id="SuccessRepairHeader">Oprava se úspěšně dokončila.</String>
-  <String Id="SuccessUninstallHeader">Odinstalace se úspěšně dokončila.</String>
-  <String Id="SuccessInstallHeader">Instalace se úspěšně dokončila.</String> 
-  <String Id="SuccessHeader">Instalace byla úspěšná.</String>	
+  <String Id="SuccessRepairHeader">Oprava byla úspěšně dokončena</String>
+  <String Id="SuccessUninstallHeader">Odinstalace se úspěšně dokončila</String>
+  <String Id="SuccessInstallHeader">Instalace se úspěšně dokončila</String>
+  <String Id="SuccessHeader">Instalace byla úspěšná.</String>
   <String Id="SuccessLaunchButton">&amp;Spustit</String>
   <String Id="SuccessRestartText">Před použitím tohoto softwaru musíte restartovat počítač.</String>
   <String Id="SuccessRestartButton">&amp;Restartovat</String>
   <String Id="SuccessCloseButton">&amp;Zavřít</String>
-  <String Id="FailureHeader">Instalace se nepovedla.</String>
-  <String Id="FailureInstallHeader">Instalace se nepovedla.</String>
-  <String Id="FailureUninstallHeader">Odinstalace se nepovedla.</String>
-  <String Id="FailureRepairHeader">Oprava se nepovedla.</String> 
-  <String Id="FailureHyperlinkLogText">Instalace se nepovedla kvůli jednomu nebo více problémům. Opravte prosím tyto problémy a zkuste software nainstalovat znovu. Další informace najdete v &lt;a href="#"&gt;souboru protokolu&lt;/a&gt;.</String>
+  <String Id="FailureHeader">Instalace se nepovedla</String>
+  <String Id="FailureInstallHeader">Instalace se nepovedla</String>
+  <String Id="FailureUninstallHeader">Odinstalace se nepovedla</String>
+  <String Id="FailureRepairHeader">Oprava se nepovedla</String>
+  <String Id="FailureHyperlinkLogText">Jeden nebo více problémů způsobilo selhání instalace. Opravte tyto problémy a znovu spusťte instalaci. Pro více informací se podívejte do &lt;a href="#"&gt;souboru protokolu&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Pro dokončení vrácení změn tohoto softwaru je potřeba restartovat počítač.</String>
   <String Id="FailureRestartButton">&amp;Restartovat</String>
   <String Id="FailureCloseButton">&amp;Zavřít</String>
-  <String Id="FilesInUseHeader">Používané soubory</String>
+  <String Id="FilesInUseHeader">Soubory jsou používány</String>
   <String Id="FilesInUseLabel">Následující aplikace používají soubory, které je potřeba aktualizovat:</String>
   <String Id="FilesInUseCloseRadioButton">Zavřete &amp;aplikace a zkuste je restartovat.</String>
   <String Id="FilesInUseDontCloseRadioButton">A&amp;plikace nezavírejte. Bude potřeba provést restart.</String>

--- a/src/Installers/Windows/SharedFrameworkBundle/1031/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1031/thm.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption">[BundleNameFull]-Setup</String>
   <String Id="Title">[BundleNameShort]</String>
@@ -8,18 +8,18 @@
   <String Id="InstallVersion">Version von [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Möchten Sie den Vorgang wirklich abbrechen?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Vorherige Version</String>
-  <String Id="HelpHeader">Hilfe zum Setup</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [Verzeichnis] - installiert, repariert, deinstalliert oder
-   erstellt eine vollständige lokale Kopie des Bundles im Verzeichnis. Installieren ist die Standardeinstellung.
+  <String Id="HelpHeader">Setup-Hilfe</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]directory[\]] – Installiert, repariert, deinstalliert oder
+   erstellt eine vollständige lokale Kopie des Pakets im Verzeichnis. Standardmäßig wird eine Installation durchgeführt.
 
-/passive | /quiet -  zeigt eine minimale Benutzeroberfläche ohne Eingabeaufforderungen oder keine
-   Benutzeroberfläche und keine Eingabeaufforderungen an. Standardmäßig werden die Benutzeroberfläche und alle Eingabeaufforderungen angezeigt.
+/passive | /quiet – Zeigt eine minimale Benutzeroberfläche ohne Eingabeaufforderungen oder weder eine Benutzeroberfläche 
+   noch Eingabeaufforderungen an. Standardmäßig wird die Benutzeroberfläche mit allen Eingabeaufforderungen angezeigt.
 
-/norestart   - Unterdrückt alle Neustartversuche. Standardmäßig fordert die Benutzeroberfläche zum Bestätigen eines Neustarts auf.
-/log log.txt - Erstellt das Protokoll in einer bestimmten Datei. Standardmäßig wird die Protokolldatei in %TEMP% erstellt.</String>
+/norestart   – Unterdrückt alle Versuche eines Neustarts. Standardmäßig wird über die Benutzeroberfläche eine Aufforderung zum Neustart ausgegeben.
+/log log.txt – Erstellt ein Protokoll in einer festgelegten Datei. Standardmäßig wird die Protokolldatei in %TEMP% erstellt.</String>
   <String Id="HelpCloseButton">S&amp;chließen</String>
   <String Id="InstallLicenseLinkText">[WixBundleName] &lt;a href="#"&gt;Lizenzbedingungen&lt;/a&gt;.</String>
-  <String Id="InstallAcceptCheckbox">Ich &amp;stimme den Lizenzbedingungen zu.</String>
+  <String Id="InstallAcceptCheckbox">Ich &amp;stimme den Bedingungen des Lizenzvertrags zu</String>
   <String Id="InstallOptionsButton">&amp;Optionen</String>
   <String Id="InstallInstallButton">&amp;Installieren</String>
   <String Id="InstallCloseButton">S&amp;chließen</String>
@@ -36,23 +36,23 @@
   <String Id="ModifyRepairButton">&amp;Reparieren</String>
   <String Id="ModifyUninstallButton">&amp;Deinstallieren</String>
   <String Id="ModifyCloseButton">S&amp;chließen</String>
-  <String Id="SuccessRepairHeader">Die Reparatur wurde erfolgreich abgeschlossen.</String>
-  <String Id="SuccessUninstallHeader">Die Deinstallation wurde erfolgreich abgeschlossen.</String>
-  <String Id="SuccessInstallHeader">Die Installation wurde erfolgreich abgeschlossen.</String> 
-  <String Id="SuccessHeader">Setup wurde erfolgreich abgeschlossen</String>	
+  <String Id="SuccessRepairHeader">Reparatur erfolgreich abgeschlossen</String>
+  <String Id="SuccessUninstallHeader">Deinstallation erfolgreich abgeschlossen</String>
+  <String Id="SuccessInstallHeader">Installation erfolgreich abgeschlossen</String>
+  <String Id="SuccessHeader">Setup wurde erfolgreich abgeschlossen</String>
   <String Id="SuccessLaunchButton">&amp;Starten</String>
   <String Id="SuccessRestartText">Sie müssen den Computer neu starten, bevor Sie die Software verwenden können.</String>
-  <String Id="SuccessRestartButton">&amp;Neu starten</String>
+  <String Id="SuccessRestartButton">&amp;Neustart</String>
   <String Id="SuccessCloseButton">S&amp;chließen</String>
   <String Id="FailureHeader">Setupfehler</String>
-  <String Id="FailureInstallHeader">Setupfehler</String>
-  <String Id="FailureUninstallHeader">Deinstallationsfehler</String>
-  <String Id="FailureRepairHeader">Reparaturfehler</String> 
-  <String Id="FailureHyperlinkLogText">Setup ist aufgrund eines oder mehrerer Probleme fehlgeschlagen. Beheben Sie die Probleme, und führen Sie das Setup erneut aus. Weitere Informationen finden Sie in der &lt;a href="#"&gt;Protokolldatei&lt;/a&gt;.</String>
+  <String Id="FailureInstallHeader">Fehler beim Setup</String>
+  <String Id="FailureUninstallHeader">Fehler bei der Deinstallation</String>
+  <String Id="FailureRepairHeader">Fehler bei der Reparatur</String>
+  <String Id="FailureHyperlinkLogText">Setup ist aufgrund eines oder mehrerer Probleme fehlgeschlagen. Beheben Sie die Probleme, und führen Sie Setup erneut aus. Weitere Informationen finden Sie in der &lt;a href="#"&gt;Protokolldatei&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Sie müssen den Computer neu starten, um das Zurücksetzen der Software abzuschließen.</String>
-  <String Id="FailureRestartButton">&amp;Neu starten</String>
-  <String Id="FailureCloseButton">&amp;Schließen</String>
-  <String Id="FilesInUseHeader">Verwendete Dateien</String>
+  <String Id="FailureRestartButton">&amp;Neustart</String>
+  <String Id="FailureCloseButton">S&amp;chließen</String>
+  <String Id="FilesInUseHeader">Dateien in Verwendung</String>
   <String Id="FilesInUseLabel">Die folgenden Anwendungen verwenden Dateien, die aktualisiert werden müssen:</String>
   <String Id="FilesInUseCloseRadioButton">Schließen Sie die &amp;Anwendungen, und versuchen Sie sie erneut zu starten.</String>
   <String Id="FilesInUseDontCloseRadioButton">&amp;Anwendungen nicht schließen. Ein Neustart ist erforderlich.</String>

--- a/src/Installers/Windows/SharedFrameworkBundle/1031/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1031/thm.wxl
@@ -9,7 +9,7 @@
   <String Id="ConfirmCancelMessage">Möchten Sie den Vorgang wirklich abbrechen?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Vorherige Version</String>
   <String Id="HelpHeader">Setup-Hilfe</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]directory[\]] – Installiert, repariert, deinstalliert oder
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]Verzeichnis[\]] – Installiert, repariert, deinstalliert oder
    erstellt eine vollständige lokale Kopie des Pakets im Verzeichnis. Standardmäßig wird eine Installation durchgeführt.
 
 /passive | /quiet – Zeigt eine minimale Benutzeroberfläche ohne Eingabeaufforderungen oder weder eine Benutzeroberfläche 
@@ -51,7 +51,7 @@
   <String Id="FailureHyperlinkLogText">Setup ist aufgrund eines oder mehrerer Probleme fehlgeschlagen. Beheben Sie die Probleme, und führen Sie Setup erneut aus. Weitere Informationen finden Sie in der &lt;a href="#"&gt;Protokolldatei&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Sie müssen den Computer neu starten, um das Zurücksetzen der Software abzuschließen.</String>
   <String Id="FailureRestartButton">&amp;Neustart</String>
-  <String Id="FailureCloseButton">S&amp;chließen</String>
+  <String Id="FailureCloseButton">&amp;Schließen</String>
   <String Id="FilesInUseHeader">Dateien in Verwendung</String>
   <String Id="FilesInUseLabel">Die folgenden Anwendungen verwenden Dateien, die aktualisiert werden müssen:</String>
   <String Id="FilesInUseCloseRadioButton">Schließen Sie die &amp;Anwendungen, und versuchen Sie sie erneut zu starten.</String>

--- a/src/Installers/Windows/SharedFrameworkBundle/1033/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1033/thm.wxl
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[BundleNameFull] Setup</String>
-  <String Id="Title">[BundleNameShort]</String>
-  <String Id="SubTitle">[BundleNameSub]</String>
+  <String Id="Caption"><!--_locComment_text="{Locked='[BundleNameFull]'}"-->[BundleNameFull] Setup</String>
+  <String Id="Title"><!--_locComment_text="{Locked}"-->[BundleNameShort]</String>
+  <String Id="SubTitle"><!--_locComment_text="{Locked}"-->[BundleNameSub]</String>
   <String Id="InstallHeader">Welcome</String>
-  <String Id="InstallMessage">Setup will install [WixBundleName] on your computer. Click install to continue, options to set the install directory or Close to exit.</String>
-  <String Id="InstallVersion">Version [WixBundleVersion]</String>
+  <String Id="InstallMessage"><!--_locComment_text="{Locked='[WixBundleName]'}"-->Setup will install [WixBundleName] on your computer. Click install to continue, options to set the install directory or Close to exit.</String>
+  <String Id="InstallVersion"><!--_locComment_text="{Locked='[WixBundleVersion]'}"-->Version [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
   <String Id="HelpHeader">Setup Help</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]directory[\]] - installs, repairs, uninstalls or
    creates a complete local copy of the bundle in directory. Install is the default.
 
 /passive | /quiet -  displays minimal UI with no prompts or displays no UI and
@@ -18,7 +18,7 @@
 /norestart   - suppress any attempts to restart. By default UI will prompt before restart.
 /log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
   <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallLicenseLinkText">[WixBundleName] &lt;a href="#"&gt;license terms&lt;/a&gt;.</String>
+  <String Id="InstallLicenseLinkText"><!--_locComment_text="{Locked='[WixBundleName]'}"-->[WixBundleName] &lt;a href="#"&gt;license terms&lt;/a&gt;.</String>
   <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
   <String Id="InstallOptionsButton">&amp;Options</String>
   <String Id="InstallInstallButton">&amp;Install</String>
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">&amp;Close</String>
   <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
   <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation Successfully Completed</String> 
-  <String Id="SuccessHeader">Setup Successful</String>	
+  <String Id="SuccessInstallHeader">Installation Successfully Completed</String>
+  <String Id="SuccessHeader">Setup Successful</String>
   <String Id="SuccessLaunchButton">&amp;Launch</String>
   <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
   <String Id="SuccessRestartButton">&amp;Restart</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">Setup Failed</String>
   <String Id="FailureInstallHeader">Setup Failed</String>
   <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String> 
+  <String Id="FailureRepairHeader">Repair Failed</String>
   <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
   <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
   <String Id="FailureRestartButton">&amp;Restart</String>
@@ -59,6 +59,6 @@
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
 
-  <String Id="Welcome">Welcome to the [WixBundleName] Setup.</String>
-  <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
+  <String Id="Welcome"><!--_locComment_text="{Locked='[WixBundleName]'}"-->Welcome to the [WixBundleName] Setup.</String>
+  <String Id="EulaPrivacy"><!--_locComment_text="{Locked='[WixBundleName]'}"-->[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/1036/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1036/thm.wxl
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption">Installation de [BundleNameFull]</String>
   <String Id="Title">[BundleNameShort]</String>
   <String Id="SubTitle">[BundleNameSub]</String>
   <String Id="InstallHeader">Bienvenue</String>
   <String Id="InstallMessage">Le programme d'installation va installer [WixBundleName] sur votre ordinateur. Cliquez sur Installer pour continuer, sur Options pour définir le répertoire d'installation ou sur Fermer pour quitter le programme.</String>
-  <String Id="InstallVersion">Version de [WixBundleVersion]</String>
-  <String Id="ConfirmCancelMessage">Voulez-vous vraiment annuler ?</String>
+  <String Id="InstallVersion">Version [WixBundleVersion]</String>
+  <String Id="ConfirmCancelMessage">Êtes-vous sûr de vouloir annuler ?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Version précédente</String>
-  <String Id="HelpHeader">Aide à l'installation</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [répertoire] - installe, répare, désinstalle ou
+  <String Id="HelpHeader">Aide du programme d'installation</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]répertoire[\]] - installe, répare, désinstalle ou
    crée une copie locale complète du bundle dans le répertoire. Install est l'option par défaut.
 
 /passive | /quiet -  affiche une interface utilisateur minimale, sans invite, ou n'affiche 
@@ -28,7 +28,7 @@
   <String Id="OptionsBrowseButton">&amp;Parcourir</String>
   <String Id="OptionsOkButton">&amp;OK</String>
   <String Id="OptionsCancelButton">&amp;Annuler</String>
-  <String Id="ProgressHeader">Progression de l'installation</String>
+  <String Id="ProgressHeader">Progression de l’opération</String>
   <String Id="ProgressLabel">En cours :</String>
   <String Id="OverallProgressPackageText">Initialisation...</String>
   <String Id="ProgressCancelButton">&amp;Annuler</String>
@@ -38,27 +38,27 @@
   <String Id="ModifyCloseButton">&amp;Fermer</String>
   <String Id="SuccessRepairHeader">Réparation terminée avec succès</String>
   <String Id="SuccessUninstallHeader">Désinstallation terminée avec succès</String>
-  <String Id="SuccessInstallHeader">Installation terminée avec succès</String> 
-  <String Id="SuccessHeader">Installation/désinstallation réussie</String>	
+  <String Id="SuccessInstallHeader">Installation terminée avec succès</String>
+  <String Id="SuccessHeader">Opération réussie</String>
   <String Id="SuccessLaunchButton">&amp;Démarrer</String>
   <String Id="SuccessRestartText">Vous devez redémarrer votre ordinateur avant de pouvoir utiliser le logiciel.</String>
   <String Id="SuccessRestartButton">&amp;Redémarrer</String>
   <String Id="SuccessCloseButton">&amp;Fermer</String>
-  <String Id="FailureHeader">Échec de l'installation</String>
+  <String Id="FailureHeader">Échec de l’opération</String>
   <String Id="FailureInstallHeader">Échec de l'installation</String>
   <String Id="FailureUninstallHeader">Échec de la désinstallation</String>
-  <String Id="FailureRepairHeader">Échec de la réparation</String> 
-  <String Id="FailureHyperlinkLogText">Un ou plusieurs problèmes sont à l'origine de l'échec de l'installation. Corrigez ces problèmes, puis recommencez l'installation. Pour plus d'informations, voir le &lt;a href="#"&gt;fichier journal&lt;/a&gt;.</String>
+  <String Id="FailureRepairHeader">Échec de la réparation</String>
+  <String Id="FailureHyperlinkLogText">Le programme d’installation a échoué en raison d’un ou de plusieurs problèmes. Veuillez corriger ces problèmes, puis relancez le programme d’installation. Pour plus d’informations, consultez le &lt;a href="#"&gt;fichier journal&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Vous devez redémarrer votre ordinateur pour terminer l'opération de restauration du logiciel.</String>
   <String Id="FailureRestartButton">&amp;Redémarrer</String>
   <String Id="FailureCloseButton">&amp;Fermer</String>
   <String Id="FilesInUseHeader">Fichiers en cours d'utilisation</String>
-  <String Id="FilesInUseLabel">Les applications suivantes utilisent des fichiers nécessitant une mise à jour :</String>
-  <String Id="FilesInUseCloseRadioButton">&amp;Fermez les applications, puis essayez de les redémarrer.</String>
+  <String Id="FilesInUseLabel">Les applications suivantes utilisent des fichiers nécessitant une mise à jour :</String>
+  <String Id="FilesInUseCloseRadioButton">&amp;Fermer les applications essayer de les ouvrir de nouveau.</String>
   <String Id="FilesInUseDontCloseRadioButton">&amp;Ne pas fermer les applications. Un redémarrage sera nécessaire.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Annuler</String>
 
   <String Id="Welcome">Bienvenue dans le programme d'installation de [WixBundleName].</String>
-  <String Id="EulaPrivacy">&lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Termes du contrat de licence&lt;/a&gt; et &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;déclaration de confidentialité&lt;/a&gt; de [WixBundleName].</String>
+  <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;termes du contrat de licence&lt;/a&gt; et &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;déclaration de confidentialité&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/1040/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1040/thm.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption">Installazione di [BundleNameFull]</String>
   <String Id="Title">[BundleNameShort]</String>
@@ -8,12 +8,12 @@
   <String Id="InstallVersion">Versione [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Annullare?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Versione precedente</String>
-  <String Id="HelpHeader">Guida alla configurazione</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installa, ripara, disinstalla o
+  <String Id="HelpHeader">Guida all'installazione</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]directory[\]] - installa, ripara, disinstalla o
    crea una copia locale completa del bundle nella directory. L'opzione predefinita è install.
 
 /passive | /quiet -  visualizza un'interfaccia utente minima senza prompt oppure non visualizza alcuna interfaccia utente
-   né prompt. Per impostazione predefinita, viene visualizzata l'intera interfaccia utente e tutti i prompt.
+   né prompt. Per impostazione predefinita, vengono visualizzati l'intera interfaccia utente e tutti i prompt.
 
 /norestart   - annulla qualsiasi tentativo di riavvio. Per impostazione predefinita, l'interfaccia utente visualizza una richiesta prima del riavvio.
 /log log.txt - registra il log in un file specifico. Per impostazione predefinita, viene creato un file di log in %TEMP%.</String>
@@ -27,29 +27,29 @@
   <String Id="OptionsLocationLabel">Percorso di installazione:</String>
   <String Id="OptionsBrowseButton">&amp;Sfoglia</String>
   <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Annulla</String>
+  <String Id="OptionsCancelButton">Ann&amp;ulla</String>
   <String Id="ProgressHeader">Stato installazione</String>
   <String Id="ProgressLabel">Elaborazione di:</String>
   <String Id="OverallProgressPackageText">Inizializzazione in corso...</String>
-  <String Id="ProgressCancelButton">&amp;Annulla</String>
+  <String Id="ProgressCancelButton">Ann&amp;ulla</String>
   <String Id="ModifyHeader">Modifica installazione</String>
   <String Id="ModifyRepairButton">&amp;Ripristina</String>
   <String Id="ModifyUninstallButton">&amp;Disinstalla</String>
   <String Id="ModifyCloseButton">&amp;Chiudi</String>
   <String Id="SuccessRepairHeader">La riparazione è stata completata</String>
   <String Id="SuccessUninstallHeader">La disinstallazione è stata completata</String>
-  <String Id="SuccessInstallHeader">L'installazione è stata completata</String> 
-  <String Id="SuccessHeader">L'installazione è stata completata</String>	
+  <String Id="SuccessInstallHeader">L'installazione è stata completata</String>
+  <String Id="SuccessHeader">Installazione completata</String>
   <String Id="SuccessLaunchButton">&amp;Avvia</String>
-  <String Id="SuccessRestartText">Per poter usare il software, è necessario riavviare il computer.</String>
+  <String Id="SuccessRestartText">È necessario riavviare il computer prima di utilizzare il software.</String>
   <String Id="SuccessRestartButton">&amp;Riavvia</String>
   <String Id="SuccessCloseButton">&amp;Chiudi</String>
-  <String Id="FailureHeader">L'installazione non è riuscita</String>
+  <String Id="FailureHeader">Installazione non riuscita</String>
   <String Id="FailureInstallHeader">L'installazione non è riuscita</String>
   <String Id="FailureUninstallHeader">La disinstallazione non è riuscita</String>
-  <String Id="FailureRepairHeader">La riparazione non è riuscita</String> 
-  <String Id="FailureHyperlinkLogText">L'installazione non è riuscita a causa di uno o più problemi. Risolvere i problemi e ripetere l'installazione. Per altre informazioni, vedere il &lt;a href="#"&gt;file di log&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">Per completare il rollback del software, è necessario riavviare il computer.</String>
+  <String Id="FailureRepairHeader">La riparazione non è riuscita</String>
+  <String Id="FailureHyperlinkLogText">Installazione non riuscita a causa di uno o più problemi. Risolvere i problemi e ritentare l'installazione. Per ulteriori informazioni, vedere il &lt;a href="#"&gt;file di log&lt;/a&gt;.</String>
+  <String Id="FailureRestartText">È necessario riavviare il computer per completare il rollback del software.</String>
   <String Id="FailureRestartButton">&amp;Riavvia</String>
   <String Id="FailureCloseButton">&amp;Chiudi</String>
   <String Id="FilesInUseHeader">File in uso</String>

--- a/src/Installers/Windows/SharedFrameworkBundle/1040/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1040/thm.wxl
@@ -27,11 +27,11 @@
   <String Id="OptionsLocationLabel">Percorso di installazione:</String>
   <String Id="OptionsBrowseButton">&amp;Sfoglia</String>
   <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">Ann&amp;ulla</String>
+  <String Id="OptionsCancelButton">&amp;Annulla</String>
   <String Id="ProgressHeader">Stato installazione</String>
   <String Id="ProgressLabel">Elaborazione di:</String>
   <String Id="OverallProgressPackageText">Inizializzazione in corso...</String>
-  <String Id="ProgressCancelButton">Ann&amp;ulla</String>
+  <String Id="ProgressCancelButton">&amp;Annulla</String>
   <String Id="ModifyHeader">Modifica installazione</String>
   <String Id="ModifyRepairButton">&amp;Ripristina</String>
   <String Id="ModifyUninstallButton">&amp;Disinstalla</String>

--- a/src/Installers/Windows/SharedFrameworkBundle/1041/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1041/thm.wxl
@@ -1,17 +1,16 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption">[BundleNameFull] のセットアップ</String>
   <String Id="Title">[BundleNameShort]</String>
   <String Id="SubTitle">[BundleNameSub]</String>
   <String Id="InstallHeader">ようこそ</String>
-  <String Id="InstallMessage">セットアップによって、コンピューターに [WixBundleName] がインストールされます。[\[]インストール[\]]をクリックしてインストール ディレクトリを設定するオプションを表示するか、[\[]閉じる[\]] をクリックして終了します。</String>
+  <String Id="InstallMessage">セットアップによって、コンピューターに [WixBundleName] がインストールされます。\[インストール\] をクリックして続行するか、\[オプション\] でインストール ディレクトリを設定するか、\[閉じる\] で終了します。</String>
   <String Id="InstallVersion">バージョン [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">取り消しますか?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">以前のバージョン</String>
   <String Id="HelpHeader">セットアップのヘルプ</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - バンドルの完全なローカル コピーに対する
-  ディレクトリへのインストール、修復、ディレクトリからのアンインストール、またはディレクトリ内への
-  作成を行います。既定の設定はインストールです。
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]ディレクトリ[\]] - バンドルの完全なローカル コピーに対する
+  ディレクトリへのインストール、修復、ディレクトリからのアンインストール、またはディレクトリ内への作成を行います。既定の設定はインストールです。
 
 /passive | /quiet -  最小限の UI だけを表示しプロンプトは表示しない、または UI もプロンプトも
    表示しません。既定では UI とすべてのプロンプトが表示されます。
@@ -39,16 +38,16 @@
   <String Id="ModifyCloseButton">閉じる(&amp;C)</String>
   <String Id="SuccessRepairHeader">修復が正常に完了しました</String>
   <String Id="SuccessUninstallHeader">アンインストールが正常に完了しました</String>
-  <String Id="SuccessInstallHeader">インストールが正常に完了しました</String> 
-  <String Id="SuccessHeader">セットアップ完了</String>	
+  <String Id="SuccessInstallHeader">インストールが正常に完了しました</String>
+  <String Id="SuccessHeader">セットアップ完了</String>
   <String Id="SuccessLaunchButton">起動(&amp;L)</String>
   <String Id="SuccessRestartText">ソフトウェアを使用する前にコンピューターを再起動する必要があります。</String>
   <String Id="SuccessRestartButton">再起動(&amp;R)</String>
   <String Id="SuccessCloseButton">閉じる(&amp;C)</String>
-  <String Id="FailureHeader">セットアップ失敗</String>
+  <String Id="FailureHeader">セットアップに失敗しました</String>
   <String Id="FailureInstallHeader">セットアップに失敗しました</String>
   <String Id="FailureUninstallHeader">アンインストールに失敗しました</String>
-  <String Id="FailureRepairHeader">修復に失敗しました</String> 
+  <String Id="FailureRepairHeader">修復に失敗しました</String>
   <String Id="FailureHyperlinkLogText">1 つまたは複数の問題により、セットアップが失敗しました。問題を解決してからセットアップを再試行してください。詳細については、&lt;a href="#"&gt;ログ ファイル&lt;/a&gt;を参照してください。</String>
   <String Id="FailureRestartText">ソフトウェアのロールバックを完了するには、コンピューターを再起動する必要があります。</String>
   <String Id="FailureRestartButton">再起動(&amp;R)</String>

--- a/src/Installers/Windows/SharedFrameworkBundle/1042/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1042/thm.wxl
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption">[BundleNameFull] 설치</String>
   <String Id="Title">[BundleNameShort]</String>
   <String Id="SubTitle">[BundleNameSub]</String>
-  <String Id="InstallHeader">환영</String>
-  <String Id="InstallMessage">설치 프로그램이 컴퓨터에 [WixBundleName]을(를) 설치합니다. 계속하려면 [\[]설치[\]]를 클릭하고, 설치 디렉터리를 설정하는 옵션을 선택하거나, 종료하려면 [\[]닫기[\]]를 클릭합니다.</String>
+  <String Id="InstallHeader">시작</String>
+  <String Id="InstallMessage">설치 프로그램이 컴퓨터에 [WixBundleName]을(를) 설치합니다. 계속하려면 설치를 클릭한 뒤 원하는 경우 옵션에서 설치 디렉터리를 설정하고, 아니면 닫기를 클릭하여 종료합니다.</String>
   <String Id="InstallVersion">버전 [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">취소하시겠습니까?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">이전 버전</String>
   <String Id="HelpHeader">설치 도움말</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - 디렉터리에 번들의 전체 로컬 복사본을 설치, 복구, 제거 또는
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]디렉터리[\]] - 디렉터리에 번들의 전체 로컬 복사본을 설치, 복구, 제거 또는
    작성합니다. 설치가 기본값입니다.
 
 /passive | /quiet -  프롬프트 없이 최소 UI를 표시하거나 UI 및
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">닫기(&amp;C)</String>
   <String Id="SuccessRepairHeader">복구 완료됨</String>
   <String Id="SuccessUninstallHeader">제거 완료됨</String>
-  <String Id="SuccessInstallHeader">설치 완료됨</String> 
-  <String Id="SuccessHeader">설치 완료</String>	
+  <String Id="SuccessInstallHeader">설치 완료됨</String>
+  <String Id="SuccessHeader">설치 완료</String>
   <String Id="SuccessLaunchButton">시작(&amp;L)</String>
   <String Id="SuccessRestartText">소프트웨어를 사용하려면 먼저 컴퓨터를 다시 시작해야 합니다.</String>
   <String Id="SuccessRestartButton">다시 시작(&amp;R)</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">설치 실패</String>
   <String Id="FailureInstallHeader">설치 실패</String>
   <String Id="FailureUninstallHeader">제거 실패</String>
-  <String Id="FailureRepairHeader">복구 실패</String> 
+  <String Id="FailureRepairHeader">복구 실패</String>
   <String Id="FailureHyperlinkLogText">하나 이상의 문제가 발생하여 설치하지 못했습니다. 문제를 해결한 다음 설치를 다시 시도하십시오. 자세한 내용은 &lt;a href="#"&gt;로그 파일&lt;/a&gt;을 참조하십시오.</String>
   <String Id="FailureRestartText">소프트웨어 롤백을 완료하려면 컴퓨터를 다시 시작해야 합니다.</String>
   <String Id="FailureRestartButton">다시 시작(&amp;R)</String>
@@ -55,7 +55,7 @@
   <String Id="FilesInUseHeader">사용 중인 파일</String>
   <String Id="FilesInUseLabel">다음의 응용 프로그램이 업데이트해야 할 파일을 사용 중입니다.</String>
   <String Id="FilesInUseCloseRadioButton">응용 프로그램을 닫고 다시 시작합니다(&amp;A).</String>
-  <String Id="FilesInUseDontCloseRadioButton">애플리케이션을 닫지 않습니다(&amp;D). 다시 부팅해야 합니다.</String>
+  <String Id="FilesInUseDontCloseRadioButton">응용 프로그램을 닫지 않습니다(&amp;D). 다시 부팅해야 합니다.</String>
   <String Id="FilesInUseOkButton">확인(&amp;O)</String>
   <String Id="FilesInUseCancelButton">취소(&amp;C)</String>
 

--- a/src/Installers/Windows/SharedFrameworkBundle/1045/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1045/thm.wxl
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">Instalator pakietu [BundleNameFull]</String>
+  <String Id="Caption">Konfiguracja pakietu [BundleNameFull]</String>
   <String Id="Title">[BundleNameShort]</String>
   <String Id="SubTitle">[BundleNameSub]</String>
   <String Id="InstallHeader">Witamy</String>
@@ -8,22 +8,22 @@
   <String Id="InstallVersion">Wersja [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Czy na pewno chcesz anulować?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Poprzednia wersja</String>
-  <String Id="HelpHeader">Pomoc dotycząca instalacji</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [katalog] - Instaluje, naprawia, odinstalowuje
-   lub tworzy pełną lokalną kopię pakietu w katalogu. Domyślnie jest używany przełącznik install.
+  <String Id="HelpHeader">Instalator — Pomoc</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]katalog[\]] — instaluje, naprawia, odinstalowuje lub
+    tworzy pełną lokalną kopię pakietu w katalogu. Instalacja jest domyślna
 
-/passive | /quiet -  Wyświetla ograniczony interfejs użytkownika bez monitów albo nie wyświetla ani interfejsu użytkownika,
-   ani monitów. Domyślnie jest wyświetlany interfejs użytkownika oraz wszystkie monity.
+/passive | /quiet — wyświetla minimalny interfejs użytkownika bez monitów albo nie wyświetla żadnego interfejsu użytkownika ani monitów
+. Domyślnie jest wyświetlany interfejs użytkownika oraz wszystkie monity.
 
-/norestart   - Pomija próby ponownego uruchomienia. Domyślnie interfejs użytkownika wyświetla monit przed ponownym uruchomieniem.
-/log log.txt - Tworzy dziennik w określonym pliku. Domyślnie plik dziennika jest tworzony w katalogu %TEMP%.</String>
+/norestart  — pomija próby ponownego uruchomienia. Domyślnie interfejs użytkownika wyświetla monit przed ponownym uruchomieniem.
+/log log.txt — tworzy dziennik w określonym pliku. Domyślnie plik dziennika jest tworzony w katalogu %TEMP%.</String>
   <String Id="HelpCloseButton">&amp;Zamknij</String>
   <String Id="InstallLicenseLinkText">&lt;a href="#"&gt;Postanowienia licencyjne&lt;/a&gt; dotyczące pakietu [WixBundleName].</String>
-  <String Id="InstallAcceptCheckbox">&amp;Zgadzam się z postanowieniami licencyjnymi</String>
+  <String Id="InstallAcceptCheckbox">Zg&amp;adzam się na warunki licencji</String>
   <String Id="InstallOptionsButton">&amp;Opcje</String>
-  <String Id="InstallInstallButton">&amp;Zainstaluj</String>
+  <String Id="InstallInstallButton">Za&amp;instaluj</String>
   <String Id="InstallCloseButton">&amp;Zamknij</String>
-  <String Id="OptionsHeader">Opcje instalacji</String>
+  <String Id="OptionsHeader">Opcje instalatora</String>
   <String Id="OptionsLocationLabel">Lokalizacja instalacji:</String>
   <String Id="OptionsBrowseButton">&amp;Przeglądaj</String>
   <String Id="OptionsOkButton">&amp;OK</String>
@@ -32,24 +32,24 @@
   <String Id="ProgressLabel">Przetwarzanie:</String>
   <String Id="OverallProgressPackageText">Trwa inicjowanie...</String>
   <String Id="ProgressCancelButton">&amp;Anuluj</String>
-  <String Id="ModifyHeader">Modyfikuj instalację</String>
-  <String Id="ModifyRepairButton">&amp;Napraw</String>
-  <String Id="ModifyUninstallButton">&amp;Odinstaluj</String>
+  <String Id="ModifyHeader">Zmodyfikuj instalatora</String>
+  <String Id="ModifyRepairButton">Nap&amp;raw</String>
+  <String Id="ModifyUninstallButton">O&amp;dinstaluj</String>
   <String Id="ModifyCloseButton">&amp;Zamknij</String>
   <String Id="SuccessRepairHeader">Pomyślnie ukończono naprawę</String>
-  <String Id="SuccessUninstallHeader">Pomyślnie ukończono dezinstalację</String>
-  <String Id="SuccessInstallHeader">Pomyślnie ukończono instalację</String> 
-  <String Id="SuccessHeader">Pomyślnie ukończono instalację</String>	
+  <String Id="SuccessUninstallHeader">Pomyślnie ukończono operację odinstalowania</String>
+  <String Id="SuccessInstallHeader">Pomyślnie ukończono instalację</String>
+  <String Id="SuccessHeader">Instalacja przebiegła pomyślnie</String>
   <String Id="SuccessLaunchButton">&amp;Uruchom</String>
-  <String Id="SuccessRestartText">Aby móc korzystać z oprogramowania, musisz uruchomić ponownie komputer.</String>
+  <String Id="SuccessRestartText">Aby korzystać z oprogramowania, należy ponownie uruchomić komputer.</String>
   <String Id="SuccessRestartButton">&amp;Uruchom ponownie</String>
   <String Id="SuccessCloseButton">&amp;Zamknij</String>
   <String Id="FailureHeader">Instalacja nie powiodła się</String>
-  <String Id="FailureInstallHeader">Instalacja nie powiodła się</String>
-  <String Id="FailureUninstallHeader">Dezinstalacja nie powiodła się</String>
-  <String Id="FailureRepairHeader">Naprawa nie powiodła się</String> 
-  <String Id="FailureHyperlinkLogText">Co najmniej jeden problem spowodował niepowodzenie instalacji. Rozwiąż problemy, a następnie ponów próbę instalacji. Aby uzyskać więcej informacji, zobacz &lt;a href="#"&gt;plik dziennika&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">Aby ukończyć wycofywanie oprogramowania, musisz uruchomić ponownie komputer.</String>
+  <String Id="FailureInstallHeader">Konfiguracja nie powiodła się</String>
+  <String Id="FailureUninstallHeader">Operacja odinstalowania nie powiodła się</String>
+  <String Id="FailureRepairHeader">Naprawa nie powiodła się</String>
+  <String Id="FailureHyperlinkLogText">Jeden lub więcej problemów spowodował niepowodzenie instalacji. Napraw błędy, a następnie uruchom ponownie instalację. Aby uzyskać więcej informacji zobacz &lt;a href="#"&gt;plik dziennika&lt;/a&gt;.</String>
+  <String Id="FailureRestartText">Należy ponownie uruchomić komputer, aby dokończyć wycofywanie oprogramowania.</String>
   <String Id="FailureRestartButton">&amp;Uruchom ponownie</String>
   <String Id="FailureCloseButton">&amp;Zamknij</String>
   <String Id="FilesInUseHeader">Pliki w użyciu</String>

--- a/src/Installers/Windows/SharedFrameworkBundle/1045/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1045/thm.wxl
@@ -19,9 +19,9 @@
 /log log.txt — tworzy dziennik w określonym pliku. Domyślnie plik dziennika jest tworzony w katalogu %TEMP%.</String>
   <String Id="HelpCloseButton">&amp;Zamknij</String>
   <String Id="InstallLicenseLinkText">&lt;a href="#"&gt;Postanowienia licencyjne&lt;/a&gt; dotyczące pakietu [WixBundleName].</String>
-  <String Id="InstallAcceptCheckbox">Zg&amp;adzam się na warunki licencji</String>
+  <String Id="InstallAcceptCheckbox">&amp;Zgadzam się na warunki licencji</String>
   <String Id="InstallOptionsButton">&amp;Opcje</String>
-  <String Id="InstallInstallButton">Za&amp;instaluj</String>
+  <String Id="InstallInstallButton">&amp;Zainstaluj</String>
   <String Id="InstallCloseButton">&amp;Zamknij</String>
   <String Id="OptionsHeader">Opcje instalatora</String>
   <String Id="OptionsLocationLabel">Lokalizacja instalacji:</String>
@@ -33,8 +33,8 @@
   <String Id="OverallProgressPackageText">Trwa inicjowanie...</String>
   <String Id="ProgressCancelButton">&amp;Anuluj</String>
   <String Id="ModifyHeader">Zmodyfikuj instalatora</String>
-  <String Id="ModifyRepairButton">Nap&amp;raw</String>
-  <String Id="ModifyUninstallButton">O&amp;dinstaluj</String>
+  <String Id="ModifyRepairButton">&amp;Napraw</String>
+  <String Id="ModifyUninstallButton">&amp;Odinstaluj</String>
   <String Id="ModifyCloseButton">&amp;Zamknij</String>
   <String Id="SuccessRepairHeader">Pomyślnie ukończono naprawę</String>
   <String Id="SuccessUninstallHeader">Pomyślnie ukończono operację odinstalowania</String>

--- a/src/Installers/Windows/SharedFrameworkBundle/1046/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1046/thm.wxl
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption">Instalação do [BundleNameFull]</String>
   <String Id="Title">[BundleNameShort]</String>
   <String Id="SubTitle">[BundleNameSub]</String>
-  <String Id="InstallHeader">Bem-vindo</String>
+  <String Id="InstallHeader">Bem-vindo(a)</String>
   <String Id="InstallMessage">O programa de instalação instalará o [WixBundleName] no seu computador. Clique em Instalar para continuar, Opções para definir o diretório de instalação ou Fechar para sair.</String>
-  <String Id="InstallVersion">Versão do [WixBundleVersion]</String>
+  <String Id="InstallVersion">Versão [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Tem certeza de que deseja cancelar?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Versão anterior</String>
-  <String Id="HelpHeader">Ajuda de Instalação</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [diretório] - instala, repara, desinstala ou
+  <String Id="HelpHeader">Ajuda da Instalação</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]diretório[\]] - instala, repara, desinstala ou
    cria uma cópia local completa do pacote no diretório. Install é o padrão
 
 /passive | /quiet -  exibe a interface do usuário mínima sem nenhum prompt ou não exibe nenhuma interface do usuário e
@@ -19,13 +19,13 @@
 /log log.txt - registra em um arquivo específico. Por padrão, um arquivo de log é criado em %TEMP%.</String>
   <String Id="HelpCloseButton">&amp;Fechar</String>
   <String Id="InstallLicenseLinkText">[WixBundleName] &lt;a href="#"&gt;termos de licença&lt;/a&gt;.</String>
-  <String Id="InstallAcceptCheckbox">&amp;Concordo com os termos e condições da licença</String>
+  <String Id="InstallAcceptCheckbox">Eu &amp;concordo com os termos e condições da licença</String>
   <String Id="InstallOptionsButton">&amp;Opções</String>
   <String Id="InstallInstallButton">&amp;Instalar</String>
   <String Id="InstallCloseButton">&amp;Fechar</String>
   <String Id="OptionsHeader">Opções de Instalação</String>
   <String Id="OptionsLocationLabel">Local de instalação:</String>
-  <String Id="OptionsBrowseButton">&amp;Navegar</String>
+  <String Id="OptionsBrowseButton">&amp;Procurar</String>
   <String Id="OptionsOkButton">&amp;OK</String>
   <String Id="OptionsCancelButton">&amp;Cancelar</String>
   <String Id="ProgressHeader">Progresso da Instalação</String>
@@ -38,27 +38,27 @@
   <String Id="ModifyCloseButton">&amp;Fechar</String>
   <String Id="SuccessRepairHeader">Reparação Concluída com Êxito</String>
   <String Id="SuccessUninstallHeader">Desinstalação Concluída com Êxito</String>
-  <String Id="SuccessInstallHeader">Instalação Concluída com Êxito</String> 
-  <String Id="SuccessHeader">Instalação com Êxito</String>	
+  <String Id="SuccessInstallHeader">Instalação Concluída com Êxito</String>
+  <String Id="SuccessHeader">Instalação com Êxito</String>
   <String Id="SuccessLaunchButton">&amp;Iniciar</String>
-  <String Id="SuccessRestartText">Você deve reiniciar seu computador antes de usar o software.</String>
+  <String Id="SuccessRestartText">Reinicie o computador para poder usar o software.</String>
   <String Id="SuccessRestartButton">&amp;Reiniciar</String>
   <String Id="SuccessCloseButton">&amp;Fechar</String>
   <String Id="FailureHeader">Falha na Instalação</String>
   <String Id="FailureInstallHeader">Falha na Instalação</String>
   <String Id="FailureUninstallHeader">Falha na Desinstalação</String>
-  <String Id="FailureRepairHeader">Falha na Reparação</String> 
+  <String Id="FailureRepairHeader">Falha ao Reparar</String>
   <String Id="FailureHyperlinkLogText">Um ou mais problemas causaram falha na instalação. Corrija-os e tente instalar novamente. Para obter mais informações, consulte o &lt;a href="#"&gt;arquivo de log&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">Você deve reiniciar seu computador para concluir a reversão do software.</String>
+  <String Id="FailureRestartText">Reinicie o computador para concluir a reversão do software.</String>
   <String Id="FailureRestartButton">&amp;Reiniciar</String>
   <String Id="FailureCloseButton">&amp;Fechar</String>
   <String Id="FilesInUseHeader">Arquivos em Uso</String>
   <String Id="FilesInUseLabel">Os aplicativos a seguir estão usando arquivos que precisam ser atualizados:</String>
   <String Id="FilesInUseCloseRadioButton">Feche os &amp;aplicativos e tente reiniciá-los.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Não feche os aplicativos. Será necessária uma reinicialização.</String>
+  <String Id="FilesInUseDontCloseRadioButton">&amp;Não feche os aplicativos. Uma reinicialização será necessária.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancelar</String>
 
   <String Id="Welcome">Bem-vindo à Instalação do [WixBundleName].</String>
-  <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;termos de licença&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;política de privacidade&lt;/a&gt;.</String>
+  <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;termos de licença&lt;/a&gt; e &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;política de privacidade&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/1049/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1049/thm.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption">Установка [BundleNameFull]</String>
   <String Id="Title">[BundleNameShort]</String>
@@ -6,10 +6,10 @@
   <String Id="InstallHeader">Добро пожаловать</String>
   <String Id="InstallMessage">Программа установки установит [WixBundleName] на ваш компьютер. Щелкните элемент "Установить", чтобы продолжить, "Параметры", чтобы указать каталог установки, или "Закрыть", чтобы выйти.</String>
   <String Id="InstallVersion">Версия [WixBundleVersion]</String>
-  <String Id="ConfirmCancelMessage">Вы действительно хотите отменить?</String>
+  <String Id="ConfirmCancelMessage">Отменить?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Предыдущая версия</String>
   <String Id="HelpHeader">Справка по установке</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [каталог] — установка, восстановление, удаление или
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]каталог[\]] — установка, восстановление, удаление или
  создание полной локальной копии пакета в каталоге. По умолчанию — установка.
 
 /passive | /quiet — отображение минимального пользовательского интерфейса без запросов или работа без пользовательского интерфейса и
@@ -30,7 +30,7 @@
   <String Id="OptionsCancelButton">Отм&amp;ена</String>
   <String Id="ProgressHeader">Ход установки</String>
   <String Id="ProgressLabel">Обработка:</String>
-  <String Id="OverallProgressPackageText">Идет инициализация...</String>
+  <String Id="OverallProgressPackageText">Инициализация...</String>
   <String Id="ProgressCancelButton">Отм&amp;ена</String>
   <String Id="ModifyHeader">Изменение установки</String>
   <String Id="ModifyRepairButton">&amp;Исправить</String>
@@ -38,26 +38,26 @@
   <String Id="ModifyCloseButton">&amp;Закрыть</String>
   <String Id="SuccessRepairHeader">Восстановление успешно завершено</String>
   <String Id="SuccessUninstallHeader">Удаление успешно завершено</String>
-  <String Id="SuccessInstallHeader">Установка успешно завершена</String> 
-  <String Id="SuccessHeader">Установка успешно завершена</String>	
+  <String Id="SuccessInstallHeader">Установка успешно завершена</String>
+  <String Id="SuccessHeader">Установка успешно завершена</String>
   <String Id="SuccessLaunchButton">&amp;Запустить</String>
   <String Id="SuccessRestartText">Перед использованием программного обеспечения необходимо перезапустить компьютер.</String>
   <String Id="SuccessRestartButton">&amp;Перезапустить</String>
   <String Id="SuccessCloseButton">&amp;Закрыть</String>
-  <String Id="FailureHeader">Настройка не завершена</String>
+  <String Id="FailureHeader">Сбой установки</String>
   <String Id="FailureInstallHeader">Сбой установки</String>
   <String Id="FailureUninstallHeader">Сбой удаления</String>
-  <String Id="FailureRepairHeader">Сбой восстановления</String> 
+  <String Id="FailureRepairHeader">Сбой восстановления</String>
   <String Id="FailureHyperlinkLogText">Одна или несколько проблем вызывали сбой программы установки. Исправьте эти проблемы и попробуйте повторить установку. Дополнительные сведения см. в &lt;a href="#"&gt;файле журнала&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Необходимо перезагрузить компьютер, чтобы завершить откат программного обеспечения.</String>
   <String Id="FailureRestartButton">&amp;Перезапустить</String>
-  <String Id="FailureCloseButton">З&amp;акрыть</String>
+  <String Id="FailureCloseButton">&amp;Закрыть</String>
   <String Id="FilesInUseHeader">Используемые файлы</String>
-  <String Id="FilesInUseLabel">Следующие приложения используют файлы, которые следует обновить:</String>
-  <String Id="FilesInUseCloseRadioButton">Закрыть &amp;приложения и попытаться перезапустить их.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Не закрывать приложения. Потребуется перезагрузка.</String>
-  <String Id="FilesInUseOkButton">О&amp;К</String>
-  <String Id="FilesInUseCancelButton">&amp;Отмена</String>
+  <String Id="FilesInUseLabel">Следующие приложения используют файлы, которые нуждаются в обновлении:</String>
+  <String Id="FilesInUseCloseRadioButton">Закройте &amp;приложения и попробуйте перезапустить их.</String>
+  <String Id="FilesInUseDontCloseRadioButton">&amp;Не закрывайте приложения. Потребуется перезагрузка компьютера.</String>
+  <String Id="FilesInUseOkButton">&amp;ОК</String>
+  <String Id="FilesInUseCancelButton">&amp;Отменить</String>
 
   <String Id="Welcome">Вас приветствует мастер установки [WixBundleName].</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;условия лицензии&lt;/a&gt; и &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;заявление о конфиденциальности&lt;/a&gt;.</String>

--- a/src/Installers/Windows/SharedFrameworkBundle/1049/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1049/thm.wxl
@@ -51,12 +51,12 @@
   <String Id="FailureHyperlinkLogText">Одна или несколько проблем вызывали сбой программы установки. Исправьте эти проблемы и попробуйте повторить установку. Дополнительные сведения см. в &lt;a href="#"&gt;файле журнала&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Необходимо перезагрузить компьютер, чтобы завершить откат программного обеспечения.</String>
   <String Id="FailureRestartButton">&amp;Перезапустить</String>
-  <String Id="FailureCloseButton">&amp;Закрыть</String>
+  <String Id="FailureCloseButton">З&amp;акрыть</String>
   <String Id="FilesInUseHeader">Используемые файлы</String>
   <String Id="FilesInUseLabel">Следующие приложения используют файлы, которые нуждаются в обновлении:</String>
   <String Id="FilesInUseCloseRadioButton">Закройте &amp;приложения и попробуйте перезапустить их.</String>
   <String Id="FilesInUseDontCloseRadioButton">&amp;Не закрывайте приложения. Потребуется перезагрузка компьютера.</String>
-  <String Id="FilesInUseOkButton">&amp;ОК</String>
+  <String Id="FilesInUseOkButton">О&amp;К</String>
   <String Id="FilesInUseCancelButton">&amp;Отменить</String>
 
   <String Id="Welcome">Вас приветствует мастер установки [WixBundleName].</String>

--- a/src/Installers/Windows/SharedFrameworkBundle/1055/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1055/thm.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption">[BundleNameFull] Kurulumu</String>
   <String Id="Title">[BundleNameShort]</String>
@@ -9,7 +9,7 @@
   <String Id="ConfirmCancelMessage">İptal etmek istediğinizden emin misiniz?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Önceki sürüm</String>
   <String Id="HelpHeader">Kurulum Yardımı</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [dizin] - yükler, onarır, kaldırır ya da
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]dizin[\]] - yükler, onarır, kaldırır ya da
    dizindeki paketin tam bir yerel kopyasını oluşturur. Varsayılan install değeridir.
 
 /passive | /quiet -  en az düzeyde istemsiz UI gösterir ya da hiç UI göstermez ve
@@ -19,9 +19,9 @@
 /log log.txt - belirli bir günlük dosyası tutar. Varsayılan olarak %TEMP% içinde bir günlük dosyası oluşturulur.</String>
   <String Id="HelpCloseButton">&amp;Kapat</String>
   <String Id="InstallLicenseLinkText">[WixBundleName] &lt;a href="#"&gt;lisans koşulları&lt;/a&gt;.</String>
-  <String Id="InstallAcceptCheckbox">Lisans &amp;hüküm ve koşullarını kabul ediyorum</String>
+  <String Id="InstallAcceptCheckbox">Lisans hüküm ve koşullarını &amp;kabul ediyorum</String>
   <String Id="InstallOptionsButton">&amp;Seçenekler</String>
-  <String Id="InstallInstallButton">&amp;Yükle</String>
+  <String Id="InstallInstallButton">Yü&amp;kle</String>
   <String Id="InstallCloseButton">&amp;Kapat</String>
   <String Id="OptionsHeader">Kurulum Seçenekleri</String>
   <String Id="OptionsLocationLabel">Yükleme konumu:</String>
@@ -32,32 +32,32 @@
   <String Id="ProgressLabel">İşleniyor:</String>
   <String Id="OverallProgressPackageText">Başlatılıyor...</String>
   <String Id="ProgressCancelButton">İ&amp;ptal</String>
-  <String Id="ModifyHeader">Kurulumu Değiştir</String>
+  <String Id="ModifyHeader">Kurulumu değiştir</String>
   <String Id="ModifyRepairButton">&amp;Onar</String>
-  <String Id="ModifyUninstallButton">K&amp;aldır</String>
+  <String Id="ModifyUninstallButton">&amp;Kaldır</String>
   <String Id="ModifyCloseButton">&amp;Kapat</String>
   <String Id="SuccessRepairHeader">Onarım Başarıyla Tamamlandı</String>
   <String Id="SuccessUninstallHeader">Kaldırma Başarıyla Tamamlandı</String>
-  <String Id="SuccessInstallHeader">Yükleme Başarıyla Tamamlandı</String> 
-  <String Id="SuccessHeader">Kurulum Başarılı</String>	
+  <String Id="SuccessInstallHeader">Yükleme Başarıyla Tamamlandı</String>
+  <String Id="SuccessHeader">Kurulum Başarılı</String>
   <String Id="SuccessLaunchButton">&amp;Başlat</String>
-  <String Id="SuccessRestartText">Yazılımı kullanabilmek için bilgisayarınızı yeniden başlatmanız gerekiyor.</String>
-  <String Id="SuccessRestartButton">Yeniden &amp;Başlat</String>
+  <String Id="SuccessRestartText">Yazılımı kullanabilmeniz için bilgisayarınızı yeniden başlatmanız gerekiyor.</String>
+  <String Id="SuccessRestartButton">&amp;Yeniden Başlat</String>
   <String Id="SuccessCloseButton">&amp;Kapat</String>
   <String Id="FailureHeader">Kurulum Başarısız</String>
   <String Id="FailureInstallHeader">Kurulum Başarısız</String>
-  <String Id="FailureUninstallHeader">Yükleme Başarısız</String>
-  <String Id="FailureRepairHeader">Onarım Başarısız</String> 
-  <String Id="FailureHyperlinkLogText">En az bir sorun nedeniyle kurulum başarısız oldu. Lütfen bu sorunları düzeltin ve kurulumu yeniden deneyin. Daha fazla bilgi için &lt;a href="#"&gt;günlük dosyasına&lt;/a&gt; bakın.</String>
+  <String Id="FailureUninstallHeader">Kaldırma Başarısız</String>
+  <String Id="FailureRepairHeader">Onarım Başarısız</String>
+  <String Id="FailureHyperlinkLogText">Bir ya da daha fazla sorun nedeniyle kurulum başarısız oldu. Lütfen bu sorunları düzeltin ve kurulumu yeniden deneyin. Daha fazla bilgi için &lt;a href="#"&gt;günlük dosyasına&lt;/a&gt; bakın.</String>
   <String Id="FailureRestartText">Yazılımın geri alınmasını tamamlamak için bilgisayarınızı yeniden başlatmanız gerekiyor.</String>
-  <String Id="FailureRestartButton">Yeniden &amp;Başlat</String>
+  <String Id="FailureRestartButton">&amp;Yeniden Başlat</String>
   <String Id="FailureCloseButton">&amp;Kapat</String>
   <String Id="FilesInUseHeader">Kullanımda Olan Dosyalar</String>
   <String Id="FilesInUseLabel">Şu uygulamalar güncelleştirilmesi gereken dosyaları kullanıyor:</String>
   <String Id="FilesInUseCloseRadioButton">&amp;Uygulamaları kapatın ve yeniden başlatmayı deneyin.</String>
   <String Id="FilesInUseDontCloseRadioButton">&amp;Uygulamaları kapatmayın. Sistemi yeniden başlatmanız gerekir.</String>
   <String Id="FilesInUseOkButton">&amp;Tamam</String>
-  <String Id="FilesInUseCancelButton">&amp;İptal</String>
+  <String Id="FilesInUseCancelButton">İ&amp;ptal</String>
 
   <String Id="Welcome">[WixBundleName] Kurulumu'na Hoş Geldiniz.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;lisans koşulları&lt;/a&gt; ve &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;gizlilik bildirimi&lt;/a&gt;.</String>

--- a/src/Installers/Windows/SharedFrameworkBundle/1055/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1055/thm.wxl
@@ -19,9 +19,9 @@
 /log log.txt - belirli bir günlük dosyası tutar. Varsayılan olarak %TEMP% içinde bir günlük dosyası oluşturulur.</String>
   <String Id="HelpCloseButton">&amp;Kapat</String>
   <String Id="InstallLicenseLinkText">[WixBundleName] &lt;a href="#"&gt;lisans koşulları&lt;/a&gt;.</String>
-  <String Id="InstallAcceptCheckbox">Lisans hüküm ve koşullarını &amp;kabul ediyorum</String>
+  <String Id="InstallAcceptCheckbox">Lisans &amp;hüküm ve koşullarını kabul ediyorum</String>
   <String Id="InstallOptionsButton">&amp;Seçenekler</String>
-  <String Id="InstallInstallButton">Yü&amp;kle</String>
+  <String Id="InstallInstallButton">&amp;Yükle</String>
   <String Id="InstallCloseButton">&amp;Kapat</String>
   <String Id="OptionsHeader">Kurulum Seçenekleri</String>
   <String Id="OptionsLocationLabel">Yükleme konumu:</String>
@@ -34,7 +34,7 @@
   <String Id="ProgressCancelButton">İ&amp;ptal</String>
   <String Id="ModifyHeader">Kurulumu değiştir</String>
   <String Id="ModifyRepairButton">&amp;Onar</String>
-  <String Id="ModifyUninstallButton">&amp;Kaldır</String>
+  <String Id="ModifyUninstallButton">K&amp;aldır</String>
   <String Id="ModifyCloseButton">&amp;Kapat</String>
   <String Id="SuccessRepairHeader">Onarım Başarıyla Tamamlandı</String>
   <String Id="SuccessUninstallHeader">Kaldırma Başarıyla Tamamlandı</String>
@@ -42,7 +42,7 @@
   <String Id="SuccessHeader">Kurulum Başarılı</String>
   <String Id="SuccessLaunchButton">&amp;Başlat</String>
   <String Id="SuccessRestartText">Yazılımı kullanabilmeniz için bilgisayarınızı yeniden başlatmanız gerekiyor.</String>
-  <String Id="SuccessRestartButton">&amp;Yeniden Başlat</String>
+  <String Id="SuccessRestartButton">Yeniden &amp;Başlat</String>
   <String Id="SuccessCloseButton">&amp;Kapat</String>
   <String Id="FailureHeader">Kurulum Başarısız</String>
   <String Id="FailureInstallHeader">Kurulum Başarısız</String>
@@ -50,14 +50,14 @@
   <String Id="FailureRepairHeader">Onarım Başarısız</String>
   <String Id="FailureHyperlinkLogText">Bir ya da daha fazla sorun nedeniyle kurulum başarısız oldu. Lütfen bu sorunları düzeltin ve kurulumu yeniden deneyin. Daha fazla bilgi için &lt;a href="#"&gt;günlük dosyasına&lt;/a&gt; bakın.</String>
   <String Id="FailureRestartText">Yazılımın geri alınmasını tamamlamak için bilgisayarınızı yeniden başlatmanız gerekiyor.</String>
-  <String Id="FailureRestartButton">&amp;Yeniden Başlat</String>
+  <String Id="FailureRestartButton">Yeniden &amp;Başlat</String>
   <String Id="FailureCloseButton">&amp;Kapat</String>
   <String Id="FilesInUseHeader">Kullanımda Olan Dosyalar</String>
   <String Id="FilesInUseLabel">Şu uygulamalar güncelleştirilmesi gereken dosyaları kullanıyor:</String>
   <String Id="FilesInUseCloseRadioButton">&amp;Uygulamaları kapatın ve yeniden başlatmayı deneyin.</String>
   <String Id="FilesInUseDontCloseRadioButton">&amp;Uygulamaları kapatmayın. Sistemi yeniden başlatmanız gerekir.</String>
   <String Id="FilesInUseOkButton">&amp;Tamam</String>
-  <String Id="FilesInUseCancelButton">İ&amp;ptal</String>
+  <String Id="FilesInUseCancelButton">&amp;İptal</String>
 
   <String Id="Welcome">[WixBundleName] Kurulumu'na Hoş Geldiniz.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;lisans koşulları&lt;/a&gt; ve &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;gizlilik bildirimi&lt;/a&gt;.</String>

--- a/src/Installers/Windows/SharedFrameworkBundle/2052/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/2052/thm.wxl
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[BundleNameFull] 安装程序</String>
+  <String Id="Caption">[BundleNameFull] 安装</String>
   <String Id="Title">[BundleNameShort]</String>
   <String Id="SubTitle">[BundleNameSub]</String>
   <String Id="InstallHeader">欢迎</String>
@@ -9,14 +9,14 @@
   <String Id="ConfirmCancelMessage">是否确实要取消?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">上一版本</String>
   <String Id="HelpHeader">安装程序帮助</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [目录] - 安装、修复、卸载
-   目录中的安装包或创建其完整本地副本。Install 为默认选择。
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]目录[\]] - 安装、修复、卸载
+   目录中的捆绑包或创建其完整本地副本。Install 为默认选择。
 
 /passive | /quiet -  显示最少的 UI 且无提示，或不显示 UI 且
-   无提示。默认显示 UI 及全部提示。
+   无提示。默认情况下，显示 UI 及全部提示。
 
-/norestart   - 禁止任何重新启动。默认在重新启动前显示提示 UI。
-/log log.txt - 向特定文件写入日志。默认在 %TEMP% 中创建日志文件。</String>
+/norestart   - 禁止任何重启尝试。默认情况下将在重启前显示提示 UI。
+/log log.txt - 向特定文件写入日志。默认情况下在 %TEMP% 中创建日志文件。</String>
   <String Id="HelpCloseButton">关闭(&amp;C)</String>
   <String Id="InstallLicenseLinkText">[WixBundleName] &lt;a href="#"&gt;许可条款&lt;/a&gt;。</String>
   <String Id="InstallAcceptCheckbox">我同意许可条款和条件(&amp;A)</String>
@@ -30,24 +30,24 @@
   <String Id="OptionsCancelButton">取消(&amp;C)</String>
   <String Id="ProgressHeader">安装进度</String>
   <String Id="ProgressLabel">正在处理:</String>
-  <String Id="OverallProgressPackageText">正在初始化…</String>
+  <String Id="OverallProgressPackageText">正在初始化...</String>
   <String Id="ProgressCancelButton">取消(&amp;C)</String>
   <String Id="ModifyHeader">修改安装程序</String>
   <String Id="ModifyRepairButton">修复(&amp;R)</String>
   <String Id="ModifyUninstallButton">卸载(&amp;U)</String>
   <String Id="ModifyCloseButton">关闭(&amp;C)</String>
-  <String Id="SuccessRepairHeader">成功完成了修复</String>
-  <String Id="SuccessUninstallHeader">成功完成了卸载</String>
-  <String Id="SuccessInstallHeader">成功完成了安装</String> 
-  <String Id="SuccessHeader">设置成功</String>	
+  <String Id="SuccessRepairHeader">已成功完成修复</String>
+  <String Id="SuccessUninstallHeader">已成功完成卸载</String>
+  <String Id="SuccessInstallHeader">已成功完成安装</String>
+  <String Id="SuccessHeader">设置成功</String>
   <String Id="SuccessLaunchButton">启动(&amp;L)</String>
-  <String Id="SuccessRestartText">在使用此软件之前，您必须重新启动计算机。</String>
+  <String Id="SuccessRestartText">您必须先重新启动计算机，然后才能使用该软件。</String>
   <String Id="SuccessRestartButton">重新启动(&amp;R)</String>
   <String Id="SuccessCloseButton">关闭(&amp;C)</String>
-  <String Id="FailureHeader">设置失败</String>
+  <String Id="FailureHeader">安装失败</String>
   <String Id="FailureInstallHeader">安装失败</String>
   <String Id="FailureUninstallHeader">卸载失败</String>
-  <String Id="FailureRepairHeader">修复失败</String> 
+  <String Id="FailureRepairHeader">修复失败</String>
   <String Id="FailureHyperlinkLogText">一个或多个问题导致了安装失败。请修复这些问题，然后重试安装。有关详细信息，请参阅&lt;a href="#"&gt;日志文件&lt;/a&gt;。</String>
   <String Id="FailureRestartText">必须重新启动计算机才能完成软件回退。</String>
   <String Id="FailureRestartButton">重新启动(&amp;R)</String>
@@ -60,5 +60,5 @@
   <String Id="FilesInUseCancelButton">取消(&amp;C)</String>
 
   <String Id="Welcome">欢迎使用 [WixBundleName] 安装程序。</String>
-  <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;许可条件&lt;/a&gt;和&lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;隐私声明&lt;/a&gt;。</String>
+  <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;许可条款&lt;/a&gt;和&lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;隐私声明&lt;/a&gt;。</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/3082/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/3082/thm.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption">Configuración de [BundleNameFull]</String>
   <String Id="Title">[BundleNameShort]</String>
@@ -6,10 +6,10 @@
   <String Id="InstallHeader">Bienvenido</String>
   <String Id="InstallMessage">El programa de instalación instalará [WixBundleName] en el equipo. Haga clic en Instalar para continuar, en Opciones para establecer el directorio de instalación o en Cerrar para salir.</String>
   <String Id="InstallVersion">Versión [WixBundleVersion]</String>
-  <String Id="ConfirmCancelMessage">¿Está seguro de que desea cancelar?</String>
+  <String Id="ConfirmCancelMessage">¿Está seguro de que desea cancelar la operación?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Versión anterior</String>
-  <String Id="HelpHeader">Ayuda de configuración</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - instala, repara, desinstala o
+  <String Id="HelpHeader">Ayuda del programa de instalación</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]directorio[\]] - instala, repara, desinstala o
    crea una copia local completa del paquete en el directorio. Install es la opción predeterminada.
 
 /passive | /quiet -  muestra una IU mínima sin peticiones, o bien no muestra la IU 
@@ -38,16 +38,16 @@
   <String Id="ModifyCloseButton">&amp;Cerrar</String>
   <String Id="SuccessRepairHeader">La reparación se completó correctamente</String>
   <String Id="SuccessUninstallHeader">La desinstalación se completó correctamente</String>
-  <String Id="SuccessInstallHeader">La instalación se completó correctamente</String> 
-  <String Id="SuccessHeader">La instalación o desinstalación se realizó correctamente</String>	
+  <String Id="SuccessInstallHeader">La instalación se completó correctamente</String>
+  <String Id="SuccessHeader">La instalación o desinstalación se realizó correctamente</String>
   <String Id="SuccessLaunchButton">&amp;Iniciar</String>
   <String Id="SuccessRestartText">Debe reiniciar el equipo para poder usar el software.</String>
   <String Id="SuccessRestartButton">&amp;Reiniciar</String>
   <String Id="SuccessCloseButton">&amp;Cerrar</String>
   <String Id="FailureHeader">Error de instalación</String>
-  <String Id="FailureInstallHeader">No se pudo instalar</String>
+  <String Id="FailureInstallHeader">Error de instalación</String>
   <String Id="FailureUninstallHeader">No se pudo desinstalar</String>
-  <String Id="FailureRepairHeader">No se pudo reparar</String> 
+  <String Id="FailureRepairHeader">No se pudo reparar</String>
   <String Id="FailureHyperlinkLogText">Error de instalación debido a uno o varios problemas. Corrija los problemas e intente de nuevo la instalación. Para obtener más información, consulte el &lt;a href="#"&gt;archivo de registro&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Debe reiniciar el equipo para completar la reversión del software.</String>
   <String Id="FailureRestartButton">&amp;Reiniciar</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1028/Strings.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1028/Strings.wxl
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
     <String Id="BalCondition_NETFX451Required">選取的某些功能需要 .NET 4.5.1。請安裝 .NET 4.5.1，再重新安裝此產品。</String>
     <String Id="BalCondition_IISRequired">此產品需要 IIS 7.5。請安裝 IIS，再重新安裝此產品。</String>
     <String Id="BalCondition_VS2015Update2Required">此產品需要 Visual Studio 2015 Update 2 或更新版本。請安裝 Visual Studio 2015 Update 2 或更新版本，再安裝一次此產品。</String>
-    <String Id="BalCondition_VS2015Update3Required">此產品需要 Visual Studio 2015 Update 3 或更新版本。請安裝 Visual Studio 2015 Update 3 或更新版本，再安裝一次此產品。</String>
+    <String Id="BalCondition_VS2015Update3Required">此產品需要 Visual Studio 2015 Update 3 或更新版本。請先安裝 Visual Studio 2015 Update 3 或更新版本，然後再安裝一次此產品。</String>
     <String Id="BalCondition_VS2015Update3Mismatch">安裝程式偵測到 Visual Studio 2015 Update 3 可能未完整安裝。請修復 Visual Studio 2015 Update 3，再重新安裝此產品。</String>
     <String Id="BalCondition_WebDeveloperToolsRequired">此產品需要 Visual Studio 2015 中的 Web Developer Tools 功能。請前往 Windows 中的 [\[]程式和功能[\]] 來啟用此功能，再修改 Visual Studio 2015。</String>
     <String Id="BalCondition_VSVWDRequired">此產品需要安裝 Visual Studio 2015 或 Visual Studio Express 2015 for Web。請安裝缺少的產品，再重新安裝此產品。</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1028/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1028/thm.wxl
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] 安裝程式</String>
+  <String Id="Caption">[WixBundleName]安裝程式</String>
   <String Id="Title">[BundleNameShort]</String>
   <String Id="SubTitle">[BundleNameSub]</String>
   <String Id="InstallHeader">歡迎</String>
@@ -8,8 +8,8 @@
   <String Id="InstallVersion">版本 [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">您確定要取消嗎?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">前一版</String>
-  <String Id="HelpHeader">安裝程式說明</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - 在目錄中安裝、修復、解除安裝或
+  <String Id="HelpHeader">安裝說明</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]目錄[\]] - 在目錄中安裝、修復、解除安裝或
    建立搭售方案的完整本機複本。預設為安裝。
 
 /passive | /quiet -  顯示最少 UI 且不含提示，或者不顯示 UI，也
@@ -38,16 +38,16 @@
   <String Id="ModifyCloseButton">關閉(&amp;C)</String>
   <String Id="SuccessRepairHeader">修復已成功完成</String>
   <String Id="SuccessUninstallHeader">解除安裝已成功完成</String>
-  <String Id="SuccessInstallHeader">安裝已成功完成</String> 
-  <String Id="SuccessHeader">設定成功</String>	
+  <String Id="SuccessInstallHeader">安裝已成功完成</String>
+  <String Id="SuccessHeader">設定成功</String>
   <String Id="SuccessLaunchButton">啟動(&amp;L)</String>
   <String Id="SuccessRestartText">必須重新啟動電腦，才能使用此軟體。</String>
   <String Id="SuccessRestartButton">重新啟動(&amp;R)</String>
   <String Id="SuccessCloseButton">關閉(&amp;C)</String>
-  <String Id="FailureHeader">設定失敗</String>
-  <String Id="FailureInstallHeader">安裝程式失敗</String>
+  <String Id="FailureHeader">安裝失敗</String>
+  <String Id="FailureInstallHeader">設定失敗</String>
   <String Id="FailureUninstallHeader">解除安裝失敗</String>
-  <String Id="FailureRepairHeader">修復失敗</String> 
+  <String Id="FailureRepairHeader">修復失敗</String>
   <String Id="FailureHyperlinkLogText">有一個或多個問題導致安裝程式失敗。請解決問題，然後重試一次安裝。如需詳細資訊，請參閱&lt;a href="#"&gt;記錄檔&lt;/a&gt;。</String>
   <String Id="FailureRestartText">必須重新啟動電腦，才能完成軟體的復原。</String>
   <String Id="FailureRestartButton">重新啟動(&amp;R)</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1029/Strings.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1029/Strings.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
     <String Id="BalCondition_NETFX451Required">Některé funkce, které byly vybrány, vyžadují .NET 4.5.1. Nainstalujte prosím .NET 4.5.1 a pak tento produkt nainstalujte znovu.</String>
     <String Id="BalCondition_IISRequired">Tento produkt vyžaduje IIS 7.5. Nainstalujte prosím IIS a pak tento produkt nainstalujte znovu.</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1029/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1029/thm.wxl
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">Instalace [WixBundleName]</String>
+  <String Id="Caption">Instalační program [WixBundleName]</String>
   <String Id="Title">[BundleNameShort]</String>
   <String Id="SubTitle">[BundleNameSub]</String>
   <String Id="InstallHeader">Vítejte</String>
@@ -8,8 +8,8 @@
   <String Id="InstallVersion">Verze [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Opravdu chcete akci zrušit?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Předchozí verze</String>
-  <String Id="HelpHeader">Nápověda k instalaci</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [adresář] – Nainstaluje, opraví, odinstaluje nebo
+  <String Id="HelpHeader">Nápověda nastavení</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]adresář[\]] – Nainstaluje, opraví, odinstaluje nebo
    vytvoří úplnou místní kopii svazku v adresáři. Výchozí možností je instalace.
 
 /passive | /quiet –  Zobrazí minimální uživatelské rozhraní bez výzev nebo nezobrazí žádné uživatelské rozhraní a
@@ -19,7 +19,7 @@
 /log log.txt – Uloží protokol do konkrétního souboru. Ve výchozím nastavení bude soubor protokolu vytvořen v adresáři %TEMP%.</String>
   <String Id="HelpCloseButton">&amp;Zavřít</String>
   <String Id="InstallLicenseLinkText">&lt;a href="#"&gt;Licenční podmínky&lt;/a&gt; pro [WixBundleName]</String>
-  <String Id="InstallAcceptCheckbox">Souhl&amp;asím s licenčními podmínkami.</String>
+  <String Id="InstallAcceptCheckbox">Souhl&amp;asím s licenčními podmínkami</String>
   <String Id="InstallOptionsButton">M&amp;ožnosti</String>
   <String Id="InstallInstallButton">&amp;Instalovat</String>
   <String Id="InstallCloseButton">&amp;Zavřít</String>
@@ -29,30 +29,30 @@
   <String Id="OptionsOkButton">&amp;OK</String>
   <String Id="OptionsCancelButton">&amp;Storno</String>
   <String Id="ProgressHeader">Průběh instalace</String>
-  <String Id="ProgressLabel">Zpracování:</String>
-  <String Id="OverallProgressPackageText">Inicializuje se...</String>
+  <String Id="ProgressLabel">Probíhá zpracování:</String>
+  <String Id="OverallProgressPackageText">Inicializace...</String>
   <String Id="ProgressCancelButton">&amp;Storno</String>
   <String Id="ModifyHeader">Změnit instalaci</String>
   <String Id="ModifyRepairButton">Op&amp;ravit</String>
   <String Id="ModifyUninstallButton">O&amp;dinstalovat</String>
   <String Id="ModifyCloseButton">&amp;Zavřít</String>
-  <String Id="SuccessRepairHeader">Oprava se úspěšně dokončila.</String>
-  <String Id="SuccessUninstallHeader">Odinstalace se úspěšně dokončila.</String>
-  <String Id="SuccessInstallHeader">Instalace se úspěšně dokončila.</String> 
-  <String Id="SuccessHeader">Instalace byla úspěšná.</String>	
+  <String Id="SuccessRepairHeader">Oprava byla úspěšně dokončena</String>
+  <String Id="SuccessUninstallHeader">Odinstalace se úspěšně dokončila</String>
+  <String Id="SuccessInstallHeader">Instalace se úspěšně dokončila</String>
+  <String Id="SuccessHeader">Instalace byla úspěšná.</String>
   <String Id="SuccessLaunchButton">&amp;Spustit</String>
   <String Id="SuccessRestartText">Před použitím tohoto softwaru musíte restartovat počítač.</String>
   <String Id="SuccessRestartButton">&amp;Restartovat</String>
   <String Id="SuccessCloseButton">&amp;Zavřít</String>
-  <String Id="FailureHeader">Instalace se nepovedla.</String>
-  <String Id="FailureInstallHeader">Instalace se nepovedla.</String>
-  <String Id="FailureUninstallHeader">Odinstalace se nepovedla.</String>
-  <String Id="FailureRepairHeader">Oprava se nepovedla.</String> 
-  <String Id="FailureHyperlinkLogText">Instalace se nepovedla kvůli jednomu nebo více problémům. Opravte prosím tyto problémy a zkuste software nainstalovat znovu. Další informace najdete v &lt;a href="#"&gt;souboru protokolu&lt;/a&gt;.</String>
+  <String Id="FailureHeader">Instalace se nepovedla</String>
+  <String Id="FailureInstallHeader">Instalace se nepovedla</String>
+  <String Id="FailureUninstallHeader">Odinstalace se nepovedla</String>
+  <String Id="FailureRepairHeader">Oprava se nepovedla</String>
+  <String Id="FailureHyperlinkLogText">Jeden nebo více problémů způsobilo selhání instalace. Opravte tyto problémy a znovu spusťte instalaci. Pro více informací se podívejte do &lt;a href="#"&gt;souboru protokolu&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Pro dokončení vrácení změn tohoto softwaru je potřeba restartovat počítač.</String>
   <String Id="FailureRestartButton">&amp;Restartovat</String>
   <String Id="FailureCloseButton">&amp;Zavřít</String>
-  <String Id="FilesInUseHeader">Používané soubory</String>
+  <String Id="FilesInUseHeader">Soubory jsou používány</String>
   <String Id="FilesInUseLabel">Následující aplikace používají soubory, které je potřeba aktualizovat:</String>
   <String Id="FilesInUseCloseRadioButton">Zavřete &amp;aplikace a zkuste je restartovat.</String>
   <String Id="FilesInUseDontCloseRadioButton">A&amp;plikace nezavírejte. Bude potřeba provést restart.</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1031/Strings.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1031/Strings.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
     <String Id="BalCondition_NETFX451Required">Für einige der ausgewählten Features ist .NET 4.5.1 erforderlich. Installieren Sie .NET 4.5.1, und installieren Sie dieses Produkt dann erneut.</String>
     <String Id="BalCondition_IISRequired">Für dieses Produkt ist IIS 7.5 erforderlich. Installieren Sie IIS, und installieren Sie dieses Produkt dann erneut.</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1031/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1031/thm.wxl
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName]-Setup</String>
+  <String Id="Caption">[WixBundleName] - Setup</String>
   <String Id="Title">[BundleNameShort]</String>
   <String Id="SubTitle">[BundleNameSub]</String>
   <String Id="InstallHeader">Willkommen</String>
@@ -8,18 +8,18 @@
   <String Id="InstallVersion">Version von [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Möchten Sie den Vorgang wirklich abbrechen?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Vorherige Version</String>
-  <String Id="HelpHeader">Hilfe zum Setup</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [Verzeichnis] - installiert, repariert, deinstalliert oder
+  <String Id="HelpHeader">Setup-Hilfe</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]Verzeichnis[\]] – installiert, repariert, deinstalliert oder
    erstellt eine vollständige lokale Kopie des Bundles im Verzeichnis. Installieren ist die Standardeinstellung.
 
-/passive | /quiet -  zeigt eine minimale Benutzeroberfläche ohne Eingabeaufforderungen oder keine
+/passive | /quiet –  zeigt eine minimale Benutzeroberfläche ohne Eingabeaufforderungen oder keine
    Benutzeroberfläche und keine Eingabeaufforderungen an. Standardmäßig werden die Benutzeroberfläche und alle Eingabeaufforderungen angezeigt.
 
-/norestart   - Unterdrückt alle Neustartversuche. Standardmäßig fordert die Benutzeroberfläche zum Bestätigen eines Neustarts auf.
-/log log.txt - Erstellt das Protokoll in einer bestimmten Datei. Standardmäßig wird die Protokolldatei in %TEMP% erstellt.</String>
+/norestart   – Unterdrückt alle Neustartversuche. Standardmäßig fordert die Benutzeroberfläche zum Bestätigen eines Neustarts auf.
+/log log.txt – Erstellt das Protokoll in einer bestimmten Datei. Standardmäßig wird die Protokolldatei in %TEMP% erstellt.</String>
   <String Id="HelpCloseButton">S&amp;chließen</String>
   <String Id="InstallLicenseLinkText">[WixBundleName] &lt;a href="#"&gt;Lizenzbedingungen&lt;/a&gt;.</String>
-  <String Id="InstallAcceptCheckbox">Ich &amp;stimme den Lizenzbedingungen zu.</String>
+  <String Id="InstallAcceptCheckbox">Ich &amp;stimme den Bedingungen des Lizenzvertrags zu</String>
   <String Id="InstallOptionsButton">&amp;Optionen</String>
   <String Id="InstallInstallButton">&amp;Installieren</String>
   <String Id="InstallCloseButton">S&amp;chließen</String>
@@ -36,23 +36,23 @@
   <String Id="ModifyRepairButton">&amp;Reparieren</String>
   <String Id="ModifyUninstallButton">&amp;Deinstallieren</String>
   <String Id="ModifyCloseButton">S&amp;chließen</String>
-  <String Id="SuccessRepairHeader">Die Reparatur wurde erfolgreich abgeschlossen.</String>
-  <String Id="SuccessUninstallHeader">Die Deinstallation wurde erfolgreich abgeschlossen.</String>
-  <String Id="SuccessInstallHeader">Die Installation wurde erfolgreich abgeschlossen.</String> 
-  <String Id="SuccessHeader">Setup wurde erfolgreich abgeschlossen</String>	
+  <String Id="SuccessRepairHeader">Reparatur erfolgreich abgeschlossen</String>
+  <String Id="SuccessUninstallHeader">Deinstallation erfolgreich abgeschlossen</String>
+  <String Id="SuccessInstallHeader">Installation erfolgreich abgeschlossen</String>
+  <String Id="SuccessHeader">Setup wurde erfolgreich abgeschlossen</String>
   <String Id="SuccessLaunchButton">&amp;Starten</String>
   <String Id="SuccessRestartText">Sie müssen den Computer neu starten, bevor Sie die Software verwenden können.</String>
-  <String Id="SuccessRestartButton">&amp;Neu starten</String>
+  <String Id="SuccessRestartButton">&amp;Neustart</String>
   <String Id="SuccessCloseButton">S&amp;chließen</String>
   <String Id="FailureHeader">Setupfehler</String>
-  <String Id="FailureInstallHeader">Setupfehler</String>
-  <String Id="FailureUninstallHeader">Deinstallationsfehler</String>
-  <String Id="FailureRepairHeader">Reparaturfehler</String> 
-  <String Id="FailureHyperlinkLogText">Setup ist aufgrund eines oder mehrerer Probleme fehlgeschlagen. Beheben Sie die Probleme, und führen Sie das Setup erneut aus. Weitere Informationen finden Sie in der &lt;a href="#"&gt;Protokolldatei&lt;/a&gt;.</String>
+  <String Id="FailureInstallHeader">Fehler beim Setup</String>
+  <String Id="FailureUninstallHeader">Fehler bei der Deinstallation</String>
+  <String Id="FailureRepairHeader">Fehler bei der Reparatur</String>
+  <String Id="FailureHyperlinkLogText">Setup ist aufgrund eines oder mehrerer Probleme fehlgeschlagen. Beheben Sie die Probleme, und führen Sie Setup erneut aus. Weitere Informationen finden Sie in der &lt;a href="#"&gt;Protokolldatei&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Sie müssen den Computer neu starten, um das Zurücksetzen der Software abzuschließen.</String>
-  <String Id="FailureRestartButton">&amp;Neu starten</String>
-  <String Id="FailureCloseButton">&amp;Schließen</String>
-  <String Id="FilesInUseHeader">Verwendete Dateien</String>
+  <String Id="FailureRestartButton">&amp;Neustart</String>
+  <String Id="FailureCloseButton">S&amp;chließen</String>
+  <String Id="FilesInUseHeader">Dateien in Verwendung</String>
   <String Id="FilesInUseLabel">Die folgenden Anwendungen verwenden Dateien, die aktualisiert werden müssen:</String>
   <String Id="FilesInUseCloseRadioButton">Schließen Sie die &amp;Anwendungen, und versuchen Sie sie erneut zu starten.</String>
   <String Id="FilesInUseDontCloseRadioButton">&amp;Anwendungen nicht schließen. Ein Neustart ist erforderlich.</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1031/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1031/thm.wxl
@@ -51,7 +51,7 @@
   <String Id="FailureHyperlinkLogText">Setup ist aufgrund eines oder mehrerer Probleme fehlgeschlagen. Beheben Sie die Probleme, und führen Sie Setup erneut aus. Weitere Informationen finden Sie in der &lt;a href="#"&gt;Protokolldatei&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Sie müssen den Computer neu starten, um das Zurücksetzen der Software abzuschließen.</String>
   <String Id="FailureRestartButton">&amp;Neustart</String>
-  <String Id="FailureCloseButton">S&amp;chließen</String>
+  <String Id="FailureCloseButton">&amp;Schließen</String>
   <String Id="FilesInUseHeader">Dateien in Verwendung</String>
   <String Id="FilesInUseLabel">Die folgenden Anwendungen verwenden Dateien, die aktualisiert werden müssen:</String>
   <String Id="FilesInUseCloseRadioButton">Schließen Sie die &amp;Anwendungen, und versuchen Sie sie erneut zu starten.</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1033/Strings.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1033/Strings.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
     <String Id="BalCondition_NETFX451Required">Some features that were selected requires .NET 4.5.1. Please install .NET 4.5.1, then install this product again.</String>
     <String Id="BalCondition_IISRequired">This product requires IIS 7.5. Please install IIS, then install this product again.</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1033/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1033/thm.wxl
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] Setup</String>
-  <String Id="Title">[BundleNameShort]</String>
-  <String Id="SubTitle">[BundleNameSub]</String>
+  <String Id="Caption"><!--_locComment_text="{Locked='[WixBundleName]'}"-->[WixBundleName] Setup</String>
+  <String Id="Title"><!--_locComment_text="{Locked}"-->[BundleNameShort]</String>
+  <String Id="SubTitle"><!--_locComment_text="{Locked}"-->[BundleNameSub]</String>
   <String Id="InstallHeader">Welcome</String>
-  <String Id="InstallMessage">Setup will install [WixBundleName] on your computer. Click install to continue, options to set the install directory or Close to exit.</String>
-  <String Id="InstallVersion">Version [WixBundleVersion]</String>
+  <String Id="InstallMessage"><!--_locComment_text="{Locked='[WixBundleName]'}"-->Setup will install [WixBundleName] on your computer. Click install to continue, options to set the install directory or Close to exit.</String>
+  <String Id="InstallVersion"><!--_locComment_text="{Locked='[WixBundleVersion]'}"-->Version [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Previous version</String>
   <String Id="HelpHeader">Setup Help</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installs, repairs, uninstalls or
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]directory[\]] - installs, repairs, uninstalls or
    creates a complete local copy of the bundle in directory. Install is the default.
 
 /passive | /quiet -  displays minimal UI with no prompts or displays no UI and
@@ -18,7 +18,7 @@
 /norestart   - suppress any attempts to restart. By default UI will prompt before restart.
 /log log.txt - logs to a specific file. By default a log file is created in %TEMP%.</String>
   <String Id="HelpCloseButton">&amp;Close</String>
-  <String Id="InstallLicenseLinkText">[WixBundleName] &lt;a href="#"&gt;license terms&lt;/a&gt;.</String>
+  <String Id="InstallLicenseLinkText"><!--_locComment_text="{Locked='[WixBundleName]'}"-->[WixBundleName] &lt;a href="#"&gt;license terms&lt;/a&gt;.</String>
   <String Id="InstallAcceptCheckbox">I &amp;agree to the license terms and conditions</String>
   <String Id="InstallOptionsButton">&amp;Options</String>
   <String Id="InstallInstallButton">&amp;Install</String>
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">&amp;Close</String>
   <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
   <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation Successfully Completed</String> 
-  <String Id="SuccessHeader">Setup Successful</String>	
+  <String Id="SuccessInstallHeader">Installation Successfully Completed</String>
+  <String Id="SuccessHeader">Setup Successful</String>
   <String Id="SuccessLaunchButton">&amp;Launch</String>
   <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
   <String Id="SuccessRestartButton">&amp;Restart</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">Setup Failed</String>
   <String Id="FailureInstallHeader">Setup Failed</String>
   <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String> 
+  <String Id="FailureRepairHeader">Repair Failed</String>
   <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
   <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
   <String Id="FailureRestartButton">&amp;Restart</String>
@@ -60,10 +60,10 @@
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
 
   <!-- Custom UI strings -->
-  <String Id="Welcome">Welcome to the [WixBundleName] Setup.</String>
+  <String Id="Welcome"><!--_locComment_text="{Locked='[WixBundleName]'}"-->Welcome to the [WixBundleName] Setup.</String>
   <String Id="InstallResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
   <String Id="InstallNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
-  <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
+  <String Id="EulaPrivacy"><!--_locComment_text="{Locked='[WixBundleName]'}"-->[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
   <String Id="ModifyResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
   <String Id="ModifyNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1036/Strings.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1036/Strings.wxl
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-    <String Id="BalCondition_NETFX451Required">Certaines des fonctionnalités sélectionnées nécessitent .NET 4.5.1. Installez .NET 4.5.1, puis réinstallez ce produit.</String>
-    <String Id="BalCondition_IISRequired">Ce produit nécessite IIS 7.5. Installez IIS, puis réinstallez ce produit.</String>
-    <String Id="BalCondition_VS2015Update2Required">Ce produit nécessite Visual Studio 2015 Update 2 ou version ultérieure. Installez Visual Studio 2015 Update 2 ou une version ultérieure, puis réinstallez ce produit.</String>
-    <String Id="BalCondition_VS2015Update3Required">Ce produit nécessite Visual Studio 2015 Update 3 ou version ultérieure. Installez Visual Studio 2015 Update 3 ou une version ultérieure, puis réinstallez ce produit.</String>
-    <String Id="BalCondition_VS2015Update3Mismatch">Le programme d'installation a détecté que Visual Studio 2015 Update 3 n'est peut-être pas complètement installé. Réparez Visual Studio 2015 Update 3, puis réinstallez ce produit.</String>
-    <String Id="BalCondition_WebDeveloperToolsRequired">Ce produit nécessite la fonctionnalité Web Developer Tools de Visual Studio 2015. Activez la fonctionnalité en accédant à Programmes et fonctionnalités dans Windows, puis modifiez Visual Studio 2015.</String>
-    <String Id="BalCondition_VSVWDRequired">Ce produit nécessite l'installation de Visual Studio 2015 ou Visual Studio Express 2015 pour le web. Installez le produit manquant, puis réinstallez ce produit.</String>
+    <String Id="BalCondition_NETFX451Required">Certaines des fonctionnalités sélectionnées nécessitent .NET 4.5.1. Veuillez installer .NET 4.5.1, puis réinstallez ce produit.</String>
+    <String Id="BalCondition_IISRequired">Ce produit nécessite Internet Information Services (IIS) 7.5. Veuillez installer IIS, puis réinstallez ce produit.</String>
+    <String Id="BalCondition_VS2015Update2Required">Ce produit nécessite Visual Studio 2015 Update 2 ou version ultérieure. Veuillez installer Visual Studio 2015 Update 2 ou une version ultérieure, puis réinstallez ce produit.</String>
+    <String Id="BalCondition_VS2015Update3Required">Ce produit nécessite Visual Studio 2015 avec la mise à jour 3 ou version ultérieure. Veuillez installer Visual Studio 2015 avec la mise à jour 3 ou une version ultérieure, puis réinstallez ce produit.</String>
+    <String Id="BalCondition_VS2015Update3Mismatch">Le programme d’installation a détecté que Visual Studio 2015 avec la mise à jour 3 n’est peut-être pas complètement installé. Veuillez réparez Visual Studio 2015 avec la mise à jour 3, puis réinstallez ce produit.</String>
+    <String Id="BalCondition_WebDeveloperToolsRequired">Ce produit nécessite la fonctionnalité Outils de développement Web de Visual Studio 2015. Veuillez activer la fonctionnalité en accédant à Programmes et fonctionnalités dans Windows, puis modifiez Visual Studio 2015.</String>
+    <String Id="BalCondition_VSVWDRequired">Ce produit nécessite l’installation de Visual Studio 2015 ou Visual Studio Express 2015 pour le Web. Veuillez installer le produit manquant, puis réinstallez ce produit.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1036/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1036/thm.wxl
@@ -5,11 +5,11 @@
   <String Id="SubTitle">[BundleNameSub]</String>
   <String Id="InstallHeader">Bienvenue</String>
   <String Id="InstallMessage">Le programme d'installation va installer [WixBundleName] sur votre ordinateur. Cliquez sur Installer pour continuer, sur Options pour définir le répertoire d'installation ou sur Fermer pour quitter le programme.</String>
-  <String Id="InstallVersion">Version de [WixBundleVersion]</String>
-  <String Id="ConfirmCancelMessage">Voulez-vous vraiment annuler ?</String>
+  <String Id="InstallVersion">Version [WixBundleVersion]</String>
+  <String Id="ConfirmCancelMessage">Êtes-vous sûr de vouloir annuler ?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Version précédente</String>
-  <String Id="HelpHeader">Aide à l'installation</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [répertoire] - installe, répare, désinstalle ou
+  <String Id="HelpHeader">Aide du programme d'installation</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]répertoire[\]] - installe, répare, désinstalle ou
    crée une copie locale complète du bundle dans le répertoire. Install est l'option par défaut.
 
 /passive | /quiet -  affiche une interface utilisateur minimale, sans invite, ou n'affiche 
@@ -28,7 +28,7 @@
   <String Id="OptionsBrowseButton">&amp;Parcourir</String>
   <String Id="OptionsOkButton">&amp;OK</String>
   <String Id="OptionsCancelButton">&amp;Annuler</String>
-  <String Id="ProgressHeader">Progression de l'installation</String>
+  <String Id="ProgressHeader">Progression de l’opération</String>
   <String Id="ProgressLabel">En cours :</String>
   <String Id="OverallProgressPackageText">Initialisation...</String>
   <String Id="ProgressCancelButton">&amp;Annuler</String>
@@ -38,23 +38,23 @@
   <String Id="ModifyCloseButton">&amp;Fermer</String>
   <String Id="SuccessRepairHeader">Réparation terminée avec succès</String>
   <String Id="SuccessUninstallHeader">Désinstallation terminée avec succès</String>
-  <String Id="SuccessInstallHeader">Installation terminée avec succès</String> 
-  <String Id="SuccessHeader">Installation/désinstallation réussie</String>	
+  <String Id="SuccessInstallHeader">Installation terminée avec succès</String>
+  <String Id="SuccessHeader">Opération réussie</String>
   <String Id="SuccessLaunchButton">&amp;Démarrer</String>
   <String Id="SuccessRestartText">Vous devez redémarrer votre ordinateur avant de pouvoir utiliser le logiciel.</String>
   <String Id="SuccessRestartButton">&amp;Redémarrer</String>
   <String Id="SuccessCloseButton">&amp;Fermer</String>
-  <String Id="FailureHeader">Échec de l'installation</String>
+  <String Id="FailureHeader">Échec de l’opération</String>
   <String Id="FailureInstallHeader">Échec de l'installation</String>
   <String Id="FailureUninstallHeader">Échec de la désinstallation</String>
-  <String Id="FailureRepairHeader">Échec de la réparation</String> 
-  <String Id="FailureHyperlinkLogText">Un ou plusieurs problèmes sont à l'origine de l'échec de l'installation. Corrigez ces problèmes, puis recommencez l'installation. Pour plus d'informations, voir le &lt;a href="#"&gt;fichier journal&lt;/a&gt;.</String>
+  <String Id="FailureRepairHeader">Échec de la réparation</String>
+  <String Id="FailureHyperlinkLogText">Le programme d’installation a échoué en raison d’un ou de plusieurs problèmes. Veuillez corriger ces problèmes, puis relancez le programme d’installation. Pour plus d’informations, consultez le &lt;a href="#"&gt;fichier journal&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Vous devez redémarrer votre ordinateur pour terminer l'opération de restauration du logiciel.</String>
   <String Id="FailureRestartButton">&amp;Redémarrer</String>
   <String Id="FailureCloseButton">&amp;Fermer</String>
   <String Id="FilesInUseHeader">Fichiers en cours d'utilisation</String>
-  <String Id="FilesInUseLabel">Les applications suivantes utilisent des fichiers nécessitant une mise à jour :</String>
-  <String Id="FilesInUseCloseRadioButton">&amp;Fermer les applications et tenter de les redémarrer.</String>
+  <String Id="FilesInUseLabel">Les applications suivantes utilisent des fichiers nécessitant une mise à jour :</String>
+  <String Id="FilesInUseCloseRadioButton">&amp;Fermer les applications essayer de les ouvrir de nouveau.</String>
   <String Id="FilesInUseDontCloseRadioButton">&amp;Ne pas fermer les applications. Un redémarrage sera nécessaire.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Annuler</String>
@@ -63,7 +63,7 @@
   <String Id="Welcome">Bienvenue dans le programme d'installation de [WixBundleName].</String>
   <String Id="InstallResetIIS">Redémarrez IIS une fois l'installation effectuée. Des informations supplémentaires sont disponibles &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;ici&lt;/a&gt;.</String>
   <String Id="InstallNoIIS">IIS n'est pas activé sur cet ordinateur. Si vous avez l'intention d'exécuter des applications ASP.NET Core avec IIS, vous devez installer IIS avant d'exécuter ce programme d'installation. Des informations supplémentaires sont disponibles &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;ici&lt;/a&gt;.</String>
-  <String Id="EulaPrivacy">&lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Termes du contrat de licence&lt;/a&gt; et &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;déclaration de confidentialité&lt;/a&gt; de [WixBundleName].</String>
+  <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;termes du contrat de licence&lt;/a&gt; et &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;déclaration de confidentialité&lt;/a&gt;.</String>
   <String Id="ModifyResetIIS">Redémarrez IIS une fois l'installation effectuée. Des informations supplémentaires sont disponibles &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;ici&lt;/a&gt;.</String>
   <String Id="ModifyNoIIS">IIS n'est pas activé sur cet ordinateur. Si vous avez l'intention d'exécuter des applications ASP.NET Core avec IIS, vous devez installer IIS avant d'exécuter ce programme d'installation. Des informations supplémentaires sont disponibles &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;ici&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1040/Strings.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1040/Strings.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
     <String Id="BalCondition_NETFX451Required">Alcune funzionalità selezionate richiedono .NET 4.5.1. Installare .NET 4.5.1, quindi installare di nuovo questo prodotto.</String>
     <String Id="BalCondition_IISRequired">Questo prodotto richiede IIS 7.5. Installare IIS, quindi installare di nuovo questo prodotto.</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1040/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1040/thm.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption">Installazione di [WixBundleName]</String>
   <String Id="Title">[BundleNameShort]</String>
@@ -8,8 +8,8 @@
   <String Id="InstallVersion">Versione [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Annullare?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Versione precedente</String>
-  <String Id="HelpHeader">Guida alla configurazione</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - installa, ripara, disinstalla o
+  <String Id="HelpHeader">Guida all'installazione</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]directory[\]] - installa, ripara, disinstalla o
    crea una copia locale completa del bundle nella directory. L'opzione predefinita è install.
 
 /passive | /quiet -  visualizza un'interfaccia utente minima senza prompt oppure non visualizza alcuna interfaccia utente
@@ -27,29 +27,29 @@
   <String Id="OptionsLocationLabel">Percorso di installazione:</String>
   <String Id="OptionsBrowseButton">&amp;Sfoglia</String>
   <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">&amp;Annulla</String>
+  <String Id="OptionsCancelButton">Ann&amp;ulla</String>
   <String Id="ProgressHeader">Stato installazione</String>
   <String Id="ProgressLabel">Elaborazione di:</String>
   <String Id="OverallProgressPackageText">Inizializzazione in corso...</String>
-  <String Id="ProgressCancelButton">&amp;Annulla</String>
+  <String Id="ProgressCancelButton">Ann&amp;ulla</String>
   <String Id="ModifyHeader">Modifica installazione</String>
   <String Id="ModifyRepairButton">&amp;Ripristina</String>
   <String Id="ModifyUninstallButton">&amp;Disinstalla</String>
   <String Id="ModifyCloseButton">&amp;Chiudi</String>
-  <String Id="SuccessRepairHeader">La riparazione è stata completata</String>
-  <String Id="SuccessUninstallHeader">La disinstallazione è stata completata</String>
-  <String Id="SuccessInstallHeader">L'installazione è stata completata</String> 
-  <String Id="SuccessHeader">L'installazione è stata completata</String>	
+  <String Id="SuccessRepairHeader">Riparazione completata correttamente</String>
+  <String Id="SuccessUninstallHeader">Disinstallazione completata correttamente</String>
+  <String Id="SuccessInstallHeader">Installazione completata correttamente</String>
+  <String Id="SuccessHeader">Installazione completata</String>
   <String Id="SuccessLaunchButton">&amp;Avvia</String>
-  <String Id="SuccessRestartText">Per poter usare il software, è necessario riavviare il computer.</String>
+  <String Id="SuccessRestartText">È necessario riavviare il computer prima di utilizzare il software.</String>
   <String Id="SuccessRestartButton">&amp;Riavvia</String>
   <String Id="SuccessCloseButton">&amp;Chiudi</String>
-  <String Id="FailureHeader">L'installazione non è riuscita</String>
-  <String Id="FailureInstallHeader">L'installazione non è riuscita</String>
-  <String Id="FailureUninstallHeader">La disinstallazione non è riuscita</String>
-  <String Id="FailureRepairHeader">La riparazione non è riuscita</String> 
-  <String Id="FailureHyperlinkLogText">L'installazione non è riuscita a causa di uno o più problemi. Risolvere i problemi e ripetere l'installazione. Per altre informazioni, vedere il &lt;a href="#"&gt;file di log&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">Per completare il rollback del software, è necessario riavviare il computer.</String>
+  <String Id="FailureHeader">Installazione non riuscita</String>
+  <String Id="FailureInstallHeader">Installazione non riuscita</String>
+  <String Id="FailureUninstallHeader">Disinstallazione non riuscita</String>
+  <String Id="FailureRepairHeader">Riparazione non riuscita</String>
+  <String Id="FailureHyperlinkLogText">Installazione non riuscita a causa di uno o più problemi. Risolvere i problemi e ritentare l'installazione. Per ulteriori informazioni, vedere il &lt;a href="#"&gt;file di log&lt;/a&gt;.</String>
+  <String Id="FailureRestartText">È necessario riavviare il computer per completare il rollback del software.</String>
   <String Id="FailureRestartButton">&amp;Riavvia</String>
   <String Id="FailureCloseButton">&amp;Chiudi</String>
   <String Id="FilesInUseHeader">File in uso</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1040/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1040/thm.wxl
@@ -27,11 +27,11 @@
   <String Id="OptionsLocationLabel">Percorso di installazione:</String>
   <String Id="OptionsBrowseButton">&amp;Sfoglia</String>
   <String Id="OptionsOkButton">&amp;OK</String>
-  <String Id="OptionsCancelButton">Ann&amp;ulla</String>
+  <String Id="OptionsCancelButton">&amp;Annulla</String>
   <String Id="ProgressHeader">Stato installazione</String>
   <String Id="ProgressLabel">Elaborazione di:</String>
   <String Id="OverallProgressPackageText">Inizializzazione in corso...</String>
-  <String Id="ProgressCancelButton">Ann&amp;ulla</String>
+  <String Id="ProgressCancelButton">&amp;Annulla</String>
   <String Id="ModifyHeader">Modifica installazione</String>
   <String Id="ModifyRepairButton">&amp;Ripristina</String>
   <String Id="ModifyUninstallButton">&amp;Disinstalla</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1041/Strings.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1041/Strings.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
     <String Id="BalCondition_NETFX451Required">選択した一部の機能には、.NET 4.5.1 が必要です。.NET 4.5.1 をインストールしてから、この製品をもう一度インストールしてください。</String>
     <String Id="BalCondition_IISRequired">この製品には IIS 7.5 が必要です。IIS をインストールしてから、この製品をもう一度インストールしてください。</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1041/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1041/thm.wxl
@@ -1,17 +1,16 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] セットアップ</String>
+  <String Id="Caption">[WixBundleName]のセットアップ</String>
   <String Id="Title">[BundleNameShort]</String>
   <String Id="SubTitle">[BundleNameSub]</String>
   <String Id="InstallHeader">ようこそ</String>
-  <String Id="InstallMessage">セットアップによって、コンピューターに [WixBundleName] がインストールされます。[\[]インストール[\]]をクリックしてインストール ディレクトリを設定するオプションを表示するか、[\[]閉じる[\]] をクリックして終了します。</String>
+  <String Id="InstallMessage">セットアップによって、コンピューターに [WixBundleName] がインストールされます。\[インストール\] をクリックして続行するか、\[オプション\] でインストール ディレクトリを設定するか、\[閉じる\] で終了します。</String>
   <String Id="InstallVersion">バージョン [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">取り消しますか?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">以前のバージョン</String>
   <String Id="HelpHeader">セットアップのヘルプ</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - バンドルの完全なローカル コピーに対する
-  ディレクトリへのインストール、修復、ディレクトリからのアンインストール、またはディレクトリ内への
-  作成を行います。既定の設定はインストールです。
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]ディレクトリ[\]] - バンドルの完全なローカル コピーに対する
+  ディレクトリへのインストール、修復、ディレクトリからのアンインストール、またはディレクトリ内への作成を行います。既定の設定はインストールです。
 
 /passive | /quiet -  最小限の UI だけを表示しプロンプトは表示しない、または UI もプロンプトも
    表示しません。既定では UI とすべてのプロンプトが表示されます。
@@ -39,16 +38,16 @@
   <String Id="ModifyCloseButton">閉じる(&amp;C)</String>
   <String Id="SuccessRepairHeader">修復が正常に完了しました</String>
   <String Id="SuccessUninstallHeader">アンインストールが正常に完了しました</String>
-  <String Id="SuccessInstallHeader">インストールが正常に完了しました</String> 
-  <String Id="SuccessHeader">セットアップ完了</String>	
+  <String Id="SuccessInstallHeader">インストールが正常に完了しました</String>
+  <String Id="SuccessHeader">セットアップ完了</String>
   <String Id="SuccessLaunchButton">起動(&amp;L)</String>
   <String Id="SuccessRestartText">ソフトウェアを使用する前にコンピューターを再起動する必要があります。</String>
   <String Id="SuccessRestartButton">再起動(&amp;R)</String>
   <String Id="SuccessCloseButton">閉じる(&amp;C)</String>
-  <String Id="FailureHeader">セットアップ失敗</String>
+  <String Id="FailureHeader">セットアップに失敗しました</String>
   <String Id="FailureInstallHeader">セットアップに失敗しました</String>
   <String Id="FailureUninstallHeader">アンインストールに失敗しました</String>
-  <String Id="FailureRepairHeader">修復に失敗しました</String> 
+  <String Id="FailureRepairHeader">修復に失敗しました</String>
   <String Id="FailureHyperlinkLogText">1 つまたは複数の問題により、セットアップが失敗しました。問題を解決してからセットアップを再試行してください。詳細については、&lt;a href="#"&gt;ログ ファイル&lt;/a&gt;を参照してください。</String>
   <String Id="FailureRestartText">ソフトウェアのロールバックを完了するには、コンピューターを再起動する必要があります。</String>
   <String Id="FailureRestartButton">再起動(&amp;R)</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1042/Strings.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1042/Strings.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
     <String Id="BalCondition_NETFX451Required">선택한 일부 기능을 사용하려면 .NET 4.5.1이 필요합니다. .NET 4.5.1을 설치한 다음, 이 제품을 다시 설치하세요.</String>
     <String Id="BalCondition_IISRequired">이 제품을 사용하려면 IIS 7.5가 필요합니다. IIS를 설치한 다음, 이 제품을 다시 설치하세요.</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1042/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1042/thm.wxl
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] 설치</String>
+  <String Id="Caption">[WixBundleName] 설치 프로그램</String>
   <String Id="Title">[BundleNameShort]</String>
   <String Id="SubTitle">[BundleNameSub]</String>
   <String Id="InstallHeader">환영</String>
-  <String Id="InstallMessage">설치 프로그램이 컴퓨터에 [WixBundleName]을(를) 설치합니다. 계속하려면 [\[]설치[\]]를 클릭하고, 설치 디렉터리를 설정하는 옵션을 선택하거나, 종료하려면 [\[]닫기[\]]를 클릭합니다.</String>
+  <String Id="InstallMessage">설치 프로그램이 컴퓨터에 [WixBundleName]을(를) 설치합니다. 계속하려면 설치를 클릭하고, 설치 디렉터리를 설정하는 옵션을 선택하거나, 종료하려면 닫기를 클릭합니다.</String>
   <String Id="InstallVersion">버전 [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">취소하시겠습니까?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">이전 버전</String>
   <String Id="HelpHeader">설치 도움말</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - 디렉터리에 번들의 전체 로컬 복사본을 설치, 복구, 제거 또는
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]디렉터리[\]] - 디렉터리에 번들의 전체 로컬 복사본을 설치, 복구, 제거 또는
    작성합니다. 설치가 기본값입니다.
 
 /passive | /quiet -  프롬프트 없이 최소 UI를 표시하거나 UI 및
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">닫기(&amp;C)</String>
   <String Id="SuccessRepairHeader">복구 완료됨</String>
   <String Id="SuccessUninstallHeader">제거 완료됨</String>
-  <String Id="SuccessInstallHeader">설치 완료됨</String> 
-  <String Id="SuccessHeader">설치 완료</String>	
+  <String Id="SuccessInstallHeader">설치 완료됨</String>
+  <String Id="SuccessHeader">설치 완료</String>
   <String Id="SuccessLaunchButton">시작(&amp;L)</String>
   <String Id="SuccessRestartText">소프트웨어를 사용하려면 먼저 컴퓨터를 다시 시작해야 합니다.</String>
   <String Id="SuccessRestartButton">다시 시작(&amp;R)</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">설치 실패</String>
   <String Id="FailureInstallHeader">설치 실패</String>
   <String Id="FailureUninstallHeader">제거 실패</String>
-  <String Id="FailureRepairHeader">복구 실패</String> 
+  <String Id="FailureRepairHeader">복구 실패</String>
   <String Id="FailureHyperlinkLogText">하나 이상의 문제가 발생하여 설치하지 못했습니다. 문제를 해결한 다음 설치를 다시 시도하십시오. 자세한 내용은 &lt;a href="#"&gt;로그 파일&lt;/a&gt;을 참조하십시오.</String>
   <String Id="FailureRestartText">소프트웨어 롤백을 완료하려면 컴퓨터를 다시 시작해야 합니다.</String>
   <String Id="FailureRestartButton">다시 시작(&amp;R)</String>
@@ -55,7 +55,7 @@
   <String Id="FilesInUseHeader">사용 중인 파일</String>
   <String Id="FilesInUseLabel">다음의 응용 프로그램이 업데이트해야 할 파일을 사용 중입니다.</String>
   <String Id="FilesInUseCloseRadioButton">응용 프로그램을 닫고 다시 시작합니다(&amp;A).</String>
-  <String Id="FilesInUseDontCloseRadioButton">애플리케이션을 닫지 않습니다(&amp;D). 다시 부팅해야 합니다.</String>
+  <String Id="FilesInUseDontCloseRadioButton">응용 프로그램을 닫지 않습니다(&amp;D). 다시 부팅해야 합니다.</String>
   <String Id="FilesInUseOkButton">확인(&amp;O)</String>
   <String Id="FilesInUseCancelButton">취소(&amp;C)</String>
 

--- a/src/Installers/Windows/WindowsHostingBundle/1045/Strings.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1045/Strings.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
     <String Id="BalCondition_NETFX451Required">Niektóre wybrane funkcje wymagają programu .NET 4.5.1. Zainstaluj program .NET 4.5.1, a następnie zainstaluj ponownie ten produkt.</String>
     <String Id="BalCondition_IISRequired">Ten produkt wymaga usług IIS 7.5. Zainstaluj usługi IIS, a następnie zainstaluj ponownie ten produkt.</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1045/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1045/thm.wxl
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] — instalacja</String>
+  <String Id="Caption">Instalator [WixBundleName]</String>
   <String Id="Title">[BundleNameShort]</String>
   <String Id="SubTitle">[BundleNameSub]</String>
   <String Id="InstallHeader">Witamy</String>
@@ -8,22 +8,22 @@
   <String Id="InstallVersion">Wersja [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Czy na pewno chcesz anulować?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Poprzednia wersja</String>
-  <String Id="HelpHeader">Pomoc dotycząca instalacji</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [katalog] - Instaluje, naprawia, odinstalowuje
-   lub tworzy pełną lokalną kopię pakietu w katalogu. Domyślnie jest używany przełącznik install.
+  <String Id="HelpHeader">Instalator — Pomoc</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]katalog[\]] — instaluje, naprawia, odinstalowuje lub
+    tworzy pełną lokalną kopię pakietu w katalogu. Instalacja jest domyślna
 
-/passive | /quiet -  Wyświetla ograniczony interfejs użytkownika bez monitów albo nie wyświetla ani interfejsu użytkownika,
-   ani monitów. Domyślnie jest wyświetlany interfejs użytkownika oraz wszystkie monity.
+/passive | /quiet — wyświetla minimalny interfejs użytkownika bez monitów albo nie wyświetla żadnego interfejsu użytkownika ani monitów
+. Domyślnie jest wyświetlany interfejs użytkownika oraz wszystkie monity.
 
-/norestart   - Pomija próby ponownego uruchomienia. Domyślnie interfejs użytkownika wyświetla monit przed ponownym uruchomieniem.
-/log log.txt - Tworzy dziennik w określonym pliku. Domyślnie plik dziennika jest tworzony w katalogu %TEMP%.</String>
+/norestart  — pomija próby ponownego uruchomienia. Domyślnie interfejs użytkownika wyświetla monit przed ponownym uruchomieniem.
+/log log.txt — tworzy dziennik w określonym pliku. Domyślnie plik dziennika jest tworzony w katalogu %TEMP%.</String>
   <String Id="HelpCloseButton">&amp;Zamknij</String>
   <String Id="InstallLicenseLinkText">&lt;a href="#"&gt;Postanowienia licencyjne&lt;/a&gt; dotyczące pakietu [WixBundleName].</String>
-  <String Id="InstallAcceptCheckbox">&amp;Zgadzam się z postanowieniami licencyjnymi</String>
+  <String Id="InstallAcceptCheckbox">Zg&amp;adzam się na warunki licencji</String>
   <String Id="InstallOptionsButton">&amp;Opcje</String>
-  <String Id="InstallInstallButton">&amp;Zainstaluj</String>
+  <String Id="InstallInstallButton">Za&amp;instaluj</String>
   <String Id="InstallCloseButton">&amp;Zamknij</String>
-  <String Id="OptionsHeader">Opcje instalacji</String>
+  <String Id="OptionsHeader">Opcje instalatora</String>
   <String Id="OptionsLocationLabel">Lokalizacja instalacji:</String>
   <String Id="OptionsBrowseButton">&amp;Przeglądaj</String>
   <String Id="OptionsOkButton">&amp;OK</String>
@@ -32,24 +32,24 @@
   <String Id="ProgressLabel">Przetwarzanie:</String>
   <String Id="OverallProgressPackageText">Trwa inicjowanie...</String>
   <String Id="ProgressCancelButton">&amp;Anuluj</String>
-  <String Id="ModifyHeader">Modyfikuj instalację</String>
-  <String Id="ModifyRepairButton">&amp;Napraw</String>
-  <String Id="ModifyUninstallButton">&amp;Odinstaluj</String>
+  <String Id="ModifyHeader">Zmodyfikuj instalatora</String>
+  <String Id="ModifyRepairButton">Nap&amp;raw</String>
+  <String Id="ModifyUninstallButton">O&amp;dinstaluj</String>
   <String Id="ModifyCloseButton">&amp;Zamknij</String>
   <String Id="SuccessRepairHeader">Pomyślnie ukończono naprawę</String>
-  <String Id="SuccessUninstallHeader">Pomyślnie ukończono dezinstalację</String>
-  <String Id="SuccessInstallHeader">Pomyślnie ukończono instalację</String> 
-  <String Id="SuccessHeader">Pomyślnie ukończono instalację</String>	
+  <String Id="SuccessUninstallHeader">Pomyślnie ukończono operację odinstalowania</String>
+  <String Id="SuccessInstallHeader">Pomyślnie ukończono instalację</String>
+  <String Id="SuccessHeader">Instalacja przebiegła pomyślnie</String>
   <String Id="SuccessLaunchButton">&amp;Uruchom</String>
-  <String Id="SuccessRestartText">Aby móc korzystać z oprogramowania, musisz uruchomić ponownie komputer.</String>
+  <String Id="SuccessRestartText">Aby korzystać z oprogramowania, należy ponownie uruchomić komputer.</String>
   <String Id="SuccessRestartButton">&amp;Uruchom ponownie</String>
   <String Id="SuccessCloseButton">&amp;Zamknij</String>
   <String Id="FailureHeader">Instalacja nie powiodła się</String>
-  <String Id="FailureInstallHeader">Instalacja nie powiodła się</String>
-  <String Id="FailureUninstallHeader">Dezinstalacja nie powiodła się</String>
-  <String Id="FailureRepairHeader">Naprawa nie powiodła się</String> 
-  <String Id="FailureHyperlinkLogText">Co najmniej jeden problem spowodował niepowodzenie instalacji. Rozwiąż problemy, a następnie ponów próbę instalacji. Aby uzyskać więcej informacji, zobacz &lt;a href="#"&gt;plik dziennika&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">Aby ukończyć wycofywanie oprogramowania, musisz uruchomić ponownie komputer.</String>
+  <String Id="FailureInstallHeader">Konfiguracja nie powiodła się</String>
+  <String Id="FailureUninstallHeader">Operacja odinstalowania nie powiodła się</String>
+  <String Id="FailureRepairHeader">Naprawa nie powiodła się</String>
+  <String Id="FailureHyperlinkLogText">Jeden lub więcej problemów spowodował niepowodzenie instalacji. Napraw błędy, a następnie uruchom ponownie instalację. Aby uzyskać więcej informacji zobacz &lt;a href="#"&gt;plik dziennika&lt;/a&gt;.</String>
+  <String Id="FailureRestartText">Należy ponownie uruchomić komputer, aby dokończyć wycofywanie oprogramowania.</String>
   <String Id="FailureRestartButton">&amp;Uruchom ponownie</String>
   <String Id="FailureCloseButton">&amp;Zamknij</String>
   <String Id="FilesInUseHeader">Pliki w użyciu</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1045/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1045/thm.wxl
@@ -19,9 +19,9 @@
 /log log.txt — tworzy dziennik w określonym pliku. Domyślnie plik dziennika jest tworzony w katalogu %TEMP%.</String>
   <String Id="HelpCloseButton">&amp;Zamknij</String>
   <String Id="InstallLicenseLinkText">&lt;a href="#"&gt;Postanowienia licencyjne&lt;/a&gt; dotyczące pakietu [WixBundleName].</String>
-  <String Id="InstallAcceptCheckbox">Zg&amp;adzam się na warunki licencji</String>
+  <String Id="InstallAcceptCheckbox">&amp;Zgadzam się na warunki licencji</String>
   <String Id="InstallOptionsButton">&amp;Opcje</String>
-  <String Id="InstallInstallButton">Za&amp;instaluj</String>
+  <String Id="InstallInstallButton">&amp;Zainstaluj</String>
   <String Id="InstallCloseButton">&amp;Zamknij</String>
   <String Id="OptionsHeader">Opcje instalatora</String>
   <String Id="OptionsLocationLabel">Lokalizacja instalacji:</String>
@@ -33,8 +33,8 @@
   <String Id="OverallProgressPackageText">Trwa inicjowanie...</String>
   <String Id="ProgressCancelButton">&amp;Anuluj</String>
   <String Id="ModifyHeader">Zmodyfikuj instalatora</String>
-  <String Id="ModifyRepairButton">Nap&amp;raw</String>
-  <String Id="ModifyUninstallButton">O&amp;dinstaluj</String>
+  <String Id="ModifyRepairButton">&amp;Napraw</String>
+  <String Id="ModifyUninstallButton">&amp;Odinstaluj</String>
   <String Id="ModifyCloseButton">&amp;Zamknij</String>
   <String Id="SuccessRepairHeader">Pomyślnie ukończono naprawę</String>
   <String Id="SuccessUninstallHeader">Pomyślnie ukończono operację odinstalowania</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1046/Strings.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1046/Strings.wxl
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
     <String Id="BalCondition_NETFX451Required">Alguns recursos que foram selecionados exigem o .NET 4.5.1. Instale o .NET 4.5.1 e instale este produto novamente.</String>
-    <String Id="BalCondition_IISRequired">Este produto requer o IIS 7.5. Instale o IIS e instale este produto novamente.</String>
+    <String Id="BalCondition_IISRequired">Este produto exige o IIS 7.5. Instale o IIS e, em seguida, instale este produto novamente.</String>
     <String Id="BalCondition_VS2015Update2Required">Este produto requer o Visual Studio 2015 Atualização 2 ou posterior. Instale o Visual Studio 2015 Atualização 2 ou posterior e instale este produto novamente.</String>
     <String Id="BalCondition_VS2015Update3Required">Este produto requer o Visual Studio 2015 Atualização 3 ou posterior. Instale o Visual Studio 2015 Atualização 3 ou posterior e instale este produto novamente.</String>
     <String Id="BalCondition_VS2015Update3Mismatch">A instalação detectou que o Visual Studio 2015 Atualização 3 não pode ser instalado completamente. Repare o Visual Studio 2015 Atualização 3 e instale este produto novamente.</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1046/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1046/thm.wxl
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">Instalação do [WixBundleName]</String>
+  <String Id="Caption">[WixBundleName] Instalação</String>
   <String Id="Title">[BundleNameShort]</String>
   <String Id="SubTitle">[BundleNameSub]</String>
-  <String Id="InstallHeader">Bem-vindo</String>
+  <String Id="InstallHeader">Bem-vindo(a)</String>
   <String Id="InstallMessage">O programa de instalação instalará o [WixBundleName] no seu computador. Clique em Instalar para continuar, Opções para definir o diretório de instalação ou Fechar para sair.</String>
-  <String Id="InstallVersion">Versão do [WixBundleVersion]</String>
+  <String Id="InstallVersion">Versão [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Tem certeza de que deseja cancelar?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Versão anterior</String>
-  <String Id="HelpHeader">Ajuda de Instalação</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [diretório] - instala, repara, desinstala ou
+  <String Id="HelpHeader">Ajuda da Instalação</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]diretório[\]] - instala, repara, desinstala ou
    cria uma cópia local completa do pacote no diretório. Install é o padrão
 
 /passive | /quiet -  exibe a interface do usuário mínima sem nenhum prompt ou não exibe nenhuma interface do usuário e
@@ -19,13 +19,13 @@
 /log log.txt - registra em um arquivo específico. Por padrão, um arquivo de log é criado em %TEMP%.</String>
   <String Id="HelpCloseButton">&amp;Fechar</String>
   <String Id="InstallLicenseLinkText">[WixBundleName] &lt;a href="#"&gt;termos de licença&lt;/a&gt;.</String>
-  <String Id="InstallAcceptCheckbox">&amp;Concordo com os termos e condições da licença</String>
+  <String Id="InstallAcceptCheckbox">Eu &amp;concordo com os termos e condições da licença</String>
   <String Id="InstallOptionsButton">&amp;Opções</String>
   <String Id="InstallInstallButton">&amp;Instalar</String>
   <String Id="InstallCloseButton">&amp;Fechar</String>
   <String Id="OptionsHeader">Opções de Instalação</String>
   <String Id="OptionsLocationLabel">Local de instalação:</String>
-  <String Id="OptionsBrowseButton">&amp;Navegar</String>
+  <String Id="OptionsBrowseButton">&amp;Procurar</String>
   <String Id="OptionsOkButton">&amp;OK</String>
   <String Id="OptionsCancelButton">&amp;Cancelar</String>
   <String Id="ProgressHeader">Progresso da Instalação</String>
@@ -36,26 +36,26 @@
   <String Id="ModifyRepairButton">&amp;Reparar</String>
   <String Id="ModifyUninstallButton">&amp;Desinstalar</String>
   <String Id="ModifyCloseButton">&amp;Fechar</String>
-  <String Id="SuccessRepairHeader">Reparação Concluída com Êxito</String>
+  <String Id="SuccessRepairHeader">Reparo Concluído com Êxito</String>
   <String Id="SuccessUninstallHeader">Desinstalação Concluída com Êxito</String>
-  <String Id="SuccessInstallHeader">Instalação Concluída com Êxito</String> 
-  <String Id="SuccessHeader">Instalação com Êxito</String>	
+  <String Id="SuccessInstallHeader">Instalação Concluída com Êxito</String>
+  <String Id="SuccessHeader">Instalação com Êxito</String>
   <String Id="SuccessLaunchButton">&amp;Iniciar</String>
-  <String Id="SuccessRestartText">Você deve reiniciar seu computador antes de usar o software.</String>
+  <String Id="SuccessRestartText">Reinicie o computador para poder usar o software.</String>
   <String Id="SuccessRestartButton">&amp;Reiniciar</String>
   <String Id="SuccessCloseButton">&amp;Fechar</String>
   <String Id="FailureHeader">Falha na Instalação</String>
   <String Id="FailureInstallHeader">Falha na Instalação</String>
   <String Id="FailureUninstallHeader">Falha na Desinstalação</String>
-  <String Id="FailureRepairHeader">Falha na Reparação</String> 
+  <String Id="FailureRepairHeader">Falha ao Reparar</String>
   <String Id="FailureHyperlinkLogText">Um ou mais problemas causaram falha na instalação. Corrija-os e tente instalar novamente. Para obter mais informações, consulte o &lt;a href="#"&gt;arquivo de log&lt;/a&gt;.</String>
-  <String Id="FailureRestartText">Você deve reiniciar seu computador para concluir a reversão do software.</String>
+  <String Id="FailureRestartText">Reinicie o computador para concluir a reversão do software.</String>
   <String Id="FailureRestartButton">&amp;Reiniciar</String>
   <String Id="FailureCloseButton">&amp;Fechar</String>
   <String Id="FilesInUseHeader">Arquivos em Uso</String>
   <String Id="FilesInUseLabel">Os aplicativos a seguir estão usando arquivos que precisam ser atualizados:</String>
   <String Id="FilesInUseCloseRadioButton">Feche os &amp;aplicativos e tente reiniciá-los.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Não feche os aplicativos. Será necessária uma reinicialização.</String>
+  <String Id="FilesInUseDontCloseRadioButton">&amp;Não feche os aplicativos. Uma reinicialização será necessária.</String>
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancelar</String>
 
@@ -63,7 +63,7 @@
   <String Id="Welcome">Bem-vindo à Instalação do [WixBundleName].</String>
   <String Id="InstallResetIIS">Reinicie o IIS após a conclusão da instalação. Você pode encontrar informações adicionais &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aqui&lt;/a&gt;.</String>
   <String Id="InstallNoIIS">O IIS não está habilitado neste computador. Se pretende executar aplicativos ASP.NET Core com o IIS, você deve instalar o IIS antes de executar este instalador. Você pode encontrar informações adicionais &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aqui&lt;/a&gt;.</String>
-  <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;termos de licença&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;política de privacidade&lt;/a&gt;.</String>
+  <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;termos de licença&lt;/a&gt; e &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;política de privacidade&lt;/a&gt;.</String>
   <String Id="ModifyResetIIS">Reinicie o IIS após a conclusão da instalação. Você pode encontrar informações adicionais &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aqui&lt;/a&gt;.</String>
   <String Id="ModifyNoIIS">O IIS não está habilitado neste computador. Se pretende executar aplicativos ASP.NET Core com o IIS, você deve instalar o IIS antes de executar este instalador. Você pode encontrar informações adicionais &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aqui&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1049/Strings.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1049/Strings.wxl
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-    <String Id="BalCondition_NETFX451Required">Для некоторых выбранных функций требуется .NET 4.5.1. Установите .NET 4.5.1, а затем повторите установку этого продукта.</String>
-    <String Id="BalCondition_IISRequired">Для этого продукта требуется IIS 7.5. Установите IIS, а затем повторите установку продукта.</String>
-    <String Id="BalCondition_VS2015Update2Required">Для этого продукта требуется Visual Studio 2015 с обновлением 2 или более поздней версии. Установите Visual Studio 2015 с обновлением 2 или более поздней версии, а затем повторите установку продукта.</String>
-    <String Id="BalCondition_VS2015Update3Required">Для этого продукта требуется Visual Studio 2015 с обновлением 3 или более поздней версии. Установите Visual Studio 2015 с обновлением 3 или более поздней версии, а затем повторите установку продукта.</String>
-    <String Id="BalCondition_VS2015Update3Mismatch">Программа установки обнаружила, что продукт Visual Studio 2015 с обновлением 3 может быть установлен не полностью. Восстановите Visual Studio 2015 с обновлением 3 и повторите установку этого продукта.</String>
-    <String Id="BalCondition_WebDeveloperToolsRequired">Для этого продукта требуется компонент инструментов разработчика Web в Visual Studio 2015. Включите этот компонент, перейдя в раздел "Программы и компоненты" в Windows, а затем измените Visual Studio 2015.</String>
-    <String Id="BalCondition_VSVWDRequired">Для этого продукта требуется установить Visual Studio 2015 или Visual Studio Express 2015 для Web. Установите отсутствующий продукт, а затем повторите установку этого продукта.</String>
+    <String Id="BalCondition_NETFX451Required">Для некоторых выбранных функций требуется .NET 4.5.1. Установите .NET 4.5.1 и повторите установку этого продукта.</String>
+    <String Id="BalCondition_IISRequired">Для этого продукта требуется IIS 7.5. Установите IIS и повторите установку продукта.</String>
+    <String Id="BalCondition_VS2015Update2Required">Для этого продукта требуется Visual Studio 2015 с обновлением 2 или более поздней версии. Установите Visual Studio 2015 с обновлением 2 или более поздней версии и повторите установку продукта.</String>
+    <String Id="BalCondition_VS2015Update3Required">Для этого продукта требуется Visual Studio 2015 с обновлением 3 или более поздней версии. Установите Visual Studio 2015 с обновлением 3 или более поздней версии и повторите установку продукта.</String>
+    <String Id="BalCondition_VS2015Update3Mismatch">Программа установки обнаружила, что продукт Visual Studio 2015 с обновлением 3 может быть установлен не полностью. Восстановите Visual Studio 2015 с обновлением 3 и повторите установку этого продукта.</String>
+    <String Id="BalCondition_WebDeveloperToolsRequired">Для этого продукта требуются Средства для разработчиков Web в Visual Studio 2015. Включите этот компонент, перейдя в раздел "Программы и компоненты" в Windows и измените Visual Studio 2015.</String>
+    <String Id="BalCondition_VSVWDRequired">Для этого продукта требуется установить Visual Studio 2015 или Visual Studio Express 2015 для Web. Установите отсутствующий продукт и повторите установку этого продукта.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1049/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1049/thm.wxl
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">Установка [WixBundleName]</String>
+  <String Id="Caption">Программа установки [WixBundleName]</String>
   <String Id="Title">[BundleNameShort]</String>
   <String Id="SubTitle">[BundleNameSub]</String>
   <String Id="InstallHeader">Добро пожаловать</String>
   <String Id="InstallMessage">Программа установки установит [WixBundleName] на ваш компьютер. Щелкните элемент "Установить", чтобы продолжить, "Параметры", чтобы указать каталог установки, или "Закрыть", чтобы выйти.</String>
   <String Id="InstallVersion">Версия [WixBundleVersion]</String>
-  <String Id="ConfirmCancelMessage">Вы действительно хотите отменить?</String>
+  <String Id="ConfirmCancelMessage">Отменить?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Предыдущая версия</String>
   <String Id="HelpHeader">Справка по установке</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [каталог] — установка, восстановление, удаление или
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]каталог[\]] — установка, восстановление, удаление или
  создание полной локальной копии пакета в каталоге. По умолчанию — установка.
 
 /passive | /quiet — отображение минимального пользовательского интерфейса без запросов или работа без пользовательского интерфейса и
@@ -30,34 +30,34 @@
   <String Id="OptionsCancelButton">Отм&amp;ена</String>
   <String Id="ProgressHeader">Ход установки</String>
   <String Id="ProgressLabel">Обработка:</String>
-  <String Id="OverallProgressPackageText">Идет инициализация...</String>
+  <String Id="OverallProgressPackageText">Инициализация...</String>
   <String Id="ProgressCancelButton">Отм&amp;ена</String>
   <String Id="ModifyHeader">Изменение установки</String>
   <String Id="ModifyRepairButton">&amp;Исправить</String>
   <String Id="ModifyUninstallButton">&amp;Удалить</String>
   <String Id="ModifyCloseButton">&amp;Закрыть</String>
-  <String Id="SuccessRepairHeader">Восстановление успешно завершено</String>
+  <String Id="SuccessRepairHeader">Исправление успешно завершено</String>
   <String Id="SuccessUninstallHeader">Удаление успешно завершено</String>
-  <String Id="SuccessInstallHeader">Установка успешно завершена</String> 
-  <String Id="SuccessHeader">Установка успешно завершена</String>	
+  <String Id="SuccessInstallHeader">Установка успешно завершена</String>
+  <String Id="SuccessHeader">Установка успешно завершена</String>
   <String Id="SuccessLaunchButton">&amp;Запустить</String>
   <String Id="SuccessRestartText">Перед использованием программного обеспечения необходимо перезапустить компьютер.</String>
   <String Id="SuccessRestartButton">&amp;Перезапустить</String>
   <String Id="SuccessCloseButton">&amp;Закрыть</String>
-  <String Id="FailureHeader">Настройка не завершена</String>
+  <String Id="FailureHeader">Сбой установки</String>
   <String Id="FailureInstallHeader">Сбой установки</String>
   <String Id="FailureUninstallHeader">Сбой удаления</String>
-  <String Id="FailureRepairHeader">Сбой восстановления</String> 
+  <String Id="FailureRepairHeader">Сбой восстановления</String>
   <String Id="FailureHyperlinkLogText">Одна или несколько проблем вызывали сбой программы установки. Исправьте эти проблемы и попробуйте повторить установку. Дополнительные сведения см. в &lt;a href="#"&gt;файле журнала&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Необходимо перезагрузить компьютер, чтобы завершить откат программного обеспечения.</String>
   <String Id="FailureRestartButton">&amp;Перезапустить</String>
-  <String Id="FailureCloseButton">З&amp;акрыть</String>
+  <String Id="FailureCloseButton">&amp;Закрыть</String>
   <String Id="FilesInUseHeader">Используемые файлы</String>
-  <String Id="FilesInUseLabel">Следующие приложения используют файлы, которые следует обновить:</String>
-  <String Id="FilesInUseCloseRadioButton">Закрыть &amp;приложения и попытаться перезапустить их.</String>
-  <String Id="FilesInUseDontCloseRadioButton">&amp;Не закрывать приложения. Потребуется перезагрузка.</String>
-  <String Id="FilesInUseOkButton">О&amp;К</String>
-  <String Id="FilesInUseCancelButton">&amp;Отмена</String>
+  <String Id="FilesInUseLabel">Следующие приложения используют файлы, которые нуждаются в обновлении:</String>
+  <String Id="FilesInUseCloseRadioButton">Закройте &amp;приложения и попробуйте перезапустить их.</String>
+  <String Id="FilesInUseDontCloseRadioButton">&amp;Не закрывайте приложения. Потребуется перезагрузка компьютера.</String>
+  <String Id="FilesInUseOkButton">&amp;ОК</String>
+  <String Id="FilesInUseCancelButton">&amp;Отменить</String>
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Вас приветствует мастер установки [WixBundleName].</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1049/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1049/thm.wxl
@@ -51,12 +51,12 @@
   <String Id="FailureHyperlinkLogText">Одна или несколько проблем вызывали сбой программы установки. Исправьте эти проблемы и попробуйте повторить установку. Дополнительные сведения см. в &lt;a href="#"&gt;файле журнала&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Необходимо перезагрузить компьютер, чтобы завершить откат программного обеспечения.</String>
   <String Id="FailureRestartButton">&amp;Перезапустить</String>
-  <String Id="FailureCloseButton">&amp;Закрыть</String>
+  <String Id="FailureCloseButton">З&amp;акрыть</String>
   <String Id="FilesInUseHeader">Используемые файлы</String>
   <String Id="FilesInUseLabel">Следующие приложения используют файлы, которые нуждаются в обновлении:</String>
   <String Id="FilesInUseCloseRadioButton">Закройте &amp;приложения и попробуйте перезапустить их.</String>
   <String Id="FilesInUseDontCloseRadioButton">&amp;Не закрывайте приложения. Потребуется перезагрузка компьютера.</String>
-  <String Id="FilesInUseOkButton">&amp;ОК</String>
+  <String Id="FilesInUseOkButton">О&amp;К</String>
   <String Id="FilesInUseCancelButton">&amp;Отменить</String>
 
   <!-- Custom UI strings -->

--- a/src/Installers/Windows/WindowsHostingBundle/1055/Strings.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1055/Strings.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
     <String Id="BalCondition_NETFX451Required">Seçilen bazı özellikler .NET 4.5.1 gerektirir. Lütfen .NET 4.5.1 sürümünü yükleyin ve ardından bu ürünü yeniden yükleyin.</String>
     <String Id="BalCondition_IISRequired">Bu ürün IIS 7.5 gerektirir. Lütfen IIS'yi yükleyin ve ardından bu ürünü yeniden yükleyin.</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1055/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1055/thm.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption">[WixBundleName] Kurulumu</String>
   <String Id="Title">[BundleNameShort]</String>
@@ -9,7 +9,7 @@
   <String Id="ConfirmCancelMessage">İptal etmek istediğinizden emin misiniz?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Önceki sürüm</String>
   <String Id="HelpHeader">Kurulum Yardımı</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [dizin] - yükler, onarır, kaldırır ya da
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]dizin[\]] - yükler, onarır, kaldırır ya da
    dizindeki paketin tam bir yerel kopyasını oluşturur. Varsayılan install değeridir.
 
 /passive | /quiet -  en az düzeyde istemsiz UI gösterir ya da hiç UI göstermez ve
@@ -19,9 +19,9 @@
 /log log.txt - belirli bir günlük dosyası tutar. Varsayılan olarak %TEMP% içinde bir günlük dosyası oluşturulur.</String>
   <String Id="HelpCloseButton">&amp;Kapat</String>
   <String Id="InstallLicenseLinkText">[WixBundleName] &lt;a href="#"&gt;lisans koşulları&lt;/a&gt;.</String>
-  <String Id="InstallAcceptCheckbox">Lisans &amp;hüküm ve koşullarını kabul ediyorum</String>
+  <String Id="InstallAcceptCheckbox">Lisans hüküm ve koşullarını &amp;kabul ediyorum</String>
   <String Id="InstallOptionsButton">&amp;Seçenekler</String>
-  <String Id="InstallInstallButton">&amp;Yükle</String>
+  <String Id="InstallInstallButton">Yü&amp;kle</String>
   <String Id="InstallCloseButton">&amp;Kapat</String>
   <String Id="OptionsHeader">Kurulum Seçenekleri</String>
   <String Id="OptionsLocationLabel">Yükleme konumu:</String>
@@ -32,32 +32,32 @@
   <String Id="ProgressLabel">İşleniyor:</String>
   <String Id="OverallProgressPackageText">Başlatılıyor...</String>
   <String Id="ProgressCancelButton">İ&amp;ptal</String>
-  <String Id="ModifyHeader">Kurulumu Değiştir</String>
+  <String Id="ModifyHeader">Kurulumu değiştir</String>
   <String Id="ModifyRepairButton">&amp;Onar</String>
-  <String Id="ModifyUninstallButton">K&amp;aldır</String>
+  <String Id="ModifyUninstallButton">&amp;Kaldır</String>
   <String Id="ModifyCloseButton">&amp;Kapat</String>
   <String Id="SuccessRepairHeader">Onarım Başarıyla Tamamlandı</String>
   <String Id="SuccessUninstallHeader">Kaldırma Başarıyla Tamamlandı</String>
-  <String Id="SuccessInstallHeader">Yükleme Başarıyla Tamamlandı</String> 
-  <String Id="SuccessHeader">Kurulum Başarılı</String>	
+  <String Id="SuccessInstallHeader">Yükleme Başarıyla Tamamlandı</String>
+  <String Id="SuccessHeader">Kurulum Başarılı</String>
   <String Id="SuccessLaunchButton">&amp;Başlat</String>
-  <String Id="SuccessRestartText">Yazılımı kullanabilmek için bilgisayarınızı yeniden başlatmanız gerekiyor.</String>
-  <String Id="SuccessRestartButton">Yeniden &amp;Başlat</String>
+  <String Id="SuccessRestartText">Yazılımı kullanabilmeniz için bilgisayarınızı yeniden başlatmanız gerekiyor.</String>
+  <String Id="SuccessRestartButton">&amp;Yeniden Başlat</String>
   <String Id="SuccessCloseButton">&amp;Kapat</String>
   <String Id="FailureHeader">Kurulum Başarısız</String>
   <String Id="FailureInstallHeader">Kurulum Başarısız</String>
-  <String Id="FailureUninstallHeader">Yükleme Başarısız</String>
-  <String Id="FailureRepairHeader">Onarım Başarısız</String> 
-  <String Id="FailureHyperlinkLogText">En az bir sorun nedeniyle kurulum başarısız oldu. Lütfen bu sorunları düzeltin ve kurulumu yeniden deneyin. Daha fazla bilgi için &lt;a href="#"&gt;günlük dosyasına&lt;/a&gt; bakın.</String>
+  <String Id="FailureUninstallHeader">Kaldırma Başarısız</String>
+  <String Id="FailureRepairHeader">Onarım Başarısız</String>
+  <String Id="FailureHyperlinkLogText">Bir ya da daha fazla sorun nedeniyle kurulum başarısız oldu. Lütfen bu sorunları düzeltin ve kurulumu yeniden deneyin. Daha fazla bilgi için &lt;a href="#"&gt;günlük dosyasına&lt;/a&gt; bakın.</String>
   <String Id="FailureRestartText">Yazılımın geri alınmasını tamamlamak için bilgisayarınızı yeniden başlatmanız gerekiyor.</String>
-  <String Id="FailureRestartButton">Yeniden &amp;Başlat</String>
+  <String Id="FailureRestartButton">&amp;Yeniden Başlat</String>
   <String Id="FailureCloseButton">&amp;Kapat</String>
   <String Id="FilesInUseHeader">Kullanımda Olan Dosyalar</String>
   <String Id="FilesInUseLabel">Şu uygulamalar güncelleştirilmesi gereken dosyaları kullanıyor:</String>
   <String Id="FilesInUseCloseRadioButton">&amp;Uygulamaları kapatın ve yeniden başlatmayı deneyin.</String>
   <String Id="FilesInUseDontCloseRadioButton">&amp;Uygulamaları kapatmayın. Sistemi yeniden başlatmanız gerekir.</String>
   <String Id="FilesInUseOkButton">&amp;Tamam</String>
-  <String Id="FilesInUseCancelButton">&amp;İptal</String>
+  <String Id="FilesInUseCancelButton">İ&amp;ptal</String>
 
   <!-- Custom UI strings -->
   <String Id="Welcome">[WixBundleName] Kurulumu'na Hoş Geldiniz.</String>

--- a/src/Installers/Windows/WindowsHostingBundle/1055/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1055/thm.wxl
@@ -19,9 +19,9 @@
 /log log.txt - belirli bir günlük dosyası tutar. Varsayılan olarak %TEMP% içinde bir günlük dosyası oluşturulur.</String>
   <String Id="HelpCloseButton">&amp;Kapat</String>
   <String Id="InstallLicenseLinkText">[WixBundleName] &lt;a href="#"&gt;lisans koşulları&lt;/a&gt;.</String>
-  <String Id="InstallAcceptCheckbox">Lisans hüküm ve koşullarını &amp;kabul ediyorum</String>
+  <String Id="InstallAcceptCheckbox">Lisans &amp;hüküm ve koşullarını kabul ediyorum</String>
   <String Id="InstallOptionsButton">&amp;Seçenekler</String>
-  <String Id="InstallInstallButton">Yü&amp;kle</String>
+  <String Id="InstallInstallButton">&amp;Yükle</String>
   <String Id="InstallCloseButton">&amp;Kapat</String>
   <String Id="OptionsHeader">Kurulum Seçenekleri</String>
   <String Id="OptionsLocationLabel">Yükleme konumu:</String>
@@ -34,7 +34,7 @@
   <String Id="ProgressCancelButton">İ&amp;ptal</String>
   <String Id="ModifyHeader">Kurulumu değiştir</String>
   <String Id="ModifyRepairButton">&amp;Onar</String>
-  <String Id="ModifyUninstallButton">&amp;Kaldır</String>
+  <String Id="ModifyUninstallButton">K&amp;aldır</String>
   <String Id="ModifyCloseButton">&amp;Kapat</String>
   <String Id="SuccessRepairHeader">Onarım Başarıyla Tamamlandı</String>
   <String Id="SuccessUninstallHeader">Kaldırma Başarıyla Tamamlandı</String>
@@ -42,7 +42,7 @@
   <String Id="SuccessHeader">Kurulum Başarılı</String>
   <String Id="SuccessLaunchButton">&amp;Başlat</String>
   <String Id="SuccessRestartText">Yazılımı kullanabilmeniz için bilgisayarınızı yeniden başlatmanız gerekiyor.</String>
-  <String Id="SuccessRestartButton">&amp;Yeniden Başlat</String>
+  <String Id="SuccessRestartButton">Yeniden &amp;Başlat</String>
   <String Id="SuccessCloseButton">&amp;Kapat</String>
   <String Id="FailureHeader">Kurulum Başarısız</String>
   <String Id="FailureInstallHeader">Kurulum Başarısız</String>
@@ -50,14 +50,14 @@
   <String Id="FailureRepairHeader">Onarım Başarısız</String>
   <String Id="FailureHyperlinkLogText">Bir ya da daha fazla sorun nedeniyle kurulum başarısız oldu. Lütfen bu sorunları düzeltin ve kurulumu yeniden deneyin. Daha fazla bilgi için &lt;a href="#"&gt;günlük dosyasına&lt;/a&gt; bakın.</String>
   <String Id="FailureRestartText">Yazılımın geri alınmasını tamamlamak için bilgisayarınızı yeniden başlatmanız gerekiyor.</String>
-  <String Id="FailureRestartButton">&amp;Yeniden Başlat</String>
+  <String Id="FailureRestartButton">Yeniden &amp;Başlat</String>
   <String Id="FailureCloseButton">&amp;Kapat</String>
   <String Id="FilesInUseHeader">Kullanımda Olan Dosyalar</String>
   <String Id="FilesInUseLabel">Şu uygulamalar güncelleştirilmesi gereken dosyaları kullanıyor:</String>
   <String Id="FilesInUseCloseRadioButton">&amp;Uygulamaları kapatın ve yeniden başlatmayı deneyin.</String>
   <String Id="FilesInUseDontCloseRadioButton">&amp;Uygulamaları kapatmayın. Sistemi yeniden başlatmanız gerekir.</String>
   <String Id="FilesInUseOkButton">&amp;Tamam</String>
-  <String Id="FilesInUseCancelButton">İ&amp;ptal</String>
+  <String Id="FilesInUseCancelButton">&amp;İptal</String>
 
   <!-- Custom UI strings -->
   <String Id="Welcome">[WixBundleName] Kurulumu'na Hoş Geldiniz.</String>

--- a/src/Installers/Windows/WindowsHostingBundle/2052/Strings.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/2052/Strings.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
     <String Id="BalCondition_NETFX451Required">所选的部分功能需要 .NET 4.5.1。请安装 .NET 4.5.1，然后再次安装此产品。</String>
     <String Id="BalCondition_IISRequired">此产品要求 IIS 7.5。请安装 IIS，然后再次安装此产品。</String>

--- a/src/Installers/Windows/WindowsHostingBundle/2052/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/2052/thm.wxl
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="Caption">[WixBundleName] 安装</String>
+  <String Id="Caption">[WixBundleName]安装程序</String>
   <String Id="Title">[BundleNameShort]</String>
   <String Id="SubTitle">[BundleNameSub]</String>
   <String Id="InstallHeader">欢迎</String>
@@ -9,14 +9,14 @@
   <String Id="ConfirmCancelMessage">是否确实要取消?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">上一版本</String>
   <String Id="HelpHeader">安装程序帮助</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [目录] - 安装、修复、卸载
-   目录中的安装包或创建其完整本地副本。Install 为默认选择。
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]目录[\]] - 安装、修复、卸载
+   目录中的捆绑包或创建其完整本地副本。Install 为默认选择。
 
 /passive | /quiet -  显示最少的 UI 且无提示，或不显示 UI 且
-   无提示。默认显示 UI 及全部提示。
+   无提示。默认情况下，显示 UI 及全部提示。
 
-/norestart   - 禁止任何重新启动。默认在重新启动前显示提示 UI。
-/log log.txt - 向特定文件写入日志。默认在 %TEMP% 中创建日志文件。</String>
+/norestart   - 禁止任何重启尝试。默认情况下将在重启前显示提示 UI。
+/log log.txt - 向特定文件写入日志。默认情况下在 %TEMP% 中创建日志文件。</String>
   <String Id="HelpCloseButton">关闭(&amp;C)</String>
   <String Id="InstallLicenseLinkText">[WixBundleName] &lt;a href="#"&gt;许可条款&lt;/a&gt;。</String>
   <String Id="InstallAcceptCheckbox">我同意许可条款和条件(&amp;A)</String>
@@ -30,7 +30,7 @@
   <String Id="OptionsCancelButton">取消(&amp;C)</String>
   <String Id="ProgressHeader">安装进度</String>
   <String Id="ProgressLabel">正在处理:</String>
-  <String Id="OverallProgressPackageText">正在初始化…</String>
+  <String Id="OverallProgressPackageText">正在初始化...</String>
   <String Id="ProgressCancelButton">取消(&amp;C)</String>
   <String Id="ModifyHeader">修改安装程序</String>
   <String Id="ModifyRepairButton">修复(&amp;R)</String>
@@ -38,16 +38,16 @@
   <String Id="ModifyCloseButton">关闭(&amp;C)</String>
   <String Id="SuccessRepairHeader">成功完成了修复</String>
   <String Id="SuccessUninstallHeader">成功完成了卸载</String>
-  <String Id="SuccessInstallHeader">成功完成了安装</String> 
-  <String Id="SuccessHeader">设置成功</String>	
+  <String Id="SuccessInstallHeader">成功完成了安装</String>
+  <String Id="SuccessHeader">设置成功</String>
   <String Id="SuccessLaunchButton">启动(&amp;L)</String>
-  <String Id="SuccessRestartText">在使用此软件之前，您必须重新启动计算机。</String>
+  <String Id="SuccessRestartText">您必须先重新启动计算机，然后才能使用该软件。</String>
   <String Id="SuccessRestartButton">重新启动(&amp;R)</String>
   <String Id="SuccessCloseButton">关闭(&amp;C)</String>
-  <String Id="FailureHeader">设置失败</String>
+  <String Id="FailureHeader">安装失败</String>
   <String Id="FailureInstallHeader">安装失败</String>
   <String Id="FailureUninstallHeader">卸载失败</String>
-  <String Id="FailureRepairHeader">修复失败</String> 
+  <String Id="FailureRepairHeader">修复失败</String>
   <String Id="FailureHyperlinkLogText">一个或多个问题导致了安装失败。请修复这些问题，然后重试安装。有关详细信息，请参阅&lt;a href="#"&gt;日志文件&lt;/a&gt;。</String>
   <String Id="FailureRestartText">必须重新启动计算机才能完成软件回退。</String>
   <String Id="FailureRestartButton">重新启动(&amp;R)</String>
@@ -63,7 +63,7 @@
   <String Id="Welcome">欢迎使用 [WixBundleName] 安装程序。</String>
   <String Id="InstallResetIIS">请在安装完成后重启 IIS。可在&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;此处&lt;/a&gt;找到其他信息。</String>
   <String Id="InstallNoIIS">此计算机上未启用 IIS。如果打算通过 IIS 运行 ASP.NET Core 应用程序，必须先安装 IIS，然后再运行此安装程序。可在&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;此处&lt;/a&gt;找到其他信息。</String>
-  <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;许可条件&lt;/a&gt;和&lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;隐私声明&lt;/a&gt;。</String>
+  <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;许可条款&lt;/a&gt;和&lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;隐私声明&lt;/a&gt;。</String>
   <String Id="ModifyResetIIS">请在安装完成后重启 IIS。可在&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;此处&lt;/a&gt;找到其他信息。</String>
   <String Id="ModifyNoIIS">此计算机上未启用 IIS。如果打算通过 IIS 运行 ASP.NET Core 应用程序，必须先安装 IIS，然后再运行此安装程序。可在&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;此处&lt;/a&gt;找到其他信息。</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/3082/Strings.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/3082/Strings.wxl
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
     <String Id="BalCondition_NETFX451Required">Algunas características que se seleccionaron requieren .NET 4.5.1. Instale .NET 4.5.1 y, a continuación, vuelva a instalar este producto.</String>
     <String Id="BalCondition_IISRequired">Este producto requiere IIS 7.5. Instale IIS y, a continuación, vuelva a instalar este producto.</String>
-    <String Id="BalCondition_VS2015Update2Required">Este producto requiere Visual Studio 2015 Update 2 o posterior. Instale Visual Studio 2015 Update 2 o posterior y, a continuación, vuelva a instalar este producto.</String>
+    <String Id="BalCondition_VS2015Update2Required">Este producto requiere Visual Studio 2015 Update 2 o posterior. Instale Visual Studio 2015 Update 2 o posterior y vuelva a instalar este producto.</String>
     <String Id="BalCondition_VS2015Update3Required">Este producto requiere Visual Studio 2015 Update 3 o posterior. Instale Visual Studio 2015 Update 3 o posterior y, a continuación, vuelva a instalar este producto.</String>
-    <String Id="BalCondition_VS2015Update3Mismatch">El programa de instalación ha detectado que es posible que Visual Studio 2015 Update 3 no se haya instalado completamente. Repare Visual Studio 2015 Update 3 y, a continuación, vuelva a instalar este producto.</String>
-    <String Id="BalCondition_WebDeveloperToolsRequired">Este producto requiere la característica Web Developer Tools en Visual Studio 2015. Para habilitar la característica, vaya a Programas y características en Windows y, a continuación, modifique Visual Studio 2015.</String>
-    <String Id="BalCondition_VSVWDRequired">Este producto requiere que se instale Visual Studio 2015 o Visual Studio Express 2015 para Web. Instale el producto que falta y, a continuación, vuelva a instalar este producto.</String>
+    <String Id="BalCondition_VS2015Update3Mismatch">El programa de instalación ha detectado que es posible que Visual Studio 2015 Update 3 no esté completamente instalada. Repare Visual Studio 2015 Update 3 y, a continuación, vuelva a instalar este producto.</String>
+    <String Id="BalCondition_WebDeveloperToolsRequired">Este producto requiere la característica Web Development Tools en Visual Studio 2015. Para habilitar la característica, vaya a Programas y características en Windows y modifique Visual Studio 2015.</String>
+    <String Id="BalCondition_VSVWDRequired">Este producto requiere que se instale Visual Studio 2015 o Visual Studio Express 2015 para web. Instale el producto que falta y, a continuación, vuelva a instalar este producto.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/3082/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/3082/thm.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption">Instalación de [WixBundleName]</String>
   <String Id="Title">[BundleNameShort]</String>
@@ -6,10 +6,10 @@
   <String Id="InstallHeader">Bienvenido</String>
   <String Id="InstallMessage">El programa de instalación instalará [WixBundleName] en el equipo. Haga clic en Instalar para continuar, en Opciones para establecer el directorio de instalación o en Cerrar para salir.</String>
   <String Id="InstallVersion">Versión [WixBundleVersion]</String>
-  <String Id="ConfirmCancelMessage">¿Está seguro de que desea cancelar?</String>
+  <String Id="ConfirmCancelMessage">¿Está seguro de que desea cancelar la operación?</String>
   <String Id="ExecuteUpgradeRelatedBundleMessage">Versión anterior</String>
-  <String Id="HelpHeader">Ayuda de configuración</String>
-  <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - instala, repara, desinstala o
+  <String Id="HelpHeader">Ayuda del programa de instalación</String>
+  <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]directorio[\]] - instala, repara, desinstala o
    crea una copia local completa del paquete en el directorio. Install es la opción predeterminada.
 
 /passive | /quiet -  muestra una IU mínima sin peticiones, o bien no muestra la IU 
@@ -38,16 +38,16 @@
   <String Id="ModifyCloseButton">&amp;Cerrar</String>
   <String Id="SuccessRepairHeader">La reparación se completó correctamente</String>
   <String Id="SuccessUninstallHeader">La desinstalación se completó correctamente</String>
-  <String Id="SuccessInstallHeader">La instalación se completó correctamente</String> 
-  <String Id="SuccessHeader">La instalación o desinstalación se realizó correctamente</String>	
+  <String Id="SuccessInstallHeader">La instalación se completó correctamente</String>
+  <String Id="SuccessHeader">La instalación o desinstalación se realizó correctamente</String>
   <String Id="SuccessLaunchButton">&amp;Iniciar</String>
   <String Id="SuccessRestartText">Debe reiniciar el equipo para poder usar el software.</String>
   <String Id="SuccessRestartButton">&amp;Reiniciar</String>
   <String Id="SuccessCloseButton">&amp;Cerrar</String>
   <String Id="FailureHeader">Error de instalación</String>
-  <String Id="FailureInstallHeader">No se pudo instalar</String>
+  <String Id="FailureInstallHeader">Error de instalación</String>
   <String Id="FailureUninstallHeader">No se pudo desinstalar</String>
-  <String Id="FailureRepairHeader">No se pudo reparar</String> 
+  <String Id="FailureRepairHeader">No se pudo reparar</String>
   <String Id="FailureHyperlinkLogText">Error de instalación debido a uno o varios problemas. Corrija los problemas e intente de nuevo la instalación. Para obtener más información, consulte el &lt;a href="#"&gt;archivo de registro&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Debe reiniciar el equipo para completar la reversión del software.</String>
   <String Id="FailureRestartButton">&amp;Reiniciar</String>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/.template.config/localize/templatestrings.de.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/.template.config/localize/templatestrings.de.json
@@ -29,7 +29,7 @@
   "symbols/NoHttps/description": "Ob HTTPS deaktiviert werden soll. Diese Option gilt nur, wenn IndividualB2C, SingleOrg oder MultiOrg nicht für --auth verwendet werden.",
   "symbols/UseLocalDB/description": "Ob LocalDB anstelle von SQLite verwendet werden soll. Diese Option gilt nur, wenn --auth Individual oder --auth IndividualB2C angegeben ist.",
   "symbols/Framework/description": "Das Zielframework für das Projekt.",
-  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/Framework/choices/net7.0/description": "Ziel net7.0",
   "symbols/CalledApiUrl/description": "URL der API, die von der Web-App aufgerufen werden soll. Diese Option gilt nur, wenn --auth SingleOrg, --auth MultiOrg oder --auth IndividualB2C angegeben ist.",
   "symbols/CallsMicrosoftGraph/description": "Gibt an, ob die Web-App Microsoft Graph aufruft. Diese Option gilt nur, wenn --auth SingleOrg oder --auth MultiOrg angegeben ist.",
   "symbols/CalledApiScopes/description": "Anzufordernde Bereiche zum Aufrufen der API von der Web-App. Diese Option gilt nur, wenn --auth SingleOrg, --auth MultiOrg oder --auth IndividualB2C angegeben ist.",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/localize/templatestrings.de.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/localize/templatestrings.de.json
@@ -3,7 +3,7 @@
   "name": "Blazor-WebAssembly App",
   "description": "Eine Projektvorlage zum Erstellen einer Blazor-App, die auf WebAssembly ausgeführt und optional durch eine ASP.NET Core-App gehostet wird. Diese Vorlage kann für Web-Apps mit umfangreichen dynamischen Benutzeroberflächen verwendet werden.",
   "symbols/Framework/description": "Das Zielframework für das Projekt.",
-  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/Framework/choices/net7.0/description": "Ziel net7.0",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "symbols/Hosted/displayName": "ASP.NET Core _gehostet",
   "symbols/Hosted/description": "Enthält, falls angegeben, einen ASP.NET Core Host für die Blazor WebAssembly App.",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyBlazorServerWeb-CSharp/.template.config/localize/templatestrings.de.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyBlazorServerWeb-CSharp/.template.config/localize/templatestrings.de.json
@@ -10,7 +10,7 @@
   "symbols/HasHttpProfile/description": "Immer HTTP Profil haben.",
   "symbols/NoHttps/description": "Ob HTTPS deaktiviert werden soll.",
   "symbols/Framework/description": "Das Zielframework für das Projekt.",
-  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/Framework/choices/net7.0/description": "Ziel net7.0",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "postActions/restore/description": "„NuGet-Pakete“ wiederherstellen, die für dieses Projekt erforderlich sind.",
   "postActions/restore/manualInstructions/default/text": "„dotnet restore“ ausführen"

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/.template.config/localize/templatestrings.de.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/.template.config/localize/templatestrings.de.json
@@ -3,7 +3,7 @@
   "name": "Blazor WebAssembly App leer",
   "description": "Eine leere Projektvorlage zum Erstellen einer Blazor-App, die auf WebAssembly ausgeführt und optional von einer ASP.NET Core App gehostet wird. Diese Vorlage enthält keinen Inhalt.",
   "symbols/Framework/description": "Das Zielframework für das Projekt.",
-  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/Framework/choices/net7.0/description": "Ziel net7.0",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "symbols/Hosted/displayName": "ASP.NET Core _gehostet",
   "symbols/Hosted/description": "Enthält, falls angegeben, einen ASP.NET Core Host für die Blazor WebAssembly App.",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/localize/templatestrings.de.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/localize/templatestrings.de.json
@@ -8,7 +8,7 @@
   "symbols/iisHttpPort/description": "Portnummer, die für den IIS Express HTTP Endpunkt in launchSettings.json verwendet werden soll.",
   "symbols/iisHttpsPort/description": "Portnummer, die für den IIS Express HTTPS Endpunkt in launchSettings.json verwendet werden soll. Diese Option ist nur anwendbar, wenn der Parameter no-https nicht verwendet wird (no-https wird ignoriert, wenn entweder IndividualAuth oder OrganizationalAuth verwendet wird).",
   "symbols/Framework/description": "Das Zielframework für das Projekt.",
-  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/Framework/choices/net7.0/description": "Ziel net7.0",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "symbols/NoHttps/description": "Ob HTTPS deaktiviert werden soll. Diese Option gilt nur, wenn Individual, IndividualB2C, SingleOrg oder MultiOrg nicht für --auth verwendet werden.",
   "symbols/UseProgramMain/displayName": "Keine Anweisungen_der obersten Ebene verwenden",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/localize/templatestrings.de.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/localize/templatestrings.de.json
@@ -8,7 +8,7 @@
   "symbols/iisHttpPort/description": "Portnummer, die für den IIS Express HTTP Endpunkt in launchSettings.json verwendet werden soll.",
   "symbols/iisHttpsPort/description": "Portnummer, die für den IIS Express HTTPS Endpunkt in launchSettings.json verwendet werden soll. Diese Option ist nur anwendbar, wenn der Parameter no-https nicht verwendet wird (no-https wird ignoriert, wenn entweder IndividualAuth oder OrganizationalAuth verwendet wird).",
   "symbols/Framework/description": "Das Zielframework für das Projekt.",
-  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/Framework/choices/net7.0/description": "Ziel net7.0",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "symbols/NoHttps/description": "Ob HTTPS deaktiviert werden soll. Diese Option gilt nur, wenn Individual, IndividualB2C, SingleOrg oder MultiOrg nicht für --auth verwendet werden.",
   "postActions/restore/description": "„NuGet-Pakete“ wiederherstellen, die für dieses Projekt erforderlich sind.",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/localize/templatestrings.de.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/localize/templatestrings.de.json
@@ -3,7 +3,7 @@
   "name": "ASP.NET Core-gRPC-Dienst",
   "description": "Eine Projektvorlage für das Erstellen eines gRPC-ASP.NET Core-Diensts.",
   "symbols/Framework/description": "Das Zielframework für das Projekt.",
-  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/Framework/choices/net7.0/description": "Ziel net7.0",
   "symbols/ExcludeLaunchSettings/description": "Ob launchSettings.json aus der generierten Vorlage ausgeschlossen werden soll.",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "symbols/kestrelHttpPort/description": "Portnummer, die für den HTTP Endpunkt in launchSettings.json verwendet werden soll.",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.de.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/localize/templatestrings.de.json
@@ -3,7 +3,7 @@
   "name": "Razor Klassenbibliothek",
   "description": "Ein Projekt zum Erstellen einer Razor Klassenbibliothek, die auf .NET Standard abzielt",
   "symbols/Framework/description": "Das Zielframework für das Projekt.",
-  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/Framework/choices/net7.0/description": "Ziel net7.0",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "symbols/SupportPagesAndViews/displayName": "Seiten und Ansichten unterstützen",
   "symbols/SupportPagesAndViews/description": "Ob das Hinzufügen herkömmlicher Razor Seiten und Ansichten zusätzlich zu Komponenten zu dieser Bibliothek unterstützt werden soll.",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/localize/templatestrings.de.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/localize/templatestrings.de.json
@@ -30,7 +30,7 @@
   "symbols/NoHttps/description": "Ob HTTPS deaktiviert werden soll. Diese Option gilt nur, wenn IndividualB2C, SingleOrg oder MultiOrg nicht für --auth verwendet werden.",
   "symbols/UseLocalDB/description": "Ob LocalDB anstelle von SQLite verwendet werden soll. Diese Option gilt nur, wenn --auth Individual oder --auth IndividualB2C angegeben ist.",
   "symbols/Framework/description": "Das Zielframework für das Projekt.",
-  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/Framework/choices/net7.0/description": "Ziel net7.0",
   "symbols/CalledApiUrl/description": "URL der API, die von der Web-App aufgerufen werden soll. Diese Option gilt nur, wenn --auth SingleOrg, --auth MultiOrg oder --auth IndividualB2C angegeben ist.",
   "symbols/CallsMicrosoftGraph/description": "Gibt an, ob die Web-App Microsoft Graph aufruft. Diese Option gilt nur, wenn --auth SingleOrg oder --auth MultiOrg angegeben ist.",
   "symbols/CalledApiScopes/description": "Anzufordernde Bereiche zum Aufrufen der API von der Web-App. Diese Option gilt nur, wenn --auth SingleOrg, --auth MultiOrg oder --auth IndividualB2C angegeben ist.",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/localize/templatestrings.de.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/localize/templatestrings.de.json
@@ -29,7 +29,7 @@
   "symbols/NoHttps/description": "Ob HTTPS deaktiviert werden soll. Diese Option gilt nur, wenn IndividualB2C, SingleOrg oder MultiOrg nicht für --auth verwendet werden.",
   "symbols/UseLocalDB/description": "Ob LocalDB anstelle von SQLite verwendet werden soll. Diese Option gilt nur, wenn --auth Individual oder --auth IndividualB2C angegeben ist.",
   "symbols/Framework/description": "Das Zielframework für das Projekt.",
-  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/Framework/choices/net7.0/description": "Ziel net7.0",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "symbols/CalledApiUrl/description": "URL der API, die von der Web-App aufgerufen werden soll. Diese Option gilt nur, wenn --auth SingleOrg, --auth MultiOrg oder --auth IndividualB2C angegeben ist.",
   "symbols/CallsMicrosoftGraph/description": "Gibt an, ob die Web-App Microsoft Graph aufruft. Diese Option gilt nur, wenn --auth SingleOrg oder --auth MultiOrg angegeben ist.",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/localize/templatestrings.de.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/localize/templatestrings.de.json
@@ -8,7 +8,7 @@
   "symbols/iisHttpPort/description": "Portnummer, die für den IIS Express HTTP Endpunkt in launchSettings.json verwendet werden soll.",
   "symbols/iisHttpsPort/description": "Portnummer, die für den IIS Express HTTPS Endpunkt in launchSettings.json verwendet werden soll. Diese Option ist nur anwendbar, wenn der Parameter no-https nicht verwendet wird (no-https wird ignoriert, wenn entweder IndividualAuth oder OrganizationalAuth verwendet wird).",
   "symbols/Framework/description": "Das Zielframework für das Projekt.",
-  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/Framework/choices/net7.0/description": "Ziel net7.0",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "symbols/NoHttps/description": "Ob HTTPS deaktiviert werden soll. Diese Option gilt nur, wenn Individual, IndividualB2C, SingleOrg oder MultiOrg nicht für --auth verwendet werden.",
   "postActions/restore/description": "„NuGet-Pakete“ wiederherstellen, die für dieses Projekt erforderlich sind.",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/localize/templatestrings.de.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/localize/templatestrings.de.json
@@ -25,7 +25,7 @@
   "symbols/UseLocalDB/description": "Ob LocalDB anstelle von SQLite verwendet werden soll. Diese Option gilt nur, wenn --auth Individual oder --auth IndividualB2C angegeben ist.",
   "symbols/UseMinimalAPIs/description": "Ob minimale APIs anstelle von Controllern verwendet werden sollen.",
   "symbols/Framework/description": "Das Zielframework für das Projekt.",
-  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/Framework/choices/net7.0/description": "Ziel net7.0",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "symbols/CalledApiUrl/description": "URL der API, die von der Web-App aufgerufen werden soll. Diese Option gilt nur, wenn --auth SingleOrg oder --auth IndividualB2C angegeben ist.",
   "symbols/CallsMicrosoftGraph/description": "Gibt an, ob die Web App Microsoft Graph aufruft. Diese Option gilt nur, wenn --auth SingleOrg angegeben ist.",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/zh-Hans/strings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/zh-Hans/strings.json
@@ -4,7 +4,7 @@
     "name": "ASP.NET Core Web API",
     "description": "用于创建包含 RESTful HTTP 服务示例控制器的 ASP.NET Core 应用程序的项目模板。此模板还可以用于 ASP.NET Core MVC 视图和控制器。",
     "parameter.DisableOpenAPI.name": "启用 OpenAPI 支持(_O)",
-    "parameter.DisableOpenAPI.description": "启用 OpenAI (Swagger)支持",
+    "parameter.DisableOpenAPI.description": "启用 OpenAPI (Swagger)支持",
     "parameter.UseMinimalAPIs.name": "使用控制器(取消选中以使用最小 API)",
     "parameter.UseMinimalAPIs.description": "是否生成显式程序类和主方法，而不是顶级语句。"
   }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/.template.config/localize/templatestrings.de.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/.template.config/localize/templatestrings.de.json
@@ -8,7 +8,7 @@
   "symbols/iisHttpPort/description": "Portnummer, die für den IIS Express HTTP Endpunkt in launchSettings.json verwendet werden soll.",
   "symbols/iisHttpsPort/description": "Portnummer, die für den IIS Express-HTTPS-Endpunkt in launchSettings.json verwendet werden soll.",
   "symbols/Framework/description": "Das Zielframework für das Projekt.",
-  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/Framework/choices/net7.0/description": "Ziel net7.0",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "symbols/NoHttps/description": "Ob HTTPS deaktiviert werden soll.",
   "postActions/restore/description": "„NuGet-Pakete“ wiederherstellen, die für dieses Projekt erforderlich sind.",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/.template.config/localize/templatestrings.de.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/.template.config/localize/templatestrings.de.json
@@ -4,7 +4,7 @@
   "description": "Eine leere Projektvorlage zum Erstellen eines Workerdiensts.",
   "symbols/ExcludeLaunchSettings/description": "Ob launchSettings.json aus der generierten Vorlage ausgeschlossen werden soll.",
   "symbols/Framework/description": "Das Zielframework für das Projekt.",
-  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/Framework/choices/net7.0/description": "Ziel net7.0",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "symbols/UseProgramMain/displayName": "Keine Anweisungen_der obersten Ebene verwenden",
   "symbols/UseProgramMain/description": "Gibt an, ob anstelle von Anweisungen der obersten Ebene eine explizite Programmklasse und eine Main-Methode generiert werden soll.",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-FSharp/.template.config/localize/templatestrings.de.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-FSharp/.template.config/localize/templatestrings.de.json
@@ -4,7 +4,7 @@
   "description": "Eine leere Projektvorlage zum Erstellen eines Workerdiensts.",
   "symbols/ExcludeLaunchSettings/description": "Ob launchSettings.json aus der generierten Vorlage ausgeschlossen werden soll.",
   "symbols/Framework/description": "Das Zielframework für das Projekt.",
-  "symbols/Framework/choices/net7.0/description": "Target net7.0",
+  "symbols/Framework/choices/net7.0/description": "Ziel net7.0",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "postActions/restore/description": "„NuGet-Pakete“ wiederherstellen, die für dieses Projekt erforderlich sind.",
   "postActions/restore/manualInstructions/default/text": "„dotnet restore“ ausführen"


### PR DESCRIPTION
# [release/7.0] Backport loc fixes

Backport automated localization improvements from main.

## Description

- backport #43956 aka 1b19eaf0d924
  - Fixes [loc ticket 710128 [C&AI Translation Feedback] - ASP.NET Core incomplete German translation](https://ceapex.visualstudio.com/CEINTL/_queries/edit/710128/)
  - Fixes #44167
  - Automates translation of WXL files in main (not directly in release/7.0)
- fixup translations
  - restore German "directory" translation
  - undo hot key changes
    - leave only Portuguese s/&amp;Navegar/&amp;Procurar/ change for `OptionsBrowseButton`
    - apparently, that's something like s/to browse/to search for/

## Customer Impact

Without these changes, translated strings are not at the quality level we could and should achieve. The ASP.NET Core localization sign-off for .NET 7.0 is (or, at least, should be) contingent on merging these new strings.

## Regression?

- [ ] Yes
- [x] No

WiX localized strings have been fairly consistent since 3.1.0.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Updates affect only the localized strings shown in
- Shared Framework Bundle installers
- Windows Hosting Bundle installers
- German project templates, their "Target net7.0" translation in particular
- a Simplified Chinese project template, a typo in "OpenAPI" in particular

## Verification

- [x] Manual (required)
- [ ] Automated

Rather thorough code inspection, especially of the French, Italian, and Russian translations. I'm also hoping @richaverma1's team will have time to run a few of the bundle installers for additional validation.

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A