### PR TITLE
[Templates] Fix links to http://useiconic.com

### DIFF
--- a/src/Components/Samples/BlazorServerApp/wwwroot/css/open-iconic/README.md
+++ b/src/Components/Samples/BlazorServerApp/wwwroot/css/open-iconic/README.md
@@ -1,7 +1,7 @@
-[Open Iconic v1.1.1](https://ionic.io/ionicons)
+[Open Iconic v1.1.1](https://github.com/iconic/open-iconic)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](https://ionic.io/ionicons). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://ionic.io/ionicons)
+### Open Iconic is the open source sibling of [Iconic](https://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://github.com/iconic/open-iconic)
 
 
 
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://ionic.io/ionicons) and [Reference](https://ionic.io/ionicons) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://github.com/iconic/open-iconic) and [Reference](https://github.com/iconic/open-iconic) sections.
 
 ### General Usage
 

--- a/src/Components/Samples/BlazorServerApp/wwwroot/css/open-iconic/README.md
+++ b/src/Components/Samples/BlazorServerApp/wwwroot/css/open-iconic/README.md
@@ -1,14 +1,14 @@
-[Open Iconic v1.1.1](http://useiconic.com/open)
+[Open Iconic v1.1.1](https://ionic.io/ionicons)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](http://useiconic.com). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://useiconic.com/open#icons)
+### Open Iconic is the open source sibling of [Iconic](https://ionic.io/ionicons). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://ionic.io/ionicons)
 
 
 
 ## What's in Open Iconic?
 
 * 223 icons designed to be legible down to 8 pixels
-* Super-light SVG files - 61.8 for the entire set 
+* Super-light SVG files - 61.8 for the entire set
 * SVG sprite&mdash;the modern replacement for icon fonts
 * Webfont (EOT, OTF, SVG, TTF, WOFF), PNG and WebP formats
 * Webfont stylesheets (including versions for Bootstrap and Foundation) in CSS, LESS, SCSS and Stylus formats
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://useiconic.com/open#icons) and [Reference](http://useiconic.com/open#reference) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://ionic.io/ionicons) and [Reference](https://ionic.io/ionicons) sections.
 
 ### General Usage
 
@@ -33,7 +33,7 @@ We like SVGs and we think they're the way to display icons on the web. Since Ope
 
 Open Iconic also comes in a SVG sprite which allows you to display all the icons in the set with a single request. It's like an icon font, without being a hack.
 
-Adding an icon from an SVG sprite is a little different than what you're used to, but it's still a piece of cake. *Tip: To make your icons easily style able, we suggest adding a general class to the* `<svg>` *tag and a unique class name for each different icon in the* `<use>` *tag.*  
+Adding an icon from an SVG sprite is a little different than what you're used to, but it's still a piece of cake. *Tip: To make your icons easily style able, we suggest adding a general class to the* `<svg>` *tag and a unique class name for each different icon in the* `<use>` *tag.*
 
 ```
 <svg class="icon">

--- a/src/Components/THIRD-PARTY-NOTICES.txt
+++ b/src/Components/THIRD-PARTY-NOTICES.txt
@@ -1,32 +1,32 @@
-﻿Blazor uses third-party libraries or other resources that may be distributed under licenses different than the Blazor software.  
+﻿Blazor uses third-party libraries or other resources that may be distributed under licenses different than the Blazor software.
 
-In the event that we accidentally failed to list a required notice, please bring it to our attention.  
+In the event that we accidentally failed to list a required notice, please bring it to our attention.
 
-Post an issue or email us: 
+Post an issue or email us:
 
-dotnet@microsoft.com 
+dotnet@microsoft.com
 
-The attached notices are provided for information only. 
+The attached notices are provided for information only.
 
 The actual third-party libraries or other resources may vary depending on the Blazor package.
 
 1.	Mono  (http://www.mono-project.com/docs/about-mono/)
-		Includes:mono/utils/memcheck.h 
-		Includes:mono/utils/freebsd-dwarf.h 
-		Includes:mono/utils/freebsd-elf_common.h 
-		Includes:mono/utils/freebsd-elf64.h 
-		Includes:mono/utils/freebsd-elf32.h 
-		Includes:mono/utils/bsearch.c 
-		Includes:mono/metadata/w32file-unix-glob.c 
-		Includes:mono/metadata/w32file-unix-glob.h 
+		Includes:mono/utils/memcheck.h
+		Includes:mono/utils/freebsd-dwarf.h
+		Includes:mono/utils/freebsd-elf_common.h
+		Includes:mono/utils/freebsd-elf64.h
+		Includes:mono/utils/freebsd-elf32.h
+		Includes:mono/utils/bsearch.c
+		Includes:mono/metadata/w32file-unix-glob.c
+		Includes:mono/metadata/w32file-unix-glob.h
 2.	AngleSharp  (https://github.com/AngleSharp/AngleSharp)
 3.	SimpleJson (https://github.com/facebook-csharp-sdk/simple-json)
 4.	Bootstrap (https://github.com/twbs/bootstrap)
-5.	Open Iconic (http://useiconic.com/open)
+5.	Open Iconic (https://ionic.io/ionicons)
 6.  fast-text-encoding (https://github.com/samthor/fast-text-encoding)
 
 
-%% License notice for Mono 
+%% License notice for Mono
 =========================================
 In general, the runtime and its class libraries are licensed under the
 terms of the MIT license, and some third party code is licensed under
@@ -49,12 +49,12 @@ furnished to do so,  subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE 
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION 
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
 The following code is linked with the final Mono runtime, the libmono
@@ -82,16 +82,16 @@ embeddable runtime:
    1. Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
 
-   2. The origin of this software must not be misrepresented; you must 
-      not claim that you wrote the original software.  If you use this 
-      software in a product, an acknowledgment in the product 
+   2. The origin of this software must not be misrepresented; you must
+      not claim that you wrote the original software.  If you use this
+      software in a product, an acknowledgment in the product
       documentation would be appreciated but is not required.
 
    3. Altered source versions must be plainly marked as such, and must
       not be misrepresented as being the original software.
 
-   4. The name of the author may not be used to endorse or promote 
-      products derived from this software without specific prior written 
+   4. The name of the author may not be used to endorse or promote
+      products derived from this software without specific prior written
       permission.
 
    THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
@@ -316,7 +316,7 @@ mono/metadata/w32file-unix-glob.h
 =========================================
 
 
-%% License notice for AngleSharp 
+%% License notice for AngleSharp
 =========================================
 The MIT License (MIT)
 

--- a/src/Components/THIRD-PARTY-NOTICES.txt
+++ b/src/Components/THIRD-PARTY-NOTICES.txt
@@ -22,7 +22,7 @@ The actual third-party libraries or other resources may vary depending on the Bl
 2.	AngleSharp  (https://github.com/AngleSharp/AngleSharp)
 3.	SimpleJson (https://github.com/facebook-csharp-sdk/simple-json)
 4.	Bootstrap (https://github.com/twbs/bootstrap)
-5.	Open Iconic (https://ionic.io/ionicons)
+5.	Open Iconic (https://github.com/iconic/open-iconic)
 6.  fast-text-encoding (https://github.com/samthor/fast-text-encoding)
 
 

--- a/src/Components/WebAssembly/Samples/HostedBlazorWebassemblyApp/Client/wwwroot/css/open-iconic/README.md
+++ b/src/Components/WebAssembly/Samples/HostedBlazorWebassemblyApp/Client/wwwroot/css/open-iconic/README.md
@@ -1,7 +1,7 @@
-[Open Iconic v1.1.1](https://ionic.io/ionicons)
+[Open Iconic v1.1.1](https://github.com/iconic/open-iconic)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](https://ionic.io/ionicons). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://ionic.io/ionicons)
+### Open Iconic is the open source sibling of [Iconic](https://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://github.com/iconic/open-iconic)
 
 
 
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://ionic.io/ionicons) and [Reference](https://ionic.io/ionicons) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://github.com/iconic/open-iconic) and [Reference](https://github.com/iconic/open-iconic) sections.
 
 ### General Usage
 

--- a/src/Components/WebAssembly/Samples/HostedBlazorWebassemblyApp/Client/wwwroot/css/open-iconic/README.md
+++ b/src/Components/WebAssembly/Samples/HostedBlazorWebassemblyApp/Client/wwwroot/css/open-iconic/README.md
@@ -1,14 +1,14 @@
-[Open Iconic v1.1.1](http://useiconic.com/open)
+[Open Iconic v1.1.1](https://ionic.io/ionicons)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](http://useiconic.com). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://useiconic.com/open#icons)
+### Open Iconic is the open source sibling of [Iconic](https://ionic.io/ionicons). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://ionic.io/ionicons)
 
 
 
 ## What's in Open Iconic?
 
 * 223 icons designed to be legible down to 8 pixels
-* Super-light SVG files - 61.8 for the entire set 
+* Super-light SVG files - 61.8 for the entire set
 * SVG sprite&mdash;the modern replacement for icon fonts
 * Webfont (EOT, OTF, SVG, TTF, WOFF), PNG and WebP formats
 * Webfont stylesheets (including versions for Bootstrap and Foundation) in CSS, LESS, SCSS and Stylus formats
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://useiconic.com/open#icons) and [Reference](http://useiconic.com/open#reference) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://ionic.io/ionicons) and [Reference](https://ionic.io/ionicons) sections.
 
 ### General Usage
 
@@ -33,7 +33,7 @@ We like SVGs and we think they're the way to display icons on the web. Since Ope
 
 Open Iconic also comes in a SVG sprite which allows you to display all the icons in the set with a single request. It's like an icon font, without being a hack.
 
-Adding an icon from an SVG sprite is a little different than what you're used to, but it's still a piece of cake. *Tip: To make your icons easily style able, we suggest adding a general class to the* `<svg>` *tag and a unique class name for each different icon in the* `<use>` *tag.*  
+Adding an icon from an SVG sprite is a little different than what you're used to, but it's still a piece of cake. *Tip: To make your icons easily style able, we suggest adding a general class to the* `<svg>` *tag and a unique class name for each different icon in the* `<use>` *tag.*
 
 ```
 <svg class="icon">

--- a/src/Components/WebAssembly/testassets/StandaloneApp/wwwroot/css/open-iconic/README.md
+++ b/src/Components/WebAssembly/testassets/StandaloneApp/wwwroot/css/open-iconic/README.md
@@ -1,7 +1,7 @@
-[Open Iconic v1.1.1](https://ionic.io/ionicons)
+[Open Iconic v1.1.1](https://github.com/iconic/open-iconic)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](https://ionic.io/ionicons). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://ionic.io/ionicons)
+### Open Iconic is the open source sibling of [Iconic](https://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://github.com/iconic/open-iconic)
 
 
 
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://ionic.io/ionicons) and [Reference](https://ionic.io/ionicons) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://github.com/iconic/open-iconic) and [Reference](https://github.com/iconic/open-iconic) sections.
 
 ### General Usage
 

--- a/src/Components/WebAssembly/testassets/StandaloneApp/wwwroot/css/open-iconic/README.md
+++ b/src/Components/WebAssembly/testassets/StandaloneApp/wwwroot/css/open-iconic/README.md
@@ -1,14 +1,14 @@
-[Open Iconic v1.1.1](http://useiconic.com/open)
+[Open Iconic v1.1.1](https://ionic.io/ionicons)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](http://useiconic.com). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://useiconic.com/open#icons)
+### Open Iconic is the open source sibling of [Iconic](https://ionic.io/ionicons). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://ionic.io/ionicons)
 
 
 
 ## What's in Open Iconic?
 
 * 223 icons designed to be legible down to 8 pixels
-* Super-light SVG files - 61.8 for the entire set 
+* Super-light SVG files - 61.8 for the entire set
 * SVG sprite&mdash;the modern replacement for icon fonts
 * Webfont (EOT, OTF, SVG, TTF, WOFF), PNG and WebP formats
 * Webfont stylesheets (including versions for Bootstrap and Foundation) in CSS, LESS, SCSS and Stylus formats
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://useiconic.com/open#icons) and [Reference](http://useiconic.com/open#reference) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://ionic.io/ionicons) and [Reference](https://ionic.io/ionicons) sections.
 
 ### General Usage
 
@@ -33,7 +33,7 @@ We like SVGs and we think they're the way to display icons on the web. Since Ope
 
 Open Iconic also comes in a SVG sprite which allows you to display all the icons in the set with a single request. It's like an icon font, without being a hack.
 
-Adding an icon from an SVG sprite is a little different than what you're used to, but it's still a piece of cake. *Tip: To make your icons easily style able, we suggest adding a general class to the* `<svg>` *tag and a unique class name for each different icon in the* `<use>` *tag.*  
+Adding an icon from an SVG sprite is a little different than what you're used to, but it's still a piece of cake. *Tip: To make your icons easily style able, we suggest adding a general class to the* `<svg>` *tag and a unique class name for each different icon in the* `<use>` *tag.*
 
 ```
 <svg class="icon">

--- a/src/Components/test/testassets/ComponentsApp.Server/wwwroot/css/open-iconic/README.md
+++ b/src/Components/test/testassets/ComponentsApp.Server/wwwroot/css/open-iconic/README.md
@@ -1,7 +1,7 @@
-[Open Iconic v1.1.1](https://ionic.io/ionicons)
+[Open Iconic v1.1.1](https://github.com/iconic/open-iconic)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](https://ionic.io/ionicons). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://ionic.io/ionicons)
+### Open Iconic is the open source sibling of [Iconic](https://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://github.com/iconic/open-iconic)
 
 
 
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://ionic.io/ionicons) and [Reference](https://ionic.io/ionicons) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://github.com/iconic/open-iconic) and [Reference](https://github.com/iconic/open-iconic) sections.
 
 ### General Usage
 

--- a/src/Components/test/testassets/ComponentsApp.Server/wwwroot/css/open-iconic/README.md
+++ b/src/Components/test/testassets/ComponentsApp.Server/wwwroot/css/open-iconic/README.md
@@ -1,14 +1,14 @@
-[Open Iconic v1.1.1](http://useiconic.com/open)
+[Open Iconic v1.1.1](https://ionic.io/ionicons)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](http://useiconic.com). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://useiconic.com/open#icons)
+### Open Iconic is the open source sibling of [Iconic](https://ionic.io/ionicons). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://ionic.io/ionicons)
 
 
 
 ## What's in Open Iconic?
 
 * 223 icons designed to be legible down to 8 pixels
-* Super-light SVG files - 61.8 for the entire set 
+* Super-light SVG files - 61.8 for the entire set
 * SVG sprite&mdash;the modern replacement for icon fonts
 * Webfont (EOT, OTF, SVG, TTF, WOFF), PNG and WebP formats
 * Webfont stylesheets (including versions for Bootstrap and Foundation) in CSS, LESS, SCSS and Stylus formats
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://useiconic.com/open#icons) and [Reference](http://useiconic.com/open#reference) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://ionic.io/ionicons) and [Reference](https://ionic.io/ionicons) sections.
 
 ### General Usage
 
@@ -33,7 +33,7 @@ We like SVGs and we think they're the way to display icons on the web. Since Ope
 
 Open Iconic also comes in a SVG sprite which allows you to display all the icons in the set with a single request. It's like an icon font, without being a hack.
 
-Adding an icon from an SVG sprite is a little different than what you're used to, but it's still a piece of cake. *Tip: To make your icons easily style able, we suggest adding a general class to the* `<svg>` *tag and a unique class name for each different icon in the* `<use>` *tag.*  
+Adding an icon from an SVG sprite is a little different than what you're used to, but it's still a piece of cake. *Tip: To make your icons easily style able, we suggest adding a general class to the* `<svg>` *tag and a unique class name for each different icon in the* `<use>` *tag.*
 
 ```
 <svg class="icon">

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/open-iconic/README.md
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/open-iconic/README.md
@@ -1,7 +1,7 @@
-[Open Iconic v1.1.1](https://ionic.io/ionicons)
+[Open Iconic v1.1.1](https://github.com/iconic/open-iconic)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](https://ionic.io/ionicons). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://ionic.io/ionicons)
+### Open Iconic is the open source sibling of [Iconic](https://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://github.com/iconic/open-iconic)
 
 
 
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://ionic.io/ionicons) and [Reference](https://ionic.io/ionicons) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://github.com/iconic/open-iconic) and [Reference](https://github.com/iconic/open-iconic) sections.
 
 ### General Usage
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/open-iconic/README.md
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/open-iconic/README.md
@@ -1,14 +1,14 @@
-[Open Iconic v1.1.1](http://useiconic.com/open)
+[Open Iconic v1.1.1](https://ionic.io/ionicons)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](http://useiconic.com). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://useiconic.com/open#icons)
+### Open Iconic is the open source sibling of [Iconic](https://ionic.io/ionicons). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://ionic.io/ionicons)
 
 
 
 ## What's in Open Iconic?
 
 * 223 icons designed to be legible down to 8 pixels
-* Super-light SVG files - 61.8 for the entire set 
+* Super-light SVG files - 61.8 for the entire set
 * SVG sprite&mdash;the modern replacement for icon fonts
 * Webfont (EOT, OTF, SVG, TTF, WOFF), PNG and WebP formats
 * Webfont stylesheets (including versions for Bootstrap and Foundation) in CSS, LESS, SCSS and Stylus formats
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://useiconic.com/open#icons) and [Reference](http://useiconic.com/open#reference) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://ionic.io/ionicons) and [Reference](https://ionic.io/ionicons) sections.
 
 ### General Usage
 
@@ -33,7 +33,7 @@ We like SVGs and we think they're the way to display icons on the web. Since Ope
 
 Open Iconic also comes in a SVG sprite which allows you to display all the icons in the set with a single request. It's like an icon font, without being a hack.
 
-Adding an icon from an SVG sprite is a little different than what you're used to, but it's still a piece of cake. *Tip: To make your icons easily style able, we suggest adding a general class to the* `<svg>` *tag and a unique class name for each different icon in the* `<use>` *tag.*  
+Adding an icon from an SVG sprite is a little different than what you're used to, but it's still a piece of cake. *Tip: To make your icons easily style able, we suggest adding a general class to the* `<svg>` *tag and a unique class name for each different icon in the* `<use>` *tag.*
 
 ```
 <svg class="icon">

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/open-iconic/README.md
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/open-iconic/README.md
@@ -1,7 +1,7 @@
-[Open Iconic v1.1.1](https://ionic.io/ionicons)
+[Open Iconic v1.1.1](https://github.com/iconic/open-iconic)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](https://ionic.io/ionicons). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://ionic.io/ionicons)
+### Open Iconic is the open source sibling of [Iconic](https://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://github.com/iconic/open-iconic)
 
 
 
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://ionic.io/ionicons) and [Reference](https://ionic.io/ionicons) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://github.com/iconic/open-iconic) and [Reference](https://github.com/iconic/open-iconic) sections.
 
 ### General Usage
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/open-iconic/README.md
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/open-iconic/README.md
@@ -1,14 +1,14 @@
-[Open Iconic v1.1.1](http://useiconic.com/open)
+[Open Iconic v1.1.1](https://ionic.io/ionicons)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](http://useiconic.com). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://useiconic.com/open#icons)
+### Open Iconic is the open source sibling of [Iconic](https://ionic.io/ionicons). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://ionic.io/ionicons)
 
 
 
 ## What's in Open Iconic?
 
 * 223 icons designed to be legible down to 8 pixels
-* Super-light SVG files - 61.8 for the entire set 
+* Super-light SVG files - 61.8 for the entire set
 * SVG sprite&mdash;the modern replacement for icon fonts
 * Webfont (EOT, OTF, SVG, TTF, WOFF), PNG and WebP formats
 * Webfont stylesheets (including versions for Bootstrap and Foundation) in CSS, LESS, SCSS and Stylus formats
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://useiconic.com/open#icons) and [Reference](http://useiconic.com/open#reference) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://ionic.io/ionicons) and [Reference](https://ionic.io/ionicons) sections.
 
 ### General Usage
 
@@ -33,7 +33,7 @@ We like SVGs and we think they're the way to display icons on the web. Since Ope
 
 Open Iconic also comes in a SVG sprite which allows you to display all the icons in the set with a single request. It's like an icon font, without being a hack.
 
-Adding an icon from an SVG sprite is a little different than what you're used to, but it's still a piece of cake. *Tip: To make your icons easily style able, we suggest adding a general class to the* `<svg>` *tag and a unique class name for each different icon in the* `<use>` *tag.*  
+Adding an icon from an SVG sprite is a little different than what you're used to, but it's still a piece of cake. *Tip: To make your icons easily style able, we suggest adding a general class to the* `<svg>` *tag and a unique class name for each different icon in the* `<use>` *tag.*
 
 ```
 <svg class="icon">


### PR DESCRIPTION
Updates links to point to up-to-date documentation

## Description

Updates the links in the readme.md of one of our template files to point out to the newer documentation site.

## Customer Impact

Customers who will read this doc will have valid links to use for getting to the icons.

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

It is updating a file in the templates that doesn't affect how the project is built or runs, only documentation.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A