### PR TITLE
[release/3.1] Skip test that times out in CI

### DIFF
--- a/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/RequestTests.cs
@@ -786,8 +786,9 @@ namespace Microsoft.AspNetCore.Server.Kestrel.FunctionalTests
             mockKestrelTrace.Verify(t => t.ConnectionStop(It.IsAny<string>()), Times.Once());
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(ConnectionMiddlewareData))]
+        [SkipOnCI]
         public async Task AppCanHandleClientAbortingConnectionMidRequest(ListenOptions listenOptions)
         {
             var readTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);


### PR DESCRIPTION
This test has been timing out consistently in 3.1, and is already quarantined in main: https://github.com/dotnet/aspnetcore/issues/27157

CC @vseanreesermsft should make the aspnetcore 3.1 build less flaky