### PR TITLE
Add AdditionalDotNetPackageFeed for helix

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -222,6 +222,7 @@ jobs:
               # Include the variables we always want.
               COMPlus_DbgEnableMiniDump: 1
               COMPlus_DbgMiniDumpName: "$(System.DefaultWorkingDirectory)/dotnet-%d.%t.core"
+              DotNetBuildsInternalReadSasToken: $(dotnetbuilds-internal-container-read-token)
               # !temporary! Remove as soon as .NET SDK includes a new-enough `msbuild` to make this hack unnecessary
               DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER: true
               # Expand provided `env:` properties, if any.
@@ -235,6 +236,7 @@ jobs:
           env:
             COMPlus_DbgEnableMiniDump: 1
             COMPlus_DbgMiniDumpName: "$(System.DefaultWorkingDirectory)/dotnet-%d.%t.core"
+            DotNetBuildsInternalReadSasToken: $(dotnetbuilds-internal-container-read-token)
             # !temporary! Remove as soon as .NET SDK includes a new-enough `msbuild` to make this hack unnecessary
             DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER: true
       - ${{ if ne(parameters.agentOs, 'Windows') }}:
@@ -243,6 +245,7 @@ jobs:
           env:
             COMPlus_DbgEnableMiniDump: 1
             COMPlus_DbgMiniDumpName: "$(System.DefaultWorkingDirectory)/dotnet-%d.%t.core"
+            DotNetBuildsInternalReadSasToken: $(dotnetbuilds-internal-container-read-token)
             # !temporary! Remove as soon as .NET SDK includes a new-enough `msbuild` to make this hack unnecessary
             DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER: true
 

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -57,6 +57,11 @@
     <AdditionalDotNetPackage Include="$(MicrosoftNETCoreBrowserDebugHostTransportVersion)">
       <PackageType>runtime</PackageType>
     </AdditionalDotNetPackage>
+    
+    <AdditionalDotNetPackageFeed Include="https://dotnetbuilds.blob.core.windows.net/internal"
+                                 Condition="'$(SYSTEM_TEAMPROJECT)' == 'internal'">
+      <SasToken>$([System.Environment]::GetEnvironmentVariable('DotNetBuildsInternalReadSasToken'))</SasToken>
+    </AdditionalDotNetPackageFeed>
 
     <!-- Grab the tool packages for what HelixTestRunner installs. -->
     <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-dump\$(DotnetDumpVersion)\dotnet-dump.$(DotnetDumpVersion).nupkg" />


### PR DESCRIPTION
This will use the internal blob feed as a fallback for downloading the runtime in Helix builds (but only in internal builds)