### PR TITLE
[6.0] Remove IsAvailable check on CommitAsync.

### DIFF
--- a/src/Middleware/Session/src/DistributedSession.cs
+++ b/src/Middleware/Session/src/DistributedSession.cs
@@ -267,12 +267,6 @@ namespace Microsoft.AspNetCore.Session
         /// <inheritdoc />
         public async Task CommitAsync(CancellationToken cancellationToken = default)
         {
-            if (!IsAvailable)
-            {
-                _logger.SessionNotAvailable();
-                return;
-            }
-
             using (var timeout = new CancellationTokenSource(_ioTimeout))
             {
                 var cts = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellationToken);


### PR DESCRIPTION
Backport https://github.com/dotnet/aspnetcore/pull/43059 to 6.0

# Remove IsAvailable check on CommitAsync.

This removes an unnecessary call to `IsAvailable` in `CommitAsync` that was added during a large change that added nullability annotations in a bunch of places.


Fixes #42009

## Customer Impact

In addition to being unnecessary, the `IsAvailable` call can cause a significant performance hit to the application since it will try to load the session each time on `CommitAsync` whether or not it needs to.

We've had multiple folks run into this issue and report it. For instance, see https://github.com/dotnet/aspnetcore/pull/43059#issuecomment-1272696654 where someone was using a setup recommended in our official docs for distributed caching and observed a massive CPU usage hit on their servers caused by this issue.

## Regression?

- [x] Yes
- [ ] No

The issue was introduced in 6.0 (https://github.com/dotnet/aspnetcore/pull/26098)

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Removes a superfluous check.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

