### PR TITLE
[release/3.1] Update Grpc.AspNetCore dependency for template

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -242,7 +242,7 @@
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <FSharpCorePackageVersion>4.2.1</FSharpCorePackageVersion>
     <GoogleProtobufPackageVersion>3.19.5</GoogleProtobufPackageVersion>
-    <GrpcAspNetCorePackageVersion>2.27.0</GrpcAspNetCorePackageVersion>
+    <GrpcAspNetCorePackageVersion>2.40.0</GrpcAspNetCorePackageVersion>
     <IdentityServer4AspNetIdentityPackageVersion>3.0.0</IdentityServer4AspNetIdentityPackageVersion>
     <IdentityServer4EntityFrameworkPackageVersion>3.0.0</IdentityServer4EntityFrameworkPackageVersion>
     <IdentityServer4PackageVersion>3.0.0</IdentityServer4PackageVersion>


### PR DESCRIPTION
# Update Grpc.AspNetCore dependency for template

This PR updates Grpc.AspNetCore dependency to 2.40.0. This dependency is used by the gRPC template.

Grpc.AspNetCore 2.40.0 includes Grpc.Tools 2.40.0, and this version fixes the gRPC tooling not working on MacOS. This is the same version used in .NET 6 template.

Fixes https://github.com/dotnet/aspnetcore/issues/37060 for 3.1
Addresses https://github.com/aspnet/AspNetCore-ManualTests/issues/1651

## Customer Impact

The project created by the gRPC template doesn't compile on MacOS. The developer must update to a newer version of Grpc.AspNetCore.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Just updates a dependency in gRPC template. The version is the same as .NET 6.

## Verification

- [ ] Manual (required)
- [ ] Automated

I don't have a MacOS device. However, this Grpc.AspNetCore version has been confirmed to work in .NET 6 template: https://github.com/dotnet/aspnetcore/pull/37229.

It can also be verified by CTI when checking https://github.com/aspnet/AspNetCore-ManualTests/issues/1651 is fixed.

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
