### PR TITLE
[6.0] Limit the hpack buffer resize

### DIFF
--- a/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
+++ b/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
@@ -620,7 +620,7 @@ namespace System.Net.Http.HPack
         {
             if (dst.Length < _stringLength)
             {
-                dst = new byte[Math.Max(_stringLength, dst.Length * 2)];
+                dst = new byte[Math.Max(_stringLength, Math.Min(dst.Length * 2, _maxHeadersLength))];
             }
         }
 

--- a/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
+++ b/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
@@ -572,7 +572,7 @@ namespace System.Net.Http.HPack
                     throw new HPackDecodingException(SR.Format(SR.net_http_headers_exceeded_length, _maxHeadersLength));
                 }
 
-                _stringOctets = new byte[Math.Max(length, _stringOctets.Length * 2)];
+                _stringOctets = new byte[Math.Max(length, Math.Min(_stringOctets.Length * 2, _maxHeadersLength))];
             }
 
             _stringLength = length;


### PR DESCRIPTION
The HPack decoder can allocate more than it can consume.

## Description

The HPack buffer grows by 2x, but that can cause it to go above the given field size limit.

Contributes to #44643

## Customer Impact

Excess memory allocation.

## Regression?

- [x] Yes
- [ ] No

Regressed in 5.0 when buffer resizing was introduced.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The limits are already enforced, just not as consistently as they should be.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
