### PR TITLE
Produce arch-specific ANCM redist packages

### DIFF
--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/AncmIISExpressV2.nuspec
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/AncmIISExpressV2.nuspec
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
-        <id>VS.Redist.Common.AspNetCore.AspNetCoreModuleV2IISExpress.$MAJOR$.$MINOR$</id>
+        <id>VS.Redist.Common.AspNetCore.AspNetCoreModuleV2IISExpress.$ARCH$.$MAJOR$.$MINOR$</id>
         <version>1.0.0</version>
-        <title>VS.Redist.Common.AspNetCore.AspNetCoreModuleV2IISExpress.$MAJOR$.$MINOR$</title>
+        <title>VS.Redist.Common.AspNetCore.AspNetCoreModuleV2IISExpress.$ARCH$.$MAJOR$.$MINOR$</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
         <license type="expression">$PackageLicenseExpression$</license>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/AncmV2.nuspec
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/AncmV2.nuspec
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
-        <id>VS.Redist.Common.AspNetCore.AspNetCoreModuleV2.$MAJOR$.$MINOR$</id>
+        <id>VS.Redist.Common.AspNetCore.AspNetCoreModuleV2.$ARCH$.$MAJOR$.$MINOR$</id>
         <version>1.0.0</version>
-        <title>VS.Redist.Common.AspNetCore.AspNetCoreModuleV2.$MAJOR$.$MINOR$</title>
+        <title>VS.Redist.Common.AspNetCore.AspNetCoreModuleV2.$ARCH$.$MAJOR$.$MINOR$</title>
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
         <license type="expression">$PackageLicenseExpression$</license>


### PR DESCRIPTION
Realized while doing the VS insertion that the package doesn't have the architecture in the name, so only 1 package was getting produced & the other 2 architectures weren't getting their own package. Follow up to https://github.com/dotnet/aspnetcore/pull/39140

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2025267&view=results