### PR TITLE
[8.0] Limit the hpack buffer resize #44643

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
@@ -36,6 +36,10 @@ public class WebHostTests : LoggedTest
                         {
                             listenOptions.Protocols = Core.HttpProtocols.Http3;
                         });
+                        o.ConfigureHttpsDefaults(httpsOptions =>
+                        {
+                            httpsOptions.ServerCertificate = TestResources.GetTestCertificate();
+                        });
                     })
                     .UseUrls("https://127.0.0.1:0")
                     .Configure(app =>

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -846,7 +846,7 @@ public class Http3RequestTests : LoggedTest
                     o.Listen(IPAddress.Parse("127.0.0.1"), port, listenOptions =>
                     {
                         listenOptions.Protocols = HttpProtocols.Http1AndHttp2AndHttp3;
-                        listenOptions.UseHttps();
+                        listenOptions.UseHttps(TestResources.GetTestCertificate());
                     });
                 });
 
@@ -1405,7 +1405,7 @@ public class Http3RequestTests : LoggedTest
                 kestrel.ListenLocalhost(5001, listenOptions =>
                 {
                     listenOptions.Protocols = HttpProtocols.Http3;
-                    listenOptions.UseHttps();
+                    listenOptions.UseHttps(TestResources.GetTestCertificate());
                     listenOptions.UseConnectionLogging();
                 });
             });
@@ -1509,7 +1509,7 @@ public class Http3RequestTests : LoggedTest
                 kestrel.Listen(IPAddress.Parse("127.0.0.1"), 0, listenOptions =>
                 {
                     listenOptions.Protocols = HttpProtocols.Http3;
-                    listenOptions.UseHttps();
+                    listenOptions.UseHttps(TestResources.GetTestCertificate());
 
                     IMultiplexedConnectionBuilder multiplexedConnectionBuilder = listenOptions;
                     multiplexedConnectionBuilder.Use(next =>
@@ -1678,7 +1678,7 @@ public class Http3RequestTests : LoggedTest
                 kestrel.Listen(IPAddress.Parse("127.0.0.1"), 0, listenOptions =>
                 {
                     listenOptions.Protocols = HttpProtocols.Http3;
-                    listenOptions.UseHttps();
+                    listenOptions.UseHttps(TestResources.GetTestCertificate());
 
                     IMultiplexedConnectionBuilder multiplexedConnectionBuilder = listenOptions;
                     multiplexedConnectionBuilder.Use(next =>
@@ -1837,7 +1837,7 @@ public class Http3RequestTests : LoggedTest
             kestrel.Listen(IPAddress.Loopback, 0, listenOptions =>
             {
                 listenOptions.Protocols = protocol;
-                listenOptions.UseHttps();
+                listenOptions.UseHttps(TestResources.GetTestCertificate());
             });
         });
 

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
@@ -265,6 +265,7 @@ public class Http3TlsTests : LoggedTest
                     listenOptions.Protocols = protocols;
                     listenOptions.UseHttps(httpsOptions =>
                     {
+                        httpsOptions.ServerCertificate = TestResources.GetTestCertificate();
                         httpsOptions.OnAuthenticate = (_, _) => { };
                     });
                 });

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpHelpers.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpHelpers.cs
@@ -73,7 +73,7 @@ internal static class HttpHelpers
                                 listenOptions.Protocols = protocol ?? HttpProtocols.Http3;
                                 if (!(plaintext ?? false))
                                 {
-                                    listenOptions.UseHttps();
+                                    listenOptions.UseHttps(TestResources.GetTestCertificate());
                                 }
                             });
                         }

--- a/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
+++ b/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
@@ -577,7 +577,7 @@ namespace System.Net.Http.HPack
                     throw new HPackDecodingException(SR.Format(SR.net_http_headers_exceeded_length, _maxHeadersLength));
                 }
 
-                _stringOctets = new byte[Math.Max(length, _stringOctets.Length * 2)];
+                _stringOctets = new byte[Math.Max(length, Math.Min(_stringOctets.Length * 2, _maxHeadersLength))];
             }
 
             _stringLength = length;

--- a/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
+++ b/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
@@ -625,7 +625,7 @@ namespace System.Net.Http.HPack
         {
             if (dst.Length < _stringLength)
             {
-                dst = new byte[Math.Max(_stringLength, dst.Length * 2)];
+                dst = new byte[Math.Max(_stringLength, Math.Min(dst.Length * 2, _maxHeadersLength))];
             }
         }
 


### PR DESCRIPTION
The HPack decoder can allocate more than it can consume.

## Description

The HPack buffer grows by 2x, but that can cause it to go above the given field size limit.

Contributes to #44643

## Customer Impact

Excess memory allocation.

## Regression?

- [x] Yes
- [ ] No

Regressed in 5.0 when buffer resizing was introduced.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The limits are already enforced, just not as consistently as they should be.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
