### PR TITLE
Update CSharp.Common.targets

### DIFF
--- a/eng/targets/CSharp.Common.targets
+++ b/eng/targets/CSharp.Common.targets
@@ -52,7 +52,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(ImplicitUsings)' == 'enable'">
+  <ItemGroup Condition="'$(ImplicitUsings)' == 'enable' or '$(ImplicitUsings)' == 'true'">
     <!-- We should make it obvious when Linq is being used in shipping code -->
     <Using Remove="System.Linq" Condition="'$(_IsSrcProject)' == 'true'" />
     <!-- System.Net.Http types will frequently conflict with ASP.NET Core types-->


### PR DESCRIPTION
According to our docs, _implicit usings_ are enabled one of two ways; `enable` or `true`.

https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#using