### PR TITLE
Use IndexOfAny(char, char) when possible

### DIFF
--- a/src/Components/Components/src/NavigationManager.cs
+++ b/src/Components/Components/src/NavigationManager.cs
@@ -12,8 +12,6 @@ namespace Microsoft.AspNetCore.Components;
 /// </summary>
 public abstract class NavigationManager
 {
-    private static readonly char[] UriPathEndChar = new[] { '#', '?' };
-
     /// <summary>
     /// An event that fires when the navigation location has changed.
     /// </summary>
@@ -232,9 +230,9 @@ public abstract class NavigationManager
             return uri.Substring(_baseUri.OriginalString.Length);
         }
 
-        var pathEndIndex = uri.IndexOfAny(UriPathEndChar);
-        var uriPathOnly = pathEndIndex < 0 ? uri : uri.Substring(0, pathEndIndex);
-        if ($"{uriPathOnly}/".Equals(_baseUri.OriginalString, StringComparison.Ordinal))
+        var pathEndIndex = uri.AsSpan().IndexOfAny('#', '?');
+        var uriPathOnly = pathEndIndex < 0 ? uri : uri.AsSpan().Slice(0, pathEndIndex);
+        if (_baseUri.OriginalString.EndsWith('/') && uriPathOnly.Equals(_baseUri.OriginalString.AsSpan().Slice(0, _baseUri.OriginalString.Length - 1), StringComparison.Ordinal))
         {
             // Special case: for the base URI "/something/", if you're at
             // "/something" then treat it as if you were at "/something/" (i.e.,
@@ -498,9 +496,9 @@ public abstract class NavigationManager
             return true;
         }
 
-        var pathEndIndex = uri.IndexOfAny(UriPathEndChar);
-        var uriPathOnly = pathEndIndex < 0 ? uri : uri.Substring(0, pathEndIndex);
-        if ($"{uriPathOnly}/".Equals(baseUri.OriginalString, StringComparison.Ordinal))
+        var pathEndIndex = uri.AsSpan().IndexOfAny('#', '?');
+        var uriPathOnly = pathEndIndex < 0 ? uri : uri.AsSpan().Slice(0, pathEndIndex);
+        if (baseUri.OriginalString.EndsWith('/') && uriPathOnly.Equals(baseUri.OriginalString.AsSpan().Slice(0, baseUri.OriginalString.Length - 1), StringComparison.Ordinal))
         {
             // Special case: for the base URI "/something/", if you're at
             // "/something" then treat it as if you were at "/something/" (i.e.,

--- a/src/Components/Components/src/NavigationManager.cs
+++ b/src/Components/Components/src/NavigationManager.cs
@@ -231,8 +231,8 @@ public abstract class NavigationManager
         }
 
         var pathEndIndex = uri.AsSpan().IndexOfAny('#', '?');
-        var uriPathOnly = pathEndIndex < 0 ? uri : uri.AsSpan().Slice(0, pathEndIndex);
-        if (_baseUri.OriginalString.EndsWith('/') && uriPathOnly.Equals(_baseUri.OriginalString.AsSpan().Slice(0, _baseUri.OriginalString.Length - 1), StringComparison.Ordinal))
+        var uriPathOnly = pathEndIndex < 0 ? uri : uri.AsSpan(0, pathEndIndex);
+        if (_baseUri.OriginalString.EndsWith('/') && uriPathOnly.Equals(_baseUri.OriginalString.AsSpan(0, _baseUri.OriginalString.Length - 1), StringComparison.Ordinal))
         {
             // Special case: for the base URI "/something/", if you're at
             // "/something" then treat it as if you were at "/something/" (i.e.,
@@ -497,8 +497,8 @@ public abstract class NavigationManager
         }
 
         var pathEndIndex = uri.AsSpan().IndexOfAny('#', '?');
-        var uriPathOnly = pathEndIndex < 0 ? uri : uri.AsSpan().Slice(0, pathEndIndex);
-        if (baseUri.OriginalString.EndsWith('/') && uriPathOnly.Equals(baseUri.OriginalString.AsSpan().Slice(0, baseUri.OriginalString.Length - 1), StringComparison.Ordinal))
+        var uriPathOnly = pathEndIndex < 0 ? uri : uri.AsSpan(0, pathEndIndex);
+        if (baseUri.OriginalString.EndsWith('/') && uriPathOnly.Equals(baseUri.OriginalString.AsSpan(0, baseUri.OriginalString.Length - 1), StringComparison.Ordinal))
         {
             // Special case: for the base URI "/something/", if you're at
             // "/something" then treat it as if you were at "/something/" (i.e.,

--- a/src/Middleware/OutputCaching/src/OutputCacheKeyProvider.cs
+++ b/src/Middleware/OutputCaching/src/OutputCacheKeyProvider.cs
@@ -17,8 +17,6 @@ internal sealed class OutputCacheKeyProvider : IOutputCacheKeyProvider
     // Use the unit separator for delimiting subcomponents of the cache key to avoid possible collisions
     private const char KeySubDelimiter = '\x1f';
 
-    private static readonly char[] KeyDelimiters = new[] { KeyDelimiter, KeySubDelimiter };
-
     private readonly ObjectPool<StringBuilder> _builderPool;
     private readonly OutputCacheOptions _options;
 
@@ -70,7 +68,7 @@ internal sealed class OutputCacheKeyProvider : IOutputCacheKeyProvider
 
     public static bool ContainsDelimiters(string? value)
     {
-        return !string.IsNullOrEmpty(value) && value.IndexOfAny(KeyDelimiters) > -1;
+        return !string.IsNullOrEmpty(value) && value.AsSpan().IndexOfAny(KeyDelimiter, KeySubDelimiter) > -1;
     }
 
     public static bool TryAppendKeyPrefix(OutputCacheContext context, StringBuilder builder)

--- a/src/Middleware/OutputCaching/src/OutputCacheKeyProvider.cs
+++ b/src/Middleware/OutputCaching/src/OutputCacheKeyProvider.cs
@@ -68,7 +68,7 @@ internal sealed class OutputCacheKeyProvider : IOutputCacheKeyProvider
 
     public static bool ContainsDelimiters(string? value)
     {
-        return !string.IsNullOrEmpty(value) && value.AsSpan().IndexOfAny(KeyDelimiter, KeySubDelimiter) > -1;
+        return !string.IsNullOrEmpty(value) && value.AsSpan().IndexOfAny(KeyDelimiter, KeySubDelimiter) >= 0;
     }
 
     public static bool TryAppendKeyPrefix(OutputCacheContext context, StringBuilder builder)

--- a/src/Mvc/Mvc.Core/src/ModelBinding/PrefixContainer.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/PrefixContainer.cs
@@ -14,8 +14,6 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding;
 /// </summary>
 public class PrefixContainer
 {
-    private static readonly char[] Delimiters = new char[] { '[', '.' };
-
     private readonly ICollection<string> _originalValues;
     private readonly string[] _sortedValues;
 
@@ -150,7 +148,7 @@ public class PrefixContainer
         {
             case '.':
                 // Handle an entry such as "prefix.key", "prefix.key.property" and "prefix.key[index]".
-                var delimiterPosition = entry.IndexOfAny(Delimiters, keyPosition);
+                var delimiterPosition = entry.AsSpan(keyPosition).IndexOfAny('[', '.');
                 if (delimiterPosition == -1)
                 {
                     // Neither '.' nor '[' found later in the name. Use rest of the string.
@@ -159,8 +157,8 @@ public class PrefixContainer
                 }
                 else
                 {
-                    key = entry.Substring(keyPosition, delimiterPosition - keyPosition);
-                    fullName = entry.Substring(0, delimiterPosition);
+                    key = entry.Substring(keyPosition, delimiterPosition);
+                    fullName = entry.Substring(0, delimiterPosition + keyPosition);
                 }
                 break;
 

--- a/src/Mvc/Mvc.Core/src/ModelBinding/PrefixContainer.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/PrefixContainer.cs
@@ -149,7 +149,7 @@ public class PrefixContainer
             case '.':
                 // Handle an entry such as "prefix.key", "prefix.key.property" and "prefix.key[index]".
                 var delimiterPosition = entry.AsSpan(keyPosition).IndexOfAny('[', '.');
-                if (delimiterPosition == -1)
+                if (delimiterPosition < 0)
                 {
                     // Neither '.' nor '[' found later in the name. Use rest of the string.
                     key = entry.Substring(keyPosition);

--- a/src/Mvc/Mvc.Core/test/ModelBinding/PrefixContainerTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/PrefixContainerTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -243,7 +243,7 @@ public class PrefixContainerTest
     public void GetKeysFromPrefix_ReturnsSubKeysThatStartWithPrefix()
     {
         // Arrange
-        var keys = new[] { "foo[0].name", "foo.age", "foo[1].name", "food[item].spice" };
+        var keys = new[] { "foo[0].name", "foo.age", "foo[1].name", "food[item].spice", "foo.name.first" };
         var container = new PrefixContainer(keys);
 
         // Act
@@ -265,6 +265,11 @@ public class PrefixContainerTest
             {
                 Assert.Equal("age", item.Key);
                 Assert.Equal("foo.age", item.Value);
+            },
+            item =>
+            {
+                Assert.Equal("name", item.Key);
+                Assert.Equal("foo.name", item.Value);
             });
     }
 

--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
@@ -408,10 +408,14 @@ public partial class NewtonsoftJsonInputFormatter : TextInputFormatter, IInputFo
             else
             {
                 // At start of "property", "property." or "property[0]".
-                var endIndex = path.IndexOfAny(new[] { '.', '[' }, index);
+                var endIndex = path.AsSpan(index).IndexOfAny('.', '[');
                 if (endIndex == -1)
                 {
                     endIndex = path.Length;
+                }
+                else
+                {
+                    endIndex += index;
                 }
 
                 var propertyName = path.Substring(index, endIndex - index);

--- a/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/NewtonsoftJsonInputFormatter.cs
@@ -409,7 +409,7 @@ public partial class NewtonsoftJsonInputFormatter : TextInputFormatter, IInputFo
             {
                 // At start of "property", "property." or "property[0]".
                 var endIndex = path.AsSpan(index).IndexOfAny('.', '[');
-                if (endIndex == -1)
+                if (endIndex < 0)
                 {
                     endIndex = path.Length;
                 }


### PR DESCRIPTION
Inspired by https://github.com/dotnet/aspnetcore/pull/39743, found more places to use the faster version of `IndexOfAny`, plus some bonus temporary string allocations removed from `NavigationManager`.