### PR TITLE
Add CodeQL3000 run to aspnetcore-ci-official

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -18,18 +18,38 @@ pr:
     include:
     - '*'
 
+schedules:
+- cron: 0 9 * * 1
+  displayName: "Run CodeQL3000 weekly, Monday at 2:00 PDT"
+  branches:
+    include:
+    - release/2.1
+    - release/6.0
+    - release/7.0
+    - main
+  always: true
+
 parameters:
 # Choose whether to skip tests when running pipeline manually.
 - name: skipTests
   default: false
   displayName: Skip tests?
   type: boolean
+# Parameters below are ignored in public builds.
+#
+# Choose whether to run the CodeQL3000 tasks.
+# Manual builds align w/ official builds unless this parameter is true.
+- name: runCodeQL3000
+  default: false
+  displayName: Run CodeQL3000 tasks
+  type: boolean
 # Choose whether to enable binlogs when running pipeline manually.
+# Binary logs are enabled by default in public builds and aren't designed to be disabled there.
 - name: produceBinlogs
   default: false
   displayName: Produce binlogs?
   type: boolean
-# Choose whether to test source indexing. Ignored in public builds.
+# Choose whether to test source indexing.
 # Will cause inaccessible links on https://source.dot.net/ unless commits are also available in GitHub.
 - name: testSourceIndexing
   default: false
@@ -130,705 +150,753 @@ variables:
   - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
     - name: _SignType
       value: test
+- name: runCodeQL3000
+  value: ${{ or(eq(variables['Build.Reason'], 'Schedule'), and(eq(variables['Build.Reason'], 'Manual'), eq(parameters.runCodeQL3000, 'true'))) }}
 
 stages:
 - stage: build
   displayName: Build
   jobs:
-  # Code check
-  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'Manual')) }}:
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), eq(variables.runCodeQL3000, 'true')) }}:
     - template: jobs/default-build.yml
       parameters:
-        jobName: Code_check
-        jobDisplayName: Code check
+        jobName: build
+        jobDisplayName: Build and run CodeQL3000
         agentOs: Windows
+        codeSign: false
+        # Component governance and SBOM creation are not needed here. Disable what Arcade would inject.
+        disableComponentGovernance: true
+        enableSbom: false
+        variables:
+        # Security analysis is included in normal runs. Disable its auto-injection.
+        - skipNugetSecurityAnalysis: true
+        # Do not let CodeQL3000 Extension gate scan frequency.
+        - Codeql.Cadence: 0
+        # Enable CodeQL3000 unconditionally so it may be run on any branch.
+        - Codeql.Enabled: true
+        # Ignore the small amount of infrastructure Python code in this repo.
+        - Codeql.Language: cpp,csharp,java,javascript
+        - Codeql.ExcludePathPatterns: submodules
+        - Codeql.SourceRoot: src
+        # CodeQL3000 needs this plumbed along as a variable to enable TSA.
+        - Codeql.TSAEnabled: ${{ eq(variables['Build.Reason'], 'Schedule') }}
+        beforeBuild:
+        - task: CodeQL3000Init@0
+          displayName: CodeQL Initialize
         steps:
-        - powershell: ./eng/scripts/CodeCheck.ps1 -ci $(_InternalRuntimeDownloadArgs)
-          displayName: Run eng/scripts/CodeCheck.ps1
-        artifacts:
-        - name: Code_Check_Logs
-          path: artifacts/log/
-          publishOnError: true
-          includeForks: true
-
-  # Build Windows (x64/x86/arm64)
-  - template: jobs/default-build.yml
-    parameters:
-      codeSign: true
-      jobName: Windows_build
-      jobDisplayName: "Build: Windows x64/x86/arm64"
-      agentOs: Windows
-      steps:
-      - ${{ if notIn(variables['Build.Reason'], 'PullRequest') }}:
-        - script: "echo ##vso[build.addbuildtag]daily-build"
-          displayName: 'Set CI daily-build tag'
-
-      # !!! NOTE !!! Some of these steps have disabled code signing.
-      # This is intentional to workaround https://github.com/dotnet/arcade/issues/1957 which always re-submits for code-signing, even
-      # if they have already been signed. This results in slower builds due to re-submitting the same .nupkg many times for signing.
-      # The sign settings have been configured to
-      - script: ./eng/build.cmd
-                -ci
-                -arch x64
-                -pack
-                -all
-                $(_BuildArgs)
-                $(_InternalRuntimeDownloadArgs)
-                $(Windows64LogArgs)
-        displayName: Build x64
-
-      # Build the x86 shared framework
-      # This is going to actually build x86 native assets.
-      - script: ./eng/build.cmd
-                -ci
-                -noBuildRepoTasks
-                -arch x86
-                -pack
-                -all
-                -noBuildJava
-                -noBuildNative
-                /p:OnlyPackPlatformSpecificPackages=true
-                $(_BuildArgs)
-                $(_InternalRuntimeDownloadArgs)
-                $(Windows86LogArgs)
-        displayName: Build x86
-
-      # Build the arm64 shared framework
-      - script: ./eng/build.cmd
-                -ci
-                -noBuildRepoTasks
-                -arch arm64
-                -sign
-                -pack
-                -noBuildJava
-                -noBuildNative
-                /p:DotNetSignType=$(_SignType)
-                /p:OnlyPackPlatformSpecificPackages=true
-                $(_BuildArgs)
-                $(_InternalRuntimeDownloadArgs)
-                $(WindowsArm64LogArgs)
-        displayName: Build ARM64
-
-      # Submit a manual build (in public or internal project) to validate changes to site extensions.
-      - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-        - script: .\src\SiteExtensions\build.cmd
+        - script: ./eng/build.cmd
                   -ci
-                  -noBuildRepoTasks
+                  -arch x64
                   -pack
-                  -noBuildDeps
-                  -noBuildNative
+                  -all
                   $(_BuildArgs)
                   $(_InternalRuntimeDownloadArgs)
-          displayName: Build SiteExtension
-
-      # This runs code-signing on all packages, zips, and jar files as defined in build/CodeSign.targets. If
-      # https://github.com/dotnet/arcade/issues/1957 is resolved, consider running code-signing inline with the other
-      # previous steps. Sign check is disabled because it is run in a separate step below, after installers are built.
-      - script: ./eng/build.cmd
-                -ci
-                -noBuildRepoTasks
-                -noBuildNative
-                -noBuild
-                -sign
-                /p:DotNetSignType=$(_SignType)
-                $(_BuildArgs)
-                $(WindowsSignLogArgs)
-        displayName: Code sign packages
-
-      # Windows installers bundle x86/x64/arm64 assets
-      - script: ./eng/build.cmd
-                -ci
-                -noBuildRepoTasks
-                -sign
-                -buildInstallers
-                -noBuildNative
-                /p:DotNetSignType=$(_SignType)
-                $(_BuildArgs)
-                $(_InternalRuntimeDownloadArgs)
-                $(WindowsInstallersLogArgs)
-        displayName: Build Installers
-
-      # Windows installers bundle and sharedfx msi for arm64
-      - script: ./eng/build.cmd
-                -ci
-                -noBuildRepoTasks
-                -arch arm64
-                -sign
-                -buildInstallers
-                -noBuildNative
-                /p:DotNetSignType=$(_SignType)
-                /p:AssetManifestFileName=aspnetcore-win.xml
-                $(_BuildArgs)
-                $(_PublishArgs)
-                /p:PublishInstallerBaseVersion=true
-                $(_InternalRuntimeDownloadArgs)
-                $(WindowsArm64InstallersLogArgs)
-        displayName: Build ARM64 Installers
-
-      artifacts:
-      - name: Windows_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Windows_Packages
-        path: artifacts/packages/
-      - name: Windows_HostingBundle
-        path: artifacts/bin/WindowsHostingBundle
-      - name: Windows_ANCM_Msi
-        path: artifacts/bin/ANCMv2
-      - name: Windows_ANCMIISExpress_Msi
-        path: artifacts/bin/AncmIISExpressV2
-
-  # Build Windows ARM
-  - template: jobs/default-build.yml
-    parameters:
-      codeSign: true
-      jobName: Windows_arm_build
-      jobDisplayName: "Build: Windows ARM"
-      agentOs: Windows
-      buildArgs:
-        -arch arm
-        -sign
-        -pack
-        -noBuildNodeJS
-        -noBuildJava
-        -binaryLog
-        /p:DotNetSignType=$(_SignType)
-        /p:OnlyPackPlatformSpecificPackages=true
-        /p:AssetManifestFileName=aspnetcore-win-arm.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
-      ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(parameters.testSourceIndexing, 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
+                  /p:UseSharedCompilation=false
+          displayName: Build x64
         afterBuild:
-        - task: UseDotNet@2
-          displayName: Use .NET Core sdk 3.1
-          inputs:
-            packageType: sdk
-            version: 3.1.x
-            installationPath: $(Build.SourcesDirectory)/.dotnet
-            workingDirectory: $(Build.SourcesDirectory)
-        - powershell: . $(Build.SourcesDirectory)/activate.ps1;
-            dotnet tool install BinLogToSln
-            --version $(SourceIndexPackageVersion)
-            --add-source $(SourceIndexPackageSource)
-            --tool-path $(Build.SourcesDirectory)/.tools;
-            $(Build.SourcesDirectory)/.tools/BinLogToSln
-            -i $(Build.SourcesDirectory)/artifacts/log/Release/Build.binlog
-            -r $(Build.SourcesDirectory)
-            -n $(Build.Repository.Name)
-            -o $(Build.ArtifactStagingDirectory)/sourceIndex/
-          displayName: Process binary log into indexable sln
-      installNodeJs: false
-      installJdk: false
-      artifacts:
-      - name: Windows_arm_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Windows_arm_Packages
-        path: artifacts/packages/
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(parameters.testSourceIndexing, 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
-          - name: Windows_arm_SourceIndex
-            path: $(Build.ArtifactStagingDirectory)/sourceIndex/
+        - task: CodeQL3000Finalize@0
+          displayName: CodeQL Finalize
+        artifacts:
+        - name: Build_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
 
-  # Build MacOS arm64
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: MacOs_arm64_build
-      jobDisplayName: "Build: macOS arm64"
-      agentOs: macOs
-      buildArgs:
-        --arch arm64
-        --pack
-        --all
-        --no-build-nodejs
-        --no-build-java
-        -p:OnlyPackPlatformSpecificPackages=true
-        -p:AssetManifestFileName=aspnetcore-MacOS_arm64.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
-      installNodeJs: false
-      artifacts:
-      - name: MacOS_arm64_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: MacOS_arm64_Packages
-        path: artifacts/packages/
+  - ${{ else }}: # regular build
+    # Code check
+    - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'Manual')) }}:
+      - template: jobs/default-build.yml
+        parameters:
+          jobName: Code_check
+          jobDisplayName: Code check
+          agentOs: Windows
+          steps:
+          - powershell: ./eng/scripts/CodeCheck.ps1 -ci $(_InternalRuntimeDownloadArgs)
+            displayName: Run eng/scripts/CodeCheck.ps1
+          artifacts:
+          - name: Code_Check_Logs
+            path: artifacts/log/
+            publishOnError: true
+            includeForks: true
 
-  - ${{ if ne(variables.PostBuildSign, 'true') }}:
-    - template: jobs/codesign-xplat.yml
+    # Build Windows (x64/x86/arm64)
+    - template: jobs/default-build.yml
       parameters:
-        inputName: MacOS_arm64
+        codeSign: true
+        jobName: Windows_build
+        jobDisplayName: "Build: Windows x64/x86/arm64"
+        agentOs: Windows
+        steps:
+        - ${{ if notIn(variables['Build.Reason'], 'PullRequest') }}:
+          - script: "echo ##vso[build.addbuildtag]daily-build"
+            displayName: 'Set CI daily-build tag'
 
-  # Build MacOS x64
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: MacOs_x64_build
-      jobDisplayName: "Build: macOS x64"
-      agentOs: macOs
-      buildArgs:
-        --pack
-        --all
-        --no-build-nodejs
-        --no-build-java
-        -p:OnlyPackPlatformSpecificPackages=true
-        -p:AssetManifestFileName=aspnetcore-MacOS_x64.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
-      installNodeJs: false
-      artifacts:
-      - name: MacOS_x64_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: MacOS_x64_Packages
-        path: artifacts/packages/
+        # !!! NOTE !!! Some of these steps have disabled code signing.
+        # This is intentional to workaround https://github.com/dotnet/arcade/issues/1957 which always re-submits for code-signing, even
+        # if they have already been signed. This results in slower builds due to re-submitting the same .nupkg many times for signing.
+        # The sign settings have been configured to
+        - script: ./eng/build.cmd
+                  -ci
+                  -arch x64
+                  -pack
+                  -all
+                  $(_BuildArgs)
+                  $(_InternalRuntimeDownloadArgs)
+                  $(Windows64LogArgs)
+          displayName: Build x64
 
-  - ${{ if ne(variables.PostBuildSign, 'true') }}:
-    - template: jobs/codesign-xplat.yml
+        # Build the x86 shared framework
+        # This is going to actually build x86 native assets.
+        - script: ./eng/build.cmd
+                  -ci
+                  -noBuildRepoTasks
+                  -arch x86
+                  -pack
+                  -all
+                  -noBuildJava
+                  -noBuildNative
+                  /p:OnlyPackPlatformSpecificPackages=true
+                  $(_BuildArgs)
+                  $(_InternalRuntimeDownloadArgs)
+                  $(Windows86LogArgs)
+          displayName: Build x86
+
+        # Build the arm64 shared framework
+        - script: ./eng/build.cmd
+                  -ci
+                  -noBuildRepoTasks
+                  -arch arm64
+                  -sign
+                  -pack
+                  -noBuildJava
+                  -noBuildNative
+                  /p:DotNetSignType=$(_SignType)
+                  /p:OnlyPackPlatformSpecificPackages=true
+                  $(_BuildArgs)
+                  $(_InternalRuntimeDownloadArgs)
+                  $(WindowsArm64LogArgs)
+          displayName: Build ARM64
+
+        # Submit a manual build (in public or internal project) to validate changes to site extensions.
+        - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+          - script: .\src\SiteExtensions\build.cmd
+                    -ci
+                    -noBuildRepoTasks
+                    -pack
+                    -noBuildDeps
+                    -noBuildNative
+                    $(_BuildArgs)
+                    $(_InternalRuntimeDownloadArgs)
+            displayName: Build SiteExtension
+
+        # This runs code-signing on all packages, zips, and jar files as defined in build/CodeSign.targets. If
+        # https://github.com/dotnet/arcade/issues/1957 is resolved, consider running code-signing inline with the other
+        # previous steps. Sign check is disabled because it is run in a separate step below, after installers are built.
+        - script: ./eng/build.cmd
+                  -ci
+                  -noBuildRepoTasks
+                  -noBuildNative
+                  -noBuild
+                  -sign
+                  /p:DotNetSignType=$(_SignType)
+                  $(_BuildArgs)
+                  $(WindowsSignLogArgs)
+          displayName: Code sign packages
+
+        # Windows installers bundle x86/x64/arm64 assets
+        - script: ./eng/build.cmd
+                  -ci
+                  -noBuildRepoTasks
+                  -sign
+                  -buildInstallers
+                  -noBuildNative
+                  /p:DotNetSignType=$(_SignType)
+                  $(_BuildArgs)
+                  $(_InternalRuntimeDownloadArgs)
+                  $(WindowsInstallersLogArgs)
+          displayName: Build Installers
+
+        # Windows installers bundle and sharedfx msi for arm64
+        - script: ./eng/build.cmd
+                  -ci
+                  -noBuildRepoTasks
+                  -arch arm64
+                  -sign
+                  -buildInstallers
+                  -noBuildNative
+                  /p:DotNetSignType=$(_SignType)
+                  /p:AssetManifestFileName=aspnetcore-win.xml
+                  $(_BuildArgs)
+                  $(_PublishArgs)
+                  /p:PublishInstallerBaseVersion=true
+                  $(_InternalRuntimeDownloadArgs)
+                  $(WindowsArm64InstallersLogArgs)
+          displayName: Build ARM64 Installers
+
+        artifacts:
+        - name: Windows_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Windows_Packages
+          path: artifacts/packages/
+        - name: Windows_HostingBundle
+          path: artifacts/bin/WindowsHostingBundle
+        - name: Windows_ANCM_Msi
+          path: artifacts/bin/ANCMv2
+        - name: Windows_ANCMIISExpress_Msi
+          path: artifacts/bin/AncmIISExpressV2
+
+    # Build Windows ARM
+    - template: jobs/default-build.yml
       parameters:
-        inputName: MacOS_x64
-
-  # Build Linux x64
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Linux_x64_build
-      jobDisplayName: "Build: Linux x64"
-      agentOs: Linux
-      useHostedUbuntu: false
-      steps:
-      - script: ./eng/build.sh
-            --ci
-            --arch x64
-            --pack
-            --all
-            --no-build-nodejs
-            --no-build-java
-            -p:OnlyPackPlatformSpecificPackages=true
-            $(_BuildArgs)
-            $(_InternalRuntimeDownloadArgs)
-        displayName: Run build.sh
-      - script: git clean -xfd src/**/obj/;
-          ./dockerbuild.sh bionic --ci --nobl --arch x64 --build-installers --no-build-deps --no-build-nodejs
-          -p:OnlyPackPlatformSpecificPackages=true -p:BuildRuntimeArchive=false -p:LinuxInstallerType=deb
-          $(_BuildArgs)
-          $(_InternalRuntimeDownloadArgs)
-        displayName: Build Debian installers
-      - script: git clean -xfd src/**/obj/;
-          ./dockerbuild.sh rhel --ci --nobl --arch x64 --build-installers --no-build-deps --no-build-nodejs
-          -p:OnlyPackPlatformSpecificPackages=true -p:BuildRuntimeArchive=false -p:LinuxInstallerType=rpm
-          -p:AssetManifestFileName=aspnetcore-Linux_x64.xml
+        codeSign: true
+        jobName: Windows_arm_build
+        jobDisplayName: "Build: Windows ARM"
+        agentOs: Windows
+        buildArgs:
+          -arch arm
+          -sign
+          -pack
+          -noBuildNodeJS
+          -noBuildJava
+          -binaryLog
+          /p:DotNetSignType=$(_SignType)
+          /p:OnlyPackPlatformSpecificPackages=true
+          /p:AssetManifestFileName=aspnetcore-win-arm.xml
           $(_BuildArgs)
           $(_PublishArgs)
           $(_InternalRuntimeDownloadArgs)
-        displayName: Build RPM installers
-      installNodeJs: false
-      artifacts:
-      - name: Linux_x64_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Linux_x64_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables.PostBuildSign, 'true') }}:
-    - template: jobs/codesign-xplat.yml
-      parameters:
-        inputName: Linux_x64
-
-  # Build Linux ARM
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Linux_arm_build
-      jobDisplayName: "Build: Linux ARM"
-      agentOs: Linux
-      buildArgs:
-        --arch arm
-        --pack
-        --all
-        --no-build-nodejs
-        --no-build-java
-        -p:OnlyPackPlatformSpecificPackages=true
-        -p:AssetManifestFileName=aspnetcore-Linux_arm.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
-      installNodeJs: false
-      artifacts:
-      - name: Linux_arm_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Linux_arm_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables.PostBuildSign, 'true') }}:
-    - template: jobs/codesign-xplat.yml
-      parameters:
-        inputName: Linux_arm
-
-  # Build Linux ARM64
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Linux_arm64_build
-      jobDisplayName: "Build: Linux ARM64"
-      agentOs: Linux
-      steps:
-      - script: ./eng/build.sh
-            --ci
-            --arch arm64
-            --pack
-            --all
-            --no-build-nodejs
-            --no-build-java
-            -p:OnlyPackPlatformSpecificPackages=true
-            $(_BuildArgs)
-            $(_InternalRuntimeDownloadArgs)
-        displayName: Run build.sh
-      - script: git clean -xfd src/**/obj/;
-          ./dockerbuild.sh rhel --ci --nobl --arch arm64 --build-installers --no-build-deps --no-build-nodejs
-          -p:OnlyPackPlatformSpecificPackages=true -p:BuildRuntimeArchive=false -p:LinuxInstallerType=rpm
-          -p:AssetManifestFileName=aspnetcore-Linux_arm64.xml
-          $(_BuildArgs)
-          $(_PublishArgs)
-          $(_InternalRuntimeDownloadArgs)
-        displayName: Build RPM installers
-      installNodeJs: false
-      artifacts:
-      - name: Linux_arm64_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Linux_arm64_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables.PostBuildSign, 'true') }}:
-    - template: jobs/codesign-xplat.yml
-      parameters:
-        inputName: Linux_arm64
-
-  # Build Linux Musl x64
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Linux_musl_x64_build
-      jobDisplayName: "Build: Linux Musl x64"
-      agentOs: Linux
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode
-      buildArgs:
-        --arch x64
-        --os-name linux-musl
-        --pack
-        --all
-        --no-build-nodejs
-        --no-build-java
-        -p:OnlyPackPlatformSpecificPackages=true
-        -p:AssetManifestFileName=aspnetcore-Linux_musl_x64.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
-      installNodeJs: false
-      disableComponentGovernance: true
-      artifacts:
-      - name: Linux_musl_x64_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Linux_musl_x64_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables.PostBuildSign, 'true') }}:
-    - template: jobs/codesign-xplat.yml
-      parameters:
-        inputName: Linux_musl_x64
-
-  # Build Linux Musl ARM
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Linux_musl_arm_build
-      jobDisplayName: "Build: Linux Musl ARM"
-      agentOs: Linux
-      useHostedUbuntu: false
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm-alpine
-      buildArgs:
-        --arch arm
-        --os-name linux-musl
-        --pack
-        --all
-        --no-build-nodejs
-        --no-build-java
-        -p:OnlyPackPlatformSpecificPackages=true
-        -p:AssetManifestFileName=aspnetcore-Linux_musl_arm.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
-      installNodeJs: false
-      artifacts:
-      - name: Linux_musl_arm_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Linux_musl_arm_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables.PostBuildSign, 'true') }}:
-    - template: jobs/codesign-xplat.yml
-      parameters:
-        inputName: Linux_musl_arm
-
-  # Build Linux Musl ARM64
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Linux_musl_arm64_build
-      jobDisplayName: "Build: Linux Musl ARM64"
-      agentOs: Linux
-      useHostedUbuntu: false
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-alpine
-      buildArgs:
-        --arch arm64
-        --os-name linux-musl
-        --pack
-        --all
-        --no-build-nodejs
-        --no-build-java
-        -p:OnlyPackPlatformSpecificPackages=true
-        -p:AssetManifestFileName=aspnetcore-Linux_musl_arm64.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
-      installNodeJs: false
-      artifacts:
-      - name: Linux_musl_arm64_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Linux_musl_arm64_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables.PostBuildSign, 'true') }}:
-    - template: jobs/codesign-xplat.yml
-      parameters:
-        inputName: Linux_musl_arm64
-
-  - ${{ if and(ne(parameters.skipTests, 'true'), or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'Manual'))) }}:
-    # Test jobs
-    - template: jobs/default-build.yml
-      parameters:
-        jobName: Windows_Test
-        jobDisplayName: "Test: Windows Server x64"
-        agentOs: Windows
-        isAzDOTestingJob: true
-        # Just uploading artifacts/logs/ files can take 15 minutes. Doubling the cancel timeout for this job.
-        cancelTimeoutInMinutes: 30
-        buildArgs: -all -pack -test -binaryLog /p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true
-                   /p:SkipIISExpressTests=true /p:SkipIISNewShimTests=true /p:RunTemplateTests=false
-                   $(_InternalRuntimeDownloadArgs)
-        beforeBuild:
-        - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
-          displayName: Setup IISExpress test certificates and schema
-        artifacts:
-        - name: Windows_Test_Logs
-          path: artifacts/log/
-          publishOnError: true
-          includeForks: true
-        - name: Windows_Test_Results
-          path: artifacts/TestResults/
-          publishOnError: true
-          includeForks: true
-
-    - template: jobs/default-build.yml
-      parameters:
-        jobName: MacOS_Test
-        jobDisplayName: "Test: macOS"
-        agentOs: macOS
-        timeoutInMinutes: 240
-        isAzDOTestingJob: true
-        buildArgs: --all --test --binaryLog "/p:RunTemplateTests=false /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
-        beforeBuild:
-        - bash: "./eng/scripts/install-nginx-mac.sh"
-          displayName: Installing Nginx
-        artifacts:
-        - name: MacOS_Test_Logs
-          path: artifacts/log/
-          publishOnError: true
-          includeForks: true
-        - name: MacOS_Test_Results
-          path: artifacts/TestResults/
-          publishOnError: true
-          includeForks: true
-
-    - template: jobs/default-build.yml
-      parameters:
-        jobName: Linux_Test
-        jobDisplayName: "Test: Ubuntu x64"
-        agentOs: Linux
-        isAzDOTestingJob: true
-        useHostedUbuntu: false
-        buildArgs: --all --test --binaryLog "/p:RunTemplateTests=false /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
-        beforeBuild:
-        - bash: "./eng/scripts/install-nginx-linux.sh"
-          displayName: Installing Nginx
-        - bash: "echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p"
-          displayName: Increase inotify limit
-        artifacts:
-        - name: Linux_Test_Logs
-          path: artifacts/log/
-          publishOnError: true
-          includeForks: true
-        - name: Linux_Test_Results
-          path: artifacts/TestResults/
-          publishOnError: true
-          includeForks: true
-
-    # Helix x64
-    - template: jobs/default-build.yml
-      parameters:
-        jobName: Helix_x64
-        jobDisplayName: 'Tests: Helix x64'
-        agentOs: Windows
-        timeoutInMinutes: 240
-        steps:
-        # Build the shared framework
-        - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64
-                  /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
-          displayName: Build shared fx
-        # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
-        - script: ./eng/build.cmd -ci -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -test
-                  -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
-                  /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
-          displayName: Run build.cmd helix target
-          env:
-            HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
-            SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
-
-        artifacts:
-        - name: Helix_logs
-          path: artifacts/log/
-          publishOnError: true
-          includeForks: true
-
-  # Source build
-  - template: /eng/common/templates/job/source-build.yml
-    parameters:
-      platform:
-        name: 'Managed'
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
-        buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks'
-        skipPublishValidation: true
-        jobProperties:
-          timeoutInMinutes: 120
-          variables:
-            # !temporary! Remove as soon as .NET SDK includes a new-enough `msbuild` to make this hack unnecessary
-            DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER: true
-            # Log environment variables in binary logs to ease debugging
-            MSBUILDLOGALLENVIRONMENTVARIABLES: true
-
-  # Publish to the BAR and perform source indexing. Wait until everything else is done.
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/common/templates/job/publish-build-assets.yml
-      parameters:
-        dependsOn:
-          - Windows_build
-          - Windows_arm_build
-          - ${{ if ne(variables.PostBuildSign, 'true') }}:
-            - CodeSign_Xplat_MacOS_arm64
-            - CodeSign_Xplat_MacOS_x64
-            - CodeSign_Xplat_Linux_x64
-            - CodeSign_Xplat_Linux_arm
-            - CodeSign_Xplat_Linux_arm64
-            - CodeSign_Xplat_Linux_musl_x64
-            - CodeSign_Xplat_Linux_musl_arm
-            - CodeSign_Xplat_Linux_musl_arm64
-          - ${{ if eq(variables.PostBuildSign, 'true') }}:
-            - MacOs_arm64_build
-            - MacOs_x64_build
-            - Linux_x64_build
-            - Linux_arm_build
-            - Linux_arm64_build
-            - Linux_musl_x64_build
-            - Linux_musl_arm_build
-            - Linux_musl_arm64_build
-          # In addition to the dependencies above that provide assets, ensure the build was successful overall.
-          - ${{ if in(variables['Build.Reason'], 'Manual') }}:
-            - Code_check
-            - ${{ if ne(parameters.skipTests, 'true') }}:
-              - Windows_Test
-              - MacOS_Test
-              - Linux_Test
-              - Helix_x64
-          - Source_Build_Managed
-        pool:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals 1es-windows-2019
-        publishUsingPipelines: ${{ variables._PublishUsingPipelines }}
-        enablePublishBuildArtifacts: true # publish artifacts/log files
-        publishAssetsImmediately: true # Don't use a separate stage for darc publishing.
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(parameters.testSourceIndexing, 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
-      - job: SourceIndexUpload
-        displayName: Upload indexable solution
-        dependsOn:
-          - Windows_arm_build
-          # In addition to the dependency above that provides assets, ensure the build was successful overall.
-          - Windows_build
-          - ${{ if ne(variables.PostBuildSign, 'true') }}:
-            - CodeSign_Xplat_MacOS_arm64
-            - CodeSign_Xplat_MacOS_x64
-            - CodeSign_Xplat_Linux_x64
-            - CodeSign_Xplat_Linux_arm
-            - CodeSign_Xplat_Linux_arm64
-            - CodeSign_Xplat_Linux_musl_x64
-            - CodeSign_Xplat_Linux_musl_arm
-            - CodeSign_Xplat_Linux_musl_arm64
-          - ${{ if eq(variables.PostBuildSign, 'true') }}:
-            - MacOs_arm64_build
-            - MacOs_x64_build
-            - Linux_x64_build
-            - Linux_arm_build
-            - Linux_arm64_build
-            - Linux_musl_x64_build
-            - Linux_musl_arm_build
-            - Linux_musl_arm64_build
-          - ${{ if in(variables['Build.Reason'], 'Manual') }}:
-            - Code_check
-            - ${{ if ne(parameters.skipTests, 'true') }}:
-              - Windows_Test
-              - MacOS_Test
-              - Linux_Test
-              - Helix_x64
-          - Source_Build_Managed
-        pool:
-          name: NetCore1ESPool-Internal
-          # Visual Studio Enterprise - no BuildTools agents exist internally and job must run on Windows
-          demands: ImageOverride -equals 1es-windows-2019
-        steps:
-          - task: DownloadBuildArtifacts@0
-            inputs:
-              artifactName: Windows_arm_SourceIndex
-              cleanDestinationFolder: true
-          # Ignore repository's global.json and any existing .NET SDK.
+        ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(parameters.testSourceIndexing, 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
+          afterBuild:
           - task: UseDotNet@2
             displayName: Use .NET Core sdk 3.1
             inputs:
               packageType: sdk
               version: 3.1.x
-              installationPath: $(Agent.TempDirectory)/.dotnet
-              workingDirectory: $(Agent.TempDirectory)
-          - script: $(Agent.TempDirectory)/.dotnet/dotnet tool install UploadIndexStage1
+              installationPath: $(Build.SourcesDirectory)/.dotnet
+              workingDirectory: $(Build.SourcesDirectory)
+          - powershell: . $(Build.SourcesDirectory)/activate.ps1;
+              dotnet tool install BinLogToSln
               --version $(SourceIndexPackageVersion)
               --add-source $(SourceIndexPackageSource)
-              --tool-path $(Agent.TempDirectory)/.tools &&
-              $(Agent.TempDirectory)/.tools/UploadIndexStage1
-              -i $(System.ArtifactsDirectory)/Windows_arm_SourceIndex/
+              --tool-path $(Build.SourcesDirectory)/.tools;
+              $(Build.SourcesDirectory)/.tools/BinLogToSln
+              -i $(Build.SourcesDirectory)/artifacts/log/Release/Build.binlog
+              -r $(Build.SourcesDirectory)
               -n $(Build.Repository.Name)
-            displayName: Upload indexable solution
-            workingDirectory: $(Agent.TempDirectory)
-            env:
-              BLOB_CONTAINER_URL: $(source-dot-net-stage1-blob-container-url)
+              -o $(Build.ArtifactStagingDirectory)/sourceIndex/
+            displayName: Process binary log into indexable sln
+        installNodeJs: false
+        installJdk: false
+        artifacts:
+        - name: Windows_arm_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Windows_arm_Packages
+          path: artifacts/packages/
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(parameters.testSourceIndexing, 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
+            - name: Windows_arm_SourceIndex
+              path: $(Build.ArtifactStagingDirectory)/sourceIndex/
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    # Build MacOS arm64
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: MacOs_arm64_build
+        jobDisplayName: "Build: macOS arm64"
+        agentOs: macOs
+        buildArgs:
+          --arch arm64
+          --pack
+          --all
+          --no-build-nodejs
+          --no-build-java
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-MacOS_arm64.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        artifacts:
+        - name: MacOS_arm64_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: MacOS_arm64_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables.PostBuildSign, 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: MacOS_arm64
+
+    # Build MacOS x64
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: MacOs_x64_build
+        jobDisplayName: "Build: macOS x64"
+        agentOs: macOs
+        buildArgs:
+          --pack
+          --all
+          --no-build-nodejs
+          --no-build-java
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-MacOS_x64.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        artifacts:
+        - name: MacOS_x64_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: MacOS_x64_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables.PostBuildSign, 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: MacOS_x64
+
+    # Build Linux x64
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: Linux_x64_build
+        jobDisplayName: "Build: Linux x64"
+        agentOs: Linux
+        useHostedUbuntu: false
+        steps:
+        - script: ./eng/build.sh
+              --ci
+              --arch x64
+              --pack
+              --all
+              --no-build-nodejs
+              --no-build-java
+              -p:OnlyPackPlatformSpecificPackages=true
+              $(_BuildArgs)
+              $(_InternalRuntimeDownloadArgs)
+          displayName: Run build.sh
+        - script: git clean -xfd src/**/obj/;
+            ./dockerbuild.sh bionic --ci --nobl --arch x64 --build-installers --no-build-deps --no-build-nodejs
+            -p:OnlyPackPlatformSpecificPackages=true -p:BuildRuntimeArchive=false -p:LinuxInstallerType=deb
+            $(_BuildArgs)
+            $(_InternalRuntimeDownloadArgs)
+          displayName: Build Debian installers
+        - script: git clean -xfd src/**/obj/;
+            ./dockerbuild.sh rhel --ci --nobl --arch x64 --build-installers --no-build-deps --no-build-nodejs
+            -p:OnlyPackPlatformSpecificPackages=true -p:BuildRuntimeArchive=false -p:LinuxInstallerType=rpm
+            -p:AssetManifestFileName=aspnetcore-Linux_x64.xml
+            $(_BuildArgs)
+            $(_PublishArgs)
+            $(_InternalRuntimeDownloadArgs)
+          displayName: Build RPM installers
+        installNodeJs: false
+        artifacts:
+        - name: Linux_x64_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_x64_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables.PostBuildSign, 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_x64
+
+    # Build Linux ARM
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: Linux_arm_build
+        jobDisplayName: "Build: Linux ARM"
+        agentOs: Linux
+        buildArgs:
+          --arch arm
+          --pack
+          --all
+          --no-build-nodejs
+          --no-build-java
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-Linux_arm.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        artifacts:
+        - name: Linux_arm_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_arm_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables.PostBuildSign, 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_arm
+
+    # Build Linux ARM64
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: Linux_arm64_build
+        jobDisplayName: "Build: Linux ARM64"
+        agentOs: Linux
+        steps:
+        - script: ./eng/build.sh
+              --ci
+              --arch arm64
+              --pack
+              --all
+              --no-build-nodejs
+              --no-build-java
+              -p:OnlyPackPlatformSpecificPackages=true
+              $(_BuildArgs)
+              $(_InternalRuntimeDownloadArgs)
+          displayName: Run build.sh
+        - script: git clean -xfd src/**/obj/;
+            ./dockerbuild.sh rhel --ci --nobl --arch arm64 --build-installers --no-build-deps --no-build-nodejs
+            -p:OnlyPackPlatformSpecificPackages=true -p:BuildRuntimeArchive=false -p:LinuxInstallerType=rpm
+            -p:AssetManifestFileName=aspnetcore-Linux_arm64.xml
+            $(_BuildArgs)
+            $(_PublishArgs)
+            $(_InternalRuntimeDownloadArgs)
+          displayName: Build RPM installers
+        installNodeJs: false
+        artifacts:
+        - name: Linux_arm64_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_arm64_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables.PostBuildSign, 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_arm64
+
+    # Build Linux Musl x64
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: Linux_musl_x64_build
+        jobDisplayName: "Build: Linux Musl x64"
+        agentOs: Linux
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode
+        buildArgs:
+          --arch x64
+          --os-name linux-musl
+          --pack
+          --all
+          --no-build-nodejs
+          --no-build-java
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-Linux_musl_x64.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        disableComponentGovernance: true
+        artifacts:
+        - name: Linux_musl_x64_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_musl_x64_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables.PostBuildSign, 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_musl_x64
+
+    # Build Linux Musl ARM
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: Linux_musl_arm_build
+        jobDisplayName: "Build: Linux Musl ARM"
+        agentOs: Linux
+        useHostedUbuntu: false
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm-alpine
+        buildArgs:
+          --arch arm
+          --os-name linux-musl
+          --pack
+          --all
+          --no-build-nodejs
+          --no-build-java
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-Linux_musl_arm.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        artifacts:
+        - name: Linux_musl_arm_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_musl_arm_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables.PostBuildSign, 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_musl_arm
+
+    # Build Linux Musl ARM64
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: Linux_musl_arm64_build
+        jobDisplayName: "Build: Linux Musl ARM64"
+        agentOs: Linux
+        useHostedUbuntu: false
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-alpine
+        buildArgs:
+          --arch arm64
+          --os-name linux-musl
+          --pack
+          --all
+          --no-build-nodejs
+          --no-build-java
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-Linux_musl_arm64.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        artifacts:
+        - name: Linux_musl_arm64_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_musl_arm64_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables.PostBuildSign, 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_musl_arm64
+
+    - ${{ if and(ne(parameters.skipTests, 'true'), or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest', 'Manual'))) }}:
+      # Test jobs
+      - template: jobs/default-build.yml
+        parameters:
+          jobName: Windows_Test
+          jobDisplayName: "Test: Windows Server x64"
+          agentOs: Windows
+          isAzDOTestingJob: true
+          # Just uploading artifacts/logs/ files can take 15 minutes. Doubling the cancel timeout for this job.
+          cancelTimeoutInMinutes: 30
+          buildArgs: -all -pack -test -binaryLog /p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true
+                     /p:SkipIISExpressTests=true /p:SkipIISNewShimTests=true /p:RunTemplateTests=false
+                     $(_InternalRuntimeDownloadArgs)
+          beforeBuild:
+          - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
+            displayName: Setup IISExpress test certificates and schema
+          artifacts:
+          - name: Windows_Test_Logs
+            path: artifacts/log/
+            publishOnError: true
+            includeForks: true
+          - name: Windows_Test_Results
+            path: artifacts/TestResults/
+            publishOnError: true
+            includeForks: true
+
+      - template: jobs/default-build.yml
+        parameters:
+          jobName: MacOS_Test
+          jobDisplayName: "Test: macOS"
+          agentOs: macOS
+          timeoutInMinutes: 240
+          isAzDOTestingJob: true
+          buildArgs: --all --test --binaryLog "/p:RunTemplateTests=false /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
+          beforeBuild:
+          - bash: "./eng/scripts/install-nginx-mac.sh"
+            displayName: Installing Nginx
+          artifacts:
+          - name: MacOS_Test_Logs
+            path: artifacts/log/
+            publishOnError: true
+            includeForks: true
+          - name: MacOS_Test_Results
+            path: artifacts/TestResults/
+            publishOnError: true
+            includeForks: true
+
+      - template: jobs/default-build.yml
+        parameters:
+          jobName: Linux_Test
+          jobDisplayName: "Test: Ubuntu x64"
+          agentOs: Linux
+          isAzDOTestingJob: true
+          useHostedUbuntu: false
+          buildArgs: --all --test --binaryLog "/p:RunTemplateTests=false /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
+          beforeBuild:
+          - bash: "./eng/scripts/install-nginx-linux.sh"
+            displayName: Installing Nginx
+          - bash: "echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p"
+            displayName: Increase inotify limit
+          artifacts:
+          - name: Linux_Test_Logs
+            path: artifacts/log/
+            publishOnError: true
+            includeForks: true
+          - name: Linux_Test_Results
+            path: artifacts/TestResults/
+            publishOnError: true
+            includeForks: true
+
+      # Helix x64
+      - template: jobs/default-build.yml
+        parameters:
+          jobName: Helix_x64
+          jobDisplayName: 'Tests: Helix x64'
+          agentOs: Windows
+          timeoutInMinutes: 240
+          steps:
+          # Build the shared framework
+          - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64
+                    /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
+            displayName: Build shared fx
+          # -noBuildRepoTasks -noBuildNative -noBuild to avoid repeating work done in the previous step.
+          - script: ./eng/build.cmd -ci -nobl -all -noBuildRepoTasks -noBuildNative -noBuild -test
+                    -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
+                    /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
+            displayName: Run build.cmd helix target
+            env:
+              HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
+
+          artifacts:
+          - name: Helix_logs
+            path: artifacts/log/
+            publishOnError: true
+            includeForks: true
+
+    # Source build
+    - template: /eng/common/templates/job/source-build.yml
+      parameters:
+        platform:
+          name: 'Managed'
+          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
+          buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks'
+          skipPublishValidation: true
+          jobProperties:
+            timeoutInMinutes: 120
+            variables:
+              # !temporary! Remove as soon as .NET SDK includes a new-enough `msbuild` to make this hack unnecessary
+              DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER: true
+              # Log environment variables in binary logs to ease debugging
+              MSBUILDLOGALLENVIRONMENTVARIABLES: true
+
+    # Publish to the BAR and perform source indexing. Wait until everything else is done.
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: /eng/common/templates/job/publish-build-assets.yml
+        parameters:
+          dependsOn:
+            - Windows_build
+            - Windows_arm_build
+            - ${{ if ne(variables.PostBuildSign, 'true') }}:
+              - CodeSign_Xplat_MacOS_arm64
+              - CodeSign_Xplat_MacOS_x64
+              - CodeSign_Xplat_Linux_x64
+              - CodeSign_Xplat_Linux_arm
+              - CodeSign_Xplat_Linux_arm64
+              - CodeSign_Xplat_Linux_musl_x64
+              - CodeSign_Xplat_Linux_musl_arm
+              - CodeSign_Xplat_Linux_musl_arm64
+            - ${{ if eq(variables.PostBuildSign, 'true') }}:
+              - MacOs_arm64_build
+              - MacOs_x64_build
+              - Linux_x64_build
+              - Linux_arm_build
+              - Linux_arm64_build
+              - Linux_musl_x64_build
+              - Linux_musl_arm_build
+              - Linux_musl_arm64_build
+            # In addition to the dependencies above that provide assets, ensure the build was successful overall.
+            - ${{ if in(variables['Build.Reason'], 'Manual') }}:
+              - Code_check
+              - ${{ if ne(parameters.skipTests, 'true') }}:
+                - Windows_Test
+                - MacOS_Test
+                - Linux_Test
+                - Helix_x64
+            - Source_Build_Managed
+          pool:
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals 1es-windows-2019
+          publishUsingPipelines: ${{ variables._PublishUsingPipelines }}
+          enablePublishBuildArtifacts: true # publish artifacts/log files
+          publishAssetsImmediately: true # Don't use a separate stage for darc publishing.
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(parameters.testSourceIndexing, 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
+        - job: SourceIndexUpload
+          displayName: Upload indexable solution
+          dependsOn:
+            - Windows_arm_build
+            # In addition to the dependency above that provides assets, ensure the build was successful overall.
+            - Windows_build
+            - ${{ if ne(variables.PostBuildSign, 'true') }}:
+              - CodeSign_Xplat_MacOS_arm64
+              - CodeSign_Xplat_MacOS_x64
+              - CodeSign_Xplat_Linux_x64
+              - CodeSign_Xplat_Linux_arm
+              - CodeSign_Xplat_Linux_arm64
+              - CodeSign_Xplat_Linux_musl_x64
+              - CodeSign_Xplat_Linux_musl_arm
+              - CodeSign_Xplat_Linux_musl_arm64
+            - ${{ if eq(variables.PostBuildSign, 'true') }}:
+              - MacOs_arm64_build
+              - MacOs_x64_build
+              - Linux_x64_build
+              - Linux_arm_build
+              - Linux_arm64_build
+              - Linux_musl_x64_build
+              - Linux_musl_arm_build
+              - Linux_musl_arm64_build
+            - ${{ if in(variables['Build.Reason'], 'Manual') }}:
+              - Code_check
+              - ${{ if ne(parameters.skipTests, 'true') }}:
+                - Windows_Test
+                - MacOS_Test
+                - Linux_Test
+                - Helix_x64
+            - Source_Build_Managed
+          pool:
+            name: NetCore1ESPool-Internal
+            # Visual Studio Enterprise - no BuildTools agents exist internally and job must run on Windows
+            demands: ImageOverride -equals 1es-windows-2019
+          steps:
+            - task: DownloadBuildArtifacts@0
+              inputs:
+                artifactName: Windows_arm_SourceIndex
+                cleanDestinationFolder: true
+            # Ignore repository's global.json and any existing .NET SDK.
+            - task: UseDotNet@2
+              displayName: Use .NET Core sdk 3.1
+              inputs:
+                packageType: sdk
+                version: 3.1.x
+                installationPath: $(Agent.TempDirectory)/.dotnet
+                workingDirectory: $(Agent.TempDirectory)
+            - script: $(Agent.TempDirectory)/.dotnet/dotnet tool install UploadIndexStage1
+                --version $(SourceIndexPackageVersion)
+                --add-source $(SourceIndexPackageSource)
+                --tool-path $(Agent.TempDirectory)/.tools &&
+                $(Agent.TempDirectory)/.tools/UploadIndexStage1
+                -i $(System.ArtifactsDirectory)/Windows_arm_SourceIndex/
+                -n $(Build.Repository.Name)
+              displayName: Upload indexable solution
+              workingDirectory: $(Agent.TempDirectory)
+              env:
+                BLOB_CONTAINER_URL: $(source-dot-net-stage1-blob-container-url)
+
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables.runCodeQL3000, 'true')) }}:
   - template: /eng/common/templates/post-build/post-build.yml
     parameters:
       publishingInfraVersion: 3

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -20,7 +20,7 @@ pr:
 
 schedules:
 - cron: 0 9 * * 1
-  displayName: "Run CodeQL3000 weekly, Monday at 2:00 PDT"
+  displayName: "Run CodeQL3000 weekly, Monday at 2:00 AM PDT"
   branches:
     include:
     - release/2.1
@@ -181,6 +181,8 @@ stages:
         # CodeQL3000 needs this plumbed along as a variable to enable TSA.
         - Codeql.TSAEnabled: ${{ eq(variables['Build.Reason'], 'Schedule') }}
         beforeBuild:
+        - script: "echo ##vso[build.addbuildtag]CodeQL3000"
+          displayName: 'Set CI CodeQL3000 tag'
         - task: CodeQL3000Init@0
           displayName: CodeQL Initialize
         steps:

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -189,7 +189,6 @@ stages:
         - script: ./eng/build.cmd
                   -ci
                   -arch x64
-                  -pack
                   -all
                   $(_BuildArgs)
                   $(_InternalRuntimeDownloadArgs)

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -38,6 +38,10 @@
 #       installations and enables test publication (unless enablePublishTestResults is overridden).
 #   enablePublishTestResults: boolean
 #       Determines if test results should be published. Defaults to the isAzDOTestingJob setting.
+#   enableSbom: boolean
+#       Determines if an SBOM should be created. Defaults to true. Ignored in public builds.
+#   variables: [array]
+#       Job-specific variables. Defined using either name/value pairs or a variable list (using name or group syntax).
 #
 # See https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema for details
 #
@@ -57,6 +61,8 @@ parameters:
   buildDirectory: $(System.DefaultWorkingDirectory)/eng/
   isAzDOTestingJob: false
   enablePublishTestResults: ''
+  enableSbom: true
+  variables: []
 
   configuration: 'Release'
   container: ''
@@ -94,6 +100,7 @@ jobs:
       testResultsFormat: xUnit # Have no vsTest results in any job.
     mergeTestResults: true
     testRunTitle: ${{ parameters.testRunTitle }}
+    enableSbom: ${{ parameters.enableSbom }}
     enableTelemetry: true
     helixRepo: dotnet/aspnetcore
     helixType: build.product/
@@ -154,7 +161,28 @@ jobs:
     - LANGUAGE: 'en_US.UTF-8'
     # Log environment variables in binary logs to ease debugging
     - MSBUILDLOGALLENVIRONMENTVARIABLES: true
-    - skipComponentGovernanceDetection: ${{ ne(variables['System.TeamProject'], 'internal') }}
+    # Rely on task Arcade injects, not auto-injected build step.
+    - skipComponentGovernanceDetection: true
+    - ${{ each variable in parameters.variables }}:
+      # handle a variable list using "name" and "value" properties
+      # example:
+      # - name: [key]
+      #   value: [value]
+      - ${{ if ne(variable.name, '') }}:
+        - name: ${{ variable.name }}
+          value: ${{ variable.value }}
+
+      # handle variable groups
+      - ${{ if ne(variable.group, '') }}:
+        - group: ${{ variable.group }}
+
+      # handle name/value pairs (converting them into variable list entries)
+      # example:
+      # - [name]: [value]
+      - ${{ if and(eq(variable.name, ''), eq(variable.group, '')) }}:
+        - ${{ each pair in variable }}:
+          - name: ${{ pair.key }}
+            value: ${{ pair.value }}
     steps:
     - ${{ if ne(parameters.agentOs, 'Windows') }}:
       - script: df -h

--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,12 @@
+{
+  "areaPath": "DevDiv\\ASP.NET Core",
+  "codebaseName": "AspNetCore",
+  "instanceUrl": "https://devdiv.visualstudio.com/",
+  "iterationPath": "DevDiv",
+  "notificationAliases": [
+    "aspnetcore-build@microsoft.com"
+  ],
+  "projectName": "DEVDIV",
+  "repositoryName": "AspNetCore",
+  "template": "TFSDEVDIV"
+}


### PR DESCRIPTION
- add new schedule for a weekly run
- add top-level parameter enabling CodeQL3000 in manual builds
- add `enableSBOM` and `variables` parameters in default-build.yml
- add a separate job w/ CodeQL3000 tasks included in build steps; run this job alone
  - use the new default-build.yml parameters
  - set `$(UseSharedCompilation)` to `false` to ease analysis

nit: Unconditionally disable the auto-injected component governance build step
- job.yml inserts the task where we need (unless overridden)
