### PR TITLE
Raise field size limit to 32kb 

### DIFF
--- a/src/Servers/Kestrel/Core/src/Http2Limits.cs
+++ b/src/Servers/Kestrel/Core/src/Http2Limits.cs
@@ -15,7 +15,7 @@ public class Http2Limits
     private int _maxStreamsPerConnection = 100;
     private int _headerTableSize = (int)Http2PeerSettings.DefaultHeaderTableSize;
     private int _maxFrameSize = (int)Http2PeerSettings.DefaultMaxFrameSize;
-    private int _maxRequestHeaderFieldSize = (int)Http2PeerSettings.DefaultMaxFrameSize;
+    private int _maxRequestHeaderFieldSize = 32 * 1024; // Matches MaxRequestHeadersTotalSize
     private int _initialConnectionWindowSize = 1024 * 1024; // Equal to SocketTransportOptions.MaxReadBufferSize and larger than any one single stream.
     private int _initialStreamWindowSize = 768 * 1024; // Larger than the default 64kb and able to use most (3/4ths) of the connection window by itself.
     private TimeSpan _keepAlivePingDelay = TimeSpan.MaxValue;

--- a/src/Servers/Kestrel/Core/src/Http3Limits.cs
+++ b/src/Servers/Kestrel/Core/src/Http3Limits.cs
@@ -10,10 +10,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core;
 /// </summary>
 public class Http3Limits
 {
-    internal const int DefaultMaxRequestHeaderFieldSize = 16 * 1024;
-
     private int _headerTableSize;
-    private int _maxRequestHeaderFieldSize = DefaultMaxRequestHeaderFieldSize;
+    private int _maxRequestHeaderFieldSize = 32 * 1024; // Matches MaxRequestHeadersTotalSize
 
     /// <summary>
     /// Limits the size of the header compression table, in octets, the QPACK decoder on the server can use.

--- a/src/Servers/Kestrel/Core/test/KestrelServerLimitsTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerLimitsTests.cs
@@ -341,7 +341,7 @@ public class KestrelServerLimitsTests
     [Fact]
     public void Http2MaxRequestHeaderFieldSizeDefault()
     {
-        Assert.Equal(16 * 1024, new KestrelServerLimits().Http2.MaxRequestHeaderFieldSize);
+        Assert.Equal(32 * 1024, new KestrelServerLimits().Http2.MaxRequestHeaderFieldSize);
     }
 
     [Theory]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -135,7 +135,7 @@ public class Http3StreamTests : Http3TestBase
             new KeyValuePair<string, string>(InternalHeaderNames.Path, "/"),
             new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
             new KeyValuePair<string, string>(InternalHeaderNames.Authority, "localhost:80"),
-            new KeyValuePair<string, string>("test", new string('a', 20000))
+            new KeyValuePair<string, string>("test", new string('a', 1024 * 32 + 1))
         };
 
         var requestStream = await Http3Api.InitializeConnectionAndStreamsAsync(_echoApplication, headers);
@@ -143,7 +143,7 @@ public class Http3StreamTests : Http3TestBase
         await requestStream.WaitForStreamErrorAsync(
             Http3ErrorCode.InternalError,
             AssertExpectedErrorMessages,
-            "The HTTP headers length exceeded the set limit of 16384 bytes.");
+            $"The HTTP headers length exceeded the set limit of {1024 * 32} bytes.");
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #12213

HTTP/2 and HTTP/3 have an individual header size limit that's not imposed on HTTP/1.x. When this limit is breached the whole connection is aborted, potentially disrupting other requests. We're raising this limit to match the total headers size limit by default, we don't specifically care about the size of individual headers.
