### PR TITLE
Reference ConnectionId always using same casing in log messages

### DIFF
--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -555,7 +555,7 @@ internal static partial class HttpsConnectionMiddlewareLoggerExtensions
     [LoggerMessage(2, LogLevel.Debug, "Authentication of the HTTPS connection timed out.", EventName = "AuthenticationTimedOut")]
     public static partial void AuthenticationTimedOut(this ILogger<HttpsConnectionMiddleware> logger);
 
-    [LoggerMessage(3, LogLevel.Debug, "Connection {connectionId} established using the following protocol: {protocol}", EventName = "HttpsConnectionEstablished")]
+    [LoggerMessage(3, LogLevel.Debug, "Connection {ConnectionId} established using the following protocol: {protocol}", EventName = "HttpsConnectionEstablished")]
     public static partial void HttpsConnectionEstablished(this ILogger<HttpsConnectionMiddleware> logger, string connectionId, SslProtocols protocol);
 
     [LoggerMessage(4, LogLevel.Information, "HTTP/2 over TLS is not supported on Windows versions older than Windows 10 and Windows Server 2016 due to incompatible ciphers or missing ALPN support. Falling back to HTTP/1.1 instead.",

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -555,7 +555,7 @@ internal static partial class HttpsConnectionMiddlewareLoggerExtensions
     [LoggerMessage(2, LogLevel.Debug, "Authentication of the HTTPS connection timed out.", EventName = "AuthenticationTimedOut")]
     public static partial void AuthenticationTimedOut(this ILogger<HttpsConnectionMiddleware> logger);
 
-    [LoggerMessage(3, LogLevel.Debug, "Connection {ConnectionId} established using the following protocol: {protocol}", EventName = "HttpsConnectionEstablished")]
+    [LoggerMessage(3, LogLevel.Debug, "Connection {ConnectionId} established using the following protocol: {Protocol}", EventName = "HttpsConnectionEstablished")]
     public static partial void HttpsConnectionEstablished(this ILogger<HttpsConnectionMiddleware> logger, string connectionId, SslProtocols protocol);
 
     [LoggerMessage(4, LogLevel.Information, "HTTP/2 over TLS is not supported on Windows versions older than Windows 10 and Windows Server 2016 due to incompatible ciphers or missing ALPN support. Falling back to HTTP/1.1 instead.",


### PR DESCRIPTION
All other instances of logging the connection ID in Kestrel write the log message field as `ConnectionId`. `HttpsConnectionMiddleware`, however, uses `connectionId`. In case-sensitive logging systems, this can cause a bit of a headache. This PR unifies it to `ConnectionId`.

![image](https://user-images.githubusercontent.com/9914262/197479788-3cacb77d-1e00-4a76-859a-ced5fe845b16.png)
