### PR TITLE
[release/6.0] Backport 'Fix Blazor RemoteAuthenticatorView processing the same action multiple times'

### DIFF
--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/RemoteAuthenticatorViewCore.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/RemoteAuthenticatorViewCore.cs
@@ -18,6 +18,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
         private string _message;
         private RemoteAuthenticationApplicationPathsOptions _applicationPaths;
         private string _action;
+        private string _lastHandledAction;
 
         /// <summary>
         /// Gets or sets the <see cref="RemoteAuthenticationActions"/> action the component needs to handle.
@@ -165,6 +166,13 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
         /// <inheritdoc />
         protected override async Task OnParametersSetAsync()
         {
+            if (_lastHandledAction == Action)
+            {
+                // Avoid processing the same action more than once.
+                return;
+            }
+
+            _lastHandledAction = Action;
             switch (Action)
             {
                 case RemoteAuthenticationActions.LogIn:

--- a/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/BasicTestAppAuthenticationWebDriverExtensions.cs
+++ b/src/Components/test/E2ETest/Infrastructure/WebDriverExtensions/BasicTestAppAuthenticationWebDriverExtensions.cs
@@ -22,13 +22,11 @@ namespace Microsoft.AspNetCore.Components.E2ETest
             {
                 // Some tests need to change the authentication state without discarding the
                 // original page, but this adds several seconds of delay
-                var javascript = (IJavaScriptExecutor)browser;
                 var originalWindow = browser.CurrentWindowHandle;
-                javascript.ExecuteScript("window.open()");
-                browser.SwitchTo().Window(browser.WindowHandles.Last());
+                browser.SwitchTo().NewWindow(WindowType.Tab);
                 browser.Navigate(baseUri, baseRelativeUri, noReload: false);
                 browser.Exists(By.CssSelector("h1#authentication"));
-                javascript.ExecuteScript("window.close()");
+                browser.Close();
                 browser.SwitchTo().Window(originalWindow);
             }
             else


### PR DESCRIPTION
# [release/6.0] Backport 'Fix Blazor RemoteAuthenticatorView processing the same action multiple times'

Backport of #43844

Fixes an issue where the `<RemoteAuthenticatorView/>` component would sometimes fire the login callback more than once.

## Description

The previous logic processed the current authentication action each time the component was re-rendered. Depending on the authentication service used, this could result in the login callback firing more than once. This PR fixes the problem by caching the last processed action and disabling authentication processing until the action changes.

Fixes #43925

## Customer Impact

It causes difficulty for customers to write their own logic in a way that accounts for login callbacks firing more than once. In addition, other expensive authentication actions may get invoked unnecessarily behind the scenes, which can degrade the experience of the customer's app.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The fix for this issue is simple, and we have extensive existing test coverage. New tests have been added validating the fix.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A