### PR TITLE
[release/6.0] Add CodeQL3000 run to aspnetcore-ci-official

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -18,6 +18,27 @@ pr:
     include:
     - '*'
 
+schedules:
+- cron: 0 9 * * 1
+  displayName: "Run CodeQL3000 weekly, Monday at 2:00 AM PDT"
+  branches:
+    include:
+    - release/2.1
+    - release/6.0
+    - release/7.0
+    - main
+  always: true
+
+parameters:
+# Parameter below is ignored in public builds.
+#
+# Choose whether to run the CodeQL3000 tasks.
+# Manual builds align w/ official builds unless this parameter is true.
+- name: runCodeQL3000
+  default: false
+  displayName: Run CodeQL3000 tasks
+  type: boolean
+
 variables:
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
@@ -113,181 +134,234 @@ variables:
   - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
     - name: _SignType
       value: test
+- name: runCodeQL3000
+  value: ${{ or(eq(variables['Build.Reason'], 'Schedule'), and(eq(variables['Build.Reason'], 'Manual'), eq(parameters.runCodeQL3000, 'true'))) }}
 
 stages:
 - stage: build
   displayName: Build
   jobs:
-  # Code check
-  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), in(variables['Build.Reason'], 'Manual')) }}:
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), eq(variables.runCodeQL3000, 'true')) }}:
     - template: jobs/default-build.yml
       parameters:
-        jobName: Code_check
-        jobDisplayName: Code check
+        jobName: build
+        jobDisplayName: Build and run CodeQL3000
         agentOs: Windows
+        codeSign: false
+        # Component governance and SBOM creation are not needed here. Disable what Arcade would inject.
+        disableComponentGovernance: true
+        enableSbom: false
+        variables:
+        # Security analysis is included in normal runs. Disable its auto-injection.
+        - skipNugetSecurityAnalysis: true
+        # Do not let CodeQL3000 Extension gate scan frequency.
+        - Codeql.Cadence: 0
+        # Enable CodeQL3000 unconditionally so it may be run on any branch.
+        - Codeql.Enabled: true
+        # Ignore the small amount of infrastructure Python code in this repo.
+        - Codeql.Language: cpp,csharp,java,javascript
+        - Codeql.ExcludePathPatterns: submodules
+        # Ignore test and infrastructure code.
+        - Codeql.SourceRoot: src
+        # CodeQL3000 needs this plumbed along as a variable to enable TSA.
+        - Codeql.TSAEnabled: ${{ eq(variables['Build.Reason'], 'Schedule') }}
+        # Default expects tsaoptions.json under SourceRoot.
+        - Codeql.TSAOptionsPath: '$(Build.SourcesDirectory)/.config/tsaoptions.json'
+        beforeBuild:
+        - task: CodeQL3000Init@0
+          displayName: CodeQL Initialize
+        - script: "echo ##vso[build.addbuildtag]CodeQL3000"
+          displayName: 'Set CI CodeQL3000 tag'
+          condition: ne(variables.CODEQL_DIST,'')
         steps:
-        - powershell: ./eng/scripts/CodeCheck.ps1 -ci $(_InternalRuntimeDownloadArgs)
-          displayName: Run eng/scripts/CodeCheck.ps1
+        - script: ./eng/build.cmd
+                  -ci
+                  -arch x64
+                  -all
+                  $(_BuildArgs)
+                  $(_InternalRuntimeDownloadArgs)
+                  /p:UseSharedCompilation=false
+          displayName: Build x64
+        afterBuild:
+        - task: CodeQL3000Finalize@0
+          displayName: CodeQL Finalize
         artifacts:
-        - name: Code_Check_Logs
+        - name: Build_Logs
           path: artifacts/log/
           publishOnError: true
           includeForks: true
 
-  # Build Windows (x64/x86)
-  - template: jobs/default-build.yml
-    parameters:
-      codeSign: true
-      jobName: Windows_build
-      jobDisplayName: "Build: Windows x64/x86"
-      agentOs: Windows
-      steps:
-      - script: "echo ##vso[build.addbuildtag]daily-build"
-        condition: and(notin(variables['Build.Reason'], 'PullRequest'), notin(variables['DotNetFinalVersionKind'], 'release', 'prerelease'))
-        displayName: 'Set CI tags'
-      - script: "echo ##vso[build.addbuildtag]release-candidate"
-        condition: and(notin(variables['Build.Reason'], 'PullRequest'), in(variables['DotNetFinalVersionKind'], 'release', 'prerelease'))
-        displayName: 'Set CI tags'
+  - ${{ else }}: # regular build
+    # Code check
+    - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), in(variables['Build.Reason'], 'Manual')) }}:
+      - template: jobs/default-build.yml
+        parameters:
+          jobName: Code_check
+          jobDisplayName: Code check
+          agentOs: Windows
+          steps:
+          - powershell: ./eng/scripts/CodeCheck.ps1 -ci $(_InternalRuntimeDownloadArgs)
+            displayName: Run eng/scripts/CodeCheck.ps1
+          artifacts:
+          - name: Code_Check_Logs
+            path: artifacts/log/
+            publishOnError: true
+            includeForks: true
 
-      # !!! NOTE !!! Some of these steps have disabled code signing.
-      # This is intentional to workaround https://github.com/dotnet/arcade/issues/1957 which always re-submits for code-signing, even
-      # if they have already been signed. This results in slower builds due to re-submitting the same .nupkg many times for signing.
-      # The sign settings have been configured to
-      - script: ./eng/build.cmd
-                -ci
-                -arch x64
-                -pack
-                -all
-                $(_BuildArgs)
-                $(_InternalRuntimeDownloadArgs)
-                $(Windows64LogArgs)
-        displayName: Build x64
+    # Build Windows (x64/x86)
+    - template: jobs/default-build.yml
+      parameters:
+        codeSign: true
+        jobName: Windows_build
+        jobDisplayName: "Build: Windows x64/x86"
+        agentOs: Windows
+        steps:
+        - script: "echo ##vso[build.addbuildtag]daily-build"
+          condition: and(notin(variables['Build.Reason'], 'PullRequest'), notin(variables['DotNetFinalVersionKind'], 'release', 'prerelease'))
+          displayName: 'Set CI tags'
+        - script: "echo ##vso[build.addbuildtag]release-candidate"
+          condition: and(notin(variables['Build.Reason'], 'PullRequest'), in(variables['DotNetFinalVersionKind'], 'release', 'prerelease'))
+          displayName: 'Set CI tags'
 
-      # Build the x86 shared framework
-      # This is going to actually build x86 native assets.
-      - script: ./eng/build.cmd
-                -ci
-                -noBuildRepoTasks
-                -arch x86
-                -pack
-                -all
-                -noBuildJava
-                -noBuildNative
-                /p:OnlyPackPlatformSpecificPackages=true
-                $(_BuildArgs)
-                $(_InternalRuntimeDownloadArgs)
-                $(Windows86LogArgs)
-        displayName: Build x86
+        # !!! NOTE !!! Some of these steps have disabled code signing.
+        # This is intentional to workaround https://github.com/dotnet/arcade/issues/1957 which always re-submits for code-signing, even
+        # if they have already been signed. This results in slower builds due to re-submitting the same .nupkg many times for signing.
+        # The sign settings have been configured to
+        - script: ./eng/build.cmd
+                  -ci
+                  -arch x64
+                  -pack
+                  -all
+                  $(_BuildArgs)
+                  $(_InternalRuntimeDownloadArgs)
+                  $(Windows64LogArgs)
+          displayName: Build x64
 
-      - script: .\src\SiteExtensions\build.cmd
-                -ci
-                -noBuildRepoTasks
-                -pack
-                -noBuildDeps
-                -noBuildNative
-                $(_BuildArgs)
-                $(_InternalRuntimeDownloadArgs)
-        condition: ne(variables['Build.Reason'], 'PullRequest')
-        displayName: Build SiteExtension
+        # Build the x86 shared framework
+        # This is going to actually build x86 native assets.
+        - script: ./eng/build.cmd
+                  -ci
+                  -noBuildRepoTasks
+                  -arch x86
+                  -pack
+                  -all
+                  -noBuildJava
+                  -noBuildNative
+                  /p:OnlyPackPlatformSpecificPackages=true
+                  $(_BuildArgs)
+                  $(_InternalRuntimeDownloadArgs)
+                  $(Windows86LogArgs)
+          displayName: Build x86
 
-      # This runs code-signing on all packages, zips, and jar files as defined in build/CodeSign.targets. If
-      # https://github.com/dotnet/arcade/issues/1957 is resolved, consider running code-signing inline with the other
-      # previous steps. Sign check is disabled because it is run in a separate step below, after installers are built.
-      - script: ./eng/build.cmd
-                -ci
-                -noBuildRepoTasks
-                -noBuildNative
-                -noBuild
-                -noRestore
-                -sign
-                /p:DotNetSignType=$(_SignType)
-                $(_BuildArgs)
-                $(WindowsSignLogArgs)
-        displayName: Code sign packages
+        - script: .\src\SiteExtensions\build.cmd
+                  -ci
+                  -noBuildRepoTasks
+                  -pack
+                  -noBuildDeps
+                  -noBuildNative
+                  $(_BuildArgs)
+                  $(_InternalRuntimeDownloadArgs)
+          condition: ne(variables['Build.Reason'], 'PullRequest')
+          displayName: Build SiteExtension
 
-      # Windows installers bundle both x86 and x64 assets
-      - script: ./eng/build.cmd
-                -ci
-                -noBuildRepoTasks
-                -sign
-                -buildInstallers
-                -noBuildNative
-                /p:DotNetSignType=$(_SignType)
-                /p:AssetManifestFileName=aspnetcore-win-x64-x86.xml
-                $(_BuildArgs)
-                $(_PublishArgs)
-                $(_InternalRuntimeDownloadArgs)
-                /p:PublishInstallerBaseVersion=true
-                $(WindowsInstallersLogArgs)
-        displayName: Build Installers
+        # This runs code-signing on all packages, zips, and jar files as defined in build/CodeSign.targets. If
+        # https://github.com/dotnet/arcade/issues/1957 is resolved, consider running code-signing inline with the other
+        # previous steps. Sign check is disabled because it is run in a separate step below, after installers are built.
+        - script: ./eng/build.cmd
+                  -ci
+                  -noBuildRepoTasks
+                  -noBuildNative
+                  -noBuild
+                  -noRestore
+                  -sign
+                  /p:DotNetSignType=$(_SignType)
+                  $(_BuildArgs)
+                  $(WindowsSignLogArgs)
+          displayName: Code sign packages
 
-      # A few files must also go to the VS package feed.
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['PostBuildSign'], 'true')) }}:
-        - task: NuGetCommand@2
-          displayName: Push Visual Studio packages
-          inputs:
-            command: push
-            packagesToPush: 'artifacts/packages/**/VS.Redist.Common.AspNetCore.*.nupkg'
-            nuGetFeedType: external
-            publishFeedCredentials: 'DevDiv - VS package feed'
+        # Windows installers bundle both x86 and x64 assets
+        - script: ./eng/build.cmd
+                  -ci
+                  -noBuildRepoTasks
+                  -sign
+                  -buildInstallers
+                  -noBuildNative
+                  /p:DotNetSignType=$(_SignType)
+                  /p:AssetManifestFileName=aspnetcore-win-x64-x86.xml
+                  $(_BuildArgs)
+                  $(_PublishArgs)
+                  $(_InternalRuntimeDownloadArgs)
+                  /p:PublishInstallerBaseVersion=true
+                  $(WindowsInstallersLogArgs)
+          displayName: Build Installers
 
-      artifacts:
-      - name: Windows_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Windows_Packages
-        path: artifacts/packages/
+        # A few files must also go to the VS package feed.
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['PostBuildSign'], 'true')) }}:
+          - task: NuGetCommand@2
+            displayName: Push Visual Studio packages
+            inputs:
+              command: push
+              packagesToPush: 'artifacts/packages/**/VS.Redist.Common.AspNetCore.*.nupkg'
+              nuGetFeedType: external
+              publishFeedCredentials: 'DevDiv - VS package feed'
 
-  # Build Windows ARM
-  - template: jobs/default-build.yml
-    parameters:
-      codeSign: true
-      jobName: Windows_arm_build
-      jobDisplayName: "Build: Windows ARM"
-      agentOs: Windows
-      buildArgs:
-        -arch arm
-        -sign
-        -pack
-        -noBuildNodeJS
-        -noBuildJava
-        /p:DotNetSignType=$(_SignType)
-        /p:OnlyPackPlatformSpecificPackages=true
-        /p:AssetManifestFileName=aspnetcore-win-arm.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
-      installNodeJs: false
-      installJdk: false
-      artifacts:
-      - name: Windows_arm_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Windows_arm_Packages
-        path: artifacts/packages/
+        artifacts:
+        - name: Windows_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Windows_Packages
+          path: artifacts/packages/
 
-  # Build Windows ARM64
-  - template: jobs/default-build.yml
-    parameters:
-      codeSign: true
-      jobName: Windows_arm64_build
-      jobDisplayName: "Build: Windows ARM64"
-      agentOs: Windows
-      installNodeJs: false
-      installJdk: false
-      artifacts:
-      - name: Windows_arm64_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Windows_arm64_Packages
-        path: artifacts/packages/
-      - name: Windows_arm64_Installers
-        path: artifacts/installers/
-      steps:
-      - script: ./eng/build.cmd
+    # Build Windows ARM
+    - template: jobs/default-build.yml
+      parameters:
+        codeSign: true
+        jobName: Windows_arm_build
+        jobDisplayName: "Build: Windows ARM"
+        agentOs: Windows
+        buildArgs:
+          -arch arm
+          -sign
+          -pack
+          -noBuildNodeJS
+          -noBuildJava
+          /p:DotNetSignType=$(_SignType)
+          /p:OnlyPackPlatformSpecificPackages=true
+          /p:AssetManifestFileName=aspnetcore-win-arm.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        installJdk: false
+        artifacts:
+        - name: Windows_arm_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Windows_arm_Packages
+          path: artifacts/packages/
+
+    # Build Windows ARM64
+    - template: jobs/default-build.yml
+      parameters:
+        codeSign: true
+        jobName: Windows_arm64_build
+        jobDisplayName: "Build: Windows ARM64"
+        agentOs: Windows
+        installNodeJs: false
+        installJdk: false
+        artifacts:
+        - name: Windows_arm64_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Windows_arm64_Packages
+          path: artifacts/packages/
+        - name: Windows_arm64_Installers
+          path: artifacts/installers/
+        steps:
+        - script: ./eng/build.cmd
                 -ci
                 -arch arm64
                 -sign
@@ -299,10 +373,10 @@ stages:
                 $(_BuildArgs)
                 $(_InternalRuntimeDownloadArgs)
                 $(WindowsArm64LogArgs)
-        displayName: Build ARM64
+          displayName: Build ARM64
 
-      # Windows installers bundle for arm64
-      - script: ./eng/build.cmd
+        # Windows installers bundle for arm64
+        - script: ./eng/build.cmd
                 -ci
                 -noBuildRepoTasks
                 -arch arm64
@@ -315,474 +389,473 @@ stages:
                 $(_PublishArgs)
                 $(_InternalRuntimeDownloadArgs)
                 $(WindowsArm64InstallersLogArgs)
-        displayName: Build Arm64 Installers
+          displayName: Build Arm64 Installers
 
-      # A few files must also go to the VS package feed.
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['PostBuildSign'], 'true')) }}:
-        - task: NuGetCommand@2
-          displayName: Push Visual Studio packages
-          inputs:
-            command: push
-            packagesToPush: 'artifacts/packages/**/VS.Redist.Common.AspNetCore.*.nupkg'
-            nuGetFeedType: external
-            publishFeedCredentials: 'DevDiv - VS package feed'
+        # A few files must also go to the VS package feed.
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables['PostBuildSign'], 'true')) }}:
+          - task: NuGetCommand@2
+            displayName: Push Visual Studio packages
+            inputs:
+              command: push
+              packagesToPush: 'artifacts/packages/**/VS.Redist.Common.AspNetCore.*.nupkg'
+              nuGetFeedType: external
+              publishFeedCredentials: 'DevDiv - VS package feed'
 
 
-  # Build MacOS arm64
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: MacOs_arm64_build
-      jobDisplayName: "Build: macOS arm64"
-      agentOs: macOs
-      buildArgs:
-        --arch arm64
-        --pack
-        --all
-        --no-build-nodejs
-        --no-build-java
-        -p:OnlyPackPlatformSpecificPackages=true
-        -p:AssetManifestFileName=aspnetcore-MacOS_arm64.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
-      installNodeJs: false
-      installJdk: false
-      artifacts:
-      - name: MacOS_arm64_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: MacOS_arm64_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables['PostBuildSign'], 'true') }}:
-    - template: jobs/codesign-xplat.yml
+    # Build MacOS arm64
+    - template: jobs/default-build.yml
       parameters:
-        inputName: MacOS_arm64
-
-  # Build MacOS x64
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: MacOs_x64_build
-      jobDisplayName: "Build: macOS x64"
-      agentOs: macOs
-      buildArgs:
-        --pack
-        --all
-        --no-build-nodejs
-        --no-build-java
-        -p:OnlyPackPlatformSpecificPackages=true
-        -p:AssetManifestFileName=aspnetcore-MacOS_x64.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
-      installNodeJs: false
-      installJdk: false
-      artifacts:
-      - name: MacOS_x64_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: MacOS_x64_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables['PostBuildSign'], 'true') }}:
-    - template: jobs/codesign-xplat.yml
-      parameters:
-        inputName: MacOS_x64
-
-  # Build Linux x64
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Linux_x64_build
-      jobDisplayName: "Build: Linux x64"
-      agentOs: Linux
-      useHostedUbuntu: false
-      steps:
-      - script: ./eng/build.sh
-            --ci
-            --arch x64
-            --pack
-            --all
-            --no-build-nodejs
-            --no-build-java
-            -p:OnlyPackPlatformSpecificPackages=true
-            $(_BuildArgs)
-            $(_InternalRuntimeDownloadArgs)
-        displayName: Run build.sh
-      - script: |
-          git clean -xfd src/**/obj/
-          ./dockerbuild.sh bionic \
-            --ci \
-            --nobl \
-            --arch x64 \
-            --build-installers \
-            --no-build-deps \
-            --no-build-nodejs \
-            -p:OnlyPackPlatformSpecificPackages=true \
-            -p:BuildRuntimeArchive=false \
-            -p:LinuxInstallerType=deb \
-            $(_BuildArgs) \
-            $(_InternalRuntimeDownloadArgs)
-        displayName: Build Debian installers
-      - script: |
-          git clean -xfd src/**/obj/
-          ./dockerbuild.sh rhel \
-            --ci \
-            --nobl \
-            --arch x64 \
-            --build-installers \
-            --no-build-deps \
-            --no-build-nodejs \
-            -p:OnlyPackPlatformSpecificPackages=true \
-            -p:BuildRuntimeArchive=false \
-            -p:LinuxInstallerType=rpm \
-            -p:AssetManifestFileName=aspnetcore-Linux_x64.xml \
-            $(_BuildArgs) \
-            $(_PublishArgs) \
-            $(_InternalRuntimeDownloadArgs)
-        displayName: Build RPM installers
-      installNodeJs: false
-      installJdk: false
-      artifacts:
-      - name: Linux_x64_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Linux_x64_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables['PostBuildSign'], 'true') }}:
-    - template: jobs/codesign-xplat.yml
-      parameters:
-        inputName: Linux_x64
-
-  # Build Linux ARM
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Linux_arm_build
-      jobDisplayName: "Build: Linux ARM"
-      agentOs: Linux
-      buildArgs:
-        --arch arm
-        --pack
-        --all
-        --no-build-nodejs
-        --no-build-java
-        -p:OnlyPackPlatformSpecificPackages=true
-        -p:AssetManifestFileName=aspnetcore-Linux_arm.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
-      installNodeJs: false
-      installJdk: false
-      artifacts:
-      - name: Linux_arm_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Linux_arm_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables['PostBuildSign'], 'true') }}:
-    - template: jobs/codesign-xplat.yml
-      parameters:
-        inputName: Linux_arm
-
-  # Build Linux ARM64
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Linux_arm64_build
-      jobDisplayName: "Build: Linux ARM64"
-      agentOs: Linux
-      steps:
-      - script: ./eng/build.sh
-            --ci
-            --arch arm64
-            --pack
-            --all
-            --no-build-nodejs
-            --no-build-java
-            -p:OnlyPackPlatformSpecificPackages=true
-            $(_BuildArgs)
-            $(_InternalRuntimeDownloadArgs)
-        displayName: Run build.sh
-      - script: git clean -xfd src/**/obj/;
-          ./dockerbuild.sh rhel --ci --nobl --arch arm64 --build-installers --no-build-deps --no-build-nodejs
-          -p:OnlyPackPlatformSpecificPackages=true -p:BuildRuntimeArchive=false -p:LinuxInstallerType=rpm
-          -p:AssetManifestFileName=aspnetcore-Linux_arm64.xml
+        jobName: MacOs_arm64_build
+        jobDisplayName: "Build: macOS arm64"
+        agentOs: macOs
+        buildArgs:
+          --arch arm64
+          --pack
+          --all
+          --no-build-nodejs
+          --no-build-java
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-MacOS_arm64.xml
           $(_BuildArgs)
           $(_PublishArgs)
           $(_InternalRuntimeDownloadArgs)
-        displayName: Build RPM installers
-      installNodeJs: false
-      installJdk: false
-      artifacts:
-      - name: Linux_arm64_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Linux_arm64_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables['PostBuildSign'], 'true') }}:
-    - template: jobs/codesign-xplat.yml
-      parameters:
-        inputName: Linux_arm64
-
-  # Build Linux Musl x64
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Linux_musl_x64_build
-      jobDisplayName: "Build: Linux Musl x64"
-      agentOs: Linux
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode-20210910135833-c401c85
-      buildArgs:
-        --arch x64
-        --os-name linux-musl
-        --pack
-        --all
-        --no-build-nodejs
-        --no-build-java
-        -p:OnlyPackPlatformSpecificPackages=true
-        -p:AssetManifestFileName=aspnetcore-Linux_musl_x64.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
-      installNodeJs: false
-      installJdk: false
-      disableComponentGovernance: true
-      skipComponentGovernanceDetection: true
-      artifacts:
-      - name: Linux_musl_x64_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Linux_musl_x64_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables['PostBuildSign'], 'true') }}:
-    - template: jobs/codesign-xplat.yml
-      parameters:
-        inputName: Linux_musl_x64
-
-  # Build Linux Musl ARM
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Linux_musl_arm_build
-      jobDisplayName: "Build: Linux Musl ARM"
-      agentOs: Linux
-      useHostedUbuntu: false
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm-alpine-20211022152824-78f7860
-      buildArgs:
-        --arch arm
-        --os-name linux-musl
-        --pack
-        --all
-        --no-build-nodejs
-        --no-build-java
-        -p:OnlyPackPlatformSpecificPackages=true
-        -p:AssetManifestFileName=aspnetcore-Linux_musl_arm.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
-      installNodeJs: false
-      installJdk: false
-      artifacts:
-      - name: Linux_musl_arm_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Linux_musl_arm_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables['PostBuildSign'], 'true') }}:
-    - template: jobs/codesign-xplat.yml
-      parameters:
-        inputName: Linux_musl_arm
-
-  # Build Linux Musl ARM64
-  - template: jobs/default-build.yml
-    parameters:
-      jobName: Linux_musl_arm64_build
-      jobDisplayName: "Build: Linux Musl ARM64"
-      agentOs: Linux
-      useHostedUbuntu: false
-      container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-alpine-20211022152824-538077f
-      buildArgs:
-        --arch arm64
-        --os-name linux-musl
-        --pack
-        --all
-        --no-build-nodejs
-        --no-build-java
-        -p:OnlyPackPlatformSpecificPackages=true
-        -p:AssetManifestFileName=aspnetcore-Linux_musl_arm64.xml
-        $(_BuildArgs)
-        $(_PublishArgs)
-        $(_InternalRuntimeDownloadArgs)
-      installNodeJs: false
-      installJdk: false
-      artifacts:
-      - name: Linux_musl_arm64_Logs
-        path: artifacts/log/
-        publishOnError: true
-        includeForks: true
-      - name: Linux_musl_arm64_Packages
-        path: artifacts/packages/
-
-  - ${{ if ne(variables['PostBuildSign'], 'true') }}:
-    - template: jobs/codesign-xplat.yml
-      parameters:
-        inputName: Linux_musl_arm64
-
-  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), in(variables['Build.Reason'], 'Manual')) }}:
-    # Test jobs
-    - template: jobs/default-build.yml
-      parameters:
-        condition: ne(variables['SkipTests'], 'true')
-        jobName: Windows_Test
-        jobDisplayName: "Test: Windows Server x64"
-        agentOs: Windows
-        isTestingJob: true
-        # Just uploading artifacts/logs/ files can take 15 minutes. Doubling the cancel timeout for this job.
-        cancelTimeoutInMinutes: 30
-        buildArgs: -all -pack -test /p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true
-                   /p:SkipIISExpressTests=true /p:SkipIISNewShimTests=true /p:RunTemplateTests=false
-                   /p:SkipComponentsE2ETests=true
-                   $(_InternalRuntimeDownloadArgs)
-        beforeBuild:
-        - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
-          displayName: Setup IISExpress test certificates and schema
+        installNodeJs: false
+        installJdk: false
         artifacts:
-        - name: Windows_Test_Logs
+        - name: MacOS_arm64_Logs
           path: artifacts/log/
           publishOnError: true
           includeForks: true
-        - name: Windows_Test_Results
-          path: artifacts/TestResults/
-          publishOnError: true
-          includeForks: true
+        - name: MacOS_arm64_Packages
+          path: artifacts/packages/
 
+    - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: MacOS_arm64
+
+    # Build MacOS x64
     - template: jobs/default-build.yml
       parameters:
-        condition: ne(variables['SkipTests'], 'true')
-        jobName: MacOS_Test
-        jobDisplayName: "Test: macOS"
-        agentOs: macOS
-        timeoutInMinutes: 240
-        isTestingJob: true
-        buildArgs: --all --test "/p:RunTemplateTests=false /p:SkipComponentsE2ETests=true /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
-        beforeBuild:
-        - bash: "./eng/scripts/install-nginx-mac.sh"
-          displayName: Installing Nginx
+        jobName: MacOs_x64_build
+        jobDisplayName: "Build: macOS x64"
+        agentOs: macOs
+        buildArgs:
+          --pack
+          --all
+          --no-build-nodejs
+          --no-build-java
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-MacOS_x64.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        installJdk: false
         artifacts:
-        - name: MacOS_Test_Logs
+        - name: MacOS_x64_Logs
           path: artifacts/log/
           publishOnError: true
           includeForks: true
-        - name: MacOS_Test_Results
-          path: artifacts/TestResults/
-          publishOnError: true
-          includeForks: true
+        - name: MacOS_x64_Packages
+          path: artifacts/packages/
 
+    - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: MacOS_x64
+
+    # Build Linux x64
     - template: jobs/default-build.yml
       parameters:
-        condition: ne(variables['SkipTests'], 'true')
-        jobName: Linux_Test
-        jobDisplayName: "Test: Ubuntu x64"
+        jobName: Linux_x64_build
+        jobDisplayName: "Build: Linux x64"
         agentOs: Linux
-        isTestingJob: true
         useHostedUbuntu: false
-        buildArgs: --all --test "/p:RunTemplateTests=false /p:SkipComponentsE2ETests=true /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
-        beforeBuild:
-        - bash: "./eng/scripts/install-nginx-linux.sh"
-          displayName: Installing Nginx
-        - bash: "echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p"
-          displayName: Increase inotify limit
+        steps:
+        - script: ./eng/build.sh
+              --ci
+              --arch x64
+              --pack
+              --all
+              --no-build-nodejs
+              --no-build-java
+              -p:OnlyPackPlatformSpecificPackages=true
+              $(_BuildArgs)
+              $(_InternalRuntimeDownloadArgs)
+          displayName: Run build.sh
+        - script: |
+            git clean -xfd src/**/obj/
+            ./dockerbuild.sh bionic \
+              --ci \
+              --nobl \
+              --arch x64 \
+              --build-installers \
+              --no-build-deps \
+              --no-build-nodejs \
+              -p:OnlyPackPlatformSpecificPackages=true \
+              -p:BuildRuntimeArchive=false \
+              -p:LinuxInstallerType=deb \
+              $(_BuildArgs) \
+              $(_InternalRuntimeDownloadArgs)
+          displayName: Build Debian installers
+        - script: |
+            git clean -xfd src/**/obj/
+            ./dockerbuild.sh rhel \
+              --ci \
+              --nobl \
+              --arch x64 \
+              --build-installers \
+              --no-build-deps \
+              --no-build-nodejs \
+              -p:OnlyPackPlatformSpecificPackages=true \
+              -p:BuildRuntimeArchive=false \
+              -p:LinuxInstallerType=rpm \
+              -p:AssetManifestFileName=aspnetcore-Linux_x64.xml \
+              $(_BuildArgs) \
+              $(_PublishArgs) \
+              $(_InternalRuntimeDownloadArgs)
+          displayName: Build RPM installers
+        installNodeJs: false
+        installJdk: false
         artifacts:
-        - name: Linux_Test_Logs
+        - name: Linux_x64_Logs
           path: artifacts/log/
           publishOnError: true
           includeForks: true
-        - name: Linux_Test_Results
-          path: artifacts/TestResults/
-          publishOnError: true
-          includeForks: true
+        - name: Linux_x64_Packages
+          path: artifacts/packages/
 
-    # Helix x64
+    - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_x64
+
+    # Build Linux ARM
     - template: jobs/default-build.yml
       parameters:
-        jobName: Helix_x64
-        jobDisplayName: 'Tests: Helix x64'
-        agentOs: Windows
-        timeoutInMinutes: 240
-        steps:
-        # Build the shared framework
-        - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64
-                  /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
-          displayName: Build shared fx
-        - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -restore -noBuild -noBuildNative -projects src/Grpc/**/*.csproj
-                  /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
-          displayName: Restore interop projects
-        - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildNative -projects eng\helix\helix.proj
-                  /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:SkipComponentsE2ETests=true
-                  /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
-          displayName: Run build.cmd helix target
-          env:
-            HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
-            SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
-
+        jobName: Linux_arm_build
+        jobDisplayName: "Build: Linux ARM"
+        agentOs: Linux
+        buildArgs:
+          --arch arm
+          --pack
+          --all
+          --no-build-nodejs
+          --no-build-java
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-Linux_arm.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        installJdk: false
         artifacts:
-        - name: Helix_logs
+        - name: Linux_arm_Logs
           path: artifacts/log/
           publishOnError: true
           includeForks: true
+        - name: Linux_arm_Packages
+          path: artifacts/packages/
 
-  # Source build
-  - template: /eng/common/templates/job/source-build.yml
-    parameters:
-      platform:
-        name: 'Managed'
-        container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-20210714125435-9b5bbc2'
-        buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks $(_InternalRuntimeDownloadArgs)'
-        skipPublishValidation: true
+    - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_arm
 
-  # Publish to the BAR
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/common/templates/job/publish-build-assets.yml
+    # Build Linux ARM64
+    - template: jobs/default-build.yml
       parameters:
-        dependsOn:
-          - Windows_build
-          - Windows_arm_build
-          - Windows_arm64_build
-          - ${{ if ne(variables['PostBuildSign'], 'true') }}:
-            - CodeSign_Xplat_MacOS_arm64
-            - CodeSign_Xplat_MacOS_x64
-            - CodeSign_Xplat_Linux_x64
-            - CodeSign_Xplat_Linux_arm
-            - CodeSign_Xplat_Linux_arm64
-            - CodeSign_Xplat_Linux_musl_x64
-            - CodeSign_Xplat_Linux_musl_arm
-            - CodeSign_Xplat_Linux_musl_arm64
-          - ${{ if eq(variables['PostBuildSign'], 'true') }}:
-            - MacOs_arm64_build
-            - MacOs_x64_build
-            - Linux_x64_build
-            - Linux_arm_build
-            - Linux_arm64_build
-            - Linux_musl_x64_build
-            - Linux_musl_arm_build
-            - Linux_musl_arm64_build
-          # In addition to the dependencies above, ensure the build was successful overall.
-          - Source_Build_Managed
-        pool:
-          name: NetCore1ESPool-Svc-Internal
-          demands: ImageOverride -equals 1es-windows-2019
-        publishUsingPipelines: ${{ variables._PublishUsingPipelines }}
-        enablePublishBuildArtifacts: true # publish artifacts/log files
+        jobName: Linux_arm64_build
+        jobDisplayName: "Build: Linux ARM64"
+        agentOs: Linux
+        steps:
+        - script: ./eng/build.sh
+              --ci
+              --arch arm64
+              --pack
+              --all
+              --no-build-nodejs
+              --no-build-java
+              -p:OnlyPackPlatformSpecificPackages=true
+              $(_BuildArgs)
+              $(_InternalRuntimeDownloadArgs)
+          displayName: Run build.sh
+        - script: git clean -xfd src/**/obj/;
+            ./dockerbuild.sh rhel --ci --nobl --arch arm64 --build-installers --no-build-deps --no-build-nodejs
+            -p:OnlyPackPlatformSpecificPackages=true -p:BuildRuntimeArchive=false -p:LinuxInstallerType=rpm
+            -p:AssetManifestFileName=aspnetcore-Linux_arm64.xml
+            $(_BuildArgs)
+            $(_PublishArgs)
+            $(_InternalRuntimeDownloadArgs)
+          displayName: Build RPM installers
+        installNodeJs: false
+        installJdk: false
+        artifacts:
+        - name: Linux_arm64_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_arm64_Packages
+          path: artifacts/packages/
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_arm64
+
+    # Build Linux Musl x64
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: Linux_musl_x64_build
+        jobDisplayName: "Build: Linux Musl x64"
+        agentOs: Linux
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode-20210910135833-c401c85
+        buildArgs:
+          --arch x64
+          --os-name linux-musl
+          --pack
+          --all
+          --no-build-nodejs
+          --no-build-java
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-Linux_musl_x64.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        installJdk: false
+        disableComponentGovernance: true
+        artifacts:
+        - name: Linux_musl_x64_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_musl_x64_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_musl_x64
+
+    # Build Linux Musl ARM
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: Linux_musl_arm_build
+        jobDisplayName: "Build: Linux Musl ARM"
+        agentOs: Linux
+        useHostedUbuntu: false
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm-alpine-20211022152824-78f7860
+        buildArgs:
+          --arch arm
+          --os-name linux-musl
+          --pack
+          --all
+          --no-build-nodejs
+          --no-build-java
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-Linux_musl_arm.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        installJdk: false
+        artifacts:
+        - name: Linux_musl_arm_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_musl_arm_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_musl_arm
+
+    # Build Linux Musl ARM64
+    - template: jobs/default-build.yml
+      parameters:
+        jobName: Linux_musl_arm64_build
+        jobDisplayName: "Build: Linux Musl ARM64"
+        agentOs: Linux
+        useHostedUbuntu: false
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-alpine-20211022152824-538077f
+        buildArgs:
+          --arch arm64
+          --os-name linux-musl
+          --pack
+          --all
+          --no-build-nodejs
+          --no-build-java
+          -p:OnlyPackPlatformSpecificPackages=true
+          -p:AssetManifestFileName=aspnetcore-Linux_musl_arm64.xml
+          $(_BuildArgs)
+          $(_PublishArgs)
+          $(_InternalRuntimeDownloadArgs)
+        installNodeJs: false
+        installJdk: false
+        artifacts:
+        - name: Linux_musl_arm64_Logs
+          path: artifacts/log/
+          publishOnError: true
+          includeForks: true
+        - name: Linux_musl_arm64_Packages
+          path: artifacts/packages/
+
+    - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+      - template: jobs/codesign-xplat.yml
+        parameters:
+          inputName: Linux_musl_arm64
+
+    - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'), in(variables['Build.Reason'], 'Manual')) }}:
+      # Test jobs
+      - template: jobs/default-build.yml
+        parameters:
+          condition: ne(variables['SkipTests'], 'true')
+          jobName: Windows_Test
+          jobDisplayName: "Test: Windows Server x64"
+          agentOs: Windows
+          isTestingJob: true
+          # Just uploading artifacts/logs/ files can take 15 minutes. Doubling the cancel timeout for this job.
+          cancelTimeoutInMinutes: 30
+          buildArgs: -all -pack -test /p:SkipHelixReadyTests=true /p:SkipIISNewHandlerTests=true /p:SkipIISTests=true
+                     /p:SkipIISExpressTests=true /p:SkipIISNewShimTests=true /p:RunTemplateTests=false
+                     /p:SkipComponentsE2ETests=true
+                     $(_InternalRuntimeDownloadArgs)
+          beforeBuild:
+          - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1; & ./src/Servers/IIS/tools/update_schema.ps1"
+            displayName: Setup IISExpress test certificates and schema
+          artifacts:
+          - name: Windows_Test_Logs
+            path: artifacts/log/
+            publishOnError: true
+            includeForks: true
+          - name: Windows_Test_Results
+            path: artifacts/TestResults/
+            publishOnError: true
+            includeForks: true
+
+      - template: jobs/default-build.yml
+        parameters:
+          condition: ne(variables['SkipTests'], 'true')
+          jobName: MacOS_Test
+          jobDisplayName: "Test: macOS"
+          agentOs: macOS
+          timeoutInMinutes: 240
+          isTestingJob: true
+          buildArgs: --all --test "/p:RunTemplateTests=false /p:SkipComponentsE2ETests=true /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
+          beforeBuild:
+          - bash: "./eng/scripts/install-nginx-mac.sh"
+            displayName: Installing Nginx
+          artifacts:
+          - name: MacOS_Test_Logs
+            path: artifacts/log/
+            publishOnError: true
+            includeForks: true
+          - name: MacOS_Test_Results
+            path: artifacts/TestResults/
+            publishOnError: true
+            includeForks: true
+
+      - template: jobs/default-build.yml
+        parameters:
+          condition: ne(variables['SkipTests'], 'true')
+          jobName: Linux_Test
+          jobDisplayName: "Test: Ubuntu x64"
+          agentOs: Linux
+          isTestingJob: true
+          useHostedUbuntu: false
+          buildArgs: --all --test "/p:RunTemplateTests=false /p:SkipComponentsE2ETests=true /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
+          beforeBuild:
+          - bash: "./eng/scripts/install-nginx-linux.sh"
+            displayName: Installing Nginx
+          - bash: "echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p"
+            displayName: Increase inotify limit
+          artifacts:
+          - name: Linux_Test_Logs
+            path: artifacts/log/
+            publishOnError: true
+            includeForks: true
+          - name: Linux_Test_Results
+            path: artifacts/TestResults/
+            publishOnError: true
+            includeForks: true
+
+      # Helix x64
+      - template: jobs/default-build.yml
+        parameters:
+          jobName: Helix_x64
+          jobDisplayName: 'Tests: Helix x64'
+          agentOs: Windows
+          timeoutInMinutes: 240
+          steps:
+          # Build the shared framework
+          - script: ./eng/build.cmd -ci -nobl -all -pack -arch x64
+                    /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
+            displayName: Build shared fx
+          - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -restore -noBuild -noBuildNative -projects src/Grpc/**/*.csproj
+                    /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
+            displayName: Restore interop projects
+          - script: ./eng/build.cmd -ci -nobl -noBuildRepoTasks -noRestore -test -all -noBuildNative -projects eng\helix\helix.proj
+                    /p:IsRequiredCheck=true /p:IsHelixJob=true /p:BuildInteropProjects=true /p:RunTemplateTests=true /p:SkipComponentsE2ETests=true
+                    /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
+            displayName: Run build.cmd helix target
+            env:
+              HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
+
+          artifacts:
+          - name: Helix_logs
+            path: artifacts/log/
+            publishOnError: true
+            includeForks: true
+
+    # Source build
+    - template: /eng/common/templates/job/source-build.yml
+      parameters:
+        platform:
+          name: 'Managed'
+          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-20210714125435-9b5bbc2'
+          buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks $(_InternalRuntimeDownloadArgs)'
+          skipPublishValidation: true
+
+    # Publish to the BAR
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: /eng/common/templates/job/publish-build-assets.yml
+        parameters:
+          dependsOn:
+            - Windows_build
+            - Windows_arm_build
+            - Windows_arm64_build
+            - ${{ if ne(variables['PostBuildSign'], 'true') }}:
+              - CodeSign_Xplat_MacOS_arm64
+              - CodeSign_Xplat_MacOS_x64
+              - CodeSign_Xplat_Linux_x64
+              - CodeSign_Xplat_Linux_arm
+              - CodeSign_Xplat_Linux_arm64
+              - CodeSign_Xplat_Linux_musl_x64
+              - CodeSign_Xplat_Linux_musl_arm
+              - CodeSign_Xplat_Linux_musl_arm64
+            - ${{ if eq(variables['PostBuildSign'], 'true') }}:
+              - MacOs_arm64_build
+              - MacOs_x64_build
+              - Linux_x64_build
+              - Linux_arm_build
+              - Linux_arm64_build
+              - Linux_musl_x64_build
+              - Linux_musl_arm_build
+              - Linux_musl_arm64_build
+            # In addition to the dependencies above, ensure the build was successful overall.
+            - Source_Build_Managed
+          pool:
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals 1es-windows-2019
+          publishUsingPipelines: ${{ variables._PublishUsingPipelines }}
+          enablePublishBuildArtifacts: true # publish artifacts/log files
+
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables.runCodeQL3000, 'true')) }}:
   - template: /eng/common/templates/post-build/post-build.yml
     parameters:
       publishingInfraVersion: 3

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -33,8 +33,10 @@
 #       This build definition is enabled for code signing. (Only applies to Windows)
 #   buildDirectory: string
 #       Specifies what directory to run build.sh/cmd
-#   skipComponentGovernanceDetection: boolean
-#       Determines if component governance detection can be skipped
+#   enableSbom: boolean
+#       Determines if an SBOM should be created. Defaults to true. Ignored in public builds.
+#   variables: [array]
+#       Job-specific variables. Defined using either name/value pairs or a variable list (using name or group syntax).
 #
 # See https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema for details
 #
@@ -53,12 +55,13 @@ parameters:
   # jobDisplayName: '' - use agentOs by default.
   artifacts: []
   buildDirectory: $(System.DefaultWorkingDirectory)/eng/
+  enableSbom: true
+  variables: []
   installNodeJs: true
   installJdk: true
   timeoutInMinutes: 180
   testRunTitle: $(AgentOsName)-$(BuildConfiguration)
   useHostedUbuntu: true
-  skipComponentGovernanceDetection: false
 
   # We need longer than the default amount of 5 minutes to upload our logs/artifacts. (We currently take around 5 mins in the best case).
   # This makes sure we have time to upload everything in the case of a build timeout - really important for investigating a build
@@ -85,6 +88,7 @@ jobs:
     enablePublishTestResults: ${{ eq(parameters.isTestingJob, 'true') }} # publish test results to AzDO (populates AzDO Tests tab)
     mergeTestResults: true
     testRunTitle: ${{ parameters.testRunTitle }}
+    enableSbom: ${{ parameters.enableSbom }}
     enableTelemetry: true
     helixRepo: dotnet/aspnetcore
     helixType: build.product/
@@ -146,6 +150,28 @@ jobs:
     - LC_ALL: 'en_US.UTF-8'
     - LANG: 'en_US.UTF-8'
     - LANGUAGE: 'en_US.UTF-8'
+    # Rely on task Arcade injects, not auto-injected build step.
+    - skipComponentGovernanceDetection: true
+    - ${{ each variable in parameters.variables }}:
+      # handle a variable list using "name" and "value" properties
+      # example:
+      # - name: [key]
+      #   value: [value]
+      - ${{ if ne(variable.name, '') }}:
+        - name: ${{ variable.name }}
+          value: ${{ variable.value }}
+
+      # handle variable groups
+      - ${{ if ne(variable.group, '') }}:
+        - group: ${{ variable.group }}
+
+      # handle name/value pairs (converting them into variable list entries)
+      # example:
+      # - [name]: [value]
+      - ${{ if and(eq(variable.name, ''), eq(variable.group, '')) }}:
+        - ${{ each pair in variable }}:
+          - name: ${{ pair.key }}
+            value: ${{ pair.value }}
     steps:
     - ${{ if ne(parameters.agentOs, 'Windows') }}:
       - script: df -h
@@ -258,12 +284,6 @@ jobs:
         displayName: Kill processes
         continueOnError: true
         condition: always()
-
-    # Run component detection after all successful Build:* jobs unless overridden e.g. for Alpine build.
-    # Make sure auto-injected component detection does _not_ execute in other jobs nor when overridden.
-    - ${{ if or(not(startsWith(parameters.jobDisplayName, 'Build:')), eq(parameters.skipComponentGovernanceDetection, 'true')) }}:
-      - script:  echo "##vso[task.setvariable variable=CG_RAN]true"
-        displayName: 'Skip Component Detection'
 
     - ${{ each artifact in parameters.artifacts }}:
       - task: PublishBuildArtifacts@1

--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,12 @@
+{
+  "areaPath": "DevDiv\\ASP.NET Core",
+  "codebaseName": "AspNetCore",
+  "instanceUrl": "https://devdiv.visualstudio.com/",
+  "iterationPath": "DevDiv",
+  "notificationAliases": [
+    "aspnetcore-build@microsoft.com"
+  ],
+  "projectName": "DEVDIV",
+  "repositoryName": "AspNetCore",
+  "template": "TFSDEVDIV"
+}


### PR DESCRIPTION
- backport of #44688, via #44717
- add new schedule for a weekly run
- add top-level parameter enabling CodeQL3000 in manual builds
- add `enableSBOM` and `variables` parameters in default-build.yml
- add a separate job w/ CodeQL3000 tasks included in build steps; run this job alone
  - use the new default-build.yml parameters
  - set `$(UseSharedCompilation)` to `false` to ease analysis
- tag CodeQL3000 runs
- add a tsaoptions.json file
  - cribbed values from our eng/sdl-tsa-vars.config file

nit: Unconditionally disable the auto-injected component governance build step
- job.yml inserts the task where we need (unless overridden)