### PR TITLE
 [release/2.1] Add CodeQL3000 run to aspnetcore-ci-official

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -12,6 +12,27 @@ pr:
     include:
     - '*'
 
+schedules:
+- cron: 0 9 * * 1
+  displayName: "Run CodeQL3000 weekly, Monday at 2:00 AM PDT"
+  branches:
+    include:
+    - release/2.1
+    - release/6.0
+    - release/7.0
+    - main
+  always: true
+
+parameters:
+# Parameter below is ignored in public builds.
+#
+# Choose whether to run the CodeQL3000 tasks.
+# Manual builds align w/ official builds unless this parameter is true.
+- name: runCodeQL3000
+  default: false
+  displayName: Run CodeQL3000 tasks
+  type: boolean
+
 variables:
 - name: ASPNETCORE_TEST_LOG_MAXPATH
   value: "200" # Keep test log file name length low enough for artifact zipping
@@ -31,451 +52,496 @@ variables:
             /t:GeneratePropsFiles
             /t:BuildSharedFx
             $(BuildNumberArg)'
+- name: runCodeQL3000
+  value: ${{ or(eq(variables['Build.Reason'], 'Schedule'), and(eq(variables['Build.Reason'], 'Manual'), eq(parameters.runCodeQL3000, 'true'))) }}
 
 jobs:
-- template: jobs/default-build.yml
-  parameters:
-    jobName: Windows_Build
-    jobDisplayName: "Build and test: Windows"
-    buildArgs: $(BuildNumberArg)
-    codeSign: true
-    beforeBuild:
-    - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1"
-      displayName: Setup IISExpress test certificates
-    # Skip tests by default in internal non-PR builds.
-    ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), eq(variables.runCodeQL3000, 'true')) }}:
+  - template: jobs/default-build.yml
+    parameters:
+      jobName: build
+      jobDisplayName: Build and run CodeQL3000
+      agentOs: Windows
+      codeSign: false
+      timeoutInMinutes: 180
       variables:
-        PB_SKIPTESTS: ${{ coalesce(variables.PB_SKIPTESTS, 'true') }}
+        # No need for testing here.
+        PB_SKIPTESTS: true
+        # Security analysis is included in normal runs. Disable its auto-injection.
+        skipNugetSecurityAnalysis: true
+        # Do not let CodeQL3000 Extension gate scan frequency.
+        Codeql.Cadence: 0
+        # Enable CodeQL3000 unconditionally so it may be run on any branch.
+        Codeql.Enabled: true
+        # Ignore the small amount of infrastructure Python code in this repo.
+        Codeql.Language: cpp,csharp,java,javascript
+        Codeql.ExcludePathPatterns: submodules
+        # Ignore test and infrastructure code.
+        Codeql.SourceRoot: src
+        # CodeQL3000 needs this plumbed along as a variable to enable TSA.
+        Codeql.TSAEnabled: ${{ eq(variables['Build.Reason'], 'Schedule') }}
+        # Default expects tsaoptions.json under SourceRoot.
+        Codeql.TSAOptionsPath: '$(Build.SourcesDirectory)/.config/tsaoptions.json'
+      beforeBuild:
+      - task: CodeQL3000Init@0
+        displayName: CodeQL Initialize
+      - script: "echo ##vso[build.addbuildtag]CodeQL3000"
+        displayName: 'Set CI CodeQL3000 tag'
+        condition: ne(variables.CODEQL_DIST,'')
+      buildArgs: $(BuildNumberArg) /p:UseSharedCompilation=false
+      afterBuild:
+      - task: CodeQL3000Finalize@0
+        displayName: CodeQL Finalize
+      artifacts:
+      - name: Build_Logs
+        path: artifacts/log/
+        publishOnError: true
+        includeForks: true
 
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - job: Windows_SharedFx
-    displayName: Build Windows x64/x86 SharedFx
-    dependsOn: Windows_Build
-    timeoutInMinutes: 90
-    workspace:
-      clean: all
-    pool:
-      name: NetCore1ESPool-Svc-Internal
-      demands: ImageOverride -equals 1es-windows-2019
-    variables:
-      _SignType: real
-      JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
-      PB_SKIPTESTS: 'true'
-    steps:
-    - checkout: self
-      clean: true
-    - task: NodeTool@0
-      displayName: Install Node 10.x
-      inputs:
-        versionSpec: 10.x
-    - powershell: ./eng/scripts/InstallJdk.ps1 '11.0.1'
-      displayName: Install JDK 11
-    - task: NuGetCommand@2
-      displayName: 'Clear NuGet caches'
-      inputs:
-        command: custom
-        arguments: 'locals all -clear'
-    - task: MicroBuildSigningPlugin@2
-      displayName: Install MicroBuild Signing plugin
-      inputs:
-        signType: $(_SignType)
-        zipSources: false
-        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-    - task: DownloadBuildArtifacts@0
-      displayName: Download artifacts
-      inputs:
-        artifactName: artifacts-Windows-Release
-        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
-    - task: CopyFiles@2
-      displayName: Copy artifacts to .deps/
-      inputs:
-        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-Release/
-        contents: '**'
-        targetFolder: $(Build.SourcesDirectory)/.deps/
-    - script: .\build.cmd
-              -ci
-              /p:SignType=$(_SignType)
-              $(SharedFxArgs)
-              /p:SharedFxRID=win-x64
-              /bl:artifacts/logs/SharedFx-win-x64.binlog
-      env:
-        PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
-        PB_ASSETROOTURL: $(PB_AssetRootUrl)
-        PB_RESTORESOURCE: $(PB_RestoreSource)
-        PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
-      displayName: Build win-x64 SharedFX
-    - powershell: eng\scripts\KillProcesses.ps1
-      displayName: Kill processes
-      condition: always()
-    - script: .\build.cmd
-              -ci
-              /p:SignType=$(_SignType)
-              $(SharedFxArgs)
-              /p:SharedFxRID=win-x86
-              /bl:artifacts/logs/SharedFx-win-x86.binlog
-      env:
-        PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
-        PB_ASSETROOTURL: $(PB_AssetRootUrl)
-        PB_RESTORESOURCE: $(PB_RestoreSource)
-        PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
-      displayName: Build win-x86 SharedFX
-    - powershell: eng\scripts\KillProcesses.ps1
-      displayName: Kill processes
-      condition: always()
-    - script: .\build.cmd
-              -ci
-              /p:SignType=$(_SignType)
-              $(BuildNumberArg)
-              /p:SkipArtifactInfoTargets=true
-              /p:DisableSignCheck=true
-              /t:DoCodeSigning
-              /bl:artifacts/logs/CodeSign.binlog
-      env:
-        PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
-        PB_ASSETROOTURL: $(PB_AssetRootUrl)
-        PB_RESTORESOURCE: $(PB_RestoreSource)
-        PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
-      displayName: Code Sign
-    - powershell: eng\scripts\KillProcesses.ps1
-      displayName: Kill processes
-      condition: always()
-    - task: MicroBuildCleanup@1
-      displayName: Cleanup MicroBuild tasks
-      condition: always()
-    - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
-      - task: PublishBuildArtifacts@1
-        displayName: Upload artifacts
-        condition: always()
-        continueOnError: true
+- ${{ else }}: # regular build
+  - template: jobs/default-build.yml
+    parameters:
+      jobName: Windows_Build
+      jobDisplayName: "Build and test: Windows"
+      buildArgs: $(BuildNumberArg)
+      codeSign: true
+      beforeBuild:
+      - powershell: "& ./src/Servers/IIS/tools/UpdateIISExpressCertificate.ps1"
+        displayName: Setup IISExpress test certificates
+      # Skip tests by default in internal non-PR builds.
+      ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        variables:
+          PB_SKIPTESTS: ${{ coalesce(variables.PB_SKIPTESTS, 'true') }}
+
+  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    - job: Windows_SharedFx
+      displayName: Build Windows x64/x86 SharedFx
+      dependsOn: Windows_Build
+      timeoutInMinutes: 90
+      workspace:
+        clean: all
+      pool:
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals 1es-windows-2019
+      variables:
+        _SignType: real
+        JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
+        PB_SKIPTESTS: 'true'
+      steps:
+      - checkout: self
+        clean: true
+      - task: NodeTool@0
+        displayName: Install Node 10.x
         inputs:
-          pathtoPublish: artifacts/
+          versionSpec: 10.x
+      - powershell: ./eng/scripts/InstallJdk.ps1 '11.0.1'
+        displayName: Install JDK 11
+      - task: NuGetCommand@2
+        displayName: 'Clear NuGet caches'
+        inputs:
+          command: custom
+          arguments: 'locals all -clear'
+      - task: MicroBuildSigningPlugin@2
+        displayName: Install MicroBuild Signing plugin
+        inputs:
+          signType: $(_SignType)
+          zipSources: false
+          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+      - task: DownloadBuildArtifacts@0
+        displayName: Download artifacts
+        inputs:
+          artifactName: artifacts-Windows-Release
+          downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+      - task: CopyFiles@2
+        displayName: Copy artifacts to .deps/
+        inputs:
+          sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-Release/
+          contents: '**'
+          targetFolder: $(Build.SourcesDirectory)/.deps/
+      - script: .\build.cmd
+                -ci
+                /p:SignType=$(_SignType)
+                $(SharedFxArgs)
+                /p:SharedFxRID=win-x64
+                /bl:artifacts/logs/SharedFx-win-x64.binlog
+        env:
+          PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+          PB_ASSETROOTURL: $(PB_AssetRootUrl)
+          PB_RESTORESOURCE: $(PB_RestoreSource)
+          PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
+        displayName: Build win-x64 SharedFX
+      - powershell: eng\scripts\KillProcesses.ps1
+        displayName: Kill processes
+        condition: always()
+      - script: .\build.cmd
+                -ci
+                /p:SignType=$(_SignType)
+                $(SharedFxArgs)
+                /p:SharedFxRID=win-x86
+                /bl:artifacts/logs/SharedFx-win-x86.binlog
+        env:
+          PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+          PB_ASSETROOTURL: $(PB_AssetRootUrl)
+          PB_RESTORESOURCE: $(PB_RestoreSource)
+          PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
+        displayName: Build win-x86 SharedFX
+      - powershell: eng\scripts\KillProcesses.ps1
+        displayName: Kill processes
+        condition: always()
+      - script: .\build.cmd
+                -ci
+                /p:SignType=$(_SignType)
+                $(BuildNumberArg)
+                /p:SkipArtifactInfoTargets=true
+                /p:DisableSignCheck=true
+                /t:DoCodeSigning
+                /bl:artifacts/logs/CodeSign.binlog
+        env:
+          PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+          PB_ASSETROOTURL: $(PB_AssetRootUrl)
+          PB_RESTORESOURCE: $(PB_RestoreSource)
+          PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
+        displayName: Code Sign
+      - powershell: eng\scripts\KillProcesses.ps1
+        displayName: Kill processes
+        condition: always()
+      - task: MicroBuildCleanup@1
+        displayName: Cleanup MicroBuild tasks
+        condition: always()
+      - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
+        - task: PublishBuildArtifacts@1
+          displayName: Upload artifacts
+          condition: always()
+          continueOnError: true
+          inputs:
+            pathtoPublish: artifacts/
+            artifactName: artifacts-Windows-SharedFx
+            artifactType: Container
+            parallel: true
+        - task: PublishBuildArtifacts@1
+          displayName: Upload dependencies.g.props
+          condition: always()
+          continueOnError: true
+          inputs:
+            pathtoPublish: .deps/dependencies.g.props
+            artifactName: artifacts-dependencies-props
+            artifactType: Container
+            parallel: true
+
+    - job: Windows_Installers
+      displayName: Build Windows Installers
+      dependsOn: Windows_SharedFx
+      timeoutInMinutes: 90
+      workspace:
+        clean: all
+      pool:
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals 1es-windows-2019
+      variables:
+        _SignType: real
+        JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
+        PB_SKIPTESTS: 'true'
+      steps:
+      - checkout: self
+        clean: true
+      - task: NuGetCommand@2
+        displayName: 'Clear NuGet caches'
+        inputs:
+          command: custom
+          arguments: 'locals all -clear'
+      - task: MicroBuildSigningPlugin@2
+        displayName: Install MicroBuild Signing plugin
+        inputs:
+          signType: $(_SignType)
+          zipSources: false
+          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+      - task: DownloadBuildArtifacts@0
+        displayName: Download artifacts
+        inputs:
           artifactName: artifacts-Windows-SharedFx
-          artifactType: Container
-          parallel: true
-      - task: PublishBuildArtifacts@1
-        displayName: Upload dependencies.g.props
-        condition: always()
-        continueOnError: true
+          downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+      - task: DownloadBuildArtifacts@0
+        displayName: Download dependencies.g.props
         inputs:
-          pathtoPublish: .deps/dependencies.g.props
           artifactName: artifacts-dependencies-props
-          artifactType: Container
-          parallel: true
-
-  - job: Windows_Installers
-    displayName: Build Windows Installers
-    dependsOn: Windows_SharedFx
-    timeoutInMinutes: 90
-    workspace:
-      clean: all
-    pool:
-      name: NetCore1ESPool-Svc-Internal
-      demands: ImageOverride -equals 1es-windows-2019
-    variables:
-      _SignType: real
-      JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
-      PB_SKIPTESTS: 'true'
-    steps:
-    - checkout: self
-      clean: true
-    - task: NuGetCommand@2
-      displayName: 'Clear NuGet caches'
-      inputs:
-        command: custom
-        arguments: 'locals all -clear'
-    - task: MicroBuildSigningPlugin@2
-      displayName: Install MicroBuild Signing plugin
-      inputs:
-        signType: $(_SignType)
-        zipSources: false
-        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-    - task: DownloadBuildArtifacts@0
-      displayName: Download artifacts
-      inputs:
-        artifactName: artifacts-Windows-SharedFx
-        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
-    - task: DownloadBuildArtifacts@0
-      displayName: Download dependencies.g.props
-      inputs:
-        artifactName: artifacts-dependencies-props
-        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
-    - task: CopyFiles@2
-      displayName: Copy SharedFx artifacts to .deps/
-      inputs:
-        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/SharedFX/
-        contents: '**'
-        targetFolder: $(Build.SourcesDirectory)/.deps/fx/
-    - task: CopyFiles@2
-      displayName: Copy SharedFx artifacts to .deps/
-      inputs:
-        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/packages/
-        contents: 'Microsoft.AspNetCore.AspNetCoreModule*.nupkg'
-        targetFolder: $(Build.SourcesDirectory)/.deps/ANCM/
-    - task: CopyFiles@2
-      displayName: Copy dependencies.g.props to .deps/
-      inputs:
-        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-dependencies-props/
-        contents: 'dependencies.g.props'
-        targetFolder: $(Build.SourcesDirectory)/.deps/
-    - powershell: src/Installers/Windows/build.ps1
-        -Config Release
-        -BuildNumber $(Build.BuildId)
-      env:
-        PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
-        PB_ASSETROOTURL: $(PB_AssetRootUrl)
-        PB_RESTORESOURCE: $(PB_RestoreSource)
-        PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
-      displayName: Run src/Installers/Windows/build.ps1
-    - powershell: eng\scripts\KillProcesses.ps1
-      displayName: Kill processes
-      condition: always()
-    - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
-      - task: PublishBuildArtifacts@1
-        displayName: Upload artifacts
-        condition: always()
-        continueOnError: true
+          downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+      - task: CopyFiles@2
+        displayName: Copy SharedFx artifacts to .deps/
         inputs:
-          pathtoPublish: artifacts/
-          artifactName: artifacts-Windows-Installers
-          artifactType: Container
-          parallel: true
+          sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/SharedFX/
+          contents: '**'
+          targetFolder: $(Build.SourcesDirectory)/.deps/fx/
+      - task: CopyFiles@2
+        displayName: Copy SharedFx artifacts to .deps/
+        inputs:
+          sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/packages/
+          contents: 'Microsoft.AspNetCore.AspNetCoreModule*.nupkg'
+          targetFolder: $(Build.SourcesDirectory)/.deps/ANCM/
+      - task: CopyFiles@2
+        displayName: Copy dependencies.g.props to .deps/
+        inputs:
+          sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-dependencies-props/
+          contents: 'dependencies.g.props'
+          targetFolder: $(Build.SourcesDirectory)/.deps/
+      - powershell: src/Installers/Windows/build.ps1
+          -Config Release
+          -BuildNumber $(Build.BuildId)
+        env:
+          PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+          PB_ASSETROOTURL: $(PB_AssetRootUrl)
+          PB_RESTORESOURCE: $(PB_RestoreSource)
+          PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
+        displayName: Run src/Installers/Windows/build.ps1
+      - powershell: eng\scripts\KillProcesses.ps1
+        displayName: Kill processes
+        condition: always()
+      - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
+        - task: PublishBuildArtifacts@1
+          displayName: Upload artifacts
+          condition: always()
+          continueOnError: true
+          inputs:
+            pathtoPublish: artifacts/
+            artifactName: artifacts-Windows-Installers
+            artifactType: Container
+            parallel: true
 
-  - job: Package_Archive
-    displayName: Build Package Archive
-    dependsOn: Windows_SharedFx
-    timeoutInMinutes: 90
-    workspace:
-      clean: all
-    pool:
-      name: NetCore1ESPool-Svc-Internal
-      demands: ImageOverride -equals 1es-windows-2019
-    variables:
-      _SignType: real
-      JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
-      PB_SKIPTESTS: 'true'
-    steps:
-    - checkout: self
-      clean: true
-    - task: NuGetCommand@2
-      displayName: 'Clear NuGet caches'
-      inputs:
-        command: custom
-        arguments: 'locals all -clear'
-    - task: DownloadBuildArtifacts@0
-      displayName: Download artifacts
-      inputs:
-        artifactName: artifacts-Windows-SharedFx
-        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
-    - task: CopyFiles@2
-      displayName: Copy artifacts to .deps/
-      inputs:
-        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/
-        contents: '**'
-        targetFolder: $(Build.SourcesDirectory)/.deps/Signed/
-    - script: .\build.cmd
-              -ci
-              $(BuildNumberArg)
-              /p:SignType=$(_SignType)
-              /t:BuildFallbackArchive
-              /bl:artifacts/logs/PackageArchive.binlog
-      env:
-        PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
-        PB_ASSETROOTURL: $(PB_AssetRootUrl)
-        PB_RESTORESOURCE: $(PB_RestoreSource)
-        PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
+    - job: Package_Archive
       displayName: Build Package Archive
-    - powershell: eng\scripts\KillProcesses.ps1
-      displayName: Kill processes
-      condition: always()
-    - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
-      - task: PublishBuildArtifacts@1
-        displayName: Upload artifacts
-        condition: always()
-        continueOnError: true
+      dependsOn: Windows_SharedFx
+      timeoutInMinutes: 90
+      workspace:
+        clean: all
+      pool:
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals 1es-windows-2019
+      variables:
+        _SignType: real
+        JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
+        PB_SKIPTESTS: 'true'
+      steps:
+      - checkout: self
+        clean: true
+      - task: NuGetCommand@2
+        displayName: 'Clear NuGet caches'
         inputs:
-          pathtoPublish: artifacts/
-          artifactName: artifacts-Package-Archive
-          artifactType: Container
-          parallel: true
+          command: custom
+          arguments: 'locals all -clear'
+      - task: DownloadBuildArtifacts@0
+        displayName: Download artifacts
+        inputs:
+          artifactName: artifacts-Windows-SharedFx
+          downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+      - task: CopyFiles@2
+        displayName: Copy artifacts to .deps/
+        inputs:
+          sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/
+          contents: '**'
+          targetFolder: $(Build.SourcesDirectory)/.deps/Signed/
+      - script: .\build.cmd
+                -ci
+                $(BuildNumberArg)
+                /p:SignType=$(_SignType)
+                /t:BuildFallbackArchive
+                /bl:artifacts/logs/PackageArchive.binlog
+        env:
+          PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+          PB_ASSETROOTURL: $(PB_AssetRootUrl)
+          PB_RESTORESOURCE: $(PB_RestoreSource)
+          PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
+        displayName: Build Package Archive
+      - powershell: eng\scripts\KillProcesses.ps1
+        displayName: Kill processes
+        condition: always()
+      - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
+        - task: PublishBuildArtifacts@1
+          displayName: Upload artifacts
+          condition: always()
+          continueOnError: true
+          inputs:
+            pathtoPublish: artifacts/
+            artifactName: artifacts-Package-Archive
+            artifactType: Container
+            parallel: true
 
-  - job: SharedFX_Installers
-    displayName: Build SharedFX Installers
-    dependsOn: Windows_SharedFx
-    timeoutInMinutes: 90
-    workspace:
-      clean: all
-    pool:
-      name: NetCore1ESPool-Svc-Internal
-      demands: ImageOverride -equals 1es-windows-2019
-    variables:
-      LC_ALL: 'en_US.UTF-8'
-      LANG: 'en_US.UTF-8'
-      LANGUAGE: 'en_US.UTF-8'
-      PB_SKIPTESTS: 'true'
-    steps:
-    - checkout: self
-      clean: true
-    - task: NuGetCommand@2
-      displayName: 'Clear NuGet caches'
-      inputs:
-        command: custom
-        arguments: 'locals all -clear'
-    - task: DownloadBuildArtifacts@0
-      displayName: Download Windows SharedFx artifacts
-      inputs:
-        artifactName: artifacts-Windows-SharedFx
-        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
-    - task: CopyFiles@2
-      displayName: Copy Windows SharedFx artifacts to .deps/
-      inputs:
-        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/
-        contents: '**'
-        targetFolder: $(Build.SourcesDirectory)/.deps/Signed/
-    - script: .\build.cmd
-              -ci
-              $(BuildNumberArg)
-              /t:BuildInstallers
-              /bl:artifacts/logs/SharedFx-Installers.binlog
-      env:
-        PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
-        PB_ASSETROOTURL: $(PB_AssetRootUrl)
-        PB_RESTORESOURCE: $(PB_RestoreSource)
-        PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
+    - job: SharedFX_Installers
       displayName: Build SharedFX Installers
-    - powershell: eng\scripts\KillProcesses.ps1
-      displayName: Kill processes
-      condition: always()
-    - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
-      - task: PublishBuildArtifacts@1
-        displayName: Upload artifacts
-        condition: always()
-        continueOnError: true
+      dependsOn: Windows_SharedFx
+      timeoutInMinutes: 90
+      workspace:
+        clean: all
+      pool:
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals 1es-windows-2019
+      variables:
+        LC_ALL: 'en_US.UTF-8'
+        LANG: 'en_US.UTF-8'
+        LANGUAGE: 'en_US.UTF-8'
+        PB_SKIPTESTS: 'true'
+      steps:
+      - checkout: self
+        clean: true
+      - task: NuGetCommand@2
+        displayName: 'Clear NuGet caches'
         inputs:
-          pathtoPublish: artifacts/
-          artifactName: artifacts-SharedFx-Installers
-          artifactType: Container
-          parallel: true
+          command: custom
+          arguments: 'locals all -clear'
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Windows SharedFx artifacts
+        inputs:
+          artifactName: artifacts-Windows-SharedFx
+          downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+      - task: CopyFiles@2
+        displayName: Copy Windows SharedFx artifacts to .deps/
+        inputs:
+          sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/
+          contents: '**'
+          targetFolder: $(Build.SourcesDirectory)/.deps/Signed/
+      - script: .\build.cmd
+                -ci
+                $(BuildNumberArg)
+                /t:BuildInstallers
+                /bl:artifacts/logs/SharedFx-Installers.binlog
+        env:
+          PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+          PB_ASSETROOTURL: $(PB_AssetRootUrl)
+          PB_RESTORESOURCE: $(PB_RestoreSource)
+          PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
+        displayName: Build SharedFX Installers
+      - powershell: eng\scripts\KillProcesses.ps1
+        displayName: Kill processes
+        condition: always()
+      - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
+        - task: PublishBuildArtifacts@1
+          displayName: Upload artifacts
+          condition: always()
+          continueOnError: true
+          inputs:
+            pathtoPublish: artifacts/
+            artifactName: artifacts-SharedFx-Installers
+            artifactType: Container
+            parallel: true
 
-  - job: Publish
-    displayName: Publish
-    dependsOn:
-      - Windows_Installers
-      - SharedFX_Installers
-      - Package_Archive
-    timeoutInMinutes: 90
-    workspace:
-      clean: all
-    pool:
-      name: NetCore1ESPool-Svc-Internal
-      demands: ImageOverride -equals 1es-windows-2019
-    variables:
-      _SignType: real
-      JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
-      PB_SKIPTESTS: 'true'
-    steps:
-    - checkout: self
-      clean: true
-    - task: NuGetCommand@2
-      displayName: 'Clear NuGet caches'
-      inputs:
-        command: custom
-        arguments: 'locals all -clear'
-    - task: DownloadBuildArtifacts@0
-      displayName: Download Windows artifacts
-      inputs:
-        artifactName: artifacts-Windows-Release
-        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
-    - task: DownloadBuildArtifacts@0
-      displayName: Download Windows SharedFx artifacts
-      inputs:
-        artifactName: artifacts-Windows-SharedFx
-        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
-    - task: DownloadBuildArtifacts@0
-      displayName: Download Package Archive artifacts
-      inputs:
-        artifactName: artifacts-Package-Archive
-        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
-    - task: DownloadBuildArtifacts@0
-      displayName: Download SharedFx installer artifacts
-      inputs:
-        artifactName: artifacts-SharedFx-Installers
-        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
-    - task: DownloadBuildArtifacts@0
-      displayName: Download Windows installer artifacts
-      inputs:
-        artifactName: artifacts-Windows-Installers
-        downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
-    - task: CopyFiles@2
-      displayName: Copy Windows artifacts to .deps/assets
-      inputs:
-        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-Release/build/
-        contents: '**/*.tgz'
-        targetFolder: $(Build.SourcesDirectory)/.deps/assets/
-        flattenFolders: true
-    - task: CopyFiles@2
-      displayName: Copy Windows SharedFx artifacts to .deps/assets
-      inputs:
-        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/
-        contents: |
-          SharedFx/**
-          OobArchives/**
-        targetFolder: $(Build.SourcesDirectory)/.deps/assets/
-        flattenFolders: true
-    - task: CopyFiles@2
-      displayName: Copy Package Archive artifacts to .deps/assets
-      inputs:
-        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Package-Archive/lzma/
-        contents: '**'
-        targetFolder: $(Build.SourcesDirectory)/.deps/assets/
-    - task: CopyFiles@2
-      displayName: Copy SharedFx Installer artifacts to .deps/assets
-      inputs:
-        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-SharedFx-Installers/installers/
-        contents: '**'
-        targetFolder: $(Build.SourcesDirectory)/.deps/assets/
-    - task: CopyFiles@2
-      displayName: Copy Windows Installer artifacts to .deps/assets
-      inputs:
-        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-Installers/bin/Release/installers/
-        contents: |
-          en-US/*.msi
-          **/*.exe
-          **/*.wixlib
-          **/*.nupkg
-        targetFolder: $(Build.SourcesDirectory)/.deps/assets/
-        flattenFolders: true
-    - task: CopyFiles@2
-      displayName: Copy Windows SharedFx artifacts to .deps/packages
-      inputs:
-        sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/Packages/
-        contents: '**'
-        targetFolder: $(Build.SourcesDirectory)/.deps/packages/
-    - task: DeleteFiles@1
-      displayName: Delete korebuild.json
-      inputs:
-        contents: korebuild.json
-    - script: .\build.cmd
-              -ci
-              $(BuildNumberArg)
-              /t:Publish
-              /p:BuildBranch=$(Build.SourceBranchName)
-              /bl:artifacts/logs/Publish.binlog
-      env:
-        PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
-        PB_ASSETROOTURL: $(PB_AssetRootUrl)
-        PB_RESTORESOURCE: $(PB_RestoreSource)
-        PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
+    - job: Publish
       displayName: Publish
-    - powershell: eng\scripts\KillProcesses.ps1
-      displayName: Kill processes
-      condition: always()
-    - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
-      - task: PublishBuildArtifacts@1
-        displayName: Upload logs
-        condition: always()
-        continueOnError: true
+      dependsOn:
+        - Windows_Installers
+        - SharedFX_Installers
+        - Package_Archive
+      timeoutInMinutes: 90
+      workspace:
+        clean: all
+      pool:
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals 1es-windows-2019
+      variables:
+        _SignType: real
+        JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
+        PB_SKIPTESTS: 'true'
+      steps:
+      - checkout: self
+        clean: true
+      - task: NuGetCommand@2
+        displayName: 'Clear NuGet caches'
         inputs:
-          pathtoPublish: artifacts/logs
-          artifactName: artifacts-Publish
-          artifactType: Container
-          parallel: true
+          command: custom
+          arguments: 'locals all -clear'
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Windows artifacts
+        inputs:
+          artifactName: artifacts-Windows-Release
+          downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Windows SharedFx artifacts
+        inputs:
+          artifactName: artifacts-Windows-SharedFx
+          downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Package Archive artifacts
+        inputs:
+          artifactName: artifacts-Package-Archive
+          downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+      - task: DownloadBuildArtifacts@0
+        displayName: Download SharedFx installer artifacts
+        inputs:
+          artifactName: artifacts-SharedFx-Installers
+          downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Windows installer artifacts
+        inputs:
+          artifactName: artifacts-Windows-Installers
+          downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+      - task: CopyFiles@2
+        displayName: Copy Windows artifacts to .deps/assets
+        inputs:
+          sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-Release/build/
+          contents: '**/*.tgz'
+          targetFolder: $(Build.SourcesDirectory)/.deps/assets/
+          flattenFolders: true
+      - task: CopyFiles@2
+        displayName: Copy Windows SharedFx artifacts to .deps/assets
+        inputs:
+          sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/
+          contents: |
+            SharedFx/**
+            OobArchives/**
+          targetFolder: $(Build.SourcesDirectory)/.deps/assets/
+          flattenFolders: true
+      - task: CopyFiles@2
+        displayName: Copy Package Archive artifacts to .deps/assets
+        inputs:
+          sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Package-Archive/lzma/
+          contents: '**'
+          targetFolder: $(Build.SourcesDirectory)/.deps/assets/
+      - task: CopyFiles@2
+        displayName: Copy SharedFx Installer artifacts to .deps/assets
+        inputs:
+          sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-SharedFx-Installers/installers/
+          contents: '**'
+          targetFolder: $(Build.SourcesDirectory)/.deps/assets/
+      - task: CopyFiles@2
+        displayName: Copy Windows Installer artifacts to .deps/assets
+        inputs:
+          sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-Installers/bin/Release/installers/
+          contents: |
+            en-US/*.msi
+            **/*.exe
+            **/*.wixlib
+            **/*.nupkg
+          targetFolder: $(Build.SourcesDirectory)/.deps/assets/
+          flattenFolders: true
+      - task: CopyFiles@2
+        displayName: Copy Windows SharedFx artifacts to .deps/packages
+        inputs:
+          sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/Packages/
+          contents: '**'
+          targetFolder: $(Build.SourcesDirectory)/.deps/packages/
+      - task: DeleteFiles@1
+        displayName: Delete korebuild.json
+        inputs:
+          contents: korebuild.json
+      - script: .\build.cmd
+                -ci
+                $(BuildNumberArg)
+                /t:Publish
+                /p:BuildBranch=$(Build.SourceBranchName)
+                /bl:artifacts/logs/Publish.binlog
+        env:
+          PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+          PB_ASSETROOTURL: $(PB_AssetRootUrl)
+          PB_RESTORESOURCE: $(PB_RestoreSource)
+          PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
+        displayName: Publish
+      - powershell: eng\scripts\KillProcesses.ps1
+        displayName: Kill processes
+        condition: always()
+      - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
+        - task: PublishBuildArtifacts@1
+          displayName: Upload logs
+          condition: always()
+          continueOnError: true
+          inputs:
+            pathtoPublish: artifacts/logs
+            artifactName: artifacts-Publish
+            artifactType: Container
+            parallel: true

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -55,12 +55,13 @@ parameters:
     path: 'artifacts/'
   buildDirectory: ''
   buildArgs: ''
+  timeoutInMinutes: 90
 
 jobs:
 - job: ${{ coalesce(parameters.jobName, parameters.agentOs) }}
   displayName: ${{ coalesce(parameters.jobDisplayName, parameters.agentOs) }}
   dependsOn: ${{ parameters.dependsOn }}
-  timeoutInMinutes: 90
+  timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
   workspace:
     clean: all
   strategy:

--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,12 @@
+{
+  "areaPath": "DevDiv\\ASP.NET Core",
+  "codebaseName": "AspNetCore",
+  "instanceUrl": "https://devdiv.visualstudio.com/",
+  "iterationPath": "DevDiv",
+  "notificationAliases": [
+    "aspnetcore-build@microsoft.com"
+  ],
+  "projectName": "DEVDIV",
+  "repositoryName": "AspNetCore",
+  "template": "TFSDEVDIV"
+}


### PR DESCRIPTION
- backport of #44688, via #44717 and #44719
  - update a bit less because we're not using Arcade here
- add new schedule for a weekly run
- add top-level parameter enabling CodeQL3000 in manual builds
- add a separate job w/ CodeQL3000 tasks included in build steps; run this job alone
  - set `$(UseSharedCompilation)` to `false` to ease analysis
- tag CodeQL3000 runs
- add a tsaoptions.json file
  - cribbed values from our eng/sdl-tsa-vars.config file (in other branches)