### PR TITLE
Set ApiParameterDescription.Type to `string` for Simple Types

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -666,10 +666,18 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
 
         private static Type GetModelType(ModelMetadata metadata)
         {
-            // !IsParseableType && !IsConvertibleType
+            // IsParseableType || IsConvertibleType
             if (!metadata.IsComplexType)
             {
-                return metadata.ModelType.IsPrimitive ? metadata.ModelType : typeof(string);
+                return metadata.ModelType.IsPrimitive
+                    // Those additional types have TypeConverter or TryParse and are not primitives
+                    // but should not be considered string in the metadata
+                    || metadata.ModelType == typeof(DateTime)
+                    || metadata.ModelType == typeof(DateOnly)
+                    || metadata.ModelType == typeof(TimeOnly)
+                    || metadata.ModelType == typeof(decimal)
+                    || metadata.ModelType == typeof(Guid)
+                    || metadata.ModelType == typeof(Uri) ? metadata.ModelType : typeof(string);
             }
 
             return metadata.ModelType;

--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -673,6 +673,7 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
                     // Those additional types have TypeConverter or TryParse and are not primitives
                     // but should not be considered string in the metadata
                     || metadata.ModelType == typeof(DateTime)
+                    || metadata.ModelType == typeof(DateTimeOffset)                    
                     || metadata.ModelType == typeof(DateOnly)
                     || metadata.ModelType == typeof(TimeOnly)
                     || metadata.ModelType == typeof(decimal)

--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -673,7 +673,7 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
                     // Those additional types have TypeConverter or TryParse and are not primitives
                     // but should not be considered string in the metadata
                     || metadata.ModelType == typeof(DateTime)
-                    || metadata.ModelType == typeof(DateTimeOffset)                    
+                    || metadata.ModelType == typeof(DateTimeOffset)
                     || metadata.ModelType == typeof(DateOnly)
                     || metadata.ModelType == typeof(TimeOnly)
                     || metadata.ModelType == typeof(decimal)

--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -669,16 +669,16 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
             // IsParseableType || IsConvertibleType
             if (!metadata.IsComplexType)
             {
-                return metadata.ModelType.IsPrimitive
+                return metadata.UnderlyingOrModelType.IsPrimitive
                     // Those additional types have TypeConverter or TryParse and are not primitives
                     // but should not be considered string in the metadata
-                    || metadata.ModelType == typeof(DateTime)
-                    || metadata.ModelType == typeof(DateTimeOffset)
-                    || metadata.ModelType == typeof(DateOnly)
-                    || metadata.ModelType == typeof(TimeOnly)
-                    || metadata.ModelType == typeof(decimal)
-                    || metadata.ModelType == typeof(Guid)
-                    || metadata.ModelType == typeof(Uri) ? metadata.ModelType : typeof(string);
+                    || metadata.UnderlyingOrModelType == typeof(DateTime)
+                    || metadata.UnderlyingOrModelType == typeof(DateTimeOffset)
+                    || metadata.UnderlyingOrModelType == typeof(DateOnly)
+                    || metadata.UnderlyingOrModelType == typeof(TimeOnly)
+                    || metadata.UnderlyingOrModelType == typeof(decimal)
+                    || metadata.UnderlyingOrModelType == typeof(Guid)
+                    || metadata.UnderlyingOrModelType == typeof(Uri) ? metadata.ModelType : typeof(string);
             }
 
             return metadata.ModelType;

--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -666,7 +666,7 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
 
         private static Type GetModelType(ModelMetadata metadata)
         {
-            // !IsParseableType && IsConvertibleType
+            // !IsParseableType && !IsConvertibleType
             if (!metadata.IsComplexType)
             {
                 return metadata.ModelType.IsPrimitive ? metadata.ModelType : typeof(string);

--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -658,10 +658,21 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
                 ModelMetadata = bindingContext.ModelMetadata,
                 Name = GetName(containerName, bindingContext),
                 Source = source,
-                Type = bindingContext.ModelMetadata.ModelType,
+                Type = GetModelType(bindingContext.ModelMetadata),
                 ParameterDescriptor = Parameter,
                 BindingInfo = bindingContext.BindingInfo
             };
+        }
+
+        private static Type GetModelType(ModelMetadata metadata)
+        {
+            // !IsParseableType && IsConvertibleType
+            if (!metadata.IsComplexType)
+            {
+                return metadata.ModelType.IsPrimitive ? metadata.ModelType : typeof(string);
+            }
+
+            return metadata.ModelType;
         }
 
         private static string GetName(string containerName, ApiParameterDescriptionContext metadata)

--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -669,16 +669,7 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
             // IsParseableType || IsConvertibleType
             if (!metadata.IsComplexType)
             {
-                return metadata.UnderlyingOrModelType.IsPrimitive
-                    // Those additional types have TypeConverter or TryParse and are not primitives
-                    // but should not be considered string in the metadata
-                    || metadata.UnderlyingOrModelType == typeof(DateTime)
-                    || metadata.UnderlyingOrModelType == typeof(DateTimeOffset)
-                    || metadata.UnderlyingOrModelType == typeof(DateOnly)
-                    || metadata.UnderlyingOrModelType == typeof(TimeOnly)
-                    || metadata.UnderlyingOrModelType == typeof(decimal)
-                    || metadata.UnderlyingOrModelType == typeof(Guid)
-                    || metadata.UnderlyingOrModelType == typeof(Uri) ? metadata.ModelType : typeof(string);
+                return EndpointModelMetadata.GetDisplayType(metadata.ModelType);
             }
 
             return metadata.ModelType;

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
@@ -288,8 +289,8 @@ internal sealed class EndpointMetadataApiDescriptionProvider : IApiDescriptionPr
         else if (parameter.ParameterType == typeof(string) || ParameterBindingMethodCache.HasTryParseMethod(parameter.ParameterType))
         {
             // complex types will display as strings since they use custom parsing via TryParse on a string
-            var displayType = !parameter.ParameterType.IsPrimitive && Nullable.GetUnderlyingType(parameter.ParameterType)?.IsPrimitive != true
-                ? typeof(string) : parameter.ParameterType;
+            var displayType = EndpointModelMetadata.GetDisplayType(parameter.ParameterType);
+
             // Path vs query cannot be determined by RequestDelegateFactory at startup currently because of the layering, but can be done here.
             if (parameter.Name is { } name && pattern.GetParameter(name) is { } routeParam)
             {

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using System.Reflection;
-using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
@@ -16,7 +15,6 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Mvc.ApiExplorer;

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Mvc.ApiExplorer;

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointModelMetadata.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointModelMetadata.cs
@@ -51,4 +51,19 @@ internal sealed class EndpointModelMetadata : ModelMetadata
     public override string? TemplateHint { get; }
     public override bool ValidateChildren { get; }
     public override IReadOnlyList<object> ValidatorMetadata { get; } = Array.Empty<object>();
+
+    public static Type GetDisplayType(Type type)
+    {
+        var underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+        return underlyingType.IsPrimitive
+            // Those additional types have TypeConverter or TryParse and are not primitives
+            // but should not be considered string in the metadata
+            || underlyingType == typeof(DateTime)
+            || underlyingType == typeof(DateTimeOffset)
+            || underlyingType == typeof(DateOnly)
+            || underlyingType == typeof(TimeOnly)
+            || underlyingType == typeof(decimal)
+            || underlyingType == typeof(Guid)
+            || underlyingType == typeof(Uri) ? type : typeof(string);
+    }
 }

--- a/src/Mvc/Mvc.ApiExplorer/src/EndpointModelMetadata.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/EndpointModelMetadata.cs
@@ -62,6 +62,7 @@ internal sealed class EndpointModelMetadata : ModelMetadata
             || underlyingType == typeof(DateTimeOffset)
             || underlyingType == typeof(DateOnly)
             || underlyingType == typeof(TimeOnly)
+            || underlyingType == typeof(TimeSpan)
             || underlyingType == typeof(decimal)
             || underlyingType == typeof(Guid)
             || underlyingType == typeof(Uri) ? type : typeof(string);

--- a/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
@@ -1584,6 +1584,44 @@ public class DefaultApiDescriptionProviderTest
     }
 
     [Fact]
+    public void GetApiDescription_ParameterDescription_ParsablePrimitiveType()
+    {
+        // Arrange
+        var action = CreateActionDescriptor(nameof(AcceptsTryParsablePrimitiveType));
+        var parameterDescriptor = action.Parameters.Single();
+
+        // Act
+        var descriptions = GetApiDescriptions(action);
+
+        // Assert
+        var description = Assert.Single(descriptions);
+        Assert.Equal(1, description.ParameterDescriptions.Count);
+
+        var id = Assert.Single(description.ParameterDescriptions, p => p.Name == "id");
+        Assert.Same(BindingSource.Query, id.Source);
+        Assert.Equal(typeof(Guid), id.Type);
+    }
+
+    [Fact]
+    public void GetApiDescription_ParameterDescription_NullableParsablePrimitiveType()
+    {
+        // Arrange
+        var action = CreateActionDescriptor(nameof(AcceptsTryParsableNullablePrimitiveType));
+        var parameterDescriptor = action.Parameters.Single();
+
+        // Act
+        var descriptions = GetApiDescriptions(action);
+
+        // Assert
+        var description = Assert.Single(descriptions);
+        Assert.Equal(1, description.ParameterDescriptions.Count);
+
+        var id = Assert.Single(description.ParameterDescriptions, p => p.Name == "id");
+        Assert.Same(BindingSource.Query, id.Source);
+        Assert.Equal(typeof(Guid?), id.Type);
+    }
+
+    [Fact]
     public void GetApiDescription_ParameterDescription_ParsableType()
     {
         // Arrange
@@ -2451,6 +2489,14 @@ public class DefaultApiDescriptionProviderTest
     }
 
     private void AcceptsEmployee([FromQuery(Name = "employee")] Employee dto)
+    {
+    }
+
+    private void AcceptsTryParsablePrimitiveType([FromQuery] Guid id)
+    {
+    }
+
+    private void AcceptsTryParsableNullablePrimitiveType([FromQuery] Guid? id)
     {
     }
 

--- a/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
@@ -1603,10 +1603,48 @@ public class DefaultApiDescriptionProviderTest
     }
 
     [Fact]
+    public void GetApiDescription_ParameterDescription_NullableParsableType()
+    {
+        // Arrange
+        var action = CreateActionDescriptor(nameof(AcceptsNullableTryParsableEmployee));
+        var parameterDescriptor = action.Parameters.Single();
+
+        // Act
+        var descriptions = GetApiDescriptions(action);
+
+        // Assert
+        var description = Assert.Single(descriptions);
+        Assert.Equal(1, description.ParameterDescriptions.Count);
+
+        var id = Assert.Single(description.ParameterDescriptions, p => p.Name == "employee");
+        Assert.Same(BindingSource.Query, id.Source);
+        Assert.Equal(typeof(string), id.Type);
+    }
+
+    [Fact]
     public void GetApiDescription_ParameterDescription_ConvertibleType()
     {
         // Arrange
         var action = CreateActionDescriptor(nameof(AcceptsConvertibleEmployee));
+        var parameterDescriptor = action.Parameters.Single();
+
+        // Act
+        var descriptions = GetApiDescriptions(action);
+
+        // Assert
+        var description = Assert.Single(descriptions);
+        Assert.Equal(1, description.ParameterDescriptions.Count);
+
+        var id = Assert.Single(description.ParameterDescriptions, p => p.Name == "employee");
+        Assert.Same(BindingSource.Query, id.Source);
+        Assert.Equal(typeof(string), id.Type);
+    }
+
+    [Fact]
+    public void GetApiDescription_ParameterDescription_NullableConvertibleType()
+    {
+        // Arrange
+        var action = CreateActionDescriptor(nameof(AcceptsNullableConvertibleEmployee));
         var parameterDescriptor = action.Parameters.Single();
 
         // Act
@@ -2420,7 +2458,15 @@ public class DefaultApiDescriptionProviderTest
     {
     }
 
+    private void AcceptsNullableTryParsableEmployee([FromQuery] TryParsableEmployee? employee)
+    {
+    }
+
     private void AcceptsConvertibleEmployee([FromQuery] ConvertibleEmployee employee)
+    {
+    }
+
+    private void AcceptsNullableConvertibleEmployee([FromQuery] ConvertibleEmployee? employee)
     {
     }
 
@@ -2555,7 +2601,7 @@ public class DefaultApiDescriptionProviderTest
         public string Name { get; set; }
     }
 
-    private class TryParsableEmployee : IParsable<TryParsableEmployee>
+    private struct TryParsableEmployee : IParsable<TryParsableEmployee>
     {
         public string Name { get; set; }
 

--- a/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
@@ -2496,15 +2496,7 @@ public class DefaultApiDescriptionProviderTest
     {
     }
 
-    private void AcceptsTryParsableNullablePrimitiveType([FromQuery] Guid? id)
-    {
-    }
-
     private void AcceptsTryParsableEmployee([FromQuery] TryParsableEmployee employee)
-    {
-    }
-
-    private void AcceptsNullableTryParsableEmployee([FromQuery] TryParsableEmployee? employee)
     {
     }
 
@@ -2512,9 +2504,21 @@ public class DefaultApiDescriptionProviderTest
     {
     }
 
+#nullable enable
+
+    private void AcceptsNullableTryParsableEmployee([FromQuery] TryParsableEmployee? employee)
+    {
+    }
+
+    private void AcceptsTryParsableNullablePrimitiveType([FromQuery] Guid? id)
+    {
+    }
+
     private void AcceptsNullableConvertibleEmployee([FromQuery] ConvertibleEmployee? employee)
     {
     }
+
+#nullable restore
 
     private void AcceptsOrderDTO(OrderDTO dto)
     {

--- a/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
@@ -2,9 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Reflection;
 using System.Text;
+using System.Xml.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ActionConstraints;
@@ -1580,6 +1584,44 @@ public class DefaultApiDescriptionProviderTest
     }
 
     [Fact]
+    public void GetApiDescription_ParameterDescription_ParsableType()
+    {
+        // Arrange
+        var action = CreateActionDescriptor(nameof(AcceptsTryParsableEmployee));
+        var parameterDescriptor = action.Parameters.Single();
+
+        // Act
+        var descriptions = GetApiDescriptions(action);
+
+        // Assert
+        var description = Assert.Single(descriptions);
+        Assert.Equal(1, description.ParameterDescriptions.Count);
+
+        var id = Assert.Single(description.ParameterDescriptions, p => p.Name == "employee");
+        Assert.Same(BindingSource.Query, id.Source);
+        Assert.Equal(typeof(string), id.Type);
+    }
+
+    [Fact]
+    public void GetApiDescription_ParameterDescription_ConvertibleType()
+    {
+        // Arrange
+        var action = CreateActionDescriptor(nameof(AcceptsConvertibleEmployee));
+        var parameterDescriptor = action.Parameters.Single();
+
+        // Act
+        var descriptions = GetApiDescriptions(action);
+
+        // Assert
+        var description = Assert.Single(descriptions);
+        Assert.Equal(1, description.ParameterDescriptions.Count);
+
+        var id = Assert.Single(description.ParameterDescriptions, p => p.Name == "employee");
+        Assert.Same(BindingSource.Query, id.Source);
+        Assert.Equal(typeof(string), id.Type);
+    }
+
+    [Fact]
     public void GetApiDescription_ParameterDescription_FromQueryManager()
     {
         // Arrange
@@ -2374,6 +2416,14 @@ public class DefaultApiDescriptionProviderTest
     {
     }
 
+    private void AcceptsTryParsableEmployee([FromQuery] TryParsableEmployee employee)
+    {
+    }
+
+    private void AcceptsConvertibleEmployee([FromQuery] ConvertibleEmployee employee)
+    {
+    }
+
     private void AcceptsOrderDTO(OrderDTO dto)
     {
     }
@@ -2497,6 +2547,33 @@ public class DefaultApiDescriptionProviderTest
     private class Employee
     {
         public string Name { get; set; }
+    }
+
+    [TypeConverter(typeof(EmployeeConverter))]
+    private class ConvertibleEmployee
+    {
+        public string Name { get; set; }
+    }
+
+    private class TryParsableEmployee : IParsable<TryParsableEmployee>
+    {
+        public string Name { get; set; }
+
+        public static TryParsableEmployee Parse(string s, IFormatProvider provider)
+        {
+            if (TryParse(s, provider, out var result))
+            {
+                return result;
+            }
+
+            throw new FormatException($"{nameof(s)} is not in the correct format");
+        }
+
+        public static bool TryParse([NotNullWhen(true)] string s, IFormatProvider provider, [MaybeNullWhen(false)] out TryParsableEmployee result)
+        {
+            result = new() { Name = s };
+            return true;
+        }
     }
 
     private class Manager
@@ -2726,5 +2803,23 @@ public class DefaultApiDescriptionProviderTest
         public Type RequestType => null;
 
         public bool IsOptional => false;
+    }
+
+    private class EmployeeConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string input)
+            {
+                return new ConvertibleEmployee() { Name = input };
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
     }
 }

--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -299,6 +299,48 @@ public class EndpointMetadataApiDescriptionProviderTest
     }
 
     [Fact]
+    public void AddsFromRouteParameterAsPathWithSpecialPrimitiveType()
+    {
+        static void AssertPathParameter(ApiDescription apiDescription, Type expectedTYpe)
+        {
+            var param = Assert.Single(apiDescription.ParameterDescriptions);
+            Assert.Equal(expectedTYpe, param.Type);
+            Assert.Equal(expectedTYpe, param.ModelMetadata.ModelType);
+            Assert.Equal(BindingSource.Path, param.Source);
+        }
+
+        AssertPathParameter(GetApiDescription((DateTime foo) => { }, "/{foo}"), typeof(DateTime));
+        AssertPathParameter(GetApiDescription((DateTimeOffset foo) => { }, "/{foo}"), typeof(DateTimeOffset));
+        AssertPathParameter(GetApiDescription((DateOnly foo) => { }, "/{foo}"), typeof(DateOnly));
+        AssertPathParameter(GetApiDescription((TimeOnly foo) => { }, "/{foo}"), typeof(TimeOnly));
+        AssertPathParameter(GetApiDescription((TimeSpan foo) => { }, "/{foo}"), typeof(TimeSpan));
+        AssertPathParameter(GetApiDescription((decimal foo) => { }, "/{foo}"), typeof(decimal));
+        AssertPathParameter(GetApiDescription((Guid foo) => { }, "/{foo}"), typeof(Guid));
+        AssertPathParameter(GetApiDescription((Uri foo) => { }, "/{foo}"), typeof(Uri));
+    }
+
+    [Fact]
+    public void AddsFromRouteParameterAsPathWithNullableSpecialPrimitiveType()
+    {
+        static void AssertPathParameter(ApiDescription apiDescription, Type expectedTYpe)
+        {
+            var param = Assert.Single(apiDescription.ParameterDescriptions);
+            Assert.Equal(expectedTYpe, param.Type);
+            Assert.Equal(expectedTYpe, param.ModelMetadata.ModelType);
+            Assert.Equal(BindingSource.Path, param.Source);
+        }
+
+        AssertPathParameter(GetApiDescription((DateTime? foo) => { }, "/{foo}"), typeof(DateTime?));
+        AssertPathParameter(GetApiDescription((DateTimeOffset? foo) => { }, "/{foo}"), typeof(DateTimeOffset?));
+        AssertPathParameter(GetApiDescription((DateOnly? foo) => { }, "/{foo}"), typeof(DateOnly?));
+        AssertPathParameter(GetApiDescription((TimeOnly? foo) => { }, "/{foo}"), typeof(TimeOnly?));
+        AssertPathParameter(GetApiDescription((TimeSpan? foo) => { }, "/{foo}"), typeof(TimeSpan?));
+        AssertPathParameter(GetApiDescription((decimal? foo) => { }, "/{foo}"), typeof(decimal?));
+        AssertPathParameter(GetApiDescription((Guid? foo) => { }, "/{foo}"), typeof(Guid?));
+        AssertPathParameter(GetApiDescription((Uri? foo) => { }, "/{foo}"), typeof(Uri));
+    }
+
+    [Fact]
     public void AddsFromRouteParameterAsPathWithNullablePrimitiveType()
     {
         static void AssertPathParameter(ApiDescription apiDescription)

--- a/src/OpenApi/src/OpenApiGenerator.cs
+++ b/src/OpenApi/src/OpenApiGenerator.cs
@@ -460,9 +460,6 @@ internal sealed class OpenApiGenerator
         }
         else if (parameter.ParameterType == typeof(string) || ParameterBindingMethodCache.HasTryParseMethod(parameter.ParameterType))
         {
-            // complex types will display as strings since they use custom parsing via TryParse on a string
-            var displayType = !parameter.ParameterType.IsPrimitive && Nullable.GetUnderlyingType(parameter.ParameterType)?.IsPrimitive != true
-                ? typeof(string) : parameter.ParameterType;
             // Path vs query cannot be determined by RequestDelegateFactory at startup currently because of the layering, but can be done here.
             if (parameter.Name is { } name && pattern.GetParameter(name) is not null)
             {


### PR DESCRIPTION
Contributes #44677

This change updates how the `ApiParameterDescription.Type` is defined for MVC Simple Types (with `TypeConverter` or `TryParse`) that are not `primitives`. Basically, setting the Type as `string`

It is a similar approach that is used here

https://github.com/brunolins16/aspnetcore/blob/7518259777aa22268843401cfa0dfdfaba37eff3/src/Mvc/Mvc.ApiExplorer/src/EndpointMetadataApiDescriptionProvider.cs#L291

But in addition to the simple `IsPrimitive` check this PR includes some additional known types that should be handled by OpenAPI spec.

- `DateTime`
- `DateTimeOffset`
- `DateOnly`
- `TimeOnly`
- `decimal`
- `Guid`
- `Uri`


Obs.: `NSwag` will not requires any change to reflect it correctly, however, `Swashbuckle` will need a simple change since it is using `Metadata.ModelType` instead of `ApiParameterDescription.Type`