### PR TITLE
Remove premature QuicListener.IsSupported check

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/Internal/QuicConnectionListener.cs
@@ -36,7 +36,7 @@ internal sealed class QuicConnectionListener : IMultiplexedConnectionListener, I
     {
         if (!QuicListener.IsSupported)
         {
-            throw new NotSupportedException("QUIC is not supported or enabled on this platform. See https://aka.ms/aspnet/kestrel/http3reqs for details.");
+            throw new NotSupportedException("QUIC and HTTP/3 are not supported or enabled on this platform. See https://aka.ms/aspnet/kestrel/http3reqs for details.");
         }
 
         if (endpoint is not IPEndPoint listenEndPoint)

--- a/src/Servers/Kestrel/Transport.Quic/src/WebHostBuilderQuicExtensions.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/WebHostBuilderQuicExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net.Quic;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Quic;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,15 +19,10 @@ public static class WebHostBuilderQuicExtensions
     /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
     public static IWebHostBuilder UseQuic(this IWebHostBuilder hostBuilder)
     {
-        if (QuicListener.IsSupported)
+        return hostBuilder.ConfigureServices(services =>
         {
-            return hostBuilder.ConfigureServices(services =>
-            {
-                services.AddSingleton<IMultiplexedConnectionListenerFactory, QuicTransportFactory>();
-            });
-        }
-
-        return hostBuilder;
+            services.AddSingleton<IMultiplexedConnectionListenerFactory, QuicTransportFactory>();
+        });
     }
 
     /// <summary>

--- a/src/Servers/Kestrel/Transport.Quic/src/WebHostBuilderQuicExtensions.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/WebHostBuilderQuicExtensions.cs
@@ -19,6 +19,7 @@ public static class WebHostBuilderQuicExtensions
     /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
     public static IWebHostBuilder UseQuic(this IWebHostBuilder hostBuilder)
     {
+        // QuicListener.IsSupported has performance costs. Always register the QUIC factory and then check for support when binding an endpoint.
         return hostBuilder.ConfigureServices(services =>
         {
             services.AddSingleton<IMultiplexedConnectionListenerFactory, QuicTransportFactory>();


### PR DESCRIPTION
There's no reason to pay the cost of this check when HTTP/3 is not enabled. I was going to file an issue, but the fix was so simple, I just went ahead and made this PR. We can still discuss the merits here.

This means that a `IMultiplexedConnectionListenerFactory` always gets added to the service collection, but the upside is that we only check `QuicListener.IsSupported` when Kestrel actually tries to bind with QUIC which means that HTTP/3 has been opted into. Today,  `QuicListener.IsSupported` is always checked and @eerhardt pointed out this hurts startup performance pretty significantly.

I think we should consider backporting this to 7.0.1.

@JamesNK 