### PR TITLE
Use the Regex source generator in the AlphaRouteConstraint.

### DIFF
--- a/src/Http/Routing/perf/Microbenchmarks/LinkGeneration/SingleRouteWithConstraintsBenchmark.cs
+++ b/src/Http/Routing/perf/Microbenchmarks/LinkGeneration/SingleRouteWithConstraintsBenchmark.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using BenchmarkDotNet.Attributes;
@@ -17,7 +17,7 @@ public class SingleRouteWithConstraintsBenchmark : EndpointRoutingBenchmarkBase
     [GlobalSetup]
     public void Setup()
     {
-        var template = "Customers/Details/{category}/{region}/{id:int}";
+        var template = "Customers/Details/{category:alpha}/{region:alpha}/{id:int}";
         var defaults = new { controller = "Customers", action = "Details" };
         var requiredValues = new { controller = "Customers", action = "Details" };
 

--- a/src/Http/Routing/src/Constraints/AlphaRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/AlphaRouteConstraint.cs
@@ -1,17 +1,22 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.RegularExpressions;
+
 namespace Microsoft.AspNetCore.Routing.Constraints;
 
 /// <summary>
 /// Constrains a route parameter to contain only lowercase or uppercase letters A through Z in the English alphabet.
 /// </summary>
-public class AlphaRouteConstraint : RegexRouteConstraint
+public partial class AlphaRouteConstraint : RegexRouteConstraint
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="AlphaRouteConstraint" /> class.
     /// </summary>
-    public AlphaRouteConstraint() : base(@"^[a-z]*$")
+    public AlphaRouteConstraint() : base(GetAlphaRouteRegex())
     {
     }
+
+    [GeneratedRegex(@"^[A-Za-z]*$", RegexOptions.CultureInvariant)]
+    private static partial Regex GetAlphaRouteRegex();
 }

--- a/src/Http/Routing/src/Constraints/AlphaRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/AlphaRouteConstraint.cs
@@ -17,6 +17,6 @@ public partial class AlphaRouteConstraint : RegexRouteConstraint
     {
     }
 
-    [GeneratedRegex(@"^[A-Za-z]*$", RegexOptions.CultureInvariant)]
+    [GeneratedRegex(@"^[A-Za-z]*$")]
     private static partial Regex GetAlphaRouteRegex();
 }

--- a/src/Http/Routing/src/Constraints/RegexRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/RegexRouteConstraint.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
@@ -33,7 +34,7 @@ public class RegexRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatch
     /// Constructor for a <see cref="RegexRouteConstraint"/> given a <paramref name="regexPattern"/>.
     /// </summary>
     /// <param name="regexPattern">A string containing the regex pattern.</param>
-    public RegexRouteConstraint(string regexPattern)
+    public RegexRouteConstraint([StringSyntax(StringSyntaxAttribute.Regex)] string regexPattern)
     {
         if (regexPattern == null)
         {

--- a/src/Http/Routing/src/Constraints/RegexRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/RegexRouteConstraint.cs
@@ -34,7 +34,9 @@ public class RegexRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatch
     /// Constructor for a <see cref="RegexRouteConstraint"/> given a <paramref name="regexPattern"/>.
     /// </summary>
     /// <param name="regexPattern">A string containing the regex pattern.</param>
-    public RegexRouteConstraint([StringSyntax(StringSyntaxAttribute.Regex)] string regexPattern)
+    public RegexRouteConstraint(
+        [StringSyntax(StringSyntaxAttribute.Regex, RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)]
+        string regexPattern)
     {
         if (regexPattern == null)
         {


### PR DESCRIPTION
The Regex source generator is faster because it doesn't need to interpret the regex. It does add slightly more code to the compiled app, but the tradeoff seems worth it.

I switched the pattern from `a-z` with IgnoreCase to `A-Za-z` because the source generator generates better code with that pattern.

The results of the changed Benchmark shows a 9-10% faster when using an `alpha` constraint:

### Before

|          Method |     Mean |     Error |    StdDev |      Op/s | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------- |---------:|----------:|----------:|----------:|------:|-------:|------:|------:|----------:|
|      TreeRouter | 1.362 us | 0.0107 us | 0.0100 us | 734,023.0 |  1.00 | 0.0134 |     - |     - |      1 KB |
| EndpointRouting | 1.763 us | 0.0107 us | 0.0100 us | 567,280.4 |  1.29 | 0.0134 |     - |     - |      1 KB |


### After

|          Method |     Mean |     Error |    StdDev |      Op/s | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------- |---------:|----------:|----------:|----------:|------:|-------:|------:|------:|----------:|
|      TreeRouter | 1.230 us | 0.0087 us | 0.0082 us | 813,331.4 |  1.00 | 0.0134 |     - |     - |      1 KB |
| EndpointRouting | 1.615 us | 0.0068 us | 0.0063 us | 619,255.2 |  1.31 | 0.0153 |     - |     - |      1 KB |

### Size

Publishing a Linux NativeAOT app shows about a 4 KB increase in code size with this change:

**Before**: 27.1 MB (28,483,016 bytes)
**After** : 27.1 MB (28,487,464 bytes)