### PR TITLE
[release/6.0] Send 431 when HTTP/2&3 headers are too large or many #33622

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -92,6 +92,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
             _requestHeaderParsingState = default;
             _parsedPseudoHeaderFields = default;
             _totalParsedHeaderSize = 0;
+            // Allow up to 2x during parsing, enforce the hard limit after when we can preserve the connection.
+            _eagerRequestHeadersParsedLimit = ServerOptions.Limits.MaxRequestHeaderCount * 2;
             _isMethodConnect = false;
             _completionState = default;
             StreamTimeoutTicks = 0;
@@ -205,10 +207,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
 
         public override void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value, bool checkForNewlineChars)
         {
-            // https://tools.ietf.org/html/rfc7540#section-6.5.2
+            // https://httpwg.org/specs/rfc9114.html#rfc.section.4.2.2
             // "The value is based on the uncompressed size of header fields, including the length of the name and value in octets plus an overhead of 32 octets for each header field.";
-            _totalParsedHeaderSize += HeaderField.RfcOverhead + name.Length + value.Length;
-            if (_totalParsedHeaderSize > _context.ServiceContext.ServerOptions.Limits.MaxRequestHeadersTotalSize)
+            // We don't include the 32 byte overhead hear so we can accept a little more than the advertised limit.
+            _totalParsedHeaderSize += name.Length + value.Length;
+            // Allow a 2x grace before aborting the stream. We'll check the size limit again later where we can send a 431.
+            if (_totalParsedHeaderSize > ServerOptions.Limits.MaxRequestHeadersTotalSize * 2)
             {
                 throw new Http3StreamErrorException(CoreStrings.BadRequest_HeadersExceedMaxTotalSize, Http3ErrorCode.RequestRejected);
             }
@@ -754,6 +758,19 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3
         protected override bool TryParseRequest(ReadResult result, out bool endConnection)
         {
             endConnection = !TryValidatePseudoHeaders();
+
+            // 431 if the headers are too large
+            if (_totalParsedHeaderSize > ServerOptions.Limits.MaxRequestHeadersTotalSize)
+            {
+                KestrelBadHttpRequestException.Throw(RequestRejectionReason.HeadersExceedMaxTotalSize);
+            }
+
+            // 431 if we received too many headers
+            if (RequestHeadersParsed > ServerOptions.Limits.MaxRequestHeaderCount)
+            {
+                KestrelBadHttpRequestException.Throw(RequestRejectionReason.TooManyHeaders);
+            }
+
             return true;
         }
 

--- a/src/Servers/Kestrel/Core/test/Http1ConnectionTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1ConnectionTests.cs
@@ -137,6 +137,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         {
             const string headerLines = "Header-1: value1\r\nHeader-2: value2\r\n";
             _serviceContext.ServerOptions.Limits.MaxRequestHeaderCount = 1;
+            _http1Connection.Initialize(_http1ConnectionContext);
 
             await _application.Output.WriteAsync(Encoding.ASCII.GetBytes($"{headerLines}\r\n"));
             var readableBuffer = (await _transport.Input.ReadAsync()).Buffer;

--- a/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
+++ b/src/Servers/Kestrel/shared/test/Http3/Http3InMemory.cs
@@ -590,7 +590,7 @@ namespace Microsoft.AspNetCore.Testing
 
     internal class Http3RequestHeaderHandler
     {
-        public readonly byte[] HeaderEncodingBuffer = new byte[64 * 1024];
+        public readonly byte[] HeaderEncodingBuffer = new byte[96 * 1024];
         public readonly QPackDecoder QpackDecoder = new QPackDecoder(8192);
         public readonly Dictionary<string, string> DecodedHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     }
@@ -639,9 +639,8 @@ namespace Microsoft.AspNetCore.Testing
             var done = QPackHeaderWriter.BeginEncode(headers, buffer.Span, ref headersTotalSize, out var length);
             if (!done)
             {
-                throw new InvalidOperationException("Headers not sent.");
+                throw new InvalidOperationException("The headers are too large.");
             }
-
             await SendFrameAsync(Http3FrameType.Headers, buffer.Slice(0, length), endStream);
         }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -2712,7 +2712,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public Task HEADERS_Received_HeaderBlockOverLimit_ConnectionError()
         {
-            // > 32kb
+            // > 32kb * 2 to exceed graceful handling limit
             var headers = new[]
             {
                 new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
@@ -2726,6 +2726,14 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 new KeyValuePair<string, string>("f", _4kHeaderValue),
                 new KeyValuePair<string, string>("g", _4kHeaderValue),
                 new KeyValuePair<string, string>("h", _4kHeaderValue),
+                new KeyValuePair<string, string>("i", _4kHeaderValue),
+                new KeyValuePair<string, string>("j", _4kHeaderValue),
+                new KeyValuePair<string, string>("k", _4kHeaderValue),
+                new KeyValuePair<string, string>("l", _4kHeaderValue),
+                new KeyValuePair<string, string>("m", _4kHeaderValue),
+                new KeyValuePair<string, string>("n", _4kHeaderValue),
+                new KeyValuePair<string, string>("o", _4kHeaderValue),
+                new KeyValuePair<string, string>("p", _4kHeaderValue),
             };
 
             return HEADERS_Received_InvalidHeaderFields_ConnectionError(headers, CoreStrings.BadRequest_HeadersExceedMaxTotalSize);
@@ -2734,7 +2742,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         [Fact]
         public Task HEADERS_Received_TooManyHeaders_ConnectionError()
         {
-            // > MaxRequestHeaderCount (100)
+            // > MaxRequestHeaderCount (100) * 2 to exceed graceful handling limit
             var headers = new List<KeyValuePair<string, string>>();
             headers.AddRange(new[]
             {
@@ -2742,7 +2750,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
                 new KeyValuePair<string, string>(HeaderNames.Path, "/"),
                 new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
             });
-            for (var i = 0; i < 100; i++)
+            for (var i = 0; i < 200; i++)
             {
                 headers.Add(new KeyValuePair<string, string>(i.ToString(CultureInfo.InvariantCulture), i.ToString(CultureInfo.InvariantCulture)));
             }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -738,6 +739,77 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             await WaitForStreamErrorAsync(expectedStreamId: 1, Http2ErrorCode.PROTOCOL_ERROR, CoreStrings.BadRequest_RequestLineTooLong);
 
             await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+        }
+
+        [Fact]
+        public async Task HEADERS_Received_MaxRequestHeadersTotalSize_431()
+        {
+            // > 32kb
+            var headers = new[]
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+                new KeyValuePair<string, string>("a", _4kHeaderValue),
+                new KeyValuePair<string, string>("b", _4kHeaderValue),
+                new KeyValuePair<string, string>("c", _4kHeaderValue),
+                new KeyValuePair<string, string>("d", _4kHeaderValue),
+                new KeyValuePair<string, string>("e", _4kHeaderValue),
+                new KeyValuePair<string, string>("f", _4kHeaderValue),
+                new KeyValuePair<string, string>("g", _4kHeaderValue),
+                new KeyValuePair<string, string>("h", _4kHeaderValue),
+            };
+            await InitializeConnectionAsync(_notImplementedApp);
+
+            await StartStreamAsync(1, headers, endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 40,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
+                withStreamId: 1);
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: true, handler: this);
+
+            Assert.Equal(3, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("431", _decodedHeaders[HeaderNames.Status]);
+            Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
+        }
+
+        [Fact]
+        public async Task HEADERS_Received_MaxRequestHeaderCount_431()
+        {
+            // > 100 headers
+            var headers = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>(HeaderNames.Method, "GET"),
+                new KeyValuePair<string, string>(HeaderNames.Path, "/"),
+                new KeyValuePair<string, string>(HeaderNames.Scheme, "http"),
+            };
+            for (var i = 0; i < 101; i++)
+            {
+                var text = i.ToString(CultureInfo.InvariantCulture);
+                headers.Add(new KeyValuePair<string, string>(text, text));
+            }
+            await InitializeConnectionAsync(_notImplementedApp);
+
+            await StartStreamAsync(1, headers, endStream: true);
+
+            var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+                withLength: 40,
+                withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
+                withStreamId: 1);
+
+            await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+            _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: true, handler: this);
+
+            Assert.Equal(3, _decodedHeaders.Count);
+            Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+            Assert.Equal("431", _decodedHeaders[HeaderNames.Status]);
+            Assert.Equal("0", _decodedHeaders[HeaderNames.ContentLength]);
         }
 
         [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2TestBase.cs
@@ -143,6 +143,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         protected readonly TaskCompletionSource _closedStateReached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         protected readonly RequestDelegate _noopApplication;
+        protected readonly RequestDelegate _notImplementedApp;
         protected readonly RequestDelegate _readHeadersApplication;
         protected readonly RequestDelegate _readTrailersApplication;
         protected readonly RequestDelegate _bufferingApplication;
@@ -193,6 +194,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
             });
 
             _noopApplication = context => Task.CompletedTask;
+            _notImplementedApp = _ => throw new NotImplementedException();
 
             _readHeadersApplication = context =>
             {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3TestBase.cs
@@ -50,6 +50,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         internal readonly Mock<ITimeoutHandler> _mockTimeoutHandler = new Mock<ITimeoutHandler>();
 
         protected readonly RequestDelegate _noopApplication;
+        protected readonly RequestDelegate _notImplementedApp;
         protected readonly RequestDelegate _echoApplication;
         protected readonly RequestDelegate _readRateApplication;
         protected readonly RequestDelegate _echoMethod;
@@ -80,6 +81,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests
         public Http3TestBase()
         {
             _noopApplication = context => Task.CompletedTask;
+            _notImplementedApp = _ => throw new NotImplementedException();
 
             _echoApplication = async context =>
             {

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
@@ -1366,10 +1366,10 @@ namespace Interop.FunctionalTests
             {
                 request.Headers.Add("header" + i, oneKbString + i);
             }
-            // Kestrel closes the connection rather than sending the recommended 431 response. https://github.com/dotnet/aspnetcore/issues/17861
-            await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(request)).DefaultTimeout();
-
+            var response = await client.SendAsync(request).DefaultTimeout();
             await host.StopAsync().DefaultTimeout();
+
+            Assert.Equal(HttpStatusCode.RequestHeaderFieldsTooLarge, response.StatusCode);
         }
 
         [Theory]


### PR DESCRIPTION
Backport of #44668 to release/6.0

# Send 431 when HTTP/2&3 headers are too large or many

Harden HTTP/2 & 3 to send back 431 errors rather than aborting the connection.

## Description

When HTTP/2 hits a header related limit (total size or count) it aborts the connection because HPACK is stateful and failing to process the rest of the headers in a request could corrupt the connection HPACK state. HTTP/3 copied this model. This causes performance and debuggability issues for applications.

To avoid this we'll allow up to 2x of the limits while processing the headers, but then enforce the hard limits later when we can send a 431.

Contributes to #17861 #33622

## Customer Impact

Customers have a hard time debugging an application when it kills the connection without reporting an error to the client. It also affects other parallel requests on the same connection.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Small modification to existing behavior.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A