### PR TITLE
Build public redist for source-build

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -68,7 +68,7 @@
       <!--
         Add the internal installers artifacts required by dotnet/installer.
       -->
-      <IntermediateNupkgArtifactFile Include="$(InstallersArtifactsDir)aspnetcore-runtime-internal-*.tar.gz" />
+      <IntermediateNupkgArtifactFile Include="$(InstallersArtifactsDir)aspnetcore-runtime-*.tar.gz" />
       <IntermediateNupkgArtifactFile Include="$(InstallersArtifactsDir)aspnetcore_base_runtime.version" />
     </ItemGroup>
   </Target>

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -667,9 +667,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       WorkingDirectory="$(CompositeFrameworkLayoutRoot)" />
   </Target>
 
-  <!-- Redist tarball including the dotnet-runtime is not needed in source build -->
   <Target Name="_CreateRedistSharedFxArchive"
-          Condition="'$(DotNetBuildFromSource)' != 'true'"
           Inputs="@(SharedFxContent)"
           Outputs="$(RedistArchiveOutputPath)">
     <Message Importance="High" Text="$(MSbuildProjectFile) -> $(RedistArchiveOutputPath)" />


### PR DESCRIPTION
During source-build, only the internal redist tarball was being created.  Source-build needs to react to the change made in https://github.com/dotnet/installer/pull/14504 which require the public redist tarball.  These changes tweak source-build to build the public redist tarball.

Fixes https://github.com/dotnet/source-build/issues/3092