### PR TITLE
Use TryGetValue() for dictionary lookup

### DIFF
--- a/src/Features/JsonPatch/src/Internal/DictionaryAdapterOfTU.cs
+++ b/src/Features/JsonPatch/src/Internal/DictionaryAdapterOfTU.cs
@@ -147,7 +147,7 @@ public class DictionaryAdapter<TKey, TValue> : IAdapter
         }
 
         // As per JsonPatch spec, the target location must exist for test to be successful
-        if (!dictionary.ContainsKey(convertedKey))
+        if (!dictionary.TryGetValue(convertedKey, out var currentValue))
         {
             errorMessage = Resources.FormatTargetLocationAtPathSegmentNotFound(segment);
             return false;
@@ -157,8 +157,6 @@ public class DictionaryAdapter<TKey, TValue> : IAdapter
         {
             return false;
         }
-
-        var currentValue = dictionary[convertedKey];
 
         // The target segment does not have an assigned value to compare the test value with
         if (currentValue == null)

--- a/src/Http/Authentication.Core/src/AuthenticationSchemeProvider.cs
+++ b/src/Http/Authentication.Core/src/AuthenticationSchemeProvider.cs
@@ -184,15 +184,14 @@ public class AuthenticationSchemeProvider : IAuthenticationSchemeProvider
     /// <param name="name">The name of the authenticationScheme being removed.</param>
     public virtual void RemoveScheme(string name)
     {
-        if (!_schemes.ContainsKey(name))
+        if (!_schemes.TryGetValue(name, out var scheme))
         {
             return;
         }
         lock (_lock)
         {
-            if (_schemes.ContainsKey(name))
+            if (_schemes.TryGetValue(name, out scheme))
             {
-                var scheme = _schemes[name];
                 if (_requestHandlers.Remove(scheme))
                 {
                     _requestHandlersCopy = _requestHandlers.ToArray();

--- a/src/Identity/Core/src/SignInManager.cs
+++ b/src/Identity/Core/src/SignInManager.cs
@@ -652,26 +652,21 @@ public class SignInManager<TUser> where TUser : class
     {
         var auth = await Context.AuthenticateAsync(IdentityConstants.ExternalScheme);
         var items = auth?.Properties?.Items;
-        if (auth?.Principal == null || items == null || !items.ContainsKey(LoginProviderKey))
+        if (auth?.Principal == null || items == null || !items.TryGetValue(LoginProviderKey, out var provider))
         {
             return null;
         }
 
         if (expectedXsrf != null)
         {
-            if (!items.ContainsKey(XsrfKey))
-            {
-                return null;
-            }
-            var userId = items[XsrfKey] as string;
-            if (userId != expectedXsrf)
+            if (!items.TryGetValue(XsrfKey, out var userId) ||
+                userId != expectedXsrf)
             {
                 return null;
             }
         }
 
         var providerKey = auth.Principal.FindFirstValue(ClaimTypes.NameIdentifier);
-        var provider = items[LoginProviderKey] as string;
         if (providerKey == null || provider == null)
         {
             return null;


### PR DESCRIPTION
# Use TryGetValue

Use `TryGetValue()` instead of `ContainsKey()` and the indexer.

## Description

While looking through the Identity code to work out why something I'm doing wasn't working, I spotted a case where `TryGetValue()` wasn't being used to access a dictionary value. I did a quick search and found a couple more, but I didn't go through the whole repo so there might be more lurking.

Enabling the new [CA1854](https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/quality-rules/ca1854) rule would surface more of this and help stop new ones being added.
