### PR TITLE
Enable CA1854

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -184,6 +184,9 @@ dotnet_diagnostic.CA1847.severity = warning
 # CA1852: Seal internal types
 dotnet_diagnostic.CA1852.severity = warning
 
+# CA1854: Prefer the IDictionary.TryGetValue(TKey, out TValue) method
+dotnet_diagnostic.CA1854.severity = warning
+
 # CA2007: Consider calling ConfigureAwait on the awaited task
 dotnet_diagnostic.CA2007.severity = warning
 
@@ -328,6 +331,8 @@ dotnet_diagnostic.CA1846.severity = suggestion
 dotnet_diagnostic.CA1847.severity = suggestion
 # CA1852: Seal internal types
 dotnet_diagnostic.CA1852.severity = suggestion
+# CA1854: Prefer the IDictionary.TryGetValue(TKey, out TValue) method
+dotnet_diagnostic.CA1854.severity = suggestion
 # CA2007: Consider calling ConfigureAwait on the awaited task
 dotnet_diagnostic.CA2007.severity = suggestion
 # CA2008: Do not create tasks without passing a TaskScheduler

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/XmlComments/GrpcXmlCommentsOperationFilter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/XmlComments/GrpcXmlCommentsOperationFilter.cs
@@ -100,9 +100,10 @@ internal sealed class GrpcXmlCommentsOperationFilter : IOperationFilter
         while (responseNodes.MoveNext())
         {
             var code = responseNodes.Current!.GetAttribute("code", "");
-            var response = operation.Responses.ContainsKey(code)
-                ? operation.Responses[code]
-                : operation.Responses[code] = new OpenApiResponse();
+            if (!operation.Responses.TryGetValue(code, out var response))
+            {
+                operation.Responses[code] = response = new OpenApiResponse();
+            }
 
             response.Description = XmlCommentsTextHelper.Humanize(responseNodes.Current.InnerXml);
         }

--- a/src/Http/Authentication.Core/src/AuthenticationSchemeProvider.cs
+++ b/src/Http/Authentication.Core/src/AuthenticationSchemeProvider.cs
@@ -120,7 +120,7 @@ public class AuthenticationSchemeProvider : IAuthenticationSchemeProvider
     /// <param name="name">The name of the authenticationScheme.</param>
     /// <returns>The scheme or null if not found.</returns>
     public virtual Task<AuthenticationScheme?> GetSchemeAsync(string name)
-        => Task.FromResult(_schemes.ContainsKey(name) ? _schemes[name] : null);
+        => Task.FromResult(_schemes.TryGetValue(name, out var scheme) ? scheme : null);
 
     /// <summary>
     /// Returns the schemes in priority order for request handling.
@@ -184,13 +184,13 @@ public class AuthenticationSchemeProvider : IAuthenticationSchemeProvider
     /// <param name="name">The name of the authenticationScheme being removed.</param>
     public virtual void RemoveScheme(string name)
     {
-        if (!_schemes.TryGetValue(name, out var scheme))
+        if (!_schemes.TryGetValue(name, out _))
         {
             return;
         }
         lock (_lock)
         {
-            if (_schemes.TryGetValue(name, out scheme))
+            if (_schemes.TryGetValue(name, out var scheme))
             {
                 if (_requestHandlers.Remove(scheme))
                 {

--- a/src/Mvc/Mvc.Core/src/Formatters/TextOutputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/TextOutputFormatter.cs
@@ -187,9 +187,9 @@ public abstract class TextOutputFormatter : OutputFormatter
     private string GetMediaTypeWithCharset(string mediaType, Encoding encoding)
     {
         if (string.Equals(encoding.WebName, Encoding.UTF8.WebName, StringComparison.OrdinalIgnoreCase) &&
-            OutputMediaTypeCache.ContainsKey(mediaType))
+            OutputMediaTypeCache.TryGetValue(mediaType, out var mediaTypeWithCharset))
         {
-            return OutputMediaTypeCache[mediaType];
+            return mediaTypeWithCharset;
         }
 
         return MediaType.ReplaceEncoding(mediaType, encoding);

--- a/src/Mvc/shared/Mvc.Views.TestCommon/TestFileProvider.cs
+++ b/src/Mvc/shared/Mvc.Views.TestCommon/TestFileProvider.cs
@@ -70,9 +70,9 @@ public class TestFileProvider : IFileProvider
 
     public virtual IFileInfo GetFileInfo(string subpath)
     {
-        if (_lookup.ContainsKey(subpath))
+        if (_lookup.TryGetValue(subpath, out var fileInfo))
         {
-            return _lookup[subpath];
+            return fileInfo;
         }
         else
         {

--- a/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
+++ b/src/Servers/IIS/IntegrationTesting.IIS/src/IISDeployer.cs
@@ -158,14 +158,14 @@ public class IISDeployer : IISDeployerBase
         {
             // Handle cases where debug file is redirected by test
             var debugLogLocations = new List<string>();
-            if (IISDeploymentParameters.HandlerSettings.ContainsKey("debugFile"))
+            if (IISDeploymentParameters.HandlerSettings.TryGetValue("debugFile", out var debugFile))
             {
-                debugLogLocations.Add(IISDeploymentParameters.HandlerSettings["debugFile"]);
+                debugLogLocations.Add(debugFile);
             }
 
-            if (DeploymentParameters.EnvironmentVariables.ContainsKey("ASPNETCORE_MODULE_DEBUG_FILE"))
+            if (DeploymentParameters.EnvironmentVariables.TryGetValue("ASPNETCORE_MODULE_DEBUG_FILE", out debugFile))
             {
-                debugLogLocations.Add(DeploymentParameters.EnvironmentVariables["ASPNETCORE_MODULE_DEBUG_FILE"]);
+                debugLogLocations.Add(debugFile);
             }
 
             // default debug file name
@@ -397,7 +397,7 @@ public class IISDeployer : IISDeployerBase
                         Logger.LogInformation($"Stopping pool, state: {state}");
                     }
                 }
-                
+
                 // Make sure all sites are stopped
                 foreach (var site in serverManager.Sites)
                 {

--- a/src/Tools/Microsoft.dotnet-openapi/src/Commands/BaseCommand.cs
+++ b/src/Tools/Microsoft.dotnet-openapi/src/Commands/BaseCommand.cs
@@ -195,7 +195,7 @@ internal abstract class BaseCommand : CommandLineApplication
         foreach (var kvp in attributePackages)
         {
             var packageId = kvp.Key;
-            var version = urlPackages != null && urlPackages.ContainsKey(packageId) ? urlPackages[packageId] : kvp.Value;
+            var version = urlPackages != null && urlPackages.TryGetValue(packageId, out var urlPackageVersion) ? urlPackageVersion : kvp.Value;
 
             await TryAddPackage(packageId, version, projectFile);
         }


### PR DESCRIPTION
# Enable CA1854

Enable [CA1854](https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/quality-rules/ca1854) to prefer `IDictionary.TryGetValue()`.

## Description

Enables the new CA1854 analyser.

See https://github.com/dotnet/aspnetcore/pull/44791#issuecomment-1297343232.

Will see what CI throws up, and then look at how many get flushed out to be fixed.

/cc @BrennanConroy
