### PR TITLE
Fix NavigationLock throwing a JSDisconnectedException on browser close in Blazor Server

### DIFF
--- a/src/Components/Web/src/Routing/NavigationLock.cs
+++ b/src/Components/Web/src/Routing/NavigationLock.cs
@@ -107,7 +107,14 @@ public sealed class NavigationLock : IComponent, IHandleAfterRender, IAsyncDispo
 
         if (_confirmExternalNavigation)
         {
-            await JSRuntime.InvokeVoidAsync(NavigationLockInterop.DisableNavigationPrompt, _id);
+            try
+            {
+                await JSRuntime.InvokeVoidAsync(NavigationLockInterop.DisableNavigationPrompt, _id);
+            }
+            catch (JSDisconnectedException)
+            {
+                // If the browser is gone, we don't need it to clean up any browser-side state
+            }
         }
     }
 }


### PR DESCRIPTION
# Fix `NavigationLock` throwing a `JSDisconnectedException` on browser close in Blazor Server

Fixes an issue where in Blazor Server, if the browser gets closed while a `<NavigationLock ConfirmExternalNavigation="true" />` is actively rendered, a `JSDisconnectedException` gets thrown.

## Description

This PR fixes the issue by catching and ignoring the `JSDisconnectedException`, which is the recommended pattern for attempting to perform JS interop on component disposal.

Fixes #44795
