### PR TITLE
[Templates] Fix links to http://useiconic.com

### DIFF
--- a/src/Components/Samples/BlazorServerApp/wwwroot/css/open-iconic/README.md
+++ b/src/Components/Samples/BlazorServerApp/wwwroot/css/open-iconic/README.md
@@ -1,7 +1,7 @@
-[Open Iconic v1.1.1](http://useiconic.com/open)
+[Open Iconic v1.1.1](http://github.com/iconic/open-iconic/open)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](http://useiconic.com). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://useiconic.com/open#icons)
+### Open Iconic is the open source sibling of [Iconic](http://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://github.com/iconic/open-iconic)
 
 
 
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://useiconic.com/open#icons) and [Reference](http://useiconic.com/open#reference) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://github.com/iconic/open-iconic) and [Reference](http://github.com/iconic/open-iconic/open#reference) sections.
 
 ### General Usage
 

--- a/src/Components/Samples/BlazorServerApp/wwwroot/css/open-iconic/README.md
+++ b/src/Components/Samples/BlazorServerApp/wwwroot/css/open-iconic/README.md
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://github.com/iconic/open-iconic) and [Reference](https://github.com/iconic/open-iconic#reference) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://github.com/iconic/open-iconic) and [Reference](https://github.com/iconic/open-iconic) sections.
 
 ### General Usage
 

--- a/src/Components/Samples/BlazorServerApp/wwwroot/css/open-iconic/README.md
+++ b/src/Components/Samples/BlazorServerApp/wwwroot/css/open-iconic/README.md
@@ -1,7 +1,7 @@
-[Open Iconic v1.1.1](http://github.com/iconic/open-iconic/open)
+[Open Iconic v1.1.1](https://github.com/iconic/open-iconic)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](http://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://github.com/iconic/open-iconic)
+### Open Iconic is the open source sibling of [Iconic](https://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://github.com/iconic/open-iconic)
 
 
 
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://github.com/iconic/open-iconic) and [Reference](http://github.com/iconic/open-iconic/open#reference) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://github.com/iconic/open-iconic) and [Reference](https://github.com/iconic/open-iconic#reference) sections.
 
 ### General Usage
 

--- a/src/Components/THIRD-PARTY-NOTICES.txt
+++ b/src/Components/THIRD-PARTY-NOTICES.txt
@@ -22,7 +22,7 @@ The actual third-party libraries or other resources may vary depending on the Bl
 2.	AngleSharp  (https://github.com/AngleSharp/AngleSharp)
 3.	SimpleJson (https://github.com/facebook-csharp-sdk/simple-json)
 4.	Bootstrap (https://github.com/twbs/bootstrap)
-5.	Open Iconic (http://github.com/iconic/open-iconic)
+5.	Open Iconic (https://github.com/iconic/open-iconic)
 6.  fast-text-encoding (https://github.com/samthor/fast-text-encoding)
 
 

--- a/src/Components/THIRD-PARTY-NOTICES.txt
+++ b/src/Components/THIRD-PARTY-NOTICES.txt
@@ -22,7 +22,7 @@ The actual third-party libraries or other resources may vary depending on the Bl
 2.	AngleSharp  (https://github.com/AngleSharp/AngleSharp)
 3.	SimpleJson (https://github.com/facebook-csharp-sdk/simple-json)
 4.	Bootstrap (https://github.com/twbs/bootstrap)
-5.	Open Iconic (http://useiconic.com/open)
+5.	Open Iconic (http://github.com/iconic/open-iconic)
 6.  fast-text-encoding (https://github.com/samthor/fast-text-encoding)
 
 

--- a/src/Components/WebAssembly/Samples/HostedBlazorWebassemblyApp/Client/wwwroot/css/open-iconic/README.md
+++ b/src/Components/WebAssembly/Samples/HostedBlazorWebassemblyApp/Client/wwwroot/css/open-iconic/README.md
@@ -1,7 +1,7 @@
-[Open Iconic v1.1.1](http://useiconic.com/open)
+[Open Iconic v1.1.1](http://github.com/iconic/open-iconic/open)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](http://useiconic.com). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://useiconic.com/open#icons)
+### Open Iconic is the open source sibling of [Iconic](http://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://github.com/iconic/open-iconic)
 
 
 
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://useiconic.com/open#icons) and [Reference](http://useiconic.com/open#reference) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://github.com/iconic/open-iconic) and [Reference](http://github.com/iconic/open-iconic) sections.
 
 ### General Usage
 

--- a/src/Components/WebAssembly/Samples/HostedBlazorWebassemblyApp/Client/wwwroot/css/open-iconic/README.md
+++ b/src/Components/WebAssembly/Samples/HostedBlazorWebassemblyApp/Client/wwwroot/css/open-iconic/README.md
@@ -1,7 +1,7 @@
-[Open Iconic v1.1.1](http://github.com/iconic/open-iconic/open)
+[Open Iconic v1.1.1](https://github.com/iconic/open-iconic)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](http://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://github.com/iconic/open-iconic)
+### Open Iconic is the open source sibling of [Iconic](https://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://github.com/iconic/open-iconic)
 
 
 
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://github.com/iconic/open-iconic) and [Reference](http://github.com/iconic/open-iconic) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://github.com/iconic/open-iconic) and [Reference](https://github.com/iconic/open-iconic) sections.
 
 ### General Usage
 

--- a/src/Components/WebAssembly/testassets/StandaloneApp/wwwroot/css/open-iconic/README.md
+++ b/src/Components/WebAssembly/testassets/StandaloneApp/wwwroot/css/open-iconic/README.md
@@ -1,7 +1,7 @@
-[Open Iconic v1.1.1](http://useiconic.com/open)
+[Open Iconic v1.1.1](http://github.com/iconic/open-iconic/open)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](http://useiconic.com). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://useiconic.com/open#icons)
+### Open Iconic is the open source sibling of [Iconic](http://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://github.com/iconic/open-iconic)
 
 
 
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://useiconic.com/open#icons) and [Reference](http://useiconic.com/open#reference) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://github.com/iconic/open-iconic) and [Reference](http://github.com/iconic/open-iconic) sections.
 
 ### General Usage
 

--- a/src/Components/WebAssembly/testassets/StandaloneApp/wwwroot/css/open-iconic/README.md
+++ b/src/Components/WebAssembly/testassets/StandaloneApp/wwwroot/css/open-iconic/README.md
@@ -1,7 +1,7 @@
-[Open Iconic v1.1.1](http://github.com/iconic/open-iconic/open)
+[Open Iconic v1.1.1](https://github.com/iconic/open-iconic)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](http://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://github.com/iconic/open-iconic)
+### Open Iconic is the open source sibling of [Iconic](https://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://github.com/iconic/open-iconic)
 
 
 
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://github.com/iconic/open-iconic) and [Reference](http://github.com/iconic/open-iconic) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://github.com/iconic/open-iconic) and [Reference](https://github.com/iconic/open-iconic) sections.
 
 ### General Usage
 

--- a/src/Components/test/testassets/ComponentsApp.Server/wwwroot/css/open-iconic/README.md
+++ b/src/Components/test/testassets/ComponentsApp.Server/wwwroot/css/open-iconic/README.md
@@ -1,7 +1,7 @@
-[Open Iconic v1.1.1](http://useiconic.com/open)
+[Open Iconic v1.1.1](http://github.com/iconic/open-iconic/open)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](http://useiconic.com). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://useiconic.com/open#icons)
+### Open Iconic is the open source sibling of [Iconic](http://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://github.com/iconic/open-iconic)
 
 
 
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://useiconic.com/open#icons) and [Reference](http://useiconic.com/open#reference) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://github.com/iconic/open-iconic) and [Reference](http://github.com/iconic/open-iconic) sections.
 
 ### General Usage
 

--- a/src/Components/test/testassets/ComponentsApp.Server/wwwroot/css/open-iconic/README.md
+++ b/src/Components/test/testassets/ComponentsApp.Server/wwwroot/css/open-iconic/README.md
@@ -1,7 +1,7 @@
-[Open Iconic v1.1.1](http://github.com/iconic/open-iconic/open)
+[Open Iconic v1.1.1](https://github.com/iconic/open-iconic)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](http://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://github.com/iconic/open-iconic)
+### Open Iconic is the open source sibling of [Iconic](https://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://github.com/iconic/open-iconic)
 
 
 
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://github.com/iconic/open-iconic) and [Reference](http://github.com/iconic/open-iconic) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://github.com/iconic/open-iconic) and [Reference](https://github.com/iconic/open-iconic) sections.
 
 ### General Usage
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/open-iconic/README.md
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/open-iconic/README.md
@@ -1,7 +1,7 @@
-[Open Iconic v1.1.1](http://useiconic.com/open)
+[Open Iconic v1.1.1](https://github.com/iconic/open-iconic/open)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](http://useiconic.com). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://useiconic.com/open#icons)
+### Open Iconic is the open source sibling of [Iconic](https://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://github.com/iconic/open-iconic)
 
 
 
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://useiconic.com/open#icons) and [Reference](http://useiconic.com/open#reference) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://github.com/iconic/open-iconic) and [Reference](http://github.com/iconic/open-iconic) sections.
 
 ### General Usage
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/open-iconic/README.md
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/wwwroot/css/open-iconic/README.md
@@ -1,7 +1,7 @@
-[Open Iconic v1.1.1](https://github.com/iconic/open-iconic/open)
+[Open Iconic v1.1.1](https://github.com/iconic/open-iconic)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](https://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://github.com/iconic/open-iconic)
+### Open Iconic is the open source sibling of [Iconic](https://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://github.com/iconic/open-iconic)
 
 
 
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://github.com/iconic/open-iconic) and [Reference](http://github.com/iconic/open-iconic) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://github.com/iconic/open-iconic) and [Reference](https://github.com/iconic/open-iconic) sections.
 
 ### General Usage
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/open-iconic/README.md
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/open-iconic/README.md
@@ -1,7 +1,7 @@
-[Open Iconic v1.1.1](http://useiconic.com/open)
+[Open Iconic v1.1.1](http://github.com/iconic/open-iconic/open)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](http://useiconic.com). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://useiconic.com/open#icons)
+### Open Iconic is the open source sibling of [Iconic](http://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://github.com/iconic/open-iconic)
 
 
 
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://useiconic.com/open#icons) and [Reference](http://useiconic.com/open#reference) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://github.com/iconic/open-iconic) and [Reference](http://github.com/iconic/open-iconic) sections.
 
 ### General Usage
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/open-iconic/README.md
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/css/open-iconic/README.md
@@ -1,7 +1,7 @@
-[Open Iconic v1.1.1](http://github.com/iconic/open-iconic/open)
+[Open Iconic v1.1.1](https://github.com/iconic/open-iconic)
 ===========
 
-### Open Iconic is the open source sibling of [Iconic](http://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](http://github.com/iconic/open-iconic)
+### Open Iconic is the open source sibling of [Iconic](https://github.com/iconic/open-iconic). It is a hyper-legible collection of 223 icons with a tiny footprint&mdash;ready to use with Bootstrap and Foundation. [View the collection](https://github.com/iconic/open-iconic)
 
 
 
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](http://github.com/iconic/open-iconic) and [Reference](http://github.com/iconic/open-iconic) sections.
+#### For code samples and everything else you need to get started with Open Iconic, check out our [Icons](https://github.com/iconic/open-iconic) and [Reference](https://github.com/iconic/open-iconic) sections.
 
 ### General Usage
 


### PR DESCRIPTION
## Description

Updates the links in the readme.md of one of our template files to point out to the newer documentation site.

## Customer Impact

Customers who will read this doc will have valid links to use for getting to the icons.

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

It is updating a file in the templates that doesn't affect how the project is built or runs, only documentation.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A