### PR TITLE
Backport 'Fix NavigationLock throwing a JSDisconnectedException on browser close in Blazor Server'

### DIFF
--- a/src/Components/Web/src/Routing/NavigationLock.cs
+++ b/src/Components/Web/src/Routing/NavigationLock.cs
@@ -107,7 +107,14 @@ public sealed class NavigationLock : IComponent, IHandleAfterRender, IAsyncDispo
 
         if (_confirmExternalNavigation)
         {
-            await JSRuntime.InvokeVoidAsync(NavigationLockInterop.DisableNavigationPrompt, _id);
+            try
+            {
+                await JSRuntime.InvokeVoidAsync(NavigationLockInterop.DisableNavigationPrompt, _id);
+            }
+            catch (JSDisconnectedException)
+            {
+                // If the browser is gone, we don't need it to clean up any browser-side state
+            }
         }
     }
 }


### PR DESCRIPTION
# Backport 'Fix `NavigationLock` throwing a `JSDisconnectedException` on browser close in Blazor Server'

Fixes an issue where in Blazor Server, if the browser gets closed while a `<NavigationLock ConfirmExternalNavigation="true" />` is actively rendered, a `JSDisconnectedException` gets thrown.

## Description

This PR fixes the issue by catching and ignoring the `JSDisconnectedException`, which is the recommended pattern for attempting to perform JS interop on component disposal.

Fixes #44795

## Customer Impact

This bug does not affect the user experience of apps written in Blazor Server, since the exception occurs just after the user closes the browser tab. However, a developer-facing error message gets logged that could be easily misinterpreted as a bug affecting app functionality. If we don't fix this, we are likely going to get numerous reports of this exception being thrown.

## Regression?

- [ ] Yes
- [X] No

Not a regression, since `NavigationLock` is a new feature in .NET 7.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

This is a simple fix that catches and ignores this specific exception. There is otherwise no change in functionality.

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A