### PR TITLE
!fixup! Correct CodeQL3000 setup

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -177,14 +177,18 @@ stages:
         # Ignore the small amount of infrastructure Python code in this repo.
         - Codeql.Language: cpp,csharp,java,javascript
         - Codeql.ExcludePathPatterns: submodules
+        # Ignore test and infrastructure code.
         - Codeql.SourceRoot: src
         # CodeQL3000 needs this plumbed along as a variable to enable TSA.
         - Codeql.TSAEnabled: ${{ eq(variables['Build.Reason'], 'Schedule') }}
+        # Default expects tsaoptions.json under SourceRoot.
+        - Codeql.TSAOptionsPath: '$(Build.SourcesDirectory)/.config/tsaoptions.json'
         beforeBuild:
-        - script: "echo ##vso[build.addbuildtag]CodeQL3000"
-          displayName: 'Set CI CodeQL3000 tag'
         - task: CodeQL3000Init@0
           displayName: CodeQL Initialize
+        - script: "echo ##vso[build.addbuildtag]CodeQL3000"
+          displayName: 'Set CI CodeQL3000 tag'
+          condition: ne(variables.CODEQL_DIST,'')
         steps:
         - script: ./eng/build.cmd
                   -ci


### PR DESCRIPTION
- add tag only when CodeQL3000 tasks did useful work
  - ignore no-op task executions
- correct tsaoptions.json location