### PR TITLE
Add transport selector interface to Kestrel sockets and QUIC transports

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/src/QuicTransportFactory.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/QuicTransportFactory.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic;
 /// <summary>
 /// A factory for QUIC based connections.
 /// </summary>
-internal sealed class QuicTransportFactory : IMultiplexedConnectionListenerFactory
+internal sealed class QuicTransportFactory : IMultiplexedConnectionListenerFactory, IConnectionListenerFactorySelector
 {
     private readonly ILogger _log;
     private readonly QuicTransportOptions _options;
@@ -55,5 +55,10 @@ internal sealed class QuicTransportFactory : IMultiplexedConnectionListenerFacto
         await transport.CreateListenerAsync();
 
         return transport;
+    }
+
+    public bool CanBind(EndPoint endpoint)
+    {
+        return endpoint is IPEndPoint;
     }
 }

--- a/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
@@ -390,7 +390,7 @@ public class WebHostTests : LoggedTest
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => host.StartAsync()).DefaultTimeout();
 
         // Assert
-        Assert.Equal("QUIC doesn't support listening on the configured endpoint type. Expected IPEndPoint but got UnixDomainSocketEndPoint.", ex.Message);
+        Assert.Equal("No registered IMultiplexedConnectionListenerFactory supports endpoint UnixDomainSocketEndPoint: /test-path", ex.Message);
     }
 
     private static HttpClient CreateClient()

--- a/src/Servers/Kestrel/Transport.Sockets/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Transport.Sockets/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportFactory.CanBind(System.Net.EndPoint! endpoint) -> bool

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportFactory.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
+using System.Net.Sockets;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -11,7 +12,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
 /// <summary>
 /// A factory for socket based connections.
 /// </summary>
-public sealed class SocketTransportFactory : IConnectionListenerFactory
+public sealed class SocketTransportFactory : IConnectionListenerFactory, IConnectionListenerFactorySelector
 {
     private readonly SocketTransportOptions _options;
     private readonly ILoggerFactory _logger;
@@ -39,5 +40,17 @@ public sealed class SocketTransportFactory : IConnectionListenerFactory
         var transport = new SocketConnectionListener(endpoint, _options, _logger);
         transport.Bind();
         return new ValueTask<IConnectionListener>(transport);
+    }
+
+    /// <inheritdoc />
+    public bool CanBind(EndPoint endpoint)
+    {
+        return endpoint switch
+        {
+            IPEndPoint _ => true,
+            UnixDomainSocketEndPoint _ => true,
+            FileHandleEndPoint _ => true,
+            _ => false
+        };
     }
 }


### PR DESCRIPTION
Follow up PR to address comment https://github.com/dotnet/aspnetcore/pull/44657#discussion_r1010869733

**Note:**
An edge case with `SocketTransportFactory` is it allows the factory method to be customized with [SocketTransportOptions.CreateBoundListenSocket](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.transport.sockets.sockettransportoptions.createboundlistensocket?view=aspnetcore-7.0).

A custom method creating the socket means potentially any endpoint could work. Inside user code, a custom `EndPoint` implementation could be changed to an endpoint type supported by sockets. Limiting the endpoints that can be used to only built-in types would be a breaking change because the custom endpoint type would no longer work.

Does anyone do this? Probably not. If someone is using a custom endpoint type to pass in custom values to the factory method, a workaround to this change is to inherit from one of the supported endpoint types, e.g. `IPEndPoint`, and add new members..

Is it worth calling out this change? I can create a breaking change issue for this situation after .NET 7 ships.