### PR TITLE
source-build: don't use crossgen when building for mono runtime.

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -55,6 +55,7 @@
 
     <PropertyGroup>
       <InnerBuildArgs>$(InnerBuildArgs) /p:SourceBuildRuntimeIdentifier=$(TargetRuntimeIdentifier)</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(SourceBuildUseMonoRuntime)' == 'true'">$(InnerBuildArgs) /p:CrossgenOutput=false</InnerBuildArgs>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
https://github.com/dotnet/installer/pull/14792 enables building .NET from source with mono runtime instead of coreclr for 'any' architecture.
With mono runtime, crossgen2 is not available so we mustn't use it while building aspnetcore.

@dougbu ptal.

cc @MichaelSimons @crummel