### PR TITLE
Remove unnecessary ToArray call

### DIFF
--- a/src/Http/WebUtilities/src/BufferedReadStream.cs
+++ b/src/Http/WebUtilities/src/BufferedReadStream.cs
@@ -413,7 +413,7 @@ public class BufferedReadStream : Stream
     {
         // Drop the final CRLF, if any
         var length = foundCRLF ? builder.Length - 2 : builder.Length;
-        return Encoding.UTF8.GetString(builder.ToArray(), 0, (int)length);
+        return Encoding.UTF8.GetString(builder.GetBuffer(), 0, (int)length);
     }
 
     private void CheckDisposed()


### PR DESCRIPTION
Change is almost not worth making 😆 
Saves 0 or 2 bytes in the common case. But since it's a super simple small change I decided to do it...