### PR TITLE
Remove default logging scope from ASP.NET Core

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingApplication.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplication.cs
@@ -121,7 +121,6 @@ internal sealed class HostingApplication : IHttpApplication<HostingApplication.C
     internal sealed class Context
     {
         public HttpContext? HttpContext { get; set; }
-        public IDisposable? Scope { get; set; }
         public Activity? Activity
         {
             get => HttpActivityFeature?.Activity;
@@ -153,7 +152,6 @@ internal sealed class HostingApplication : IHttpApplication<HostingApplication.C
         {
             // Not resetting HttpContext here as we pool it on the Context
 
-            Scope = null;
             Activity = null;
             StartLog = null;
 

--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -1,10 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -97,11 +95,6 @@ internal sealed class HostingApplicationDiagnostics
         // To avoid allocation, return a null scope if the logger is not on at least to some degree.
         if (loggingEnabled)
         {
-            // Scope may be relevant for a different level of logging, so we always create it
-            // see: https://github.com/aspnet/Hosting/pull/944
-            // Scope can be null if logging is not on.
-            context.Scope = Log.RequestScope(_logger, httpContext);
-
             if (_logger.IsEnabled(LogLevel.Information))
             {
                 if (startTimestamp == 0)
@@ -215,9 +208,6 @@ internal sealed class HostingApplicationDiagnostics
                 _eventSource.RequestFailed();
             }
         }
-
-        // Logging Scope is finshed with
-        context.Scope?.Dispose();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -505,75 +495,5 @@ internal sealed class HostingApplicationDiagnostics
         }
         WriteDiagnosticEvent(_diagnosticListener, ActivityStopKey, httpContext);
         activity.Stop();    // Resets Activity.Current (we want this after the Write)
-    }
-
-    private static class Log
-    {
-        public static IDisposable? RequestScope(ILogger logger, HttpContext httpContext)
-        {
-            return logger.BeginScope(new HostingLogScope(httpContext));
-        }
-
-        private sealed class HostingLogScope : IReadOnlyList<KeyValuePair<string, object>>
-        {
-            private readonly string _path;
-            private readonly string _traceIdentifier;
-
-            private string? _cachedToString;
-
-            public int Count => 2;
-
-            public KeyValuePair<string, object> this[int index]
-            {
-                get
-                {
-                    if (index == 0)
-                    {
-                        return new KeyValuePair<string, object>("RequestId", _traceIdentifier);
-                    }
-                    else if (index == 1)
-                    {
-                        return new KeyValuePair<string, object>("RequestPath", _path);
-                    }
-
-                    throw new ArgumentOutOfRangeException(nameof(index));
-                }
-            }
-
-            public HostingLogScope(HttpContext httpContext)
-            {
-                _traceIdentifier = httpContext.TraceIdentifier;
-                _path = (httpContext.Request.PathBase.HasValue
-                         ? httpContext.Request.PathBase + httpContext.Request.Path
-                         : httpContext.Request.Path).ToString();
-            }
-
-            public override string ToString()
-            {
-                if (_cachedToString == null)
-                {
-                    _cachedToString = string.Format(
-                        CultureInfo.InvariantCulture,
-                        "RequestPath:{0} RequestId:{1}",
-                        _path,
-                        _traceIdentifier);
-                }
-
-                return _cachedToString;
-            }
-
-            public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
-            {
-                for (var i = 0; i < Count; ++i)
-                {
-                    yield return this[i];
-                }
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return GetEnumerator();
-            }
-        }
     }
 }

--- a/src/Hosting/Hosting/test/WebHostTests.cs
+++ b/src/Hosting/Hosting/test/WebHostTests.cs
@@ -869,28 +869,6 @@ public partial class WebHostTests
     }
 
     [Fact]
-    public async Task WebHost_CreatesDefaultRequestIdentifierFeature_IfNotPresent()
-    {
-        // Arrange
-        var requestDelegate = new RequestDelegate(httpContext =>
-        {
-            // Assert
-            Assert.NotNull(httpContext);
-            var featuresTraceIdentifier = httpContext.Features.Get<IHttpRequestIdentifierFeature>().TraceIdentifier;
-            Assert.False(string.IsNullOrWhiteSpace(httpContext.TraceIdentifier));
-            Assert.Same(httpContext.TraceIdentifier, featuresTraceIdentifier);
-
-            return Task.CompletedTask;
-        });
-
-        using (var host = CreateHost(requestDelegate))
-        {
-            // Act
-            await host.StartAsync();
-        }
-    }
-
-    [Fact]
     public async Task WebHost_DoesNot_CreateDefaultRequestIdentifierFeature_IfPresent()
     {
         // Arrange


### PR DESCRIPTION
- We log the activity information by default, the span id is more useful than the traceidentifier.
- Add the path and trace id as activity tags

I was looking at this and wondering why we still need it other than compatibility. I'm thinking we can lean into activity (as big as it is 😄) and use it's scope instead of having 2 by default. This reduces the number of async locals as well which is a plus. @noahfalk do you think it's reasonable to have a feature for logging adding tags to the logging activity scope as well?

cc @noahfalk @tarekgh @adityamandaleeka 

These are the per request allocations (excluding execution context overhead) (10K requests):

|Type|Allocations|Bytes|Average Size \(Bytes\)|
|-|-|-|-|
|\| - Microsoft.Extensions.Logging.Logger.Scope|10,125|486,000|48|
|\| - Microsoft.Extensions.Logging.LoggerFactoryScopeProvider.Scope|10,125|486,000|48|
|\| - Microsoft.AspNetCore.Hosting.HostingApplicationDiagnostics.Log.HostingLogScope|10,000|400,000|40|
|\| - System.IDisposable\[\]|10,125|324,000|32|