### PR TITLE
Fix SiteExtension loading on App Service

### DIFF
--- a/src/SiteExtensions/Microsoft.Web.Xdt.Extensions/src/Microsoft.Web.Xdt.Extensions.csproj
+++ b/src/SiteExtensions/Microsoft.Web.Xdt.Extensions/src/Microsoft.Web.Xdt.Extensions.csproj
@@ -10,7 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Microsoft.Web.Xdt" />
+    <!-- We need to reference the same version (or lower maybe) as App Service otherwise the custom transform cannot be loaded -->
+    <PackageReference Include="Microsoft.Web.Xdt" Version="1.4.0" AllowExplicitReference="true" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description

App Service uses version 1.4.0 of Microsoft.Web.Xdt which (I think) has issues loading our site extension if we reference a newer version.
Example error:
```
Microsoft.Web.XmlTransform.XmlNodeException: Could not resolve 'InsertOrAppendAttribute' as a type of Transform ---> Microsoft.Web.XmlTransform.XmlTransformationException: Could not resolve 'InsertOrAppendAttribute' as a type of Transformat 
Microsoft.Web.XmlTransform.NamedTypeFactory.Construct[ObjectType](String typeName)at
 Microsoft.Web.XmlTransform.XmlElementContext.CreateObjectFromAttribute[ObjectType](String& argumentString, XmlAttribute& objectAttribute)--- End of inner exception stack trace ---at 
Microsoft.Web.XmlTransform.XmlElementContext.ConstructTransform(String& argumentString)at
 Microsoft.Web.XmlTransform.XmlTransformation.HandleElement(XmlElementContext context)at
 Microsoft.Web.XmlTransform.XmlTransformation.TransformLoop(XmlNodeContext parentContext)
```

Reason I think this is that if I build the SiteExtension with version 2.1.X it has the same problem, but when I build with 1.4.0 it works fine. Plus, no real changes have been made to the Microsoft.Web.Xdt package in years.

## Customer Impact

The SiteExtension, which makes it easy to add logging in Azure for ASP.NET Core apps, is broken.

## Regression?

- [x] Yes
- [ ] No

Regressed from 6.0

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Currently the package is completely broken, hard to break it even more 😄 
Also, manually verified by building locally and overwriting the dll on an App Service site.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A