### PR TITLE
[release/3.1] nit: Update `$(RepositoryUrl)`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
-    <RepositoryUrl>https://github.com/aspnet/AspNetCore</RepositoryUrl>
+    <RepositoryUrl>https://github.com/dotnet/aspnetcore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 


### PR DESCRIPTION
- this shows up in all package .nuspec files
  - `<repository type="git" url="$repositoryUrl$" commit="$repositoryCommit$" />`
- also part of an `[AssemblyMetadataAttribute]` value (`SourceCommitUrl`)
- bit confusing though redirects to our new location **do** work