### PR TITLE
Change X-Requested-With header to "Fetch" in FetchHttpClient

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/FetchHttpClient.ts
+++ b/src/SignalR/clients/ts/signalr/src/FetchHttpClient.ts
@@ -104,7 +104,7 @@ export class FetchHttpClient extends HttpClient {
                 cache: "no-cache",
                 credentials: request.withCredentials === true ? "include" : "same-origin",
                 headers: {
-                    "X-Requested-With": "XMLHttpRequest",
+                    "X-Requested-With": "Fetch",
                     ...request.headers,
                 },
                 method: request.method!,


### PR DESCRIPTION
# Change X-Requested-With header to "Fetch" in FetchHttpClient

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Change X-Requested-With header to "Fetch" from "XmlHttpRequest" in FetchHttpClient

## Description

In [its initial version](https://github.com/dotnet/aspnetcore/blame/2be0ffae194c320472235173b8a18ab6c6ef78d0/src/SignalR/clients/ts/signalr/src/FetchHttpClient.ts#L39), FetchHttpClient used to set X-Requested-With header to "Fetch" but it was changed in a later commit and it currently sets it as "XmlHttpRequest" which makes it harder to know which client is really used.

Fixes #44933