### PR TITLE
Fixed a concatenation issue in special URIs.

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
+++ b/src/JSInterop/Microsoft.JSInterop.JS/src/src/Microsoft.JSInterop.ts
@@ -71,7 +71,7 @@ export module DotNet {
       // However since we're the one calling the import keyword, they would be resolved relative to
       // this framework bundle URL. Fix this by providing an absolute URL.
       if (typeof url === "string" && url.startsWith("./")) {
-          url = document.baseURI + url.substr(2);
+          url = new URL(url.substr(2), document.baseURI).toString();
       }
 
       return import(/* webpackIgnore: true */ url);


### PR DESCRIPTION
# Fixed a concatenation issue in special URIs.

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

When the URL end with an hash, current code concatenate the file name to the URL, which doesn't lead in the wanted behavior.

Fixes #44927.
