### PR TITLE
[release/2.1] nit: Update `$(RepositoryUrl)`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Product>Microsoft ASP.NET Core</Product>
     <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
-    <RepositoryUrl>https://github.com/aspnet/AspNetCore</RepositoryUrl>
+    <RepositoryUrl>https://github.com/dotnet/aspnetcore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)eng\AspNetCore.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/src/AzureIntegration/Directory.Build.props
+++ b/src/AzureIntegration/Directory.Build.props
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <Product>Microsoft ASP.NET Core</Product>
-    <RepositoryUrl>https://github.com/aspnet/AspNetCore</RepositoryUrl>
+    <RepositoryUrl>https://github.com/dotnet/aspnetcore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\..\eng\AspNetCore.snk</AssemblyOriginatorKeyFile>

--- a/src/Templating/Directory.Build.props
+++ b/src/Templating/Directory.Build.props
@@ -10,7 +10,7 @@
   <PropertyGroup>
     <Product>Microsoft ASP.NET Core</Product>
     <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
-    <RepositoryUrl>https://github.com/aspnet/AspNetCore</RepositoryUrl>
+    <RepositoryUrl>https://github.com/dotnet/aspnetcore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SharedSourceRoot>$(MSBuildThisFileDirectory)..\Shared\</SharedSourceRoot>


### PR DESCRIPTION
- backport of #44891; doesn't affect assembly attributes here
- this shows up in all package .nuspec files
  - `<repository type="git" url="$repositoryUrl$" commit="$repositoryCommit$" />`
- bit confusing though redirects to our new location **do** work