### PR TITLE
Fix predicate evaluation in OutputCacheAttribute

### DIFF
--- a/src/Middleware/OutputCaching/src/OutputCacheAttribute.cs
+++ b/src/Middleware/OutputCaching/src/OutputCacheAttribute.cs
@@ -66,11 +66,17 @@ public sealed class OutputCacheAttribute : Attribute
             return _builtPolicy;
         }
 
-        var builder = new OutputCachePolicyBuilder();
+        OutputCachePolicyBuilder builder;
 
         if (PolicyName != null)
         {
+            // Don't add the default policy if i named one is used as it could already contain it
+            builder = new OutputCachePolicyBuilder(excludeDefaultPolicy: true);
             builder.AddPolicy(new NamedPolicy(PolicyName));
+        }
+        else
+        {
+            builder = new();
         }
 
         if (_noCache != null && _noCache.Value)

--- a/src/Middleware/OutputCaching/src/OutputCacheAttribute.cs
+++ b/src/Middleware/OutputCaching/src/OutputCacheAttribute.cs
@@ -70,7 +70,7 @@ public sealed class OutputCacheAttribute : Attribute
 
         if (PolicyName != null)
         {
-            // Don't add the default policy if i named one is used as it could already contain it
+            // Don't add the default policy if a named one is used as it could already contain it
             builder = new OutputCachePolicyBuilder(excludeDefaultPolicy: true);
             builder.AddPolicy(new NamedPolicy(PolicyName));
         }

--- a/src/Middleware/OutputCaching/test/OutputCacheAttributeTests.cs
+++ b/src/Middleware/OutputCaching/test/OutputCacheAttributeTests.cs
@@ -58,7 +58,7 @@ public class OutputCacheAttributeTests
     }
 
     [Fact]
-    public async Task Attribute_NamedPolicyDoesntInjectDefaultPolicy()
+    public async Task Attribute_NamedPolicyDoesNotInjectDefaultPolicy()
     {
         var options = new OutputCacheOptions();
         options.AddPolicy("MyPolicy", b => b.With(x => false).Cache());

--- a/src/Middleware/OutputCaching/test/OutputCacheAttributeTests.cs
+++ b/src/Middleware/OutputCaching/test/OutputCacheAttributeTests.cs
@@ -48,13 +48,27 @@ public class OutputCacheAttributeTests
         var options = new OutputCacheOptions();
         options.AddPolicy("MyPolicy", b => b.Expire(TimeSpan.FromSeconds(42)));
 
-        var context = TestUtils.CreateTestContext(options: options);
+        var context = TestUtils.CreateUninitializedContext(options: options);
 
         var attribute = OutputCacheMethods.GetAttribute(nameof(OutputCacheMethods.PolicyName));
         await attribute.BuildPolicy().CacheRequestAsync(context, cancellation: default);
 
         Assert.True(context.EnableOutputCaching);
         Assert.Equal(42, context.ResponseExpirationTimeSpan?.TotalSeconds);
+    }
+
+    [Fact]
+    public async Task Attribute_NamedPolicyDoesntInjectDefaultPolicy()
+    {
+        var options = new OutputCacheOptions();
+        options.AddPolicy("MyPolicy", b => b.With(x => false).Cache());
+
+        var context = TestUtils.CreateUninitializedContext(options: options);
+
+        var attribute = OutputCacheMethods.GetAttribute(nameof(OutputCacheMethods.PolicyName));
+        await attribute.BuildPolicy().CacheRequestAsync(context, cancellation: default);
+
+        Assert.False(context.EnableOutputCaching);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #44739

When using a named policy from a controller/action, it currently injects a `DefaultPolicy` before it, which then won't be part of the predicate if there is one specified. The `DefaultPolicy` should only be included if a named policy is not defined, or if the named policy is using one internally (by default).