### PR TITLE
[Blazor] Workaround linker regression

### DIFF
--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/ILLink.Descriptors.xml
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/ILLink.Descriptors.xml
@@ -1,0 +1,5 @@
+<linker>
+  <assembly fullname="Microsoft.AspNetCore.Components.WebAssembly.Authentication">
+    <type fullname="Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationContext`1" preserve="all" />
+  </assembly>
+</linker>

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Microsoft.AspNetCore.Components.WebAssembly.Authentication.csproj
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Microsoft.AspNetCore.Components.WebAssembly.Authentication.csproj
@@ -40,6 +40,10 @@
 
     <Content Remove="$(YarnWorkingDir)**" />
     <None Include="$(YarnWorkingDir)*" Exclude="$(YarnWorkingDir)node_modules\**" />
+    
+    <EmbeddedResource Include="ILLink.Descriptors.xml">
+      <LogicalName>ILLink.Descriptors.xml</LogicalName>
+    </EmbeddedResource>
 
     <UpToDateCheckInput Include="@(YarnInputs)" Set="StaticWebassets" />
     <UpToDateCheckOutput Include="@(YarnOutputs)" Set="StaticWebassets" />

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/RemoteAuthenticatorViewCore.Log.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/RemoteAuthenticatorViewCore.Log.cs
@@ -53,5 +53,8 @@ public partial class RemoteAuthenticatorViewCore<TAuthenticationState> where TAu
 
         [LoggerMessage(15, LogLevel.Debug, "Logout redirect completed successfully.", EventName = nameof(LogoutRedirectCompletedSuccessfully))]
         public static partial void LogoutRedirectCompletedSuccessfully(ILogger logger);
+
+        [LoggerMessage(16, LogLevel.Debug, "Login request '{Request}'.", EventName = nameof(LoginRequest))]
+        public static partial void LoginRequest(ILogger logger, string request);
     }
 }

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/RemoteAuthenticatorViewCore.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/RemoteAuthenticatorViewCore.cs
@@ -210,6 +210,7 @@ public partial class RemoteAuthenticatorViewCore<[DynamicallyAccessedMembers(Jso
 
     private async Task ProcessLogIn(string returnUrl)
     {
+        Log.LoginRequest(Logger, Navigation.HistoryEntryState);
         AuthenticationState.ReturnUrl = returnUrl;
         var interactiveRequest = GetCachedNavigationState();
         var result = await AuthenticationService.SignInAsync(new RemoteAuthenticationContext<TAuthenticationState>


### PR DESCRIPTION
The linker seems to be incorrectly trimming the getters for one of our types. This PR includes a descriptor to ensure that the members of the exchange type are never serialized out and avoids using a serialization context as that breaks serialization for user provided data types.

## Description

The linker is linking out the getters for one of our exchange types. This is the link output in 7.0
![MicrosoftTeams-image](https://user-images.githubusercontent.com/6995051/201389145-7badc5f6-825c-4ad8-b816-e5b7c393159c.png)

This is the link output in 6.0
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/6995051/201389153-05bd8006-0110-4dce-961d-f9a109d1490a.png)

Fixes https://github.com/dotnet/aspnetcore/issues/44973

## Customer Impact

Breaks the ability to return to the original page after the user is redirected for authentication purposes as well as the ability to pass options to control the login process.

**Workaround**

Add this to your csproj
```
<ItemGroup>
  <TrimmerRootDescriptor Include="TrimmerRootDescriptor.xml" />
</ItemGroup>
```
And this is TrimmerRootDescriptor.xml:

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<linker>
	<assembly fullname="Microsoft.Authentication.WebAssembly.Msal" preserve="all" />
	<assembly fullname="Microsoft.AspNetCore.Components.WebAssembly.Authentication" preserve="all" />
</linker>
```

## Regression?

- [X] Yes
- [ ] No

6.0

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The fix uses a linker descriptor to explicitly prevent the members for that type from being trimmed away.

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props