### PR TITLE
[6.0] Restore IISServerSetupFilter server type check

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -239,7 +239,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core
                         else
                         {
                             // Mismatch, fall back
-                            // The failing test case here is "/base/call//../ball//path1//path2", reduced to "/base/call/ball//path1//path2",
+                            // The failing test case here is "/base/call//../bat//path1//path2", reduced to "/base/call/bat//path1//path2",
                             // where http.sys collapses "//" before "../", but we do "../" first. We've lost the context that there were dot segments,
                             // or duplicate slashes, how do we figure out that "call/" can be eliminated?
                             originalOffset = 0;

--- a/src/Servers/IIS/IIS/src/Core/IISServerSetupFilter.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISServerSetupFilter.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Server.IIS.Core
+{
+    internal class IISServerSetupFilter : IStartupFilter
+    {
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+        {
+            return app =>
+            {
+                var server = app.ApplicationServices.GetService<IServer>();
+                if (server?.GetType() != typeof(IISHttpServer))
+                {
+                    throw new InvalidOperationException("Application is running inside IIS process but is not configured to use IIS server.");
+                }
+
+                next(app);
+            };
+        }
+    }
+}

--- a/src/Servers/IIS/IIS/src/WebHostBuilderIISExtensions.cs
+++ b/src/Servers/IIS/IIS/src/WebHostBuilderIISExtensions.cs
@@ -42,6 +42,7 @@ namespace Microsoft.AspNetCore.Hosting
                         services.AddSingleton(new IISNativeApplication(new NativeSafeHandle(iisConfigData.pNativeApplication)));
                         services.AddSingleton<IServer, IISHttpServer>();
                         services.AddTransient<IISServerAuthenticationHandlerInternal>();
+                        services.AddSingleton<IStartupFilter, IISServerSetupFilter>();
                         services.AddAuthenticationCore();
                         services.AddSingleton<IServerIntegratedAuth>(_ => new ServerIntegratedAuth()
                         {


### PR DESCRIPTION
Fixing a mistake from https://github.com/dotnet/aspnetcore/pull/44753/ where I removed too much code from IISServerSetupFilter. This IServer type check is only to provide a better error and has no functional impact on a working app. The test covering this is disabled in the 6.0 branch, but caught the issue in the 7.0 and main branches.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1675300/

@danmoseley, do we need this re-approved by tactics?

