### PR TITLE
Remove array allocation from multi-span header parsing

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -288,11 +288,6 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
                 // This was a multi-line header. Advance the reader.
                 reader.Advance(length);
 
-                if (reader.End)
-                {
-                    return true;
-                }
-
                 continue;
             }
 
@@ -333,7 +328,7 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
         // Skip the first segment as the caller already searched it for CR/LF
         if (!currentSlice.TryGet(ref position, out ReadOnlyMemory<byte> memory) || position.GetObject() == null)
         {
-            // Shouldn't be possible, unless maybe there was a 0 length second segment and no more segments after?
+            // Only 1 segment in the reader currently, this is a partial header, wait for more data
             return -1;
         }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -325,8 +325,13 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
         var currentSlice = reader.UnreadSequence;
 
         SequencePosition position = currentSlice.Start;
+
         // Skip the first segment as the caller already searched it for CR/LF
-        if (!currentSlice.TryGet(ref position, out ReadOnlyMemory<byte> memory) || position.GetObject() == null)
+        var result = currentSlice.TryGet(ref position, out ReadOnlyMemory<byte> memory);
+        // there will always be at least 1 segment so this will never return false
+        Debug.Assert(result);
+
+        if (position.GetObject() == null)
         {
             // Only 1 segment in the reader currently, this is a partial header, wait for more data
             return -1;
@@ -377,7 +382,7 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
             }
         }
 
-        ReadOnlySequence<byte> header = new();
+        ReadOnlySequence<byte> header;
         if (memory.Span[index] == ByteCR)
         {
             // First EOL char is CR, include the char after CR
@@ -436,6 +441,7 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
         {
             ArrayPool<byte>.Shared.Return(array);
         }
+
         return headerLength;
     }
 

--- a/src/Servers/Kestrel/Core/test/HttpParserTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpParserTests.cs
@@ -679,6 +679,22 @@ public class HttpParserTests : LoggedTest
         Assert.True(result);
     }
 
+    [Fact]
+    public void ParseLargeHeaderLineWithGratuitouslySplitBuffers()
+    {
+        // Must be greater than the stackalloc we use (256) to test the array pool path
+        var stringLength = 300;
+        var headers = $"Host: {new string('a', stringLength)}\r\nConnection: keep-alive\r\n";
+        var parser = CreateParser(_nullTrace, false);
+        var buffer = BytePerSegmentTestSequenceFactory.Instance.CreateWithContent(headers);
+
+        var requestHandler = new RequestHandler();
+        var reader = new SequenceReader<byte>(buffer);
+        var result = parser.ParseHeaders(requestHandler, ref reader);
+
+        Assert.True(result);
+    }
+
     private bool ParseRequestLine(IHttpParser<RequestHandler> parser, RequestHandler requestHandler, ReadOnlySequence<byte> readableBuffer, out SequencePosition consumed, out SequencePosition examined)
     {
         var reader = new SequenceReader<byte>(readableBuffer);

--- a/src/Servers/Kestrel/perf/Microbenchmarks/HttpParserBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/HttpParserBenchmark.cs
@@ -29,35 +29,35 @@ public class HttpParserBenchmark : IHttpRequestLineHandler, IHttpHeadersHandler
         _multispanHeader = new ReadOnlySequence<byte>(segment, 0, next, next.Memory.Length);
     }
 
-    //[Benchmark(Baseline = true, OperationsPerInvoke = RequestParsingData.InnerLoopCount)]
-    //public void PlaintextTechEmpower()
-    //{
-    //    for (var i = 0; i < RequestParsingData.InnerLoopCount; i++)
-    //    {
-    //        InsertData(RequestParsingData.PlaintextTechEmpowerRequest);
-    //        ParseData();
-    //    }
-    //}
+    [Benchmark(Baseline = true, OperationsPerInvoke = RequestParsingData.InnerLoopCount)]
+    public void PlaintextTechEmpower()
+    {
+        for (var i = 0; i < RequestParsingData.InnerLoopCount; i++)
+        {
+            InsertData(RequestParsingData.PlaintextTechEmpowerRequest);
+            ParseData();
+        }
+    }
 
-    //[Benchmark(OperationsPerInvoke = RequestParsingData.InnerLoopCount)]
-    //public void JsonTechEmpower()
-    //{
-    //    for (var i = 0; i < RequestParsingData.InnerLoopCount; i++)
-    //    {
-    //        InsertData(RequestParsingData.JsonTechEmpowerRequest);
-    //        ParseData();
-    //    }
-    //}
+    [Benchmark(OperationsPerInvoke = RequestParsingData.InnerLoopCount)]
+    public void JsonTechEmpower()
+    {
+        for (var i = 0; i < RequestParsingData.InnerLoopCount; i++)
+        {
+            InsertData(RequestParsingData.JsonTechEmpowerRequest);
+            ParseData();
+        }
+    }
 
-    //[Benchmark(OperationsPerInvoke = RequestParsingData.InnerLoopCount)]
-    //public void LiveAspNet()
-    //{
-    //    for (var i = 0; i < RequestParsingData.InnerLoopCount; i++)
-    //    {
-    //        InsertData(RequestParsingData.LiveaspnetRequest);
-    //        ParseData();
-    //    }
-    //}
+    [Benchmark(OperationsPerInvoke = RequestParsingData.InnerLoopCount)]
+    public void LiveAspNet()
+    {
+        for (var i = 0; i < RequestParsingData.InnerLoopCount; i++)
+        {
+            InsertData(RequestParsingData.LiveaspnetRequest);
+            ParseData();
+        }
+    }
 
     [Benchmark(OperationsPerInvoke = RequestParsingData.InnerLoopCount)]
     public void Unicode()

--- a/src/Servers/Kestrel/perf/Microbenchmarks/HttpParserBenchmark.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/HttpParserBenchmark.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.IO.Pipelines;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
@@ -12,36 +13,51 @@ public class HttpParserBenchmark : IHttpRequestLineHandler, IHttpHeadersHandler
     private readonly HttpParser<Adapter> _parser = new HttpParser<Adapter>();
 
     private ReadOnlySequence<byte> _buffer;
+    private ReadOnlySequence<byte> _multispanHeader;
 
-    [Benchmark(Baseline = true, OperationsPerInvoke = RequestParsingData.InnerLoopCount)]
-    public void PlaintextTechEmpower()
+    [GlobalSetup]
+    public void Setup()
     {
-        for (var i = 0; i < RequestParsingData.InnerLoopCount; i++)
-        {
-            InsertData(RequestParsingData.PlaintextTechEmpowerRequest);
-            ParseData();
-        }
+        var segment = new BufferSegment();
+        var split = RequestParsingData.UnicodeRequest.Length / 2;
+        segment.SetOwnedMemory(RequestParsingData.UnicodeRequest.AsSpan(0, split).ToArray());
+        segment.End = split;
+        var next = new BufferSegment();
+        next.SetOwnedMemory(RequestParsingData.UnicodeRequest.AsSpan(split).ToArray());
+        next.End = split;
+        segment.SetNext(next);
+        _multispanHeader = new ReadOnlySequence<byte>(segment, 0, next, next.Memory.Length);
     }
 
-    [Benchmark(OperationsPerInvoke = RequestParsingData.InnerLoopCount)]
-    public void JsonTechEmpower()
-    {
-        for (var i = 0; i < RequestParsingData.InnerLoopCount; i++)
-        {
-            InsertData(RequestParsingData.JsonTechEmpowerRequest);
-            ParseData();
-        }
-    }
+    //[Benchmark(Baseline = true, OperationsPerInvoke = RequestParsingData.InnerLoopCount)]
+    //public void PlaintextTechEmpower()
+    //{
+    //    for (var i = 0; i < RequestParsingData.InnerLoopCount; i++)
+    //    {
+    //        InsertData(RequestParsingData.PlaintextTechEmpowerRequest);
+    //        ParseData();
+    //    }
+    //}
 
-    [Benchmark(OperationsPerInvoke = RequestParsingData.InnerLoopCount)]
-    public void LiveAspNet()
-    {
-        for (var i = 0; i < RequestParsingData.InnerLoopCount; i++)
-        {
-            InsertData(RequestParsingData.LiveaspnetRequest);
-            ParseData();
-        }
-    }
+    //[Benchmark(OperationsPerInvoke = RequestParsingData.InnerLoopCount)]
+    //public void JsonTechEmpower()
+    //{
+    //    for (var i = 0; i < RequestParsingData.InnerLoopCount; i++)
+    //    {
+    //        InsertData(RequestParsingData.JsonTechEmpowerRequest);
+    //        ParseData();
+    //    }
+    //}
+
+    //[Benchmark(OperationsPerInvoke = RequestParsingData.InnerLoopCount)]
+    //public void LiveAspNet()
+    //{
+    //    for (var i = 0; i < RequestParsingData.InnerLoopCount; i++)
+    //    {
+    //        InsertData(RequestParsingData.LiveaspnetRequest);
+    //        ParseData();
+    //    }
+    //}
 
     [Benchmark(OperationsPerInvoke = RequestParsingData.InnerLoopCount)]
     public void Unicode()
@@ -49,6 +65,16 @@ public class HttpParserBenchmark : IHttpRequestLineHandler, IHttpHeadersHandler
         for (var i = 0; i < RequestParsingData.InnerLoopCount; i++)
         {
             InsertData(RequestParsingData.UnicodeRequest);
+            ParseData();
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = RequestParsingData.InnerLoopCount)]
+    public void MultispanUnicodeHeader()
+    {
+        for (var i = 0; i < RequestParsingData.InnerLoopCount; i++)
+        {
+            _buffer = _multispanHeader;
             ParseData();
         }
     }


### PR DESCRIPTION
Noticed this allocation while looking at a memory profile for CertAuth. My hypothesis is that the certificate/tls handshake is pushing the header bytes across a PipeSegment boundary which goes through the multi-span header parsing path, and that path would allocate a `byte[]` if the header crossed multiple spans. This change avoids the allocation by using `stackalloc` or `ArrayPool<byte>.Shared`.

![remove_alloc](https://user-images.githubusercontent.com/7574801/201448592-86bdcefc-c00b-4d0d-bbea-4eab8940cc4f.png)
The highlighted line is now gone from the benchmark 😃 

**Before:**
|                 Method |     Mean |    Error |   StdDev |   Median |        Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------- |---------:|---------:|---------:|---------:|------------:|------:|------:|------:|----------:|
|                Unicode | 371.2 ns | 11.94 ns | 35.22 ns | 356.3 ns | 2,693,742.3 |     - |     - |     - |         - |
| MultispanUnicodeHeader | 573.8 ns | 18.61 ns | 54.87 ns | 552.9 ns | 1,742,893.2 |     - |     - |     - |      48 B |

**After:**
|                 Method |     Mean |    Error |   StdDev |   Median |        Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------- |---------:|---------:|---------:|---------:|------------:|------:|------:|------:|----------:|
|                Unicode | 351.9 ns | 10.64 ns | 31.03 ns | 339.3 ns | 2,841,974.0 |     - |     - |     - |         - |
| MultispanUnicodeHeader - First Commit | 553.0 ns | 16.74 ns | 48.82 ns | 533.3 ns | 1,808,160.4 |     - |     - |     - |         - |
| MultispanUnicodeHeader - Second Commit | 484.9 ns | 11.75 ns | 33.90 ns | 471.2 ns | 2,062,450.8 |     - |     - |     - |         - |

The Op/s difference is noise, especially since `Unicode` shouldn't hit the changed code path.