### PR TITLE
Endpoint filter pipeline now returns EmptyHttpResult in case of 400 BadRequest

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -92,7 +92,7 @@ public static partial class RequestDelegateFactory
     private static readonly MemberExpression FormFilesExpr = Expression.Property(FormExpr, typeof(IFormCollection).GetProperty(nameof(IFormCollection.Files))!);
     private static readonly MemberExpression StatusCodeExpr = Expression.Property(HttpResponseExpr, typeof(HttpResponse).GetProperty(nameof(HttpResponse.StatusCode))!);
     private static readonly MemberExpression CompletedTaskExpr = Expression.Property(null, (PropertyInfo)GetMemberInfo<Func<Task>>(() => Task.CompletedTask));
-    private static readonly ConstantExpression EmptyResultValueTaskExpr = Expression.Constant(new ValueTask<object?>(EmptyHttpResult.Instance));
+    private static readonly NewExpression EmptyHttpResultValueTaskExpr = Expression.New(typeof(ValueTask<object>).GetConstructor(new[] { typeof(EmptyHttpResult) })!, Expression.Property(null, typeof(EmptyHttpResult), nameof(EmptyHttpResult.Instance)));
 
     private static readonly ParameterExpression TempSourceStringExpr = ParameterBindingMethodCache.TempSourceStringExpr;
     private static readonly BinaryExpression TempSourceStringNotNullExpr = Expression.NotEqual(TempSourceStringExpr, Expression.Constant(null));
@@ -432,7 +432,7 @@ public static partial class RequestDelegateFactory
         var filteredInvocation = Expression.Lambda<EndpointFilterDelegate>(
             Expression.Condition(
                 Expression.GreaterThanOrEqual(FilterContextHttpContextStatusCodeExpr, Expression.Constant(400)),
-                EmptyResultValueTaskExpr,
+                EmptyHttpResultValueTaskExpr,
                 handlerInvocation),
             FilterContextExpr).Compile();
         var routeHandlerContext = new EndpointFilterFactoryContext
@@ -463,7 +463,7 @@ public static partial class RequestDelegateFactory
     {
         if (returnType == typeof(void))
         {
-            return Expression.Block(methodCall, EmptyResultValueTaskExpr);
+            return Expression.Block(methodCall, EmptyHttpResultValueTaskExpr);
         }
         else if (returnType == typeof(Task))
         {

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -5671,6 +5671,8 @@ public partial class RequestDelegateFactoryTests : LoggedTest
         };
 
         var httpContext = CreateHttpContext();
+        var responseBodyStream = new MemoryStream();
+        httpContext.Response.Body = responseBodyStream;
 
         // Act
         var factoryResult = RequestDelegateFactory.Create(HelloName, new RequestDelegateFactoryOptions()
@@ -5690,6 +5692,7 @@ public partial class RequestDelegateFactoryTests : LoggedTest
         // Assert
         Assert.False(invoked);
         Assert.Equal(400, httpContext.Response.StatusCode);
+        Assert.Equal(0, responseBodyStream.Position);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

The endpoint filter pipeline will now return an EmptyHttpResult instance instead of ValueTask<object>(Task.CompletedTask) when the status code is greater or equal to 400 to prevent the returned task from being serialized and written to the response body.

Before:
```C#
if (httpContext.Response.StatusCode >= 400)
{
  return new ValueTask<object>(Task.CompletedTask);
}
```

After:
```C#
if (httpContext.Response.StatusCode >= 400)
{
  return new ValueTask<object>(EmptyHttpResult.Instance);
}
```

Fixes #45040
