### PR TITLE
Fixed docs in NavigationManagerExtensions suggesting login operations perform logouts

### DIFF
--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/NavigationManagerExtensions.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/NavigationManagerExtensions.cs
@@ -45,11 +45,11 @@ public static class NavigationManagerExtensions
     }
 
     /// <summary>
-    /// Initiates a logout operation by navigating to the log out endpoint.
+    /// Initiates a login operation by navigating to the login endpoint.
     /// </summary>
     /// <remarks>
     /// The navigation includes state that is added to the browser history entry to
-    /// prevent logout operations performed from different contexts.
+    /// prevent login operations performed from different contexts.
     /// </remarks>
     /// <param name="manager">The <see cref="NavigationManager"/>.</param>
     /// <param name="loginPath">The path to the login url.</param>
@@ -63,11 +63,11 @@ public static class NavigationManagerExtensions
     }
 
     /// <summary>
-    /// Initiates a logout operation by navigating to the log out endpoint.
+    /// Initiates a login operation by navigating to the login endpoint.
     /// </summary>
     /// <remarks>
     /// The navigation includes state that is added to the browser history entry to
-    /// prevent logout operations performed from different contexts.
+    /// prevent login operations performed from different contexts.
     /// </remarks>
     /// <param name="manager">The <see cref="NavigationManager"/>.</param>
     /// <param name="loginPath">The path to the login url.</param>


### PR DESCRIPTION
# Fixed docs in NavigationManagerExtensions suggesting login operations perform logouts

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable. _not applicable_
- [ ] You've included inline docs for your change, where applicable. _not applicable_
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

>Documentation of both overloads of NavigateToLogin in [NavigationManagerExtensions](https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/WebAssembly.Authentication/src/NavigationManagerExtensions.cs) seems to have been copied from NavigateToLogout, including mentions of logout instead of login.

Fixes #45089
