### PR TITLE
[release/7.0] Add init-nuget workaround back

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -489,13 +489,13 @@ stages:
               $(_InternalRuntimeDownloadArgs)
           displayName: Run build.sh
         - script: git clean -xfd src/**/obj/;
-            ./dockerbuild.sh bionic --ci --nobl --arch x64 --build-installers --no-build-deps --no-build-nodejs
+            ./dockerbuild.sh bionic --ci --nobl --arch x64 --build-installers --no-build-deps --no-build-nodejs --init-nuget
             -p:OnlyPackPlatformSpecificPackages=true -p:BuildRuntimeArchive=false -p:LinuxInstallerType=deb
             $(_BuildArgs)
             $(_InternalRuntimeDownloadArgs)
           displayName: Build Debian installers
         - script: git clean -xfd src/**/obj/;
-            ./dockerbuild.sh rhel --ci --nobl --arch x64 --build-installers --no-build-deps --no-build-nodejs
+            ./dockerbuild.sh rhel --ci --nobl --arch x64 --build-installers --no-build-deps --no-build-nodejs --init-nuget
             -p:OnlyPackPlatformSpecificPackages=true -p:BuildRuntimeArchive=false -p:LinuxInstallerType=rpm
             -p:AssetManifestFileName=aspnetcore-Linux_x64.xml
             $(_BuildArgs)

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -568,7 +568,7 @@ stages:
               $(_InternalRuntimeDownloadArgs)
           displayName: Run build.sh
         - script: git clean -xfd src/**/obj/;
-            ./dockerbuild.sh rhel --ci --nobl --arch arm64 --build-installers --no-build-deps --no-build-nodejs
+            ./dockerbuild.sh rhel --ci --nobl --arch arm64 --build-installers --no-build-deps --no-build-nodejs  --init-nuget
             -p:OnlyPackPlatformSpecificPackages=true -p:BuildRuntimeArchive=false -p:LinuxInstallerType=rpm
             -p:AssetManifestFileName=aspnetcore-Linux_arm64.xml
             $(_BuildArgs)


### PR DESCRIPTION
Arcade update was supposed to fix this but it didn't

> /mnt/vss/_work/1/s/.dotnet/sdk/7.0.100/NuGet.targets(132,5): error MSB4018: System.Threading.AbandonedMutexException: The wait completed due to an abandoned mutex. [/tmp/f3284e0d-cdf1-4fe9-8649-4fb39001755c/restore.csproj] [/mnt/vss/_work/1/s/.packages/microsoft.dotnet.arcade.sdk/7.0.0-beta.22558.4/tools/Tools.proj]

CC @mmitche 