### PR TITLE
Don't require configuration for Auth

### DIFF
--- a/src/Security/Authentication/Core/src/DefaultAuthenticationConfigurationProvider.cs
+++ b/src/Security/Authentication/Core/src/DefaultAuthenticationConfigurationProvider.cs
@@ -10,10 +10,12 @@ internal sealed class DefaultAuthenticationConfigurationProvider : IAuthenticati
     private readonly IConfiguration _configuration;
     private const string AuthenticationKey = "Authentication";
 
+    // Note: this generally will never be called except in unit tests as IConfiguration is generally available from the host
+    public DefaultAuthenticationConfigurationProvider() : this(new ConfigurationManager())
+    { }
+
     public DefaultAuthenticationConfigurationProvider(IConfiguration configuration)
-    {
-        _configuration = configuration;
-    }
+        => _configuration = configuration;
 
     public IConfiguration AuthenticationConfiguration => _configuration.GetSection(AuthenticationKey);
 }

--- a/src/Security/Authentication/test/TestExtensions.cs
+++ b/src/Security/Authentication/test/TestExtensions.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Authentication;
@@ -80,11 +79,6 @@ public static class TestExtensions
     }
 
     public static IServiceCollection ConfigureAuthTestServices(this IServiceCollection services)
-    {
-        return services
-            .AddOptions()
-            .AddLogging()
-            .AddSingleton<IConfiguration>(new ConfigurationManager());
-    }
-
+        => services.AddOptions()
+                   .AddLogging();
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/44966

Generally hosting adds IConfiguration but for some (mostly) test scenarios configuration might not be in DI.  This fix makes us no-op instead of fail.