### PR TITLE
[release/7.0] Use simpler Docker tags

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -595,7 +595,7 @@ stages:
         jobName: Linux_musl_x64_build
         jobDisplayName: "Build: Linux Musl x64"
         agentOs: Linux
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode-20210910135833-c401c85
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode
         buildArgs:
           --arch x64
           --os-name linux-musl
@@ -631,7 +631,7 @@ stages:
         jobDisplayName: "Build: Linux Musl ARM"
         agentOs: Linux
         useHostedUbuntu: false
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm-alpine-20211022152824-78f7860
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm-alpine
         buildArgs:
           --arch arm
           --os-name linux-musl
@@ -666,7 +666,7 @@ stages:
         jobDisplayName: "Build: Linux Musl ARM64"
         agentOs: Linux
         useHostedUbuntu: false
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-alpine-20211022152824-538077f
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-alpine
         buildArgs:
           --arch arm64
           --os-name linux-musl
@@ -796,10 +796,11 @@ stages:
       parameters:
         platform:
           name: 'Managed'
-          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8-20220809204800-17a4aab'
+          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
           buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks $(_InternalRuntimeDownloadArgs)'
           skipPublishValidation: true
-          timeoutInMinutes: 120
+          jobProperties:
+            timeoutInMinutes: 120
 
     # Publish to the BAR and perform source indexing. Wait until everything else is done.
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/docker/rhel.Dockerfile
+++ b/eng/docker/rhel.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile that creates a container suitable to build dotnet-cli
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-rpmpkg-20220505130359-d0fa36f
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-rpmpkg
 
 # Setup User to match Host User, and give superuser permissions
 ARG USER

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -1,11 +1,11 @@
 <Project>
   <!-- This file is shared between Helix.proj and .csproj files. -->
   <PropertyGroup>
-    <HelixQueueAlpine314>(Alpine.314.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-helix-amd64-20210910135833-1848e19</HelixQueueAlpine314>
-    <HelixQueueDebian11>(Debian.11.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64-20211001171307-0ece9b3</HelixQueueDebian11>
-    <HelixQueueFedora34>(Fedora.34.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-helix-20210924174119-4f64125</HelixQueueFedora34>
-    <HelixQueueMariner>(Mariner)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix-20210528192219-92bf620</HelixQueueMariner>
-    <HelixQueueArmDebian11>(Debian.11.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-arm64v8-20211001171229-97d8652</HelixQueueArmDebian11>
+    <HelixQueueAlpine314>(Alpine.314.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-helix-amd64</HelixQueueAlpine314>
+    <HelixQueueDebian11>(Debian.11.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64</HelixQueueDebian11>
+    <HelixQueueFedora34>(Fedora.34.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-helix</HelixQueueFedora34>
+    <HelixQueueMariner>(Mariner)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix</HelixQueueMariner>
+    <HelixQueueArmDebian11>(Debian.11.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-arm64v8</HelixQueueArmDebian11>
 
     <!-- Do not attempt to override global property. -->
     <RunQuarantinedTests Condition=" '$(RunQuarantinedTests)' == '' ">false</RunQuarantinedTests>

--- a/src/Installers/Rpm/Directory.Build.targets
+++ b/src/Installers/Rpm/Directory.Build.targets
@@ -85,7 +85,7 @@
       <FpmArgs Include="&quot;$(PackageContentRoot)=$(RpmPackageInstallRoot)&quot;" />
     </ItemGroup>
 
-    <Exec Command="scl enable rh-ruby25 'fpm @(FpmArgs,' ')'" />
+    <Exec Command="scl enable rh-ruby26 'fpm @(FpmArgs,' ')'" />
 
     <Copy SourceFiles="$(TargetPath)"
           DestinationFiles="$(CblMariner1TargetPath)"


### PR DESCRIPTION
- `cherry-pick` of 5f4bc82d94f8, Update docker tag to latest schema
  - This change moves all of the docker images to the -latest tag as part of #10377.
- `cherry-pick` of f79f2d1ca12d, Replace -latest docker tags with new schema
  - We changed the latest tags to not include the -latest suffix, so this change updates those tags to the new schema.

nit: Correct timeout of source-build job
- not honoured as a top-level parameter to source-build.yml