### PR TITLE
[release/6.0] Use simpler Docker tags

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -610,7 +610,7 @@ stages:
         jobName: Linux_musl_x64_build
         jobDisplayName: "Build: Linux Musl x64"
         agentOs: Linux
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode-20210910135833-c401c85
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-WithNode
         buildArgs:
           --arch x64
           --os-name linux-musl
@@ -646,7 +646,7 @@ stages:
         jobDisplayName: "Build: Linux Musl ARM"
         agentOs: Linux
         useHostedUbuntu: false
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm-alpine-20211022152824-78f7860
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm-alpine
         buildArgs:
           --arch arm
           --os-name linux-musl
@@ -681,7 +681,7 @@ stages:
         jobDisplayName: "Build: Linux Musl ARM64"
         agentOs: Linux
         useHostedUbuntu: false
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-alpine-20211022152824-538077f
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-alpine
         buildArgs:
           --arch arm64
           --os-name linux-musl
@@ -817,9 +817,11 @@ stages:
       parameters:
         platform:
           name: 'Managed'
-          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-20210714125435-9b5bbc2'
+          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7'
           buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks $(_InternalRuntimeDownloadArgs)'
           skipPublishValidation: true
+          jobProperties:
+            timeoutInMinutes: 120
 
     # Publish to the BAR
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/docker/rhel.Dockerfile
+++ b/eng/docker/rhel.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile that creates a container suitable to build dotnet-cli
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:rhel-7-rpmpkg-e1b4a89-20175311035359
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-rpmpkg
 
 # Setup User to match Host User, and give superuser permissions
 ARG USER

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -1,11 +1,11 @@
 <Project>
   <!-- this file is shared between Helix.proj and .csproj files -->
   <PropertyGroup>
-    <HelixQueueAlpine314>(Alpine.314.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-helix-amd64-20210910135833-1848e19</HelixQueueAlpine314>
-    <HelixQueueDebian11>(Debian.11.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64-20211001171307-0ece9b3</HelixQueueDebian11>
-    <HelixQueueFedora34>(Fedora.34.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-helix-20210924174119-4f64125</HelixQueueFedora34>
-    <HelixQueueMariner>(Mariner)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix-20210528192219-92bf620</HelixQueueMariner>
-    <HelixQueueArmDebian11>(Debian.11.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-arm64v8-20211001171229-97d8652</HelixQueueArmDebian11>
+    <HelixQueueAlpine314>(Alpine.314.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.14-helix-amd64</HelixQueueAlpine314>
+    <HelixQueueDebian11>(Debian.11.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64</HelixQueueDebian11>
+    <HelixQueueFedora34>(Fedora.34.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-helix</HelixQueueFedora34>
+    <HelixQueueMariner>(Mariner)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix</HelixQueueMariner>
+    <HelixQueueArmDebian11>(Debian.11.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-arm64v8</HelixQueueArmDebian11>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsWindowsOnlyTest)' != 'true'">


### PR DESCRIPTION
- `cherry-pick` of 5f4bc82d94f8, Update docker tag to latest schema
  - This change moves all of the docker images to the -latest tag as part of #10377.
- `cherry-pick` of f79f2d1ca12d, Replace -latest docker tags with new schema
  - We changed the latest tags to not include the -latest suffix, so this change updates those tags to the new schema.
- via #45115, w/ a slight adjustment from rhel-7 to centos-7 in rhel.Dockerfile

nit: Correct timeout of source-build job
- not honoured as a top-level parameter to source-build.yml