### PR TITLE
[release/3.1] Use simpler Docker tags

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -7,9 +7,9 @@ trigger:
   batch: true
   branches:
     include:
-    - master
+    - main
     - release/*
-    - internal/release/3.*
+    - internal/release/*
 
 # Run PR validation on all branches
 pr:

--- a/eng/docker/rhel.Dockerfile
+++ b/eng/docker/rhel.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile that creates a container suitable to build dotnet-cli
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:rhel-7-rpmpkg-e1b4a89-20175311035359
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-rpmpkg
 
 # Setup User to match Host User, and give superuser permissions
 ARG USER

--- a/eng/docker/ubuntu-alpine37.Dockerfile
+++ b/eng/docker/ubuntu-alpine37.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-alpine-85814b7-20200327151156
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm64-alpine
 ARG USER
 ARG USER_ID
 ARG GROUP_ID


### PR DESCRIPTION
- analogous to 5f4bc82d94f8, Update docker tag to latest schema
  - This change moves all of the docker images to the -latest tag as part of #10377.
- analogous to f79f2d1ca12d, Replace -latest docker tags with new schema
  - We changed the latest tags to not include the -latest suffix, so this change updates those tags to the new schema.
- slight adjustment to images: from rhel-7-rpmpkg to centos-7-rpmpkg in rhel.Dockerfile

nit: update `trigger` branch names