### PR TITLE
[release/7.0] Use new Arm64 Helix queues

### DIFF
--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -13,7 +13,6 @@ schedules:
     include:
     - release/6.0
     - release/7.0
-  always: false
 
 variables:
 - name: _UseHelixOpenQueues

--- a/eng/helix/content/runtests.cmd
+++ b/eng/helix/content/runtests.cmd
@@ -24,8 +24,8 @@ echo.
 
 set exit_code=0
 
-echo "Running tests: %HELIX_CORRELATION_PAYLOAD%/HelixTestRunner/HelixTestRunner.exe --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --helixTimeout %$helixTimeout% --playwright %$installPlaywright%"
-%HELIX_CORRELATION_PAYLOAD%/HelixTestRunner/HelixTestRunner.exe --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --helixTimeout %$helixTimeout% --playwright %$installPlaywright%
+echo "Running tests: dotnet %HELIX_CORRELATION_PAYLOAD%/HelixTestRunner/HelixTestRunner.dll --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --helixTimeout %$helixTimeout% --playwright %$installPlaywright%"
+dotnet %HELIX_CORRELATION_PAYLOAD%/HelixTestRunner/HelixTestRunner.dll --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --helixTimeout %$helixTimeout% --playwright %$installPlaywright%
 if not errorlevel 0 (
     set exit_code=%errorlevel%
 )

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -5,7 +5,7 @@
     <HelixQueueDebian11>(Debian.11.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64</HelixQueueDebian11>
     <HelixQueueFedora34>(Fedora.34.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-helix</HelixQueueFedora34>
     <HelixQueueMariner>(Mariner)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix</HelixQueueMariner>
-    <HelixQueueArmDebian11>(Debian.11.Arm64.Open)Ubuntu.1804.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-arm64v8</HelixQueueArmDebian11>
+    <HelixQueueArmDebian11>(Debian.11.Arm64.Open)ubuntu.2004.armarch.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-arm64v8</HelixQueueArmDebian11>
 
     <!-- Do not attempt to override global property. -->
     <RunQuarantinedTests Condition=" '$(RunQuarantinedTests)' == '' ">false</RunQuarantinedTests>
@@ -53,7 +53,7 @@
         <HelixAvailableTargetQueue Include="Windows.Amd64.Server2022.Open" Platform="Windows" />
 
         <!-- IIS Express isn't supported on arm64 and most of the IsWindowsOnlyTests depend on its setup scripts. -->
-        <HelixAvailableTargetQueue Include="Windows.10.Arm64v8.Open" Platform="Windows"
+        <HelixAvailableTargetQueue Include="windows.11.arm64.open" Platform="Windows"
             Condition=" '$(IsWindowsOnlyTest)' != 'true' "/>
       </ItemGroup>
     </Otherwise>
@@ -69,9 +69,9 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <IsArm64HelixQueue>$(HelixTargetQueue.Contains('Arm64'))</IsArm64HelixQueue>
-        <IsWindowsHelixQueue>$(HelixTargetQueue.Contains('Windows'))</IsWindowsHelixQueue>
-        <IsMacHelixQueue>$(HelixTargetQueue.Contains('OSX'))</IsMacHelixQueue>
+        <IsArm64HelixQueue>$(HelixTargetQueue.ToUpperInvariant().Contains('ARM64'))</IsArm64HelixQueue>
+        <IsWindowsHelixQueue>$(HelixTargetQueue.ToUpperInvariant().Contains('WINDOWS'))</IsWindowsHelixQueue>
+        <IsMacHelixQueue>$(HelixTargetQueue.ToUpperInvariant().Contains('OSX'))</IsMacHelixQueue>
       </PropertyGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
- clean `cherry-pick` of e609b1cad60e plus touch our YAML
- Update `HelixTestRunner` command on Windows
  - use `dotnet` to avoid x64 requirements when using Win11 ARM64
- also, get scheduled runs going for aspnetcore-helix-matrix
  - release/6.0 and release/7.0 builds have not run since move to dnceng-public/public

nit: Change `$(IsXYZQueue)` properties to ignore case
- removes one gotcha going forward