### PR TITLE
fix DefaultPolicy unreasonable behavior.

### DIFF
--- a/src/Security/Authorization/Core/src/AuthorizationPolicy.cs
+++ b/src/Security/Authorization/Core/src/AuthorizationPolicy.cs
@@ -173,7 +173,6 @@ public class AuthorizationPolicy
                 {
                     var trimmedRolesSplit = rolesSplit.Where(r => !string.IsNullOrWhiteSpace(r)).Select(r => r.Trim());
                     policyBuilder.RequireRole(trimmedRolesSplit);
-                    useDefaultPolicy = false;
                 }
 
                 var authTypesSplit = authorizeDatum.AuthenticationSchemes?.Split(',');


### PR DESCRIPTION
services.AddAuthorization(options =>
{
    var builder = new AuthorizationPolicyBuilder();
    builder.RequireAuthenticatedUser();
    builder.AddRequirements(new PermissionRequirement());

    options.AddPolicy("MyPolicy", builder.Build());

    options.DefaultPolicy = builder.Build();  //override
});

[Authorize("MyPolicy", Roles = "RoleName")]   // there is three requirements.
[Authorize(Roles = "RoleName")]    // only one requirement，it should be three requirements too.