### PR TITLE
Re-enable Blazor touch event test

### DIFF
--- a/src/Components/test/E2ETest/Tests/EventTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventTest.cs
@@ -219,10 +219,7 @@ public class EventTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
         Browser.Equal("dragstart,", () => output.Text);
     }
 
-    // Skipped because it will never pass because Selenium doesn't support this kind of event
-    // The linked issue tracks the desire to find a way of testing this
-    // There's no point quarantining it - we know it will always fail
-    [Fact(Skip = "https://github.com/dotnet/aspnetcore/issues/32373")]
+    [Fact]
     public void TouchEvent_CanTrigger()
     {
         Browser.MountTestComponent<TouchEventComponent>();
@@ -232,9 +229,13 @@ public class EventTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
         var output = Browser.Exists(By.Id("output"));
         Assert.Equal(string.Empty, output.Text);
 
-        var actions = new TouchActions(Browser).SingleTap(input);
+        var finger = new PointerInputDevice(PointerKind.Touch);
+        var tap = new ActionBuilder()
+            .AddAction(finger.CreatePointerMove(input, 0, 0, TimeSpan.Zero))
+            .AddAction(finger.CreatePointerDown(MouseButton.Left))
+            .AddAction(finger.CreatePointerUp(MouseButton.Left));
+        ((IActionExecutor)Browser).PerformActions(tap.ToActionSequenceList());
 
-        actions.Perform();
         Browser.Equal("touchstart,touchend,", () => output.Text);
     }
 

--- a/src/Components/test/E2ETest/Tests/EventTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventTest.cs
@@ -229,12 +229,12 @@ public class EventTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
         var output = Browser.Exists(By.Id("output"));
         Assert.Equal(string.Empty, output.Text);
 
-        var finger = new PointerInputDevice(PointerKind.Touch);
-        var tap = new ActionBuilder()
-            .AddAction(finger.CreatePointerMove(input, 0, 0, TimeSpan.Zero))
-            .AddAction(finger.CreatePointerDown(MouseButton.Left))
-            .AddAction(finger.CreatePointerUp(MouseButton.Left));
-        ((IActionExecutor)Browser).PerformActions(tap.ToActionSequenceList());
+        var touchPointer = new PointerInputDevice(PointerKind.Touch);
+        var singleTap = new ActionBuilder()
+            .AddAction(touchPointer.CreatePointerMove(input, 0, 0, TimeSpan.Zero))
+            .AddAction(touchPointer.CreatePointerDown(MouseButton.Touch))
+            .AddAction(touchPointer.CreatePointerUp(MouseButton.Touch));
+        ((IActionExecutor)Browser).PerformActions(singleTap.ToActionSequenceList());
 
         Browser.Equal("touchstart,touchend,", () => output.Text);
     }


### PR DESCRIPTION
# Re-enable Blazor touch event test

Re-enables a Blazor touch event test that was disabled due to `TouchActions` being deprecated (see https://github.com/SeleniumHQ/selenium/issues/10746).

This fix uses the same APIs that `TouchActions` used under the hood, so the test is functionally equivalent to what it was doing previously.

Fixes #32373
