### PR TITLE
ApiAuthorizationDbContext.cs missing ServerSideSessions  Patch

### DIFF
--- a/src/Identity/ApiAuthorization.IdentityServer/src/Data/ApiAuthorizationDbContext.cs
+++ b/src/Identity/ApiAuthorization.IdentityServer/src/Data/ApiAuthorizationDbContext.cs
@@ -34,6 +34,14 @@ public class ApiAuthorizationDbContext<TUser> : IdentityDbContext<TUser>, IPersi
     }
 
     /// <summary>
+    /// Gets or sets the user sessions.
+    /// </summary>
+    /// <value>
+    /// The keys.
+    /// </value>
+    public DbSet<ServerSideSession> ServerSideSessions { get; set; }
+
+    /// <summary>
     /// Gets or sets the <see cref="DbSet{PersistedGrant}"/>.
     /// </summary>
     public DbSet<PersistedGrant> PersistedGrants { get; set; }


### PR DESCRIPTION
# Missing ServerSideSessions property added to ApiAuthorizationDbContext.cs

## Description
reflection is throwing this error 

"Method 'get_ServerSideSessions' in type 'Microsoft.AspNetCore.ApiAuthorization.IdentityServer.ApiAuthorizationDbContext`1' from assembly 'Microsoft.AspNetCore.ApiAuthorization.IdentityServer, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' does not have an implementation."

IPersistedGrantDbContext.ServerSideSessions property must be implemented in the API ApiAuthorizationDbContext, this is required by IPersistedGrantDbContext Interface.

Fixes #44990
