### PR TITLE
Add route string syntax to more APIs

### DIFF
--- a/src/Http/Routing/src/Template/RouteTemplate.cs
+++ b/src/Http/Routing/src/Template/RouteTemplate.cs
@@ -53,7 +53,7 @@ public class RouteTemplate
     /// </summary>
     /// <param name="template">A string representation of the route template.</param>
     /// <param name="segments">A list of <see cref="TemplateSegment"/>.</param>
-    public RouteTemplate([StringSyntax("Route")] string template, List<TemplateSegment> segments)
+    public RouteTemplate(string template, List<TemplateSegment> segments)
     {
         if (segments == null)
         {

--- a/src/Http/Routing/src/Template/RouteTemplate.cs
+++ b/src/Http/Routing/src/Template/RouteTemplate.cs
@@ -53,7 +53,7 @@ public class RouteTemplate
     /// </summary>
     /// <param name="template">A string representation of the route template.</param>
     /// <param name="segments">A list of <see cref="TemplateSegment"/>.</param>
-    public RouteTemplate(string template, List<TemplateSegment> segments)
+    public RouteTemplate([StringSyntax("Route")] string template, List<TemplateSegment> segments)
     {
         if (segments == null)
         {

--- a/src/Middleware/HealthChecks/src/Builder/HealthCheckEndpointRouteBuilderExtensions.cs
+++ b/src/Middleware/HealthChecks/src/Builder/HealthCheckEndpointRouteBuilderExtensions.cs
@@ -25,7 +25,7 @@ public static class HealthCheckEndpointRouteBuilderExtensions
     /// <returns>A convention routes for the health checks endpoint.</returns>
     public static IEndpointConventionBuilder MapHealthChecks(
        this IEndpointRouteBuilder endpoints,
-       string pattern)
+       [StringSyntax("Route")] string pattern)
     {
         if (endpoints == null)
         {
@@ -44,7 +44,7 @@ public static class HealthCheckEndpointRouteBuilderExtensions
     /// <returns>A convention routes for the health checks endpoint.</returns>
     public static IEndpointConventionBuilder MapHealthChecks(
        this IEndpointRouteBuilder endpoints,
-       string pattern,
+       [StringSyntax("Route")] string pattern,
        HealthCheckOptions options)
     {
         if (endpoints == null)

--- a/src/Mvc/Mvc.RazorPages/src/Builder/RazorPagesEndpointRouteBuilderExtensions.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Builder/RazorPagesEndpointRouteBuilderExtensions.cs
@@ -120,7 +120,7 @@ public static class RazorPagesEndpointRouteBuilderExtensions
     /// </remarks>
     public static IEndpointConventionBuilder MapFallbackToPage(
         this IEndpointRouteBuilder endpoints,
-        string pattern,
+        [StringSyntax("Route")] string pattern,
         string page)
     {
         if (endpoints == null)
@@ -251,7 +251,7 @@ public static class RazorPagesEndpointRouteBuilderExtensions
     /// </remarks>
     public static IEndpointConventionBuilder MapFallbackToAreaPage(
         this IEndpointRouteBuilder endpoints,
-        string pattern,
+        [StringSyntax("Route")] string pattern,
         string page,
         string area)
     {
@@ -308,7 +308,7 @@ public static class RazorPagesEndpointRouteBuilderExtensions
     /// Register <typeparamref name="TTransformer"/> with the desired service lifetime in <c>ConfigureServices</c>.
     /// </para>
     /// </remarks>
-    public static void MapDynamicPageRoute<TTransformer>(this IEndpointRouteBuilder endpoints, string pattern)
+    public static void MapDynamicPageRoute<TTransformer>(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string pattern)
         where TTransformer : DynamicRouteValueTransformer
     {
         MapDynamicPageRoute<TTransformer>(endpoints, pattern, state: null);
@@ -332,7 +332,7 @@ public static class RazorPagesEndpointRouteBuilderExtensions
     /// Register <typeparamref name="TTransformer"/> with the desired service lifetime in <c>ConfigureServices</c>.
     /// </para>
     /// </remarks>
-    public static void MapDynamicPageRoute<TTransformer>(this IEndpointRouteBuilder endpoints, string pattern, object? state)
+    public static void MapDynamicPageRoute<TTransformer>(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string pattern, object? state)
         where TTransformer : DynamicRouteValueTransformer
     {
         if (endpoints == null)
@@ -373,7 +373,7 @@ public static class RazorPagesEndpointRouteBuilderExtensions
     /// Register <typeparamref name="TTransformer"/> with the desired service lifetime in <c>ConfigureServices</c>.
     /// </para>
     /// </remarks>
-    public static void MapDynamicPageRoute<TTransformer>(this IEndpointRouteBuilder endpoints, string pattern, object state, int order)
+    public static void MapDynamicPageRoute<TTransformer>(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string pattern, object state, int order)
         where TTransformer : DynamicRouteValueTransformer
     {
         if (endpoints == null)

--- a/src/Mvc/Mvc.RazorPages/src/Builder/RazorPagesEndpointRouteBuilderExtensions.cs
+++ b/src/Mvc/Mvc.RazorPages/src/Builder/RazorPagesEndpointRouteBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.Infrastructure;

--- a/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
+++ b/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class ConnectionEndpointRouteBuilderExtensions
     /// <param name="pattern">The route pattern.</param>
     /// <param name="configure">A callback to configure the connection.</param>
     /// <returns>An <see cref="ConnectionEndpointRouteBuilder"/> for endpoints associated with the connections.</returns>
-    public static ConnectionEndpointRouteBuilder MapConnections(this IEndpointRouteBuilder endpoints, string pattern, Action<IConnectionBuilder> configure) =>
+    public static ConnectionEndpointRouteBuilder MapConnections(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string pattern, Action<IConnectionBuilder> configure) =>
         endpoints.MapConnections(pattern, new HttpConnectionDispatcherOptions(), configure);
 
     /// <summary>
@@ -33,7 +33,7 @@ public static class ConnectionEndpointRouteBuilderExtensions
     /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
     /// <param name="pattern">The route pattern.</param>
     /// <returns>An <see cref="ConnectionEndpointRouteBuilder"/> for endpoints associated with the connections.</returns>
-    public static ConnectionEndpointRouteBuilder MapConnectionHandler<TConnectionHandler>(this IEndpointRouteBuilder endpoints, string pattern) where TConnectionHandler : ConnectionHandler
+    public static ConnectionEndpointRouteBuilder MapConnectionHandler<TConnectionHandler>(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string pattern) where TConnectionHandler : ConnectionHandler
     {
         return endpoints.MapConnectionHandler<TConnectionHandler>(pattern, configureOptions: null);
     }
@@ -46,7 +46,7 @@ public static class ConnectionEndpointRouteBuilderExtensions
     /// <param name="pattern">The route pattern.</param>
     /// <param name="configureOptions">A callback to configure dispatcher options.</param>
     /// <returns>An <see cref="ConnectionEndpointRouteBuilder"/> for endpoints associated with the connections.</returns>
-    public static ConnectionEndpointRouteBuilder MapConnectionHandler<TConnectionHandler>(this IEndpointRouteBuilder endpoints, string pattern, Action<HttpConnectionDispatcherOptions>? configureOptions) where TConnectionHandler : ConnectionHandler
+    public static ConnectionEndpointRouteBuilder MapConnectionHandler<TConnectionHandler>(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string pattern, Action<HttpConnectionDispatcherOptions>? configureOptions) where TConnectionHandler : ConnectionHandler
     {
         var options = new HttpConnectionDispatcherOptions();
         configureOptions?.Invoke(options);
@@ -78,7 +78,7 @@ public static class ConnectionEndpointRouteBuilderExtensions
     /// <param name="options">Options used to configure the connection.</param>
     /// <param name="configure">A callback to configure the connection.</param>
     /// <returns>An <see cref="ConnectionEndpointRouteBuilder"/> for endpoints associated with the connections.</returns>
-    public static ConnectionEndpointRouteBuilder MapConnections(this IEndpointRouteBuilder endpoints, string pattern, HttpConnectionDispatcherOptions options, Action<IConnectionBuilder> configure)
+    public static ConnectionEndpointRouteBuilder MapConnections(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string pattern, HttpConnectionDispatcherOptions options, Action<IConnectionBuilder> configure)
     {
         var dispatcher = endpoints.ServiceProvider.GetRequiredService<HttpConnectionDispatcher>();
 

--- a/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
+++ b/src/SignalR/common/Http.Connections/src/ConnectionEndpointRouteBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Http.Connections.Internal;

--- a/src/SignalR/server/SignalR/src/HubEndpointRouteBuilderExtensions.cs
+++ b/src/SignalR/server/SignalR/src/HubEndpointRouteBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class HubEndpointRouteBuilderExtensions
     /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
     /// <param name="pattern">The route pattern.</param>
     /// <returns>An <see cref="HubEndpointConventionBuilder"/> for endpoints associated with the connections.</returns>
-    public static HubEndpointConventionBuilder MapHub<[DynamicallyAccessedMembers(HubAccessibility)] THub>(this IEndpointRouteBuilder endpoints, string pattern) where THub : Hub
+    public static HubEndpointConventionBuilder MapHub<[DynamicallyAccessedMembers(HubAccessibility)] THub>(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string pattern) where THub : Hub
     {
         return endpoints.MapHub<THub>(pattern, configureOptions: null);
     }
@@ -36,7 +36,7 @@ public static class HubEndpointRouteBuilderExtensions
     /// <param name="pattern">The route pattern.</param>
     /// <param name="configureOptions">A callback to configure dispatcher options.</param>
     /// <returns>An <see cref="HubEndpointConventionBuilder"/> for endpoints associated with the connections.</returns>
-    public static HubEndpointConventionBuilder MapHub<[DynamicallyAccessedMembers(HubAccessibility)] THub>(this IEndpointRouteBuilder endpoints, string pattern, Action<HttpConnectionDispatcherOptions>? configureOptions) where THub : Hub
+    public static HubEndpointConventionBuilder MapHub<[DynamicallyAccessedMembers(HubAccessibility)] THub>(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string pattern, Action<HttpConnectionDispatcherOptions>? configureOptions) where THub : Hub
     {
         var marker = endpoints.ServiceProvider.GetService<SignalRMarkerService>();
 


### PR DESCRIPTION
Add `[StringSyntax("Route")]` to some APIs that were missed earlier.