### PR TITLE
Infer parameter source from ElementType for IEnumerable

### DIFF
--- a/src/Mvc/Mvc.Core/src/ApplicationModels/InferParameterBindingInfoConvention.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationModels/InferParameterBindingInfoConvention.cs
@@ -144,7 +144,7 @@ public class InferParameterBindingInfoConvention : IActionModelConvention
         }
 
         // IServiceProviderIsService will special case IEnumerable<> and always return true
-        // , so, in this case checking the element type instead
+        // so, in this case checking the element type instead
         if (type.IsConstructedGenericType &&
             type.GetGenericTypeDefinition() is Type genericDefinition &&
             genericDefinition == typeof(IEnumerable<>))

--- a/src/Mvc/Mvc.Core/test/ApplicationModels/InferParameterBindingInfoConventionTest.cs
+++ b/src/Mvc/Mvc.Core/test/ApplicationModels/InferParameterBindingInfoConventionTest.cs
@@ -544,7 +544,7 @@ Environment.NewLine + "int b";
     }
 
     [Fact]
-    public void InferBindingSourceForParameter_eturnsBodyForIEnumerableOfSimpleTypes()
+    public void InferBindingSourceForParameter_ReturnsBodyForIEnumerableOfSimpleTypes()
     {
         // Arrange
         var actionName = nameof(ParameterBindingController.IEnumerableOfSimpleTypes);

--- a/src/Mvc/Mvc.Core/test/ApplicationModels/InferParameterBindingInfoConventionTest.cs
+++ b/src/Mvc/Mvc.Core/test/ApplicationModels/InferParameterBindingInfoConventionTest.cs
@@ -544,6 +544,21 @@ Environment.NewLine + "int b";
     }
 
     [Fact]
+    public void InferBindingSourceForParameter_eturnsBodyForIEnumerableOfSimpleTypes()
+    {
+        // Arrange
+        var actionName = nameof(ParameterBindingController.IEnumerableOfSimpleTypes);
+        var parameter = GetParameterModel(typeof(ParameterBindingController), actionName);
+        var convention = GetConvention();
+
+        // Act
+        var result = convention.InferBindingSourceForParameter(parameter);
+
+        // Assert
+        Assert.Same(BindingSource.Body, result);
+    }
+
+    [Fact]
     public void InferBindingSourceForParameter_ReturnsBodyForCollectionOfComplexTypes()
     {
         // Arrange
@@ -559,10 +574,43 @@ Environment.NewLine + "int b";
     }
 
     [Fact]
+    public void InferBindingSourceForParameter_ReturnsBodyForIEnumerableOfComplexTypes()
+    {
+        // Arrange
+        var actionName = nameof(ParameterBindingController.IEnumerableOfComplexTypes);
+        var parameter = GetParameterModel(typeof(ParameterBindingController), actionName);
+        var convention = GetConvention();
+
+        // Act
+        var result = convention.InferBindingSourceForParameter(parameter);
+
+        // Assert
+        Assert.Same(BindingSource.Body, result);
+    }
+
+    [Fact]
     public void InferBindingSourceForParameter_ReturnsServicesForComplexTypesRegisteredInDI()
     {
         // Arrange
         var actionName = nameof(ParameterBindingController.ServiceParameter);
+        var parameter = GetParameterModel(typeof(ParameterBindingController), actionName);
+        // Using any built-in type defined in the Test action
+        var serviceProvider = Mock.Of<IServiceProviderIsService>(s => s.IsService(typeof(IApplicationModelProvider)) == true);
+        var convention = GetConvention(serviceProviderIsService: serviceProvider);
+
+        // Act
+        var result = convention.InferBindingSourceForParameter(parameter);
+
+        // Assert
+        Assert.True(convention.IsInferForServiceParametersEnabled);
+        Assert.Same(BindingSource.Services, result);
+    }
+
+    [Fact]
+    public void InferBindingSourceForParameter_ReturnsServicesForIEnumerableOfComplexTypesRegisteredInDI()
+    {
+        // Arrange
+        var actionName = nameof(ParameterBindingController.IEnumerableServiceParameter);
         var parameter = GetParameterModel(typeof(ParameterBindingController), actionName);
         // Using any built-in type defined in the Test action
         var serviceProvider = Mock.Of<IServiceProviderIsService>(s => s.IsService(typeof(IApplicationModelProvider)) == true);
@@ -982,9 +1030,15 @@ Environment.NewLine + "int b";
 
         public IActionResult CollectionOfSimpleTypes(IList<int> parameter) => null;
 
+        public IActionResult IEnumerableOfSimpleTypes(IEnumerable<int> parameter) => null;
+
         public IActionResult CollectionOfComplexTypes(IList<TestModel> parameter) => null;
 
+        public IActionResult IEnumerableOfComplexTypes(IEnumerable<TestModel> parameter) => null;
+
         public IActionResult ServiceParameter(IApplicationModelProvider parameter) => null;
+
+        public IActionResult IEnumerableServiceParameter(IEnumerable<IApplicationModelProvider> parameter) => null;
     }
 
     [ApiController]

--- a/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
+++ b/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
@@ -80,7 +80,7 @@ internal sealed class HubMethodDescriptor
                 return false;
             }
             else if (p.CustomAttributes.Any(a => typeof(IFromServiceMetadata).IsAssignableFrom(a.AttributeType)) ||
-                serviceProviderIsService?.IsService(p.ParameterType) == true)
+                serviceProviderIsService?.IsService(GetServiceType(p.ParameterType)) == true)
             {
                 if (index >= 64)
                 {
@@ -159,5 +159,19 @@ internal sealed class HubMethodDescriptor
         var methodCall = Expression.Call(null, genericMethodInfo, methodArguments);
         var lambda = Expression.Lambda<Func<object, CancellationToken, IAsyncEnumerator<object>>>(methodCall, parameters);
         return lambda.Compile();
+    }
+
+    private static Type GetServiceType(Type type)
+    {
+        // IServiceProviderIsService will special case IEnumerable<> and always return true
+        // so, in this case checking the element type instead
+        if (type.IsConstructedGenericType &&
+            type.GetGenericTypeDefinition() is Type genericDefinition &&
+            genericDefinition == typeof(IEnumerable<>))
+        {
+            return type.GenericTypeArguments[0];
+        }
+
+        return type;
     }
 }

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -1372,6 +1372,11 @@ public class ServicesHub : TestHub
         return 1;
     }
 
+    public int IEnumerableOfServiceWithoutAttribute(IEnumerable<Service1> services)
+    {
+        return 1;
+    }
+
     public async Task Stream(ChannelReader<int> channelReader)
     {
         while (await channelReader.WaitToReadAsync())

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -4750,6 +4750,27 @@ public partial class HubConnectionHandlerTests : VerifiableLoggedTest
     }
 
     [Fact]
+    public async Task ServiceResolvedForIEnumerableParameter()
+    {
+        var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(provider =>
+        {
+            provider.AddSignalR(options =>
+            {
+                options.EnableDetailedErrors = true;
+            });
+            provider.AddSingleton<Service1>();
+        });
+        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<ServicesHub>>();
+
+        using (var client = new TestClient())
+        {
+            var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+            var res = await client.InvokeAsync(nameof(ServicesHub.IEnumerableOfServiceWithoutAttribute)).DefaultTimeout();
+            Assert.Equal(1L, res.Result);
+        }
+    }
+
+    [Fact]
     public async Task ServiceResolvedWithoutAttribute_WithHubSpecificSettingEnabled()
     {
         var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(provider =>
@@ -4836,6 +4857,26 @@ public partial class HubConnectionHandlerTests : VerifiableLoggedTest
             var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
             var res = await client.InvokeAsync(nameof(ServicesHub.ServiceWithoutAttribute)).DefaultTimeout();
             Assert.Equal("Failed to invoke 'ServiceWithoutAttribute' due to an error on the server. InvalidDataException: Invocation provides 0 argument(s) but target expects 1.", res.Error);
+        }
+    }
+
+    [Fact]
+    public async Task ServiceNotResolvedForIEnumerableParameterIfNotInDI()
+    {
+        var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(provider =>
+        {
+            provider.AddSignalR(options =>
+            {
+                options.EnableDetailedErrors = true;
+            });
+        });
+        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<ServicesHub>>();
+
+        using (var client = new TestClient())
+        {
+            var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+            var res = await client.InvokeAsync(nameof(ServicesHub.IEnumerableOfServiceWithoutAttribute)).DefaultTimeout();
+            Assert.Equal("Failed to invoke 'IEnumerableOfServiceWithoutAttribute' due to an error on the server. InvalidDataException: Invocation provides 0 argument(s) but target expects 1.", res.Error);
         }
     }
 


### PR DESCRIPTION
Instead of skipping infer source for `IEnumerable<>` parameters, in took the approach of trying to check if the `Type Argument` is registered as a service instead, since something like this is supported:

```c#
[HttpPost("WithAttribute")]
public IActionResult PostWithAttribute([FromServices]IEnumerable<IMyService> myServices) => forecasts.Any() ? Ok() : BadRequest();
```

Also, unfortunately, before this PR, the unit tests cover the `IList<>` scenario but not `IEnumerable<>` scenario that matters for the `IServiceProviderIsService` and we missed this bad behavior change.

Fixes #45162
