### PR TITLE
Add support for comment syntax to route detector

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/samples/WebAppSample/Pages/Index.cshtml.cs
+++ b/src/Framework/AspNetCoreAnalyzers/samples/WebAppSample/Pages/Index.cshtml.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/EmbeddedLanguageCommentDetector.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/EmbeddedLanguageCommentDetector.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
+
+/// <summary>
+/// Helps match patterns of the form: language=name,option1,option2,option3
+/// <para/>
+/// All matching is case insensitive, with spaces allowed between the punctuation. Option values are
+/// returned as strings.
+/// <para/>
+/// Option names are the values from the TOptions enum.
+/// </summary>
+internal readonly struct EmbeddedLanguageCommentDetector
+{
+    private readonly Regex _regex;
+
+    public EmbeddedLanguageCommentDetector(ImmutableArray<string> identifiers)
+    {
+        var namePortion = string.Join("|", identifiers.Select(n => $"({Regex.Escape(n)})"));
+        _regex = new Regex($@"^((//)|(')|(/\*))\s*lang(uage)?\s*=\s*(?<identifier>{namePortion})\b((\s*,\s*)(?<option>[a-zA-Z]+))*",
+            RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    }
+
+    public bool TryMatch(
+        string text,
+        [NotNullWhen(true)] out string? identifier,
+        [NotNullWhen(true)] out IEnumerable<string>? options)
+    {
+        var match = _regex.Match(text);
+        identifier = null;
+        options = null;
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        identifier = match.Groups["identifier"].Value;
+        var optionGroup = match.Groups["option"];
+        options = optionGroup.Captures.OfType<Capture>().Select(c => c.Value);
+        return true;
+    }
+}

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/EmbeddedLanguageCommentDetector.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/EmbeddedLanguageCommentDetector.cs
@@ -9,6 +9,8 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
 
+// Copied from https://github.com/dotnet/roslyn/blob/9fee6f5461baae5152c956c3c3024ca15b85feb9/src/Features/Core/Portable/EmbeddedLanguages/EmbeddedLanguageCommentDetector.cs
+
 /// <summary>
 /// Helps match patterns of the form: language=name,option1,option2,option3
 /// <para/>

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/EmbeddedLanguageCommentOptions.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/EmbeddedLanguageCommentOptions.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
+
+// Copied from https://github.com/dotnet/roslyn/blob/9fee6f5461baae5152c956c3c3024ca15b85feb9/src/Features/Core/Portable/EmbeddedLanguages/EmbeddedLanguageCommentOptions.cs
+
+/// <summary>
+/// Helps match patterns of the form: language=name,option1,option2,option3
+/// <para/>
+/// All matching is case insensitive, with spaces allowed between the punctuation. Option values will be or'ed
+/// together to produce final options value.  If an unknown option is encountered, processing will stop with
+/// whatever value has accumulated so far.
+/// <para/>
+/// Option names are the values from the TOptions enum.
+/// </summary>
+internal static class EmbeddedLanguageCommentOptions<TOptions> where TOptions : struct, Enum
+{
+    private static readonly Dictionary<string, TOptions> s_nameToOption =
+        typeof(TOptions).GetTypeInfo().DeclaredFields
+            .Where(f => f.FieldType == typeof(TOptions))
+            .ToDictionary(f => f.Name, f => (TOptions)f.GetValue(null)!, StringComparer.OrdinalIgnoreCase);
+
+    public static bool TryGetOptions(IEnumerable<string> captures, out TOptions options)
+    {
+        options = default;
+
+        foreach (var capture in captures)
+        {
+            if (!s_nameToOption.TryGetValue(capture, out var specificOption))
+            {
+                // hit something we don't understand.  bail out.  that will help ensure
+                // users don't have weird behavior just because they misspelled something.
+                // instead, they will know they need to fix it up.
+                return false;
+            }
+
+            options = CombineOptions(options, specificOption);
+        }
+
+        return true;
+    }
+
+    private static TOptions CombineOptions(TOptions options, TOptions specificOption)
+    {
+        var int1 = (int)(object)options;
+        var int2 = (int)(object)specificOption;
+        return (TOptions)(object)(int1 | int2);
+    }
+}

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/RouteStringSyntaxDetector.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/RouteStringSyntaxDetector.cs
@@ -14,8 +14,7 @@ namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
 
 internal static class RouteStringSyntaxDetector
 {
-    private static readonly ImmutableArray<string> _languageIdentifiers = ImmutableArray.Create("Route");
-    private static readonly EmbeddedLanguageCommentDetector _commentDetector = new(_languageIdentifiers);
+    private static readonly EmbeddedLanguageCommentDetector _commentDetector = new(ImmutableArray.Create("Route"));
     
     public static bool IsRouteStringSyntaxToken(SyntaxToken token, SemanticModel semanticModel, CancellationToken cancellationToken)
     {

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/RouteStringSyntaxDetectorDocument.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/RouteStringSyntaxDetectorDocument.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
 /// </summary>
 internal static class RouteStringSyntaxDetectorDocument
 {
-    internal static async ValueTask<(bool success, SyntaxToken token, SemanticModel? model)> TryGetStringSyntaxTokenAtPositionAsync(
+    internal static async ValueTask<(bool success, SyntaxToken token, SemanticModel? model, RouteOptions options)> TryGetStringSyntaxTokenAtPositionAsync(
         Document document, int position, CancellationToken cancellationToken)
     {
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
@@ -29,11 +29,11 @@ internal static class RouteStringSyntaxDetectorDocument
             return default;
         }
 
-        if (!RouteStringSyntaxDetector.IsRouteStringSyntaxToken(token, semanticModel, cancellationToken))
+        if (!RouteStringSyntaxDetector.IsRouteStringSyntaxToken(token, semanticModel, cancellationToken, out var options))
         {
             return default;
         }
 
-        return (true, token, semanticModel);
+        return (true, token, semanticModel, options);
     }
 }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RouteOptions.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RouteOptions.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage;
+
+[Flags]
+internal enum RouteOptions
+{
+    /// <summary>
+    /// HTTP route. Used to match endpoints for Minimal API, MVC, SignalR, gRPC, etc.
+    /// </summary> 
+    Http = 0,
+    /// <summary>
+    /// Component route. Used to match Razor components for Blazor.
+    /// </summary>
+    Component = 1,
+}

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternAnalyzer.cs
@@ -52,7 +52,7 @@ public class RoutePatternAnalyzer : DiagnosticAnalyzer
             else
             {
                 var token = child.AsToken();
-                if (!RouteStringSyntaxDetector.IsRouteStringSyntaxToken(token, context.SemanticModel, cancellationToken, out var options))
+                if (!RouteStringSyntaxDetector.IsRouteStringSyntaxToken(token, context.SemanticModel, cancellationToken, out var _))
                 {
                     continue;
                 }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternAnalyzer.cs
@@ -52,7 +52,7 @@ public class RoutePatternAnalyzer : DiagnosticAnalyzer
             else
             {
                 var token = child.AsToken();
-                if (!RouteStringSyntaxDetector.IsRouteStringSyntaxToken(token, context.SemanticModel, cancellationToken))
+                if (!RouteStringSyntaxDetector.IsRouteStringSyntaxToken(token, context.SemanticModel, cancellationToken, out var options))
                 {
                     continue;
                 }
@@ -175,7 +175,7 @@ public class RoutePatternAnalyzer : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.ReportDiagnostics);
         context.EnableConcurrentExecution();
 
         context.RegisterSemanticModelAction(Analyze);

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternAnalyzerTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternAnalyzerTests.cs
@@ -4,12 +4,37 @@
 using System.Globalization;
 using Microsoft.AspNetCore.Analyzer.Testing;
 using Microsoft.AspNetCore.Analyzers.RenderTreeBuilder;
+using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
 
 namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage;
 
 public partial class RoutePatternAnalyzerTests
 {
     private TestDiagnosticAnalyzerRunner Runner { get; } = new(new RoutePatternAnalyzer());
+
+    [Fact]
+    public async Task CommentOnString_ReportResults()
+    {
+        var source = TestSource.Read(
+@"
+class Program
+{
+    static void Main()
+    {
+        // language=Route
+        var s = @""/*MM*/~hi"";
+    }
+}");
+
+        // Act
+        var diagnostics = await Runner.GetDiagnosticsAsync(source.Source);
+
+        // Assert
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Same(DiagnosticDescriptors.RoutePatternIssue, diagnostic.Descriptor);
+        AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
+        Assert.Equal(Resources.FormatAnalyzer_RouteIssue_Message(Resources.TemplateRoute_InvalidRouteTemplate), diagnostic.GetMessage(CultureInfo.InvariantCulture));
+    }
 
     [Fact]
     public async Task StringSyntax_AttributeProperty_ReportResults()

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternClassifierTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternClassifierTests.cs
@@ -41,6 +41,26 @@ public class RoutePatternClassifierTests
     }
 
     [Fact]
+    public async Task CommentOnString_Classified()
+    {
+        await TestAsync(
+@"
+class Program
+{
+    void Goo()
+    {
+        // language=Route
+        var s = [|@""{id?}""|];
+    }
+}" + EmbeddedLanguagesTestConstants.StringSyntaxAttributeCodeCSharp,
+Verbatim(@"@""{id?}"""),
+Regex.CharacterClass("{"),
+Parameter("id"),
+Regex.Anchor("?"),
+Regex.CharacterClass("}"));
+    }
+
+    [Fact]
     public async Task AttributeOnField_Classified()
     {
         await TestAsync(

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternCompletionProviderTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternCompletionProviderTests.cs
@@ -643,6 +643,8 @@ class Program
     static void Main()
     {
         // lang=Route,Component
+        // lang=Route,Component
+        #line 1 "/user/foo/index.razor"
         var s = @""{hi:$$"";
     }
 }

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternCompletionProviderTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternCompletionProviderTests.cs
@@ -609,6 +609,50 @@ public class TestController
             i => Assert.Equal("id", i.DisplayText));
     }
 
+    [Fact]
+    public async Task Invoke_Comment_PolicyColon_ReturnPolicies()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System.Diagnostics.CodeAnalysis;
+
+class Program
+{
+    static void Main()
+    {
+        // lang=Route
+        var s = @""{hi:$$"";
+    }
+}
+", CompletionTrigger.Invoke);
+
+        // Assert
+        Assert.NotEmpty(result.Completions.ItemsList);
+        Assert.Equal("alpha", result.Completions.ItemsList[0].DisplayText);
+    }
+
+    [Fact]
+    public async Task Invoke_Comment_Component_PolicyColon_ReturnPolicies()
+    {
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System.Diagnostics.CodeAnalysis;
+
+class Program
+{
+    static void Main()
+    {
+        // lang=Route,Component
+        var s = @""{hi:$$"";
+    }
+}
+", CompletionTrigger.Invoke);
+
+        // Assert
+        Assert.NotEmpty(result.Completions.ItemsList);
+        Assert.Equal("bool", result.Completions.ItemsList[0].DisplayText);
+    }
+
     private Task<CompletionResult> GetCompletionsAndServiceAsync(string source, CompletionTrigger? completionTrigger = null)
     {
         return CompletionTestHelpers.GetCompletionsAndServiceAsync(Runner, source, completionTrigger);

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternCompletionProviderTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternCompletionProviderTests.cs
@@ -610,7 +610,7 @@ public class TestController
     }
 
     [Fact]
-    public async Task Invoke_Comment_PolicyColon_ReturnPolicies()
+    public async Task Invoke_Comment_PolicyColon_ReturnHttpPolicies()
     {
         // Arrange & Act
         var result = await GetCompletionsAndServiceAsync(@"
@@ -632,7 +632,7 @@ class Program
     }
 
     [Fact]
-    public async Task Invoke_Comment_Component_PolicyColon_ReturnPolicies()
+    public async Task Invoke_Comment_Http_PolicyColon_ReturnHttpPolicies()
     {
         // Arrange & Act
         var result = await GetCompletionsAndServiceAsync(@"
@@ -642,9 +642,33 @@ class Program
 {
     static void Main()
     {
+        // lang=Route,Http
+        var s = @""{hi:$$"";
+    }
+}
+", CompletionTrigger.Invoke);
+
+        // Assert
+        Assert.NotEmpty(result.Completions.ItemsList);
+        Assert.Equal("alpha", result.Completions.ItemsList[0].DisplayText);
+    }
+
+    [Fact]
+    public async Task Invoke_Comment_Component_PolicyColon_ReturnComponentPolicies()
+    {
+        // Note: This test adds #line pragma comment to simulate that situation in generated Razor source code.
+        // See example in https://github.com/dotnet/razor/pull/6997
+
+        // Arrange & Act
+        var result = await GetCompletionsAndServiceAsync(@"
+using System.Diagnostics.CodeAnalysis;
+
+class Program
+{
+    static void Main()
+    {
         // lang=Route,Component
-        // lang=Route,Component
-        #line 1 "/user/foo/index.razor"
+        #line 1 ""/user/foo/index.razor""
         var s = @""{hi:$$"";
     }
 }


### PR DESCRIPTION
String syntax can be set using a comment:

```cs
// language=Route
var s = "/product/{name}";
```

Razor pages uses a comment to enable route syntax. This PR adds support for detecting comments.