### PR TITLE
Support `sub` as `ExternalLoginInfo.ProviderKey`

### DIFF
--- a/src/Identity/Core/src/SignInManager.cs
+++ b/src/Identity/Core/src/SignInManager.cs
@@ -667,7 +667,7 @@ public class SignInManager<TUser> where TUser : class
             }
         }
 
-        var providerKey = auth.Principal.FindFirstValue(JwtRegisteredClaimNames.Sub) ?? auth.Principal.FindFirstValue(ClaimTypes.NameIdentifier);
+        var providerKey = auth.Principal.FindFirstValue(ClaimTypes.NameIdentifier) ?? auth.Principal.FindFirstValue(JwtRegisteredClaimNames.Sub);
         if (providerKey == null || provider == null)
         {
             return null;

--- a/src/Identity/Core/src/SignInManager.cs
+++ b/src/Identity/Core/src/SignInManager.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
@@ -666,7 +667,7 @@ public class SignInManager<TUser> where TUser : class
             }
         }
 
-        var providerKey = auth.Principal.FindFirstValue(ClaimTypes.NameIdentifier);
+        var providerKey = auth.Principal.FindFirstValue(JwtRegisteredClaimNames.Sub) ?? auth.Principal.FindFirstValue(ClaimTypes.NameIdentifier);
         if (providerKey == null || provider == null)
         {
             return null;

--- a/src/Identity/Core/src/SignInManager.cs
+++ b/src/Identity/Core/src/SignInManager.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
-using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
@@ -667,7 +666,7 @@ public class SignInManager<TUser> where TUser : class
             }
         }
 
-        var providerKey = auth.Principal.FindFirstValue(ClaimTypes.NameIdentifier) ?? auth.Principal.FindFirstValue(JwtRegisteredClaimNames.Sub);
+        var providerKey = auth.Principal.FindFirstValue(ClaimTypes.NameIdentifier) ?? auth.Principal.FindFirstValue("sub");
         if (providerKey == null || provider == null)
         {
             return null;


### PR DESCRIPTION
# Support `sub` as `ExternalLoginInfo.ProviderKey`

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

If `ClaimTypes.NameIdentifier` is not found, look for `sub`

Fixes #45197
