### PR TITLE
Fix for W3C cookie logging

### DIFF
--- a/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
@@ -174,7 +174,7 @@ internal sealed class W3CLoggingMiddleware
                     {
                         shouldLog |= AddToList(elements, _userAgentIndex, agent.ToString());
                     }
-                }                
+                }
             }
         }
         

--- a/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
@@ -174,15 +174,15 @@ internal sealed class W3CLoggingMiddleware
                     {
                         shouldLog |= AddToList(elements, _userAgentIndex, agent.ToString());
                     }
-                }
-
-                if (options.LoggingFields.HasFlag(W3CLoggingFields.Cookie))
-                {
-                    if (request.Headers.TryGetValue(HeaderNames.Cookie, out var cookie))
-                    {
-                        shouldLog |= AddToList(elements, _cookieIndex, cookie.ToString());
-                    }
-                }
+                }                
+            }
+        }
+        
+        if (options.LoggingFields.HasFlag(W3CLoggingFields.Cookie))
+        {
+            if (request.Headers.TryGetValue(HeaderNames.Cookie, out var cookie))
+            {
+                shouldLog |= AddToList(elements, _cookieIndex, cookie.ToString());
             }
         }
 


### PR DESCRIPTION
# Fix for W3C cookie logging 

Moves the cookie logging outside of the "RequestHeaders" conditional block so that it can be logged by itself. Previously, cookie values would only be logged if one of the other request headers was also logged, otherwise it would always be logged as a missing field.

Fixes #45212
