### PR TITLE
Fix for W3C cookie logging

### DIFF
--- a/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggingMiddleware.cs
@@ -125,11 +125,11 @@ internal sealed class W3CLoggingMiddleware
                 shouldLog |= AddToList(elements, _serverPortIndex, connectionInfo.LocalPort.ToString(CultureInfo.InvariantCulture));
             }
         }
-
+        
+        var request = context.Request;
+        
         if ((W3CLoggingFields.Request & options.LoggingFields) != W3CLoggingFields.None)
         {
-            var request = context.Request;
-
             if (options.LoggingFields.HasFlag(W3CLoggingFields.ProtocolVersion))
             {
                 shouldLog |= AddToList(elements, _protocolVersionIndex, request.Protocol);
@@ -175,14 +175,14 @@ internal sealed class W3CLoggingMiddleware
                         shouldLog |= AddToList(elements, _userAgentIndex, agent.ToString());
                     }
                 }
-
-                if (options.LoggingFields.HasFlag(W3CLoggingFields.Cookie))
-                {
-                    if (request.Headers.TryGetValue(HeaderNames.Cookie, out var cookie))
-                    {
-                        shouldLog |= AddToList(elements, _cookieIndex, cookie.ToString());
-                    }
-                }
+            }
+        }
+        
+        if (options.LoggingFields.HasFlag(W3CLoggingFields.Cookie))
+        {
+            if (request.Headers.TryGetValue(HeaderNames.Cookie, out var cookie))
+            {
+                shouldLog |= AddToList(elements, _cookieIndex, cookie.ToString());
             }
         }
 
@@ -192,7 +192,7 @@ internal sealed class W3CLoggingMiddleware
 
             for (var i = 0; i < additionalRequestHeaders.Count; i++)
             {
-                if (context.Request.Headers.TryGetValue(additionalRequestHeaders[i], out var headerValue))
+                if (request.Headers.TryGetValue(additionalRequestHeaders[i], out var headerValue))
                 {
                     shouldLog |= AddToList(additionalHeaderElements, i, headerValue.ToString());
                 }


### PR DESCRIPTION
Moves the cookie logging outside of the "RequestHeaders" conditional block so that it can be logged by itself. Previously, cookie values would only be logged if one of the other request headers was also logged, otherwise it would always be logged as a missing field.

Fixes #45212