### PR TITLE
Fix response code description in Minimal APIs

### DIFF
--- a/src/OpenApi/src/OpenApiGenerator.cs
+++ b/src/OpenApi/src/OpenApiGenerator.cs
@@ -31,6 +31,76 @@ internal sealed class OpenApiGenerator
 
     internal static readonly ParameterBindingMethodCache ParameterBindingMethodCache = new();
 
+    private static readonly Dictionary<int, string> Phrases = new()
+    {
+        { 100, "Continue" },
+        { 101, "Switching Protocols" },
+        { 102, "Processing" },
+
+        { 200, "OK" },
+        { 201, "Created" },
+        { 202, "Accepted" },
+        { 203, "Non-Authoritative Information" },
+        { 204, "No Content" },
+        { 205, "Reset Content" },
+        { 206, "Partial Content" },
+        { 207, "Multi-Status" },
+        { 208, "Already Reported" },
+        { 226, "IM Used" },
+
+        { 300, "Multiple Choices" },
+        { 301, "Moved Permanently" },
+        { 302, "Found" },
+        { 303, "See Other" },
+        { 304, "Not Modified" },
+        { 305, "Use Proxy" },
+        { 306, "Switch Proxy" },
+        { 307, "Temporary Redirect" },
+        { 308, "Permanent Redirect" },
+
+        { 400, "Bad Request" },
+        { 401, "Unauthorized" },
+        { 402, "Payment Required" },
+        { 403, "Forbidden" },
+        { 404, "Not Found" },
+        { 405, "Method Not Allowed" },
+        { 406, "Not Acceptable" },
+        { 407, "Proxy Authentication Required" },
+        { 408, "Request Timeout" },
+        { 409, "Conflict" },
+        { 410, "Gone" },
+        { 411, "Length Required" },
+        { 412, "Precondition Failed" },
+        { 413, "Payload Too Large" },
+        { 414, "URI Too Long" },
+        { 415, "Unsupported Media Type" },
+        { 416, "Range Not Satisfiable" },
+        { 417, "Expectation Failed" },
+        { 418, "I'm a teapot" },
+        { 419, "Authentication Timeout" },
+        { 421, "Misdirected Request" },
+        { 422, "Unprocessable Entity" },
+        { 423, "Locked" },
+        { 424, "Failed Dependency" },
+        { 426, "Upgrade Required" },
+        { 428, "Precondition Required" },
+        { 429, "Too Many Requests" },
+        { 431, "Request Header Fields Too Large" },
+        { 451, "Unavailable For Legal Reasons" },
+
+        { 500, "Internal Server Error" },
+        { 501, "Not Implemented" },
+        { 502, "Bad Gateway" },
+        { 503, "Service Unavailable" },
+        { 504, "Gateway Timeout" },
+        { 505, "HTTP Version Not Supported" },
+        { 506, "Variant Also Negotiates" },
+        { 507, "Insufficient Storage" },
+        { 508, "Loop Detected" },
+        { 510, "Not Extended" },
+        { 511, "Network Authentication Required" },
+    };
+
     /// <summary>
     /// Creates an <see cref="OpenApiGenerator" /> instance given an <see cref="IHostEnvironment" />
     /// and an <see cref="IServiceProviderIsService" /> instance.
@@ -192,7 +262,7 @@ internal sealed class OpenApiGenerator
 
         foreach (var annotation in eligibileAnnotations)
         {
-            var statusCode = annotation.Key.ToString(CultureInfo.InvariantCulture);
+            var statusCode = annotation.Key;
 
             // TODO: Use the discarded response Type for schema generation
             var (_, contentTypes) = annotation.Value;
@@ -203,7 +273,7 @@ internal sealed class OpenApiGenerator
                 responseContent[contentType] = new OpenApiMediaType();
             }
 
-            responses[statusCode] = new OpenApiResponse
+            responses[statusCode.ToString(CultureInfo.InvariantCulture)] = new OpenApiResponse
             {
                 Content = responseContent,
                 Description = GetResponseDescription(statusCode)
@@ -212,23 +282,8 @@ internal sealed class OpenApiGenerator
         return responses;
     }
 
-    private static string GetResponseDescription(string statusCode)
-    {
-        if (statusCode.Length != 3)
-        {
-            return string.Empty;
-        }
-        var first = statusCode[0];
-        return first switch
-        {
-            '1' => "Information",
-            '2' => "Success",
-            '3' => "Redirection",
-            '4' => "Client error",
-            '5' => "Server error",
-            _ => string.Empty,
-        };
-    }
+    private static string GetResponseDescription(int statusCode)
+        => Phrases.TryGetValue(statusCode, out var phrase) ? phrase : string.Empty;
 
     private static void GenerateDefaultContent(MediaTypeCollection discoveredContentTypeAnnotation, Type? discoveredTypeAnnotation)
     {

--- a/src/OpenApi/src/OpenApiGenerator.cs
+++ b/src/OpenApi/src/OpenApiGenerator.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Internal;
@@ -30,76 +31,6 @@ internal sealed class OpenApiGenerator
     private readonly IServiceProviderIsService? _serviceProviderIsService;
 
     internal static readonly ParameterBindingMethodCache ParameterBindingMethodCache = new();
-
-    private static readonly Dictionary<int, string> Phrases = new()
-    {
-        { 100, "Continue" },
-        { 101, "Switching Protocols" },
-        { 102, "Processing" },
-
-        { 200, "OK" },
-        { 201, "Created" },
-        { 202, "Accepted" },
-        { 203, "Non-Authoritative Information" },
-        { 204, "No Content" },
-        { 205, "Reset Content" },
-        { 206, "Partial Content" },
-        { 207, "Multi-Status" },
-        { 208, "Already Reported" },
-        { 226, "IM Used" },
-
-        { 300, "Multiple Choices" },
-        { 301, "Moved Permanently" },
-        { 302, "Found" },
-        { 303, "See Other" },
-        { 304, "Not Modified" },
-        { 305, "Use Proxy" },
-        { 306, "Switch Proxy" },
-        { 307, "Temporary Redirect" },
-        { 308, "Permanent Redirect" },
-
-        { 400, "Bad Request" },
-        { 401, "Unauthorized" },
-        { 402, "Payment Required" },
-        { 403, "Forbidden" },
-        { 404, "Not Found" },
-        { 405, "Method Not Allowed" },
-        { 406, "Not Acceptable" },
-        { 407, "Proxy Authentication Required" },
-        { 408, "Request Timeout" },
-        { 409, "Conflict" },
-        { 410, "Gone" },
-        { 411, "Length Required" },
-        { 412, "Precondition Failed" },
-        { 413, "Payload Too Large" },
-        { 414, "URI Too Long" },
-        { 415, "Unsupported Media Type" },
-        { 416, "Range Not Satisfiable" },
-        { 417, "Expectation Failed" },
-        { 418, "I'm a teapot" },
-        { 419, "Authentication Timeout" },
-        { 421, "Misdirected Request" },
-        { 422, "Unprocessable Entity" },
-        { 423, "Locked" },
-        { 424, "Failed Dependency" },
-        { 426, "Upgrade Required" },
-        { 428, "Precondition Required" },
-        { 429, "Too Many Requests" },
-        { 431, "Request Header Fields Too Large" },
-        { 451, "Unavailable For Legal Reasons" },
-
-        { 500, "Internal Server Error" },
-        { 501, "Not Implemented" },
-        { 502, "Bad Gateway" },
-        { 503, "Service Unavailable" },
-        { 504, "Gateway Timeout" },
-        { 505, "HTTP Version Not Supported" },
-        { 506, "Variant Also Negotiates" },
-        { 507, "Insufficient Storage" },
-        { 508, "Loop Detected" },
-        { 510, "Not Extended" },
-        { 511, "Network Authentication Required" },
-    };
 
     /// <summary>
     /// Creates an <see cref="OpenApiGenerator" /> instance given an <see cref="IHostEnvironment" />
@@ -283,7 +214,7 @@ internal sealed class OpenApiGenerator
     }
 
     private static string GetResponseDescription(int statusCode)
-        => Phrases.TryGetValue(statusCode, out var phrase) ? phrase : string.Empty;
+        => ReasonPhrases.GetReasonPhrase(statusCode);
 
     private static void GenerateDefaultContent(MediaTypeCollection discoveredContentTypeAnnotation, Type? discoveredTypeAnnotation)
     {

--- a/src/OpenApi/test/OpenApiGeneratorTests.cs
+++ b/src/OpenApi/test/OpenApiGeneratorTests.cs
@@ -242,10 +242,10 @@ public class OpenApiOperationGeneratorTests
         Assert.Equal(2, operation.Responses.Count);
 
         var successResponse = operation.Responses["201"];
-        Assert.Equal("Success", successResponse.Description);
+        Assert.Equal("Created", successResponse.Description);
 
         var clientErrorResponse = operation.Responses["400"];
-        Assert.Equal("Client error", clientErrorResponse.Description);
+        Assert.Equal("Bad Request", clientErrorResponse.Description);
     }
 
     [Fact]
@@ -259,10 +259,10 @@ public class OpenApiOperationGeneratorTests
         Assert.Equal(2, operation.Responses.Count);
 
         var continueResponse = operation.Responses["100"];
-        Assert.Equal("Information", continueResponse.Description);
+        Assert.Equal("Continue", continueResponse.Description);
 
         var switchingProtocolsResponse = operation.Responses["101"];
-        Assert.Equal("Information", switchingProtocolsResponse.Description);
+        Assert.Equal("Switching Protocols", switchingProtocolsResponse.Description);
     }
 
     [Fact]
@@ -279,19 +279,19 @@ public class OpenApiOperationGeneratorTests
         Assert.Equal(5, operation.Responses.Count);
 
         var continueResponse = operation.Responses["100"];
-        Assert.Equal("Information", continueResponse.Description);
+        Assert.Equal("Continue", continueResponse.Description);
 
         var createdResponse = operation.Responses["201"];
-        Assert.Equal("Success", createdResponse.Description);
+        Assert.Equal("Created", createdResponse.Description);
 
         var multipleChoicesResponse = operation.Responses["300"];
-        Assert.Equal("Redirection", multipleChoicesResponse.Description);
+        Assert.Equal("Multiple Choices", multipleChoicesResponse.Description);
 
         var badRequestResponse = operation.Responses["400"];
-        Assert.Equal("Client error", badRequestResponse.Description);
+        Assert.Equal("Bad Request", badRequestResponse.Description);
 
         var InternalServerErrorResponse = operation.Responses["500"];
-        Assert.Equal("Server error", InternalServerErrorResponse.Description);
+        Assert.Equal("Internal Server Error", InternalServerErrorResponse.Description);
     }
 
     [Fact]


### PR DESCRIPTION
# Fix response code description when using WithOpenApi in Minimal APIs

When using `WithOpenApi` extension method, the response code description is incorrectly set, for example:

![image](https://user-images.githubusercontent.com/3522534/203273856-da62cab6-3d39-4644-85fb-6038b52534b6.png)

In this case, the description for 404 response should be "Not Found". This PR fixes the issue by returning the standard reason phrase for each status code, as defined at: https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml.

Fixes #45192
