### PR TITLE
Add DateOnly and TimeOnly to MVC Model Binding

### DIFF
--- a/src/Mvc/Mvc.Core/src/Infrastructure/MvcCoreMvcOptionsSetup.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/MvcCoreMvcOptionsSetup.cs
@@ -74,6 +74,8 @@ internal sealed class MvcCoreMvcOptionsSetup : IConfigureOptions<MvcOptions>, IP
         options.ModelBinderProviders.Add(new ArrayModelBinderProvider());
         options.ModelBinderProviders.Add(new CollectionModelBinderProvider());
         options.ModelBinderProviders.Add(new ComplexObjectModelBinderProvider());
+        options.ModelBinderProviders.Add(new DateOnlyModelBinderProvider());
+        options.ModelBinderProviders.Add(new TimeOnlyModelBinderProvider());
 
         // Set up filters
         options.Filters.Add(new UnsupportedContentTypeFilter());

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateOnlyModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateOnlyModelBinder.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+
+/// <summary>
+/// An <see cref="IModelBinder"/> for <see cref="DateOnly"/> and nullable <see cref="DateOnly"/> models.
+/// </summary>
+public class DateOnlyModelBinder : IModelBinder
+{
+    private readonly DateTimeStyles _supportedStyles;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="DateOnlyModelBinder"/>.
+    /// </summary>
+    /// <param name="supportedStyles">The <see cref="DateTimeStyles"/>.</param>
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
+    public DateOnlyModelBinder(DateTimeStyles supportedStyles, ILoggerFactory loggerFactory)
+    {
+        if (loggerFactory == null)
+        {
+            throw new ArgumentNullException(nameof(loggerFactory));
+        }
+
+        _supportedStyles = supportedStyles;
+        _logger = loggerFactory.CreateLogger<DateOnlyModelBinder>();
+    }
+
+    /// <inheritdoc />
+    public Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        if (bindingContext == null)
+        {
+            throw new ArgumentNullException(nameof(bindingContext));
+        }
+
+        _logger.AttemptingToBindModel(bindingContext);
+
+        var modelName = bindingContext.ModelName;
+        var valueProviderResult = bindingContext.ValueProvider.GetValue(modelName);
+        if (valueProviderResult == ValueProviderResult.None)
+        {
+            _logger.FoundNoValueInRequest(bindingContext);
+
+            // no entry
+            _logger.DoneAttemptingToBindModel(bindingContext);
+            return Task.CompletedTask;
+        }
+
+        var modelState = bindingContext.ModelState;
+        modelState.SetModelValue(modelName, valueProviderResult);
+
+        var metadata = bindingContext.ModelMetadata;
+        var type = metadata.UnderlyingOrModelType;
+        try
+        {
+            var value = valueProviderResult.FirstValue;
+
+            object? model;
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                // Parse() method trims the value (with common DateTimeSyles) then throws if the result is empty.
+                model = null;
+            }
+            else if (type == typeof(DateOnly))
+            {
+                model = DateOnly.Parse(value, valueProviderResult.Culture, _supportedStyles);
+            }
+            else
+            {
+                throw new NotSupportedException();
+            }
+
+            // When converting value, a null model may indicate a failed conversion for an otherwise required
+            // model (can't set a ValueType to null). This detects if a null model value is acceptable given the
+            // current bindingContext. If not, an error is logged.
+            if (model == null && !metadata.IsReferenceOrNullableType)
+            {
+                modelState.TryAddModelError(
+                    modelName,
+                    metadata.ModelBindingMessageProvider.ValueMustNotBeNullAccessor(
+                        valueProviderResult.ToString()));
+            }
+            else
+            {
+                bindingContext.Result = ModelBindingResult.Success(model);
+            }
+        }
+        catch (Exception exception)
+        {
+            // Conversion failed.
+            modelState.TryAddModelError(modelName, exception, metadata);
+        }
+
+        _logger.DoneAttemptingToBindModel(bindingContext);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateOnlyModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateOnlyModelBinder.cs
@@ -23,10 +23,7 @@ public class DateOnlyModelBinder : IModelBinder
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
     public DateOnlyModelBinder(DateTimeStyles supportedStyles, ILoggerFactory loggerFactory)
     {
-        if (loggerFactory == null)
-        {
-            throw new ArgumentNullException(nameof(loggerFactory));
-        }
+        ArgumentNullException.ThrowIfNull(loggerFactory, nameof(loggerFactory));
 
         _supportedStyles = supportedStyles;
         _logger = loggerFactory.CreateLogger<DateOnlyModelBinder>();
@@ -35,10 +32,7 @@ public class DateOnlyModelBinder : IModelBinder
     /// <inheritdoc />
     public Task BindModelAsync(ModelBindingContext bindingContext)
     {
-        if (bindingContext == null)
-        {
-            throw new ArgumentNullException(nameof(bindingContext));
-        }
+        ArgumentNullException.ThrowIfNull(bindingContext, nameof(bindingContext));
 
         _logger.AttemptingToBindModel(bindingContext);
 

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateOnlyModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateOnlyModelBinderProvider.cs
@@ -19,10 +19,7 @@ public class DateOnlyModelBinderProvider : IModelBinderProvider
     /// <inheritdoc />
     public IModelBinder? GetBinder(ModelBinderProviderContext context)
     {
-        if (context == null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
+        ArgumentNullException.ThrowIfNull(context, nameof(context));
 
         var modelType = context.Metadata.UnderlyingOrModelType;
         if (modelType == typeof(DateOnly))

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateOnlyModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateOnlyModelBinderProvider.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+
+/// <summary>
+/// An <see cref="IModelBinderProvider"/> for binding <see cref="DateOnly" /> and nullable <see cref="DateOnly"/> models.
+/// </summary>
+public class DateOnlyModelBinderProvider : IModelBinderProvider
+{
+    internal const DateTimeStyles SupportedStyles = DateTimeStyles.AdjustToUniversal | DateTimeStyles.AllowWhiteSpaces;
+
+    /// <inheritdoc />
+    public IModelBinder? GetBinder(ModelBinderProviderContext context)
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        var modelType = context.Metadata.UnderlyingOrModelType;
+        if (modelType == typeof(DateOnly))
+        {
+            var loggerFactory = context.Services.GetRequiredService<ILoggerFactory>();
+            return new DateOnlyModelBinder(SupportedStyles, loggerFactory);
+        }
+
+        return null;
+    }
+}

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateOnlyModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateOnlyModelBinderProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 /// </summary>
 public class DateOnlyModelBinderProvider : IModelBinderProvider
 {
-    internal const DateTimeStyles SupportedStyles = DateTimeStyles.AdjustToUniversal | DateTimeStyles.AllowWhiteSpaces;
+    internal const DateTimeStyles SupportedStyles = DateTimeStyles.AllowWhiteSpaces;
 
     /// <inheritdoc />
     public IModelBinder? GetBinder(ModelBinderProviderContext context)

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/TimeOnlyModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/TimeOnlyModelBinder.cs
@@ -23,10 +23,7 @@ public class TimeOnlyModelBinder : IModelBinder
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
     public TimeOnlyModelBinder(DateTimeStyles supportedStyles, ILoggerFactory loggerFactory)
     {
-        if (loggerFactory == null)
-        {
-            throw new ArgumentNullException(nameof(loggerFactory));
-        }
+        ArgumentNullException.ThrowIfNull(loggerFactory, nameof(loggerFactory));
 
         _supportedStyles = supportedStyles;
         _logger = loggerFactory.CreateLogger<TimeOnlyModelBinder>();
@@ -35,10 +32,7 @@ public class TimeOnlyModelBinder : IModelBinder
     /// <inheritdoc />
     public Task BindModelAsync(ModelBindingContext bindingContext)
     {
-        if (bindingContext == null)
-        {
-            throw new ArgumentNullException(nameof(bindingContext));
-        }
+        ArgumentNullException.ThrowIfNull(bindingContext, nameof(bindingContext));
 
         _logger.AttemptingToBindModel(bindingContext);
 

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/TimeOnlyModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/TimeOnlyModelBinder.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+
+/// <summary>
+/// An <see cref="IModelBinder"/> for <see cref="TimeOnly"/> and nullable <see cref="TimeOnly"/> models.
+/// </summary>
+public class TimeOnlyModelBinder : IModelBinder
+{
+    private readonly DateTimeStyles _supportedStyles;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="TimeOnlyModelBinder"/>.
+    /// </summary>
+    /// <param name="supportedStyles">The <see cref="DateTimeStyles"/>.</param>
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
+    public TimeOnlyModelBinder(DateTimeStyles supportedStyles, ILoggerFactory loggerFactory)
+    {
+        if (loggerFactory == null)
+        {
+            throw new ArgumentNullException(nameof(loggerFactory));
+        }
+
+        _supportedStyles = supportedStyles;
+        _logger = loggerFactory.CreateLogger<TimeOnlyModelBinder>();
+    }
+
+    /// <inheritdoc />
+    public Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        if (bindingContext == null)
+        {
+            throw new ArgumentNullException(nameof(bindingContext));
+        }
+
+        _logger.AttemptingToBindModel(bindingContext);
+
+        var modelName = bindingContext.ModelName;
+        var valueProviderResult = bindingContext.ValueProvider.GetValue(modelName);
+        if (valueProviderResult == ValueProviderResult.None)
+        {
+            _logger.FoundNoValueInRequest(bindingContext);
+
+            // no entry
+            _logger.DoneAttemptingToBindModel(bindingContext);
+            return Task.CompletedTask;
+        }
+
+        var modelState = bindingContext.ModelState;
+        modelState.SetModelValue(modelName, valueProviderResult);
+
+        var metadata = bindingContext.ModelMetadata;
+        var type = metadata.UnderlyingOrModelType;
+        try
+        {
+            var value = valueProviderResult.FirstValue;
+
+            object? model;
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                // Parse() method trims the value (with common DateTimeSyles) then throws if the result is empty.
+                model = null;
+            }
+            else if (type == typeof(TimeOnly))
+            {
+                model = TimeOnly.Parse(value, valueProviderResult.Culture, _supportedStyles);
+            }
+            else
+            {
+                throw new NotSupportedException();
+            }
+
+            // When converting value, a null model may indicate a failed conversion for an otherwise required
+            // model (can't set a ValueType to null). This detects if a null model value is acceptable given the
+            // current bindingContext. If not, an error is logged.
+            if (model == null && !metadata.IsReferenceOrNullableType)
+            {
+                modelState.TryAddModelError(
+                    modelName,
+                    metadata.ModelBindingMessageProvider.ValueMustNotBeNullAccessor(
+                        valueProviderResult.ToString()));
+            }
+            else
+            {
+                bindingContext.Result = ModelBindingResult.Success(model);
+            }
+        }
+        catch (Exception exception)
+        {
+            // Conversion failed.
+            modelState.TryAddModelError(modelName, exception, metadata);
+        }
+
+        _logger.DoneAttemptingToBindModel(bindingContext);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/TimeOnlyModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/TimeOnlyModelBinderProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 /// </summary>
 public class TimeOnlyModelBinderProvider : IModelBinderProvider
 {
-    internal const DateTimeStyles SupportedStyles = DateTimeStyles.AdjustToUniversal | DateTimeStyles.AllowWhiteSpaces;
+    internal const DateTimeStyles SupportedStyles = DateTimeStyles.AllowWhiteSpaces;
 
     /// <inheritdoc />
     public IModelBinder? GetBinder(ModelBinderProviderContext context)

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/TimeOnlyModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/TimeOnlyModelBinderProvider.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+
+/// <summary>
+/// An <see cref="IModelBinderProvider"/> for binding <see cref="TimeOnly"/> and nullable <see cref="TimeOnly"/> models.
+/// </summary>
+public class TimeOnlyModelBinderProvider : IModelBinderProvider
+{
+    internal const DateTimeStyles SupportedStyles = DateTimeStyles.AdjustToUniversal | DateTimeStyles.AllowWhiteSpaces;
+
+    /// <inheritdoc />
+    public IModelBinder? GetBinder(ModelBinderProviderContext context)
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        var modelType = context.Metadata.UnderlyingOrModelType;
+        if (modelType == typeof(TimeOnly))
+        {
+            var loggerFactory = context.Services.GetRequiredService<ILoggerFactory>();
+            return new TimeOnlyModelBinder(SupportedStyles, loggerFactory);
+        }
+
+        return null;
+    }
+}

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/TimeOnlyModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/TimeOnlyModelBinderProvider.cs
@@ -19,10 +19,7 @@ public class TimeOnlyModelBinderProvider : IModelBinderProvider
     /// <inheritdoc />
     public IModelBinder? GetBinder(ModelBinderProviderContext context)
     {
-        if (context == null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
+        ArgumentNullException.ThrowIfNull(context, nameof(context));
 
         var modelType = context.Metadata.UnderlyingOrModelType;
         if (modelType == typeof(TimeOnly))

--- a/src/Mvc/Mvc.Core/src/PublicAPI.Shipped.txt
+++ b/src/Mvc/Mvc.Core/src/PublicAPI.Shipped.txt
@@ -1139,6 +1139,12 @@ Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ComplexObjectModelBinderProvider.G
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ComplexTypeModelBinder
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ComplexTypeModelBinderProvider
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ComplexTypeModelBinderProvider.ComplexTypeModelBinderProvider() -> void
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateOnlyModelBinder
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateOnlyModelBinder.BindModelAsync(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBindingContext! bindingContext) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateOnlyModelBinder.DateOnlyModelBinder(System.Globalization.DateTimeStyles supportedStyles, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateOnlyModelBinderProvider
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateOnlyModelBinderProvider.DateOnlyModelBinderProvider() -> void
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateOnlyModelBinderProvider.GetBinder(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBinderProviderContext! context) -> Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder?
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinder
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinder.BindModelAsync(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBindingContext! bindingContext) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinder.DateTimeModelBinder(System.Globalization.DateTimeStyles supportedStyles, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
@@ -1206,6 +1212,12 @@ Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinder.SimpleTypeMo
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider.GetBinder(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBinderProviderContext! context) -> Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder?
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider.SimpleTypeModelBinderProvider() -> void
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TimeOnlyModelBinder
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TimeOnlyModelBinder.BindModelAsync(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBindingContext! bindingContext) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TimeOnlyModelBinder.TimeOnlyModelBinder(System.Globalization.DateTimeStyles supportedStyles, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TimeOnlyModelBinderProvider
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TimeOnlyModelBinderProvider.TimeOnlyModelBinderProvider() -> void
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TimeOnlyModelBinderProvider.GetBinder(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBinderProviderContext! context) -> Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder?
 Microsoft.AspNetCore.Mvc.ModelBinding.BindingBehavior
 Microsoft.AspNetCore.Mvc.ModelBinding.BindingBehavior.Never = 1 -> Microsoft.AspNetCore.Mvc.ModelBinding.BindingBehavior
 Microsoft.AspNetCore.Mvc.ModelBinding.BindingBehavior.Optional = 0 -> Microsoft.AspNetCore.Mvc.ModelBinding.BindingBehavior

--- a/src/Mvc/Mvc.Core/src/PublicAPI.Shipped.txt
+++ b/src/Mvc/Mvc.Core/src/PublicAPI.Shipped.txt
@@ -1139,12 +1139,6 @@ Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ComplexObjectModelBinderProvider.G
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ComplexTypeModelBinder
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ComplexTypeModelBinderProvider
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.ComplexTypeModelBinderProvider.ComplexTypeModelBinderProvider() -> void
-Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateOnlyModelBinder
-Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateOnlyModelBinder.BindModelAsync(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBindingContext! bindingContext) -> System.Threading.Tasks.Task!
-Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateOnlyModelBinder.DateOnlyModelBinder(System.Globalization.DateTimeStyles supportedStyles, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
-Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateOnlyModelBinderProvider
-Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateOnlyModelBinderProvider.DateOnlyModelBinderProvider() -> void
-Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateOnlyModelBinderProvider.GetBinder(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBinderProviderContext! context) -> Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder?
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinder
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinder.BindModelAsync(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBindingContext! bindingContext) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateTimeModelBinder.DateTimeModelBinder(System.Globalization.DateTimeStyles supportedStyles, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
@@ -1212,12 +1206,6 @@ Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinder.SimpleTypeMo
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider.GetBinder(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBinderProviderContext! context) -> Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder?
 Microsoft.AspNetCore.Mvc.ModelBinding.Binders.SimpleTypeModelBinderProvider.SimpleTypeModelBinderProvider() -> void
-Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TimeOnlyModelBinder
-Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TimeOnlyModelBinder.BindModelAsync(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBindingContext! bindingContext) -> System.Threading.Tasks.Task!
-Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TimeOnlyModelBinder.TimeOnlyModelBinder(System.Globalization.DateTimeStyles supportedStyles, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
-Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TimeOnlyModelBinderProvider
-Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TimeOnlyModelBinderProvider.TimeOnlyModelBinderProvider() -> void
-Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TimeOnlyModelBinderProvider.GetBinder(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBinderProviderContext! context) -> Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder?
 Microsoft.AspNetCore.Mvc.ModelBinding.BindingBehavior
 Microsoft.AspNetCore.Mvc.ModelBinding.BindingBehavior.Never = 1 -> Microsoft.AspNetCore.Mvc.ModelBinding.BindingBehavior
 Microsoft.AspNetCore.Mvc.ModelBinding.BindingBehavior.Optional = 0 -> Microsoft.AspNetCore.Mvc.ModelBinding.BindingBehavior

--- a/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
@@ -36,3 +36,15 @@ virtual Microsoft.AspNetCore.Mvc.Infrastructure.ConfigureCompatibilityOptions<TO
 static Microsoft.AspNetCore.Mvc.ControllerBase.Empty.get -> Microsoft.AspNetCore.Mvc.EmptyResult!
 *REMOVED*virtual Microsoft.AspNetCore.Mvc.ModelBinding.DefaultPropertyFilterProvider<TModel>.PropertyIncludeExpressions.get -> System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression<System.Func<TModel!, object!>!>!>?
 virtual Microsoft.AspNetCore.Mvc.ModelBinding.DefaultPropertyFilterProvider<TModel>.PropertyIncludeExpressions.get -> System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression<System.Func<TModel!, object?>!>!>?
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateOnlyModelBinder
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateOnlyModelBinder.BindModelAsync(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBindingContext! bindingContext) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateOnlyModelBinder.DateOnlyModelBinder(System.Globalization.DateTimeStyles supportedStyles, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateOnlyModelBinderProvider
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateOnlyModelBinderProvider.DateOnlyModelBinderProvider() -> void
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.DateOnlyModelBinderProvider.GetBinder(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBinderProviderContext! context) -> Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder?
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TimeOnlyModelBinder
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TimeOnlyModelBinder.BindModelAsync(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBindingContext! bindingContext) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TimeOnlyModelBinder.TimeOnlyModelBinder(System.Globalization.DateTimeStyles supportedStyles, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TimeOnlyModelBinderProvider
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TimeOnlyModelBinderProvider.TimeOnlyModelBinderProvider() -> void
+Microsoft.AspNetCore.Mvc.ModelBinding.Binders.TimeOnlyModelBinderProvider.GetBinder(Microsoft.AspNetCore.Mvc.ModelBinding.ModelBinderProviderContext! context) -> Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder?

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/DateOnlyModelBinderProviderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/DateOnlyModelBinderProviderTest.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+
+public class DateOnlyModelBinderProviderTest
+{
+    private readonly DateOnlyModelBinderProvider _provider = new DateOnlyModelBinderProvider();
+
+    [Theory]
+    [InlineData(typeof(string))]
+    [InlineData(typeof(DateTimeOffset))]
+    [InlineData(typeof(DateTimeOffset?))]
+    [InlineData(typeof(DateTime))]
+    [InlineData(typeof(DateTime?))]
+    [InlineData(typeof(TimeSpan))]
+    public void Create_ForNonDateOnly_ReturnsNull(Type modelType)
+    {
+        // Arrange
+        var context = new TestModelBinderProviderContext(modelType);
+
+        // Act
+        var result = _provider.GetBinder(context);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Create_ForDateOnly_ReturnsBinder()
+    {
+        // Arrange
+        var context = new TestModelBinderProviderContext(typeof(DateOnly));
+
+        // Act
+        var result = _provider.GetBinder(context);
+
+        // Assert
+        Assert.IsType<DateOnlyModelBinder>(result);
+    }
+
+    [Fact]
+    public void Create_ForNullableDateOnly_ReturnsBinder()
+    {
+        // Arrange
+        var context = new TestModelBinderProviderContext(typeof(DateOnly?));
+
+        // Act
+        var result = _provider.GetBinder(context);
+
+        // Assert
+        Assert.IsType<DateOnlyModelBinder>(result);
+    }
+}

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/DateOnlyModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/DateOnlyModelBinderTest.cs
@@ -1,0 +1,216 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+
+public class DateOnlyModelBinderTest
+{
+    [Fact]
+    public async Task BindModel_ReturnsFailure_IfAttemptedValueCannotBeParsed()
+    {
+        // Arrange
+        var bindingContext = GetBindingContext();
+        bindingContext.ValueProvider = new SimpleValueProvider
+            {
+                { "theModelName", "some-value" }
+            };
+        var binder = GetBinder();
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.False(bindingContext.Result.IsModelSet);
+    }
+
+    [Fact]
+    public async Task BindModel_CreatesError_IfAttemptedValueCannotBeParsed()
+    {
+        // Arrange
+        var message = "The value 'not a date' is not valid.";
+        var bindingContext = GetBindingContext();
+        bindingContext.ValueProvider = new SimpleValueProvider
+            {
+                { "theModelName", "not a date" },
+            };
+        var binder = GetBinder();
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.False(bindingContext.Result.IsModelSet);
+        Assert.Null(bindingContext.Result.Model);
+        Assert.False(bindingContext.ModelState.IsValid);
+
+        var error = Assert.Single(bindingContext.ModelState["theModelName"].Errors);
+        Assert.Equal(message, error.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task BindModel_CreatesError_IfAttemptedValueCannotBeCompletelyParsed()
+    {
+        // Arrange
+        var bindingContext = GetBindingContext();
+        bindingContext.ValueProvider = new SimpleValueProvider(new CultureInfo("en-GB"))
+            {
+                { "theModelName", "2020-08-not-a-date" }
+            };
+        var binder = GetBinder();
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.False(bindingContext.Result.IsModelSet);
+        Assert.Null(bindingContext.Result.Model);
+
+        var error = Assert.Single(bindingContext.ModelState["theModelName"].Errors);
+        Assert.Equal("The value '2020-08-not-a-date' is not valid.", error.ErrorMessage, StringComparer.Ordinal);
+        Assert.Null(error.Exception);
+    }
+
+    [Fact]
+    public async Task BindModel_ReturnsFailed_IfValueProviderEmpty()
+    {
+        // Arrange
+        var bindingContext = GetBindingContext(typeof(DateOnly));
+        var binder = GetBinder();
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.Equal(ModelBindingResult.Failed(), bindingContext.Result);
+        Assert.Empty(bindingContext.ModelState);
+    }
+
+    [Fact]
+    public async Task BindModel_NullableDateOnly_ReturnsFailed_IfValueProviderEmpty()
+    {
+        // Arrange
+        var bindingContext = GetBindingContext(typeof(DateOnly?));
+        var binder = GetBinder();
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.Equal(ModelBindingResult.Failed(), bindingContext.Result);
+        Assert.Empty(bindingContext.ModelState);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" \t \r\n ")]
+    public async Task BindModel_CreatesError_IfTrimmedAttemptedValueIsEmpty_NonNullableDestination(string value)
+    {
+        // Arrange
+        var message = $"The value '{value}' is invalid.";
+        var bindingContext = GetBindingContext();
+        bindingContext.ValueProvider = new SimpleValueProvider
+            {
+                { "theModelName", value },
+            };
+        var binder = GetBinder();
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.False(bindingContext.Result.IsModelSet);
+        Assert.Null(bindingContext.Result.Model);
+
+        var error = Assert.Single(bindingContext.ModelState["theModelName"].Errors);
+        Assert.Equal(message, error.ErrorMessage, StringComparer.Ordinal);
+        Assert.Null(error.Exception);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" \t \r\n ")]
+    public async Task BindModel_ReturnsNull_IfTrimmedAttemptedValueIsEmpty_NullableDestination(string value)
+    {
+        // Arrange
+        var bindingContext = GetBindingContext(typeof(DateOnly?));
+        bindingContext.ValueProvider = new SimpleValueProvider
+            {
+                { "theModelName", value }
+            };
+        var binder = GetBinder();
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.Null(bindingContext.Result.Model);
+        var entry = Assert.Single(bindingContext.ModelState);
+        Assert.Equal("theModelName", entry.Key);
+    }
+
+    [Theory]
+    [InlineData(typeof(DateOnly))]
+    [InlineData(typeof(DateOnly?))]
+    public async Task BindModel_ReturnsModel_IfAttemptedValueIsValid(Type type)
+    {
+        // Arrange
+        var expected = new DateOnly(2019, 06, 14);
+        var bindingContext = GetBindingContext(type);
+        bindingContext.ValueProvider = new SimpleValueProvider(new CultureInfo("fr-FR"))
+            {
+                { "theModelName", "2019-06-14" }
+            };
+        var binder = GetBinder();
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.True(bindingContext.Result.IsModelSet);
+        var model = Assert.IsType<DateOnly>(bindingContext.Result.Model);
+        Assert.Equal(expected, model);
+        Assert.True(bindingContext.ModelState.ContainsKey("theModelName"));
+    }
+
+    [Fact]
+    public async Task UsesSpecifiedStyleToParseModel()
+    {
+        // Arrange
+        var bindingContext = GetBindingContext();
+        var expected = DateOnly.Parse("2019-06-14", CultureInfo.InvariantCulture);
+        bindingContext.ValueProvider = new SimpleValueProvider(new CultureInfo("fr-FR"))
+            {
+                { "theModelName", "   2019-06-14" }
+            };
+        var binder = GetBinder(DateTimeStyles.AllowLeadingWhite);
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.True(bindingContext.Result.IsModelSet);
+        var model = Assert.IsType<DateOnly>(bindingContext.Result.Model);
+        Assert.Equal(expected, model);
+        Assert.True(bindingContext.ModelState.ContainsKey("theModelName"));
+    }
+
+    private IModelBinder GetBinder(DateTimeStyles? dateTimeStyles = null)
+    {
+        return new DateOnlyModelBinder(dateTimeStyles ?? DateOnlyModelBinderProvider.SupportedStyles, NullLoggerFactory.Instance);
+    }
+
+    private static DefaultModelBindingContext GetBindingContext(Type modelType = null)
+    {
+        modelType ??= typeof(DateOnly);
+        return new DefaultModelBindingContext
+        {
+            ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(modelType),
+            ModelName = "theModelName",
+            ModelState = new ModelStateDictionary(),
+            ValueProvider = new SimpleValueProvider() // empty
+        };
+    }
+}

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/TimeOnlyModelBinderProviderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/TimeOnlyModelBinderProviderTest.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+
+public class TimeOnlyModelBinderProviderTest
+{
+    private readonly TimeOnlyModelBinderProvider _provider = new TimeOnlyModelBinderProvider();
+
+    [Theory]
+    [InlineData(typeof(string))]
+    [InlineData(typeof(DateTimeOffset))]
+    [InlineData(typeof(DateTimeOffset?))]
+    [InlineData(typeof(DateTime))]
+    [InlineData(typeof(DateTime?))]
+    [InlineData(typeof(TimeSpan))]
+    public void Create_ForNonDateTime_ReturnsNull(Type modelType)
+    {
+        // Arrange
+        var context = new TestModelBinderProviderContext(modelType);
+
+        // Act
+        var result = _provider.GetBinder(context);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Create_ForTimeOnly_ReturnsBinder()
+    {
+        // Arrange
+        var context = new TestModelBinderProviderContext(typeof(TimeOnly));
+
+        // Act
+        var result = _provider.GetBinder(context);
+
+        // Assert
+        Assert.IsType<TimeOnlyModelBinder>(result);
+    }
+
+    [Fact]
+    public void Create_ForNullableTimeOnly_ReturnsBinder()
+    {
+        // Arrange
+        var context = new TestModelBinderProviderContext(typeof(TimeOnly?));
+
+        // Act
+        var result = _provider.GetBinder(context);
+
+        // Assert
+        Assert.IsType<TimeOnlyModelBinder>(result);
+    }
+}

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/TimeOnlyModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/TimeOnlyModelBinderTest.cs
@@ -1,0 +1,216 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Globalization;
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+
+public class TimeOnlyModelBinderTest
+{
+    [Fact]
+    public async Task BindModel_ReturnsFailure_IfAttemptedValueCannotBeParsed()
+    {
+        // Arrange
+        var bindingContext = GetBindingContext();
+        bindingContext.ValueProvider = new SimpleValueProvider
+            {
+                { "theModelName", "some-value" }
+            };
+        var binder = GetBinder();
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.False(bindingContext.Result.IsModelSet);
+    }
+
+    [Fact]
+    public async Task BindModel_CreatesError_IfAttemptedValueCannotBeParsed()
+    {
+        // Arrange
+        var message = "The value 'not a time' is not valid.";
+        var bindingContext = GetBindingContext();
+        bindingContext.ValueProvider = new SimpleValueProvider
+            {
+                { "theModelName", "not a time" },
+            };
+        var binder = GetBinder();
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.False(bindingContext.Result.IsModelSet);
+        Assert.Null(bindingContext.Result.Model);
+        Assert.False(bindingContext.ModelState.IsValid);
+
+        var error = Assert.Single(bindingContext.ModelState["theModelName"].Errors);
+        Assert.Equal(message, error.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task BindModel_CreatesError_IfAttemptedValueCannotBeCompletelyParsed()
+    {
+        // Arrange
+        var bindingContext = GetBindingContext();
+        bindingContext.ValueProvider = new SimpleValueProvider(new CultureInfo("en-GB"))
+            {
+                { "theModelName", "11:05:08-not-a-time" }
+            };
+        var binder = GetBinder();
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.False(bindingContext.Result.IsModelSet);
+        Assert.Null(bindingContext.Result.Model);
+
+        var error = Assert.Single(bindingContext.ModelState["theModelName"].Errors);
+        Assert.Equal("The value '11:05:08-not-a-time' is not valid.", error.ErrorMessage, StringComparer.Ordinal);
+        Assert.Null(error.Exception);
+    }
+
+    [Fact]
+    public async Task BindModel_ReturnsFailed_IfValueProviderEmpty()
+    {
+        // Arrange
+        var bindingContext = GetBindingContext(typeof(TimeOnly));
+        var binder = GetBinder();
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.Equal(ModelBindingResult.Failed(), bindingContext.Result);
+        Assert.Empty(bindingContext.ModelState);
+    }
+
+    [Fact]
+    public async Task BindModel_NullableTimeOnly_ReturnsFailed_IfValueProviderEmpty()
+    {
+        // Arrange
+        var bindingContext = GetBindingContext(typeof(TimeOnly?));
+        var binder = GetBinder();
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.Equal(ModelBindingResult.Failed(), bindingContext.Result);
+        Assert.Empty(bindingContext.ModelState);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" \t \r\n ")]
+    public async Task BindModel_CreatesError_IfTrimmedAttemptedValueIsEmpty_NonNullableDestination(string value)
+    {
+        // Arrange
+        var message = $"The value '{value}' is invalid.";
+        var bindingContext = GetBindingContext();
+        bindingContext.ValueProvider = new SimpleValueProvider
+            {
+                { "theModelName", value },
+            };
+        var binder = GetBinder();
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.False(bindingContext.Result.IsModelSet);
+        Assert.Null(bindingContext.Result.Model);
+
+        var error = Assert.Single(bindingContext.ModelState["theModelName"].Errors);
+        Assert.Equal(message, error.ErrorMessage, StringComparer.Ordinal);
+        Assert.Null(error.Exception);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" \t \r\n ")]
+    public async Task BindModel_ReturnsNull_IfTrimmedAttemptedValueIsEmpty_NullableDestination(string value)
+    {
+        // Arrange
+        var bindingContext = GetBindingContext(typeof(TimeOnly?));
+        bindingContext.ValueProvider = new SimpleValueProvider
+            {
+                { "theModelName", value }
+            };
+        var binder = GetBinder();
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.Null(bindingContext.Result.Model);
+        var entry = Assert.Single(bindingContext.ModelState);
+        Assert.Equal("theModelName", entry.Key);
+    }
+
+    [Theory]
+    [InlineData(typeof(TimeOnly))]
+    [InlineData(typeof(TimeOnly?))]
+    public async Task BindModel_ReturnsModel_IfAttemptedValueIsValid(Type type)
+    {
+        // Arrange
+        var expected = new TimeOnly(2, 30, 4, 0);
+        var bindingContext = GetBindingContext(type);
+        bindingContext.ValueProvider = new SimpleValueProvider(new CultureInfo("fr-FR"))
+            {
+                { "theModelName", "02:30:04.0000000" }
+            };
+        var binder = GetBinder();
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.True(bindingContext.Result.IsModelSet);
+        var model = Assert.IsType<TimeOnly>(bindingContext.Result.Model);
+        Assert.Equal(expected, model);
+        Assert.True(bindingContext.ModelState.ContainsKey("theModelName"));
+    }
+
+    [Fact]
+    public async Task UsesSpecifiedStyleToParseModel()
+    {
+        // Arrange
+        var bindingContext = GetBindingContext();
+        var expected = TimeOnly.Parse("02:30:04.0000000", CultureInfo.InvariantCulture);
+        bindingContext.ValueProvider = new SimpleValueProvider(new CultureInfo("fr-FR"))
+            {
+                { "theModelName", "   02:30:04.0000000" }
+            };
+        var binder = GetBinder(DateTimeStyles.AllowLeadingWhite);
+
+        // Act
+        await binder.BindModelAsync(bindingContext);
+
+        // Assert
+        Assert.True(bindingContext.Result.IsModelSet);
+        var model = Assert.IsType<TimeOnly>(bindingContext.Result.Model);
+        Assert.Equal(expected, model);
+        Assert.True(bindingContext.ModelState.ContainsKey("theModelName"));
+    }
+
+    private IModelBinder GetBinder(DateTimeStyles? dateTimeStyles = null)
+    {
+        return new TimeOnlyModelBinder(dateTimeStyles ?? TimeOnlyModelBinderProvider.SupportedStyles, NullLoggerFactory.Instance);
+    }
+
+    private static DefaultModelBindingContext GetBindingContext(Type modelType = null)
+    {
+        modelType ??= typeof(TimeOnly);
+        return new DefaultModelBindingContext
+        {
+            ModelMetadata = new EmptyModelMetadataProvider().GetMetadataForType(modelType),
+            ModelName = "theModelName",
+            ModelState = new ModelStateDictionary(),
+            ValueProvider = new SimpleValueProvider() // empty
+        };
+    }
+}

--- a/src/Mvc/Mvc/test/MvcOptionsSetupTest.cs
+++ b/src/Mvc/Mvc/test/MvcOptionsSetupTest.cs
@@ -62,7 +62,9 @@ public class MvcOptionsSetupTest
             binder => Assert.IsType<DictionaryModelBinderProvider>(binder),
             binder => Assert.IsType<ArrayModelBinderProvider>(binder),
             binder => Assert.IsType<CollectionModelBinderProvider>(binder),
-            binder => Assert.IsType<ComplexObjectModelBinderProvider>(binder));
+            binder => Assert.IsType<ComplexObjectModelBinderProvider>(binder),
+            binder => Assert.IsType<DateOnlyModelBinderProvider>(binder),
+            binder => Assert.IsType<TimeOnlyModelBinderProvider>(binder));
     }
 
     [Fact]


### PR DESCRIPTION
# Add DateOnly and TimeOnly to MVC Model Binding

Adds nullable `DateOnly` and `TimeOnly` to list of model binding simple types.

## Description

Part of the effort tracked in #34591 to add `DateOnly` and `TimeOnly` support to Model binding as well as Blazor/regular routing.

The logic almost exactly matches the implementation for `DateTime` with the exception of `DateTimeStyles.AdjustToUniversal` being included as a supported style as this style is not supported by the `DateOnly` and `TimeOnly` types.

On the completion and merge of this PR, I will create an additional PR to add `DateOnly` and `TimeOnly` to our [list of supported types](https://learn.microsoft.com/aspnet/core/mvc/models/model-binding?view=aspnetcore-7.0#simple-types).