### PR TITLE
Reimplement the default object pool for improved performance

### DIFF
--- a/src/ObjectPool/perf/Microbenchmarks/DrainRefillMultiTheaded.cs
+++ b/src/ObjectPool/perf/Microbenchmarks/DrainRefillMultiTheaded.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Extensions.ObjectPool.Microbenchmarks;
+
+[MemoryDiagnoser]
+public class DrainRefillMultiTheaded
+{
+    private DefaultObjectPool<Foo> _pool = null!;
+    private Foo[][] _stores = null!;
+    private ManualResetEventSlim _terminate = null!;
+    private Task[] _tasks = null!;
+
+    [Params(8, 16, 64, 256, 1024, 2048)]
+    public int Count { get; set; }
+
+    [Params(1, 2, 4, 8)]
+    public int ThreadCount { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _pool = new DefaultObjectPool<Foo>(new DefaultPooledObjectPolicy<Foo>(), Count);
+        for (int i = 0; i < Count; i++)
+        {
+            _pool.Return(new Foo());
+        }
+
+        _stores = new Foo[ThreadCount][];
+        for (int i = 0; i < ThreadCount; i++)
+        {
+            _stores[i] = new Foo[Count];
+        }
+
+        _terminate = new ManualResetEventSlim();
+
+        _tasks = new Task[ThreadCount - 1];
+        for (int i = 0; i < ThreadCount - 1; i++)
+        {
+            int threadIndex = i;
+            _tasks[i] = Task.Run(() =>
+            {
+                while (!_terminate.IsSet)
+                {
+                    BenchmarkLoop(_stores[threadIndex]);
+                }
+            });
+        }
+
+        // give ample time to the contention tasks to start running
+        Thread.Sleep(250);
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        _terminate.Set();
+        Task.WaitAll(_tasks);
+        _terminate.Dispose();
+    }
+
+    [Benchmark]
+    public void DrainRefillMulti()
+    {
+        BenchmarkLoop(_stores[ThreadCount - 1]);  // take the last slot
+    }
+
+    private void BenchmarkLoop(Foo[] store)
+    {
+        int num = (Count / ThreadCount) - 1;
+
+        for (int i = 0; i < num; i++)
+        {
+            store[i] = _pool.Get();
+            store[i].SimulateWork();
+        }
+
+        for (int i = 0; i < num; i++)
+        {
+            store[i].SimulateWork();
+            _pool.Return(store[i]);
+        }
+    }
+}

--- a/src/ObjectPool/perf/Microbenchmarks/DrainRefillSingleThreaded.cs
+++ b/src/ObjectPool/perf/Microbenchmarks/DrainRefillSingleThreaded.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Extensions.ObjectPool.Microbenchmarks;
+
+#pragma warning disable R9A038, S109
+
+[MemoryDiagnoser]
+public class DrainRefillSingleThreaded
+{
+    private DefaultObjectPool<Foo> _pool = null!;
+    private Foo[] _store = null!;
+
+    [Params(8, 16, 64, 256, 1024, 2048)]
+    public int Count { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _pool = new DefaultObjectPool<Foo>(new DefaultPooledObjectPolicy<Foo>(), Count);
+        for (int i = 0; i < Count; i++)
+        {
+            _pool.Return(new Foo());
+        }
+
+        _store = new Foo[Count];
+    }
+
+    [Benchmark]
+    public void DrainRefillSingle()
+    {
+        for (int i = 0; i < Count; i++)
+        {
+            _store[i] = _pool.Get();
+        }
+
+        for (int i = 0; i < Count; i++)
+        {
+            _pool.Return(_store[i]);
+        }
+    }
+}

--- a/src/ObjectPool/perf/Microbenchmarks/Foo.cs
+++ b/src/ObjectPool/perf/Microbenchmarks/Foo.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Extensions.ObjectPool.Microbenchmarks;
+
+#pragma warning disable S109, CPR138
+
+internal sealed class Foo
+{
+    public int LastRandom;
+
+    public void SimulateWork()
+    {
+        // burn some cycles to simulate work being done between get and return
+        for (int i = 0; i <= 32; i++)
+        {
+            LastRandom = Random.Shared.Next();
+        }
+    }
+}

--- a/src/ObjectPool/perf/Microbenchmarks/GetReturnMultiThreaded.cs
+++ b/src/ObjectPool/perf/Microbenchmarks/GetReturnMultiThreaded.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Extensions.ObjectPool.Microbenchmarks;
+
+[MemoryDiagnoser]
+public class GetReturnMultiThreaded
+{
+    private const int Count = 8;
+
+    private DefaultObjectPool<Foo> _pool = null!;
+    private ManualResetEventSlim _terminate = null!;
+    private Task[] _tasks = null!;
+
+    [Params(1, 2, 4, 8)]
+    public int ThreadCount { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _pool = new DefaultObjectPool<Foo>(new DefaultPooledObjectPolicy<Foo>(), Count);
+        for (int i = 0; i < Count; i++)
+        {
+            _pool.Return(new Foo());
+        }
+
+        _terminate = new ManualResetEventSlim();
+
+        _tasks = new Task[ThreadCount - 1];
+        for (int i = 0; i < ThreadCount - 1; i++)
+        {
+            int threadIndex = i;
+            _tasks[i] = Task.Run(() =>
+            {
+                while (!_terminate.IsSet)
+                {
+                    BenchmarkLoop();
+                }
+            });
+        }
+
+        // give ample time to the contention tasks to start running
+        Thread.Sleep(250);
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        _terminate.Set();
+        Task.WaitAll(_tasks);
+        _terminate.Dispose();
+    }
+
+    [Benchmark]
+    public void GetReturnMulti()
+    {
+        BenchmarkLoop();
+    }
+
+    private void BenchmarkLoop()
+    {
+        var o = _pool.Get();
+
+        o.SimulateWork();
+
+        _pool.Return(o);
+    }
+}

--- a/src/ObjectPool/perf/Microbenchmarks/GetReturnSingleThreaded.cs
+++ b/src/ObjectPool/perf/Microbenchmarks/GetReturnSingleThreaded.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Extensions.ObjectPool.Microbenchmarks;
+
+[MemoryDiagnoser]
+public class GetReturnSingleThreaded
+{
+    private const int Count = 8;
+    private DefaultObjectPool<Foo> _pool = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _pool = new DefaultObjectPool<Foo>(new DefaultPooledObjectPolicy<Foo>(), Count);
+        for (int i = 0; i < Count; i++)
+        {
+            _pool.Return(new Foo());
+        }
+    }
+
+    [Benchmark]
+    public void GetReturnSingle()
+    {
+        _pool.Return(_pool.Get());
+    }
+}

--- a/src/ObjectPool/perf/Microbenchmarks/Microsoft.Extensions.ObjectPool.Microbenchmark.csproj
+++ b/src/ObjectPool/perf/Microbenchmarks/Microsoft.Extensions.ObjectPool.Microbenchmark.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TieredCompilation>false</TieredCompilation>
+    <DefineConstants>$(DefineConstants);IS_BENCHMARKS</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.Extensions.ObjectPool" />
+    <Reference Include="BenchmarkDotNet" />
+    <Compile Include="$(SharedSourceRoot)BenchmarkRunner\*.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/ObjectPool/perf/Microbenchmarks/README.md
+++ b/src/ObjectPool/perf/Microbenchmarks/README.md
@@ -1,0 +1,124 @@
+There are two primary types of uses for pools:
+
+* Short Rental Times. This is when code needs objects for a short amount of time
+and then returns them to the pool. For example, a pool of StringBuilder instances
+typically behaves this way. Often, this means that the process has a whole will
+often just have one, or few, instances of the pooled objects in flight at any one
+time.
+
+* Long Rental Times. This is when code needs objects for a long amount of time. For
+example, a service that needs an object for the time it takes to process an
+incoming request. This means that a busy service could have thousands of instances
+of the pooled objects in flight at any one time. And if the service receives spiky
+traffic, then on a regular basis large number of objects will be added, then removed,
+then added again.
+
+We try to capture this duality of use by having two different kinds of benchmarks:
+
+* GetReturn just try to get and return a small number of items.
+
+* DrainRefill empty and fill the pool
+
+We have single-threaded versions of the benchmarks which runs full out. Then we have multi-threaded
+versions which start concurrent threads to test how well the pool implementation scales. In the
+threaded tests, we inject some busy loops in order to simulate work being done in the application,
+to give a more representative view of real world contention on the pool (without this,
+the benchmarks create an unnatural amount of contention on the pool which
+wouldn't happen in the real world)
+
+Note in the results below, the Default pool is the original implementation
+of the default object pool, while Scaled represents an updated version built
+around ConcurrentQueue. The checked in benchmark code no longer includes 
+test cases for the legacy pool
+
+```
+BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.819)
+Intel Core i7-9700K CPU 3.60GHz (Coffee Lake), 1 CPU, 8 logical and 8 physical cores
+.NET SDK=7.0.100
+  [Host] : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+
+Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15
+LaunchCount=2  WarmupCount=10
+
+|          Method |    Pool |     Mean |    Error |   StdDev | Allocated |
+|---------------- |-------- |---------:|---------:|---------:|----------:|
+| GetReturnSingle | Default | 14.85 ns | 2.542 ns | 0.139 ns |         - |
+| GetReturnSingle |  Scaled | 13.87 ns | 3.672 ns | 0.201 ns |         - |
+
+|         Method | ThreadCount |    Pool |       Mean |       Error |    StdDev | Allocated |
+|--------------- |------------ |-------- |-----------:|------------:|----------:|----------:|
+| GetReturnMulti |           1 | Default |   236.8 ns |    14.93 ns |   0.82 ns |         - |
+| GetReturnMulti |           1 |  Scaled |   230.5 ns |    31.11 ns |   1.70 ns |         - |
+| GetReturnMulti |           2 | Default |   311.6 ns |    83.49 ns |   4.58 ns |         - |
+| GetReturnMulti |           2 |  Scaled |   271.8 ns |    74.50 ns |   4.08 ns |         - |
+| GetReturnMulti |           4 | Default |   561.3 ns |   523.72 ns |  28.71 ns |         - |
+| GetReturnMulti |           4 |  Scaled |   692.5 ns |   167.71 ns |   9.19 ns |         - |
+| GetReturnMulti |           8 | Default |   857.2 ns | 1,892.29 ns | 103.72 ns |         - |
+| GetReturnMulti |           8 |  Scaled | 1,021.1 ns |   500.68 ns |  27.44 ns |         - |
+
+|            Method | Count |    Pool |            Mean |         Error |       StdDev | Allocated |
+|------------------ |------ |-------- |----------------:|--------------:|-------------:|----------:|
+| DrainRefillSingle |     8 | Default |        253.3 ns |       9.31 ns |      0.51 ns |         - |
+| DrainRefillSingle |     8 |  Scaled |        227.9 ns |       3.57 ns |      0.20 ns |         - |
+| DrainRefillSingle |    16 | Default |        901.8 ns |     109.49 ns |      6.00 ns |         - |
+| DrainRefillSingle |    16 |  Scaled |        455.1 ns |      45.04 ns |      2.47 ns |         - |
+| DrainRefillSingle |    64 | Default |     14,087.7 ns |     709.81 ns |     38.91 ns |         - |
+| DrainRefillSingle |    64 |  Scaled |      1,855.6 ns |     240.62 ns |     13.19 ns |         - |
+| DrainRefillSingle |   256 | Default |    212,392.1 ns |  15,057.03 ns |    825.33 ns |         - |
+| DrainRefillSingle |   256 |  Scaled |      7,490.5 ns |     278.66 ns |     15.27 ns |         - |
+| DrainRefillSingle |  1024 | Default |  3,350,706.9 ns | 324,499.03 ns | 17,786.89 ns |       5 B |
+| DrainRefillSingle |  1024 |  Scaled |     29,987.0 ns |   1,420.77 ns |     77.88 ns |         - |
+| DrainRefillSingle |  2048 | Default | 13,269,695.8 ns | 814,400.01 ns | 44,640.01 ns |      20 B |
+| DrainRefillSingle |  2048 |  Scaled |     66,323.3 ns |  11,331.39 ns |    621.11 ns |         - |
+
+|           Method | Count | ThreadCount |    Pool |              Mean |             Error |         StdDev | Allocated |
+|----------------- |------ |------------ |-------- |------------------:|------------------:|---------------:|----------:|
+| DrainRefillMulti |     8 |           1 | Default |      3,402.040 ns |       600.7019 ns |     32.9265 ns |         - |
+| DrainRefillMulti |     8 |           1 |  Scaled |      3,340.664 ns |       603.0542 ns |     33.0554 ns |         - |
+| DrainRefillMulti |     8 |           2 | Default |      2,342.273 ns |     1,601.9624 ns |     87.8090 ns |         - |
+| DrainRefillMulti |     8 |           2 |  Scaled |      2,243.490 ns |     1,048.4364 ns |     57.4683 ns |         - |
+| DrainRefillMulti |     8 |           4 | Default |      1,369.241 ns |       552.3366 ns |     30.2754 ns |         - |
+| DrainRefillMulti |     8 |           4 |  Scaled |      1,013.460 ns |     2,311.3719 ns |    126.6941 ns |         - |
+| DrainRefillMulti |     8 |           8 | Default |          2.490 ns |         0.0310 ns |      0.0017 ns |         - |
+| DrainRefillMulti |     8 |           8 |  Scaled |          2.490 ns |         0.0176 ns |      0.0010 ns |         - |
+| DrainRefillMulti |    16 |           1 | Default |      7,696.936 ns |     1,441.3538 ns |     79.0055 ns |         - |
+| DrainRefillMulti |    16 |           1 |  Scaled |      6,976.167 ns |       677.5599 ns |     37.1393 ns |         - |
+| DrainRefillMulti |    16 |           2 | Default |      4,672.361 ns |        89.7377 ns |      4.9188 ns |         - |
+| DrainRefillMulti |    16 |           2 |  Scaled |      4,462.518 ns |       784.9351 ns |     43.0249 ns |         - |
+| DrainRefillMulti |    16 |           4 | Default |      3,027.048 ns |       806.3016 ns |     44.1961 ns |         - |
+| DrainRefillMulti |    16 |           4 |  Scaled |      2,524.434 ns |     1,692.4096 ns |     92.7667 ns |         - |
+| DrainRefillMulti |    16 |           8 | Default |      2,359.546 ns |       139.8285 ns |      7.6645 ns |         - |
+| DrainRefillMulti |    16 |           8 |  Scaled |      1,318.973 ns |     2,819.4887 ns |    154.5457 ns |         - |
+| DrainRefillMulti |    64 |           1 | Default |     42,156.917 ns |     6,252.2089 ns |    342.7047 ns |         - |
+| DrainRefillMulti |    64 |           1 |  Scaled |     34,420.998 ns |     4,824.3074 ns |    264.4366 ns |         - |
+| DrainRefillMulti |    64 |           2 | Default |     20,528.296 ns |    10,638.3506 ns |    583.1239 ns |         - |
+| DrainRefillMulti |    64 |           2 |  Scaled |     19,258.943 ns |     1,403.3149 ns |     76.9204 ns |         - |
+| DrainRefillMulti |    64 |           4 | Default |     10,090.506 ns |     1,897.5224 ns |    104.0096 ns |         - |
+| DrainRefillMulti |    64 |           4 |  Scaled |     10,361.626 ns |     1,210.3394 ns |     66.3428 ns |         - |
+| DrainRefillMulti |    64 |           8 | Default |      6,266.454 ns |     1,319.7780 ns |     72.3415 ns |         - |
+| DrainRefillMulti |    64 |           8 |  Scaled |      5,802.875 ns |     2,609.1042 ns |    143.0138 ns |         - |
+| DrainRefillMulti |   256 |           1 | Default |    329,837.142 ns |    28,180.8139 ns |  1,544.6855 ns |         - |
+| DrainRefillMulti |   256 |           1 |  Scaled |    118,653.739 ns |     5,552.4422 ns |    304.3481 ns |         - |
+| DrainRefillMulti |   256 |           2 | Default |     76,942.582 ns |   156,667.0744 ns |  8,587.4510 ns |         - |
+| DrainRefillMulti |   256 |           2 |  Scaled |     76,145.129 ns |    27,993.7132 ns |  1,534.4299 ns |         - |
+| DrainRefillMulti |   256 |           4 | Default |     38,844.476 ns |     5,150.0739 ns |    282.2929 ns |         - |
+| DrainRefillMulti |   256 |           4 |  Scaled |     42,601.213 ns |    18,958.2889 ns |  1,039.1678 ns |         - |
+| DrainRefillMulti |   256 |           8 | Default |     21,718.325 ns |     1,174.3632 ns |     64.3708 ns |         - |
+| DrainRefillMulti |   256 |           8 |  Scaled |     24,667.206 ns |    15,298.1144 ns |    838.5413 ns |         - |
+| DrainRefillMulti |  1024 |           1 | Default |  3,931,928.906 ns |   502,418.7402 ns | 27,539.2665 ns |       5 B |
+| DrainRefillMulti |  1024 |           1 |  Scaled |    475,052.637 ns |    62,820.3506 ns |  3,443.3954 ns |         - |
+| DrainRefillMulti |  1024 |           2 | Default |    428,420.475 ns |   949,652.4645 ns | 52,053.6560 ns |         - |
+| DrainRefillMulti |  1024 |           2 |  Scaled |    312,404.215 ns |    31,360.8510 ns |  1,718.9941 ns |         - |
+| DrainRefillMulti |  1024 |           4 | Default |    153,662.158 ns |    25,638.8645 ns |  1,405.3527 ns |         - |
+| DrainRefillMulti |  1024 |           4 |  Scaled |    158,768.604 ns |    68,297.3126 ns |  3,743.6062 ns |         - |
+| DrainRefillMulti |  1024 |           8 | Default |     86,047.257 ns |       495.9489 ns |     27.1846 ns |         - |
+| DrainRefillMulti |  1024 |           8 |  Scaled |     88,594.971 ns |     8,521.3088 ns |    467.0817 ns |         - |
+| DrainRefillMulti |  2048 |           1 | Default | 14,744,884.896 ns |   582,454.6067 ns | 31,926.3024 ns |      10 B |
+| DrainRefillMulti |  2048 |           1 |  Scaled |    947,932.682 ns |    59,063.8970 ns |  3,237.4915 ns |       1 B |
+| DrainRefillMulti |  2048 |           2 | Default |  1,375,669.466 ns | 1,389,879.8763 ns | 76,184.0060 ns |       1 B |
+| DrainRefillMulti |  2048 |           2 |  Scaled |    614,905.078 ns |   207,382.6684 ns | 11,367.3438 ns |       1 B |
+| DrainRefillMulti |  2048 |           4 | Default |    738,090.462 ns | 1,812,923.2145 ns | 99,372.4388 ns |       1 B |
+| DrainRefillMulti |  2048 |           4 |  Scaled |    321,501.628 ns |    60,639.0375 ns |  3,323.8303 ns |         - |
+| DrainRefillMulti |  2048 |           8 | Default |    214,069.694 ns |   116,308.1865 ns |  6,375.2442 ns |         - |
+| DrainRefillMulti |  2048 |           8 |  Scaled |    175,667.798 ns |    15,600.4542 ns |    855.1135 ns |         - |
+```

--- a/src/ObjectPool/src/DefaultObjectPool.cs
+++ b/src/ObjectPool/src/DefaultObjectPool.cs
@@ -1,9 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
+using System.Collections.Concurrent;
 using System.Threading;
 
 namespace Microsoft.Extensions.ObjectPool;
@@ -15,13 +14,13 @@ namespace Microsoft.Extensions.ObjectPool;
 /// <remarks>This implementation keeps a cache of retained objects. This means that if objects are returned when the pool has already reached "maximumRetained" objects they will be available to be Garbage Collected.</remarks>
 public class DefaultObjectPool<T> : ObjectPool<T> where T : class
 {
-    private protected readonly ObjectWrapper[] _items;
-    private protected readonly IPooledObjectPolicy<T> _policy;
-    private protected readonly bool _isDefaultPolicy;
-    private protected T? _firstItem;
+    private readonly Func<T> _createFunc;
+    private readonly Func<T, bool> _returnFunc;
+    private readonly int _maxCapacity;
+    private int _numItems;
 
-    // This class was introduced in 2.1 to avoid the interface call where possible
-    private protected readonly PooledObjectPolicy<T>? _fastPolicy;
+    private protected readonly ConcurrentQueue<T> _items = new();
+    private protected T? _fastItem;
 
     /// <summary>
     /// Creates an instance of <see cref="DefaultObjectPool{T}"/>.
@@ -39,66 +38,62 @@ public class DefaultObjectPool<T> : ObjectPool<T> where T : class
     /// <param name="maximumRetained">The maximum number of objects to retain in the pool.</param>
     public DefaultObjectPool(IPooledObjectPolicy<T> policy, int maximumRetained)
     {
-        _policy = policy ?? throw new ArgumentNullException(nameof(policy));
-        _fastPolicy = policy as PooledObjectPolicy<T>;
-        _isDefaultPolicy = IsDefaultPolicy();
-
-        // -1 due to _firstItem
-        _items = new ObjectWrapper[maximumRetained - 1];
-
-        bool IsDefaultPolicy()
-        {
-            var type = policy.GetType();
-
-            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(DefaultPooledObjectPolicy<>);
-        }
+        // cache the target interface methods, to avoid interface lookup overhead
+        _createFunc = policy.Create;
+        _returnFunc = policy.Return;
+        _maxCapacity = maximumRetained - 1;  // -1 to account for _fastItem
     }
 
     /// <inheritdoc />
     public override T Get()
     {
-        var item = _firstItem;
-        if (item == null || Interlocked.CompareExchange(ref _firstItem, null, item) != item)
+        var item = _fastItem;
+        if (item == null || Interlocked.CompareExchange(ref _fastItem, null, item) != item)
         {
-            var items = _items;
-            for (var i = 0; i < items.Length; i++)
+            if (_items.TryDequeue(out item))
             {
-                item = items[i].Element;
-                if (item != null && Interlocked.CompareExchange(ref items[i].Element, null, item) == item)
-                {
-                    return item;
-                }
+                _ = Interlocked.Decrement(ref _numItems);
+                return item;
             }
 
-            item = Create();
+            // no object available, so go get a brand new one
+            return _createFunc();
         }
 
         return item;
     }
 
-    // Non-inline to improve its code quality as uncommon path
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private T Create() => _fastPolicy?.Create() ?? _policy.Create();
-
     /// <inheritdoc />
     public override void Return(T obj)
     {
-        if (_isDefaultPolicy || (_fastPolicy?.Return(obj) ?? _policy.Return(obj)))
-        {
-            if (_firstItem != null || Interlocked.CompareExchange(ref _firstItem, obj, null) != null)
-            {
-                var items = _items;
-                for (var i = 0; i < items.Length && Interlocked.CompareExchange(ref items[i].Element, obj, null) != null; ++i)
-                {
-                }
-            }
-        }
+        _ = ReturnCore(obj);
     }
 
-    // PERF: the struct wrapper avoids array-covariance-checks from the runtime when assigning to elements of the array.
-    [DebuggerDisplay("{Element}")]
-    private protected struct ObjectWrapper
+    /// <summary>
+    /// Returns an object to the pool.
+    /// </summary>
+    /// <returns>true if the object was returned to the pool</returns>
+    private protected bool ReturnCore(T obj)
     {
-        public T? Element;
+        if (!_returnFunc(obj))
+        {
+            // policy says to drop this object
+            return false;
+        }
+
+        if (_fastItem != null || Interlocked.CompareExchange(ref _fastItem, obj, null) != null)
+        {
+            if (Interlocked.Increment(ref _numItems) <= _maxCapacity)
+            {
+                _items.Enqueue(obj);
+                return true;
+            }
+
+            // no room, clean up the count and drop the object on the floor
+            _ = Interlocked.Decrement(ref _numItems);
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/ObjectPool/src/DefaultObjectPool.cs
+++ b/src/ObjectPool/src/DefaultObjectPool.cs
@@ -52,7 +52,7 @@ public class DefaultObjectPool<T> : ObjectPool<T> where T : class
         {
             if (_items.TryDequeue(out item))
             {
-                _ = Interlocked.Decrement(ref _numItems);
+                Interlocked.Decrement(ref _numItems);
                 return item;
             }
 
@@ -66,7 +66,7 @@ public class DefaultObjectPool<T> : ObjectPool<T> where T : class
     /// <inheritdoc />
     public override void Return(T obj)
     {
-        _ = ReturnCore(obj);
+        ReturnCore(obj);
     }
 
     /// <summary>
@@ -90,7 +90,7 @@ public class DefaultObjectPool<T> : ObjectPool<T> where T : class
             }
 
             // no room, clean up the count and drop the object on the floor
-            _ = Interlocked.Decrement(ref _numItems);
+            Interlocked.Decrement(ref _numItems);
             return false;
         }
 

--- a/src/ObjectPool/src/DisposableObjectPool.cs
+++ b/src/ObjectPool/src/DisposableObjectPool.cs
@@ -44,40 +44,16 @@ internal sealed class DisposableObjectPool<T> : DefaultObjectPool<T>, IDisposabl
         }
     }
 
-    private bool ReturnCore(T obj)
-    {
-        bool returnedToPool = false;
-
-        if (_isDefaultPolicy || (_fastPolicy?.Return(obj) ?? _policy.Return(obj)))
-        {
-            if (_firstItem == null && Interlocked.CompareExchange(ref _firstItem, obj, null) == null)
-            {
-                returnedToPool = true;
-            }
-            else
-            {
-                var items = _items;
-                for (var i = 0; i < items.Length && !(returnedToPool = Interlocked.CompareExchange(ref items[i].Element, obj, null) == null); i++)
-                {
-                }
-            }
-        }
-
-        return returnedToPool;
-    }
-
     public void Dispose()
     {
         _isDisposed = true;
 
-        DisposeItem(_firstItem);
-        _firstItem = null;
+        DisposeItem(_fastItem);
+        _fastItem = null;
 
-        ObjectWrapper[] items = _items;
-        for (var i = 0; i < items.Length; i++)
+        while (_items.TryDequeue(out var item))
         {
-            DisposeItem(items[i].Element);
-            items[i].Element = null;
+            DisposeItem(item);
         }
     }
 


### PR DESCRIPTION
# Reimplement the default object pool for improved performance

Rewrite the default pool so that it scales better.

## Description

The existing object pool performs very poorly at scale, this new one is considerably better. Attached is a benchmark, here are the results:

```
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22621
Intel Core i7-9700K CPU 3.60GHz (Coffee Lake), 1 CPU, 8 logical and 8 physical cores
.NET SDK=7.0.100
  [Host] : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT

Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15
LaunchCount=2  WarmupCount=10

|              Method | MaxRetained | OverflowCount |             Mean |             Error |         StdDev |   Gen 0 |  Gen 1 | Allocated |
|-------------------- |------------ |-------------- |-----------------:|------------------:|---------------:|--------:|-------:|----------:|
|         DefaultPool |           2 |             0 |         44.68 ns |          1.764 ns |       0.097 ns |  0.0114 |      - |      72 B |
|          ScaledPool |           2 |             0 |         68.11 ns |         18.306 ns |       1.003 ns |  0.0114 |      - |      72 B |
| DefaultPoolThreaded |           2 |             0 |      1,168.21 ns |        352.497 ns |      19.322 ns |  0.0877 |      - |     552 B |
|  ScaledPoolThreaded |           2 |             0 |      1,264.33 ns |         97.744 ns |       5.358 ns |  0.0877 |      - |     552 B |
|         DefaultPool |           2 |             8 |        248.33 ns |         10.358 ns |       0.568 ns |  0.0520 |      - |     328 B |
|          ScaledPool |           2 |             8 |        320.39 ns |         26.485 ns |       1.452 ns |  0.0520 |      - |     328 B |
| DefaultPoolThreaded |           2 |             8 |      1,542.80 ns |         46.447 ns |       2.546 ns |  0.1640 |      - |   1,026 B |
|  ScaledPoolThreaded |           2 |             8 |      1,975.74 ns |        462.439 ns |      25.348 ns |  0.1602 |      - |   1,017 B |
|         DefaultPool |           2 |            16 |        483.25 ns |        151.602 ns |       8.310 ns |  0.0925 |      - |     584 B |
|          ScaledPool |           2 |            16 |        531.66 ns |         43.929 ns |       2.408 ns |  0.0925 |      - |     584 B |
| DefaultPoolThreaded |           2 |            16 |      2,214.69 ns |        671.443 ns |      36.804 ns |  0.2251 |      - |   1,421 B |
|  ScaledPoolThreaded |           2 |            16 |      2,858.96 ns |        468.512 ns |      25.681 ns |  0.2327 |      - |   1,460 B |
|         DefaultPool |           8 |             0 |        274.24 ns |        130.700 ns |       7.164 ns |  0.0191 |      - |     120 B |
|          ScaledPool |           8 |             0 |        247.56 ns |         34.002 ns |       1.864 ns |  0.0191 |      - |     120 B |
| DefaultPoolThreaded |           8 |             0 |      1,523.70 ns |         46.087 ns |       2.526 ns |  0.1030 |      - |     649 B |
|  ScaledPoolThreaded |           8 |             0 |      1,783.37 ns |        142.507 ns |       7.811 ns |  0.1049 |      - |     662 B |
|         DefaultPool |           8 |             8 |        748.95 ns |         54.202 ns |       2.971 ns |  0.0591 |      - |     376 B |
|          ScaledPool |           8 |             8 |        507.71 ns |         45.306 ns |       2.483 ns |  0.0591 |      - |     376 B |
| DefaultPoolThreaded |           8 |             8 |      2,802.51 ns |        781.559 ns |      42.840 ns |  0.1640 |      - |   1,030 B |
|  ScaledPoolThreaded |           8 |             8 |      3,191.83 ns |        269.748 ns |      14.786 ns |  0.1717 |      - |   1,089 B |
|         DefaultPool |           8 |            16 |      1,211.42 ns |         64.968 ns |       3.561 ns |  0.0992 |      - |     632 B |
|          ScaledPool |           8 |            16 |        794.87 ns |        188.223 ns |      10.317 ns |  0.1001 |      - |     632 B |
| DefaultPoolThreaded |           8 |            16 |      4,380.27 ns |        616.885 ns |      33.814 ns |  0.2365 |      - |   1,494 B |
|  ScaledPoolThreaded |           8 |            16 |      4,191.86 ns |        807.913 ns |      44.284 ns |  0.2441 |      - |   1,561 B |
|         DefaultPool |          16 |             0 |        940.04 ns |         84.770 ns |       4.647 ns |  0.0286 |      - |     184 B |
|          ScaledPool |          16 |             0 |        491.76 ns |        104.593 ns |       5.733 ns |  0.0286 |      - |     184 B |
| DefaultPoolThreaded |          16 |             0 |      2,936.22 ns |        219.266 ns |      12.019 ns |  0.1259 |      - |     804 B |
|  ScaledPoolThreaded |          16 |             0 |      3,318.14 ns |        300.985 ns |      16.498 ns |  0.1411 |      - |     885 B |
|         DefaultPool |          16 |             8 |      1,797.72 ns |        105.442 ns |       5.780 ns |  0.0687 |      - |     440 B |
|          ScaledPool |          16 |             8 |        737.92 ns |         52.615 ns |       2.884 ns |  0.0696 |      - |     440 B |
| DefaultPoolThreaded |          16 |             8 |      5,991.02 ns |     10,513.578 ns |     576.285 ns |  0.2060 |      - |   1,282 B |
|  ScaledPoolThreaded |          16 |             8 |      4,697.17 ns |      1,173.322 ns |      64.314 ns |  0.2136 |      - |   1,355 B |
|         DefaultPool |          16 |            16 |      2,712.82 ns |         72.291 ns |       3.963 ns |  0.1106 |      - |     696 B |
|          ScaledPool |          16 |            16 |        967.34 ns |         33.708 ns |       1.848 ns |  0.1106 |      - |     696 B |
| DefaultPoolThreaded |          16 |            16 |      6,359.90 ns |      2,140.569 ns |     117.332 ns |  0.2441 |      - |   1,529 B |
|  ScaledPoolThreaded |          16 |            16 |      5,489.48 ns |        996.884 ns |      54.643 ns |  0.2975 |      - |   1,854 B |
|         DefaultPool |          32 |             0 |      3,688.01 ns |        340.371 ns |      18.657 ns |  0.0496 |      - |     312 B |
|          ScaledPool |          32 |             0 |        959.45 ns |         96.638 ns |       5.297 ns |  0.0496 |      - |     312 B |
| DefaultPoolThreaded |          32 |             0 |      7,078.16 ns |      1,508.652 ns |      82.694 ns |  0.1602 |      - |   1,042 B |
|  ScaledPoolThreaded |          32 |             0 |      6,605.99 ns |        736.397 ns |      40.364 ns |  0.2289 |      - |   1,457 B |
|         DefaultPool |          32 |             8 |      5,329.30 ns |        530.654 ns |      29.087 ns |  0.0839 |      - |     568 B |
|          ScaledPool |          32 |             8 |      1,219.61 ns |        343.039 ns |      18.803 ns |  0.0896 |      - |     568 B |
| DefaultPoolThreaded |          32 |             8 |     15,415.34 ns |      3,619.665 ns |     198.406 ns |  0.2136 |      - |   1,442 B |
|  ScaledPoolThreaded |          32 |             8 |      9,148.38 ns |      2,839.667 ns |     155.652 ns |  0.2899 |      - |   1,828 B |
|         DefaultPool |          32 |            16 |      7,009.57 ns |        730.620 ns |      40.048 ns |  0.1297 |      - |     824 B |
|          ScaledPool |          32 |            16 |      1,460.06 ns |        407.207 ns |      22.320 ns |  0.1297 |      - |     824 B |
| DefaultPoolThreaded |          32 |            16 |     20,256.24 ns |        235.299 ns |      12.898 ns |  0.3052 |      - |   1,934 B |
|  ScaledPoolThreaded |          32 |            16 |     11,299.54 ns |        132.306 ns |       7.252 ns |  0.3662 |      - |   2,289 B |
|         DefaultPool |         256 |             0 |    211,333.36 ns |      3,244.642 ns |     177.850 ns |  0.2441 |      - |   2,104 B |
|          ScaledPool |         256 |             0 |      7,690.17 ns |      1,184.234 ns |      64.912 ns |  0.3204 |      - |   2,104 B |
| DefaultPoolThreaded |         256 |             0 |    313,654.62 ns |      9,027.318 ns |     494.818 ns |  0.4883 |      - |   4,691 B |
|  ScaledPoolThreaded |         256 |             0 |     54,328.24 ns |      2,422.108 ns |     132.764 ns |  1.4038 | 0.0610 |   8,643 B |
|         DefaultPool |         256 |             8 |    228,629.05 ns |     23,122.629 ns |   1,267.429 ns |  0.2441 |      - |   2,360 B |
|          ScaledPool |         256 |             8 |      8,030.68 ns |      1,678.930 ns |      92.028 ns |  0.3662 |      - |   2,360 B |
| DefaultPoolThreaded |         256 |             8 |    328,962.43 ns |     54,308.771 ns |   2,976.847 ns |  0.4883 |      - |   5,000 B |
|  ScaledPoolThreaded |         256 |             8 |     56,798.18 ns |     10,027.466 ns |     549.639 ns |  1.4648 | 0.0610 |   9,089 B |
|         DefaultPool |         256 |            16 |    238,517.85 ns |     15,151.359 ns |     830.497 ns |  0.2441 |      - |   2,616 B |
|          ScaledPool |         256 |            16 |      8,239.36 ns |        592.850 ns |      32.496 ns |  0.4120 |      - |   2,616 B |
| DefaultPoolThreaded |         256 |            16 |    343,755.09 ns |     33,664.928 ns |   1,845.288 ns |  0.4883 |      - |   5,345 B |
|  ScaledPoolThreaded |         256 |            16 |     59,618.83 ns |      3,281.243 ns |     179.856 ns |  1.5869 | 0.0610 |   9,427 B |
|         DefaultPool |        1024 |             0 |  3,398,009.77 ns |    238,064.426 ns |  13,049.114 ns |       - |      - |   8,250 B |
|          ScaledPool |        1024 |             0 |     31,462.74 ns |      6,005.615 ns |     329.188 ns |  1.2817 |      - |   8,248 B |
| DefaultPoolThreaded |        1024 |             0 |  8,614,992.19 ns |  8,226,028.008 ns | 450,896.353 ns |       - |      - |  38,970 B |
|  ScaledPoolThreaded |        1024 |             0 |    199,449.64 ns |    162,597.330 ns |   8,912.508 ns |  6.5918 | 0.9766 |  35,416 B |
|         DefaultPool |        1024 |             8 |  3,382,532.81 ns |    274,655.386 ns |  15,054.788 ns |       - |      - |   8,507 B |
|          ScaledPool |        1024 |             8 |     31,712.71 ns |      6,495.328 ns |     356.031 ns |  1.3428 |      - |   8,504 B |
| DefaultPoolThreaded |        1024 |             8 |  9,150,567.71 ns |  2,476,182.558 ns | 135,727.922 ns |       - |      - |  39,117 B |
|  ScaledPoolThreaded |        1024 |             8 |    221,463.66 ns |     48,602.706 ns |   2,664.078 ns |  6.8359 | 0.9766 |  37,705 B |
|         DefaultPool |        1024 |            16 |  3,479,460.29 ns |    249,832.734 ns |  13,694.175 ns |       - |      - |   8,763 B |
|          ScaledPool |        1024 |            16 |     31,992.68 ns |     11,835.673 ns |     648.753 ns |  1.3428 |      - |   8,760 B |
| DefaultPoolThreaded |        1024 |            16 |  9,574,946.35 ns |  2,604,403.907 ns | 142,756.166 ns |       - |      - |  39,992 B |
|  ScaledPoolThreaded |        1024 |            16 |    206,739.87 ns |     38,262.191 ns |   2,097.280 ns |  6.8359 | 0.9766 |  38,010 B |
|         DefaultPool |        2048 |             0 | 13,320,174.48 ns |  1,762,278.720 ns |  96,596.443 ns |       - |      - |  16,450 B |
|          ScaledPool |        2048 |             0 |     62,331.40 ns |     12,716.250 ns |     697.021 ns |  2.5635 | 0.1221 |  16,440 B |
| DefaultPoolThreaded |        2048 |             0 | 30,269,091.67 ns |    693,908.844 ns |  38,035.485 ns |       - |      - |  80,080 B |
|  ScaledPoolThreaded |        2048 |             0 |    418,387.11 ns |    394,976.144 ns |  21,649.975 ns | 12.2070 | 2.9297 |  72,913 B |
|         DefaultPool |        2048 |             8 | 13,402,975.00 ns |  3,371,275.902 ns | 184,791.008 ns |       - |      - |  16,709 B |
|          ScaledPool |        2048 |             8 |     62,205.85 ns |      3,719.147 ns |     203.859 ns |  2.5635 | 0.1221 |  16,697 B |
| DefaultPoolThreaded |        2048 |             8 | 31,661,502.08 ns |  7,142,611.831 ns | 391,510.656 ns |       - |      - |  80,196 B |
|  ScaledPoolThreaded |        2048 |             8 |    398,977.90 ns |    253,608.316 ns |  13,901.128 ns | 10.2539 | 2.4414 |  60,371 B |
|         DefaultPool |        2048 |            16 | 13,505,204.17 ns |  1,375,577.311 ns |  75,400.034 ns |       - |      - |  16,965 B |
|          ScaledPool |        2048 |            16 |     62,527.04 ns |      4,092.726 ns |     224.336 ns |  2.6855 | 0.1221 |  16,953 B |
| DefaultPoolThreaded |        2048 |            16 | 30,531,625.00 ns | 12,412,926.068 ns | 680,394.363 ns |       - |      - |  80,959 B |
|  ScaledPoolThreaded |        2048 |            16 |    403,439.65 ns |    131,650.477 ns |   7,216.207 ns | 11.2305 | 2.4414 |  66,841 B |
[Pools.zip](https://github.com/dotnet/aspnetcore/files/10078581/Pools.zip)
```