### PR TITLE
Adding id to manifest.json files

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/manifest.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "ComponentsWebAssembly-CSharp",
   "short_name": "ComponentsWebAssembly-CSharp",
+  "id": "./",
   "start_url": "./",
   "display": "standalone",
   "background_color": "#ffffff",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/Client/wwwroot/manifest.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/Client/wwwroot/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "EmptyComponentsWebAssembly-CSharp",
   "short_name": "EmptyComponentsWebAssembly-CSharp",
+  "id": "./",
   "start_url": "./",
   "display": "standalone",
   "background_color": "#ffffff",


### PR DESCRIPTION
# Adding id to manifest.json files

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

We needed to add a new property `id` to the `manifest.json`, this is, for now, optional, but in the future might be required.

Following @sayedihashimi advice to use the same `start_url` property.

https://developer.mozilla.org/en-US/docs/Web/Manifest/id

Fixes #45239
