### PR TITLE
gRPC JSON transcoding: Support deserializing non-nested enum from string

### DIFF
--- a/src/Grpc/JsonTranscoding/perf/Microsoft.AspNetCore.Grpc.Microbenchmarks/Json/JsonReading.cs
+++ b/src/Grpc/JsonTranscoding/perf/Microsoft.AspNetCore.Grpc.Microbenchmarks/Json/JsonReading.cs
@@ -7,6 +7,7 @@ using Google.Protobuf;
 using Google.Protobuf.Reflection;
 using Greet;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding;
+using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;
 
 namespace Microsoft.AspNetCore.Grpc.Microbenchmarks.Json;
@@ -21,7 +22,7 @@ public class JsonReading
     public void GlobalSetup()
     {
         _requestJson = (new HelloRequest() { Name = "Hello world" }).ToString();
-        _serializerOptions = JsonConverterHelper.CreateSerializerOptions(new JsonContext(new GrpcJsonSettings { WriteIndented = false }, TypeRegistry.Empty));
+        _serializerOptions = JsonConverterHelper.CreateSerializerOptions(new JsonContext(new GrpcJsonSettings { WriteIndented = false }, TypeRegistry.Empty, new DescriptorRegistry()));
         _jsonFormatter = new JsonParser(new JsonParser.Settings(recursionLimit: 100));
     }
 

--- a/src/Grpc/JsonTranscoding/perf/Microsoft.AspNetCore.Grpc.Microbenchmarks/Json/JsonWriting.cs
+++ b/src/Grpc/JsonTranscoding/perf/Microsoft.AspNetCore.Grpc.Microbenchmarks/Json/JsonWriting.cs
@@ -7,6 +7,7 @@ using Google.Protobuf;
 using Google.Protobuf.Reflection;
 using Greet;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding;
+using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;
 
 namespace Microsoft.AspNetCore.Grpc.Microbenchmarks.Json;
@@ -22,7 +23,7 @@ public class JsonWriting
     {
         _request = new HelloRequest() { Name = "Hello world" };
         _serializerOptions = JsonConverterHelper.CreateSerializerOptions(
-            new JsonContext(new GrpcJsonSettings { WriteIndented = false }, TypeRegistry.Empty));
+            new JsonContext(new GrpcJsonSettings { WriteIndented = false }, TypeRegistry.Empty, new DescriptorRegistry()));
         _jsonFormatter = new JsonFormatter(new JsonFormatter.Settings(formatDefaultValues: false));
     }
 

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonTranscodingOptions.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonTranscodingOptions.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using Google.Protobuf.Reflection;
+using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;
 
 namespace Microsoft.AspNetCore.Grpc.JsonTranscoding;
@@ -18,15 +19,16 @@ public sealed class GrpcJsonTranscodingOptions
     public GrpcJsonTranscodingOptions()
     {
         _unaryOptions = new Lazy<JsonSerializerOptions>(
-            () => JsonConverterHelper.CreateSerializerOptions(new JsonContext(JsonSettings, TypeRegistry)),
+            () => JsonConverterHelper.CreateSerializerOptions(new JsonContext(JsonSettings, TypeRegistry, ServiceDescriptorRegistry)),
             LazyThreadSafetyMode.ExecutionAndPublication);
         _serverStreamingOptions = new Lazy<JsonSerializerOptions>(
-            () => JsonConverterHelper.CreateSerializerOptions(new JsonContext(JsonSettings, TypeRegistry), isStreamingOptions: true),
+            () => JsonConverterHelper.CreateSerializerOptions(new JsonContext(JsonSettings, TypeRegistry, ServiceDescriptorRegistry), isStreamingOptions: true),
             LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
     internal JsonSerializerOptions UnarySerializerOptions => _unaryOptions.Value;
     internal JsonSerializerOptions ServerStreamingSerializerOptions => _serverStreamingOptions.Value;
+    internal DescriptorRegistry ServiceDescriptorRegistry { get; set; } = default!;
 
     /// <summary>
     /// Gets or sets the <see cref="Google.Protobuf.Reflection.TypeRegistry"/> used to lookup types from type names.

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonTranscodingOptions.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonTranscodingOptions.cs
@@ -19,16 +19,16 @@ public sealed class GrpcJsonTranscodingOptions
     public GrpcJsonTranscodingOptions()
     {
         _unaryOptions = new Lazy<JsonSerializerOptions>(
-            () => JsonConverterHelper.CreateSerializerOptions(new JsonContext(JsonSettings, TypeRegistry, ServiceDescriptorRegistry)),
+            () => JsonConverterHelper.CreateSerializerOptions(new JsonContext(JsonSettings, TypeRegistry, DescriptorRegistry)),
             LazyThreadSafetyMode.ExecutionAndPublication);
         _serverStreamingOptions = new Lazy<JsonSerializerOptions>(
-            () => JsonConverterHelper.CreateSerializerOptions(new JsonContext(JsonSettings, TypeRegistry, ServiceDescriptorRegistry), isStreamingOptions: true),
+            () => JsonConverterHelper.CreateSerializerOptions(new JsonContext(JsonSettings, TypeRegistry, DescriptorRegistry), isStreamingOptions: true),
             LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
     internal JsonSerializerOptions UnarySerializerOptions => _unaryOptions.Value;
     internal JsonSerializerOptions ServerStreamingSerializerOptions => _serverStreamingOptions.Value;
-    internal DescriptorRegistry ServiceDescriptorRegistry { get; set; } = default!;
+    internal DescriptorRegistry DescriptorRegistry { get; set; } = default!;
 
     /// <summary>
     /// Gets or sets the <see cref="Google.Protobuf.Reflection.TypeRegistry"/> used to lookup types from type names.

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonTranscodingOptions.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonTranscodingOptions.cs
@@ -28,6 +28,8 @@ public sealed class GrpcJsonTranscodingOptions
 
     internal JsonSerializerOptions UnarySerializerOptions => _unaryOptions.Value;
     internal JsonSerializerOptions ServerStreamingSerializerOptions => _serverStreamingOptions.Value;
+
+    // Registry is set by DI during startup.
     internal DescriptorRegistry DescriptorRegistry { get; set; } = default!;
 
     /// <summary>

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonTranscodingServiceExtensions.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonTranscodingServiceExtensions.cs
@@ -53,7 +53,7 @@ public static class GrpcJsonTranscodingServiceExtensions
         return builder.AddJsonTranscoding();
     }
 
-    internal sealed class GrpcJsonTranscodingOptionsSetup : IConfigureOptions<GrpcJsonTranscodingOptions>
+    private sealed class GrpcJsonTranscodingOptionsSetup : IConfigureOptions<GrpcJsonTranscodingOptions>
     {
         private readonly DescriptorRegistry _descriptorRegistry;
 

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonTranscodingServiceExtensions.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonTranscodingServiceExtensions.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Google.Api;
-using System.Xml.Linq;
 using Grpc.AspNetCore.Server;
 using Grpc.AspNetCore.Server.Model;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding;
@@ -54,7 +52,7 @@ public static class GrpcJsonTranscodingServiceExtensions
         {
             return new ConfigureOptions<GrpcJsonTranscodingOptions>(options =>
             {
-                options.ServiceDescriptorRegistry = services.GetRequiredService<DescriptorRegistry>();
+                options.DescriptorRegistry = services.GetRequiredService<DescriptorRegistry>();
             });
         });
 

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonTranscodingServiceExtensions.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonTranscodingServiceExtensions.cs
@@ -1,11 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Google.Api;
+using System.Xml.Linq;
 using Grpc.AspNetCore.Server;
 using Grpc.AspNetCore.Server.Model;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding;
+using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Binding;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -27,6 +31,7 @@ public static class GrpcJsonTranscodingServiceExtensions
         }
 
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IServiceMethodProvider<>), typeof(JsonTranscodingServiceMethodProvider<>)));
+        builder.Services.AddSingleton<DescriptorRegistry>();
 
         return builder;
     }
@@ -45,6 +50,14 @@ public static class GrpcJsonTranscodingServiceExtensions
         }
 
         builder.Services.Configure(configureOptions);
+        builder.Services.AddTransient<IConfigureOptions<GrpcJsonTranscodingOptions>>(services =>
+        {
+            return new ConfigureOptions<GrpcJsonTranscodingOptions>(options =>
+            {
+                options.ServiceDescriptorRegistry = services.GetRequiredService<DescriptorRegistry>();
+            });
+        });
+
         return builder.AddJsonTranscoding();
     }
 }

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Binding/JsonTranscodingProviderServiceBinder.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Binding/JsonTranscodingProviderServiceBinder.cs
@@ -34,7 +34,7 @@ internal sealed partial class JsonTranscodingProviderServiceBinder<TService> : S
     private readonly GrpcServiceOptions _globalOptions;
     private readonly GrpcServiceOptions<TService> _serviceOptions;
     private readonly IGrpcServiceActivator<TService> _serviceActivator;
-    private readonly GrpcJsonTranscodingOptions _JsonTranscodingOptions;
+    private readonly GrpcJsonTranscodingOptions _jsonTranscodingOptions;
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger _logger;
 
@@ -46,7 +46,7 @@ internal sealed partial class JsonTranscodingProviderServiceBinder<TService> : S
         GrpcServiceOptions<TService> serviceOptions,
         ILoggerFactory loggerFactory,
         IGrpcServiceActivator<TService> serviceActivator,
-        GrpcJsonTranscodingOptions JsonTranscodingOptions)
+        GrpcJsonTranscodingOptions jsonTranscodingOptions)
     {
         _context = context;
         _invokerResolver = invokerResolver;
@@ -54,7 +54,7 @@ internal sealed partial class JsonTranscodingProviderServiceBinder<TService> : S
         _globalOptions = globalOptions;
         _serviceOptions = serviceOptions;
         _serviceActivator = serviceActivator;
-        _JsonTranscodingOptions = JsonTranscodingOptions;
+        _jsonTranscodingOptions = jsonTranscodingOptions;
         _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<JsonTranscodingProviderServiceBinder<TService>>();
     }
@@ -168,7 +168,7 @@ internal sealed partial class JsonTranscodingProviderServiceBinder<TService> : S
             methodInvoker,
             _loggerFactory,
             descriptorInfo,
-            _JsonTranscodingOptions.UnarySerializerOptions);
+            _jsonTranscodingOptions.UnarySerializerOptions);
 
         return (callHandler.HandleCallAsync, metadata);
     }
@@ -195,7 +195,7 @@ internal sealed partial class JsonTranscodingProviderServiceBinder<TService> : S
             methodInvoker,
             _loggerFactory,
             descriptorInfo,
-            _JsonTranscodingOptions.ServerStreamingSerializerOptions);
+            _jsonTranscodingOptions.ServerStreamingSerializerOptions);
 
         return (callHandler.HandleCallAsync, metadata);
     }

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/DescriptorRegistry.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/DescriptorRegistry.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Google.Protobuf.Reflection;
+
+namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
+
+internal sealed class DescriptorRegistry
+{
+    private readonly HashSet<FileDescriptor> _fileDescriptors = new HashSet<FileDescriptor>();
+    private readonly HashSet<EnumDescriptor> _enumDescriptors = new HashSet<EnumDescriptor>();
+
+    public void RegisterFileDescriptor(FileDescriptor fileDescriptor)
+    {
+        AddFileDescriptorsRecursive(fileDescriptor);
+    }
+
+    private void AddFileDescriptorsRecursive(FileDescriptor fileDescriptor)
+    {
+        var added = _fileDescriptors.Add(fileDescriptor);
+
+        // If a descriptor is already added then all its types and dependencies must have already be present.
+        // This guards against the possibility of cyclical dependencies.
+        if (!added)
+        {
+            return;
+        }
+
+        foreach (var descriptor in fileDescriptor.EnumTypes)
+        {
+            _enumDescriptors.Add(descriptor);
+        }
+
+        foreach (var messageDescriptor in fileDescriptor.MessageTypes)
+        {
+            AddNestedEnumDescriptorsRecursive(messageDescriptor);
+        }
+
+        foreach (var dependencyFile in fileDescriptor.Dependencies)
+        {
+            AddFileDescriptorsRecursive(dependencyFile);
+        }
+    }
+
+    private void AddNestedEnumDescriptorsRecursive(MessageDescriptor messageDescriptor)
+    {
+        foreach (var enumDescriptor in messageDescriptor.EnumTypes)
+        {
+            _enumDescriptors.Add(enumDescriptor);
+        }
+
+        foreach (var nestedMessageDescriptor in messageDescriptor.NestedTypes)
+        {
+            AddNestedEnumDescriptorsRecursive(nestedMessageDescriptor);
+        }
+    }
+
+    public IEnumerable<EnumDescriptor> GetEnumDescriptors()
+    {
+        return _enumDescriptors;
+    }
+}

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/EnumConverter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/EnumConverter.cs
@@ -43,15 +43,7 @@ internal sealed class EnumConverter<TEnum> : SettingsConverterBase<TEnum> where 
         // to get the enum descriptor from.
         //
         // Search for enum descriptor using the enum type in a registry of descriptors.
-        foreach (var enumDescriptor in Context.DescriptorRegistry.GetEnumDescriptors())
-        {
-            if (enumDescriptor.ClrType == typeToConvert)
-            {
-                return enumDescriptor;
-            }
-        }
-
-        return null;
+        return Context.DescriptorRegistry.FindEnumDescriptorByType(typeToConvert);
     }
 
     public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/EnumConverter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/EnumConverter.cs
@@ -37,22 +37,32 @@ internal sealed class EnumConverter<TEnum> : SettingsConverterBase<TEnum> where 
         }
     }
 
-    private static EnumDescriptor? ResolveEnumDescriptor(Type typeToConvert)
+    private EnumDescriptor? ResolveEnumDescriptor(Type typeToConvert)
     {
-        var containingType = typeToConvert?.DeclaringType?.DeclaringType;
+        // If enum is declared as a nested type then go to its parent type and find descriptor from it.
+        //var containingType = typeToConvert.DeclaringType?.DeclaringType;
+        //if (containingType != null)
+        //{
+        //    var messageDescriptor = JsonConverterHelper.GetMessageDescriptor(containingType);
+        //    if (messageDescriptor != null)
+        //    {
+        //        for (var i = 0; i < messageDescriptor.EnumTypes.Count; i++)
+        //        {
+        //            if (messageDescriptor.EnumTypes[i].ClrType == typeToConvert)
+        //            {
+        //                return messageDescriptor.EnumTypes[i];
+        //            }
+        //        }
+        //    }
+        //}
 
-        if (containingType != null)
+        // Enum is not nested. There isn't a way to link the enum to a descriptor using reflection.
+        // Search through registered service descriptors.
+        foreach (var enumDescriptor in Context.ServiceDescriptorRegistry.GetEnumDescriptors())
         {
-            var messageDescriptor = JsonConverterHelper.GetMessageDescriptor(containingType);
-            if (messageDescriptor != null)
+            if (enumDescriptor.ClrType == typeToConvert)
             {
-                for (var i = 0; i < messageDescriptor.EnumTypes.Count; i++)
-                {
-                    if (messageDescriptor.EnumTypes[i].ClrType == typeToConvert)
-                    {
-                        return messageDescriptor.EnumTypes[i];
-                    }
-                }
+                return enumDescriptor;
             }
         }
 

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/EnumConverter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/EnumConverter.cs
@@ -39,26 +39,11 @@ internal sealed class EnumConverter<TEnum> : SettingsConverterBase<TEnum> where 
 
     private EnumDescriptor? ResolveEnumDescriptor(Type typeToConvert)
     {
-        // If enum is declared as a nested type then go to its parent type and find descriptor from it.
-        //var containingType = typeToConvert.DeclaringType?.DeclaringType;
-        //if (containingType != null)
-        //{
-        //    var messageDescriptor = JsonConverterHelper.GetMessageDescriptor(containingType);
-        //    if (messageDescriptor != null)
-        //    {
-        //        for (var i = 0; i < messageDescriptor.EnumTypes.Count; i++)
-        //        {
-        //            if (messageDescriptor.EnumTypes[i].ClrType == typeToConvert)
-        //            {
-        //                return messageDescriptor.EnumTypes[i];
-        //            }
-        //        }
-        //    }
-        //}
-
-        // Enum is not nested. There isn't a way to link the enum to a descriptor using reflection.
-        // Search through registered service descriptors.
-        foreach (var enumDescriptor in Context.ServiceDescriptorRegistry.GetEnumDescriptors())
+        // Enum types in generated DTOs are regular enum types. That means there is no static Descriptor property
+        // to get the enum descriptor from.
+        //
+        // Search for enum descriptor using the enum type in a registry of descriptors.
+        foreach (var enumDescriptor in Context.DescriptorRegistry.GetEnumDescriptors())
         {
             if (enumDescriptor.ClrType == typeToConvert)
             {

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonContext.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonContext.cs
@@ -7,12 +7,14 @@ namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;
 
 internal sealed class JsonContext
 {
-    public JsonContext(GrpcJsonSettings settings, TypeRegistry typeRegistry)
+    public JsonContext(GrpcJsonSettings settings, TypeRegistry typeRegistry, DescriptorRegistry serviceDescriptorRegistry)
     {
         Settings = settings;
         TypeRegistry = typeRegistry;
+        ServiceDescriptorRegistry = serviceDescriptorRegistry;
     }
 
     public GrpcJsonSettings Settings { get; }
     public TypeRegistry TypeRegistry { get; }
+    public DescriptorRegistry ServiceDescriptorRegistry { get; }
 }

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonContext.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonContext.cs
@@ -7,14 +7,14 @@ namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;
 
 internal sealed class JsonContext
 {
-    public JsonContext(GrpcJsonSettings settings, TypeRegistry typeRegistry, DescriptorRegistry serviceDescriptorRegistry)
+    public JsonContext(GrpcJsonSettings settings, TypeRegistry typeRegistry, DescriptorRegistry descriptorRegistry)
     {
         Settings = settings;
         TypeRegistry = typeRegistry;
-        ServiceDescriptorRegistry = serviceDescriptorRegistry;
+        DescriptorRegistry = descriptorRegistry;
     }
 
     public GrpcJsonSettings Settings { get; }
     public TypeRegistry TypeRegistry { get; }
-    public DescriptorRegistry ServiceDescriptorRegistry { get; }
+    public DescriptorRegistry DescriptorRegistry { get; }
 }

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/Infrastructure/DynamicGrpcServiceRegistry.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/Infrastructure/DynamicGrpcServiceRegistry.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Google.Api;
 using Google.Protobuf;
 using Google.Protobuf.Reflection;
@@ -40,6 +41,11 @@ public class DynamicGrpcServiceRegistry
 
         AddServiceCore(c =>
         {
+            // File descriptor is done in JsonTranscodingServiceMethodProvider.
+            // Need to replicate that logic here so tests that lookup descriptors are successful.
+            var descriptorRegistry = _serviceProvider.GetRequiredService<DescriptorRegistry>();
+            descriptorRegistry.RegisterFileDescriptor(methodDescriptor.File);
+
             var unaryMethod = new UnaryServerMethod<DynamicService, TRequest, TResponse>((service, request, context) => callHandler(request, context));
             var binder = CreateJsonTranscodingBinder<TRequest, TResponse>(methodDescriptor, c, new DynamicServiceInvokerResolver(unaryMethod));
 

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/UnaryTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/UnaryTests.cs
@@ -222,4 +222,33 @@ public class UnaryTests : IntegrationTestBase
         Assert.Equal("utf-8", response.Content.Headers.ContentType!.CharSet);
         Assert.Contains(errorMessage, result.RootElement.GetProperty("message").GetString());
     }
+
+    [Fact]
+    public async Task Request_SendEnumString_Success()
+    {
+        // Arrange
+        Task<HelloReply> UnaryMethod(EnumHelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply { Message = $"Hello {request.Name}!" });
+        }
+        var method = Fixture.DynamicGrpc.AddUnaryMethod<EnumHelloRequest, HelloReply>(
+            UnaryMethod,
+            Greeter.Descriptor.FindMethodByName("SayHelloPostEnum"));
+
+        var client = new HttpClient(Fixture.Handler) { BaseAddress = new Uri("http://localhost") };
+
+        var requestMessage = new EnumHelloRequest { Name = NameOptions.Jane };
+        var content = new ByteArrayContent(Encoding.UTF8.GetBytes(requestMessage.ToString()));
+        content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+
+        // Act
+        var response = await client.PostAsync("/v1/greeter_enum", content).DefaultTimeout();
+        var responseText = await response.Content.ReadAsStringAsync();
+        using var result = JsonDocument.Parse(responseText);
+
+        // Assert
+        Assert.Equal("application/json", response.Content.Headers.ContentType!.MediaType);
+        Assert.Equal("utf-8", response.Content.Headers.ContentType!.CharSet);
+        Assert.Equal("Hello Jane!", result.RootElement.GetProperty("message").GetString());
+    }
 }

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterWriteTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterWriteTests.cs
@@ -3,9 +3,11 @@
 
 using System.Text;
 using System.Text.Json;
+using Example.Hello;
 using Google.Protobuf;
 using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
+using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;
 using Transcoding;
 using Xunit.Abstractions;
@@ -466,6 +468,15 @@ public class JsonConverterWriteTests
         AssertWrittenJson(dataTypes, new GrpcJsonSettings { WriteEnumsAsIntegers = true, IgnoreDefaultValues = true });
     }
 
+    [Fact]
+    public void Enum_Imported()
+    {
+        var m = new SayRequest();
+        m.Country = Example.Country.Alpha3CountryCode.Afg;
+
+        AssertWrittenJson(m);
+    }
+
     private void AssertWrittenJson<TValue>(TValue value, GrpcJsonSettings? settings = null, bool? compareRawStrings = null) where TValue : IMessage
     {
         var typeRegistery = TypeRegistry.FromFiles(
@@ -500,7 +511,7 @@ public class JsonConverterWriteTests
 
     internal static JsonSerializerOptions CreateSerializerOptions(GrpcJsonSettings? settings, TypeRegistry? typeRegistery)
     {
-        var context = new JsonContext(settings ?? new GrpcJsonSettings(), typeRegistery ?? TypeRegistry.Empty);
+        var context = new JsonContext(settings ?? new GrpcJsonSettings(), typeRegistery ?? TypeRegistry.Empty, new DescriptorRegistry());
 
         return JsonConverterHelper.CreateSerializerOptions(context);
     }

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/JsonTranscodingServiceMethodProviderTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/JsonTranscodingServiceMethodProviderTests.cs
@@ -247,9 +247,9 @@ public class JsonTranscodingServiceMethodProviderTests
         {
             configureLogging?.Invoke(log);
         });
-        serviceCollection.AddGrpc();
+        var builder = serviceCollection.AddGrpc();
         serviceCollection.RemoveAll(typeof(IServiceMethodProvider<>));
-        serviceCollection.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IServiceMethodProvider<>), typeof(JsonTranscodingServiceMethodProvider<>)));
+        builder.AddJsonTranscoding();
 
         IEndpointRouteBuilder endpointRouteBuilder = new TestEndpointRouteBuilder(serviceCollection.BuildServiceProvider());
 

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.csproj
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.csproj
@@ -7,6 +7,8 @@
   <ItemGroup>
     <Protobuf Include="Proto\httpbody.proto" GrpcServices="Both" />
     <Protobuf Include="Proto\transcoding.proto" GrpcServices="Both" />
+    <Protobuf Include="Proto\Issue045270\hello.proto" GrpcServices="Both" />
+    <Protobuf Include="Proto\Issue045270\country.proto" GrpcServices="Both" />
 
     <Compile Include="..\Shared\TestGrpcServiceActivator.cs" Link="Infrastructure\TestGrpcServiceActivator.cs" />
 

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/Issue045270/country.proto
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/Issue045270/country.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package example.country;
+
+option csharp_namespace = "Example.Country";
+
+enum Alpha3CountryCode
+{
+  ALPHA_3_COUNTRY_CODE_UNSPECIFIED = 0;
+  ALPHA_3_COUNTRY_CODE_AFG = 4;
+}

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/Issue045270/hello.proto
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/Issue045270/hello.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+import "google/api/annotations.proto";
+import "Proto/Issue045270/country.proto";
+
+package example.hello;
+
+option csharp_namespace = "Example.Hello";
+
+service HelloService {
+  rpc Say(SayRequest) returns (SayResponse) {
+    option (google.api.http) = {
+      post: "/say",
+      body: "*"
+    };
+  };
+}
+
+message SayRequest {
+  string name = 1;
+  country.Alpha3CountryCode country = 2;
+}
+
+message SayResponse {
+  string message = 1;
+  country.Alpha3CountryCode country = 2;
+}

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ServerStreamingServerCallHandlerTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ServerStreamingServerCallHandlerTests.cs
@@ -15,6 +15,7 @@ using Grpc.Core;
 using Grpc.Shared;
 using Grpc.Shared.Server;
 using Grpc.Tests.Shared;
+using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.CallHandlers;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.Infrastructure;
@@ -341,7 +342,7 @@ public class ServerStreamingServerCallHandlerTests : LoggedTest
             new TestGrpcServiceActivator<JsonTranscodingGreeterService>());
 
         var jsonSettings = jsonTranscodingOptions?.JsonSettings ?? new GrpcJsonSettings() { WriteIndented = false };
-        var jsonContext = new JsonContext(jsonSettings, jsonTranscodingOptions?.TypeRegistry ?? TypeRegistry.Empty);
+        var jsonContext = new JsonContext(jsonSettings, jsonTranscodingOptions?.TypeRegistry ?? TypeRegistry.Empty, new DescriptorRegistry());
 
         return new ServerStreamingServerCallHandler<JsonTranscodingGreeterService, TRequest, TResponse>(
             callInvoker,

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/UnaryServerCallHandlerTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/UnaryServerCallHandlerTests.cs
@@ -16,6 +16,7 @@ using Grpc.Core.Interceptors;
 using Grpc.Shared;
 using Grpc.Shared.Server;
 using Grpc.Tests.Shared;
+using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.CallHandlers;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.Infrastructure;
@@ -1272,7 +1273,8 @@ public class UnaryServerCallHandlerTests : LoggedTest
 
         var jsonContext = new JsonContext(
             jsonTranscodingOptions?.JsonSettings ?? new GrpcJsonSettings(),
-            jsonTranscodingOptions?.TypeRegistry ?? TypeRegistry.Empty);
+            jsonTranscodingOptions?.TypeRegistry ?? TypeRegistry.Empty,
+            new DescriptorRegistry());
 
         return new UnaryServerCallHandler<JsonTranscodingGreeterService, TRequest, TResponse>(
             unaryServerCallInvoker,

--- a/src/Grpc/JsonTranscoding/test/testassets/IntegrationTestsWebsite/Protos/greet.proto
+++ b/src/Grpc/JsonTranscoding/test/testassets/IntegrationTestsWebsite/Protos/greet.proto
@@ -25,6 +25,12 @@ service Greeter {
       get: "/v1/greeter/{name=from/*}"
     };
   }
+  rpc SayHelloPostEnum (EnumHelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      post: "/v1/greeter_enum",
+      body: "*"
+    };
+  }
   rpc SayHelloComplexCatchAll1 (HelloRequest) returns (HelloReply) {
     option (google.api.http) = {
       get: "/{name=v1/greeter/**/b}/c/d/one"
@@ -53,6 +59,17 @@ message ComplextHelloRequest {
     string first_name = 1;
     string last_name = 2;
   }
+}
+
+message EnumHelloRequest {
+  NameOptions name = 1;
+}
+
+enum NameOptions {
+    JAMES = 0;
+    JOHN = 1;
+    JANE = 2;
+    JESS = 3;
 }
 
 // The response message containing the greetings.


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/45270

Proto messages support enums. These enums can either be nested in a message or specified in the root scope of the proto file.

```proto
// root scope
enum Alpha3CountryCode
{
  ALPHA_3_COUNTRY_CODE_UNSPECIFIED = 0;
  ALPHA_3_COUNTRY_CODE_AFG = 4;
}

// nested
message DataTypes {
  enum NestedEnum {
    NESTED_ENUM_UNSPECIFIED = 0;
    FOO = 1;
    BAR = 2;
    BAZ = 3;
    NEG = -1;  // Intentionally negative.
  }
}
```

 There is a bug in the current serializer that means root scope enum values can't be deserialized from strings. How the enum descriptor (like reflection but for proto messages) is resolved today only works for nested enum types.

This PR adds a registry for descriptors populated as services are registered. The registry is used to find the descriptor for enum types.

There is no workaround in .NET 7. Should be backported.