### PR TITLE
Vectorized HttpCharacters (and used IndexOfAnyValues in other places found)

### DIFF
--- a/src/Components/Components/src/Routing/TemplateParser.cs
+++ b/src/Components/Components/src/Routing/TemplateParser.cs
@@ -74,6 +74,7 @@ internal sealed class TemplateParser
                 var invalidCharacter = segment.AsSpan(1, segment.Length - 2).IndexOfAny(_invalidParameterNameCharacters);
                 if (invalidCharacter >= 0)
                 {
+                    invalidCharacter++;     // accommodate the slice above
                     throw new InvalidOperationException(
                         $"Invalid template '{template}'. The character '{segment[invalidCharacter]}' in parameter segment '{segment}' is not allowed.");
                 }

--- a/src/Components/Components/src/Routing/TemplateParser.cs
+++ b/src/Components/Components/src/Routing/TemplateParser.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
+
 namespace Microsoft.AspNetCore.Components.Routing;
 
 // This implementation is temporary, in the future we'll want to have
@@ -18,8 +20,7 @@ namespace Microsoft.AspNetCore.Components.Routing;
 // * Catch-all parameters (Like /blog/{*slug})
 internal sealed class TemplateParser
 {
-    public static readonly char[] InvalidParameterNameCharacters =
-        new char[] { '{', '}', '=', '.' };
+    private static readonly IndexOfAnyValues<char> _invalidParameterNameCharacters = IndexOfAnyValues.Create("{}=.");
 
     internal static RouteTemplate ParseTemplate(string template)
     {
@@ -70,8 +71,8 @@ internal sealed class TemplateParser
                         $"Invalid template '{template}'. Empty parameter name in segment '{segment}' is not allowed.");
                 }
 
-                var invalidCharacter = segment.IndexOfAny(InvalidParameterNameCharacters, 1, segment.Length - 2);
-                if (invalidCharacter != -1)
+                var invalidCharacter = segment.AsSpan(1, segment.Length - 2).IndexOfAny(_invalidParameterNameCharacters);
+                if (invalidCharacter >= 0)
                 {
                     throw new InvalidOperationException(
                         $"Invalid template '{template}'. The character '{segment[invalidCharacter]}' in parameter segment '{segment}' is not allowed.");

--- a/src/Http/Routing/src/Patterns/RoutePatternFactory.cs
+++ b/src/Http/Routing/src/Patterns/RoutePatternFactory.cs
@@ -807,7 +807,7 @@ public static class RoutePatternFactory
             throw new ArgumentException(Resources.Argument_NullOrEmpty, nameof(parameterName));
         }
 
-        if (parameterName.IndexOfAny(RoutePatternParser.InvalidParameterNameChars) >= 0)
+        if (parameterName.AsSpan().IndexOfAny(RoutePatternParser.InvalidParameterNameChars) >= 0)
         {
             throw new ArgumentException(Resources.FormatTemplateRoute_InvalidParameterName(parameterName));
         }
@@ -833,7 +833,7 @@ public static class RoutePatternFactory
             throw new ArgumentException(Resources.Argument_NullOrEmpty, nameof(parameterName));
         }
 
-        if (parameterName.IndexOfAny(RoutePatternParser.InvalidParameterNameChars) >= 0)
+        if (parameterName.AsSpan().IndexOfAny(RoutePatternParser.InvalidParameterNameChars) >= 0)
         {
             throw new ArgumentException(Resources.FormatTemplateRoute_InvalidParameterName(parameterName));
         }
@@ -863,7 +863,7 @@ public static class RoutePatternFactory
             throw new ArgumentException(Resources.Argument_NullOrEmpty, nameof(parameterName));
         }
 
-        if (parameterName.IndexOfAny(RoutePatternParser.InvalidParameterNameChars) >= 0)
+        if (parameterName.AsSpan().IndexOfAny(RoutePatternParser.InvalidParameterNameChars) >= 0)
         {
             throw new ArgumentException(Resources.FormatTemplateRoute_InvalidParameterName(parameterName));
         }
@@ -900,7 +900,7 @@ public static class RoutePatternFactory
             throw new ArgumentException(Resources.Argument_NullOrEmpty, nameof(parameterName));
         }
 
-        if (parameterName.IndexOfAny(RoutePatternParser.InvalidParameterNameChars) >= 0)
+        if (parameterName.AsSpan().IndexOfAny(RoutePatternParser.InvalidParameterNameChars) >= 0)
         {
             throw new ArgumentException(Resources.FormatTemplateRoute_InvalidParameterName(parameterName));
         }
@@ -942,7 +942,7 @@ public static class RoutePatternFactory
             throw new ArgumentException(Resources.Argument_NullOrEmpty, nameof(parameterName));
         }
 
-        if (parameterName.IndexOfAny(RoutePatternParser.InvalidParameterNameChars) >= 0)
+        if (parameterName.AsSpan().IndexOfAny(RoutePatternParser.InvalidParameterNameChars) >= 0)
         {
             throw new ArgumentException(Resources.FormatTemplateRoute_InvalidParameterName(parameterName));
         }

--- a/src/Http/Routing/src/Patterns/RoutePatternParser.cs
+++ b/src/Http/Routing/src/Patterns/RoutePatternParser.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Buffers;
 using System.Diagnostics;
 
 namespace Microsoft.AspNetCore.Routing.Patterns;
@@ -16,14 +17,7 @@ internal static class RoutePatternParser
     private const char Asterisk = '*';
     private const string PeriodString = ".";
 
-    internal static readonly char[] InvalidParameterNameChars = new char[]
-    {
-        Separator,
-        OpenBrace,
-        CloseBrace,
-        QuestionMark,
-        Asterisk
-    };
+    private static readonly IndexOfAnyValues<char> _invalidParameterNameChars = IndexOfAnyValues.Create("/{}?*");
 
     public static RoutePattern Parse(string pattern)
     {
@@ -431,7 +425,7 @@ internal static class RoutePatternParser
 
     private static bool IsValidParameterName(Context context, string parameterName)
     {
-        if (parameterName.Length == 0 || parameterName.IndexOfAny(InvalidParameterNameChars) >= 0)
+        if (parameterName.Length == 0 || parameterName.AsSpan().IndexOfAny(_invalidParameterNameChars) >= 0)
         {
             context.Error = Resources.FormatTemplateRoute_InvalidParameterName(parameterName);
             return false;

--- a/src/Http/Routing/src/Patterns/RoutePatternParser.cs
+++ b/src/Http/Routing/src/Patterns/RoutePatternParser.cs
@@ -14,10 +14,9 @@ internal static class RoutePatternParser
     private const char OpenBrace = '{';
     private const char CloseBrace = '}';
     private const char QuestionMark = '?';
-    private const char Asterisk = '*';
     private const string PeriodString = ".";
 
-    private static readonly IndexOfAnyValues<char> _invalidParameterNameChars = IndexOfAnyValues.Create("/{}?*");
+    internal static readonly IndexOfAnyValues<char> InvalidParameterNameChars = IndexOfAnyValues.Create("/{}?*");
 
     public static RoutePattern Parse(string pattern)
     {
@@ -425,7 +424,7 @@ internal static class RoutePatternParser
 
     private static bool IsValidParameterName(Context context, string parameterName)
     {
-        if (parameterName.Length == 0 || parameterName.AsSpan().IndexOfAny(_invalidParameterNameChars) >= 0)
+        if (parameterName.Length == 0 || parameterName.AsSpan().IndexOfAny(InvalidParameterNameChars) >= 0)
         {
             context.Error = Resources.FormatTemplateRoute_InvalidParameterName(parameterName);
             return false;

--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
@@ -89,8 +88,6 @@ internal sealed class KestrelServerImpl : IServer
         Features.Set<IServerAddressesFeature>(_serverAddresses);
 
         _transportManager = new TransportManager(_transportFactories, _multiplexedTransportFactories, ServiceContext);
-
-        HttpCharacters.Initialize();
     }
 
     private static ServiceContext CreateServiceContext(IOptions<KestrelServerOptions> options, ILoggerFactory loggerFactory, DiagnosticSource? diagnosticSource)

--- a/src/Shared/HttpSys/RequestProcessing/HeaderCollection.cs
+++ b/src/Shared/HttpSys/RequestProcessing/HeaderCollection.cs
@@ -272,10 +272,12 @@ internal sealed class HeaderCollection : IHeaderDictionary
     {
         if (headerCharacters != null)
         {
-            var invalid = HttpCharacters.IndexOfInvalidFieldValueCharExtended(headerCharacters);
-            if (invalid >= 0)
+            var invalidIndex = HttpCharacters.IndexOfInvalidFieldValueCharExtended(headerCharacters);
+            if (invalidIndex >= 0)
             {
-                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "Invalid control character in header: 0x{0:X2}", headerCharacters[invalid]));
+                Throw(headerCharacters, invalidIndex);
+                static void Throw(string headerCharacters, int invalidIndex)
+                    => throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "Invalid control character in header: 0x{0:X2}", headerCharacters[invalidIndex]));
             }
         }
     }

--- a/src/Shared/ServerInfrastructure/HttpCharacters.cs
+++ b/src/Shared/ServerInfrastructure/HttpCharacters.cs
@@ -33,6 +33,7 @@ internal static class HttpCharacters
     // HTAB, [VCHAR, SP]
     private static readonly IndexOfAnyValues<char> _allowedFieldChars = IndexOfAnyValues.Create("\t !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~" + AlphaNumeric);
 
+    // Values are [0x00, 0x1F] without 0x09 (HTAB) and with 0x7F.
     private static readonly IndexOfAnyValues<char> _invalidFieldChars = IndexOfAnyValues.Create(
         "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u000A\u000B\u000C\u000D\u000E\u000F\u0010" +
         "\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F\u007F");

--- a/src/Shared/ServerInfrastructure/HttpCharacters.cs
+++ b/src/Shared/ServerInfrastructure/HttpCharacters.cs
@@ -31,7 +31,7 @@ internal static class HttpCharacters
 
     // field-value https://tools.ietf.org/html/rfc7230#section-3.2
     // HTAB, [VCHAR, SP]
-    private static readonly IndexOfAnyValues<char> _allowedFieldChars = IndexOfAnyValues.Create("\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~");
+    private static readonly IndexOfAnyValues<char> _allowedFieldChars = IndexOfAnyValues.Create("\t !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~" + AlphaNumeric);
 
     private static readonly IndexOfAnyValues<char> _invalidFieldChars = IndexOfAnyValues.Create(
         "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u000A\u000B\u000C\u000D\u000E\u000F\u0010" +


### PR DESCRIPTION
The title sounds like a complicated change, but thanks to https://github.com/dotnet/runtime/issues/68328 it got trivial and is a way better alternative to doing it manually as in https://github.com/dotnet/aspnetcore/pull/44041.

Unfortunately the .NET daily builds are way behind at the moment, so these new APIs aren't available to run benchmarks in an easy way. 

Edit: searched for other places where applicable as well. Some of the found were analyzers (NS2.0) or built for older targets where this API isn't available.