### PR TITLE
Explicitly de-dupe ReferenceCopyLocalPaths in Microsoft.AspNetCore.App.Runtime.csproj

### DIFF
--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -259,8 +259,24 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
     <ItemGroup>
       <RuntimePackageFiles Include="$(RuntimePackageRoot)runtimes\**\*" />
-      <ReferenceCopyLocalPaths Include="@(RuntimePackageFiles)" Condition="'%(FileName)' == 'System.Formats.Asn1'"/>
-      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition=" '%(ReferenceCopyLocalPaths.FileName)' == '%(RuntimePackageFiles.FileName)' " />
+      <!--
+        Filter out any overlap between our SharedFx (ReferenceCopyLocalPaths) and dotnet/runtime's SharedFx (RuntimePackageFiles).
+        Most of the time there is no overlap, but in certain rare corner cases there can be.
+        See https://github.com/dotnet/aspnetcore/issues/45033 for more detail.
+      -->
+      <ReferenceCopyLocalPathsFileNames Include="%(ReferenceCopyLocalPaths.FileName)">
+        <OriginalIdentity>%(Identity)</OriginalIdentity>
+      </ReferenceCopyLocalPathsFileNames>
+      <RuntimePackageFilesFileNames Include="%(RuntimePackageFiles.FileName)" />
+    </ItemGroup>
+
+    <JoinItems Left="@(ReferenceCopyLocalPathsFileNames)" Right="@(RuntimePackageFilesFileNames)" LeftMetadata="*" RightMetadata="*">
+      <Output TaskParameter="JoinResult" ItemName="_SharedFxOverlap" />
+    </JoinItems>
+
+    <ItemGroup>
+      <ReferenceCopyLocalPathsOverlap Include="%(_SharedFxOverlap.OriginalIdentity)" />
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPathsOverlap)"/>
     </ItemGroup>
   </Target>
 

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -397,7 +397,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
   <Target Name="PrepareForCrossGen"
           Condition="'$(CrossgenOutput)' == 'true'"
-          DependsOnTargets="_ExpandRuntimePackageRoot">
+          DependsOnTargets="FilterUnwantedContent">
     <!-- The output directories of assemblies built in this repo contain a mix of ref and impl assemblies. Copy impl assemblies to a separate directory. -->
     <RemoveDir Directories="$(CrossgenPlatformAssembliesDir)" />
     <Copy SourceFiles="@(ReferenceCopyLocalPaths)" DestinationFolder="$(CrossgenPlatformAssembliesDir)" Condition="'%(ReferenceCopyLocalPaths.ProjectPath)' != ''"/>

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -264,19 +264,19 @@ This package is an internal implementation of the .NET Core SDK and is not meant
         Most of the time there is no overlap, but in certain rare corner cases there can be.
         See https://github.com/dotnet/aspnetcore/issues/45033 for more detail.
       -->
-      <ReferenceCopyLocalPathsFileNames Include="%(ReferenceCopyLocalPaths.FileName)">
+      <_ReferenceCopyLocalPathsFileNames Include="%(ReferenceCopyLocalPaths.FileName)">
         <OriginalIdentity>%(Identity)</OriginalIdentity>
-      </ReferenceCopyLocalPathsFileNames>
-      <RuntimePackageFilesFileNames Include="%(RuntimePackageFiles.FileName)" />
+      </_ReferenceCopyLocalPathsFileNames>
+      <_RuntimePackageFilesFileNames Include="%(RuntimePackageFiles.FileName)" />
     </ItemGroup>
 
-    <JoinItems Left="@(ReferenceCopyLocalPathsFileNames)" Right="@(RuntimePackageFilesFileNames)" LeftMetadata="*" RightMetadata="*">
+    <JoinItems Left="@(_ReferenceCopyLocalPathsFileNames)" Right="@(_RuntimePackageFilesFileNames)" LeftMetadata="*" RightMetadata="*">
       <Output TaskParameter="JoinResult" ItemName="_SharedFxOverlap" />
     </JoinItems>
 
     <ItemGroup>
-      <ReferenceCopyLocalPathsOverlap Include="%(_SharedFxOverlap.OriginalIdentity)" />
-      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPathsOverlap)"/>
+      <_ReferenceCopyLocalPathsOverlap Include="%(_SharedFxOverlap.OriginalIdentity)" />
+      <ReferenceCopyLocalPaths Remove="@(_ReferenceCopyLocalPathsOverlap)"/>
     </ItemGroup>
   </Target>
 

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -254,7 +254,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
           DependsOnTargets="_ExpandRuntimePackageRoot">
     <ItemGroup>
       <!-- These files end up in this item group as a result of setting CopyLocalLockFileAssemblies, but shouldn't be. -->
-      <ReferenceCopyLocalPaths Remove="@(RuntimePackageFiles)" Condition="'%(FileName)' == 'apphost' OR '%(FileName)' == '$(LibPrefix)hostfxr' OR '%(FileName)' == '$(LibPrefix)hostpolicy' "/>
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(FileName)' == 'apphost' OR '%(FileName)' == '$(LibPrefix)hostfxr' OR '%(FileName)' == '$(LibPrefix)hostpolicy' "/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -250,10 +250,17 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   <!-- This project doesn't compile anything. -->
   <Target Name="CoreCompile" />
 
-  <Target Name="FilterUnwantedContent">
+  <Target Name="FilterUnwantedContent"
+          DependsOnTargets="_ExpandRuntimePackageRoot">
     <ItemGroup>
       <!-- These files end up in this item group as a result of setting CopyLocalLockFileAssemblies, but shouldn't be. -->
-      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(FileName)' == 'apphost' OR '%(FileName)' == '$(LibPrefix)hostfxr' OR '%(FileName)' == '$(LibPrefix)hostpolicy' "/>
+      <ReferenceCopyLocalPaths Remove="@(RuntimePackageFiles)" Condition="'%(FileName)' == 'apphost' OR '%(FileName)' == '$(LibPrefix)hostfxr' OR '%(FileName)' == '$(LibPrefix)hostpolicy' "/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <RuntimePackageFiles Include="$(RuntimePackageRoot)runtimes\**\*" />
+      <ReferenceCopyLocalPaths Include="@(RuntimePackageFiles)" Condition="'%(FileName)' == 'System.Formats.Asn1'"/>
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition=" '%(ReferenceCopyLocalPaths.FileName)' == '%(RuntimePackageFiles.FileName)' " />
     </ItemGroup>
   </Target>
 
@@ -426,10 +433,6 @@ This package is an internal implementation of the .NET Core SDK and is not meant
         Lines="@(Crossgen2PlatformAssemblyPaths)"
         File="$(CrossgenToolDir)PlatformAssembliesPathsCrossgen2.rsp"
         Overwrite="true" />
-
-    <ItemGroup>
-      <RuntimePackageFiles Include="$(RuntimePackageRoot)runtimes\**\*" />
-    </ItemGroup>
 
     <Error Text="Could not find crossgen2 $(CrossgenToolPath)" Condition=" ! Exists($(CrossgenToolPath))" />
 

--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -264,19 +264,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
         Most of the time there is no overlap, but in certain rare corner cases there can be.
         See https://github.com/dotnet/aspnetcore/issues/45033 for more detail.
       -->
-      <_ReferenceCopyLocalPathsFileNames Include="%(ReferenceCopyLocalPaths.FileName)">
-        <OriginalIdentity>%(Identity)</OriginalIdentity>
-      </_ReferenceCopyLocalPathsFileNames>
-      <_RuntimePackageFilesFileNames Include="%(RuntimePackageFiles.FileName)" />
-    </ItemGroup>
-
-    <JoinItems Left="@(_ReferenceCopyLocalPathsFileNames)" Right="@(_RuntimePackageFilesFileNames)" LeftMetadata="*" RightMetadata="*">
-      <Output TaskParameter="JoinResult" ItemName="_SharedFxOverlap" />
-    </JoinItems>
-
-    <ItemGroup>
-      <_ReferenceCopyLocalPathsOverlap Include="%(_SharedFxOverlap.OriginalIdentity)" />
-      <ReferenceCopyLocalPaths Remove="@(_ReferenceCopyLocalPathsOverlap)"/>
+      <ReferenceCopyLocalPaths Remove="@(RuntimePackageFiles)" MatchOnMetadata="FileName"/>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
See https://github.com/dotnet/aspnetcore/issues/45033

CC @MichaelSimons @crummel 

Should be backported to 6.0 & 7.0 at least