### PR TITLE
Avoid allocations from getting JsonOptions in Minimal

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactoryContext.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactoryContext.cs
@@ -60,4 +60,5 @@ internal sealed class RequestDelegateFactoryContext
 
     // Grab these options upfront to avoid the per request DI scope that would be made otherwise to get the options when writing Json
     public JsonSerializerOptions? JsonSerializerOptions { get; set; }
+    public Expression JsonSerializerOptionsExpression { get; set; }
 }

--- a/src/Http/Http.Extensions/src/RequestDelegateFactoryContext.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactoryContext.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -56,4 +57,7 @@ internal sealed class RequestDelegateFactoryContext
     public bool FilterFactoriesHaveRunWithoutModifyingPerRequestBehavior { get; set; }
 
     public List<ParameterInfo> Parameters { get; set; } = new();
+
+    // Grab these options upfront to avoid the per request DI scope that would be made otherwise to get the options when writing Json
+    public JsonSerializerOptions? JsonSerializerOptions { get; set; }
 }

--- a/src/Http/Http.Extensions/src/RequestDelegateFactoryContext.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactoryContext.cs
@@ -60,5 +60,5 @@ internal sealed class RequestDelegateFactoryContext
 
     // Grab these options upfront to avoid the per request DI scope that would be made otherwise to get the options when writing Json
     public JsonSerializerOptions? JsonSerializerOptions { get; set; }
-    public Expression JsonSerializerOptionsExpression { get; set; }
+    public required Expression JsonSerializerOptionsExpression { get; set; }
 }


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/45330
Removes the two DI allocations and `RequestServices` allocation seen in https://github.com/dotnet/aspnetcore/issues/45330#issuecomment-1330965903 which reduces the allocation rate of the [JsonMapAction benchmark](https://github.com/aspnet/Benchmarks/blob/c755e9e8af3d9821744a367b3d7e830a37d592ce/src/BenchmarksApps/MapAction/Program.cs#L26) from **307M bytes/sec to 160M bytes/sec** as well as increasing the **RPS from from 845k to 894k**.

We don't really have any E2E tests for RequestDelegateFactory, at least none that I could find. Fortunately, we do hit the code paths that were changed so it was easy to find all the Expression Tree code that I needed to update (follow the exceptions from tests).

Bonus: Updated the read path as well, so it'll be faster for Json requests.