### PR TITLE
Allow concurrent accept (improve connection-accept performance)

### DIFF
--- a/src/Servers/Connections.Abstractions/src/IConcurrentConnectionListener.cs
+++ b/src/Servers/Connections.Abstractions/src/IConcurrentConnectionListener.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Connections;
+
+/// <summary>
+/// Indicates that a <see cref="IConnectionListener"/> or <see cref="IMultiplexedConnectionListener"/> supports concurrent accept operations.
+/// </summary>
+public interface IConcurrentConnectionListener
+{
+    /// <summary>
+    /// The maximum number of concurrent accept operations supported by this listener.
+    /// </summary>
+    int MaxAccepts { get; }
+}

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
 Microsoft.AspNetCore.Connections.Features.IStreamClosedFeature
 Microsoft.AspNetCore.Connections.Features.IStreamClosedFeature.OnClosed(System.Action<object?>! callback, object? state) -> void
+Microsoft.AspNetCore.Connections.IConcurrentConnectionListener
+Microsoft.AspNetCore.Connections.IConcurrentConnectionListener.MaxAccepts.get -> int
 Microsoft.AspNetCore.Connections.IConnectionListenerFactorySelector
 Microsoft.AspNetCore.Connections.IConnectionListenerFactorySelector.CanBind(System.Net.EndPoint! endpoint) -> bool

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/net7.0/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/net7.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 Microsoft.AspNetCore.Connections.Features.IStreamClosedFeature
 Microsoft.AspNetCore.Connections.Features.IStreamClosedFeature.OnClosed(System.Action<object?>! callback, object? state) -> void
+Microsoft.AspNetCore.Connections.IConcurrentConnectionListener
+Microsoft.AspNetCore.Connections.IConcurrentConnectionListener.MaxAccepts.get -> int
 Microsoft.AspNetCore.Connections.IConnectionListenerFactorySelector
 Microsoft.AspNetCore.Connections.IConnectionListenerFactorySelector.CanBind(System.Net.EndPoint! endpoint) -> bool
 Microsoft.AspNetCore.Connections.TlsConnectionCallbackContext

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
 Microsoft.AspNetCore.Connections.Features.IStreamClosedFeature
 Microsoft.AspNetCore.Connections.Features.IStreamClosedFeature.OnClosed(System.Action<object?>! callback, object? state) -> void
+Microsoft.AspNetCore.Connections.IConcurrentConnectionListener
+Microsoft.AspNetCore.Connections.IConcurrentConnectionListener.MaxAccepts.get -> int
 Microsoft.AspNetCore.Connections.IConnectionListenerFactorySelector
 Microsoft.AspNetCore.Connections.IConnectionListenerFactorySelector.CanBind(System.Net.EndPoint! endpoint) -> bool

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
 Microsoft.AspNetCore.Connections.Features.IStreamClosedFeature
 Microsoft.AspNetCore.Connections.Features.IStreamClosedFeature.OnClosed(System.Action<object?>! callback, object? state) -> void
+Microsoft.AspNetCore.Connections.IConcurrentConnectionListener
+Microsoft.AspNetCore.Connections.IConcurrentConnectionListener.MaxAccepts.get -> int
 Microsoft.AspNetCore.Connections.IConnectionListenerFactorySelector
 Microsoft.AspNetCore.Connections.IConnectionListenerFactorySelector.CanBind(System.Net.EndPoint! endpoint) -> bool

--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -204,7 +204,7 @@ internal sealed class KestrelServerImpl : IServer
                     // Add the connection limit middleware
                     connectionDelegate = EnforceConnectionLimit(connectionDelegate, Options.Limits.MaxConcurrentConnections, Trace);
 
-                    options.EndPoint = await _transportManager.BindAsync(configuredEndpoint, connectionDelegate, options.EndpointConfig, onBindCancellationToken).ConfigureAwait(false);
+                    options.EndPoint = await _transportManager.BindAsync(configuredEndpoint, connectionDelegate, options, onBindCancellationToken).ConfigureAwait(false);
                 }
 
                 if (hasHttp3 && _multiplexedTransportFactories.Count > 0)

--- a/src/Servers/Kestrel/Core/src/ListenOptions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptions.cs
@@ -112,6 +112,12 @@ public class ListenOptions : IConnectionBuilder, IMultiplexedConnectionBuilder
     internal TlsHandshakeCallbackOptions? HttpsCallbackOptions { get; set; }
 
     /// <summary>
+    /// The maximum number of concurrent accepts.
+    /// The default is the number of processors as returned by <see cref="Environment.ProcessorCount" />.
+    /// </summary>
+    public int MaxAccepts { get; set; } = Environment.ProcessorCount; // note: HttpSysOptions.MaxAccepts uses 5 * {proccount}; we can be a *little* less aggressive
+
+    /// <summary>
     /// Gets the name of this endpoint to display on command-line when the web server starts.
     /// </summary>
     internal virtual string GetDisplayName()

--- a/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
+Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.MaxAccepts.get -> int
+Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.MaxAccepts.set -> void
 Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions.ServerCertificateChain.get -> System.Security.Cryptography.X509Certificates.X509Certificate2Collection?
 Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions.ServerCertificateChain.set -> void

--- a/src/Servers/Kestrel/Core/test/ConnectionDispatcherTests.cs
+++ b/src/Servers/Kestrel/Core/test/ConnectionDispatcherTests.cs
@@ -59,7 +59,8 @@ public class ConnectionDispatcherTests : LoggedTest
     {
         var serviceContext = new TestServiceContext(LoggerFactory);
 
-        var dispatcher = new ConnectionDispatcher<ConnectionContext>(serviceContext, _ => Task.CompletedTask, new TransportConnectionManager(serviceContext.ConnectionManager));
+        var dispatcher = new ConnectionDispatcher<ConnectionContext>(serviceContext, _ => Task.CompletedTask, new TransportConnectionManager(serviceContext.ConnectionManager),
+            new(new IPEndPoint(IPAddress.Any, 80)));
 
         await dispatcher.StartAcceptingConnections(new ThrowingListener());
 

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionListener.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
 
-internal sealed class SocketConnectionListener : IConnectionListener
+internal sealed class SocketConnectionListener : IConnectionListener, IConcurrentConnectionListener
 {
     private readonly SocketConnectionContextFactory _factory;
     private readonly ILogger _logger;
@@ -18,6 +18,7 @@ internal sealed class SocketConnectionListener : IConnectionListener
     private readonly SocketTransportOptions _options;
 
     public EndPoint EndPoint { get; private set; }
+    int IConcurrentConnectionListener.MaxAccepts => int.MaxValue; // not restricted
 
     internal SocketConnectionListener(
         EndPoint endpoint,


### PR DESCRIPTION
# Allow concurrent accept (improve connection-accept performance)

Kestrel's socket-accept performance under load (as measured by the ConnectionClose benchmark) has historically been significantly behind http.sys's ranking. Here we attempt to mitigate that by allowing concurrent accept

## Description

Hypothesis: one of the possible reasons http.sys is winning so spectacularly here is that we allow ([here](https://github.com/dotnet/aspnetcore/blob/522bbeef952a78d2e0907e23391e18f0cf583a8e/src/Servers/HttpSys/src/MessagePump.cs#L125-L131)) concurrent accepts from http.sys, with the default level being 5 * proc-count ([here](https://github.com/dotnet/aspnetcore/blob/522bbeef952a78d2e0907e23391e18f0cf583a8e/src/Servers/HttpSys/src/HttpSysOptions.cs#L18)). From local testing, sockets allow concurrent accept for both Windows and linux, so here we attempt to offer similar concurrency, to see how that impacts Kestrel accept performance under load. Initially, I've used a more conservative 1 * proc-count, but we can play with this default number.

A `MaxAccepts` property is added to `ListenOptions` to make this level configurable.

To avoid existing listeners being impacted (who may not support concurrent accept), `IConcurrentConnectionListener` is added, which a: signals this capability, and b: allows the implementation to specify a maximum concurrency level, which is combined with the user's concurrency level; `SocketConnectionListener` implements this interface in an unbounded way.

The `Task` that signals listener exit is now signaled by the last async listener loop to exit.

<!-- Fixes #{bug number} (in this specific format) -->
