### PR TITLE
Add Logging to AuthenticationService Scripts

### DIFF
--- a/src/Components/WebAssembly/Authentication.Msal/src/Interop/AuthenticationService.ts
+++ b/src/Components/WebAssembly/Authentication.Msal/src/Interop/AuthenticationService.ts
@@ -251,7 +251,9 @@ class MsalAuthorizeService implements AuthorizeService {
                 return this.success(state);
             }
         } catch (e) {
-            return this.error((e as Error).message);
+            const message = (e as Error).message;
+            this.debug(`Sign in error '${message}'`);
+            return this.error(message);
         }
     }
 

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/AuthenticationService.ts
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/AuthenticationService.ts
@@ -242,9 +242,11 @@ class OidcAuthorizeService implements AuthorizeService {
     }
 
     async signInInteractive(context: AuthenticationContext) {
+        this.trace('signInInteractive', context);
         try {
             await this._userManager.clearStaleState();
             await this._userManager.signinRedirect(this.createArguments(context.state, context.interactiveRequest));
+            this.debug('Redirect sign in succeeded');
             return this.redirect();
         } catch (redirectError) {
             const message = this.getExceptionMessage(redirectError);
@@ -275,6 +277,7 @@ class OidcAuthorizeService implements AuthorizeService {
     }
 
     async signOut(context: AuthenticationContext) {
+        this.trace('signOut', context);
         try {
             if (!(await this._userManager.metadataService.getEndSessionEndpoint())) {
                 await this._userManager.removeUser();
@@ -283,11 +286,14 @@ class OidcAuthorizeService implements AuthorizeService {
             await this._userManager.signoutRedirect(this.createArguments(context.state, context.interactiveRequest));
             return this.redirect();
         } catch (redirectSignOutError) {
-            return this.error(this.getExceptionMessage(redirectSignOutError));
+            const message = this.getExceptionMessage(redirectSignOutError);
+            this.debug(`Sign out error '${message}'.`);
+            return this.error(message);
         }
     }
 
     async completeSignOut(url: string) {
+        this.trace('completeSignOut', url);
         try {
             if (await this.stateExists(url)) {
                 const response = await this._userManager.signoutCallback(url);
@@ -296,7 +302,9 @@ class OidcAuthorizeService implements AuthorizeService {
                 return this.operationCompleted();
             }
         } catch (error) {
-            return this.error(this.getExceptionMessage(error));
+            const message = this.getExceptionMessage(error);
+            this.debug(`Complete sign out error '${message}'`);
+            return this.error(error);
         }
     }
 

--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/AuthenticationService.ts
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/AuthenticationService.ts
@@ -304,7 +304,7 @@ class OidcAuthorizeService implements AuthorizeService {
         } catch (error) {
             const message = this.getExceptionMessage(error);
             this.debug(`Complete sign out error '${message}'`);
-            return this.error(error);
+            return this.error(message);
         }
     }
 


### PR DESCRIPTION
# Add Logging to AuthenticationService Scripts

Fills out Blazor WASM authentication scripts with more logging statements to debug customer issues easier.

cc @javiercn
Fixes #45234 
