### PR TITLE
[release/6.0] Use non-localized 6.0.x links in installer

### DIFF
--- a/src/Installers/Windows/WindowsHostingBundle/1028/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1028/thm.wxl
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">關閉(&amp;C)</String>
   <String Id="SuccessRepairHeader">修復已成功完成</String>
   <String Id="SuccessUninstallHeader">解除安裝已成功完成</String>
-  <String Id="SuccessInstallHeader">安裝已成功完成</String> 
-  <String Id="SuccessHeader">設定成功</String>	
+  <String Id="SuccessInstallHeader">安裝已成功完成</String>
+  <String Id="SuccessHeader">設定成功</String>
   <String Id="SuccessLaunchButton">啟動(&amp;L)</String>
   <String Id="SuccessRestartText">必須重新啟動電腦，才能使用此軟體。</String>
   <String Id="SuccessRestartButton">重新啟動(&amp;R)</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">設定失敗</String>
   <String Id="FailureInstallHeader">安裝程式失敗</String>
   <String Id="FailureUninstallHeader">解除安裝失敗</String>
-  <String Id="FailureRepairHeader">修復失敗</String> 
+  <String Id="FailureRepairHeader">修復失敗</String>
   <String Id="FailureHyperlinkLogText">有一個或多個問題導致安裝程式失敗。請解決問題，然後重試一次安裝。如需詳細資訊，請參閱&lt;a href="#"&gt;記錄檔&lt;/a&gt;。</String>
   <String Id="FailureRestartText">必須重新啟動電腦，才能完成軟體的復原。</String>
   <String Id="FailureRestartButton">重新啟動(&amp;R)</String>
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">歡迎使用 [WixBundleName] 安裝程式。</String>
-  <String Id="InstallResetIIS">請在安裝完成後重新啟動 IIS。如需其他資訊，請參閱&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;這裡&lt;/a&gt;。</String>
-  <String Id="InstallNoIIS">這部電腦上未啟用 IIS。如果您要使用 IIS 執行 ASP.NET Core 應用程式，就必須先安裝 IIS 才能執行此安裝程式。如需其他資訊，請參閱&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;這裡&lt;/a&gt;。</String>
+  <String Id="InstallResetIIS">請在安裝完成後重新啟動 IIS。如需其他資訊，請參閱&lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;這裡&lt;/a&gt;。</String>
+  <String Id="InstallNoIIS">這部電腦上未啟用 IIS。如果您要使用 IIS 執行 ASP.NET Core 應用程式，就必須先安裝 IIS 才能執行此安裝程式。如需其他資訊，請參閱&lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;這裡&lt;/a&gt;。</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;授權條款&lt;/a&gt;和&lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;隱私權聲明&lt;/a&gt;。</String>
-  <String Id="ModifyResetIIS">請在安裝完成後重新啟動 IIS。如需其他資訊，請參閱&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;這裡&lt;/a&gt;。</String>
-  <String Id="ModifyNoIIS">這部電腦上未啟用 IIS。如果您要使用 IIS 執行 ASP.NET Core 應用程式，就必須先安裝 IIS 才能執行此安裝程式。如需其他資訊，請參閱&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;這裡&lt;/a&gt;。</String>
+  <String Id="ModifyResetIIS">請在安裝完成後重新啟動 IIS。如需其他資訊，請參閱&lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;這裡&lt;/a&gt;。</String>
+  <String Id="ModifyNoIIS">這部電腦上未啟用 IIS。如果您要使用 IIS 執行 ASP.NET Core 應用程式，就必須先安裝 IIS 才能執行此安裝程式。如需其他資訊，請參閱&lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;這裡&lt;/a&gt;。</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1029/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1029/thm.wxl
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">&amp;Zavřít</String>
   <String Id="SuccessRepairHeader">Oprava se úspěšně dokončila.</String>
   <String Id="SuccessUninstallHeader">Odinstalace se úspěšně dokončila.</String>
-  <String Id="SuccessInstallHeader">Instalace se úspěšně dokončila.</String> 
-  <String Id="SuccessHeader">Instalace byla úspěšná.</String>	
+  <String Id="SuccessInstallHeader">Instalace se úspěšně dokončila.</String>
+  <String Id="SuccessHeader">Instalace byla úspěšná.</String>
   <String Id="SuccessLaunchButton">&amp;Spustit</String>
   <String Id="SuccessRestartText">Před použitím tohoto softwaru musíte restartovat počítač.</String>
   <String Id="SuccessRestartButton">&amp;Restartovat</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">Instalace se nepovedla.</String>
   <String Id="FailureInstallHeader">Instalace se nepovedla.</String>
   <String Id="FailureUninstallHeader">Odinstalace se nepovedla.</String>
-  <String Id="FailureRepairHeader">Oprava se nepovedla.</String> 
+  <String Id="FailureRepairHeader">Oprava se nepovedla.</String>
   <String Id="FailureHyperlinkLogText">Instalace se nepovedla kvůli jednomu nebo více problémům. Opravte prosím tyto problémy a zkuste software nainstalovat znovu. Další informace najdete v &lt;a href="#"&gt;souboru protokolu&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Pro dokončení vrácení změn tohoto softwaru je potřeba restartovat počítač.</String>
   <String Id="FailureRestartButton">&amp;Restartovat</String>
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Vítá vás instalační program produktu [WixBundleName]</String>
-  <String Id="InstallResetIIS">Po dokončení instalace prosím restartujte službu IIS. Další informace najdete &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;tady&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">Služba IIS není na tomto počítači povolená. Pokud máte v úmyslu spouštět aplikace ASP.NET Core se službou IIS, je nutné před spuštěním tohoto instalačního programu nainstalovat službu IIS. Další informace najdete &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;tady&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Po dokončení instalace prosím restartujte službu IIS. Další informace najdete &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;tady&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">Služba IIS není na tomto počítači povolená. Pokud máte v úmyslu spouštět aplikace ASP.NET Core se službou IIS, je nutné před spuštěním tohoto instalačního programu nainstalovat službu IIS. Další informace najdete &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;tady&lt;/a&gt;.</String>
   <String Id="EulaPrivacy">[WixBundleName] – &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;licenční podmínky&lt;/a&gt; a &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;prohlášení o zásadách ochrany osobních údajů&lt;/a&gt;</String>
-  <String Id="ModifyResetIIS">Po dokončení instalace prosím restartujte službu IIS. Další informace najdete &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;tady&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">Služba IIS není na tomto počítači povolená. Pokud máte v úmyslu spouštět aplikace ASP.NET Core se službou IIS, je nutné před spuštěním tohoto instalačního programu nainstalovat službu IIS. Další informace najdete &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;tady&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Po dokončení instalace prosím restartujte službu IIS. Další informace najdete &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;tady&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">Služba IIS není na tomto počítači povolená. Pokud máte v úmyslu spouštět aplikace ASP.NET Core se službou IIS, je nutné před spuštěním tohoto instalačního programu nainstalovat službu IIS. Další informace najdete &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;tady&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1031/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1031/thm.wxl
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">S&amp;chließen</String>
   <String Id="SuccessRepairHeader">Die Reparatur wurde erfolgreich abgeschlossen.</String>
   <String Id="SuccessUninstallHeader">Die Deinstallation wurde erfolgreich abgeschlossen.</String>
-  <String Id="SuccessInstallHeader">Die Installation wurde erfolgreich abgeschlossen.</String> 
-  <String Id="SuccessHeader">Setup wurde erfolgreich abgeschlossen</String>	
+  <String Id="SuccessInstallHeader">Die Installation wurde erfolgreich abgeschlossen.</String>
+  <String Id="SuccessHeader">Setup wurde erfolgreich abgeschlossen</String>
   <String Id="SuccessLaunchButton">&amp;Starten</String>
   <String Id="SuccessRestartText">Sie müssen den Computer neu starten, bevor Sie die Software verwenden können.</String>
   <String Id="SuccessRestartButton">&amp;Neu starten</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">Setupfehler</String>
   <String Id="FailureInstallHeader">Setupfehler</String>
   <String Id="FailureUninstallHeader">Deinstallationsfehler</String>
-  <String Id="FailureRepairHeader">Reparaturfehler</String> 
+  <String Id="FailureRepairHeader">Reparaturfehler</String>
   <String Id="FailureHyperlinkLogText">Setup ist aufgrund eines oder mehrerer Probleme fehlgeschlagen. Beheben Sie die Probleme, und führen Sie das Setup erneut aus. Weitere Informationen finden Sie in der &lt;a href="#"&gt;Protokolldatei&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Sie müssen den Computer neu starten, um das Zurücksetzen der Software abzuschließen.</String>
   <String Id="FailureRestartButton">&amp;Neu starten</String>
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Willkommen beim Setup von [WixBundleName].</String>
-  <String Id="InstallResetIIS">Starten Sie IIS nach Abschluss der Installation neu. Zusätzliche Informationen finden Sie &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;hier&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">IIS ist auf diesem Computer nicht aktiviert. Wenn Sie ASP.NET Core-Anwendungen mit IIS ausführen möchten, müssen Sie IIS installieren, bevor Sie diesen Installer ausführen. Zusätzliche Informationen finden Sie &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;hier&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Starten Sie IIS nach Abschluss der Installation neu. Zusätzliche Informationen finden Sie &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;hier&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">IIS ist auf diesem Computer nicht aktiviert. Wenn Sie ASP.NET Core-Anwendungen mit IIS ausführen möchten, müssen Sie IIS installieren, bevor Sie diesen Installer ausführen. Zusätzliche Informationen finden Sie &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;hier&lt;/a&gt;.</String>
   <String Id="EulaPrivacy">&lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Lizenzbedingungen&lt;/a&gt; und &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;Datenschutzerklärung&lt;/a&gt; für [WixBundleName].</String>
-  <String Id="ModifyResetIIS">Starten Sie IIS nach Abschluss der Installation neu. Zusätzliche Informationen finden Sie &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;hier&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">IIS ist auf diesem Computer nicht aktiviert. Wenn Sie ASP.NET Core-Anwendungen mit IIS ausführen möchten, müssen Sie IIS installieren, bevor Sie diesen Installer ausführen. Zusätzliche Informationen finden Sie &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;hier&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Starten Sie IIS nach Abschluss der Installation neu. Zusätzliche Informationen finden Sie &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;hier&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">IIS ist auf diesem Computer nicht aktiviert. Wenn Sie ASP.NET Core-Anwendungen mit IIS ausführen möchten, müssen Sie IIS installieren, bevor Sie diesen Installer ausführen. Zusätzliche Informationen finden Sie &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;hier&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1033/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1033/thm.wxl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption">[WixBundleName] Setup</String>
   <String Id="Title">[BundleNameShort]</String>
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">&amp;Close</String>
   <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
   <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation Successfully Completed</String> 
-  <String Id="SuccessHeader">Setup Successful</String>	
+  <String Id="SuccessInstallHeader">Installation Successfully Completed</String>
+  <String Id="SuccessHeader">Setup Successful</String>
   <String Id="SuccessLaunchButton">&amp;Launch</String>
   <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
   <String Id="SuccessRestartButton">&amp;Restart</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">Setup Failed</String>
   <String Id="FailureInstallHeader">Setup Failed</String>
   <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String> 
+  <String Id="FailureRepairHeader">Repair Failed</String>
   <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
   <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
   <String Id="FailureRestartButton">&amp;Restart</String>
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Welcome to the [WixBundleName] Setup.</String>
-  <String Id="InstallResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
-  <String Id="ModifyResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1036/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1036/thm.wxl
@@ -12,7 +12,7 @@
   <String Id="HelpText">/install | /repair | /uninstall | /layout [répertoire] - installe, répare, désinstalle ou
    crée une copie locale complète du bundle dans le répertoire. Install est l'option par défaut.
 
-/passive | /quiet -  affiche une interface utilisateur minimale, sans invite, ou n'affiche 
+/passive | /quiet -  affiche une interface utilisateur minimale, sans invite, ou n'affiche
    ni interface utilisateur, ni invite. Par défaut, l'interface utilisateur et toutes les invites sont affichées.
 
 /norestart   - supprime toutes les tentatives de redémarrage. Par défaut, l'interface utilisateur affiche une invite avant le redémarrage.
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">&amp;Fermer</String>
   <String Id="SuccessRepairHeader">Réparation terminée avec succès</String>
   <String Id="SuccessUninstallHeader">Désinstallation terminée avec succès</String>
-  <String Id="SuccessInstallHeader">Installation terminée avec succès</String> 
-  <String Id="SuccessHeader">Installation/désinstallation réussie</String>	
+  <String Id="SuccessInstallHeader">Installation terminée avec succès</String>
+  <String Id="SuccessHeader">Installation/désinstallation réussie</String>
   <String Id="SuccessLaunchButton">&amp;Démarrer</String>
   <String Id="SuccessRestartText">Vous devez redémarrer votre ordinateur avant de pouvoir utiliser le logiciel.</String>
   <String Id="SuccessRestartButton">&amp;Redémarrer</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">Échec de l'installation</String>
   <String Id="FailureInstallHeader">Échec de l'installation</String>
   <String Id="FailureUninstallHeader">Échec de la désinstallation</String>
-  <String Id="FailureRepairHeader">Échec de la réparation</String> 
+  <String Id="FailureRepairHeader">Échec de la réparation</String>
   <String Id="FailureHyperlinkLogText">Un ou plusieurs problèmes sont à l'origine de l'échec de l'installation. Corrigez ces problèmes, puis recommencez l'installation. Pour plus d'informations, voir le &lt;a href="#"&gt;fichier journal&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Vous devez redémarrer votre ordinateur pour terminer l'opération de restauration du logiciel.</String>
   <String Id="FailureRestartButton">&amp;Redémarrer</String>
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Bienvenue dans le programme d'installation de [WixBundleName].</String>
-  <String Id="InstallResetIIS">Redémarrez IIS une fois l'installation effectuée. Des informations supplémentaires sont disponibles &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;ici&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">IIS n'est pas activé sur cet ordinateur. Si vous avez l'intention d'exécuter des applications ASP.NET Core avec IIS, vous devez installer IIS avant d'exécuter ce programme d'installation. Des informations supplémentaires sont disponibles &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;ici&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Redémarrez IIS une fois l'installation effectuée. Des informations supplémentaires sont disponibles &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;ici&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">IIS n'est pas activé sur cet ordinateur. Si vous avez l'intention d'exécuter des applications ASP.NET Core avec IIS, vous devez installer IIS avant d'exécuter ce programme d'installation. Des informations supplémentaires sont disponibles &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;ici&lt;/a&gt;.</String>
   <String Id="EulaPrivacy">&lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Termes du contrat de licence&lt;/a&gt; et &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;déclaration de confidentialité&lt;/a&gt; de [WixBundleName].</String>
-  <String Id="ModifyResetIIS">Redémarrez IIS une fois l'installation effectuée. Des informations supplémentaires sont disponibles &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;ici&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">IIS n'est pas activé sur cet ordinateur. Si vous avez l'intention d'exécuter des applications ASP.NET Core avec IIS, vous devez installer IIS avant d'exécuter ce programme d'installation. Des informations supplémentaires sont disponibles &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;ici&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Redémarrez IIS une fois l'installation effectuée. Des informations supplémentaires sont disponibles &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;ici&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">IIS n'est pas activé sur cet ordinateur. Si vous avez l'intention d'exécuter des applications ASP.NET Core avec IIS, vous devez installer IIS avant d'exécuter ce programme d'installation. Des informations supplémentaires sont disponibles &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;ici&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1040/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1040/thm.wxl
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">&amp;Chiudi</String>
   <String Id="SuccessRepairHeader">La riparazione è stata completata</String>
   <String Id="SuccessUninstallHeader">La disinstallazione è stata completata</String>
-  <String Id="SuccessInstallHeader">L'installazione è stata completata</String> 
-  <String Id="SuccessHeader">L'installazione è stata completata</String>	
+  <String Id="SuccessInstallHeader">L'installazione è stata completata</String>
+  <String Id="SuccessHeader">L'installazione è stata completata</String>
   <String Id="SuccessLaunchButton">&amp;Avvia</String>
   <String Id="SuccessRestartText">Per poter usare il software, è necessario riavviare il computer.</String>
   <String Id="SuccessRestartButton">&amp;Riavvia</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">L'installazione non è riuscita</String>
   <String Id="FailureInstallHeader">L'installazione non è riuscita</String>
   <String Id="FailureUninstallHeader">La disinstallazione non è riuscita</String>
-  <String Id="FailureRepairHeader">La riparazione non è riuscita</String> 
+  <String Id="FailureRepairHeader">La riparazione non è riuscita</String>
   <String Id="FailureHyperlinkLogText">L'installazione non è riuscita a causa di uno o più problemi. Risolvere i problemi e ripetere l'installazione. Per altre informazioni, vedere il &lt;a href="#"&gt;file di log&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Per completare il rollback del software, è necessario riavviare il computer.</String>
   <String Id="FailureRestartButton">&amp;Riavvia</String>
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Installazione di [WixBundleName].</String>
-  <String Id="InstallResetIIS">Riavviare IIS dopo il completamento dell'installazione. Per altre informazioni, vedere &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;qui&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">IIS non è abilitato in questo computer. Se si intende eseguire applicazioni ASP.NET Core con IIS, è necessario installare IIS prima di eseguire questo programma di installazione. Per altre informazioni, vedere &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;qui&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Riavviare IIS dopo il completamento dell'installazione. Per altre informazioni, vedere &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;qui&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">IIS non è abilitato in questo computer. Se si intende eseguire applicazioni ASP.NET Core con IIS, è necessario installare IIS prima di eseguire questo programma di installazione. Per altre informazioni, vedere &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;qui&lt;/a&gt;.</String>
   <String Id="EulaPrivacy">&lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Condizioni di licenza&lt;/a&gt; e &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;informativa sulla privacy&lt;/a&gt; di [WixBundleName].</String>
-  <String Id="ModifyResetIIS">Riavviare IIS dopo il completamento dell'installazione. Per altre informazioni, vedere &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;qui&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">IIS non è abilitato in questo computer. Se si intende eseguire applicazioni ASP.NET Core con IIS, è necessario installare IIS prima di eseguire questo programma di installazione. Per altre informazioni, vedere &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;qui&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Riavviare IIS dopo il completamento dell'installazione. Per altre informazioni, vedere &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;qui&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">IIS non è abilitato in questo computer. Se si intende eseguire applicazioni ASP.NET Core con IIS, è necessario installare IIS prima di eseguire questo programma di installazione. Per altre informazioni, vedere &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;qui&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1041/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1041/thm.wxl
@@ -39,8 +39,8 @@
   <String Id="ModifyCloseButton">閉じる(&amp;C)</String>
   <String Id="SuccessRepairHeader">修復が正常に完了しました</String>
   <String Id="SuccessUninstallHeader">アンインストールが正常に完了しました</String>
-  <String Id="SuccessInstallHeader">インストールが正常に完了しました</String> 
-  <String Id="SuccessHeader">セットアップ完了</String>	
+  <String Id="SuccessInstallHeader">インストールが正常に完了しました</String>
+  <String Id="SuccessHeader">セットアップ完了</String>
   <String Id="SuccessLaunchButton">起動(&amp;L)</String>
   <String Id="SuccessRestartText">ソフトウェアを使用する前にコンピューターを再起動する必要があります。</String>
   <String Id="SuccessRestartButton">再起動(&amp;R)</String>
@@ -48,7 +48,7 @@
   <String Id="FailureHeader">セットアップ失敗</String>
   <String Id="FailureInstallHeader">セットアップに失敗しました</String>
   <String Id="FailureUninstallHeader">アンインストールに失敗しました</String>
-  <String Id="FailureRepairHeader">修復に失敗しました</String> 
+  <String Id="FailureRepairHeader">修復に失敗しました</String>
   <String Id="FailureHyperlinkLogText">1 つまたは複数の問題により、セットアップが失敗しました。問題を解決してからセットアップを再試行してください。詳細については、&lt;a href="#"&gt;ログ ファイル&lt;/a&gt;を参照してください。</String>
   <String Id="FailureRestartText">ソフトウェアのロールバックを完了するには、コンピューターを再起動する必要があります。</String>
   <String Id="FailureRestartButton">再起動(&amp;R)</String>
@@ -62,9 +62,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">[WixBundleName] のセットアップへようこそ。</String>
-  <String Id="InstallResetIIS">インストールの完了後に IIS を再起動してください。追加情報については、&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;こちら&lt;/a&gt;を参照してください。</String>
-  <String Id="InstallNoIIS">このマシンでは IIS が有効になっていません。IIS を使用して ASP.NET Core アプリケーションを実行する場合は、このインストーラーを実行する前に IIS をインストールする必要があります。追加情報については、&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;こちら&lt;/a&gt;を参照してください。</String>
+  <String Id="InstallResetIIS">インストールの完了後に IIS を再起動してください。追加情報については、&lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;こちら&lt;/a&gt;を参照してください。</String>
+  <String Id="InstallNoIIS">このマシンでは IIS が有効になっていません。IIS を使用して ASP.NET Core アプリケーションを実行する場合は、このインストーラーを実行する前に IIS をインストールする必要があります。追加情報については、&lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;こちら&lt;/a&gt;を参照してください。</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;ライセンス条項&lt;/a&gt;および&lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;プライバシーに関する声明&lt;/a&gt;。</String>
-  <String Id="ModifyResetIIS">インストールの完了後に IIS を再起動してください。追加情報については、&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;こちら&lt;/a&gt;を参照してください。</String>
-  <String Id="ModifyNoIIS">このマシンでは IIS が有効になっていません。IIS を使用して ASP.NET Core アプリケーションを実行する場合は、このインストーラーを実行する前に IIS をインストールする必要があります。追加情報については、&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;こちら&lt;/a&gt;を参照してください。</String>
+  <String Id="ModifyResetIIS">インストールの完了後に IIS を再起動してください。追加情報については、&lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;こちら&lt;/a&gt;を参照してください。</String>
+  <String Id="ModifyNoIIS">このマシンでは IIS が有効になっていません。IIS を使用して ASP.NET Core アプリケーションを実行する場合は、このインストーラーを実行する前に IIS をインストールする必要があります。追加情報については、&lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;こちら&lt;/a&gt;を参照してください。</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1042/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1042/thm.wxl
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">닫기(&amp;C)</String>
   <String Id="SuccessRepairHeader">복구 완료됨</String>
   <String Id="SuccessUninstallHeader">제거 완료됨</String>
-  <String Id="SuccessInstallHeader">설치 완료됨</String> 
-  <String Id="SuccessHeader">설치 완료</String>	
+  <String Id="SuccessInstallHeader">설치 완료됨</String>
+  <String Id="SuccessHeader">설치 완료</String>
   <String Id="SuccessLaunchButton">시작(&amp;L)</String>
   <String Id="SuccessRestartText">소프트웨어를 사용하려면 먼저 컴퓨터를 다시 시작해야 합니다.</String>
   <String Id="SuccessRestartButton">다시 시작(&amp;R)</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">설치 실패</String>
   <String Id="FailureInstallHeader">설치 실패</String>
   <String Id="FailureUninstallHeader">제거 실패</String>
-  <String Id="FailureRepairHeader">복구 실패</String> 
+  <String Id="FailureRepairHeader">복구 실패</String>
   <String Id="FailureHyperlinkLogText">하나 이상의 문제가 발생하여 설치하지 못했습니다. 문제를 해결한 다음 설치를 다시 시도하십시오. 자세한 내용은 &lt;a href="#"&gt;로그 파일&lt;/a&gt;을 참조하십시오.</String>
   <String Id="FailureRestartText">소프트웨어 롤백을 완료하려면 컴퓨터를 다시 시작해야 합니다.</String>
   <String Id="FailureRestartButton">다시 시작(&amp;R)</String>
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">[WixBundleName] 설치를 시작합니다.</String>
-  <String Id="InstallResetIIS">설치가 완료된 후 IIS를 다시 시작하세요. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;여기&lt;/a&gt;에서 자세한 내용을 확인할 수 있습니다.</String>
-  <String Id="InstallNoIIS">이 머신에는 IIS가 사용하도록 설정되어 있지 않습니다. IIS에서 ASP.NET Core 애플리케이션을 실행하려면 이 설치 관리자를 실행하기 전에 IIS를 설치해야 합니다. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;여기&lt;/a&gt;에서 자세한 내용을 확인할 수 있습니다.</String>
+  <String Id="InstallResetIIS">설치가 완료된 후 IIS를 다시 시작하세요. &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;여기&lt;/a&gt;에서 자세한 내용을 확인할 수 있습니다.</String>
+  <String Id="InstallNoIIS">이 머신에는 IIS가 사용하도록 설정되어 있지 않습니다. IIS에서 ASP.NET Core 애플리케이션을 실행하려면 이 설치 관리자를 실행하기 전에 IIS를 설치해야 합니다. &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;여기&lt;/a&gt;에서 자세한 내용을 확인할 수 있습니다.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;사용 조건&lt;/a&gt; 및 &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;개인정보처리방침&lt;/a&gt;.</String>
-  <String Id="ModifyResetIIS">설치가 완료된 후 IIS를 다시 시작하세요. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;여기&lt;/a&gt;에서 자세한 내용을 확인할 수 있습니다.</String>
-  <String Id="ModifyNoIIS">이 머신에는 IIS가 사용하도록 설정되어 있지 않습니다. IIS에서 ASP.NET Core 애플리케이션을 실행하려면 이 설치 관리자를 실행하기 전에 IIS를 설치해야 합니다. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;여기&lt;/a&gt;에서 자세한 내용을 확인할 수 있습니다.</String>
+  <String Id="ModifyResetIIS">설치가 완료된 후 IIS를 다시 시작하세요. &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;여기&lt;/a&gt;에서 자세한 내용을 확인할 수 있습니다.</String>
+  <String Id="ModifyNoIIS">이 머신에는 IIS가 사용하도록 설정되어 있지 않습니다. IIS에서 ASP.NET Core 애플리케이션을 실행하려면 이 설치 관리자를 실행하기 전에 IIS를 설치해야 합니다. &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;여기&lt;/a&gt;에서 자세한 내용을 확인할 수 있습니다.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1045/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1045/thm.wxl
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">&amp;Zamknij</String>
   <String Id="SuccessRepairHeader">Pomyślnie ukończono naprawę</String>
   <String Id="SuccessUninstallHeader">Pomyślnie ukończono dezinstalację</String>
-  <String Id="SuccessInstallHeader">Pomyślnie ukończono instalację</String> 
-  <String Id="SuccessHeader">Pomyślnie ukończono instalację</String>	
+  <String Id="SuccessInstallHeader">Pomyślnie ukończono instalację</String>
+  <String Id="SuccessHeader">Pomyślnie ukończono instalację</String>
   <String Id="SuccessLaunchButton">&amp;Uruchom</String>
   <String Id="SuccessRestartText">Aby móc korzystać z oprogramowania, musisz uruchomić ponownie komputer.</String>
   <String Id="SuccessRestartButton">&amp;Uruchom ponownie</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">Instalacja nie powiodła się</String>
   <String Id="FailureInstallHeader">Instalacja nie powiodła się</String>
   <String Id="FailureUninstallHeader">Dezinstalacja nie powiodła się</String>
-  <String Id="FailureRepairHeader">Naprawa nie powiodła się</String> 
+  <String Id="FailureRepairHeader">Naprawa nie powiodła się</String>
   <String Id="FailureHyperlinkLogText">Co najmniej jeden problem spowodował niepowodzenie instalacji. Rozwiąż problemy, a następnie ponów próbę instalacji. Aby uzyskać więcej informacji, zobacz &lt;a href="#"&gt;plik dziennika&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Aby ukończyć wycofywanie oprogramowania, musisz uruchomić ponownie komputer.</String>
   <String Id="FailureRestartButton">&amp;Uruchom ponownie</String>
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Witamy w instalatorze produktu [WixBundleName].</String>
-  <String Id="InstallResetIIS">Po zakończeniu instalacji uruchom ponownie usługi IIS. Dodatkowe informacje znajdziesz &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;tutaj&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">Usługi IIS nie są włączone na tej maszynie. Jeśli zamierzasz uruchamiać aplikacje platformy ASP.NET Core za pomocą usług IIS, musisz zainstalować usługi IIS przed uruchomieniem tego instalatora. Dodatkowe informacje znajdziesz &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;tutaj&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Po zakończeniu instalacji uruchom ponownie usługi IIS. Dodatkowe informacje znajdziesz &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;tutaj&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">Usługi IIS nie są włączone na tej maszynie. Jeśli zamierzasz uruchamiać aplikacje platformy ASP.NET Core za pomocą usług IIS, musisz zainstalować usługi IIS przed uruchomieniem tego instalatora. Dodatkowe informacje znajdziesz &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;tutaj&lt;/a&gt;.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;postanowienia licencyjne&lt;/a&gt; i &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;oświadczenie o ochronie prywatności&lt;/a&gt;.</String>
-  <String Id="ModifyResetIIS">Po zakończeniu instalacji uruchom ponownie usługi IIS. Dodatkowe informacje znajdziesz &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;tutaj&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">Usługi IIS nie są włączone na tej maszynie. Jeśli zamierzasz uruchamiać aplikacje platformy ASP.NET Core za pomocą usług IIS, musisz zainstalować usługi IIS przed uruchomieniem tego instalatora. Dodatkowe informacje znajdziesz &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;tutaj&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Po zakończeniu instalacji uruchom ponownie usługi IIS. Dodatkowe informacje znajdziesz &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;tutaj&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">Usługi IIS nie są włączone na tej maszynie. Jeśli zamierzasz uruchamiać aplikacje platformy ASP.NET Core za pomocą usług IIS, musisz zainstalować usługi IIS przed uruchomieniem tego instalatora. Dodatkowe informacje znajdziesz &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;tutaj&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1046/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1046/thm.wxl
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">&amp;Fechar</String>
   <String Id="SuccessRepairHeader">Reparação Concluída com Êxito</String>
   <String Id="SuccessUninstallHeader">Desinstalação Concluída com Êxito</String>
-  <String Id="SuccessInstallHeader">Instalação Concluída com Êxito</String> 
-  <String Id="SuccessHeader">Instalação com Êxito</String>	
+  <String Id="SuccessInstallHeader">Instalação Concluída com Êxito</String>
+  <String Id="SuccessHeader">Instalação com Êxito</String>
   <String Id="SuccessLaunchButton">&amp;Iniciar</String>
   <String Id="SuccessRestartText">Você deve reiniciar seu computador antes de usar o software.</String>
   <String Id="SuccessRestartButton">&amp;Reiniciar</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">Falha na Instalação</String>
   <String Id="FailureInstallHeader">Falha na Instalação</String>
   <String Id="FailureUninstallHeader">Falha na Desinstalação</String>
-  <String Id="FailureRepairHeader">Falha na Reparação</String> 
+  <String Id="FailureRepairHeader">Falha na Reparação</String>
   <String Id="FailureHyperlinkLogText">Um ou mais problemas causaram falha na instalação. Corrija-os e tente instalar novamente. Para obter mais informações, consulte o &lt;a href="#"&gt;arquivo de log&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Você deve reiniciar seu computador para concluir a reversão do software.</String>
   <String Id="FailureRestartButton">&amp;Reiniciar</String>
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Bem-vindo à Instalação do [WixBundleName].</String>
-  <String Id="InstallResetIIS">Reinicie o IIS após a conclusão da instalação. Você pode encontrar informações adicionais &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aqui&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">O IIS não está habilitado neste computador. Se pretende executar aplicativos ASP.NET Core com o IIS, você deve instalar o IIS antes de executar este instalador. Você pode encontrar informações adicionais &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aqui&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Reinicie o IIS após a conclusão da instalação. Você pode encontrar informações adicionais &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;aqui&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">O IIS não está habilitado neste computador. Se pretende executar aplicativos ASP.NET Core com o IIS, você deve instalar o IIS antes de executar este instalador. Você pode encontrar informações adicionais &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;aqui&lt;/a&gt;.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;termos de licença&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;política de privacidade&lt;/a&gt;.</String>
-  <String Id="ModifyResetIIS">Reinicie o IIS após a conclusão da instalação. Você pode encontrar informações adicionais &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aqui&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">O IIS não está habilitado neste computador. Se pretende executar aplicativos ASP.NET Core com o IIS, você deve instalar o IIS antes de executar este instalador. Você pode encontrar informações adicionais &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aqui&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Reinicie o IIS após a conclusão da instalação. Você pode encontrar informações adicionais &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;aqui&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">O IIS não está habilitado neste computador. Se pretende executar aplicativos ASP.NET Core com o IIS, você deve instalar o IIS antes de executar este instalador. Você pode encontrar informações adicionais &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;aqui&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1049/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1049/thm.wxl
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">&amp;Закрыть</String>
   <String Id="SuccessRepairHeader">Восстановление успешно завершено</String>
   <String Id="SuccessUninstallHeader">Удаление успешно завершено</String>
-  <String Id="SuccessInstallHeader">Установка успешно завершена</String> 
-  <String Id="SuccessHeader">Установка успешно завершена</String>	
+  <String Id="SuccessInstallHeader">Установка успешно завершена</String>
+  <String Id="SuccessHeader">Установка успешно завершена</String>
   <String Id="SuccessLaunchButton">&amp;Запустить</String>
   <String Id="SuccessRestartText">Перед использованием программного обеспечения необходимо перезапустить компьютер.</String>
   <String Id="SuccessRestartButton">&amp;Перезапустить</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">Настройка не завершена</String>
   <String Id="FailureInstallHeader">Сбой установки</String>
   <String Id="FailureUninstallHeader">Сбой удаления</String>
-  <String Id="FailureRepairHeader">Сбой восстановления</String> 
+  <String Id="FailureRepairHeader">Сбой восстановления</String>
   <String Id="FailureHyperlinkLogText">Одна или несколько проблем вызывали сбой программы установки. Исправьте эти проблемы и попробуйте повторить установку. Дополнительные сведения см. в &lt;a href="#"&gt;файле журнала&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Необходимо перезагрузить компьютер, чтобы завершить откат программного обеспечения.</String>
   <String Id="FailureRestartButton">&amp;Перезапустить</String>
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Вас приветствует мастер установки [WixBundleName].</String>
-  <String Id="InstallResetIIS">Перезапустите службы IIS после завершения установки. Дополнительные сведения см. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;здесь&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">Службы IIS не включены на этом компьютере. Если вы планируете запускать приложения ASP.NET Core с IIS, перед запуском этого установщика необходимо установить службы IIS. Дополнительные сведения см. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;здесь&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Перезапустите службы IIS после завершения установки. Дополнительные сведения см. &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;здесь&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">Службы IIS не включены на этом компьютере. Если вы планируете запускать приложения ASP.NET Core с IIS, перед запуском этого установщика необходимо установить службы IIS. Дополнительные сведения см. &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;здесь&lt;/a&gt;.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;условия лицензии&lt;/a&gt; и &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;заявление о конфиденциальности&lt;/a&gt;.</String>
-  <String Id="ModifyResetIIS">Перезапустите службы IIS после завершения установки. Дополнительные сведения см. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;здесь&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">Службы IIS не включены на этом компьютере. Если вы планируете запускать приложения ASP.NET Core с IIS, перед запуском этого установщика необходимо установить службы IIS. Дополнительные сведения см. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;здесь&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Перезапустите службы IIS после завершения установки. Дополнительные сведения см. &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;здесь&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">Службы IIS не включены на этом компьютере. Если вы планируете запускать приложения ASP.NET Core с IIS, перед запуском этого установщика необходимо установить службы IIS. Дополнительные сведения см. &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;здесь&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1055/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1055/thm.wxl
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">&amp;Kapat</String>
   <String Id="SuccessRepairHeader">Onarım Başarıyla Tamamlandı</String>
   <String Id="SuccessUninstallHeader">Kaldırma Başarıyla Tamamlandı</String>
-  <String Id="SuccessInstallHeader">Yükleme Başarıyla Tamamlandı</String> 
-  <String Id="SuccessHeader">Kurulum Başarılı</String>	
+  <String Id="SuccessInstallHeader">Yükleme Başarıyla Tamamlandı</String>
+  <String Id="SuccessHeader">Kurulum Başarılı</String>
   <String Id="SuccessLaunchButton">&amp;Başlat</String>
   <String Id="SuccessRestartText">Yazılımı kullanabilmek için bilgisayarınızı yeniden başlatmanız gerekiyor.</String>
   <String Id="SuccessRestartButton">Yeniden &amp;Başlat</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">Kurulum Başarısız</String>
   <String Id="FailureInstallHeader">Kurulum Başarısız</String>
   <String Id="FailureUninstallHeader">Yükleme Başarısız</String>
-  <String Id="FailureRepairHeader">Onarım Başarısız</String> 
+  <String Id="FailureRepairHeader">Onarım Başarısız</String>
   <String Id="FailureHyperlinkLogText">En az bir sorun nedeniyle kurulum başarısız oldu. Lütfen bu sorunları düzeltin ve kurulumu yeniden deneyin. Daha fazla bilgi için &lt;a href="#"&gt;günlük dosyasına&lt;/a&gt; bakın.</String>
   <String Id="FailureRestartText">Yazılımın geri alınmasını tamamlamak için bilgisayarınızı yeniden başlatmanız gerekiyor.</String>
   <String Id="FailureRestartButton">Yeniden &amp;Başlat</String>
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">[WixBundleName] Kurulumu'na Hoş Geldiniz.</String>
-  <String Id="InstallResetIIS">Yükleme tamamlandıktan sonra lütfen IIS'yi yeniden başlatın. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;Buradan&lt;/a&gt; daha fazla bilgi bulabilirsiniz.</String>
-  <String Id="InstallNoIIS">IIS bu makinede etkin değil. ASP.NET Core uygulamalarını IIS ile çalıştırmak istiyorsanız, bu yükleyiciyi çalıştırmadan önce IIS'yi yüklemeniz gerekir. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;Buradan&lt;/a&gt; daha fazla bilgi bulabilirsiniz.</String>
+  <String Id="InstallResetIIS">Yükleme tamamlandıktan sonra lütfen IIS'yi yeniden başlatın. &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;Buradan&lt;/a&gt; daha fazla bilgi bulabilirsiniz.</String>
+  <String Id="InstallNoIIS">IIS bu makinede etkin değil. ASP.NET Core uygulamalarını IIS ile çalıştırmak istiyorsanız, bu yükleyiciyi çalıştırmadan önce IIS'yi yüklemeniz gerekir. &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;Buradan&lt;/a&gt; daha fazla bilgi bulabilirsiniz.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;lisans koşulları&lt;/a&gt; ve &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;gizlilik bildirimi&lt;/a&gt;.</String>
-  <String Id="ModifyResetIIS">Yükleme tamamlandıktan sonra lütfen IIS'yi yeniden başlatın. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;Buradan&lt;/a&gt; daha fazla bilgi bulabilirsiniz.</String>
-  <String Id="ModifyNoIIS">IIS bu makinede etkin değil. ASP.NET Core uygulamalarını IIS ile çalıştırmak istiyorsanız, bu yükleyiciyi çalıştırmadan önce IIS'yi yüklemeniz gerekir. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;Buradan&lt;/a&gt; daha fazla bilgi bulabilirsiniz.</String>
+  <String Id="ModifyResetIIS">Yükleme tamamlandıktan sonra lütfen IIS'yi yeniden başlatın. &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;Buradan&lt;/a&gt; daha fazla bilgi bulabilirsiniz.</String>
+  <String Id="ModifyNoIIS">IIS bu makinede etkin değil. ASP.NET Core uygulamalarını IIS ile çalıştırmak istiyorsanız, bu yükleyiciyi çalıştırmadan önce IIS'yi yüklemeniz gerekir. &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;Buradan&lt;/a&gt; daha fazla bilgi bulabilirsiniz.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/2052/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/2052/thm.wxl
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">关闭(&amp;C)</String>
   <String Id="SuccessRepairHeader">成功完成了修复</String>
   <String Id="SuccessUninstallHeader">成功完成了卸载</String>
-  <String Id="SuccessInstallHeader">成功完成了安装</String> 
-  <String Id="SuccessHeader">设置成功</String>	
+  <String Id="SuccessInstallHeader">成功完成了安装</String>
+  <String Id="SuccessHeader">设置成功</String>
   <String Id="SuccessLaunchButton">启动(&amp;L)</String>
   <String Id="SuccessRestartText">在使用此软件之前，您必须重新启动计算机。</String>
   <String Id="SuccessRestartButton">重新启动(&amp;R)</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">设置失败</String>
   <String Id="FailureInstallHeader">安装失败</String>
   <String Id="FailureUninstallHeader">卸载失败</String>
-  <String Id="FailureRepairHeader">修复失败</String> 
+  <String Id="FailureRepairHeader">修复失败</String>
   <String Id="FailureHyperlinkLogText">一个或多个问题导致了安装失败。请修复这些问题，然后重试安装。有关详细信息，请参阅&lt;a href="#"&gt;日志文件&lt;/a&gt;。</String>
   <String Id="FailureRestartText">必须重新启动计算机才能完成软件回退。</String>
   <String Id="FailureRestartButton">重新启动(&amp;R)</String>
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">欢迎使用 [WixBundleName] 安装程序。</String>
-  <String Id="InstallResetIIS">请在安装完成后重启 IIS。可在&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;此处&lt;/a&gt;找到其他信息。</String>
-  <String Id="InstallNoIIS">此计算机上未启用 IIS。如果打算通过 IIS 运行 ASP.NET Core 应用程序，必须先安装 IIS，然后再运行此安装程序。可在&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;此处&lt;/a&gt;找到其他信息。</String>
+  <String Id="InstallResetIIS">请在安装完成后重启 IIS。可在&lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;此处&lt;/a&gt;找到其他信息。</String>
+  <String Id="InstallNoIIS">此计算机上未启用 IIS。如果打算通过 IIS 运行 ASP.NET Core 应用程序，必须先安装 IIS，然后再运行此安装程序。可在&lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;此处&lt;/a&gt;找到其他信息。</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;许可条件&lt;/a&gt;和&lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;隐私声明&lt;/a&gt;。</String>
-  <String Id="ModifyResetIIS">请在安装完成后重启 IIS。可在&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;此处&lt;/a&gt;找到其他信息。</String>
-  <String Id="ModifyNoIIS">此计算机上未启用 IIS。如果打算通过 IIS 运行 ASP.NET Core 应用程序，必须先安装 IIS，然后再运行此安装程序。可在&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;此处&lt;/a&gt;找到其他信息。</String>
+  <String Id="ModifyResetIIS">请在安装完成后重启 IIS。可在&lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;此处&lt;/a&gt;找到其他信息。</String>
+  <String Id="ModifyNoIIS">此计算机上未启用 IIS。如果打算通过 IIS 运行 ASP.NET Core 应用程序，必须先安装 IIS，然后再运行此安装程序。可在&lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;此处&lt;/a&gt;找到其他信息。</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/3082/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/3082/thm.wxl
@@ -12,7 +12,7 @@
   <String Id="HelpText">/install | /repair | /uninstall | /layout [directory] - instala, repara, desinstala o
    crea una copia local completa del paquete en el directorio. Install es la opción predeterminada.
 
-/passive | /quiet -  muestra una IU mínima sin peticiones, o bien no muestra la IU 
+/passive | /quiet -  muestra una IU mínima sin peticiones, o bien no muestra la IU
   ni las peticiones. De forma predeterminada, se muestran la IU y todas las peticiones.
 
 /norestart   - suprime los intentos de reiniciar. De forma predeterminada, la IU preguntará antes de reiniciar.
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">&amp;Cerrar</String>
   <String Id="SuccessRepairHeader">La reparación se completó correctamente</String>
   <String Id="SuccessUninstallHeader">La desinstalación se completó correctamente</String>
-  <String Id="SuccessInstallHeader">La instalación se completó correctamente</String> 
-  <String Id="SuccessHeader">La instalación o desinstalación se realizó correctamente</String>	
+  <String Id="SuccessInstallHeader">La instalación se completó correctamente</String>
+  <String Id="SuccessHeader">La instalación o desinstalación se realizó correctamente</String>
   <String Id="SuccessLaunchButton">&amp;Iniciar</String>
   <String Id="SuccessRestartText">Debe reiniciar el equipo para poder usar el software.</String>
   <String Id="SuccessRestartButton">&amp;Reiniciar</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">Error de instalación</String>
   <String Id="FailureInstallHeader">No se pudo instalar</String>
   <String Id="FailureUninstallHeader">No se pudo desinstalar</String>
-  <String Id="FailureRepairHeader">No se pudo reparar</String> 
+  <String Id="FailureRepairHeader">No se pudo reparar</String>
   <String Id="FailureHyperlinkLogText">Error de instalación debido a uno o varios problemas. Corrija los problemas e intente de nuevo la instalación. Para obtener más información, consulte el &lt;a href="#"&gt;archivo de registro&lt;/a&gt;.</String>
   <String Id="FailureRestartText">Debe reiniciar el equipo para completar la reversión del software.</String>
   <String Id="FailureRestartButton">&amp;Reiniciar</String>
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Programa de instalación de [WixBundleName].</String>
-  <String Id="InstallResetIIS">Reinicie IIS una vez completada la instalación. Puede encontrar información adicional &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aquí&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">IIS no está habilitado en esta máquina. Si tiene previsto ejecutar aplicaciones ASP.NET Core con IIS, debe instalar IIS antes de ejecutar este instalador. Puede encontrar información adicional &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aquí&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Reinicie IIS una vez completada la instalación. Puede encontrar información adicional &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;aquí&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">IIS no está habilitado en esta máquina. Si tiene previsto ejecutar aplicaciones ASP.NET Core con IIS, debe instalar IIS antes de ejecutar este instalador. Puede encontrar información adicional &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;aquí&lt;/a&gt;.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Términos de licencia&lt;/a&gt; y &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;declaración de privacidad&lt;/a&gt;.</String>
-  <String Id="ModifyResetIIS">Reinicie IIS una vez completada la instalación. Puede encontrar información adicional &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aquí&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">IIS no está habilitado en esta máquina. Si tiene previsto ejecutar aplicaciones ASP.NET Core con IIS, debe instalar IIS antes de ejecutar este instalador. Puede encontrar información adicional &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aquí&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Reinicie IIS una vez completada la instalación. Puede encontrar información adicional &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;aquí&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">IIS no está habilitado en esta máquina. Si tiene previsto ejecutar aplicaciones ASP.NET Core con IIS, debe instalar IIS antes de ejecutar este instalador. Puede encontrar información adicional &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;aquí&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/thm.wxl
@@ -38,8 +38,8 @@
   <String Id="ModifyCloseButton">&amp;Close</String>
   <String Id="SuccessRepairHeader">Repair Successfully Completed</String>
   <String Id="SuccessUninstallHeader">Uninstall Successfully Completed</String>
-  <String Id="SuccessInstallHeader">Installation Successfully Completed</String> 
-  <String Id="SuccessHeader">Setup Successful</String>	
+  <String Id="SuccessInstallHeader">Installation Successfully Completed</String>
+  <String Id="SuccessHeader">Setup Successful</String>
   <String Id="SuccessLaunchButton">&amp;Launch</String>
   <String Id="SuccessRestartText">You must restart your computer before you can use the software.</String>
   <String Id="SuccessRestartButton">&amp;Restart</String>
@@ -47,7 +47,7 @@
   <String Id="FailureHeader">Setup Failed</String>
   <String Id="FailureInstallHeader">Setup Failed</String>
   <String Id="FailureUninstallHeader">Uninstall Failed</String>
-  <String Id="FailureRepairHeader">Repair Failed</String> 
+  <String Id="FailureRepairHeader">Repair Failed</String>
   <String Id="FailureHyperlinkLogText">One or more issues caused the setup to fail. Please fix the issues and then retry setup. For more information see the &lt;a href="#"&gt;log file&lt;/a&gt;.</String>
   <String Id="FailureRestartText">You must restart your computer to complete the rollback of the software.</String>
   <String Id="FailureRestartButton">&amp;Restart</String>
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Welcome to the [WixBundleName] Setup.</String>
-  <String Id="InstallResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
-  <String Id="ModifyResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://aka.ms/aspnet/6.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
 </WixLocalization>


### PR DESCRIPTION
# [release/6.0] Use non-localized 6.0.x links in installer

Update error messages in the Windows Hosting Bundle to use non-localized 6.0.x links for IIS information.

Fixes #44615 for 6.0.x and contributes to fixing #44613. Note the subject of the first issue is incorrect; users land on a 7.0.x IIS information page currently.

## Description

Without this, localized installer messages link to English (`en-us`) and **7.0.x** information about IIS. New locale-independent link will redirect to the correct 6.0.x localized page based on browser / OS settings.

## Customer impact

Landing on https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/?view=aspnetcore-6.0 instead of (for me) https://learn.microsoft.com/en-ca/aspnet/core/host-and-deploy/iis/?view=aspnetcore-6.0 is, at best, an annoyance. This part at least violates our localization tenets.

For this branch however, the problem is worse. The `fwlink`s we're replacing in this PR link to the `?view=aspnetcore-7.0` page, potentially providing 7.0.x-specific information when hitting problems installing the 6.0.x Windows Hosting Bundle.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

We created new aka.ms links going to the unlocalized URIs that are specific to the correct information pages (per ASP.NET Core version). Other than using those links in our error message strings, nothing is changing in this PR.

## Verification

- [x] Manual (required)
- [ ] Automated

We don't have automated tests of the installers and don't follow URIs found in error messages. CTI however tests this area and found the problems linked above. I manually confirmed the new aka.ms links go where we hoped.

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A