### PR TITLE
Fix Http3ConnectionEmptyBenchmark

### DIFF
--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http3/Http3ConnectionBenchmarkBase.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http3/Http3ConnectionBenchmarkBase.cs
@@ -72,6 +72,8 @@ public abstract class Http3ConnectionBenchmarkBase
 
         var stream = await _http3.CreateRequestStream(_requestHeadersEnumerator, _headerHandler);
 
+        _requestHeadersEnumerator.Initialize(_httpRequestHeaders);
+
         await stream.SendHeadersAsync(_requestHeadersEnumerator);
 
         while (true)

--- a/src/Servers/Kestrel/perf/Microbenchmarks/Http3/Http3ConnectionBenchmarkBase.cs
+++ b/src/Servers/Kestrel/perf/Microbenchmarks/Http3/Http3ConnectionBenchmarkBase.cs
@@ -72,10 +72,6 @@ public abstract class Http3ConnectionBenchmarkBase
 
         var stream = await _http3.CreateRequestStream(_requestHeadersEnumerator, _headerHandler);
 
-        _requestHeadersEnumerator.Initialize(_httpRequestHeaders);
-
-        await stream.SendHeadersAsync(_requestHeadersEnumerator);
-
         while (true)
         {
             var frame = await stream.ReceiveFrameAsync(allowEnd: true, frame: _httpFrame);


### PR DESCRIPTION
It was reusing an enumerator that had already been enumerated.  The enumerator doesn't support Reset, so this change just reinitializes it.