### PR TITLE
[release/2.1] Use non-localized 2.1.x links in installer

### DIFF
--- a/src/Installers/Windows/WindowsHostingBundle/thm.xml
+++ b/src/Installers/Windows/WindowsHostingBundle/thm.xml
@@ -18,8 +18,8 @@
     </Page>
     <Page Name="Install">
         <Hypertext X="11" Y="90" Width="-11" Height="15" FontId="3">Welcome to the #(loc.Caption).</Hypertext>
-        <Hypertext X="11" Y="119" Width="-11" Height="45" FontId="3" Name="InstallResetIIS" HideWhenDisabled="yes">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</Hypertext>
-        <Hypertext X="11" Y="119" Width="-11" Height="45" FontId="3" Name="InstallNoIIS" HideWhenDisabled="yes">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</Hypertext>
+        <Hypertext X="11" Y="119" Width="-11" Height="45" FontId="3" Name="InstallResetIIS" HideWhenDisabled="yes">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://aka.ms/aspnet/2.1/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</Hypertext>
+        <Hypertext X="11" Y="119" Width="-11" Height="45" FontId="3" Name="InstallNoIIS" HideWhenDisabled="yes">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://aka.ms/aspnet/2.1/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</Hypertext>
         <Hypertext Name="EulaAndPrivacyHyperlink" X="11" Y="178" Width="-11" Height="51" TabStop="yes" FontId="3" HideWhenDisabled="yes">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=320539"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</Hypertext>
         <Checkbox Name="EulaAcceptCheckbox" X="-11" Y="-41" Width="260" Height="17" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.InstallAcceptCheckbox)</Checkbox>
         <Button Name="OptionsButton" X="-171" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.InstallOptionsButton)</Button>
@@ -54,8 +54,8 @@
     </Page>
     <Page Name="Modify">
         <Text X="11" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ModifyHeader)</Text>
-        <Hypertext X="11" Y="121" Width="-11" Height="45" FontId="3" Name="ModifyResetIIS" HideWhenDisabled="yes">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</Hypertext>
-        <Hypertext X="11" Y="121" Width="-11" Height="45" FontId="3" Name="ModifyNoIIS" HideWhenDisabled="yes">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</Hypertext>
+        <Hypertext X="11" Y="121" Width="-11" Height="45" FontId="3" Name="ModifyResetIIS" HideWhenDisabled="yes">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://aka.ms/aspnet/2.1/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</Hypertext>
+        <Hypertext X="11" Y="121" Width="-11" Height="45" FontId="3" Name="ModifyNoIIS" HideWhenDisabled="yes">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://aka.ms/aspnet/2.1/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</Hypertext>
         <Button Name="RepairButton" X="-171" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.ModifyRepairButton)</Button>
         <Button Name="UninstallButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ModifyUninstallButton)</Button>
         <Button Name="ModifyCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ModifyCloseButton)</Button>
@@ -63,8 +63,8 @@
     <Page Name="Success">
         <Text Name="SuccessHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessHeader)</Text>
         <Text Name="SuccessInstallHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessInstallHeader)</Text>
-        <Text Name="SuccessRepairHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRepairHeader)</Text> 	
-        <Text Name="SuccessUninstallHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessUninstallHeader)</Text> 
+        <Text Name="SuccessRepairHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRepairHeader)</Text>
+        <Text Name="SuccessUninstallHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessUninstallHeader)</Text>
         <Button Name="LaunchButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessLaunchButton)</Button>
         <Text Name="SuccessRestartText" X="-11" Y="-51" Width="400" Height="34" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRestartText)</Text>
         <Button Name="SuccessRestartButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessRestartButton)</Button>
@@ -74,7 +74,7 @@
         <Text Name="FailureHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureHeader)</Text>
         <Text Name="FailureInstallHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureInstallHeader)</Text>
         <Text Name="FailureUninstallHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureUninstallHeader)</Text>
-        <Text Name="FailureRepairHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureRepairHeader)</Text>	
+        <Text Name="FailureRepairHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureRepairHeader)</Text>
         <Hypertext Name="FailureLogFileLink" X="11" Y="121" Width="-11" Height="42" FontId="3" TabStop="yes" HideWhenDisabled="yes">#(loc.FailureHyperlinkLogText)</Hypertext>
         <Hypertext Name="FailureMessageText" X="22" Y="163" Width="-11" Height="51" FontId="3" TabStop="yes" HideWhenDisabled="yes" />
         <Text Name="FailureRestartText" X="-11" Y="-51" Width="400" Height="34" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureRestartText)</Text>


### PR DESCRIPTION
# [release/2.1] Use non-localized 2.1.x links in installer

Update error messages in the Windows Hosting Bundle to use non-localized 6.0.x links for IIS information.

Fixes #44615 for 2.1.x and contributes to fixing #44613. Note the subject of the first issue is incorrect; users land on a 7.0.x IIS information page currently.

## Description

Without this, localized installer messages link to English (`en-us`) and **7.0.x** information about IIS. New locale-independent link will redirect to the correct 2.1.x localized page based on browser / OS settings.

## Customer impact

Landing on https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/?view=aspnetcore-2.1 instead of (for me) https://learn.microsoft.com/en-ca/aspnet/core/host-and-deploy/iis/?view=aspnetcore-2.1 is, at best, an annoyance. This part may violate our localization tenets. However, it's less visible for 2.1.x than later releases because the Windows Hosting Bundle installer itself is not localized in this branch.

For this branch however, the problem is worse. The `fwlink`s we're replacing in this PR link to the `?view=aspnetcore-7.0` page, potentially providing 7.0.x-specific information when hitting problems installing the 2.1.x Windows Hosting Bundle.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

We created new aka.ms links going to the unlocalized URIs that are specific to the correct information pages (per ASP.NET Core version). Other than using those links in our error message strings, nothing is changing in this PR.

## Verification

- [x] Manual (required)
- [ ] Automated

We don't have automated tests of the installers and don't follow URIs found in error messages. CTI however tests this area and found the problems linked above. I manually confirmed the new aka.ms links go where we hoped.

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A