### PR TITLE
[main] Use non-localized 8.0.x links in installer

### DIFF
--- a/src/Installers/Windows/WindowsHostingBundle/1028/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1028/thm.wxl
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">歡迎使用 [WixBundleName] 安裝程式。</String>
-  <String Id="InstallResetIIS">請在安裝完成後重新啟動 IIS。如需其他資訊，請參閱&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;這裡&lt;/a&gt;。</String>
-  <String Id="InstallNoIIS">這部電腦上未啟用 IIS。如果您要使用 IIS 執行 ASP.NET Core 應用程式，就必須先安裝 IIS 才能執行此安裝程式。如需其他資訊，請參閱&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;這裡&lt;/a&gt;。</String>
+  <String Id="InstallResetIIS">請在安裝完成後重新啟動 IIS。如需其他資訊，請參閱&lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;這裡&lt;/a&gt;。</String>
+  <String Id="InstallNoIIS">這部電腦上未啟用 IIS。如果您要使用 IIS 執行 ASP.NET Core 應用程式，就必須先安裝 IIS 才能執行此安裝程式。如需其他資訊，請參閱&lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;這裡&lt;/a&gt;。</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;授權條款&lt;/a&gt;和&lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;隱私權聲明&lt;/a&gt;。</String>
-  <String Id="ModifyResetIIS">請在安裝完成後重新啟動 IIS。如需其他資訊，請參閱&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;這裡&lt;/a&gt;。</String>
-  <String Id="ModifyNoIIS">這部電腦上未啟用 IIS。如果您要使用 IIS 執行 ASP.NET Core 應用程式，就必須先安裝 IIS 才能執行此安裝程式。如需其他資訊，請參閱&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;這裡&lt;/a&gt;。</String>
+  <String Id="ModifyResetIIS">請在安裝完成後重新啟動 IIS。如需其他資訊，請參閱&lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;這裡&lt;/a&gt;。</String>
+  <String Id="ModifyNoIIS">這部電腦上未啟用 IIS。如果您要使用 IIS 執行 ASP.NET Core 應用程式，就必須先安裝 IIS 才能執行此安裝程式。如需其他資訊，請參閱&lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;這裡&lt;/a&gt;。</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1029/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1029/thm.wxl
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Vítá vás instalační program produktu [WixBundleName]</String>
-  <String Id="InstallResetIIS">Po dokončení instalace prosím restartujte službu IIS. Další informace najdete &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;tady&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">Služba IIS není na tomto počítači povolená. Pokud máte v úmyslu spouštět aplikace ASP.NET Core se službou IIS, je nutné před spuštěním tohoto instalačního programu nainstalovat službu IIS. Další informace najdete &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;tady&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Po dokončení instalace prosím restartujte službu IIS. Další informace najdete &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;tady&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">Služba IIS není na tomto počítači povolená. Pokud máte v úmyslu spouštět aplikace ASP.NET Core se službou IIS, je nutné před spuštěním tohoto instalačního programu nainstalovat službu IIS. Další informace najdete &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;tady&lt;/a&gt;.</String>
   <String Id="EulaPrivacy">[WixBundleName] – &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;licenční podmínky&lt;/a&gt; a &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;prohlášení o zásadách ochrany osobních údajů&lt;/a&gt;</String>
-  <String Id="ModifyResetIIS">Po dokončení instalace prosím restartujte službu IIS. Další informace najdete &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;tady&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">Služba IIS není na tomto počítači povolená. Pokud máte v úmyslu spouštět aplikace ASP.NET Core se službou IIS, je nutné před spuštěním tohoto instalačního programu nainstalovat službu IIS. Další informace najdete &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;tady&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Po dokončení instalace prosím restartujte službu IIS. Další informace najdete &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;tady&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">Služba IIS není na tomto počítači povolená. Pokud máte v úmyslu spouštět aplikace ASP.NET Core se službou IIS, je nutné před spuštěním tohoto instalačního programu nainstalovat službu IIS. Další informace najdete &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;tady&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1031/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1031/thm.wxl
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Willkommen beim Setup von [WixBundleName].</String>
-  <String Id="InstallResetIIS">Starten Sie IIS nach Abschluss der Installation neu. Zusätzliche Informationen finden Sie &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;hier&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">IIS ist auf diesem Computer nicht aktiviert. Wenn Sie ASP.NET Core-Anwendungen mit IIS ausführen möchten, müssen Sie IIS installieren, bevor Sie diesen Installer ausführen. Zusätzliche Informationen finden Sie &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;hier&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Starten Sie IIS nach Abschluss der Installation neu. Zusätzliche Informationen finden Sie &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;hier&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">IIS ist auf diesem Computer nicht aktiviert. Wenn Sie ASP.NET Core-Anwendungen mit IIS ausführen möchten, müssen Sie IIS installieren, bevor Sie diesen Installer ausführen. Zusätzliche Informationen finden Sie &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;hier&lt;/a&gt;.</String>
   <String Id="EulaPrivacy">&lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Lizenzbedingungen&lt;/a&gt; und &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;Datenschutzerklärung&lt;/a&gt; für [WixBundleName].</String>
-  <String Id="ModifyResetIIS">Starten Sie IIS nach Abschluss der Installation neu. Zusätzliche Informationen finden Sie &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;hier&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">IIS ist auf diesem Computer nicht aktiviert. Wenn Sie ASP.NET Core-Anwendungen mit IIS ausführen möchten, müssen Sie IIS installieren, bevor Sie diesen Installer ausführen. Zusätzliche Informationen finden Sie &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;hier&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Starten Sie IIS nach Abschluss der Installation neu. Zusätzliche Informationen finden Sie &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;hier&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">IIS ist auf diesem Computer nicht aktiviert. Wenn Sie ASP.NET Core-Anwendungen mit IIS ausführen möchten, müssen Sie IIS installieren, bevor Sie diesen Installer ausführen. Zusätzliche Informationen finden Sie &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;hier&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1033/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1033/thm.wxl
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome"><!--_locComment_text="{Locked='[WixBundleName]'}"-->Welcome to the [WixBundleName] Setup.</String>
-  <String Id="InstallResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
   <String Id="EulaPrivacy"><!--_locComment_text="{Locked='[WixBundleName]'}"-->[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
-  <String Id="ModifyResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1036/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1036/thm.wxl
@@ -12,7 +12,7 @@
   <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]répertoire[\]] - installe, répare, désinstalle ou
    crée une copie locale complète du bundle dans le répertoire. Install est l'option par défaut.
 
-/passive | /quiet -  affiche une interface utilisateur minimale, sans invite, ou n'affiche 
+/passive | /quiet -  affiche une interface utilisateur minimale, sans invite, ou n'affiche
    ni interface utilisateur, ni invite. Par défaut, l'interface utilisateur et toutes les invites sont affichées.
 
 /norestart   - supprime toutes les tentatives de redémarrage. Par défaut, l'interface utilisateur affiche une invite avant le redémarrage.
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Bienvenue dans le programme d'installation de [WixBundleName].</String>
-  <String Id="InstallResetIIS">Redémarrez IIS une fois l'installation effectuée. Des informations supplémentaires sont disponibles &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;ici&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">IIS n'est pas activé sur cet ordinateur. Si vous avez l'intention d'exécuter des applications ASP.NET Core avec IIS, vous devez installer IIS avant d'exécuter ce programme d'installation. Des informations supplémentaires sont disponibles &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;ici&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Redémarrez IIS une fois l'installation effectuée. Des informations supplémentaires sont disponibles &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;ici&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">IIS n'est pas activé sur cet ordinateur. Si vous avez l'intention d'exécuter des applications ASP.NET Core avec IIS, vous devez installer IIS avant d'exécuter ce programme d'installation. Des informations supplémentaires sont disponibles &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;ici&lt;/a&gt;.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;termes du contrat de licence&lt;/a&gt; et &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;déclaration de confidentialité&lt;/a&gt;.</String>
-  <String Id="ModifyResetIIS">Redémarrez IIS une fois l'installation effectuée. Des informations supplémentaires sont disponibles &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;ici&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">IIS n'est pas activé sur cet ordinateur. Si vous avez l'intention d'exécuter des applications ASP.NET Core avec IIS, vous devez installer IIS avant d'exécuter ce programme d'installation. Des informations supplémentaires sont disponibles &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;ici&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Redémarrez IIS une fois l'installation effectuée. Des informations supplémentaires sont disponibles &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;ici&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">IIS n'est pas activé sur cet ordinateur. Si vous avez l'intention d'exécuter des applications ASP.NET Core avec IIS, vous devez installer IIS avant d'exécuter ce programme d'installation. Des informations supplémentaires sont disponibles &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;ici&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1040/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1040/thm.wxl
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Installazione di [WixBundleName].</String>
-  <String Id="InstallResetIIS">Riavviare IIS dopo il completamento dell'installazione. Per altre informazioni, vedere &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;qui&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">IIS non è abilitato in questo computer. Se si intende eseguire applicazioni ASP.NET Core con IIS, è necessario installare IIS prima di eseguire questo programma di installazione. Per altre informazioni, vedere &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;qui&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Riavviare IIS dopo il completamento dell'installazione. Per altre informazioni, vedere &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;qui&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">IIS non è abilitato in questo computer. Se si intende eseguire applicazioni ASP.NET Core con IIS, è necessario installare IIS prima di eseguire questo programma di installazione. Per altre informazioni, vedere &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;qui&lt;/a&gt;.</String>
   <String Id="EulaPrivacy">&lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Condizioni di licenza&lt;/a&gt; e &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;informativa sulla privacy&lt;/a&gt; di [WixBundleName].</String>
-  <String Id="ModifyResetIIS">Riavviare IIS dopo il completamento dell'installazione. Per altre informazioni, vedere &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;qui&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">IIS non è abilitato in questo computer. Se si intende eseguire applicazioni ASP.NET Core con IIS, è necessario installare IIS prima di eseguire questo programma di installazione. Per altre informazioni, vedere &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;qui&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Riavviare IIS dopo il completamento dell'installazione. Per altre informazioni, vedere &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;qui&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">IIS non è abilitato in questo computer. Se si intende eseguire applicazioni ASP.NET Core con IIS, è necessario installare IIS prima di eseguire questo programma di installazione. Per altre informazioni, vedere &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;qui&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1041/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1041/thm.wxl
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">[WixBundleName] のセットアップへようこそ。</String>
-  <String Id="InstallResetIIS">インストールの完了後に IIS を再起動してください。追加情報については、&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;こちら&lt;/a&gt;を参照してください。</String>
-  <String Id="InstallNoIIS">このマシンでは IIS が有効になっていません。IIS を使用して ASP.NET Core アプリケーションを実行する場合は、このインストーラーを実行する前に IIS をインストールする必要があります。追加情報については、&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;こちら&lt;/a&gt;を参照してください。</String>
+  <String Id="InstallResetIIS">インストールの完了後に IIS を再起動してください。追加情報については、&lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;こちら&lt;/a&gt;を参照してください。</String>
+  <String Id="InstallNoIIS">このマシンでは IIS が有効になっていません。IIS を使用して ASP.NET Core アプリケーションを実行する場合は、このインストーラーを実行する前に IIS をインストールする必要があります。追加情報については、&lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;こちら&lt;/a&gt;を参照してください。</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;ライセンス条項&lt;/a&gt;および&lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;プライバシーに関する声明&lt;/a&gt;。</String>
-  <String Id="ModifyResetIIS">インストールの完了後に IIS を再起動してください。追加情報については、&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;こちら&lt;/a&gt;を参照してください。</String>
-  <String Id="ModifyNoIIS">このマシンでは IIS が有効になっていません。IIS を使用して ASP.NET Core アプリケーションを実行する場合は、このインストーラーを実行する前に IIS をインストールする必要があります。追加情報については、&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;こちら&lt;/a&gt;を参照してください。</String>
+  <String Id="ModifyResetIIS">インストールの完了後に IIS を再起動してください。追加情報については、&lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;こちら&lt;/a&gt;を参照してください。</String>
+  <String Id="ModifyNoIIS">このマシンでは IIS が有効になっていません。IIS を使用して ASP.NET Core アプリケーションを実行する場合は、このインストーラーを実行する前に IIS をインストールする必要があります。追加情報については、&lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;こちら&lt;/a&gt;を参照してください。</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1042/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1042/thm.wxl
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">[WixBundleName] 설치를 시작합니다.</String>
-  <String Id="InstallResetIIS">설치가 완료된 후 IIS를 다시 시작하세요. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;여기&lt;/a&gt;에서 자세한 내용을 확인할 수 있습니다.</String>
-  <String Id="InstallNoIIS">이 머신에는 IIS가 사용하도록 설정되어 있지 않습니다. IIS에서 ASP.NET Core 애플리케이션을 실행하려면 이 설치 관리자를 실행하기 전에 IIS를 설치해야 합니다. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;여기&lt;/a&gt;에서 자세한 내용을 확인할 수 있습니다.</String>
+  <String Id="InstallResetIIS">설치가 완료된 후 IIS를 다시 시작하세요. &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;여기&lt;/a&gt;에서 자세한 내용을 확인할 수 있습니다.</String>
+  <String Id="InstallNoIIS">이 머신에는 IIS가 사용하도록 설정되어 있지 않습니다. IIS에서 ASP.NET Core 애플리케이션을 실행하려면 이 설치 관리자를 실행하기 전에 IIS를 설치해야 합니다. &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;여기&lt;/a&gt;에서 자세한 내용을 확인할 수 있습니다.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;사용 조건&lt;/a&gt; 및 &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;개인정보처리방침&lt;/a&gt;.</String>
-  <String Id="ModifyResetIIS">설치가 완료된 후 IIS를 다시 시작하세요. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;여기&lt;/a&gt;에서 자세한 내용을 확인할 수 있습니다.</String>
-  <String Id="ModifyNoIIS">이 머신에는 IIS가 사용하도록 설정되어 있지 않습니다. IIS에서 ASP.NET Core 애플리케이션을 실행하려면 이 설치 관리자를 실행하기 전에 IIS를 설치해야 합니다. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;여기&lt;/a&gt;에서 자세한 내용을 확인할 수 있습니다.</String>
+  <String Id="ModifyResetIIS">설치가 완료된 후 IIS를 다시 시작하세요. &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;여기&lt;/a&gt;에서 자세한 내용을 확인할 수 있습니다.</String>
+  <String Id="ModifyNoIIS">이 머신에는 IIS가 사용하도록 설정되어 있지 않습니다. IIS에서 ASP.NET Core 애플리케이션을 실행하려면 이 설치 관리자를 실행하기 전에 IIS를 설치해야 합니다. &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;여기&lt;/a&gt;에서 자세한 내용을 확인할 수 있습니다.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1045/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1045/thm.wxl
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Witamy w instalatorze produktu [WixBundleName].</String>
-  <String Id="InstallResetIIS">Po zakończeniu instalacji uruchom ponownie usługi IIS. Dodatkowe informacje znajdziesz &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;tutaj&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">Usługi IIS nie są włączone na tej maszynie. Jeśli zamierzasz uruchamiać aplikacje platformy ASP.NET Core za pomocą usług IIS, musisz zainstalować usługi IIS przed uruchomieniem tego instalatora. Dodatkowe informacje znajdziesz &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;tutaj&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Po zakończeniu instalacji uruchom ponownie usługi IIS. Dodatkowe informacje znajdziesz &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;tutaj&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">Usługi IIS nie są włączone na tej maszynie. Jeśli zamierzasz uruchamiać aplikacje platformy ASP.NET Core za pomocą usług IIS, musisz zainstalować usługi IIS przed uruchomieniem tego instalatora. Dodatkowe informacje znajdziesz &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;tutaj&lt;/a&gt;.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;postanowienia licencyjne&lt;/a&gt; i &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;oświadczenie o ochronie prywatności&lt;/a&gt;.</String>
-  <String Id="ModifyResetIIS">Po zakończeniu instalacji uruchom ponownie usługi IIS. Dodatkowe informacje znajdziesz &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;tutaj&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">Usługi IIS nie są włączone na tej maszynie. Jeśli zamierzasz uruchamiać aplikacje platformy ASP.NET Core za pomocą usług IIS, musisz zainstalować usługi IIS przed uruchomieniem tego instalatora. Dodatkowe informacje znajdziesz &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;tutaj&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Po zakończeniu instalacji uruchom ponownie usługi IIS. Dodatkowe informacje znajdziesz &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;tutaj&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">Usługi IIS nie są włączone na tej maszynie. Jeśli zamierzasz uruchamiać aplikacje platformy ASP.NET Core za pomocą usług IIS, musisz zainstalować usługi IIS przed uruchomieniem tego instalatora. Dodatkowe informacje znajdziesz &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;tutaj&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1046/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1046/thm.wxl
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Bem-vindo à Instalação do [WixBundleName].</String>
-  <String Id="InstallResetIIS">Reinicie o IIS após a conclusão da instalação. Você pode encontrar informações adicionais &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aqui&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">O IIS não está habilitado neste computador. Se pretende executar aplicativos ASP.NET Core com o IIS, você deve instalar o IIS antes de executar este instalador. Você pode encontrar informações adicionais &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aqui&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Reinicie o IIS após a conclusão da instalação. Você pode encontrar informações adicionais &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;aqui&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">O IIS não está habilitado neste computador. Se pretende executar aplicativos ASP.NET Core com o IIS, você deve instalar o IIS antes de executar este instalador. Você pode encontrar informações adicionais &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;aqui&lt;/a&gt;.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;termos de licença&lt;/a&gt; e &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;política de privacidade&lt;/a&gt;.</String>
-  <String Id="ModifyResetIIS">Reinicie o IIS após a conclusão da instalação. Você pode encontrar informações adicionais &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aqui&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">O IIS não está habilitado neste computador. Se pretende executar aplicativos ASP.NET Core com o IIS, você deve instalar o IIS antes de executar este instalador. Você pode encontrar informações adicionais &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aqui&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Reinicie o IIS após a conclusão da instalação. Você pode encontrar informações adicionais &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;aqui&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">O IIS não está habilitado neste computador. Se pretende executar aplicativos ASP.NET Core com o IIS, você deve instalar o IIS antes de executar este instalador. Você pode encontrar informações adicionais &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;aqui&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1049/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1049/thm.wxl
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Вас приветствует мастер установки [WixBundleName].</String>
-  <String Id="InstallResetIIS">Перезапустите службы IIS после завершения установки. Дополнительные сведения см. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;здесь&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">Службы IIS не включены на этом компьютере. Если вы планируете запускать приложения ASP.NET Core с IIS, перед запуском этого установщика необходимо установить службы IIS. Дополнительные сведения см. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;здесь&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Перезапустите службы IIS после завершения установки. Дополнительные сведения см. &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;здесь&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">Службы IIS не включены на этом компьютере. Если вы планируете запускать приложения ASP.NET Core с IIS, перед запуском этого установщика необходимо установить службы IIS. Дополнительные сведения см. &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;здесь&lt;/a&gt;.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;условия лицензии&lt;/a&gt; и &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;заявление о конфиденциальности&lt;/a&gt;.</String>
-  <String Id="ModifyResetIIS">Перезапустите службы IIS после завершения установки. Дополнительные сведения см. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;здесь&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">Службы IIS не включены на этом компьютере. Если вы планируете запускать приложения ASP.NET Core с IIS, перед запуском этого установщика необходимо установить службы IIS. Дополнительные сведения см. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;здесь&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Перезапустите службы IIS после завершения установки. Дополнительные сведения см. &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;здесь&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">Службы IIS не включены на этом компьютере. Если вы планируете запускать приложения ASP.NET Core с IIS, перед запуском этого установщика необходимо установить службы IIS. Дополнительные сведения см. &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;здесь&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/1055/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1055/thm.wxl
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">[WixBundleName] Kurulumu'na Hoş Geldiniz.</String>
-  <String Id="InstallResetIIS">Yükleme tamamlandıktan sonra lütfen IIS'yi yeniden başlatın. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;Buradan&lt;/a&gt; daha fazla bilgi bulabilirsiniz.</String>
-  <String Id="InstallNoIIS">IIS bu makinede etkin değil. ASP.NET Core uygulamalarını IIS ile çalıştırmak istiyorsanız, bu yükleyiciyi çalıştırmadan önce IIS'yi yüklemeniz gerekir. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;Buradan&lt;/a&gt; daha fazla bilgi bulabilirsiniz.</String>
+  <String Id="InstallResetIIS">Yükleme tamamlandıktan sonra lütfen IIS'yi yeniden başlatın. &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;Buradan&lt;/a&gt; daha fazla bilgi bulabilirsiniz.</String>
+  <String Id="InstallNoIIS">IIS bu makinede etkin değil. ASP.NET Core uygulamalarını IIS ile çalıştırmak istiyorsanız, bu yükleyiciyi çalıştırmadan önce IIS'yi yüklemeniz gerekir. &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;Buradan&lt;/a&gt; daha fazla bilgi bulabilirsiniz.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;lisans koşulları&lt;/a&gt; ve &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;gizlilik bildirimi&lt;/a&gt;.</String>
-  <String Id="ModifyResetIIS">Yükleme tamamlandıktan sonra lütfen IIS'yi yeniden başlatın. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;Buradan&lt;/a&gt; daha fazla bilgi bulabilirsiniz.</String>
-  <String Id="ModifyNoIIS">IIS bu makinede etkin değil. ASP.NET Core uygulamalarını IIS ile çalıştırmak istiyorsanız, bu yükleyiciyi çalıştırmadan önce IIS'yi yüklemeniz gerekir. &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;Buradan&lt;/a&gt; daha fazla bilgi bulabilirsiniz.</String>
+  <String Id="ModifyResetIIS">Yükleme tamamlandıktan sonra lütfen IIS'yi yeniden başlatın. &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;Buradan&lt;/a&gt; daha fazla bilgi bulabilirsiniz.</String>
+  <String Id="ModifyNoIIS">IIS bu makinede etkin değil. ASP.NET Core uygulamalarını IIS ile çalıştırmak istiyorsanız, bu yükleyiciyi çalıştırmadan önce IIS'yi yüklemeniz gerekir. &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;Buradan&lt;/a&gt; daha fazla bilgi bulabilirsiniz.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/2052/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/2052/thm.wxl
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">欢迎使用 [WixBundleName] 安装程序。</String>
-  <String Id="InstallResetIIS">请在安装完成后重启 IIS。可在&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;此处&lt;/a&gt;找到其他信息。</String>
-  <String Id="InstallNoIIS">此计算机上未启用 IIS。如果打算通过 IIS 运行 ASP.NET Core 应用程序，必须先安装 IIS，然后再运行此安装程序。可在&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;此处&lt;/a&gt;找到其他信息。</String>
+  <String Id="InstallResetIIS">请在安装完成后重启 IIS。可在&lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;此处&lt;/a&gt;找到其他信息。</String>
+  <String Id="InstallNoIIS">此计算机上未启用 IIS。如果打算通过 IIS 运行 ASP.NET Core 应用程序，必须先安装 IIS，然后再运行此安装程序。可在&lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;此处&lt;/a&gt;找到其他信息。</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;许可条款&lt;/a&gt;和&lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;隐私声明&lt;/a&gt;。</String>
-  <String Id="ModifyResetIIS">请在安装完成后重启 IIS。可在&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;此处&lt;/a&gt;找到其他信息。</String>
-  <String Id="ModifyNoIIS">此计算机上未启用 IIS。如果打算通过 IIS 运行 ASP.NET Core 应用程序，必须先安装 IIS，然后再运行此安装程序。可在&lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;此处&lt;/a&gt;找到其他信息。</String>
+  <String Id="ModifyResetIIS">请在安装完成后重启 IIS。可在&lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;此处&lt;/a&gt;找到其他信息。</String>
+  <String Id="ModifyNoIIS">此计算机上未启用 IIS。如果打算通过 IIS 运行 ASP.NET Core 应用程序，必须先安装 IIS，然后再运行此安装程序。可在&lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;此处&lt;/a&gt;找到其他信息。</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/3082/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/3082/thm.wxl
@@ -12,7 +12,7 @@
   <String Id="HelpText">/install | /repair | /uninstall | /layout [\[]directorio[\]] - instala, repara, desinstala o
    crea una copia local completa del paquete en el directorio. Install es la opción predeterminada.
 
-/passive | /quiet -  muestra una IU mínima sin peticiones, o bien no muestra la IU 
+/passive | /quiet -  muestra una IU mínima sin peticiones, o bien no muestra la IU
   ni las peticiones. De forma predeterminada, se muestran la IU y todas las peticiones.
 
 /norestart   - suprime los intentos de reiniciar. De forma predeterminada, la IU preguntará antes de reiniciar.
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome">Programa de instalación de [WixBundleName].</String>
-  <String Id="InstallResetIIS">Reinicie IIS una vez completada la instalación. Puede encontrar información adicional &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aquí&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">IIS no está habilitado en esta máquina. Si tiene previsto ejecutar aplicaciones ASP.NET Core con IIS, debe instalar IIS antes de ejecutar este instalador. Puede encontrar información adicional &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aquí&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Reinicie IIS una vez completada la instalación. Puede encontrar información adicional &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;aquí&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">IIS no está habilitado en esta máquina. Si tiene previsto ejecutar aplicaciones ASP.NET Core con IIS, debe instalar IIS antes de ejecutar este instalador. Puede encontrar información adicional &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;aquí&lt;/a&gt;.</String>
   <String Id="EulaPrivacy">[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;Términos de licencia&lt;/a&gt; y &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;declaración de privacidad&lt;/a&gt;.</String>
-  <String Id="ModifyResetIIS">Reinicie IIS una vez completada la instalación. Puede encontrar información adicional &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aquí&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">IIS no está habilitado en esta máquina. Si tiene previsto ejecutar aplicaciones ASP.NET Core con IIS, debe instalar IIS antes de ejecutar este instalador. Puede encontrar información adicional &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;aquí&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Reinicie IIS una vez completada la instalación. Puede encontrar información adicional &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;aquí&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">IIS no está habilitado en esta máquina. Si tiene previsto ejecutar aplicaciones ASP.NET Core con IIS, debe instalar IIS antes de ejecutar este instalador. Puede encontrar información adicional &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;aquí&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/thm.wxl
@@ -61,9 +61,9 @@
 
   <!-- Custom UI strings -->
   <String Id="Welcome"><!--_locComment_text="{Locked='[WixBundleName]'}"-->Welcome to the [WixBundleName] Setup.</String>
-  <String Id="InstallResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
-  <String Id="InstallNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
+  <String Id="InstallResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
+  <String Id="InstallNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
   <String Id="EulaPrivacy"><!--_locComment_text="{Locked='[WixBundleName]'}"-->[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
-  <String Id="ModifyResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
-  <String Id="ModifyNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://go.microsoft.com/fwlink/?LinkId=798277"&gt;here&lt;/a&gt;.</String>
+  <String Id="ModifyResetIIS">Please restart IIS after the installation completes. You can find additional information &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
+  <String Id="ModifyNoIIS">IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
 </WixLocalization>


### PR DESCRIPTION
- see #44613 and #44615
- replace link that takes user from error messages to a 7.0.x IIS information page
  - for now, 8.0.x page doesn't exist and new link still shows 7.0.x information
- new locale-independent link will redirect to localized page base on browser / OS settings