### PR TITLE
Introduce non-virtual RegisterTokenProviderCore method.

### DIFF
--- a/src/Identity/Extensions.Core/src/PublicAPI.Unshipped.txt
+++ b/src/Identity/Extensions.Core/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.AspNetCore.Identity.UserManager<TUser>.RegisterTokenProviderCore(string! providerName, Microsoft.AspNetCore.Identity.IUserTwoFactorTokenProvider<TUser!>! provider) -> void

--- a/src/Identity/Extensions.Core/src/UserManager.cs
+++ b/src/Identity/Extensions.Core/src/UserManager.cs
@@ -112,7 +112,7 @@ public class UserManager<TUser> : IDisposable where TUser : class
                     as IUserTwoFactorTokenProvider<TUser>;
                 if (provider != null)
                 {
-                    RegisterTokenProvider(providerName, provider);
+                    RegisterTokenProviderCore(providerName, provider);
                 }
             }
         }
@@ -1766,7 +1766,7 @@ public class UserManager<TUser> : IDisposable where TUser : class
     /// </summary>
     /// <param name="providerName">The name of the provider to register.</param>
     /// <param name="provider">The provider to register.</param>
-    public virtual void RegisterTokenProvider(string providerName, IUserTwoFactorTokenProvider<TUser> provider)
+    protected void RegisterTokenProviderCore(string providerName, IUserTwoFactorTokenProvider<TUser> provider)
     {
         ThrowIfDisposed();
         if (provider == null)
@@ -1774,6 +1774,16 @@ public class UserManager<TUser> : IDisposable where TUser : class
             throw new ArgumentNullException(nameof(provider));
         }
         _tokenProviders[providerName] = provider;
+    }
+
+    /// <summary>
+    /// Registers a token provider.
+    /// </summary>
+    /// <param name="providerName">The name of the provider to register.</param>
+    /// <param name="provider">The provider to register.</param>
+    public virtual void RegisterTokenProvider(string providerName, IUserTwoFactorTokenProvider<TUser> provider)
+    {
+        RegisterTokenProviderCore(providerName, provider);
     }
 
     /// <summary>


### PR DESCRIPTION
# ```RegisterTokenProviderCore``` for ```UserManager<TUser>```

Addresses issue #45358 

## Description

Introduces a non-virtual protected ```RegisterTokenProviderCore(...)``` method which can be used without issue from the constructor. We retain the existing ```RegisterTokenProvider``` public virtual method to maintain compatibiilty.