### PR TITLE
Use built in methods

### DIFF
--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -530,14 +530,7 @@ public class ContentDispositionHeaderValue
     {
         Contract.Assert(input != null);
 
-        for (int i = 0; i < input.Length; i++)
-        {
-            if ((int)input[i] > 0x7f || (int)input[i] < 0x20)
-            {
-                return true;
-            }
-        }
-        return false;
+        return input.AsSpan().IndexOfAnyExceptInRange((char)0x20, (char)0x7f) >= 0;
     }
 
     // Encode using MIME encoding

--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/TagBuilder.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/TagBuilder.cs
@@ -442,7 +442,7 @@ public class TagBuilder : IHtmlContent
     {
         public static bool IsValidIdCharacter(char testChar)
         {
-            return char.IsAsciiLetter(testChar) || char.IsAsciiDigit(testChar) || IsAllowableSpecialCharacter(testChar);
+            return char.IsAsciiLetterOrDigit(testChar) || IsAllowableSpecialCharacter(testChar);
         }
 
         private static bool IsAllowableSpecialCharacter(char testChar)

--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/TagBuilder.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/TagBuilder.cs
@@ -170,7 +170,7 @@ public class TagBuilder : IHtmlContent
         }
 
         var firstChar = name[0];
-        var startsWithAsciiLetter = Html401IdUtil.IsAsciiLetter(firstChar);
+        var startsWithAsciiLetter = char.IsAsciiLetter(firstChar);
         if (!startsWithAsciiLetter)
         {
             // The first character must be a letter according to the HTML 4.01 specification.
@@ -440,19 +440,9 @@ public class TagBuilder : IHtmlContent
 
     private static class Html401IdUtil
     {
-        public static bool IsAsciiLetter(char testChar)
-        {
-            return (('A' <= testChar && testChar <= 'Z') || ('a' <= testChar && testChar <= 'z'));
-        }
-
         public static bool IsValidIdCharacter(char testChar)
         {
-            return (IsAsciiLetter(testChar) || IsAsciiDigit(testChar) || IsAllowableSpecialCharacter(testChar));
-        }
-
-        private static bool IsAsciiDigit(char testChar)
-        {
-            return ('0' <= testChar && testChar <= '9');
+            return char.IsAsciiLetter(testChar) || char.IsAsciiDigit(testChar) || IsAllowableSpecialCharacter(testChar);
         }
 
         private static bool IsAllowableSpecialCharacter(char testChar)


### PR DESCRIPTION
While searching for potential usages for new ASCII APIs (https://github.com/dotnet/runtime/issues/28230) I've found few places where we could use existing built-in methods.

`IndexOfAnyExceptInRange` is vectorized and should provide perf improvements for larger inputs. It requires .NET 8, I am hoping that this repo is already targeting it. If not, I am going to close the PR and re-open it when it does.

