### PR TITLE
gRPC JSON transcoding: Resolve all descriptors from registry

### DIFF
--- a/src/Grpc/JsonTranscoding/perf/Microsoft.AspNetCore.Grpc.Microbenchmarks/Json/JsonReading.cs
+++ b/src/Grpc/JsonTranscoding/perf/Microsoft.AspNetCore.Grpc.Microbenchmarks/Json/JsonReading.cs
@@ -21,8 +21,11 @@ public class JsonReading
     [GlobalSetup]
     public void GlobalSetup()
     {
+        var descriptorRegistry = new DescriptorRegistry();
+        descriptorRegistry.RegisterFileDescriptor(HelloRequest.Descriptor.File);
+
         _requestJson = (new HelloRequest() { Name = "Hello world" }).ToString();
-        _serializerOptions = JsonConverterHelper.CreateSerializerOptions(new JsonContext(new GrpcJsonSettings { WriteIndented = false }, TypeRegistry.Empty, new DescriptorRegistry()));
+        _serializerOptions = JsonConverterHelper.CreateSerializerOptions(new JsonContext(new GrpcJsonSettings { WriteIndented = false }, TypeRegistry.Empty, descriptorRegistry));
         _jsonFormatter = new JsonParser(new JsonParser.Settings(recursionLimit: 100));
     }
 

--- a/src/Grpc/JsonTranscoding/perf/Microsoft.AspNetCore.Grpc.Microbenchmarks/Json/JsonWriting.cs
+++ b/src/Grpc/JsonTranscoding/perf/Microsoft.AspNetCore.Grpc.Microbenchmarks/Json/JsonWriting.cs
@@ -21,9 +21,12 @@ public class JsonWriting
     [GlobalSetup]
     public void GlobalSetup()
     {
+        var descriptorRegistry = new DescriptorRegistry();
+        descriptorRegistry.RegisterFileDescriptor(HelloRequest.Descriptor.File);
+
         _request = new HelloRequest() { Name = "Hello world" };
         _serializerOptions = JsonConverterHelper.CreateSerializerOptions(
-            new JsonContext(new GrpcJsonSettings { WriteIndented = false }, TypeRegistry.Empty, new DescriptorRegistry()));
+            new JsonContext(new GrpcJsonSettings { WriteIndented = false }, TypeRegistry.Empty, descriptorRegistry));
         _jsonFormatter = new JsonFormatter(new JsonFormatter.Settings(formatDefaultValues: false));
     }
 

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/DescriptorRegistry.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/DescriptorRegistry.cs
@@ -59,6 +59,7 @@ internal sealed class DescriptorRegistry
 
     private void AddDescriptorsRecursive(MessageDescriptor messageDescriptor)
     {
+        // Type is null for map entry message types. Just skip adding them.
         if (messageDescriptor.ClrType != null)
         {
             _typeDescriptorMap[messageDescriptor.ClrType] = messageDescriptor;

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/AnyConverter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/AnyConverter.cs
@@ -35,6 +35,9 @@ internal sealed class AnyConverter<TMessage> : SettingsConverterBase<TMessage> w
             throw new InvalidOperationException($"Type registry has no descriptor for type name '{typeName}'.");
         }
 
+        // Ensure the payload descriptor is registered.
+        Context.DescriptorRegistry.RegisterFileDescriptor(descriptor.File);
+
         IMessage data;
         if (ServiceDescriptorHelpers.IsWellKnownType(descriptor))
         {
@@ -67,6 +70,10 @@ internal sealed class AnyConverter<TMessage> : SettingsConverterBase<TMessage> w
         {
             throw new InvalidOperationException($"Type registry has no descriptor for type name '{typeName}'.");
         }
+
+        // Ensure the payload descriptor is registered.
+        Context.DescriptorRegistry.RegisterFileDescriptor(descriptor.File);
+        
         var valueMessage = descriptor.Parser.ParseFrom(data);
         writer.WriteStartObject();
         writer.WriteString(AnyTypeUrlField, typeUrl);

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/AnyConverter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/AnyConverter.cs
@@ -35,7 +35,8 @@ internal sealed class AnyConverter<TMessage> : SettingsConverterBase<TMessage> w
             throw new InvalidOperationException($"Type registry has no descriptor for type name '{typeName}'.");
         }
 
-        // Ensure the payload descriptor is registered.
+        // Ensure the payload descriptor is registered. It's possible the payload type isn't in a proto referenced by the service, and is only in the user-specified TypeRegistry.
+        // There isn't a way to enumerate the contents of the TypeRegistry so we have to ensure the descriptor is present every time.
         Context.DescriptorRegistry.RegisterFileDescriptor(descriptor.File);
 
         IMessage data;
@@ -71,7 +72,8 @@ internal sealed class AnyConverter<TMessage> : SettingsConverterBase<TMessage> w
             throw new InvalidOperationException($"Type registry has no descriptor for type name '{typeName}'.");
         }
 
-        // Ensure the payload descriptor is registered.
+        // Ensure the payload descriptor is registered. It's possible the payload type isn't in a proto referenced by the service, and is only in the user-specified TypeRegistry.
+        // There isn't a way to enumerate the contents of the TypeRegistry so we have to ensure the descriptor is present every time.
         Context.DescriptorRegistry.RegisterFileDescriptor(descriptor.File);
         
         var valueMessage = descriptor.Parser.ParseFrom(data);

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/EnumConverter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/EnumConverter.cs
@@ -20,7 +20,7 @@ internal sealed class EnumConverter<TEnum> : SettingsConverterBase<TEnum> where 
         switch (reader.TokenType)
         {
             case JsonTokenType.String:
-                var enumDescriptor = ResolveEnumDescriptor(typeToConvert);
+                var enumDescriptor = (EnumDescriptor?)Context.DescriptorRegistry.FindDescriptorByType(typeToConvert);
                 if (enumDescriptor == null)
                 {
                     throw new InvalidOperationException($"Unable to resolve descriptor for {typeToConvert}.");
@@ -35,15 +35,6 @@ internal sealed class EnumConverter<TEnum> : SettingsConverterBase<TEnum> where 
             default:
                 throw new InvalidOperationException($"Unexpected JSON token: {reader.TokenType}.");
         }
-    }
-
-    private EnumDescriptor? ResolveEnumDescriptor(Type typeToConvert)
-    {
-        // Enum types in generated DTOs are regular enum types. That means there is no static Descriptor property
-        // to get the enum descriptor from.
-        //
-        // Search for enum descriptor using the enum type in a registry of descriptors.
-        return Context.DescriptorRegistry.FindEnumDescriptorByType(typeToConvert);
     }
 
     public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonConverterFactoryForWellKnownTypes.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonConverterFactoryForWellKnownTypes.cs
@@ -25,7 +25,7 @@ internal sealed class JsonConverterFactoryForWellKnownTypes : JsonConverterFacto
             return false;
         }
 
-        var descriptor = JsonConverterHelper.GetMessageDescriptor(typeToConvert);
+        var descriptor = _context.DescriptorRegistry.FindDescriptorByType(typeToConvert);
         if (descriptor == null)
         {
             return false;
@@ -37,7 +37,7 @@ internal sealed class JsonConverterFactoryForWellKnownTypes : JsonConverterFacto
     public override JsonConverter CreateConverter(
         Type typeToConvert, JsonSerializerOptions options)
     {
-        var descriptor = JsonConverterHelper.GetMessageDescriptor(typeToConvert)!;
+        var descriptor = _context.DescriptorRegistry.FindDescriptorByType(typeToConvert)!;
         var converterType = JsonConverterHelper.WellKnownTypeNames[descriptor.FullName];
 
         var converter = (JsonConverter)Activator.CreateInstance(

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonConverterFactoryForWrappers.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonConverterFactoryForWrappers.cs
@@ -26,7 +26,7 @@ internal sealed class JsonConverterFactoryForWrappers : JsonConverterFactory
             return false;
         }
 
-        var descriptor = JsonConverterHelper.GetMessageDescriptor(typeToConvert);
+        var descriptor = _context.DescriptorRegistry.FindDescriptorByType(typeToConvert);
         if (descriptor == null)
         {
             return false;

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonConverterHelper.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonConverterHelper.cs
@@ -131,17 +131,6 @@ internal static class JsonConverterHelper
         }
     }
 
-    internal static MessageDescriptor? GetMessageDescriptor(Type typeToConvert)
-    {
-        var property = typeToConvert.GetProperty("Descriptor", BindingFlags.Static | BindingFlags.Public, binder: null, typeof(MessageDescriptor), Type.EmptyTypes, modifiers: null);
-        if (property == null)
-        {
-            return null;
-        }
-
-        return property.GetValue(null, null) as MessageDescriptor;
-    }
-
     public static void PopulateMap(ref Utf8JsonReader reader, JsonSerializerOptions options, IMessage message, FieldDescriptor fieldDescriptor)
     {
         var mapFields = fieldDescriptor.MessageType.Fields.InFieldNumberOrder();

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/MessageTypeInfoResolver.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/MessageTypeInfoResolver.cs
@@ -59,7 +59,7 @@ internal sealed class MessageTypeInfoResolver : IJsonTypeInfoResolver
         return typeInfo;
     }
 
-    private static bool IsStandardMessage(Type type, [NotNullWhen(true)] out MessageDescriptor? messageDescriptor)
+    private bool IsStandardMessage(Type type, [NotNullWhen(true)] out MessageDescriptor? messageDescriptor)
     {
         if (!typeof(IMessage).IsAssignableFrom(type))
         {
@@ -67,10 +67,10 @@ internal sealed class MessageTypeInfoResolver : IJsonTypeInfoResolver
             return false;
         }
 
-        messageDescriptor = JsonConverterHelper.GetMessageDescriptor(type);
+        messageDescriptor = (MessageDescriptor?) _context.DescriptorRegistry.FindDescriptorByType(type);
         if (messageDescriptor == null)
         {
-            return false;
+            throw new InvalidOperationException("Couldn't resolve descriptor for message type: " + type);
         }
 
         // Wrappers and well known types are handled by converters.

--- a/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
@@ -49,7 +49,7 @@ internal static class ServiceDescriptorHelpers
     internal static bool IsWellKnownType(MessageDescriptor messageDescriptor) => messageDescriptor.File.Package == "google.protobuf" &&
         WellKnownTypeNames.Contains(messageDescriptor.File.Name);
 
-    internal static bool IsWrapperType(MessageDescriptor m) =>
+    internal static bool IsWrapperType(DescriptorBase m) =>
         m.File.Package == "google.protobuf" && m.File.Name == "google/protobuf/wrappers.proto";
 
     public static ServiceDescriptor? GetServiceDescriptor(Type serviceReflectionType)

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/Infrastructure/DynamicGrpcServiceRegistry.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/Infrastructure/DynamicGrpcServiceRegistry.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using Google.Api;
 using Google.Protobuf;
 using Google.Protobuf.Reflection;
@@ -41,10 +40,7 @@ public class DynamicGrpcServiceRegistry
 
         AddServiceCore(c =>
         {
-            // File descriptor is done in JsonTranscodingServiceMethodProvider.
-            // Need to replicate that logic here so tests that lookup descriptors are successful.
-            var descriptorRegistry = _serviceProvider.GetRequiredService<DescriptorRegistry>();
-            descriptorRegistry.RegisterFileDescriptor(methodDescriptor.File);
+            RegisterDescriptor(methodDescriptor);
 
             var unaryMethod = new UnaryServerMethod<DynamicService, TRequest, TResponse>((service, request, context) => callHandler(request, context));
             var binder = CreateJsonTranscodingBinder<TRequest, TResponse>(methodDescriptor, c, new DynamicServiceInvokerResolver(unaryMethod));
@@ -63,6 +59,8 @@ public class DynamicGrpcServiceRegistry
 
         AddServiceCore(c =>
         {
+            RegisterDescriptor(methodDescriptor);
+
             var serverStreamingMethod = new ServerStreamingServerMethod<DynamicService, TRequest, TResponse>((service, request, stream, context) => callHandler(request, stream, context));
             var binder = CreateJsonTranscodingBinder<TRequest, TResponse>(methodDescriptor, c, new DynamicServiceInvokerResolver(serverStreamingMethod));
 
@@ -110,6 +108,14 @@ public class DynamicGrpcServiceRegistry
                 m.MergeFrom(d);
                 return m;
             });
+    }
+
+    private void RegisterDescriptor(MethodDescriptor methodDescriptor)
+    {
+        // File descriptor is done in JsonTranscodingServiceMethodProvider.
+        // Need to replicate that logic here so tests that lookup descriptors are successful.
+        var descriptorRegistry = _serviceProvider.GetRequiredService<DescriptorRegistry>();
+        descriptorRegistry.RegisterFileDescriptor(methodDescriptor.File);
     }
 
     private class DynamicEndpointRouteBuilder : IEndpointRouteBuilder

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
@@ -8,6 +8,7 @@ using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;
+using Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.Infrastructure;
 using Transcoding;
 using Xunit.Abstractions;
 
@@ -472,7 +473,7 @@ public class JsonConverterReadTests
         var objectOld = formatter.Parse<TValue>(value);
 
         descriptorRegistry ??= new DescriptorRegistry();
-        descriptorRegistry.RegisterFileDescriptor(JsonConverterHelper.GetMessageDescriptor(typeof(TValue))!.File);
+        descriptorRegistry.RegisterFileDescriptor(TestHelpers.GetMessageDescriptor(typeof(TValue)).File);
         var jsonSerializerOptions = CreateSerializerOptions(settings, typeRegistery, descriptorRegistry);
 
         var objectNew = JsonSerializer.Deserialize<TValue>(value, jsonSerializerOptions)!;
@@ -495,7 +496,7 @@ public class JsonConverterReadTests
             Timestamp.Descriptor.File);
 
         serviceDescriptorRegistry ??= new DescriptorRegistry();
-        serviceDescriptorRegistry.RegisterFileDescriptor(JsonConverterHelper.GetMessageDescriptor(typeof(TValue))!.File);
+        serviceDescriptorRegistry.RegisterFileDescriptor(TestHelpers.GetMessageDescriptor(typeof(TValue)).File);
         var jsonSerializerOptions = CreateSerializerOptions(settings, typeRegistery, serviceDescriptorRegistry);
 
         var ex = Assert.ThrowsAny<Exception>(() => JsonSerializer.Deserialize<TValue>(value, jsonSerializerOptions));

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
@@ -489,15 +489,15 @@ public class JsonConverterReadTests
         return objectNew;
     }
 
-    private void AssertReadJsonError<TValue>(string value, Action<Exception> assertException, GrpcJsonSettings? settings = null, DescriptorRegistry? serviceDescriptorRegistry = null) where TValue : IMessage, new()
+    private void AssertReadJsonError<TValue>(string value, Action<Exception> assertException, GrpcJsonSettings? settings = null, DescriptorRegistry? descriptorRegistry = null) where TValue : IMessage, new()
     {
         var typeRegistery = TypeRegistry.FromFiles(
             HelloRequest.Descriptor.File,
             Timestamp.Descriptor.File);
 
-        serviceDescriptorRegistry ??= new DescriptorRegistry();
-        serviceDescriptorRegistry.RegisterFileDescriptor(TestHelpers.GetMessageDescriptor(typeof(TValue)).File);
-        var jsonSerializerOptions = CreateSerializerOptions(settings, typeRegistery, serviceDescriptorRegistry);
+        descriptorRegistry ??= new DescriptorRegistry();
+        descriptorRegistry.RegisterFileDescriptor(TestHelpers.GetMessageDescriptor(typeof(TValue)).File);
+        var jsonSerializerOptions = CreateSerializerOptions(settings, typeRegistery, descriptorRegistry);
 
         var ex = Assert.ThrowsAny<Exception>(() => JsonSerializer.Deserialize<TValue>(value, jsonSerializerOptions));
         assertException(ex);
@@ -510,12 +510,12 @@ public class JsonConverterReadTests
         assertException(ex);
     }
 
-    internal static JsonSerializerOptions CreateSerializerOptions(GrpcJsonSettings? settings, TypeRegistry? typeRegistery, DescriptorRegistry serviceDescriptorRegistry)
+    internal static JsonSerializerOptions CreateSerializerOptions(GrpcJsonSettings? settings, TypeRegistry? typeRegistery, DescriptorRegistry descriptorRegistry)
     {
         var context = new JsonContext(
             settings ?? new GrpcJsonSettings(),
             typeRegistery ?? TypeRegistry.Empty,
-            serviceDescriptorRegistry);
+            descriptorRegistry);
 
         return JsonConverterHelper.CreateSerializerOptions(context);
     }

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterWriteTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterWriteTests.cs
@@ -10,7 +10,6 @@ using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.Infrastructure;
-using Newtonsoft.Json.Linq;
 using Transcoding;
 using Xunit.Abstractions;
 using Type = System.Type;

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterWriteTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterWriteTests.cs
@@ -9,6 +9,7 @@ using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;
+using Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.Infrastructure;
 using Newtonsoft.Json.Linq;
 using Transcoding;
 using Xunit.Abstractions;
@@ -517,7 +518,7 @@ public class JsonConverterWriteTests
     private static DescriptorRegistry CreateDescriptorRegistry(Type type)
     {
         var descriptorRegistry = new DescriptorRegistry();
-        descriptorRegistry.RegisterFileDescriptor(JsonConverterHelper.GetMessageDescriptor(type)!.File);
+        descriptorRegistry.RegisterFileDescriptor(TestHelpers.GetMessageDescriptor(type).File);
         return descriptorRegistry;
     }
 

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterWriteTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterWriteTests.cs
@@ -9,8 +9,10 @@ using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;
+using Newtonsoft.Json.Linq;
 using Transcoding;
 using Xunit.Abstractions;
+using Type = System.Type;
 
 namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.ConverterTests;
 
@@ -221,8 +223,9 @@ public class JsonConverterWriteTests
     {
         var v = new Int64Value { Value = 1 };
 
+        var descriptorRegistry = CreateDescriptorRegistry(typeof(Int64Value));
         var settings = new GrpcJsonSettings { WriteInt64sAsStrings = writeInt64sAsStrings };
-        var jsonSerializerOptions = CreateSerializerOptions(settings, TypeRegistry.Empty);
+        var jsonSerializerOptions = CreateSerializerOptions(settings, TypeRegistry.Empty, descriptorRegistry);
         var json = JsonSerializer.Serialize(v, jsonSerializerOptions);
 
         Assert.Equal(expectedJson, json);
@@ -235,8 +238,9 @@ public class JsonConverterWriteTests
     {
         var v = new UInt64Value { Value = 2 };
 
+        var descriptorRegistry = CreateDescriptorRegistry(typeof(UInt64Value));
         var settings = new GrpcJsonSettings { WriteInt64sAsStrings = writeInt64sAsStrings };
-        var jsonSerializerOptions = CreateSerializerOptions(settings, TypeRegistry.Empty);
+        var jsonSerializerOptions = CreateSerializerOptions(settings, TypeRegistry.Empty, descriptorRegistry);
         var json = JsonSerializer.Serialize(v, jsonSerializerOptions);
 
         Assert.Equal(expectedJson, json);
@@ -496,7 +500,8 @@ public class JsonConverterWriteTests
         _output.WriteLine("Old:");
         _output.WriteLine(jsonOld);
 
-        var jsonSerializerOptions = CreateSerializerOptions(settings, typeRegistery);
+        var descriptorRegistry = CreateDescriptorRegistry(typeof(TValue));
+        var jsonSerializerOptions = CreateSerializerOptions(settings, typeRegistery, descriptorRegistry);
         var jsonNew = JsonSerializer.Serialize(value, jsonSerializerOptions);
 
         _output.WriteLine("New:");
@@ -509,9 +514,16 @@ public class JsonConverterWriteTests
         Assert.True(comparer.Equals(doc1.RootElement, doc2.RootElement));
     }
 
-    internal static JsonSerializerOptions CreateSerializerOptions(GrpcJsonSettings? settings, TypeRegistry? typeRegistery)
+    private static DescriptorRegistry CreateDescriptorRegistry(Type type)
     {
-        var context = new JsonContext(settings ?? new GrpcJsonSettings(), typeRegistery ?? TypeRegistry.Empty, new DescriptorRegistry());
+        var descriptorRegistry = new DescriptorRegistry();
+        descriptorRegistry.RegisterFileDescriptor(JsonConverterHelper.GetMessageDescriptor(type)!.File);
+        return descriptorRegistry;
+    }
+
+    internal static JsonSerializerOptions CreateSerializerOptions(GrpcJsonSettings? settings, TypeRegistry? typeRegistery, DescriptorRegistry descriptorRegistry)
+    {
+        var context = new JsonContext(settings ?? new GrpcJsonSettings(), typeRegistery ?? TypeRegistry.Empty, descriptorRegistry);
 
         return JsonConverterHelper.CreateSerializerOptions(context);
     }

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Infrastructure/TestHelpers.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Infrastructure/TestHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
+using System.Reflection;
 using Google.Protobuf.Reflection;
 using Grpc.AspNetCore.Server;
 using Grpc.Core.Interceptors;
@@ -10,6 +11,7 @@ using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.CallHandlers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.IIS.Core;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.Infrastructure;
@@ -29,6 +31,22 @@ internal static class TestHelpers
         httpContext.Connection.RemoteIpAddress = IPAddress.Parse("127.0.0.1");
         httpContext.Features.Set<IHttpRequestLifetimeFeature>(new HttpRequestLifetimeFeature(cancellationToken));
         return httpContext;
+    }
+
+    internal static MessageDescriptor GetMessageDescriptor(Type typeToConvert)
+    {
+        var property = typeToConvert.GetProperty("Descriptor", BindingFlags.Static | BindingFlags.Public, binder: null, typeof(MessageDescriptor), Type.EmptyTypes, modifiers: null);
+        if (property == null)
+        {
+            throw new InvalidOperationException("Couldn't find Descriptor property on message type: " + typeToConvert);
+        }
+
+        var descriptor = property.GetValue(null, null) as MessageDescriptor;
+        if (descriptor == null)
+        {
+            throw new InvalidOperationException("Couldn't resolve MessageDescriptor for message type: " + typeToConvert);
+        }
+        return descriptor;
     }
 
     private class TestInterceptorActivator<T> : IGrpcInterceptorActivator<T> where T : Interceptor

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Infrastructure/TestHelpers.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Infrastructure/TestHelpers.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.CallHandlers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Server.IIS.Core;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.Infrastructure;

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ServerStreamingServerCallHandlerTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ServerStreamingServerCallHandlerTests.cs
@@ -344,8 +344,8 @@ public class ServerStreamingServerCallHandlerTests : LoggedTest
         var jsonSettings = jsonTranscodingOptions?.JsonSettings ?? new GrpcJsonSettings() { WriteIndented = false };
 
         var descriptorRegistry = new DescriptorRegistry();
-        descriptorRegistry.RegisterFileDescriptor(JsonConverterHelper.GetMessageDescriptor(typeof(TRequest))!.File);
-        descriptorRegistry.RegisterFileDescriptor(JsonConverterHelper.GetMessageDescriptor(typeof(TResponse))!.File);
+        descriptorRegistry.RegisterFileDescriptor(TestHelpers.GetMessageDescriptor(typeof(TRequest)).File);
+        descriptorRegistry.RegisterFileDescriptor(TestHelpers.GetMessageDescriptor(typeof(TResponse)).File);
 
         var jsonContext = new JsonContext(jsonSettings, jsonTranscodingOptions?.TypeRegistry ?? TypeRegistry.Empty, descriptorRegistry);
 

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ServerStreamingServerCallHandlerTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ServerStreamingServerCallHandlerTests.cs
@@ -342,7 +342,12 @@ public class ServerStreamingServerCallHandlerTests : LoggedTest
             new TestGrpcServiceActivator<JsonTranscodingGreeterService>());
 
         var jsonSettings = jsonTranscodingOptions?.JsonSettings ?? new GrpcJsonSettings() { WriteIndented = false };
-        var jsonContext = new JsonContext(jsonSettings, jsonTranscodingOptions?.TypeRegistry ?? TypeRegistry.Empty, new DescriptorRegistry());
+
+        var descriptorRegistry = new DescriptorRegistry();
+        descriptorRegistry.RegisterFileDescriptor(JsonConverterHelper.GetMessageDescriptor(typeof(TRequest))!.File);
+        descriptorRegistry.RegisterFileDescriptor(JsonConverterHelper.GetMessageDescriptor(typeof(TResponse))!.File);
+
+        var jsonContext = new JsonContext(jsonSettings, jsonTranscodingOptions?.TypeRegistry ?? TypeRegistry.Empty, descriptorRegistry);
 
         return new ServerStreamingServerCallHandler<JsonTranscodingGreeterService, TRequest, TResponse>(
             callInvoker,

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/UnaryServerCallHandlerTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/UnaryServerCallHandlerTests.cs
@@ -1272,8 +1272,8 @@ public class UnaryServerCallHandlerTests : LoggedTest
             new TestGrpcServiceActivator<JsonTranscodingGreeterService>());
 
         var descriptorRegistry = new DescriptorRegistry();
-        descriptorRegistry.RegisterFileDescriptor(JsonConverterHelper.GetMessageDescriptor(typeof(TRequest))!.File);
-        descriptorRegistry.RegisterFileDescriptor(JsonConverterHelper.GetMessageDescriptor(typeof(TResponse))!.File);
+        descriptorRegistry.RegisterFileDescriptor(TestHelpers.GetMessageDescriptor(typeof(TRequest)).File);
+        descriptorRegistry.RegisterFileDescriptor(TestHelpers.GetMessageDescriptor(typeof(TResponse)).File);
 
         var jsonContext = new JsonContext(
             jsonTranscodingOptions?.JsonSettings ?? new GrpcJsonSettings(),

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/UnaryServerCallHandlerTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/UnaryServerCallHandlerTests.cs
@@ -1271,10 +1271,14 @@ public class UnaryServerCallHandlerTests : LoggedTest
             MethodOptions.Create(new[] { serviceOptions }),
             new TestGrpcServiceActivator<JsonTranscodingGreeterService>());
 
+        var descriptorRegistry = new DescriptorRegistry();
+        descriptorRegistry.RegisterFileDescriptor(JsonConverterHelper.GetMessageDescriptor(typeof(TRequest))!.File);
+        descriptorRegistry.RegisterFileDescriptor(JsonConverterHelper.GetMessageDescriptor(typeof(TResponse))!.File);
+
         var jsonContext = new JsonContext(
             jsonTranscodingOptions?.JsonSettings ?? new GrpcJsonSettings(),
             jsonTranscodingOptions?.TypeRegistry ?? TypeRegistry.Empty,
-            new DescriptorRegistry());
+            descriptorRegistry);
 
         return new UnaryServerCallHandler<JsonTranscodingGreeterService, TRequest, TResponse>(
             unaryServerCallInvoker,


### PR DESCRIPTION
Currently, reflection is used to get descriptors for message types. This PR changes serialization to use a registry to resolve descriptors.