### PR TITLE
Enable nullable reference types in analyzer projects

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -88,7 +88,7 @@ internal static class DiagnosticDescriptors
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: "https://aka.ms/aspnet/analyzers");
-  
+
     internal static readonly DiagnosticDescriptor DoNotUseHostConfigureServices = new(
         "ASP0012",
         "Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices",

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Http/HeaderDictionaryIndexerAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Http/HeaderDictionaryIndexerAnalyzer.cs
@@ -168,7 +168,7 @@ public partial class HeaderDictionaryIndexerAnalyzer : DiagnosticAnalyzer
 
     private static void AddDiagnosticWarning(OperationAnalysisContext context, Location location, string headerName, string propertyName)
     {
-        var propertiesBuilder = ImmutableDictionary.CreateBuilder<string, string>();
+        var propertiesBuilder = ImmutableDictionary.CreateBuilder<string, string?>();
         propertiesBuilder.Add("HeaderName", headerName);
         propertiesBuilder.Add("ResolvedPropertyName", propertyName);
 

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Http/RequestDelegateReturnTypeAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Http/RequestDelegateReturnTypeAnalyzer.cs
@@ -22,7 +22,7 @@ public partial class RequestDelegateReturnTypeAnalyzer : DiagnosticAnalyzer
         {
             var compilation = context.Compilation;
             var wellKnownTypes = WellKnownTypes.GetOrCreate(compilation);
-            
+
             context.RegisterOperationAction(context =>
             {
                 var methodReference = (IMethodReferenceOperation)context.Operation;

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/AnalyzerDebug.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/AnalyzerDebug.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.Analyzers.Infrastructure;
+
+// Debug.Assert is missing nullable annotation in netstandard2.0
+internal static class AnalyzerDebug
+{
+    /// <inheritdoc cref="Debug.Assert(bool)"/>
+    [Conditional("DEBUG")]
+    public static void Assert([DoesNotReturnIf(false)] bool b) => Debug.Assert(b);
+
+    /// <inheritdoc cref="Debug.Assert(bool, string)"/>
+    [Conditional("DEBUG")]
+    public static void Assert([DoesNotReturnIf(false)] bool b, string message)
+        => Debug.Assert(b, message);
+}

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/WellKnownTypes.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/WellKnownTypes.cs
@@ -13,11 +13,13 @@ namespace Microsoft.AspNetCore.App.Analyzers.Infrastructure;
 internal enum WellKnownType
 {
     Microsoft_AspNetCore_Components_Rendering_RenderTreeBuilder,
+    Microsoft_AspNetCore_Http_IHeaderDictionary,
     Microsoft_AspNetCore_Http_Metadata_IFromBodyMetadata,
     Microsoft_AspNetCore_Http_Metadata_IFromFormMetadata,
     Microsoft_AspNetCore_Http_Metadata_IFromHeaderMetadata,
     Microsoft_AspNetCore_Http_Metadata_IFromQueryMetadata,
     Microsoft_AspNetCore_Http_Metadata_IFromServiceMetadata,
+    Microsoft_AspNetCore_Http_HeaderDictionaryExtensions,
     Microsoft_AspNetCore_Routing_IEndpointRouteBuilder,
     Microsoft_AspNetCore_Mvc_ControllerAttribute,
     Microsoft_AspNetCore_Mvc_NonControllerAttribute,
@@ -59,11 +61,13 @@ internal class WellKnownTypes
     private static readonly string[] WellKnownTypeNames = new[]
     {
         "Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder",
+        "Microsoft.AspNetCore.Http.IHeaderDictionary",
         "Microsoft.AspNetCore.Http.Metadata.IFromBodyMetadata",
         "Microsoft.AspNetCore.Http.Metadata.IFromFormMetadata",
         "Microsoft.AspNetCore.Http.Metadata.IFromHeaderMetadata",
         "Microsoft.AspNetCore.Http.Metadata.IFromQueryMetadata",
         "Microsoft.AspNetCore.Http.Metadata.IFromServiceMetadata",
+        "Microsoft.AspNetCore.Http.HeaderDictionaryExtensions",
         "Microsoft.AspNetCore.Routing.IEndpointRouteBuilder",
         "Microsoft.AspNetCore.Mvc.ControllerAttribute",
         "Microsoft.AspNetCore.Mvc.NonControllerAttribute",
@@ -98,10 +102,10 @@ internal class WellKnownTypes
         "Microsoft.AspNetCore.Http.RequestDelegate",
         "System.Threading.Tasks.Task`1",
     };
-    
+
     public static WellKnownTypes GetOrCreate(Compilation compilation) =>
         LazyWellKnownTypesCache.GetOrCreateValue(compilation, static c => new WellKnownTypes(c));
-    
+
     private readonly INamedTypeSymbol?[] _lazyWellKnownTypes;
     private readonly Compilation _compilation;
 
@@ -109,7 +113,7 @@ internal class WellKnownTypes
     {
         AssertEnumAndTableInSync();
     }
-    
+
     [Conditional("DEBUG")]
     private static void AssertEnumAndTableInSync()
     {

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Microsoft.AspNetCore.App.Analyzers.csproj
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Microsoft.AspNetCore.App.Analyzers.csproj
@@ -7,6 +7,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <Nullable>Enable</Nullable>
     <RootNamespace>Microsoft.AspNetCore.Analyzers</RootNamespace>
+    <SuppressNullableAttributesImport>true</SuppressNullableAttributesImport>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,6 +21,7 @@
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)IsExternalInit.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Roslyn\CodeAnalysisExtensions.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Nullable\NullableAttributes.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RenderTreeBuilder/RenderTreeBuilderAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RenderTreeBuilder/RenderTreeBuilderAnalyzer.cs
@@ -36,7 +36,7 @@ public partial class RenderTreeBuilderAnalyzer : DiagnosticAnalyzer
 
                 foreach (var argument in invocation.Arguments)
                 {
-                    if (argument.Parameter.Ordinal == SequenceParameterOrdinal)
+                    if (argument.Parameter?.Ordinal == SequenceParameterOrdinal)
                     {
                         if (!argument.Value.Syntax.IsKind(SyntaxKind.NumericLiteralExpression))
                         {

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
@@ -60,14 +60,14 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
         return false;
     }
 
-    public override Task<CompletionDescription> GetDescriptionAsync(Document document, CompletionItem item, CancellationToken cancellationToken)
+    public override Task<CompletionDescription?> GetDescriptionAsync(Document document, CompletionItem item, CancellationToken cancellationToken)
     {
         if (!item.Properties.TryGetValue(DescriptionKey, out var description))
         {
-            return Task.FromResult<CompletionDescription>(null);
+            return Task.FromResult<CompletionDescription?>(null);
         }
 
-        return Task.FromResult(CompletionDescription.Create(
+        return Task.FromResult<CompletionDescription?>(CompletionDescription.Create(
             ImmutableArray.Create(new TaggedText(TextTags.Text, description))));
     }
 
@@ -186,6 +186,11 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
         {
             // MVC
             var methodSyntax = container.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+            if (methodSyntax == null)
+            {
+                return;
+            }
+
             var methodSymbol = semanticModel.GetDeclaredSymbol(methodSyntax, context.CancellationToken);
 
             // Check method is a valid MVC action.
@@ -251,7 +256,7 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
             var properties = ImmutableDictionary.CreateBuilder<string, string>();
             properties.Add(StartKey, textChange.Span.Start.ToString(CultureInfo.InvariantCulture));
             properties.Add(LengthKey, textChange.Span.Length.ToString(CultureInfo.InvariantCulture));
-            properties.Add(NewTextKey, textChange.NewText);
+            properties.Add(NewTextKey, textChange.NewText ?? string.Empty);
             properties.Add(DescriptionKey, embeddedItem.FullDescription);
 
             if (change.NewPosition != null)
@@ -283,23 +288,29 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
         return SyntaxFacts.IsPredefinedType(token.Kind()) || token.IsKind(SyntaxKind.IdentifierToken);
     }
 
-    private static SyntaxToken? TryGetMvcActionRouteToken(CompletionContext context, SemanticModel? semanticModel, MethodDeclarationSyntax? method)
+    private static SyntaxToken? TryGetMvcActionRouteToken(CompletionContext context, SemanticModel semanticModel, MethodDeclarationSyntax? method)
     {
-        foreach (var attributeList in method.AttributeLists)
+        if (method != null)
         {
-            foreach (var attribute in attributeList.Attributes)
+            foreach (var attributeList in method.AttributeLists)
             {
-                foreach (var attributeArgument in attribute.ArgumentList.Arguments)
+                foreach (var attribute in attributeList.Attributes)
                 {
-                    if (RouteStringSyntaxDetector.IsArgumentToAttributeParameterWithMatchingStringSyntaxAttribute(
-                        semanticModel,
-                        attributeArgument,
-                        context.CancellationToken,
-                        out var identifer) &&
-                        identifer == "Route" &&
-                        attributeArgument.Expression is LiteralExpressionSyntax literalExpression)
+                    if (attribute.ArgumentList != null)
                     {
-                        return literalExpression.Token;
+                        foreach (var attributeArgument in attribute.ArgumentList.Arguments)
+                        {
+                            if (RouteStringSyntaxDetector.IsArgumentToAttributeParameterWithMatchingStringSyntaxAttribute(
+                                semanticModel,
+                                attributeArgument,
+                                context.CancellationToken,
+                                out var identifer) &&
+                                identifer == "Route" &&
+                                attributeArgument.Expression is LiteralExpressionSyntax literalExpression)
+                            {
+                                return literalExpression.Token;
+                            }
+                        }
                     }
                 }
             }
@@ -308,7 +319,7 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
         return null;
     }
 
-    private static SyntaxNode? TryFindMvcActionParameter(SyntaxNode node)
+    private static SyntaxNode? TryFindMvcActionParameter(SyntaxNode? node)
     {
         var current = node;
         while (current != null)
@@ -324,7 +335,7 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
         return null;
     }
 
-    private static SyntaxNode? TryFindMinimalApiArgument(SyntaxNode node)
+    private static SyntaxNode? TryFindMinimalApiArgument(SyntaxNode? node)
     {
         var current = node;
         while (current != null)
@@ -380,7 +391,7 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
             return true;
         }
 
-        var parameterTypeSymbol = semanticModel.GetSymbolInfo(token.Parent, cancellationToken).GetAnySymbol();
+        var parameterTypeSymbol = semanticModel.GetSymbolInfo(token.Parent!, cancellationToken).GetAnySymbol();
         if (parameterTypeSymbol is INamedTypeSymbol typeSymbol)
         {
             // String is valid.
@@ -425,7 +436,7 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
 
         // The cursor is on an identifier (parameter name) and completion is explicitly triggered (e.g. CTRL+SPACE)
         return true;
-        
+
         static bool IsTryParse(ISymbol item)
         {
             return item is IMethodSymbol methodSymbol &&
@@ -495,7 +506,7 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
     {
         foreach (var routeParameter in context.Tree.RouteParameters)
         {
-            context.AddIfMissing(routeParameter.Name, suffix: null, description: "(Route parameter)", WellKnownTags.Parameter, parentOpt);
+            context.AddIfMissing(routeParameter.Name, suffix: string.Empty, description: "(Route parameter)", WellKnownTags.Parameter, parentOpt);
         }
     }
 
@@ -580,7 +591,7 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
 
         public void AddIfMissing(
             string displayText, string suffix, string description, string glyph,
-            SyntaxToken? parentOpt, int? positionOffset = null, string insertionText = null)
+            SyntaxToken? parentOpt, int? positionOffset = null, string? insertionText = null)
         {
             var replacementStart = parentOpt != null
                 ? parentOpt.Value.GetLocation().SourceSpan.Start

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
@@ -288,28 +288,25 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
         return SyntaxFacts.IsPredefinedType(token.Kind()) || token.IsKind(SyntaxKind.IdentifierToken);
     }
 
-    private static SyntaxToken? TryGetMvcActionRouteToken(CompletionContext context, SemanticModel semanticModel, MethodDeclarationSyntax? method)
+    private static SyntaxToken? TryGetMvcActionRouteToken(CompletionContext context, SemanticModel semanticModel, MethodDeclarationSyntax method)
     {
-        if (method != null)
+        foreach (var attributeList in method.AttributeLists)
         {
-            foreach (var attributeList in method.AttributeLists)
+            foreach (var attribute in attributeList.Attributes)
             {
-                foreach (var attribute in attributeList.Attributes)
+                if (attribute.ArgumentList != null)
                 {
-                    if (attribute.ArgumentList != null)
+                    foreach (var attributeArgument in attribute.ArgumentList.Arguments)
                     {
-                        foreach (var attributeArgument in attribute.ArgumentList.Arguments)
+                        if (RouteStringSyntaxDetector.IsArgumentToAttributeParameterWithMatchingStringSyntaxAttribute(
+                            semanticModel,
+                            attributeArgument,
+                            context.CancellationToken,
+                            out var identifer) &&
+                            identifer == "Route" &&
+                            attributeArgument.Expression is LiteralExpressionSyntax literalExpression)
                         {
-                            if (RouteStringSyntaxDetector.IsArgumentToAttributeParameterWithMatchingStringSyntaxAttribute(
-                                semanticModel,
-                                attributeArgument,
-                                context.CancellationToken,
-                                out var identifer) &&
-                                identifer == "Route" &&
-                                attributeArgument.Expression is LiteralExpressionSyntax literalExpression)
-                            {
-                                return literalExpression.Token;
-                            }
+                            return literalExpression.Token;
                         }
                     }
                 }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/EmbeddedSyntax/EmbeddedDiagnostic.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/EmbeddedSyntax/EmbeddedDiagnostic.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using Microsoft.AspNetCore.Analyzers.Infrastructure;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure.EmbeddedSyntax;
@@ -15,7 +15,7 @@ internal struct EmbeddedDiagnostic : IEquatable<EmbeddedDiagnostic>
 
     public EmbeddedDiagnostic(string message, TextSpan span)
     {
-        Debug.Assert(message != null);
+        AnalyzerDebug.Assert(message != null);
         Message = message;
         Span = span;
     }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/EmbeddedSyntax/EmbeddedSeparatedSyntaxNodeList.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/EmbeddedSyntax/EmbeddedSeparatedSyntaxNodeList.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Microsoft.AspNetCore.Analyzers.Infrastructure;
 
 namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure.EmbeddedSyntax;
 
@@ -63,8 +64,8 @@ internal readonly struct EmbeddedSeparatedSyntaxNodeList<TSyntaxKind, TSyntaxNod
                 // x2 here to get only even indexed numbers. Follows same logic 
                 // as SeparatedSyntaxList in that the separator tokens are not returned
                 var nodeOrToken = NodesAndTokens[index * 2];
-                Debug.Assert(nodeOrToken.IsNode);
-                Debug.Assert(nodeOrToken.Node != null);
+                AnalyzerDebug.Assert(nodeOrToken.IsNode);
+                AnalyzerDebug.Assert(nodeOrToken.Node != null);
                 return (TDerivedNode)nodeOrToken.Node;
             }
 

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/EmbeddedSyntax/EmbeddedSyntaxHelpers.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/EmbeddedSyntax/EmbeddedSyntaxHelpers.cs
@@ -19,7 +19,7 @@ internal static class EmbeddedSyntaxHelpers
     public static TextSpan GetSpan(VirtualChar firstChar, VirtualChar lastChar)
         => TextSpan.FromBounds(firstChar.Span.Start, lastChar.Span.End);
 
-    public static RoutePatternNode GetChildNode(this RoutePatternNode node, RoutePatternKind kind)
+    public static RoutePatternNode? GetChildNode(this RoutePatternNode node, RoutePatternKind kind)
     {
         foreach (var child in node)
         {

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/EmbeddedSyntax/EmbeddedSyntaxToken.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/EmbeddedSyntax/EmbeddedSyntaxToken.cs
@@ -20,12 +20,12 @@ internal struct EmbeddedSyntaxToken<TSyntaxKind> where TSyntaxKind : struct
     /// Returns the value of the token. For example, if the token represents an integer capture,
     /// then this property would return the actual integer.
     /// </summary>
-    public readonly object Value;
+    public readonly object? Value;
 
     public EmbeddedSyntaxToken(
         TSyntaxKind kind,
         VirtualCharSequence virtualChars,
-        ImmutableArray<EmbeddedDiagnostic> diagnostics, object value)
+        ImmutableArray<EmbeddedDiagnostic> diagnostics, object? value)
     {
         Debug.Assert(!diagnostics.IsDefault);
         Kind = kind;

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/MvcDetector.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/MvcDetector.cs
@@ -13,8 +13,13 @@ internal static class MvcDetector
 
     // Replicates logic from ControllerFeatureProvider.IsController.
     // https://github.com/dotnet/aspnetcore/blob/785cf9bd845a8d28dce3a079c4fedf4a4c2afe57/src/Mvc/Mvc.Core/src/Controllers/ControllerFeatureProvider.cs#L39
-    public static bool IsController(INamedTypeSymbol typeSymbol, WellKnownTypes wellKnownTypes)
+    public static bool IsController(INamedTypeSymbol? typeSymbol, WellKnownTypes wellKnownTypes)
     {
+        if (typeSymbol is null)
+        {
+            return false;
+        }
+
         if (!typeSymbol.IsReferenceType)
         {
             return false;

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/RoutePatternParametersDetector.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/RoutePatternParametersDetector.cs
@@ -69,7 +69,7 @@ internal static class RoutePatternParametersDetector
         {
             var attributeClass = attributeData.AttributeClass;
 
-            if (wellKnownTypes.Implements(attributeClass, allNoneRouteMetadataTypes))
+            if (attributeClass != null && wellKnownTypes.Implements(attributeClass, allNoneRouteMetadataTypes))
             {
                 return true;
             }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/RoutePatternUsageDetector.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/RoutePatternUsageDetector.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
 
 internal readonly record struct RoutePatternUsageContext(
     IMethodSymbol? MethodSymbol,
-    SyntaxNode MethodSyntax,
+    SyntaxNode? MethodSyntax,
     bool IsMinimal,
     bool IsMvcAttribute);
 
@@ -81,7 +81,7 @@ internal static class RoutePatternUsageDetector
     private static SyntaxNode? FindAttributeParent(SyntaxNode container)
     {
         var argument = container.Parent;
-        if (argument.Parent is not AttributeArgumentListSyntax argumentList)
+        if (argument?.Parent is not AttributeArgumentListSyntax argumentList)
         {
             return null;
         }
@@ -99,9 +99,9 @@ internal static class RoutePatternUsageDetector
         return attributeList.Parent;
     }
 
-    private static IMethodSymbol? FindMvcMethod(WellKnownTypes wellKnownTypes, IMethodSymbol methodSymbol)
+    private static IMethodSymbol? FindMvcMethod(WellKnownTypes wellKnownTypes, IMethodSymbol? methodSymbol)
     {
-        if (methodSymbol.ContainingType is not INamedTypeSymbol typeSymbol)
+        if (methodSymbol?.ContainingType is not INamedTypeSymbol typeSymbol)
         {
             return null;
         }
@@ -122,7 +122,7 @@ internal static class RoutePatternUsageDetector
     public static MapMethodParts? FindMapMethodParts(SemanticModel semanticModel, WellKnownTypes wellKnownTypes, SyntaxNode container, CancellationToken cancellationToken)
     {
         var argument = container.Parent;
-        if (argument.Parent is not BaseArgumentListSyntax argumentList ||
+        if (argument?.Parent is not BaseArgumentListSyntax argumentList ||
             argumentList.Parent is null)
         {
             return null;
@@ -195,7 +195,7 @@ internal static class RoutePatternUsageDetector
         return new MapMethodParts(method, literalExpression, delegateArgument.Expression);
     }
 
-    private static ArgumentSyntax? GetArgumentSyntax(BaseArgumentListSyntax argumentList, IMethodSymbol methodSymbol, IParameterSymbol? parameterSymbol)
+    private static ArgumentSyntax? GetArgumentSyntax(BaseArgumentListSyntax argumentList, IMethodSymbol methodSymbol, IParameterSymbol parameterSymbol)
     {
         foreach (var argument in argumentList.Arguments)
         {

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/RouteStringSyntaxDetector.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/RouteStringSyntaxDetector.cs
@@ -15,11 +15,11 @@ namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
 internal static class RouteStringSyntaxDetector
 {
     private static readonly EmbeddedLanguageCommentDetector _commentDetector = new(ImmutableArray.Create("Route"));
-    
+
     public static bool IsRouteStringSyntaxToken(SyntaxToken token, SemanticModel semanticModel, CancellationToken cancellationToken, out RouteOptions options)
     {
         options = default;
-        
+
         if (!IsAnyStringLiteral(token.RawKind))
         {
             return false;
@@ -57,11 +57,11 @@ internal static class RouteStringSyntaxDetector
         SyntaxToken token,
         SemanticModel semanticModel,
         CancellationToken cancellationToken,
-        [NotNullWhen(true)] out string identifier,
-        [NotNullWhen(true)] out IEnumerable<string>? options)
+        [NotNullWhen(true)] out string? identifier,
+        out IEnumerable<string>? options)
     {
         options = null;
-        
+
         if (token.Parent is not LiteralExpressionSyntax)
         {
             identifier = null;
@@ -351,15 +351,15 @@ internal static class RouteStringSyntaxDetector
         return true;
     }
 
-    private static ISymbol FindFieldOrPropertyForAttributeArgument(SemanticModel semanticModel, SyntaxNode argument, CancellationToken cancellationToken)
+    private static ISymbol? FindFieldOrPropertyForAttributeArgument(SemanticModel semanticModel, SyntaxNode argument, CancellationToken cancellationToken)
         => argument is AttributeArgumentSyntax { NameEquals.Name: var name }
             ? semanticModel.GetSymbolInfo(name, cancellationToken).GetAnySymbol()
             : null;
 
-    private static IParameterSymbol FindParameterForArgument(SemanticModel semanticModel, SyntaxNode argument, bool allowUncertainCandidates, CancellationToken cancellationToken)
+    private static IParameterSymbol? FindParameterForArgument(SemanticModel semanticModel, SyntaxNode argument, bool allowUncertainCandidates, CancellationToken cancellationToken)
         => ((ArgumentSyntax)argument).DetermineParameter(semanticModel, allowUncertainCandidates, allowParams: false, cancellationToken);
 
-    private static IParameterSymbol FindParameterForAttributeArgument(SemanticModel semanticModel, SyntaxNode argument, bool allowUncertainCandidates, CancellationToken cancellationToken)
+    private static IParameterSymbol? FindParameterForAttributeArgument(SemanticModel semanticModel, SyntaxNode argument, bool allowUncertainCandidates, CancellationToken cancellationToken)
         => ((AttributeArgumentSyntax)argument).DetermineParameter(semanticModel, allowUncertainCandidates, allowParams: false, cancellationToken);
 
     /// <summary>

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePattern/RoutePatternHelpers.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePattern/RoutePatternHelpers.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Analyzers.Infrastructure;
 using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure.EmbeddedSyntax;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
 
@@ -24,7 +25,11 @@ internal static class RoutePatternHelpers
     {
         if (Equals(nodeOrToken.Kind, kind))
         {
-            node = nodeOrToken.Node!;
+            // Caller is specifying the kind so should know that the kind is for a node.
+            // Double check just in case.
+            AnalyzerDebug.Assert(nodeOrToken.Node != null);
+
+            node = nodeOrToken.Node;
             return true;
         }
 

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePattern/RoutePatternHelpers.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePattern/RoutePatternHelpers.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Analyzers.Infrastructure;
@@ -23,10 +24,10 @@ internal static class RoutePatternHelpers
         where TSyntaxKind : struct
         where TSyntaxNode : EmbeddedSyntaxNode<TSyntaxKind, TSyntaxNode>
     {
-        if (Equals(nodeOrToken.Kind, kind))
+        // Use EqualityComparer.Equals instead of object.Equals to avoid boxing.
+        if (EqualityComparer<TSyntaxKind>.Default.Equals(nodeOrToken.Kind, kind))
         {
-            // Caller is specifying the kind so should know that the kind is for a node.
-            // Double check just in case.
+            // Caller is specifying the kind so should know that the kind is for a node. Assert to double check.
             AnalyzerDebug.Assert(nodeOrToken.Node != null);
 
             node = nodeOrToken.Node;

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePattern/RoutePatternHelpers.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePattern/RoutePatternHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure.EmbeddedSyntax;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
 
@@ -16,4 +17,18 @@ internal static class RoutePatternHelpers
 
     public static RoutePatternToken CreateMissingToken(RoutePatternKind kind)
         => CreateToken(kind, VirtualCharSequence.Empty);
+
+    public static bool TryGetNode<TSyntaxKind, TSyntaxNode>(this EmbeddedSyntaxNodeOrToken<TSyntaxKind, TSyntaxNode> nodeOrToken, TSyntaxKind kind, [NotNullWhen(true)] out TSyntaxNode? node)
+        where TSyntaxKind : struct
+        where TSyntaxNode : EmbeddedSyntaxNode<TSyntaxKind, TSyntaxNode>
+    {
+        if (Equals(nodeOrToken.Kind, kind))
+        {
+            node = nodeOrToken.Node!;
+            return true;
+        }
+
+        node = null;
+        return false;
+    }
 }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePattern/RoutePatternLexer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePattern/RoutePatternLexer.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
 using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure.EmbeddedSyntax;
 using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure.VirtualChars;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
@@ -236,7 +235,7 @@ internal struct RoutePatternLexer
         if (hasInvalidChar)
         {
             token = token.AddDiagnosticIfNone(
-                new EmbeddedDiagnostic(Resources.FormatTemplateRoute_InvalidParameterName(token.Value.ToString().Replace("{{", "{").Replace("}}", "}")), token.GetSpan()));
+                new EmbeddedDiagnostic(Resources.FormatTemplateRoute_InvalidParameterName(token.Value!.ToString().Replace("{{", "{").Replace("}}", "}")), token.GetSpan()));
         }
 
         return token;

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePattern/RoutePatternParser.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePattern/RoutePatternParser.cs
@@ -7,11 +7,9 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure.EmbeddedSyntax;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
 using Microsoft.CodeAnalysis.Text;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.RoutePattern;
 

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePattern/RoutePatternTree.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePattern/RoutePatternTree.cs
@@ -51,7 +51,7 @@ internal sealed class RoutePatternTree : EmbeddedSyntaxTree<RoutePatternKind, Ro
 
 internal readonly struct RouteParameter
 {
-    public RouteParameter(string name, bool encodeSlashes, string defaultValue, bool isOptional, bool isCatchAll, ImmutableArray<string> policies, TextSpan span)
+    public RouteParameter(string name, bool encodeSlashes, string? defaultValue, bool isOptional, bool isCatchAll, ImmutableArray<string> policies, TextSpan span)
     {
         Name = name;
         EncodeSlashes = encodeSlashes;
@@ -64,7 +64,7 @@ internal readonly struct RouteParameter
 
     public readonly string Name;
     public readonly bool EncodeSlashes;
-    public readonly string DefaultValue;
+    public readonly string? DefaultValue;
     public readonly bool IsOptional;
     public readonly bool IsCatchAll;
     public readonly ImmutableArray<string> Policies;

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternAnalyzer.cs
@@ -85,7 +85,7 @@ public class RoutePatternAnalyzer : DiagnosticAnalyzer
                     // Get method parameters, including properties on AsParameters objects.
                     var parameterSymbols = RoutePatternParametersDetector.GetParameterSymbols(usageContext.MethodSymbol);
                     var resolvedParameterSymbols = RoutePatternParametersDetector.ResolvedParameters(usageContext.MethodSymbol, wellKnownTypes);
-                    
+
                     foreach (var parameter in resolvedParameterSymbols)
                     {
                         routeParameterNames.Remove(parameter.Symbol.Name);
@@ -110,7 +110,7 @@ public class RoutePatternAnalyzer : DiagnosticAnalyzer
                         }
 
                         // These properties are used by the fixer.
-                        var propertiesBuilder = ImmutableDictionary.CreateBuilder<string, string>();
+                        var propertiesBuilder = ImmutableDictionary.CreateBuilder<string, string?>();
                         propertiesBuilder.Add("RouteParameterName", unusedParameter.Name);
                         propertiesBuilder.Add("RouteParameterPolicy", string.Join(string.Empty, unusedParameter.Policies));
                         propertiesBuilder.Add("RouteParameterIsOptional", unusedParameter.IsOptional.ToString(CultureInfo.InvariantCulture));

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternHighlighter.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternHighlighter.cs
@@ -37,7 +37,7 @@ internal class RoutePatternHighlighter : IAspNetCoreEmbeddedLanguageDocumentHigh
     }
 
     private static ImmutableArray<AspNetCoreDocumentHighlights> GetHighlights(
-        RoutePatternTree tree, SemanticModel semanticModel, WellKnownTypes wellKnownTypes, int position, IMethodSymbol methodSymbol, CancellationToken cancellationToken)
+        RoutePatternTree tree, SemanticModel semanticModel, WellKnownTypes wellKnownTypes, int position, IMethodSymbol? methodSymbol, CancellationToken cancellationToken)
     {
         var virtualChar = tree.Text.Find(position);
         if (virtualChar == null)
@@ -64,7 +64,7 @@ internal class RoutePatternHighlighter : IAspNetCoreEmbeddedLanguageDocumentHigh
 
             // Match route parameter to method parameter. Parameters in a route aren't case sensitive.
             // First attempt an exact match, then a case insensitive match.
-            var parameterName = node.ParameterNameToken.Value.ToString();
+            var parameterName = node.ParameterNameToken.Value!.ToString();
             var matchingParameterSymbol = parameterSymbols.FirstOrDefault(s => s.Name == parameterName)
                 ?? parameterSymbols.FirstOrDefault(s => string.Equals(s.Name, parameterName, StringComparison.OrdinalIgnoreCase));
 
@@ -77,7 +77,7 @@ internal class RoutePatternHighlighter : IAspNetCoreEmbeddedLanguageDocumentHigh
         return ImmutableArray.Create(new AspNetCoreDocumentHighlights(highlightSpans.ToImmutable()));
     }
 
-    private static void HighlightSymbol(SemanticModel semanticModel, IMethodSymbol methodSymbol, IList<AspNetCoreHighlightSpan> highlightSpans, ISymbol? matchingParameter, CancellationToken cancellationToken)
+    private static void HighlightSymbol(SemanticModel semanticModel, IMethodSymbol methodSymbol, IList<AspNetCoreHighlightSpan> highlightSpans, ISymbol matchingParameter, CancellationToken cancellationToken)
     {
         // Highlight parameter in method signature.
         // e.g. "{id}" in route highlights id in "void Foo(string id) {}"

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectMismatchedParameterOptionality.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectMismatchedParameterOptionality.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics;
 using System.Linq;
+using Microsoft.AspNetCore.Analyzers.Infrastructure;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -25,13 +25,13 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
         IOperation? value = null;
         foreach (var argument in invocation.Arguments)
         {
-            if (argument.Parameter.Ordinal == 1)
+            if (argument.Parameter?.Ordinal == 1)
             {
                 value = argument.Value;
             }
         }
 
-        Debug.Assert(value is not null);
+        AnalyzerDebug.Assert(value is not null);
         if (value.ConstantValue is not { HasValue: true } constant ||
             constant.Value is not string routeTemplate)
         {

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DisallowMvcBindArgumentsOnParameters.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DisallowMvcBindArgumentsOnParameters.cs
@@ -22,7 +22,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
             var modelBindingAttribute = parameter.GetAttributes(wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Mvc_ModelBinding_IBinderTypeProviderMetadata)).FirstOrDefault() ??
                 parameter.GetAttributes(wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Mvc_BindAttribute)).FirstOrDefault();
 
-            if (modelBindingAttribute is not null)
+            if (modelBindingAttribute?.AttributeClass is not null)
             {
                 var location = Location.None;
                 if (!parameter.DeclaringSyntaxReferences.IsEmpty)

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
@@ -44,7 +44,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
                 IDelegateCreationOperation? delegateCreation = null;
                 foreach (var argument in invocation.Arguments)
                 {
-                    if (argument.Parameter.Ordinal == DelegateParameterOrdinal)
+                    if (argument.Parameter?.Ordinal == DelegateParameterOrdinal)
                     {
                         delegateCreation = argument.Descendants().OfType<IDelegateCreationOperation>().FirstOrDefault();
                         break;
@@ -75,7 +75,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
                     {
                         var syntaxReference = methodReference.Method.DeclaringSyntaxReferences.Single();
                         var syntaxNode = syntaxReference.GetSyntax(context.CancellationToken);
-                        var methodOperation = syntaxNode.SyntaxTree == invocation.SemanticModel.SyntaxTree
+                        var methodOperation = syntaxNode.SyntaxTree == invocation.SemanticModel!.SyntaxTree
                             ? invocation.SemanticModel.GetOperation(syntaxNode, context.CancellationToken)
                             : null;
                         if (methodOperation is ILocalFunctionOperation { Body: not null } localFunction)

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/WebApplicationBuilder/WebApplicationBuilderAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/WebApplicationBuilder/WebApplicationBuilderAnalyzer.cs
@@ -151,7 +151,7 @@ public sealed class WebApplicationBuilderAnalyzer : DiagnosticAnalyzer
                             DiagnosticDescriptors.DoNotUseHostConfigureLogging,
                             invocation));
                 }
-                
+
                 // var builder = WebApplication.CreateBuilder(args);
                 // builder.Host.ConfigureServices(x => {});
                 if (IsDisallowedMethod(
@@ -183,7 +183,7 @@ public sealed class WebApplicationBuilderAnalyzer : DiagnosticAnalyzer
                             DiagnosticDescriptors.DoNotUseHostConfigureServices,
                             invocation));
                 }
-                
+
                 // var builder = WebApplication.CreateBuilder();
                 // builder.WebHost.ConfigureAppConfiguration(builder => {});
                 if (IsDisallowedMethod(
@@ -333,7 +333,7 @@ public sealed class WebApplicationBuilderAnalyzer : DiagnosticAnalyzer
             string disallowedMethodName,
             INamedTypeSymbol[] disallowedMethodTypes)
         {
-            if (!string.Equals(methodSymbol?.Name, disallowedMethodName, StringComparison.Ordinal))
+            if (!string.Equals(methodSymbol.Name, disallowedMethodName, StringComparison.Ordinal))
             {
                 return false;
             }

--- a/src/Framework/AspNetCoreAnalyzers/src/CodeFixes/Http/HeaderDictionaryIndexerFixer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/CodeFixes/Http/HeaderDictionaryIndexerFixer.cs
@@ -30,7 +30,7 @@ public class HeaderDictionaryIndexerFixer : CodeFixProvider
                 var title = $"Access header '{headerName}' with {resolvedPropertyName} property";
                 context.RegisterCodeFix(
                     CodeAction.Create(title,
-                        cancellationToken => FixHeaderDictionaryIndexer(diagnostic, context.Document, resolvedPropertyName, cancellationToken),
+                        cancellationToken => FixHeaderDictionaryIndexer(diagnostic, context.Document, resolvedPropertyName!, cancellationToken),
                         equivalenceKey: title),
                     diagnostic);
             }

--- a/src/Framework/AspNetCoreAnalyzers/src/CodeFixes/Microsoft.AspNetCore.App.CodeFixes.csproj
+++ b/src/Framework/AspNetCoreAnalyzers/src/CodeFixes/Microsoft.AspNetCore.App.CodeFixes.csproj
@@ -14,6 +14,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <Nullable>Enable</Nullable>
     <RootNamespace>Microsoft.AspNetCore.Analyzers</RootNamespace>
+    <SuppressNullableAttributesImport>true</SuppressNullableAttributesImport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternParserTests_BasicTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternParserTests_BasicTests.cs
@@ -977,6 +977,109 @@ public partial class RoutePatternParserTests
     }
 
     [Fact]
+    public void TestOptionalOnlyParameter()
+    {
+        Test(@"""{?}""", @"<Tree>
+  <CompilationUnit>
+    <Segment>
+      <Parameter>
+        <OpenBraceToken>{</OpenBraceToken>
+        <ParameterName>
+          <ParameterNameToken />
+        </ParameterName>
+        <Optional>
+          <QuestionMarkToken>?</QuestionMarkToken>
+        </Optional>
+        <CloseBraceToken>}</CloseBraceToken>
+      </Parameter>
+    </Segment>
+    <EndOfFile />
+  </CompilationUnit>
+  <Diagnostics>
+    <Diagnostic Message=""The route parameter name '' is invalid. Route parameter names must be non-empty and cannot contain these characters: '{', '}', '/'. The '?' character marks a parameter as optional, and can occur only at the end of the parameter. The '*' character marks a parameter as catch-all, and can occur only at the start of the parameter."" Span=""[10..11)"" Text=""?"" />
+  </Diagnostics>
+  <Parameters />
+</Tree>");
+    }
+
+    [Fact]
+    public void TestCatchallEscapeOnlyParameter()
+    {
+        Test(@"""{*}""", @"<Tree>
+  <CompilationUnit>
+    <Segment>
+      <Parameter>
+        <OpenBraceToken>{</OpenBraceToken>
+        <CatchAll>
+          <AsteriskToken>*</AsteriskToken>
+        </CatchAll>
+        <ParameterName>
+          <ParameterNameToken />
+        </ParameterName>
+        <CloseBraceToken>}</CloseBraceToken>
+      </Parameter>
+    </Segment>
+    <EndOfFile />
+  </CompilationUnit>
+  <Diagnostics>
+    <Diagnostic Message=""The route parameter name '' is invalid. Route parameter names must be non-empty and cannot contain these characters: '{', '}', '/'. The '?' character marks a parameter as optional, and can occur only at the end of the parameter. The '*' character marks a parameter as catch-all, and can occur only at the start of the parameter."" Span=""[11..12)"" Text=""}"" />
+  </Diagnostics>
+  <Parameters />
+</Tree>");
+    }
+
+    [Fact]
+    public void TestCatchallOnlyParameter()
+    {
+        Test(@"""{**}""", @"<Tree>
+  <CompilationUnit>
+    <Segment>
+      <Parameter>
+        <OpenBraceToken>{</OpenBraceToken>
+        <CatchAll>
+          <AsteriskToken>**</AsteriskToken>
+        </CatchAll>
+        <ParameterName>
+          <ParameterNameToken />
+        </ParameterName>
+        <CloseBraceToken>}</CloseBraceToken>
+      </Parameter>
+    </Segment>
+    <EndOfFile />
+  </CompilationUnit>
+  <Diagnostics>
+    <Diagnostic Message=""The route parameter name '' is invalid. Route parameter names must be non-empty and cannot contain these characters: '{', '}', '/'. The '?' character marks a parameter as optional, and can occur only at the end of the parameter. The '*' character marks a parameter as catch-all, and can occur only at the start of the parameter."" Span=""[12..13)"" Text=""}"" />
+  </Diagnostics>
+  <Parameters />
+</Tree>");
+    }
+
+    [Fact]
+    public void TestCatchallPolicyParameter()
+    {
+        Test(@"""{**:int}""", @"<Tree>
+  <CompilationUnit>
+    <Segment>
+      <Parameter>
+        <OpenBraceToken>{</OpenBraceToken>
+        <CatchAll>
+          <AsteriskToken>**</AsteriskToken>
+        </CatchAll>
+        <ParameterName>
+          <ParameterNameToken value="":int"">:int</ParameterNameToken>
+        </ParameterName>
+        <CloseBraceToken>}</CloseBraceToken>
+      </Parameter>
+    </Segment>
+    <EndOfFile />
+  </CompilationUnit>
+  <Parameters>
+    <Parameter Name="":int"" IsCatchAll=""true"" IsOptional=""false"" EncodeSlashes=""false"" />
+  </Parameters>
+</Tree>");
+    }
+
+    [Fact]
     public void TestParameterWithEscapedPolicyArgument()
     {
         Test(@"""{ssn:regex(^\\d{{3}}-\\d{{2}}-\\d{{4}}$)}""", @"<Tree>

--- a/src/Shared/Roslyn/CodeAnalysisExtensions.cs
+++ b/src/Shared/Roslyn/CodeAnalysisExtensions.cs
@@ -22,7 +22,7 @@ internal static class CodeAnalysisExtensions
     {
         foreach (var declaredAttribute in symbol.GetAttributes())
         {
-            if (attribute.IsAssignableFrom(declaredAttribute.AttributeClass))
+            if (declaredAttribute.AttributeClass is not null && attribute.IsAssignableFrom(declaredAttribute.AttributeClass))
             {
                 yield return declaredAttribute;
             }
@@ -132,7 +132,7 @@ internal static class CodeAnalysisExtensions
     {
         foreach (var declaredAttribute in symbol.GetAttributes())
         {
-            if (attribute.IsAssignableFrom(declaredAttribute.AttributeClass))
+            if (declaredAttribute.AttributeClass is not null && attribute.IsAssignableFrom(declaredAttribute.AttributeClass))
             {
                 return true;
             }


### PR DESCRIPTION
Enable nullable annotations in some analyzer projects. Quite a few analyzer errors I've seen during dev and runtime are from NREs. Nullable warnings will help make our analyzer more resilient to unexpected bugs.

These are netstandard2.0 projects, so enabling nullable references is not 100% kosher, but other analyzer projects enable nullable references, e.g. https://github.com/dotnet/roslyn-analyzers, and Roslyn APIs are annotated.