### PR TITLE
Enable configuring the connection timeouts in HubConnectionBuilder

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnectionBuilder.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnectionBuilder.cs
@@ -22,6 +22,22 @@ public class HubConnectionBuilder : IHubConnectionBuilder
     public IServiceCollection Services { get; }
 
     /// <summary>
+    /// Gets or sets the server timeout interval for the connection.
+    /// </summary>
+    /// <remarks>
+    /// The client times out if it hasn't heard from the server for `this` long.
+    /// </remarks>
+    public TimeSpan? ServerTimeout { get; set; }
+
+    /// <summary>
+    /// Gets or sets the interval at which the client sends ping messages.
+    /// </summary>
+    /// <remarks>
+    /// Sending any message resets the timer to the start of the interval.
+    /// </remarks>
+    public TimeSpan? KeepAliveInterval { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="HubConnectionBuilder"/> class.
     /// </summary>
     public HubConnectionBuilder()
@@ -52,7 +68,19 @@ public class HubConnectionBuilder : IHubConnectionBuilder
         var endPoint = serviceProvider.GetService<EndPoint>() ??
             throw new InvalidOperationException($"Cannot create {nameof(HubConnection)} instance. An {nameof(EndPoint)} was not configured.");
 
-        return serviceProvider.GetRequiredService<HubConnection>();
+        var hubConnection =  serviceProvider.GetRequiredService<HubConnection>();
+
+        if (ServerTimeout.HasValue)
+        {
+            hubConnection.ServerTimeout = ServerTimeout.Value;
+        }
+            
+        if (KeepAliveInterval.HasValue)
+        {
+            hubConnection.KeepAliveInterval = KeepAliveInterval.Value;
+        }
+            
+        return hubConnection;
     }
 
     // Prevents from being displayed in intellisense

--- a/src/SignalR/clients/csharp/Client.Core/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/clients/csharp/Client.Core/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,8 @@
 #nullable enable
+Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilder.KeepAliveInterval.get -> System.TimeSpan?
+Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilder.KeepAliveInterval.set -> void
+Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilder.ServerTimeout.get -> System.TimeSpan?
+Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilder.ServerTimeout.set -> void
 static Microsoft.AspNetCore.SignalR.Client.HubConnectionExtensions.On<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this Microsoft.AspNetCore.SignalR.Client.HubConnection! hubConnection, string! methodName, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, System.Threading.Tasks.Task<TResult>!>! handler) -> System.IDisposable!
 static Microsoft.AspNetCore.SignalR.Client.HubConnectionExtensions.On<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this Microsoft.AspNetCore.SignalR.Client.HubConnection! hubConnection, string! methodName, System.Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult>! handler) -> System.IDisposable!
 static Microsoft.AspNetCore.SignalR.Client.HubConnectionExtensions.On<T1, T2, T3, T4, T5, T6, T7, TResult>(this Microsoft.AspNetCore.SignalR.Client.HubConnection! hubConnection, string! methodName, System.Func<T1, T2, T3, T4, T5, T6, T7, System.Threading.Tasks.Task<TResult>!>! handler) -> System.IDisposable!

--- a/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionBuilderTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/HubConnectionBuilderTests.cs
@@ -77,4 +77,32 @@ public class HubConnectionBuilderTests
 
         Assert.IsType<MessagePackHubProtocol>(serviceProvider.GetService<IHubProtocol>());
     }
+
+    [Fact]
+    public void CanSetServerTimeout()
+    {
+        var serverTimeout = TimeSpan.FromMinutes(1);
+        var builder = new HubConnectionBuilder();
+        builder.Services.AddSingleton<IConnectionFactory>(new HttpConnectionFactory(Options.Create(new HttpConnectionOptions()), NullLoggerFactory.Instance));
+        builder.WithUrl("http://example.com");
+        builder.ServerTimeout = serverTimeout;
+
+        var connection = builder.Build();
+
+        Assert.Equal(builder.ServerTimeout, connection.ServerTimeout);
+    }
+
+    [Fact]
+    public void CanSetKeepAliveInterval()
+    {
+        var keepAliveInterval = TimeSpan.FromMinutes(2);
+        var builder = new HubConnectionBuilder();
+        builder.Services.AddSingleton<IConnectionFactory>(new HttpConnectionFactory(Options.Create(new HttpConnectionOptions()), NullLoggerFactory.Instance));
+        builder.WithUrl("http://example.com");
+        builder.KeepAliveInterval = keepAliveInterval;
+
+        var connection = builder.Build();
+
+        Assert.Equal(builder.KeepAliveInterval, connection.KeepAliveInterval);
+    }
 }

--- a/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
@@ -48,6 +48,22 @@ export class HubConnectionBuilder {
     /** @internal */
     public logger?: ILogger;
 
+    /** The server timeout in milliseconds.
+     *
+     * If this timeout elapses without receiving any messages from the server, the connection will be terminated with an error.
+     * The default timeout value is 30,000 milliseconds (30 seconds).
+     */
+    public serverTimeoutInMilliseconds?: number;
+
+    /** Default interval at which to ping the server.
+     *
+     * The default value is 15,000 milliseconds (15 seconds).
+     * Allows the server to detect hard disconnects (like when a client unplugs their computer).
+     * The ping will happen at most as often as the server pings.
+     * If the server pings every 5 seconds, a value lower than 5 will ping every 5 seconds.
+     */
+    public keepAliveIntervalInMilliseconds?: number;
+
     /** If defined, this indicates the client should automatically attempt to reconnect if the connection is lost. */
     /** @internal */
     public reconnectPolicy?: IRetryPolicy;
@@ -204,11 +220,21 @@ export class HubConnectionBuilder {
         }
         const connection = new HttpConnection(this.url, httpConnectionOptions);
 
-        return HubConnection.create(
+        const hubConnection = HubConnection.create(
             connection,
             this.logger || NullLogger.instance,
             this.protocol || new JsonHubProtocol(),
             this.reconnectPolicy);
+
+        if (this.serverTimeoutInMilliseconds !== undefined) {
+            hubConnection.serverTimeoutInMilliseconds = this.serverTimeoutInMilliseconds;
+        }
+
+        if (this.keepAliveIntervalInMilliseconds !== undefined) {
+            hubConnection.keepAliveIntervalInMilliseconds = this.keepAliveIntervalInMilliseconds;
+        }
+
+        return hubConnection;
     }
 }
 


### PR DESCRIPTION
# Enable configuring the connection timeouts in HubConnectionBuilder

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Added `serverTimeoutInMillisecons` and `keepAliveIntervalInMilliseconds ` to `HubConnectionBuilder` ts client.
Added `ServerTimeout ` and `KeepAliveInterval ` o `HubConnectionBuilder` csharp client.

Fixes #44742