### PR TITLE
Remove framework boxing in Minimal when writing Json

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -2264,6 +2264,7 @@ public static partial class RequestDelegateFactory
     // Only for use with structs, use WriteJsonResponse for classes to preserve polymorphism
     private static Task WriteJsonResponseOfT<T>(HttpResponse response, T value, JsonSerializerOptions? options)
     {
+        Debug.Assert(typeof(T).IsValueType);
         return HttpResponseJsonExtensions.WriteAsJsonAsync(response, value, options, default);
     }
 

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -66,6 +66,7 @@ public static partial class RequestDelegateFactory
     private static readonly PropertyInfo FormIndexerProperty = typeof(IFormCollection).GetProperty("Item")!;
 
     private static readonly MethodInfo JsonResultWriteResponseAsyncMethod = typeof(RequestDelegateFactory).GetMethod(nameof(WriteJsonResponse), BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly MethodInfo JsonResultWriteResponseOfTAsyncMethod = typeof(RequestDelegateFactory).GetMethod(nameof(WriteJsonResponseOfT), BindingFlags.NonPublic | BindingFlags.Static)!;
 
     private static readonly MethodInfo LogParameterBindingFailedMethod = GetMethodInfo<Action<HttpContext, string, string, string, bool>>((httpContext, parameterType, parameterName, sourceValue, shouldThrow) =>
         Log.ParameterBindingFailed(httpContext, parameterType, parameterName, sourceValue, shouldThrow));
@@ -1111,8 +1112,8 @@ public static partial class RequestDelegateFactory
         }
         else if (returnType.IsValueType)
         {
-            var box = Expression.TypeAs(methodCall, typeof(object));
-            return Expression.Call(JsonResultWriteResponseAsyncMethod, HttpResponseExpr, box, factoryContext.JsonSerializerOptionsExpression);
+            return Expression.Call(JsonResultWriteResponseOfTAsyncMethod.MakeGenericMethod(returnType),
+                HttpResponseExpr, methodCall, factoryContext.JsonSerializerOptionsExpression);
         }
         else
         {
@@ -2258,7 +2259,12 @@ public static partial class RequestDelegateFactory
         // https://github.com/dotnet/aspnetcore/issues/43894
         // https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-polymorphism
         return HttpResponseJsonExtensions.WriteAsJsonAsync(response, value, value is null ? typeof(object) : value.GetType(), options, default);
+    }
 
+    // Only for use with structs, use WriteJsonResponse for classes to preserve polymorphism
+    private static Task WriteJsonResponseOfT<T>(HttpResponse response, T value, JsonSerializerOptions? options)
+    {
+        return HttpResponseJsonExtensions.WriteAsJsonAsync(response, value, options, default);
     }
 
     private static NotSupportedException GetUnsupportedReturnTypeException(Type returnType)

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -2988,6 +2988,28 @@ public partial class RequestDelegateFactoryTests : LoggedTest
         Assert.Equal("Write even more tests!", deserializedResponseBody!.Name);
     }
 
+    [Fact]
+    public async Task RequestDelegateWritesComplexStructReturnValueAsJsonResponseBody()
+    {
+        var httpContext = CreateHttpContext();
+        var responseBodyStream = new MemoryStream();
+        httpContext.Response.Body = responseBodyStream;
+
+        var factoryResult = RequestDelegateFactory.Create(() => new TodoStruct(42, "Bob", true));
+        var requestDelegate = factoryResult.RequestDelegate;
+
+        await requestDelegate(httpContext);
+
+        var deserializedResponseBody = JsonSerializer.Deserialize<TodoStruct>(responseBodyStream.ToArray(), new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.Equal(42, deserializedResponseBody.Id);
+        Assert.Equal("Bob", deserializedResponseBody.Name);
+        Assert.True(deserializedResponseBody.IsComplete);
+    }
+
     public static IEnumerable<object[]> ChildResult
     {
         get
@@ -3363,6 +3385,8 @@ public partial class RequestDelegateFactoryTests : LoggedTest
             Task<Todo?> TaskTestTodoAction() => Task.FromResult<Todo?>(null);
             ValueTask<Todo?> ValueTaskTestTodoAction() => ValueTask.FromResult<Todo?>(null);
 
+            TodoStruct? TodoStructAction() => null;
+
             return new List<object[]>
                 {
                     new object[] { (Func<bool?>)TestBoolAction },
@@ -3374,6 +3398,7 @@ public partial class RequestDelegateFactoryTests : LoggedTest
                     new object[] { (Func<Todo?>)TestTodoAction },
                     new object[] { (Func<Task<Todo?>>)TaskTestTodoAction },
                     new object[] { (Func<ValueTask<Todo?>>)ValueTaskTestTodoAction },
+                    new object[] { (Func<TodoStruct?>)TodoStructAction },
                 };
         }
     }


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/45330

This removes the boxing of struct Json results from our layer and pushes it into the System.Text.Json layer. Users can then avoid the boxing by using the source generator or `JsonConverter` APIs.