### PR TITLE
Remove allocation of logger name from constructor of Renderer

### DIFF
--- a/src/Components/Components/src/RenderTree/Renderer.Log.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.Log.cs
@@ -43,9 +43,9 @@ public abstract partial class Renderer
         }
 
         [LoggerMessage(4, LogLevel.Debug, "Disposing component {ComponentId} of type {ComponentType}", EventName = "DisposingComponent", SkipEnabledCheck = true)]
-        private static partial void DisposingComponent(ILogger<Renderer> logger, int componentId, Type componentType);
+        private static partial void DisposingComponent(ILogger logger, int componentId, Type componentType);
 
-        public static void DisposingComponent(ILogger<Renderer> logger, ComponentState componentState)
+        public static void DisposingComponent(ILogger logger, ComponentState componentState)
         {
             if (logger.IsEnabled(LogLevel.Debug)) // This is almost always false, so skip the evaluations
             {
@@ -54,9 +54,9 @@ public abstract partial class Renderer
         }
 
         [LoggerMessage(5, LogLevel.Debug, "Handling event {EventId} of type '{EventType}'", EventName = "HandlingEvent", SkipEnabledCheck = true)]
-        public static partial void HandlingEvent(ILogger<Renderer> logger, ulong eventId, string eventType);
+        public static partial void HandlingEvent(ILogger logger, ulong eventId, string eventType);
 
-        public static void HandlingEvent(ILogger<Renderer> logger, ulong eventHandlerId, EventArgs? eventArgs)
+        public static void HandlingEvent(ILogger logger, ulong eventHandlerId, EventArgs? eventArgs)
         {
             if (logger.IsEnabled(LogLevel.Debug)) // This is almost always false, so skip the evaluations
             {

--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -93,7 +93,10 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
         }
 
         _serviceProvider = serviceProvider;
-        _logger = loggerFactory.CreateLogger<Renderer>();
+        // Would normally use ILogger<T> here to get the benefit of the string name being cached but this is a public ctor that
+        // has always taken ILoggerFactory so to avoid the per-instance string allocation of the logger name we just pass the
+        // logger name in here as a string literal.
+        _logger = loggerFactory.CreateLogger("Microsoft.AspNetCore.Components.RenderTree.Renderer");
         _componentFactory = new ComponentFactory(componentActivator);
     }
 

--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -29,7 +29,7 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
     private readonly RenderBatchBuilder _batchBuilder = new RenderBatchBuilder();
     private readonly Dictionary<ulong, EventCallback> _eventBindings = new Dictionary<ulong, EventCallback>();
     private readonly Dictionary<ulong, ulong> _eventHandlerIdReplacements = new Dictionary<ulong, ulong>();
-    private readonly ILogger<Renderer> _logger;
+    private readonly ILogger _logger;
     private readonly ComponentFactory _componentFactory;
     private Dictionary<int, ParameterView>? _rootComponentsLatestParameters;
     private Task? _ongoingQuiescenceTask;


### PR DESCRIPTION
# Remove allocation of logger name from constructor of Renderer

Found when profiling a prototype for component rendering from minimal API endpoints. The `Renderer` is created per logical render operation, e.g. per request in server rendering, and today it allocates a new string for the `ILogger` instance name.

<img width="964" alt="image" src="https://user-images.githubusercontent.com/249088/205992494-779b0733-1eb8-4e0a-987c-a3166df5da5e.png">

We can't just switch to using `ILogger<T>` in the constructor instead of `ILoggerFactory` as it's public API so we need to hard code the logger name as a string literal.
