### PR TITLE
Harden IPv6Any error handling

### DIFF
--- a/src/Servers/Kestrel/Core/src/AnyIPListenOptions.cs
+++ b/src/Servers/Kestrel/Core/src/AnyIPListenOptions.cs
@@ -24,9 +24,12 @@ internal sealed class AnyIPListenOptions : ListenOptions
         {
             await base.BindAsync(context, cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception ex) when (!(ex is IOException))
+        catch (Exception ex) when (ex is not IOException
+            // HttpsConnectionMiddleware.CreateHttp3Options, Http3 doesn't support OnAuthenticate.
+            && ex is not NotSupportedException)
         {
-            context.Logger.LogDebug(CoreStrings.FormatFallbackToIPv4Any(IPEndPoint.Port));
+            context.Logger.LogTrace(ex, CoreStrings.FailedToBindToIPv6Any, IPEndPoint.Port);
+            context.Logger.LogDebug(CoreStrings.FallbackToIPv4Any, IPEndPoint.Port, IPEndPoint.Port);
 
             // for machines that do not support IPv6
             EndPoint = new IPEndPoint(IPAddress.Any, IPEndPoint.Port);

--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -719,4 +719,7 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="ConnectResponseCanNotHaveBody" xml:space="preserve">
     <value>Responses to 'CONNECT' requests with the success status code '{StatusCode}' cannot have a response body. Use the 'IHttpExtendedConnectFeature' to accept and write to the 'CONNECT' stream.</value>
   </data>
+  <data name="FailedToBindToIPv6Any" xml:space="preserve">
+    <value>Failed to bind to http://[::]:{port} (IPv6Any).</value>
+  </data>
 </root>

--- a/src/Servers/Kestrel/shared/test/ServerRetryHelper.cs
+++ b/src/Servers/Kestrel/shared/test/ServerRetryHelper.cs
@@ -34,7 +34,7 @@ public static class ServerRetryHelper
             catch (Exception ex)
             {
                 retryCount++;
-                nextPortAttempt = port + Random.Shared.Next(1000);
+                nextPortAttempt = port + Random.Shared.Next(100);
 
                 if (retryCount >= RetryCount)
                 {

--- a/src/Servers/Kestrel/shared/test/ServerRetryHelper.cs
+++ b/src/Servers/Kestrel/shared/test/ServerRetryHelper.cs
@@ -19,11 +19,11 @@ public static class ServerRetryHelper
         var retryCount = 0;
 
         // Add a random number to starting port to reduce chance of conflicts because of multiple tests using this retry.
-        var nextPortAttempt = 5000 + Random.Shared.Next(500);
+        var nextPortAttempt = 30000 + Random.Shared.Next(10000);
 
         while (true)
         {
-            // Find a port that's available for TCP and UDP. Start with port 5000 and search upwards from there.
+            // Find a port that's available for TCP and UDP. Start with the given port search upwards from there.
             var port = GetAvailablePort(nextPortAttempt, logger);
 
             try
@@ -34,7 +34,7 @@ public static class ServerRetryHelper
             catch (Exception ex)
             {
                 retryCount++;
-                nextPortAttempt = port + 1;
+                nextPortAttempt = port + Random.Shared.Next(1000);
 
                 if (retryCount >= RetryCount)
                 {
@@ -42,7 +42,7 @@ public static class ServerRetryHelper
                 }
                 else
                 {
-                    logger.LogError(ex, $"Error running test {retryCount}. Retrying.");
+                    logger.LogError(ex, "Error running test {retryCount}. Retrying.", retryCount);
                 }
             }
         }
@@ -50,7 +50,7 @@ public static class ServerRetryHelper
 
     private static int GetAvailablePort(int startingPort, ILogger logger)
     {
-        logger.LogInformation($"Searching for free port starting at {startingPort}.");
+        logger.LogInformation("Searching for free port starting at {startingPort}.", startingPort);
 
         var unavailableEndpoints = new List<IPEndPoint>();
 
@@ -65,19 +65,19 @@ public static class ServerRetryHelper
         // Ignore active UDP listeners
         AddEndpoints(startingPort, unavailableEndpoints, properties.GetActiveUdpListeners());
 
-        logger.LogInformation($"Found {unavailableEndpoints.Count} unavailable endpoints.");
+        logger.LogInformation("Found {count} unavailable endpoints.", unavailableEndpoints.Count);
 
         for (var i = startingPort; i < ushort.MaxValue; i++)
         {
             var match = unavailableEndpoints.FirstOrDefault(ep => ep.Port == i);
             if (match == null)
             {
-                logger.LogInformation($"Port {i} free.");
+                logger.LogInformation("Port {i} free.", i);
                 return i;
             }
             else
             {
-                logger.LogInformation($"Port {i} in use. End point: {match}");
+                logger.LogInformation("Port {i} in use. End point: {match}", i, match);
             }
         }
 

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
@@ -272,7 +272,6 @@ public class Http3TlsTests : LoggedTest
             });
 
             using var host = builder.Build();
-            using var client = HttpHelpers.CreateClient();
 
             var exception = await Assert.ThrowsAsync<NotSupportedException>(() =>
                 host.StartAsync().DefaultTimeout());


### PR DESCRIPTION
Fixes flaky test #43548

This test starts the server and expect a NotSupportedException due to some TLS options we don't support with HTTP/3(Quic).

Buggy flow:
- Bind to IPv6Any for Sockets / HTTP1 & 2
- Bind to IPv6Any for Quic, throw NotSupportedException when setting up TLS
- AnyIPListenOptions catches the Exception and tries to rebind to IPv4Any for Sockets instead. However, we were just on that port so we'll often get a conflict.

Fix: Don't fall back to IPv4Any for a NotSupportedException.

I also cleaned up some log statements and adjusted the port scanning to skip around more and avoid conflicts with other tests.