### PR TITLE
Correct XML Doc spelling mistake

### DIFF
--- a/src/Security/Authentication/OpenIdConnect/src/Events/AuthenticationFailedContext.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/Events/AuthenticationFailedContext.cs
@@ -7,7 +7,7 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 namespace Microsoft.AspNetCore.Authentication.OpenIdConnect;
 
 /// <summary>
-/// A conext for <see cref="OpenIdConnectEvents.AuthenticationFailed"/>.
+/// A context for <see cref="OpenIdConnectEvents.AuthenticationFailed"/>.
 /// </summary>
 public class AuthenticationFailedContext : RemoteAuthenticationContext<OpenIdConnectOptions>
 {


### PR DESCRIPTION
# Correct XML Doc spelling mistake

Changed `conext` to `context`

## Description

Corrects a spelling mistake which is reflected in the docs
