### PR TITLE
remove duplicate null check

### DIFF
--- a/src/Components/Components/src/PersistentComponentState.cs
+++ b/src/Components/Components/src/PersistentComponentState.cs
@@ -68,11 +68,6 @@ public class PersistentComponentState
             throw new ArgumentNullException(nameof(key));
         }
 
-        if (key is null)
-        {
-            throw new ArgumentNullException(nameof(key));
-        }
-
         if (!PersistingState)
         {
             throw new InvalidOperationException("Persisting state is only allowed during an OnPersisting callback.");


### PR DESCRIPTION
# Summary
removes identical repeat of the preceding `if` block. 

# Details 
This block may have been a copy/paste error originally or intended to be a null check of the TValue object instead, but I don't see a problem with letting people store null if they want to.