### PR TITLE
Add ambiguous route analyzer

### DIFF
--- a/src/Framework/App.Ref/src/CompatibilitySuppressions.xml
+++ b/src/Framework/App.Ref/src/CompatibilitySuppressions.xml
@@ -1,7 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<Suppressions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Suppression>
     <DiagnosticId>PKV004</DiagnosticId>
     <Target>net7.0</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>PKV004</DiagnosticId>
+    <Target>net8.0</Target>
   </Suppression>
 </Suppressions>

--- a/src/Framework/App.Ref/src/CompatibilitySuppressions.xml
+++ b/src/Framework/App.Ref/src/CompatibilitySuppressions.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Suppressions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>PKV004</DiagnosticId>
     <Target>net7.0</Target>

--- a/src/Framework/App.Runtime/src/CompatibilitySuppressions.xml
+++ b/src/Framework/App.Runtime/src/CompatibilitySuppressions.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Suppressions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>PKV0001</DiagnosticId>
     <Target>net7.0</Target>

--- a/src/Framework/App.Runtime/src/CompatibilitySuppressions.xml
+++ b/src/Framework/App.Runtime/src/CompatibilitySuppressions.xml
@@ -1,7 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<Suppressions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Suppression>
     <DiagnosticId>PKV0001</DiagnosticId>
     <Target>net7.0</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>PKV0001</DiagnosticId>
+    <Target>net8.0</Target>
   </Suppression>
 </Suppressions>

--- a/src/Framework/AspNetCoreAnalyzers/samples/WebAppSample/Program.cs
+++ b/src/Framework/AspNetCoreAnalyzers/samples/WebAppSample/Program.cs
@@ -17,8 +17,8 @@ app.MapGet("/users/{userId}/books/{bookId?}", IResult (int userId, int? bookId) 
 });
 
 app.MapGet("/posts/{**rest}", (string rest) => $"Routing to {rest}");
-app.MapGet("/todos/{id}", (int id) => db.Todos.Find(id));
-app.MapGet("/todos/{text}", (string text) => db.Todos.Where(t => t.Text.Contains(text)));
+app.MapGet("/todos/{id:int}", (int id) => db.Todos.Find(id));
+app.MapGet("/todos/{text:alpha}", (string text) => db.Todos.Where(t => t.Text.Contains(text)));
 app.MapGet("/posts/{slug:regex(^[a-z0-9_-]+$)}", (string slug) =>
 {
     return $"Match slug: {Regex.IsMatch(slug, "[a-z0-9_-]+")}";

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -182,7 +182,7 @@ internal static class DiagnosticDescriptors
     internal static readonly DiagnosticDescriptor AmbiguousRouteHandlerRoute = new(
         "ASP0022",
         "Route conflict detected between route handlers",
-        "Route '{0}' conflicts with another handler route. An HTTP request that matches multiple routes results in an ambiguous match error. Fix the conflict by changing the route's path, HTTP method, or route constraints.",
+        "Route '{0}' conflicts with another handler route. An HTTP request that matches multiple routes results in an ambiguous match error. Fix the conflict by changing the route's pattern, HTTP method, or route constraints.",
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -182,7 +182,7 @@ internal static class DiagnosticDescriptors
     internal static readonly DiagnosticDescriptor AmbiguousRouteHandlerRoute = new(
         "ASP0022",
         "Route used by multiple route handlers is ambiguous and will fail to match.",
-        "Route '{0}' is ambiguous with other route handler routes. An HTTP request must match a single route handler to succeed. Consider changing the route path, HTTP method, or add parameter constraints to one of the routes to remove route ambiguity.",
+        "Route '{0}' conflicts with another handler route. An HTTP request that matches multiple routes results in an ambiguous match error. Fix the conflict by changing the route's path, HTTP method, or route constraints.",
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -181,7 +181,7 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor AmbiguousRouteHandlerRoute = new(
         "ASP0022",
-        "Route used by multiple route handlers is ambiguous and will fail to match.",
+        "Route conflict detected between route handlers",
         "Route '{0}' conflicts with another handler route. An HTTP request that matches multiple routes results in an ambiguous match error. Fix the conflict by changing the route's path, HTTP method, or route constraints.",
         "Usage",
         DiagnosticSeverity.Warning,

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -178,4 +178,13 @@ internal static class DiagnosticDescriptors
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         helpLinkUri: "https://aka.ms/aspnet/analyzers");
+
+    internal static readonly DiagnosticDescriptor AmbiguousRouteHandlerRoute = new(
+        "ASP0022",
+        "Route used by multiple route handlers is ambiguous and will fail to match.",
+        "Route '{0}' is ambiguous with other route handler routes. An HTTP request must match a single route handler to succeed. Consider changing the route path, HTTP method, or add parameter constraints to one of the routes to remove route ambiguity.",
+        "Usage",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        helpLinkUri: "https://aka.ms/aspnet/analyzers");
 }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/AmbiguousRoutePatternComparer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/AmbiguousRoutePatternComparer.cs
@@ -30,7 +30,7 @@ internal sealed class AmbiguousRoutePatternComparer : IEqualityComparer<RoutePat
 
             var equal = xPart switch
             {
-                RoutePatternSegmentSeperatorNode _ => yPart is RoutePatternSegmentSeperatorNode,
+                RoutePatternSegmentSeparatorNode _ => yPart is RoutePatternSegmentSeparatorNode,
                 RoutePatternSegmentNode xSegment => Equals(xSegment, yPart as RoutePatternSegmentNode),
                 _ => throw new InvalidOperationException($"Unexpected part type '{xPart.Kind}'."),
             };
@@ -63,7 +63,7 @@ internal sealed class AmbiguousRoutePatternComparer : IEqualityComparer<RoutePat
 
             var equal = xChild switch
             {
-                RoutePatternOptionalSeperatorNode _ => yChild is RoutePatternOptionalSeperatorNode,
+                RoutePatternOptionalSeparatorNode _ => yChild is RoutePatternOptionalSeparatorNode,
                 RoutePatternReplacementNode xReplacement => yChild is RoutePatternReplacementNode yReplacement && Equals(xReplacement.TextToken.Value, yReplacement.TextToken.Value),
                 RoutePatternLiteralNode xLiteral => yChild is RoutePatternLiteralNode yLiteral && Equals(xLiteral.LiteralToken.Value, yLiteral.LiteralToken.Value),
                 RoutePatternParameterNode xParameter => Equals(xParameter, yChild as RoutePatternParameterNode),

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/AmbiguousRoutePatternComparer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/AmbiguousRoutePatternComparer.cs
@@ -139,7 +139,7 @@ internal sealed class AmbiguousRoutePatternComparer : IEqualityComparer<RoutePat
 
     public int GetHashCode(RoutePatternTree obj)
     {
-        // TODO: Improve hash code calculate. This is rudimentary and will generate a lot of collisions.
+        // TODO: Improve hash code calculation. This is rudimentary and will generate a lot of collisions.
         return obj.Root.ChildCount;
     }
 }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/AmbiguousRoutePatternComparer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/AmbiguousRoutePatternComparer.cs
@@ -9,8 +9,8 @@ using Microsoft.AspNetCore.Analyzers.Infrastructure.RoutePattern;
 namespace Microsoft.AspNetCore.Analyzers.Infrastructure;
 
 /// <summary>
-/// This route pattern comparer checks to see if two route patterns match the same URL and create ambiguous match exceptions.
-/// It doesn't check two routes exactly equal each other. For example, "/product/{id}" and "/product/{name}" equal because they match the same URL.
+/// This route pattern comparer checks to see if two route patterns match the same URL and create ambiguous match exceptions at runtime.
+/// It doesn't check two routes exactly equal each other. For example, "/product/{id}" and "/product/{name}" aren't exactly equal but will match the same URL.
 /// </summary>
 internal sealed class AmbiguousRoutePatternComparer : IEqualityComparer<RoutePatternTree>
 {
@@ -86,7 +86,7 @@ internal sealed class AmbiguousRoutePatternComparer : IEqualityComparer<RoutePat
             return false;
         }
 
-        // Only parameter policies can be used to differentiate between parameters.
+        // Only parameter policies differentiate between parameters.
         var xParameterPolicies = x.ParameterParts.Where(p => p.Kind == RoutePatternKind.ParameterPolicy).OfType<RoutePatternPolicyParameterPartNode>().ToList();
         var yParameterPolicies = y.ParameterParts.Where(p => p.Kind == RoutePatternKind.ParameterPolicy).OfType<RoutePatternPolicyParameterPartNode>().ToList();
 

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/AmbiguousRoutePatternComparer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/AmbiguousRoutePatternComparer.cs
@@ -64,8 +64,8 @@ internal sealed class AmbiguousRoutePatternComparer : IEqualityComparer<RoutePat
             var equal = xChild switch
             {
                 RoutePatternOptionalSeparatorNode _ => yChild is RoutePatternOptionalSeparatorNode,
-                RoutePatternReplacementNode xReplacement => yChild is RoutePatternReplacementNode yReplacement && Equals(xReplacement.TextToken.Value, yReplacement.TextToken.Value),
-                RoutePatternLiteralNode xLiteral => yChild is RoutePatternLiteralNode yLiteral && Equals(xLiteral.LiteralToken.Value, yLiteral.LiteralToken.Value),
+                RoutePatternReplacementNode xReplacement => yChild is RoutePatternReplacementNode yReplacement && IgnoreCaseEquals(xReplacement.TextToken.Value, yReplacement.TextToken.Value),
+                RoutePatternLiteralNode xLiteral => yChild is RoutePatternLiteralNode yLiteral && IgnoreCaseEquals(xLiteral.LiteralToken.Value, yLiteral.LiteralToken.Value),
                 RoutePatternParameterNode xParameter => Equals(xParameter, yChild as RoutePatternParameterNode),
                 _ => throw new InvalidOperationException($"Unexpected segment node type '{xChild.Kind}'."),
             };
@@ -77,6 +77,19 @@ internal sealed class AmbiguousRoutePatternComparer : IEqualityComparer<RoutePat
         }
 
         return true;
+    }
+
+    private static bool IgnoreCaseEquals(object? value1, object? value2)
+    {
+        var s1 = value1 as string;
+        var s2 = value2 as string;
+
+        if (s1 is null || s2 is null)
+        {
+            return false;
+        }
+
+        return string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool Equals(RoutePatternParameterNode x, RoutePatternParameterNode? y)

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/IRoutePatternNodeVisitor.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/IRoutePatternNodeVisitor.cs
@@ -10,8 +10,8 @@ internal interface IRoutePatternNodeVisitor
     void Visit(RoutePatternReplacementNode node);
     void Visit(RoutePatternParameterNode node);
     void Visit(RoutePatternLiteralNode node);
-    void Visit(RoutePatternSegmentSeperatorNode node);
-    void Visit(RoutePatternOptionalSeperatorNode node);
+    void Visit(RoutePatternSegmentSeparatorNode node);
+    void Visit(RoutePatternOptionalSeparatorNode node);
     void Visit(RoutePatternCatchAllParameterPartNode node);
     void Visit(RoutePatternNameParameterPartNode node);
     void Visit(RoutePatternPolicyParameterPartNode node);

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/RoutePatternKind.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/RoutePatternKind.cs
@@ -9,7 +9,7 @@ internal enum RoutePatternKind
     EndOfFile,
     Segment,
     CompilationUnit,
-    Seperator,
+    Separator,
     Literal,
     Replacement,
     Parameter,

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/RoutePatternLexer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/RoutePatternLexer.cs
@@ -102,7 +102,7 @@ internal struct RoutePatternLexer
 
             if (ch.Value == '/')
             {
-                // Literal ends at a seperator or start of a parameter.
+                // Literal ends at a separator or start of a parameter.
                 break;
             }
             else if (ch.Value == '{' && IsUnescapedChar(ref Position, '{'))

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/RoutePatternNodes.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/RoutePatternNodes.cs
@@ -162,23 +162,23 @@ internal sealed class RoutePatternLiteralNode : RoutePatternSegmentPartNode
         => visitor.Visit(this);
 }
 
-internal sealed class RoutePatternOptionalSeperatorNode : RoutePatternSegmentPartNode
+internal sealed class RoutePatternOptionalSeparatorNode : RoutePatternSegmentPartNode
 {
-    public RoutePatternOptionalSeperatorNode(RoutePatternToken seperatorToken)
-        : base(RoutePatternKind.Seperator)
+    public RoutePatternOptionalSeparatorNode(RoutePatternToken separatorToken)
+        : base(RoutePatternKind.Separator)
     {
-        Debug.Assert(seperatorToken.Kind == RoutePatternKind.DotToken);
-        SeperatorToken = seperatorToken;
+        Debug.Assert(separatorToken.Kind == RoutePatternKind.DotToken);
+        SeparatorToken = separatorToken;
     }
 
-    public RoutePatternToken SeperatorToken { get; }
+    public RoutePatternToken SeparatorToken { get; }
 
     internal override int ChildCount => 1;
 
     internal override RoutePatternNodeOrToken ChildAt(int index)
         => index switch
         {
-            0 => SeperatorToken,
+            0 => SeparatorToken,
             _ => throw new InvalidOperationException(),
         };
 
@@ -186,23 +186,23 @@ internal sealed class RoutePatternOptionalSeperatorNode : RoutePatternSegmentPar
         => visitor.Visit(this);
 }
 
-internal sealed class RoutePatternSegmentSeperatorNode : RoutePatternRootPartNode
+internal sealed class RoutePatternSegmentSeparatorNode : RoutePatternRootPartNode
 {
-    public RoutePatternSegmentSeperatorNode(RoutePatternToken seperatorToken)
-        : base(RoutePatternKind.Seperator)
+    public RoutePatternSegmentSeparatorNode(RoutePatternToken separatorToken)
+        : base(RoutePatternKind.Separator)
     {
-        Debug.Assert(seperatorToken.Kind == RoutePatternKind.SlashToken);
-        SeperatorToken = seperatorToken;
+        Debug.Assert(separatorToken.Kind == RoutePatternKind.SlashToken);
+        SeparatorToken = separatorToken;
     }
 
-    public RoutePatternToken SeperatorToken { get; }
+    public RoutePatternToken SeparatorToken { get; }
 
     internal override int ChildCount => 1;
 
     internal override RoutePatternNodeOrToken ChildAt(int index)
         => index switch
         {
-            0 => SeperatorToken,
+            0 => SeparatorToken,
             _ => throw new InvalidOperationException(),
         };
 

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/RoutePatternNodes.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/RoutePatternNodes.cs
@@ -43,11 +43,11 @@ internal sealed class RoutePatternCompilationUnit : RoutePatternNode
 
 internal sealed class RoutePatternSegmentNode : RoutePatternRootPartNode
 {
-    public ImmutableArray<RoutePatternNode> Children { get; }
+    public ImmutableArray<RoutePatternSegmentPartNode> Children { get; }
 
     internal override int ChildCount => Children.Length;
 
-    public RoutePatternSegmentNode(ImmutableArray<RoutePatternNode> children)
+    public RoutePatternSegmentNode(ImmutableArray<RoutePatternSegmentPartNode> children)
         : base(RoutePatternKind.Segment)
     {
         Children = children;

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/RoutePatternParser.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/RoutePatternParser.cs
@@ -427,7 +427,7 @@ internal partial struct RoutePatternParser
 
     private RoutePatternSegmentNode ParseSegment()
     {
-        var result = ImmutableArray.CreateBuilder<RoutePatternNode>();
+        var result = ImmutableArray.CreateBuilder<RoutePatternSegmentPartNode>();
 
         while (_currentToken.Kind != RoutePatternKind.EndOfFile &&
             _currentToken.Kind != RoutePatternKind.SlashToken)

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/RoutePatternParser.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/RoutePatternParser.cs
@@ -171,7 +171,7 @@ internal partial struct RoutePatternParser
                     // No problem if tilde is followed by slash.
                     if (root.ChildCount > 2 &&
                         root.ChildAt(1).Node is var secondNode &&
-                        secondNode?.Kind == RoutePatternKind.Seperator)
+                        secondNode?.Kind == RoutePatternKind.Separator)
                     {
                         return;
                     }
@@ -351,18 +351,18 @@ internal partial struct RoutePatternParser
 
     private static void ValidateNoConsecutiveSeparators(RoutePatternCompilationUnit root, IList<EmbeddedDiagnostic> diagnostics)
     {
-        RoutePatternSegmentSeperatorNode? previousNode = null;
+        RoutePatternSegmentSeparatorNode? previousNode = null;
         foreach (var part in root)
         {
-            if (part.TryGetNode(RoutePatternKind.Seperator, out var seperatorNode))
+            if (part.TryGetNode(RoutePatternKind.Separator, out var separatorNode))
             {
-                var currentNode = (RoutePatternSegmentSeperatorNode)seperatorNode;
+                var currentNode = (RoutePatternSegmentSeparatorNode)separatorNode;
                 if (previousNode != null)
                 {
                     diagnostics.Add(
                         new EmbeddedDiagnostic(
                             Resources.TemplateRoute_CannotHaveConsecutiveSeparators,
-                            EmbeddedSyntaxHelpers.GetSpan(previousNode.SeperatorToken, currentNode.SeperatorToken)));
+                            EmbeddedSyntaxHelpers.GetSpan(previousNode.SeparatorToken, currentNode.SeparatorToken)));
                 }
                 previousNode = currentNode;
             }
@@ -421,7 +421,7 @@ internal partial struct RoutePatternParser
     private RoutePatternRootPartNode ParseRootPart()
         => _currentToken.Kind switch
         {
-            RoutePatternKind.SlashToken => ParseSegmentSeperator(),
+            RoutePatternKind.SlashToken => ParseSegmentSeparator(),
             _ => ParseSegment(),
         };
 
@@ -686,7 +686,7 @@ internal partial struct RoutePatternParser
         return new(colonToken, fragments.ToImmutable());
     }
 
-    private RoutePatternSegmentSeperatorNode ParseSegmentSeperator()
+    private RoutePatternSegmentSeparatorNode ParseSegmentSeparator()
         => new(ConsumeCurrentToken());
 
     private TextSpan GetTokenStartPositionSpan(RoutePatternToken token)

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/WellKnownTypes.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/WellKnownTypes.cs
@@ -56,7 +56,13 @@ internal enum WellKnownType
     System_Threading_Tasks_ValueTask_T,
     System_Reflection_ParameterInfo,
     Microsoft_AspNetCore_Http_IBindableFromHttpContext_T,
-    System_IParsable_T
+    System_IParsable_T,
+    Microsoft_AspNetCore_Builder_AuthorizationEndpointConventionBuilderExtensions,
+    Microsoft_AspNetCore_Http_OpenApiRouteHandlerBuilderExtensions,
+    Microsoft_AspNetCore_Builder_CorsEndpointConventionBuilderExtensions,
+    Microsoft_Extensions_DependencyInjection_OutputCacheConventionBuilderExtensions,
+    Microsoft_AspNetCore_Builder_RateLimiterEndpointConventionBuilderExtensions,
+    Microsoft_AspNetCore_Builder_RoutingEndpointConventionBuilderExtensions,
 }
 
 internal sealed class WellKnownTypes
@@ -108,7 +114,13 @@ internal sealed class WellKnownTypes
         "System.Threading.Tasks.ValueTask`1",
         "System.Reflection.ParameterInfo",
         "Microsoft.AspNetCore.Http.IBindableFromHttpContext`1",
-        "System.IParsable`1"
+        "System.IParsable`1",
+        "Microsoft.AspNetCore.Builder.AuthorizationEndpointConventionBuilderExtensions",
+        "Microsoft.AspNetCore.Http.OpenApiRouteHandlerBuilderExtensions",
+        "Microsoft.AspNetCore.Builder.CorsEndpointConventionBuilderExtensions",
+        "Microsoft.Extensions.DependencyInjection.OutputCacheConventionBuilderExtensions",
+        "Microsoft.AspNetCore.Builder.RateLimiterEndpointConventionBuilderExtensions",
+        "Microsoft.AspNetCore.Builder.RoutingEndpointConventionBuilderExtensions",
     };
 
     public static WellKnownTypes GetOrCreate(Compilation compilation) =>

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/RouteUsageDetector.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/RouteUsageDetector.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Net.Http;
 using System.Threading;
 using Microsoft.AspNetCore.Analyzers.Infrastructure.RoutePattern;
 using Microsoft.AspNetCore.App.Analyzers.Infrastructure;
@@ -158,16 +157,16 @@ internal static class RouteUsageDetector
             switch (mapMethodSymbol.Name)
             {
                 case "MapGet":
-                    httpMethodsBuilder.Add(HttpMethod.Get.Method);
+                    httpMethodsBuilder.Add("GET");
                     break;
                 case "MapPost":
-                    httpMethodsBuilder.Add(HttpMethod.Post.Method);
+                    httpMethodsBuilder.Add("POST");
                     break;
                 case "MapPut":
-                    httpMethodsBuilder.Add(HttpMethod.Put.Method);
+                    httpMethodsBuilder.Add("PUT");
                     break;
                 case "MapDelete":
-                    httpMethodsBuilder.Add(HttpMethod.Delete.Method);
+                    httpMethodsBuilder.Add("DELETE");
                     break;
                 case "MapPatch":
                     httpMethodsBuilder.Add("PATCH");

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/RouteUsageDetector.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/RouteUsageDetector.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using Microsoft.AspNetCore.Analyzers.Infrastructure.RoutePattern;
 using Microsoft.AspNetCore.App.Analyzers.Infrastructure;
@@ -28,11 +29,13 @@ internal record struct ParameterSymbol(ISymbol Symbol, ISymbol? TopLevelSymbol =
 }
 
 internal readonly record struct RouteUsageContext(
+    SyntaxToken RouteToken,
     IMethodSymbol? MethodSymbol,
     SyntaxNode? MethodSyntax,
     RouteUsageType UsageType,
     ImmutableArray<ISymbol> Parameters,
-    ImmutableArray<ParameterSymbol> ResolvedParameters)
+    ImmutableArray<ParameterSymbol> ResolvedParameters,
+    ImmutableArray<string> HttpMethods)
 {
     public RoutePatternOptions RoutePatternOptions => UsageType switch
     {
@@ -54,11 +57,13 @@ internal static class RouteUsageDetector
         if (routeOptions == RouteOptions.Component)
         {
             return new(
+                RouteToken: token,
                 MethodSymbol: null,
                 MethodSyntax: null,
                 UsageType: RouteUsageType.Component,
                 Parameters: ImmutableArray<ISymbol>.Empty,
-                ResolvedParameters: ImmutableArray<ParameterSymbol>.Empty);
+                ResolvedParameters: ImmutableArray<ParameterSymbol>.Empty,
+                HttpMethods: default);
         }
 
         if (token.Parent is not LiteralExpressionSyntax)
@@ -91,11 +96,13 @@ internal static class RouteUsageDetector
             var parameterSymbols = RoutePatternParametersDetector.GetParameterSymbols(mapMethodSymbol);
             var resolvedParameterSymbols = RoutePatternParametersDetector.ResolvedParameters(mapMethodSymbol, wellKnownTypes);
             return new(
+                RouteToken: token,
                 MethodSymbol: mapMethodSymbol,
                 MethodSyntax: mapMethodParts.Value.DelegateExpression,
                 UsageType: RouteUsageType.MinimalApi,
                 Parameters: parameterSymbols,
-                ResolvedParameters: resolvedParameterSymbols);
+                ResolvedParameters: resolvedParameterSymbols,
+                HttpMethods: CalculateHttpMethods(wellKnownTypes, mapMethodParts.Value.Method));
         }
         else if (container.Parent.IsKind(SyntaxKind.AttributeArgument))
         {
@@ -113,24 +120,67 @@ internal static class RouteUsageDetector
 
                 var parameterSymbols = RoutePatternParametersDetector.GetParameterSymbols(actionMethodSymbol);
                 var resolvedParameterSymbols = RoutePatternParametersDetector.ResolvedParameters(actionMethodSymbol, wellKnownTypes);
+
+                // TODO: Find HttpMethods for MVC actions.
                 return new(
+                    RouteToken: token,
                     MethodSymbol: actionMethodSymbol,
                     MethodSyntax: methodDeclarationSyntax,
                     UsageType: RouteUsageType.MvcAction,
                     Parameters: parameterSymbols,
-                    ResolvedParameters: resolvedParameterSymbols);
+                    ResolvedParameters: resolvedParameterSymbols,
+                    HttpMethods: default);
             }
             else if (attributeParent is ClassDeclarationSyntax classDeclarationSyntax)
             {
                 var classSymbol = semanticModel.GetDeclaredSymbol(classDeclarationSyntax, cancellationToken);
                 var usageType = MvcDetector.IsController(classSymbol, wellKnownTypes) ? RouteUsageType.MvcController : RouteUsageType.Other;
                 return new(
+                    RouteToken: token,
                     MethodSymbol: null,
                     MethodSyntax: null,
                     UsageType: usageType,
                     Parameters: ImmutableArray<ISymbol>.Empty,
-                    ResolvedParameters: ImmutableArray<ParameterSymbol>.Empty);
+                    ResolvedParameters: ImmutableArray<ParameterSymbol>.Empty,
+                    HttpMethods: default);
             }
+        }
+
+        return default;
+    }
+
+    private static ImmutableArray<string> CalculateHttpMethods(WellKnownTypes wellKnownTypes, IMethodSymbol mapMethodSymbol)
+    {
+        if (SymbolEqualityComparer.Default.Equals(wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Builder_EndpointRouteBuilderExtensions), mapMethodSymbol.ContainingType))
+        {
+            var httpMethodsBuilder = ImmutableArray.CreateBuilder<string>();
+            // TODO: Support MapMethods.
+            switch (mapMethodSymbol.Name)
+            {
+                case "MapGet":
+                    httpMethodsBuilder.Add(HttpMethod.Get.Method);
+                    break;
+                case "MapPost":
+                    httpMethodsBuilder.Add(HttpMethod.Post.Method);
+                    break;
+                case "MapPut":
+                    httpMethodsBuilder.Add(HttpMethod.Put.Method);
+                    break;
+                case "MapDelete":
+                    httpMethodsBuilder.Add(HttpMethod.Delete.Method);
+                    break;
+                case "MapPatch":
+                    httpMethodsBuilder.Add("PATCH");
+                    break;
+                case "Map":
+                    // No HTTP methods.
+                    break;
+                default:
+                    // Unknown/unsupported method.
+                    return default;
+            }
+
+            return httpMethodsBuilder.ToImmutable();
         }
 
         return default;

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternClassifier.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternClassifier.cs
@@ -77,12 +77,12 @@ internal sealed class RoutePatternClassifier : IAspNetCoreEmbeddedLanguageClassi
             // Nothing to highlight.
         }
 
-        public void Visit(RoutePatternSegmentSeperatorNode node)
+        public void Visit(RoutePatternSegmentSeparatorNode node)
         {
             // Nothing to highlight.
         }
 
-        public void Visit(RoutePatternOptionalSeperatorNode node)
+        public void Visit(RoutePatternOptionalSeparatorNode node)
         {
             // Nothing to highlight.
         }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectAmbiguousRoutes.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectAmbiguousRoutes.cs
@@ -56,15 +56,21 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
 
         private static IOperation? GetParentOperation(IOperation operation)
         {
-            var parent = operation.Parent;
-            while (parent is not null)
+            var current = operation;
+            while (current != null)
             {
-                if (parent is IBlockOperation)
+                if (current.Parent is IBlockOperation blockOperation)
                 {
-                    return parent;
+                    return blockOperation;
                 }
-
-                parent = parent.Parent;
+                else if (current.Parent is IConditionalOperation ||
+                    current.Parent is ICoalesceOperation ||
+                    current.Parent is ICoalesceAssignmentOperation)
+                {
+                    return current;
+                }
+                
+                current = current.Parent;
             }
 
             return null;

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectAmbiguousRoutes.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectAmbiguousRoutes.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.AspNetCore.Analyzers.Infrastructure.RoutePattern;
+using Microsoft.AspNetCore.App.Analyzers.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.AspNetCore.Analyzers.RouteHandlers;
+
+public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
+{
+    private static void DetectAmbiguousRoutes(in OperationBlockAnalysisContext context, List<MapOperation> blockRouteUsage)
+    {
+        var groupedByParent = blockRouteUsage
+            .Where(u => !u.RouteUsageModel.UsageContext.HttpMethods.IsDefault)
+            .GroupBy(u => new MapOperationGroupKey(u.Operation, u.RouteUsageModel.RoutePattern, u.RouteUsageModel.UsageContext.HttpMethods));
+
+        foreach (var ambigiousGroup in groupedByParent.Where(g => g.Count() >= 2))
+        {
+            foreach (var ambigiousMapOperation in ambigiousGroup)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.AmbiguousRouteHandlerRoute,
+                    ambigiousMapOperation.RouteUsageModel.UsageContext.RouteToken.GetLocation(),
+                    ambigiousMapOperation.RouteUsageModel.RoutePattern.Root.ToString()));
+            }
+        }
+    }
+
+    private record struct MapOperation(IInvocationOperation Operation, RouteUsageModel RouteUsageModel);
+
+    private readonly struct MapOperationGroupKey : IEquatable<MapOperationGroupKey>
+    {
+        public IOperation? ParentOperation { get; }
+        public RoutePatternTree RoutePattern { get; }
+        public ImmutableArray<string> HttpMethods { get; }
+
+        public MapOperationGroupKey(IOperation operation, RoutePatternTree routePattern, ImmutableArray<string> httpMethods)
+        {
+            Debug.Assert(!httpMethods.IsDefault);
+
+            ParentOperation = GetParentOperation(operation);
+            RoutePattern = routePattern;
+            HttpMethods = httpMethods;
+        }
+
+        private static IOperation? GetParentOperation(IOperation operation)
+        {
+            var parent = operation.Parent;
+            while (parent is not null)
+            {
+                if (parent is IBlockOperation)
+                {
+                    return parent;
+                }
+
+                parent = parent.Parent;
+            }
+
+            return null;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is MapOperationGroupKey key)
+            {
+                return Equals(key);
+            }
+            return false;
+        }
+
+        public bool Equals(MapOperationGroupKey other)
+        {
+            return
+                Equals(ParentOperation, other.ParentOperation) &&
+                RoutePatternComparer.Instance.Equals(RoutePattern, other.RoutePattern) &&
+                HasMatchingHttpMethods(HttpMethods, other.HttpMethods);
+        }
+
+        private static bool HasMatchingHttpMethods(ImmutableArray<string> httpMethods1, ImmutableArray<string> httpMethods2)
+        {
+            if (httpMethods1.IsEmpty || httpMethods2.IsEmpty)
+            {
+                return true;
+            }
+
+            foreach (var item1 in httpMethods1)
+            {
+                foreach (var item2 in httpMethods2)
+                {
+                    if (item2 == item1)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return (ParentOperation?.GetHashCode() ?? 0) ^ RoutePatternComparer.Instance.GetHashCode(RoutePattern);
+        }
+    }
+}

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectAmbiguousRoutes.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectAmbiguousRoutes.cs
@@ -6,8 +6,8 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.AspNetCore.Analyzers.Infrastructure;
 using Microsoft.AspNetCore.Analyzers.Infrastructure.RoutePattern;
-using Microsoft.AspNetCore.App.Analyzers.Infrastructure;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -33,8 +33,6 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
             }
         }
     }
-
-    private record struct MapOperation(IInvocationOperation Operation, RouteUsageModel RouteUsageModel);
 
     private readonly struct MapOperationGroupKey : IEquatable<MapOperationGroupKey>
     {
@@ -80,7 +78,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
         {
             return
                 Equals(ParentOperation, other.ParentOperation) &&
-                RoutePatternComparer.Instance.Equals(RoutePattern, other.RoutePattern) &&
+                AmbiguousRoutePatternComparer.Instance.Equals(RoutePattern, other.RoutePattern) &&
                 HasMatchingHttpMethods(HttpMethods, other.HttpMethods);
         }
 
@@ -107,7 +105,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
 
         public override int GetHashCode()
         {
-            return (ParentOperation?.GetHashCode() ?? 0) ^ RoutePatternComparer.Instance.GetHashCode(RoutePattern);
+            return (ParentOperation?.GetHashCode() ?? 0) ^ AmbiguousRoutePatternComparer.Instance.GetHashCode(RoutePattern);
         }
     }
 }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectAmbiguousRoutes.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectAmbiguousRoutes.cs
@@ -107,7 +107,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
                 ParentOperation != null &&
                 Equals(ParentOperation, other.ParentOperation) &&
                 Builder != null &&
-                Equals((Builder as ILocalReferenceOperation)?.Local, (other.Builder as ILocalReferenceOperation)?.Local) &&
+                SymbolEqualityComparer.Default.Equals((Builder as ILocalReferenceOperation)?.Local, (other.Builder as ILocalReferenceOperation)?.Local) &&
                 AmbiguousRoutePatternComparer.Instance.Equals(RoutePattern, other.RoutePattern) &&
                 HasMatchingHttpMethods(HttpMethods, other.HttpMethods);
         }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectAmbiguousRoutes.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectAmbiguousRoutes.cs
@@ -57,8 +57,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
         // - It's assigned to a variable.
         // - It's an argument to a method call, unless in a known safe method.
         var current = operation;
-        if (current.Parent is IArgumentOperation argumentOperation &&
-            argumentOperation.Parent is IInvocationOperation invocationOperation &&
+        if (current.Parent is IArgumentOperation { Parent: IInvocationOperation invocationOperation } &&
             IsAllowedEndpointBuilderMethod(invocationOperation, wellKnownTypes))
         {
             return ResolveOperation(invocationOperation, wellKnownTypes);
@@ -70,11 +69,11 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
             {
                 return blockOperation;
             }
-            else if (current.Parent is IConditionalOperation ||
-                current.Parent is ICoalesceOperation ||
-                current.Parent is IAssignmentOperation ||
-                current.Parent is IArgumentOperation ||
-                current.Parent is IInvocationOperation)
+            else if (current.Parent is IConditionalOperation or
+                ICoalesceOperation or
+                IAssignmentOperation or
+                IArgumentOperation or
+                IInvocationOperation)
             {
                 return current;
             }
@@ -106,12 +105,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
         }
         else if (SymbolEqualityComparer.Default.Equals(method.ContainingType, wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Builder_AuthorizationEndpointConventionBuilderExtensions)))
         {
-            return method.Name switch
-            {
-                "RequireAuthorization" => true,
-                "AllowAnonymous" => true,
-                _ => false
-            };
+            return method.Name is "RequireAuthorization" or "AllowAnonymous";
         }
         else if (SymbolEqualityComparer.Default.Equals(method.ContainingType, wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Http_OpenApiRouteHandlerBuilderExtensions)))
         {
@@ -138,12 +132,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
         }
         else if (SymbolEqualityComparer.Default.Equals(method.ContainingType, wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Builder_RateLimiterEndpointConventionBuilderExtensions)))
         {
-            return method.Name switch
-            {
-                "RequireRateLimiting" => true,
-                "DisableRateLimiting" => true,
-                _ => false
-            };
+            return method.Name is "RequireRateLimiting" or "DisableRateLimiting";
         }
 
         return false;

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectAmbiguousRoutes.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectAmbiguousRoutes.cs
@@ -18,6 +18,11 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
 {
     private static void DetectAmbiguousRoutes(in OperationBlockAnalysisContext context, List<MapOperation> blockRouteUsage)
     {
+        if (blockRouteUsage.Count == 0)
+        {
+            return;
+        }
+
         var groupedByParent = blockRouteUsage
             .Where(u => !u.RouteUsageModel.UsageContext.HttpMethods.IsDefault)
             .GroupBy(u => new MapOperationGroupKey(u.Operation, u.RouteUsageModel.RoutePattern, u.RouteUsageModel.UsageContext.HttpMethods));

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
@@ -54,7 +54,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
 
                 context.RegisterOperationBlockEndAction(c =>
                 {
-                    DetectAmbiguousRoutes(c, mapOperations);
+                    DetectAmbiguousRoutes(c, wellKnownTypes, mapOperations);
 
                     // Return to the pool.
                     mapOperations.Clear();

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
@@ -30,83 +30,6 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
         DiagnosticDescriptors.AmbiguousRouteHandlerRoute
     );
 
-    private record struct MapOperation(IInvocationOperation Operation, RouteUsageModel RouteUsageModel);
-
-    private readonly struct MapOperationGroupKey : IEquatable<MapOperationGroupKey>
-    {
-        public IOperation? ParentOperation { get; }
-        public RoutePatternTree RoutePattern { get; }
-        public ImmutableArray<string> HttpMethods { get; }
-
-        public MapOperationGroupKey(IOperation operation, RoutePatternTree routePattern, ImmutableArray<string> httpMethods)
-        {
-            Debug.Assert(!httpMethods.IsDefault);
-
-            ParentOperation = GetParentOperation(operation);
-            RoutePattern = routePattern;
-            HttpMethods = httpMethods;
-        }
-
-        private static IOperation? GetParentOperation(IOperation operation)
-        {
-            var parent = operation.Parent;
-            while (parent is not null)
-            {
-                if (parent is IBlockOperation)
-                {
-                    return parent;
-                }
-
-                parent = parent.Parent;
-            }
-
-            return null;
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is MapOperationGroupKey key)
-            {
-                return Equals(key);
-            }
-            return false;
-        }
-
-        public bool Equals(MapOperationGroupKey other)
-        {
-            return
-                Equals(ParentOperation, other.ParentOperation) &&
-                RoutePatternComparer.Instance.Equals(RoutePattern, other.RoutePattern) &&
-                HasMatchingHttpMethods(HttpMethods, other.HttpMethods);
-        }
-
-        private static bool HasMatchingHttpMethods(ImmutableArray<string> httpMethods1, ImmutableArray<string> httpMethods2)
-        {
-            if (httpMethods1.IsEmpty || httpMethods2.IsEmpty)
-            {
-                return true;
-            }
-
-            foreach (var item1 in httpMethods1)
-            {
-                foreach (var item2 in httpMethods2)
-                {
-                    if (item2 == item1)
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        public override int GetHashCode()
-        {
-            return (ParentOperation?.GetHashCode() ?? 0) ^ RoutePatternComparer.Instance.GetHashCode(RoutePattern);
-        }
-    }
-
     public override void Initialize(AnalysisContext context)
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
@@ -126,20 +49,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
             });
             context.RegisterOperationBlockAction(context =>
             {
-                var groupedByParent = blockRouteUsage
-                    .Where(u => !u.RouteUsageModel.UsageContext.HttpMethods.IsDefault)
-                    .GroupBy(u => new MapOperationGroupKey(u.Operation, u.RouteUsageModel.RoutePattern, u.RouteUsageModel.UsageContext.HttpMethods));
-
-                foreach (var ambigiousGroup in groupedByParent.Where(g => g.Count() >= 2))
-                {
-                    foreach (var ambigiousMapOperation in ambigiousGroup)
-                    {
-                        context.ReportDiagnostic(Diagnostic.Create(
-                            DiagnosticDescriptors.AmbiguousRouteHandlerRoute,
-                            ambigiousMapOperation.RouteUsageModel.UsageContext.RouteToken.GetLocation(),
-                            ambigiousMapOperation.RouteUsageModel.RoutePattern.Root.ToString()));
-                    }
-                }
+                DetectAmbiguousRoutes(in context, blockRouteUsage);
             });
 
             void DoOperationAnalysis(OperationAnalysisContext context)

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
@@ -196,7 +196,21 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
             SymbolEqualityComparer.Default.Equals(wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Builder_EndpointRouteBuilderExtensions), targetMethod.ContainingType) &&
             invocation.Arguments.Length == 3 &&
             targetMethod.Parameters.Length == 3 &&
-            SymbolEqualityComparer.Default.Equals(wellKnownTypes.Get(WellKnownType.System_Delegate), targetMethod.Parameters[DelegateParameterOrdinal].Type);
+            IsCompatibleDelegateType(wellKnownTypes, targetMethod);
+
+        static bool IsCompatibleDelegateType(WellKnownTypes wellKnownTypes, IMethodSymbol targetMethod)
+        {
+            var parmeterType = targetMethod.Parameters[DelegateParameterOrdinal].Type;
+            if (SymbolEqualityComparer.Default.Equals(wellKnownTypes.Get(WellKnownType.System_Delegate), parmeterType))
+            {
+                return true;
+            }
+            if (SymbolEqualityComparer.Default.Equals(wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Http_RequestDelegate), parmeterType))
+            {
+                return true;
+            }
+            return false;
+        }
     }
 
     private record struct MapOperation(IOperation? Builder, IInvocationOperation Operation, RouteUsageModel RouteUsageModel)

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
@@ -39,7 +39,8 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
             var wellKnownTypes = WellKnownTypes.GetOrCreate(compilation);
             var routeUsageCache = RouteUsageCache.GetOrCreate(compilation);
 
-            // Want ConcurrentHashSet here but since that doesn't exist, using ConcurrentDictionary and not caring about the value instead.
+            // We want ConcurrentHashSet here in case RegisterOperationAction runs in parallel.
+            // Since ConcurrentHashSet doesn't exist, use ConcurrentDictionary and ignore the value.
             var concurrentQueue = new ConcurrentQueue<ConcurrentDictionary<MapOperation, byte>>();
             context.RegisterOperationBlockStartAction(context =>
             {
@@ -50,6 +51,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
                 }
 
                 context.RegisterOperationAction(c => DoOperationAnalysis(c, mapOperations), OperationKind.Invocation);
+
                 context.RegisterOperationBlockEndAction(c =>
                 {
                     DetectAmbiguousRoutes(c, mapOperations);

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
-using Microsoft.AspNetCore.Analyzers.Infrastructure.RoutePattern;
 using Microsoft.AspNetCore.App.Analyzers.Infrastructure;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -188,4 +185,6 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
             targetMethod.Parameters.Length == 3 &&
             SymbolEqualityComparer.Default.Equals(wellKnownTypes.Get(WellKnownType.System_Delegate), targetMethod.Parameters[DelegateParameterOrdinal].Type);
     }
+
+    private record struct MapOperation(IInvocationOperation Operation, RouteUsageModel RouteUsageModel);
 }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RoutePatternComparer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RoutePatternComparer.cs
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Analyzers.Infrastructure.RoutePattern;
+
+namespace Microsoft.AspNetCore.Analyzers.RouteHandlers;
+
+internal sealed class RoutePatternComparer : IEqualityComparer<RoutePatternTree>
+{
+    public static RoutePatternComparer Instance { get; } = new();
+
+    public bool Equals(RoutePatternTree x, RoutePatternTree y)
+    {
+        if (x.Root.Parts.Length != y.Root.Parts.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < x.Root.Parts.Length; i++)
+        {
+            var xPart = x.Root.Parts[i];
+            var yPart = y.Root.Parts[i];
+
+            var equal = xPart switch
+            {
+                RoutePatternSegmentSeperatorNode _ => yPart is RoutePatternSegmentSeperatorNode,
+                RoutePatternSegmentNode xSegment => Equals(xSegment, yPart as RoutePatternSegmentNode),
+                _ => throw new InvalidOperationException($"Unexpected part type '{xPart.Kind}'."),
+            };
+
+            if (!equal)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool Equals(RoutePatternSegmentNode x, RoutePatternSegmentNode? y)
+    {
+        if (y is null)
+        {
+            return false;
+        }
+
+        if (x.Children.Length != y.Children.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < x.Children.Length; i++)
+        {
+            var xPart = x.Children[i];
+            var yPart = y.Children[i];
+
+            var equal = xPart switch
+            {
+                RoutePatternOptionalSeperatorNode _ => yPart is RoutePatternOptionalSeperatorNode,
+                RoutePatternReplacementNode xReplacement => yPart is RoutePatternReplacementNode yReplacement && Equals(xReplacement.TextToken.Value, yReplacement.TextToken.Value),
+                RoutePatternLiteralNode xLiteral => yPart is RoutePatternLiteralNode yLiteral && Equals(xLiteral.LiteralToken.Value, yLiteral.LiteralToken.Value),
+                RoutePatternParameterNode xParameter => Equals(xParameter, yPart as RoutePatternParameterNode),
+                _ => throw new InvalidOperationException($"Unexpected segment node type '{xPart.Kind}'."),
+            };
+
+            if (!equal)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool Equals(RoutePatternParameterNode x, RoutePatternParameterNode? y)
+    {
+        if (y is null)
+        {
+            return false;
+        }
+
+        // Only parameter policies can be used to differentiate between parameters.
+        var xParameterPolicies = x.ParameterParts.Where(p => p.Kind == RoutePatternKind.ParameterPolicy).OfType<RoutePatternPolicyParameterPartNode>().ToList();
+        var yParameterPolicies = y.ParameterParts.Where(p => p.Kind == RoutePatternKind.ParameterPolicy).OfType<RoutePatternPolicyParameterPartNode>().ToList();
+
+        if (xParameterPolicies.Count != yParameterPolicies.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < xParameterPolicies.Count; i++)
+        {
+            var xPart = xParameterPolicies[i];
+            var yPart = yParameterPolicies[i];
+
+            if (!Equals(xPart, yPart))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool Equals(RoutePatternPolicyParameterPartNode x, RoutePatternPolicyParameterPartNode y)
+    {
+        if (x.PolicyFragments.Length != y.PolicyFragments.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < x.PolicyFragments.Length; i++)
+        {
+            var xPart = x.PolicyFragments[i];
+            var yPart = y.PolicyFragments[i];
+
+            var equal = xPart switch
+            {
+                RoutePatternPolicyFragment xFragment => yPart is RoutePatternPolicyFragment yFragment && Equals(xFragment.ArgumentToken.Value, yFragment.ArgumentToken.Value),
+                RoutePatternPolicyFragmentEscapedNode xFragmentEscaped => yPart is RoutePatternPolicyFragmentEscapedNode yFragmentEscaped && Equals(xFragmentEscaped.ArgumentToken.Value, yFragmentEscaped.ArgumentToken.Value),
+                _ => throw new InvalidOperationException($"Unexpected segment node type '{xPart.Kind}'."),
+            };
+
+            if (!equal)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public int GetHashCode(RoutePatternTree obj)
+    {
+        return obj.Root.ChildCount;
+    }
+}

--- a/src/Framework/AspNetCoreAnalyzers/test/Infrastructure/AmbiguousRoutePatternComparerTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/Infrastructure/AmbiguousRoutePatternComparerTests.cs
@@ -1,0 +1,103 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Analyzers.Infrastructure.RoutePattern;
+using Microsoft.AspNetCore.Analyzers.Infrastructure.VirtualChars;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Microsoft.AspNetCore.Analyzers.Infrastructure;
+
+public partial class AmbiguousRoutePatternComparerTests
+{
+    [Fact]
+    public void Equals_RootMatching_True()
+    {
+        // Arrange
+        var route1 = ParseRoutePattern(@"""/""");
+        var route2 = ParseRoutePattern(@"""/""");
+
+        // Act
+        var result = AmbiguousRoutePatternComparer.Instance.Equals(route1, route2);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData(@"""/a""", @"""/a""")]
+    [InlineData(@"""/a""", @"""/A""")]
+    [InlineData(@"""/{a}""", @"""/{b}""")]
+    [InlineData(@"""/{a}/{b}""", @"""/{b}/{c}""")]
+    [InlineData(@"""/{a:int}""", @"""/{b:int}""")]
+    [InlineData(@"""/{a:min(5)}""", @"""/{b:min(5)}""")]
+    [InlineData(@"""/{a}""", @"""/{a?}""")]
+    [InlineData(@"""/{a}""", @"""/{*a}""")]
+    [InlineData(@"""/{a}""", @"""/{**a}""")]
+    [InlineData(@"""/{a}""", @"""/{a=default}""")]
+    [InlineData(@"""/[controller]""", @"""/[controller]""")]
+    [InlineData(@"""/[controller]""", @"""/[CONTROLLER]""")]
+    public void Equals_Equivalent_True(string pattern1, string pattern2)
+    {
+        // Arrange
+        var route1 = ParseRoutePattern(pattern1);
+        var route2 = ParseRoutePattern(pattern2);
+
+        // Act
+        var hashCode1 = AmbiguousRoutePatternComparer.Instance.GetHashCode(route1);
+        var hashCode2 = AmbiguousRoutePatternComparer.Instance.GetHashCode(route2);
+        var result = AmbiguousRoutePatternComparer.Instance.Equals(route1, route2);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(hashCode1, hashCode2);
+    }
+
+    [Theory]
+    [InlineData(@"""/a""", @"""/""")]
+    [InlineData(@"""/{a}/b""", @"""/{b}/c""")]
+    [InlineData(@"""/{a:int}""", @"""/{b:long}""")]
+    [InlineData(@"""/{a:min(5)}""", @"""/{a:min(6)}""")]
+    [InlineData(@"""/[controller]""", @"""/[controller1]""")]
+    [InlineData(@"""/{a:min(5)}""", @"""/{a:MIN(5)}""")]
+    [InlineData(@"""/{a:regex(abc)}""", @"""/{a:regex(ABC)}""")]
+    public void Equals_NotEquivalent_False(string pattern1, string pattern2)
+    {
+        // Arrange
+        var route1 = ParseRoutePattern(pattern1);
+        var route2 = ParseRoutePattern(pattern2);
+
+        // Act
+        var result = AmbiguousRoutePatternComparer.Instance.Equals(route1, route2);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    private static SyntaxToken GetStringToken(string text)
+    {
+        const string statmentPrefix = "var v = ";
+        var statement = statmentPrefix + text;
+        var parsedStatement = SyntaxFactory.ParseStatement(statement);
+        var token = parsedStatement.DescendantTokens().ToArray()[3];
+        Assert.True(token.IsKind(SyntaxKind.StringLiteralToken));
+        return token;
+    }
+
+    private static RoutePatternTree ParseRoutePattern(string text)
+    {
+        var token = GetStringToken(text);
+        var allChars = CSharpVirtualCharService.Instance.TryConvertToVirtualChars(token);
+        if (allChars.IsDefault)
+        {
+            Assert.Fail("Failed to convert text to token.");
+        }
+
+        var tree = RoutePatternParser.TryParse(allChars, RoutePatternOptions.MvcAttributeRoute);
+        if (tree is null)
+        {
+            Assert.Fail("Failed to parse virtual chars to route pattern.");
+        }
+        return tree!;
+    }
+}

--- a/src/Framework/AspNetCoreAnalyzers/test/Microsoft.AspNetCore.App.Analyzers.Test.csproj
+++ b/src/Framework/AspNetCoreAnalyzers/test/Microsoft.AspNetCore.App.Analyzers.Test.csproj
@@ -19,6 +19,7 @@
     <Reference Include="Microsoft.AspNetCore" />
     <Reference Include="Microsoft.AspNetCore.Mvc" />
     <Reference Include="Microsoft.AspNetCore.Http.Results" />
+    <Reference Include="Microsoft.AspNetCore.RateLimiting" />
     <Reference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" />
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" />
   </ItemGroup>

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternParserTests_BasicTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternParserTests_BasicTests.cs
@@ -64,9 +64,9 @@ public partial class RoutePatternParserTests
         <Literal value=""hello"">hello</Literal>
       </Literal>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""world"">world</Literal>
@@ -92,9 +92,9 @@ public partial class RoutePatternParserTests
         <CloseBraceToken>}</CloseBraceToken>
       </Parameter>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -129,9 +129,9 @@ public partial class RoutePatternParserTests
         <CloseBraceToken>}</CloseBraceToken>
       </Parameter>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -167,9 +167,9 @@ public partial class RoutePatternParserTests
         <CloseBraceToken>}</CloseBraceToken>
       </Parameter>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <EndOfFile />
   </CompilationUnit>
   <Parameters>
@@ -195,9 +195,9 @@ public partial class RoutePatternParserTests
         <CloseBraceToken>}</CloseBraceToken>
       </Parameter>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -1438,9 +1438,9 @@ public partial class RoutePatternParserTests
         <Literal value=""~"">~</Literal>
       </Literal>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <EndOfFile />
   </CompilationUnit>
   <Parameters />

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternParserTests_ComponentsTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternParserTests_ComponentsTests.cs
@@ -27,9 +27,9 @@ public partial class RoutePatternParserTests
         <CloseBraceToken>}</CloseBraceToken>
       </Parameter>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -42,9 +42,9 @@ public partial class RoutePatternParserTests
         <CloseBraceToken>}</CloseBraceToken>
       </Parameter>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -102,17 +102,17 @@ public partial class RoutePatternParserTests
         <Literal value=""awesome"">awesome</Literal>
       </Literal>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""wow"">wow</Literal>
       </Literal>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -143,9 +143,9 @@ public partial class RoutePatternParserTests
         <Literal value=""awesome"">awesome</Literal>
       </Literal>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -155,9 +155,9 @@ public partial class RoutePatternParserTests
         <CloseBraceToken>}</CloseBraceToken>
       </Parameter>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -197,17 +197,17 @@ public partial class RoutePatternParserTests
     {
         Test(@"""/test/{a?}/test""", @"<Tree>
   <CompilationUnit>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""test"">test</Literal>
       </Literal>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -220,9 +220,9 @@ public partial class RoutePatternParserTests
         <CloseBraceToken>}</CloseBraceToken>
       </Parameter>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""test"">test</Literal>
@@ -241,17 +241,17 @@ public partial class RoutePatternParserTests
     {
         Test(@"""/test/{a?}/{b}""", @"<Tree>
   <CompilationUnit>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""test"">test</Literal>
       </Literal>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -264,9 +264,9 @@ public partial class RoutePatternParserTests
         <CloseBraceToken>}</CloseBraceToken>
       </Parameter>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -290,17 +290,17 @@ public partial class RoutePatternParserTests
     {
         Test(@"""/test/{a}/{**b}""", @"<Tree>
   <CompilationUnit>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""test"">test</Literal>
       </Literal>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -310,9 +310,9 @@ public partial class RoutePatternParserTests
         <CloseBraceToken>}</CloseBraceToken>
       </Parameter>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -342,17 +342,17 @@ public partial class RoutePatternParserTests
     {
         Test(@"""/test/{*a}/{b}""", @"<Tree>
   <CompilationUnit>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""test"">test</Literal>
       </Literal>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -365,9 +365,9 @@ public partial class RoutePatternParserTests
         <CloseBraceToken>}</CloseBraceToken>
       </Parameter>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -394,17 +394,17 @@ public partial class RoutePatternParserTests
     {
         Test(@"""/test/{a?bc}/{b}""", @"<Tree>
   <CompilationUnit>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""test"">test</Literal>
       </Literal>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -414,9 +414,9 @@ public partial class RoutePatternParserTests
         <CloseBraceToken>}</CloseBraceToken>
       </Parameter>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternParserTests_ConformanceTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternParserTests_ConformanceTests.cs
@@ -81,17 +81,17 @@ public partial class RoutePatternParserTests
         <Literal value=""cool"">cool</Literal>
       </Literal>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""awesome"">awesome</Literal>
       </Literal>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""super"">super</Literal>
@@ -117,9 +117,9 @@ public partial class RoutePatternParserTests
         <CloseBraceToken>}</CloseBraceToken>
       </Parameter>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -129,9 +129,9 @@ public partial class RoutePatternParserTests
         <CloseBraceToken>}</CloseBraceToken>
       </Parameter>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -452,9 +452,9 @@ public partial class RoutePatternParserTests
         <CloseBraceToken>}</CloseBraceToken>
       </Parameter>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -488,9 +488,9 @@ public partial class RoutePatternParserTests
         <CloseBraceToken>}</CloseBraceToken>
       </Parameter>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -537,9 +537,9 @@ public partial class RoutePatternParserTests
         <CloseBraceToken>}</CloseBraceToken>
       </Parameter>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""."">.</Literal>

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternParserTests_ReplacementTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternParserTests_ReplacementTests.cs
@@ -161,9 +161,9 @@ public partial class RoutePatternParserTests
         <CloseBracketToken>]</CloseBracketToken>
       </Replacement>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Replacement>
         <OpenBracketToken>[</OpenBracketToken>
@@ -229,9 +229,9 @@ public partial class RoutePatternParserTests
         <Literal value=""[[-]][["">[[-]][[</Literal>
       </Literal>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""[[controller]]"">[[controller]]</Literal>
@@ -255,9 +255,9 @@ public partial class RoutePatternParserTests
         <CloseBracketToken>]</CloseBracketToken>
       </Replacement>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Replacement>
         <OpenBracketToken>[</OpenBracketToken>
@@ -283,9 +283,9 @@ public partial class RoutePatternParserTests
         <CloseBracketToken>]</CloseBracketToken>
       </Replacement>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Replacement>
         <OpenBracketToken>[</OpenBracketToken>
@@ -293,9 +293,9 @@ public partial class RoutePatternParserTests
         <CloseBracketToken>]</CloseBracketToken>
       </Replacement>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Parameter>
         <OpenBraceToken>{</OpenBraceToken>
@@ -325,9 +325,9 @@ public partial class RoutePatternParserTests
         <CloseBracketToken>]</CloseBracketToken>
       </Replacement>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""[["">[[</Literal>
@@ -341,9 +341,9 @@ public partial class RoutePatternParserTests
         <Literal value=""]]"">]]</Literal>
       </Literal>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""id"">id</Literal>
@@ -367,9 +367,9 @@ public partial class RoutePatternParserTests
         <CloseBracketToken>]</CloseBracketToken>
       </Replacement>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""[[[["">[[[[</Literal>
@@ -383,9 +383,9 @@ public partial class RoutePatternParserTests
         <Literal value=""]]]]"">]]]]</Literal>
       </Literal>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""id"">id</Literal>
@@ -409,9 +409,9 @@ public partial class RoutePatternParserTests
         <CloseBracketToken>]</CloseBracketToken>
       </Replacement>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""[[[[[["">[[[[[[</Literal>
@@ -425,9 +425,9 @@ public partial class RoutePatternParserTests
         <Literal value=""]]]]]]"">]]]]]]</Literal>
       </Literal>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""id"">id</Literal>
@@ -451,9 +451,9 @@ public partial class RoutePatternParserTests
         <CloseBracketToken>]</CloseBracketToken>
       </Replacement>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""[[[["">[[[[</Literal>
@@ -467,9 +467,9 @@ public partial class RoutePatternParserTests
         <Literal value=""]]]]]]"">]]]]]]</Literal>
       </Literal>
     </Segment>
-    <Seperator>
+    <Separator>
       <SlashToken>/</SlashToken>
-    </Seperator>
+    </Separator>
     <Segment>
       <Literal>
         <Literal value=""id"">id</Literal>

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/DetectAmbiguousMappedRoutesTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/DetectAmbiguousMappedRoutesTest.cs
@@ -58,6 +58,54 @@ void Hello() { }
     }
 
     [Fact]
+    public async Task DuplicateRoutes_TernaryStatement_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+var app = WebApplication.Create();
+_ = (true)
+    ? app.MapGet(""/"", () => Hello())
+    : app.MapGet(""/"", () => Hello());
+void Hello() { }
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task DuplicateRoutes_NullCoalescing_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+var app = WebApplication.Create();
+_ = app.MapGet(""/"", () => Hello()) ?? app.MapGet(""/"", () => Hello());
+void Hello() { }
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task DuplicateRoutes_NullCoalescingAssignment_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+var app = WebApplication.Create();
+var ep = app.MapPost(""/"", () => Hello());
+ep ??= app.MapPost(""/"", () => Hello());
+void Hello() { }
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
     public async Task DuplicateRoutes_DifferentMethods_HasDiagnostics()
     {
         // Arrange

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/DetectAmbiguousMappedRoutesTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/DetectAmbiguousMappedRoutesTest.cs
@@ -222,5 +222,23 @@ void Hello() { }
         // Act & Assert
         await VerifyCS.VerifyAnalyzerAsync(source);
     }
+
+    [Fact]
+    public async Task DuplicateRoutes_MultipleGroups_HasDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+var app = WebApplication.Create();
+var group1 = app.MapGroup(""/group1"");
+var group2 = app.MapGroup(""/group2"");
+group1.MapGet(""/"", () => Hello());
+group2.MapGet(""/"", () => Hello());
+void Hello() { }
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
 }
 

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/DetectAmbiguousMappedRoutesTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/DetectAmbiguousMappedRoutesTest.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis.Testing;
+using VerifyCS = Microsoft.AspNetCore.Analyzers.Verifiers.CSharpAnalyzerVerifier<Microsoft.AspNetCore.Analyzers.RouteHandlers.RouteHandlerAnalyzer>;
+
+namespace Microsoft.AspNetCore.Analyzers.RouteHandlers;
+
+public partial class DetectAmbiguousMappedRoutesTest
+{
+    [Fact]
+    public async Task DuplicateRoutes_SameMethod_HasDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+var app = WebApplication.Create();
+app.MapGet({|#0:""/""|}, () => Hello());
+app.MapGet({|#1:""/""|}, () => Hello());
+void Hello() { }
+";
+
+        var expectedDiagnostics = new[] {
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousRouteHandlerRoute).WithArguments("/").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousRouteHandlerRoute).WithArguments("/").WithLocation(1)
+        };
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source, expectedDiagnostics);
+    }
+
+    [Fact]
+    public async Task DuplicateRoutes_DifferentMethods_HasDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+var app = WebApplication.Create();
+app.MapGet({|#0:""/""|}, () => Hello());
+app.MapPost({|#1:""/""|}, () => Hello());
+void Hello() { }
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task DuplicateMapGetRoutes_InsideConditional_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+var app = WebApplication.Create();
+if (true)
+{
+    app.MapGet(""/"", () => Hello());
+}
+else
+{
+    app.MapGet(""/"", () => Hello());
+}
+void Hello() { }
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+}
+

--- a/src/Framework/AspNetCoreAnalyzers/test/Verifiers/CSharpAnalyzerVerifier.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/Verifiers/CSharpAnalyzerVerifier.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Analyzers.Verifiers;
 
@@ -60,6 +62,7 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
 
         return net8Ref.AddAssemblies(ImmutableArray.Create(
             TrimAssemblyExtension(typeof(System.IO.Pipelines.PipeReader).Assembly.Location),
+            TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Authorization.IAuthorizeData).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Mvc.ModelBinding.IBinderTypeProviderMetadata).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Mvc.BindAttribute).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions).Assembly.Location),
@@ -68,8 +71,11 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Builder.ConfigureHostBuilder).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Builder.ConfigureWebHostBuilder).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Builder.EndpointRoutingApplicationBuilderExtensions).Assembly.Location),
-            TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Builder.EndpointRoutingApplicationBuilderExtensions).Assembly.Location),
+            TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Builder.RateLimiterEndpointConventionBuilderExtensions).Assembly.Location),
+            TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Builder.CorsEndpointConventionBuilderExtensions).Assembly.Location),
+            TrimAssemblyExtension(typeof(Microsoft.Extensions.DependencyInjection.OutputCacheConventionBuilderExtensions).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions).Assembly.Location),
+            TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Builder.AuthorizationEndpointConventionBuilderExtensions).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Routing.RouteData).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Components.ComponentBase).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Components.ParameterAttribute).Assembly.Location),

--- a/src/Framework/Framework.slnf
+++ b/src/Framework/Framework.slnf
@@ -60,6 +60,7 @@
       "src\\Middleware\\Localization.Routing\\src\\Microsoft.AspNetCore.Localization.Routing.csproj",
       "src\\Middleware\\Localization\\src\\Microsoft.AspNetCore.Localization.csproj",
       "src\\Middleware\\OutputCaching\\src\\Microsoft.AspNetCore.OutputCaching.csproj",
+      "src\\Middleware\\RateLimiting\\src\\Microsoft.AspNetCore.RateLimiting.csproj",
       "src\\Middleware\\ResponseCaching.Abstractions\\src\\Microsoft.AspNetCore.ResponseCaching.Abstractions.csproj",
       "src\\Middleware\\ResponseCaching\\src\\Microsoft.AspNetCore.ResponseCaching.csproj",
       "src\\Middleware\\ResponseCompression\\src\\Microsoft.AspNetCore.ResponseCompression.csproj",


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/45223

Not quite finished. The remaining work:
- [x] Check that the map call's `IEndpointConventionBuilder` isn't used to add metadata that could affect routing.
- [x] Allow list of metadata methods that don't affect matching and still allow endpoints to be compared, e.g. `RequireAuthorization`.

It only works with Minimal API. Most of the infrastructure is in place to expand it to analyze controller actions in the future.