### PR TITLE
Add support for {**catch-all routes} in Blazor

### DIFF
--- a/src/Components/Components/src/Routing/TemplateSegment.cs
+++ b/src/Components/Components/src/Routing/TemplateSegment.cs
@@ -13,13 +13,20 @@ internal sealed class TemplateSegment
 
         if (IsCatchAll)
         {
-            // Only one '*' currently allowed
-            Value = segment[1..];
+            // Only '*' and '**' allowed at the beginning
+            if (segment.Length > 1 && segment[1] == '*')
+            {
+                Value = segment[2..];
+            }
+            else
+            {
+                Value = segment[1..];
+            }
 
             var invalidCharacterIndex = Value.IndexOf('*');
             if (invalidCharacterIndex != -1)
             {
-                throw new InvalidOperationException($"Invalid template '{template}'. A catch-all parameter may only have one '*' at the beginning of the segment.");
+                throw new InvalidOperationException($"Invalid template '{template}'. A catch-all parameter may only have '*' or '**' at the beginning of the segment.");
             }
         }
         else

--- a/src/Components/Components/test/Routing/TemplateParserTests.cs
+++ b/src/Components/Components/test/Routing/TemplateParserTests.cs
@@ -78,14 +78,16 @@ public class TemplateParserTests
         Assert.Equal(expected, actual, RouteTemplateTestComparer.Instance);
     }
 
-    [Fact]
-    public void Parse_SingleCatchAllParameter()
+    [Theory]
+    [InlineData("p", "{*p}")]
+    [InlineData("p", "{**p}")]
+    public void Parse_SingleCatchAllParameter(string parsedTemplate, string template)
     {
         // Arrange
-        var expected = new ExpectedTemplateBuilder().Parameter("p");
+        var expected = new ExpectedTemplateBuilder().Parameter(parsedTemplate);
 
         // Act
-        var actual = TemplateParser.ParseTemplate("{*p}");
+        var actual = TemplateParser.ParseTemplate(template);
 
         // Assert
         Assert.Equal(expected, actual, RouteTemplateTestComparer.Instance);
@@ -201,13 +203,16 @@ public class TemplateParserTests
         Assert.Equal(expectedMessage, ex.Message);
     }
 
-    [Fact]
-    public void InvalidTemplate_CatchAllParamWithMultipleAsterisks()
+    [Theory]
+    [InlineData("/test/{a}/{***b}")]
+    [InlineData("/test/{a}/{**b*c}")]
+    [InlineData("/test/{a}/{*b*c}")]
+    public void InvalidTemplate_CatchAllParamWithIncorrectPlacedAsterisks(string template)
     {
-        var ex = Assert.Throws<InvalidOperationException>(() => TemplateParser.ParseTemplate("/test/{a}/{**b}"));
+        var ex = Assert.Throws<InvalidOperationException>(() => TemplateParser.ParseTemplate(template));
 
-        var expectedMessage = "Invalid template '/test/{a}/{**b}'. A catch-all parameter may only have one '*' at the beginning of the segment.";
-
+        var expectedMessage = $"Invalid template '{template}'. A catch-all parameter may only have '*' or '**' at the beginning of the segment.";
+        
         Assert.Equal(expectedMessage, ex.Message);
     }
 


### PR DESCRIPTION
# Add support for {**catch-all routes} in Blazor

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

Currently there is only support for one asterisk * catch-all routes in Blazor. https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing?view=aspnetcore-7.0#catch-all-route-parameters
Added support for double asterisk ** catch-all route support for Components.Routing

Fixes #44067