### PR TITLE
Fix support for parameter names sourced from attributes (#45572)

### DIFF
--- a/src/OpenApi/src/OpenApiGenerator.cs
+++ b/src/OpenApi/src/OpenApiGenerator.cs
@@ -273,7 +273,7 @@ internal sealed class OpenApiGenerator
         var parameters = PropertyAsParameterInfo.Flatten(methodInfo.GetParameters(), ParameterBindingMethodCache);
         foreach (var parameter in parameters)
         {
-            var (bodyOrFormParameter, _) = GetOpenApiParameterLocation(parameter, pattern, false);
+            var (bodyOrFormParameter, _, _) = GetOpenApiParameterLocation(parameter, pattern, false);
             hasFormOrBodyParameter |= bodyOrFormParameter;
             if (hasFormOrBodyParameter)
             {
@@ -382,7 +382,7 @@ internal sealed class OpenApiGenerator
                 throw new InvalidOperationException($"Encountered a parameter of type '{parameter.ParameterType}' without a name. Parameters must have a name.");
             }
 
-            var (_, parameterLocation) = GetOpenApiParameterLocation(parameter, pattern, disableInferredBody);
+            var (_, parameterLocation, attributeName) = GetOpenApiParameterLocation(parameter, pattern, disableInferredBody);
 
             // if the parameter doesn't have a valid location
             // then we should ignore it
@@ -393,7 +393,7 @@ internal sealed class OpenApiGenerator
             var nullabilityContext = new NullabilityInfoContext();
             var nullability = nullabilityContext.Create(parameter);
             var isOptional = parameter.HasDefaultValue || nullability.ReadState != NullabilityState.NotNull;
-            var name = pattern.GetParameter(parameter.Name) is { } routeParameter ? routeParameter.Name : parameter.Name;
+            var name = attributeName ?? (pattern.GetParameter(parameter.Name) is { } routeParameter ? routeParameter.Name : parameter.Name);
             var openApiParameter = new OpenApiParameter()
             {
                 Name = name,
@@ -423,29 +423,29 @@ internal sealed class OpenApiGenerator
         return openApiParameterContent;
     }
 
-    private (bool isBodyOrForm, ParameterLocation? locatedIn) GetOpenApiParameterLocation(ParameterInfo parameter, RoutePattern pattern, bool disableInferredBody)
+    private (bool isBodyOrForm, ParameterLocation? locatedIn, string? name) GetOpenApiParameterLocation(ParameterInfo parameter, RoutePattern pattern, bool disableInferredBody)
     {
         var attributes = parameter.GetCustomAttributes();
 
         if (attributes.OfType<IFromRouteMetadata>().FirstOrDefault() is { } routeAttribute)
         {
-            return (false, ParameterLocation.Path);
+            return (false, ParameterLocation.Path, routeAttribute.Name);
         }
         else if (attributes.OfType<IFromQueryMetadata>().FirstOrDefault() is { } queryAttribute)
         {
-            return (false, ParameterLocation.Query);
+            return (false, ParameterLocation.Query, queryAttribute.Name);
         }
         else if (attributes.OfType<IFromHeaderMetadata>().FirstOrDefault() is { } headerAttribute)
         {
-            return (false, ParameterLocation.Header);
+            return (false, ParameterLocation.Header, headerAttribute.Name);
         }
         else if (attributes.OfType<IFromBodyMetadata>().FirstOrDefault() is { } fromBodyAttribute)
         {
-            return (true, null);
+            return (true, null, null);
         }
         else if (attributes.OfType<IFromFormMetadata>().FirstOrDefault() is { } fromFormAttribute)
         {
-            return (true, null);
+            return (true, null, null);
         }
         else if (parameter.CustomAttributes.Any(a => typeof(IFromServiceMetadata).IsAssignableFrom(a.AttributeType)) ||
                 parameter.ParameterType == typeof(HttpContext) ||
@@ -456,7 +456,7 @@ internal sealed class OpenApiGenerator
                 ParameterBindingMethodCache.HasBindAsyncMethod(parameter) ||
                 _serviceProviderIsService?.IsService(parameter.ParameterType) == true)
         {
-            return (false, null);
+            return (false, null, null);
         }
         else if (parameter.ParameterType == typeof(string) || ParameterBindingMethodCache.HasTryParseMethod(parameter.ParameterType))
         {
@@ -466,27 +466,27 @@ internal sealed class OpenApiGenerator
             // Path vs query cannot be determined by RequestDelegateFactory at startup currently because of the layering, but can be done here.
             if (parameter.Name is { } name && pattern.GetParameter(name) is not null)
             {
-                return (false, ParameterLocation.Path);
+                return (false, ParameterLocation.Path, null);
             }
             else
             {
-                return (false, ParameterLocation.Query);
+                return (false, ParameterLocation.Query, null);
             }
         }
         else if (parameter.ParameterType == typeof(IFormFile) || parameter.ParameterType == typeof(IFormFileCollection))
         {
-            return (true, null);
+            return (true, null, null);
         }
         else if (disableInferredBody && (
                  (parameter.ParameterType.IsArray && ParameterBindingMethodCache.HasTryParseMethod(parameter.ParameterType.GetElementType()!)) ||
                  parameter.ParameterType == typeof(string[]) ||
                  parameter.ParameterType == typeof(StringValues)))
         {
-            return (false, ParameterLocation.Query);
+            return (false, ParameterLocation.Query, null);
         }
         else
         {
-            return (true, null);
+            return (true, null, null);
         }
     }
 }

--- a/src/OpenApi/test/OpenApiGeneratorTests.cs
+++ b/src/OpenApi/test/OpenApiGeneratorTests.cs
@@ -901,6 +901,21 @@ public class OpenApiOperationGeneratorTests
         Assert.Null(operationWithNoBodyParams.RequestBody);
     }
 
+    [Fact]
+    public void HandlesParameterWithNameInAttribute()
+    {
+        static void ValidateParameter(OpenApiOperation operation, string expectedName)
+        {
+            var parameter = Assert.Single(operation.Parameters);
+            Assert.Equal(expectedName, parameter.Name);
+        }
+
+        ValidateParameter(GetOpenApiOperation(([FromRoute(Name = "routeName")] string param) => ""), "routeName");
+        ValidateParameter(GetOpenApiOperation(([FromRoute(Name = "routeName")] string param) => "", "/{param}"), "routeName");
+        ValidateParameter(GetOpenApiOperation(([FromQuery(Name = "queryName")] string param) => ""), "queryName");
+        ValidateParameter(GetOpenApiOperation(([FromHeader(Name = "headerName")] string param) => ""), "headerName");
+    }
+
     private static OpenApiOperation GetOpenApiOperation(
         Delegate action,
         string pattern = null,


### PR DESCRIPTION
Backport of #45572 to `release/7.0`.

## Description

This change resolves an issue where OpenAPI generation via the `WithOpenApi` method did not factor for the `Name` argument in parameters sourced from routes or queries via the explicit `FromRoute` and `FromQuery`.

Fixes https://github.com/dotnet/aspnetcore/issues/45542

## Customer Impact

This bug fix addresses a user-submitted bug report that is presented as a regression from .NET 6. Without this bug fix, users are not able to successfully test endpoints that use explicit binding source attributes with a name via the Swagger UI and the generated OpenAPI document.

## Regression?

- [X] Yes
- [ ] No

This is a regression in behavior that was available in .NET 6.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Low risk because this change updates the new OpenAPI package to match the behavior of the existing ApiExplorer implementation.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A