### PR TITLE
[blazor] remove custom loader for .wasm file

### DIFF
--- a/src/Components/Web.JS/@types/dotnet/dotnet.d.ts
+++ b/src/Components/Web.JS/@types/dotnet/dotnet.d.ts
@@ -163,6 +163,11 @@ declare type MonoConfigError = {
     message: string;
     error: any;
 };
+interface LoadingResource {
+    name: string;
+    url: string;
+    response: Promise<Response>;
+}
 declare type AllAssetEntryTypes = AssetEntry | AssemblyEntry | SatelliteAssemblyEntry | VfsEntry | IcuData;
 declare type AssetEntry = {
     name: string;
@@ -172,6 +177,7 @@ declare type AssetEntry = {
     load_remote?: boolean;
     is_optional?: boolean;
     buffer?: ArrayBuffer;
+    pendingDownload?: LoadingResource;
 };
 interface AssemblyEntry extends AssetEntry {
     name: "assembly";
@@ -188,13 +194,7 @@ interface IcuData extends AssetEntry {
     name: "icu";
     load_remote: boolean;
 }
-declare const enum AssetBehaviours {
-    Resource = "resource",
-    Assembly = "assembly",
-    Heap = "heap",
-    ICU = "icu",
-    VFS = "vfs"
-}
+type AssetBehaviours = "resource" | "assembly" | "pdb" | "heap" | "icu" | "vfs" | "dotnetwasm" | "js-module-threads";
 declare const enum GlobalizationMode {
     ICU = "icu",
     INVARIANT = "invariant",


### PR DESCRIPTION
Proposed fix for blazor wasm startup issue

The issue is caused by removal of obsolete generated code, which is supplemented another way in the default runtime startup sequence.
https://github.com/dotnet/runtime/pull/79466/files#diff-68c787b9334a397c996fd6183dec57c08c883c8fba04cafc6387491c2b7f8452L124

I prefer to reduce the difference in startup sequence.
There further differences which could be eliminated, but rather on proper PR.