### PR TITLE
ChecksumValidator: support SHA256

### DIFF
--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/ChecksumValidator.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/ChecksumValidator.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Razor.Hosting;

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/src/ChecksumValidator.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/src/ChecksumValidator.cs
@@ -108,26 +108,25 @@ internal static class ChecksumValidator
             throw new ArgumentNullException(nameof(projectItem));
         }
 
-        Func<HashAlgorithm> createHashAlgorithm;
+        Func<Stream, byte[]> hashData;
         string algorithmName;
 
         //only SHA1 and SHA256 are supported.  Default to SHA1
         switch (checksumAlgorithm)
         {
             case nameof(SHA256):
-                createHashAlgorithm = SHA256.Create;
+                hashData = SHA256.HashData;
                 algorithmName = nameof(SHA256);
                 break;
             default:
-                createHashAlgorithm = SHA1.Create;
+                hashData = SHA1.HashData;
                 algorithmName = nameof(SHA1);
                 break;
         }
 
         using (var stream = projectItem.Read())
-        using (var hashAlgorithm = createHashAlgorithm())
         {
-            return (hashAlgorithm.ComputeHash(stream), algorithmName);
+            return (hashData(stream), algorithmName);
         }
     }
 

--- a/src/Mvc/Mvc.Razor.RuntimeCompilation/test/ChecksumValidatorTest.cs
+++ b/src/Mvc/Mvc.Razor.RuntimeCompilation/test/ChecksumValidatorTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Razor.Hosting;
@@ -173,6 +173,28 @@ public class ChecksumValidatorTest
                 new RazorSourceChecksumAttribute("SHA1", GetChecksum("some other import"), "/Views/_ViewImports.cstml"),
                 new RazorSourceChecksumAttribute("SHA1", GetChecksum("some import"), "/Views/Home/_ViewImports.cstml"),
                 new RazorSourceChecksumAttribute("SHA1", GetChecksum("some content"), "/Views/Home/Index.cstml"),
+        });
+
+        ProjectFileSystem.Add(new TestRazorProjectItem("/Views/Home/Index.cstml", "some content"));
+        ProjectFileSystem.Add(new TestRazorProjectItem("/Views/Home/_ViewImports.cstml", "some import"));
+        ProjectFileSystem.Add(new TestRazorProjectItem("/Views/_ViewImports.cstml", "some other import"));
+
+        // Act
+        var result = ChecksumValidator.IsItemValid(ProjectFileSystem, item);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsItemValid_AllFilesMatch_UsingSHA256_ReturnsTrue()
+    {
+        // Arrange
+        var item = new TestRazorCompiledItem(typeof(string), "mvc.1.0.view", "/Views/Home/Index.cstml", new object[]
+        {
+                new RazorSourceChecksumAttribute("SHA256", GetChecksumSHA256("some other import"), "/Views/_ViewImports.cstml"),
+                new RazorSourceChecksumAttribute("SHA1", GetChecksum("some import"), "/Views/Home/_ViewImports.cstml"),
+                new RazorSourceChecksumAttribute("SHA256", GetChecksumSHA256("some content"), "/Views/Home/Index.cstml"),
         });
 
         ProjectFileSystem.Add(new TestRazorProjectItem("/Views/Home/Index.cstml", "some content"));

--- a/src/Mvc/shared/Mvc.Views.TestCommon/TestRazorCompiledItem.cs
+++ b/src/Mvc/shared/Mvc.Views.TestCommon/TestRazorCompiledItem.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Security.Cryptography;
@@ -47,6 +47,12 @@ public class TestRazorCompiledItem : RazorCompiledItem
     public static string GetChecksum(string content)
     {
         var bytes = SHA1.HashData(Encoding.UTF8.GetBytes(content));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    public static string GetChecksumSHA256(string content)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(content));
         return Convert.ToHexString(bytes).ToLowerInvariant();
     }
 }


### PR DESCRIPTION
Modifications to ChecksumValidator to support SHA256 for checksum validation.

## Description

It now uses the algorithm specified in the precompiled view instead of using always SHA1.  It is now able to use precompiled views when SHA256 is used instead of recompiling them.

Design change: I compute the checksum directly in ChecksumValidator instead of relying on RazorSourceDocument.ReadFrom.  The reason is that it is in a different repository and everything is "hardcoded" to use SHA1.  A lot stuff is internal and some classes are also sealed (StreamSourceDocument).  So it would require to copy the code from a lot of classes to get it to work using RazorSourceDocument for checksum computation.

One thing I am not sure about:  I was not able to use projectItem.RazorSourceDocument like it is done in RazorSourceDocument.ReadFrom because that property is internal.  I tried to search in the "razor" repository and the only place I found where it is used is for ReadFrom...  I don't know if we need to do something about that.

The only other difference I see is that now it only does checksum computation.  Before it was loading the RazorSourceDocument, so it was taking a little more resources and there was a possibility that something failed during the loading of the document.  Now, nothing of that is done except for checksum computation.  I think it is better but I may miss something.

Fixes #45577
