### PR TITLE
[Servers] Fix test broken by Hosting log message format change

### DIFF
--- a/src/Servers/test/FunctionalTests/HelloWorldTest.cs
+++ b/src/Servers/test/FunctionalTests/HelloWorldTest.cs
@@ -160,7 +160,7 @@ public class HelloWorldTests : LoggedTest
             }
             // Output should contain the ApplicationException and the 500 status code
             Assert.Contains("System.ApplicationException: Application exception", output);
-            Assert.Contains("/throwexception - - - 500", output);
+            Assert.Contains("/throwexception - 500", output);
         }
     }
 }


### PR DESCRIPTION
Relates to #45253
Relates to https://github.com/dotnet/aspnetcore/pull/45475#issuecomment-1351871229

Fixes HelloWorldTests.ApplicationException test broken by the new format introduced on #45253.

/cc @Tratcher 