### PR TITLE
Revert "Bump SDK to 8.0.100-alpha.1.22616.4"

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "8.0.100-alpha.1.22616.4"
+    "version": "8.0.100-alpha.1.22531.1"
   },
   "tools": {
-    "dotnet": "8.0.100-alpha.1.22616.4",
+    "dotnet": "8.0.100-alpha.1.22531.1",
     "runtimes": {
       "dotnet/x86": [
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"

--- a/src/Components/WebAssembly/WebAssembly/src/HotReload/HotReloadAgent.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/HotReload/HotReloadAgent.cs
@@ -95,13 +95,13 @@ internal sealed class HotReloadAgent : IDisposable
     {
         bool methodFound = false;
 
-        if (GetUpdateMethod("ClearCache") is MethodInfo clearCache)
+        if (GetUpdateMethod(handlerType, "ClearCache") is MethodInfo clearCache)
         {
             handlerActions.ClearCache.Add(CreateAction(clearCache));
             methodFound = true;
         }
 
-        if (GetUpdateMethod("UpdateApplication") is MethodInfo updateApplication)
+        if (GetUpdateMethod(handlerType, "UpdateApplication") is MethodInfo updateApplication)
         {
             handlerActions.UpdateApplication.Add(CreateAction(updateApplication));
             methodFound = true;
@@ -129,7 +129,7 @@ internal sealed class HotReloadAgent : IDisposable
             };
         }
 
-        MethodInfo? GetUpdateMethod(string name)
+        MethodInfo? GetUpdateMethod([DynamicallyAccessedMembers(HotReloadHandlerLinkerFlags)] Type handlerType, string name)
         {
             if (handlerType.GetMethod(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, new[] { typeof(Type[]) }) is MethodInfo updateMethod &&
                 updateMethod.ReturnType == typeof(void))

--- a/src/Servers/IIS/IIS/test/IIS.Tests/MaxRequestBodySizeTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/MaxRequestBodySizeTests.cs
@@ -37,7 +37,7 @@ public class MaxRequestBodySizeTests : LoggedTest
                 catch (BadHttpRequestException ex)
                 {
                     exception = ex;
-                    throw;
+                    throw ex;
                 }
             }, LoggerFactory))
         {
@@ -80,7 +80,7 @@ public class MaxRequestBodySizeTests : LoggedTest
                 catch (BadHttpRequestException ex)
                 {
                     exception = ex;
-                    throw;
+                    throw ex;
                 }
             }, LoggerFactory, new IISServerOptions { MaxRequestBodySize = maxRequestSize }))
         {
@@ -286,7 +286,7 @@ public class MaxRequestBodySizeTests : LoggedTest
                 catch (BadHttpRequestException ex)
                 {
                     exception = ex;
-                    throw;
+                    throw ex;
                 }
             }, LoggerFactory, new IISServerOptions { MaxRequestBodySize = maxRequestSize }))
         {


### PR DESCRIPTION
Reverts dotnet/aspnetcore#44925

Unfortunately, after different engineers working on it and validating the update. After we merged the change our internal CI build is failing with:

```log
Unhandled exception. System.NotSupportedException: Unsupported log file format. Latest supported version is 14, the log file has version 15.
   at Microsoft.Build.Logging.StructuredLogger.BinLogReader.Replay(Stream stream, Progress progress)
```

The FR teams is working on the update of `MSBuild.StructuredLogger` https://github.com/dotnet/source-indexer/pull/109, however, look into the source code https://github.com/KirillOsenkov/MSBuildStructuredLog/blob/main/src/StructuredLogger/BinaryLogger/BinaryLogger.cs#L58 I don't believe the version 15 is supported yet and it will take longer to make it work again.

Since we usually update every Monday, will let the next Monday update check if the newer version https://github.com/dotnet/arcade/issues/11995 will work.

Also, I believe we need make sure the tools used in the CI build are validated in PR validation as well