### PR TITLE
[AOT] Fixing the problems with ProblemDetails

### DIFF
--- a/src/Http/Http.Abstractions/src/ProblemDetails/ProblemDetails.cs
+++ b/src/Http/Http.Abstractions/src/ProblemDetails/ProblemDetails.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
 
@@ -12,6 +13,8 @@ namespace Microsoft.AspNetCore.Mvc;
 [JsonConverter(typeof(ProblemDetailsJsonConverter))]
 public class ProblemDetails
 {
+    private readonly IDictionary<string, object?> _extensions = new Dictionary<string, object?>(StringComparer.Ordinal);
+
     /// <summary>
     /// A URI reference [RFC3986] that identifies the problem type. This specification encourages that, when
     /// dereferenced, it provide human-readable documentation for the problem type
@@ -59,5 +62,10 @@ public class ProblemDetails
     /// In particular, complex types or collection types may not round-trip to the original type when using the built-in JSON or XML formatters.
     /// </remarks>
     [JsonExtensionData]
-    public IDictionary<string, object?> Extensions { get; } = new Dictionary<string, object?>(StringComparer.Ordinal);
+    public IDictionary<string, object?> Extensions
+    {
+        [RequiresUnreferencedCode("JSON serialization and deserialization of ProblemDetails.Extensions might require types that cannot be statically analyzed.")]
+        [RequiresDynamicCode("JSON serialization and deserialization of ProblemDetails.Extensions might require types that cannot be statically analyzed.")]
+        get => _extensions;
+    }
 }

--- a/src/Http/Http.Abstractions/test/HttpValidationProblemDetailsJsonConverterTest.cs
+++ b/src/Http/Http.Abstractions/test/HttpValidationProblemDetailsJsonConverterTest.cs
@@ -12,6 +12,40 @@ public class HttpValidationProblemDetailsJsonConverterTest
     private static JsonSerializerOptions JsonSerializerOptions => new JsonOptions().SerializerOptions;
 
     [Fact]
+    public void Write_Works()
+    {
+        var converter = new HttpValidationProblemDetailsJsonConverter();
+        var problemDetails = new HttpValidationProblemDetails();
+
+        problemDetails.Type = "https://tools.ietf.org/html/rfc9110#section-15.5.5";
+        problemDetails.Title = "Not found";
+        problemDetails.Status = 404;
+        problemDetails.Detail = "Product not found";
+        problemDetails.Instance = "http://example.com/products/14";
+        problemDetails.Extensions["traceId"] = "|37dd3dd5-4a9619f953c40a16.";
+        problemDetails.Errors.Add("key0", new[] { "error0" });
+        problemDetails.Errors.Add("key1", new[] { "error1", "error2" });
+
+        var ms = new MemoryStream();
+        var writer = new Utf8JsonWriter(ms);
+        converter.Write(writer, problemDetails, JsonSerializerOptions);
+        writer.Flush();
+
+        ms.Seek(0, SeekOrigin.Begin);
+        var document = JsonDocument.Parse(ms);
+        Assert.Equal(problemDetails.Type, document.RootElement.GetProperty("type").GetString());
+        Assert.Equal(problemDetails.Title, document.RootElement.GetProperty("title").GetString());
+        Assert.Equal(problemDetails.Status, document.RootElement.GetProperty("status").GetInt32());
+        Assert.Equal(problemDetails.Detail, document.RootElement.GetProperty("detail").GetString());
+        Assert.Equal(problemDetails.Instance, document.RootElement.GetProperty("instance").GetString());
+        Assert.Equal((string)problemDetails.Extensions["traceId"]!, document.RootElement.GetProperty("traceId").GetString());
+        var errorsElement = document.RootElement.GetProperty("errors");
+        Assert.Equal("error0", errorsElement.GetProperty("key0")[0].GetString());
+        Assert.Equal("error1", errorsElement.GetProperty("key1")[0].GetString());
+        Assert.Equal("error2", errorsElement.GetProperty("key1")[1].GetString());
+    }
+
+    [Fact]
     public void Read_Works()
     {
         // Arrange

--- a/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
+++ b/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;

--- a/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
+++ b/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
@@ -72,12 +73,9 @@ internal sealed partial class DefaultProblemDetailsWriter : IProblemDetailsWrite
     }
 
     // Additional values are specified on JsonSerializerContext to support some values for extensions.
+    // For example, the DeveloperExceptionMiddleware serializes its complex type to JsonElement, which problem details then needs to serialize.
     [JsonSerializable(typeof(ProblemDetails))]
-    [JsonSerializable(typeof(Dictionary<string, object>))]
-    [JsonSerializable(typeof(JsonNode))]
-    [JsonSerializable(typeof(JsonObject))]
-    [JsonSerializable(typeof(JsonArray))]
-    [JsonSerializable(typeof(JsonValue))]
+    [JsonSerializable(typeof(JsonElement))]
     [JsonSerializable(typeof(string))]
     [JsonSerializable(typeof(decimal))]
     [JsonSerializable(typeof(float))]

--- a/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
+++ b/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
@@ -71,7 +71,7 @@ internal sealed partial class DefaultProblemDetailsWriter : IProblemDetailsWrite
                         contentType: "application/problem+json"));
     }
 
-    // Additional values are specified on JsonContext to support some values for extensions.
+    // Additional values are specified on JsonSerializerContext to support some values for extensions.
     [JsonSerializable(typeof(ProblemDetails))]
     [JsonSerializable(typeof(Dictionary<string, object>))]
     [JsonSerializable(typeof(JsonNode))]
@@ -85,6 +85,7 @@ internal sealed partial class DefaultProblemDetailsWriter : IProblemDetailsWrite
     [JsonSerializable(typeof(int))]
     [JsonSerializable(typeof(long))]
     [JsonSerializable(typeof(Guid))]
+    [JsonSerializable(typeof(Uri))]
     [JsonSerializable(typeof(TimeSpan))]
     [JsonSerializable(typeof(DateTime))]
     [JsonSerializable(typeof(DateTimeOffset))]

--- a/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
+++ b/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
@@ -71,6 +71,7 @@ internal sealed partial class DefaultProblemDetailsWriter : IProblemDetailsWrite
                         contentType: "application/problem+json"));
     }
 
+    // Additional values are specified on JsonContext to support some values for extensions.
     [JsonSerializable(typeof(ProblemDetails))]
     [JsonSerializable(typeof(Dictionary<string, object>))]
     [JsonSerializable(typeof(JsonNode))]

--- a/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
+++ b/src/Http/Http.Extensions/src/DefaultProblemDetailsWriter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -43,20 +45,20 @@ internal sealed partial class DefaultProblemDetailsWriter : IProblemDetailsWrite
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026",
-        Justification = "JSON serialization of ProblemDetails.Extensions might require types that cannot be statically analyzed and we need to fallback" +
-        "to reflection-based. The ProblemDetailsConverter is marked as RequiresUnreferencedCode already.")]
+        Justification = "JSON serialization of ProblemDetails.Extensions might require types that cannot be statically analyzed. The property is annotated with a warning")]
     [UnconditionalSuppressMessage("Trimming", "IL3050",
-        Justification = "JSON serialization of ProblemDetails.Extensions might require types that cannot be statically analyzed and we need to fallback" +
-        "to reflection-based. The ProblemDetailsConverter is marked as RequiresDynamicCode already.")]
+        Justification = "JSON serialization of ProblemDetails.Extensions might require types that cannot be statically analyzed. The property is annotated with a warning")]
     public ValueTask WriteAsync(ProblemDetailsContext context)
     {
         var httpContext = context.HttpContext;
         ProblemDetailsDefaults.Apply(context.ProblemDetails, httpContext.Response.StatusCode);
         _options.CustomizeProblemDetails?.Invoke(context);
 
-        if (context.ProblemDetails.Extensions is { Count: 0 })
+        // Use source generation serialization in two scenarios:
+        // 1. There are no extensions. Source generation is faster and works well with trimming.
+        // 2. Native AOT. In this case only the data types specified on ProblemDetailsJsonContext will work.
+        if (context.ProblemDetails.Extensions is { Count: 0 } || !RuntimeFeature.IsDynamicCodeSupported)
         {
-            // We can use the source generation in this case
             return new ValueTask(httpContext.Response.WriteAsJsonAsync(
                 context.ProblemDetails,
                 ProblemDetailsJsonContext.Default.ProblemDetails,
@@ -70,6 +72,22 @@ internal sealed partial class DefaultProblemDetailsWriter : IProblemDetailsWrite
     }
 
     [JsonSerializable(typeof(ProblemDetails))]
+    [JsonSerializable(typeof(Dictionary<string, object>))]
+    [JsonSerializable(typeof(JsonNode))]
+    [JsonSerializable(typeof(JsonObject))]
+    [JsonSerializable(typeof(JsonArray))]
+    [JsonSerializable(typeof(JsonValue))]
+    [JsonSerializable(typeof(string))]
+    [JsonSerializable(typeof(decimal))]
+    [JsonSerializable(typeof(float))]
+    [JsonSerializable(typeof(double))]
+    [JsonSerializable(typeof(int))]
+    [JsonSerializable(typeof(long))]
+    [JsonSerializable(typeof(Guid))]
+    [JsonSerializable(typeof(TimeSpan))]
+    [JsonSerializable(typeof(DateTime))]
+    [JsonSerializable(typeof(DateTimeOffset))]
     internal sealed partial class ProblemDetailsJsonContext : JsonSerializerContext
-    { }
+    {
+    }
 }

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddlewareImpl.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddlewareImpl.cs
@@ -94,6 +94,7 @@ internal class DeveloperExceptionPageMiddlewareImpl
 
     private static ExtensionsExceptionJsonContext CreateSerializationContext(JsonOptions? jsonOptions)
     {
+        // Create context from configured options to get settings such as PropertyNamePolicy and DictionaryKeyPolicy.
         jsonOptions ??= new JsonOptions();
         return new ExtensionsExceptionJsonContext(new JsonSerializerOptions(jsonOptions.SerializerOptions));
     }
@@ -214,7 +215,7 @@ internal class DeveloperExceptionPageMiddlewareImpl
 
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Values set on ProblemDetails.Extensions are supported by the default writer.")]
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Values set on ProblemDetails.Extensions are supported by the default writer.")]
-    private static ProblemDetails CreateProblemDetails(ErrorContext errorContext, HttpContext httpContext)
+    private ProblemDetails CreateProblemDetails(ErrorContext errorContext, HttpContext httpContext)
     {
         var problemDetails = new ProblemDetails
         {

--- a/src/Middleware/Diagnostics/test/FunctionalTests/DeveloperExceptionPageSampleTest.cs
+++ b/src/Middleware/Diagnostics/test/FunctionalTests/DeveloperExceptionPageSampleTest.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Mvc;
 using System.Net.Http.Json;
+using System.Text.Json;
 
 namespace Microsoft.AspNetCore.Diagnostics.FunctionalTests;
 
@@ -49,5 +50,14 @@ public class DeveloperExceptionPageSampleTest : IClassFixture<TestFixture<Develo
         Assert.NotNull(body);
         Assert.Equal(500, body.Status);
         Assert.Contains("Demonstration exception", body.Detail);
+
+        var exceptionNode = (JsonElement)body.Extensions["exception"];
+        Assert.Contains("System.Exception: Demonstration exception.", exceptionNode.GetProperty("details").GetString());
+        Assert.Equal("application/json", exceptionNode.GetProperty("headers").GetProperty("Accept")[0].GetString());
+        Assert.Equal("localhost", exceptionNode.GetProperty("headers").GetProperty("Host")[0].GetString());
+        Assert.Equal("/", exceptionNode.GetProperty("path").GetString());
+        Assert.Equal("Endpoint display name", exceptionNode.GetProperty("endpoint").GetString());
+        Assert.Equal("Value1", exceptionNode.GetProperty("routeValues").GetProperty("routeValue1").GetString());
+        Assert.Equal("Value2", exceptionNode.GetProperty("routeValues").GetProperty("routeValue2").GetString());
     }
 }

--- a/src/Mvc/Mvc.Core/test/Infrastructure/ValidationProblemDetailsJsonConverterTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ValidationProblemDetailsJsonConverterTest.cs
@@ -148,7 +148,7 @@ public class ValidationProblemDetailsJsonConverterTest
         using Utf8JsonWriter writer = new(stream);
 
         // Act
-        converter.Write(writer, problemDetails, new JsonSerializationOptions());
+        converter.Write(writer, problemDetails, new JsonSerializerOptions());
 
         writer.Flush();
         var json = Encoding.UTF8.GetString(stream.ToArray());

--- a/src/Mvc/Mvc.Core/test/Infrastructure/ValidationProblemDetailsJsonConverterTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ValidationProblemDetailsJsonConverterTest.cs
@@ -148,7 +148,7 @@ public class ValidationProblemDetailsJsonConverterTest
         using Utf8JsonWriter writer = new(stream);
 
         // Act
-        converter.Write(writer, problemDetails, null);
+        converter.Write(writer, problemDetails, new JsonSerializationOptions());
 
         writer.Flush();
         var json = Encoding.UTF8.GetString(stream.ToArray());

--- a/src/Shared/ProblemDetails/HttpValidationProblemDetailsJsonConverter.cs
+++ b/src/Shared/ProblemDetails/HttpValidationProblemDetailsJsonConverter.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.AspNetCore.Http;
 
-internal sealed partial class HttpValidationProblemDetailsJsonConverter : JsonConverter<HttpValidationProblemDetails>
+internal sealed class HttpValidationProblemDetailsJsonConverter : JsonConverter<HttpValidationProblemDetails>
 {
     private static readonly JsonEncodedText Errors = JsonEncodedText.Encode("errors");
 

--- a/src/Shared/ProblemDetails/HttpValidationProblemDetailsJsonConverter.cs
+++ b/src/Shared/ProblemDetails/HttpValidationProblemDetailsJsonConverter.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -11,18 +10,12 @@ internal sealed partial class HttpValidationProblemDetailsJsonConverter : JsonCo
 {
     private static readonly JsonEncodedText Errors = JsonEncodedText.Encode("errors");
 
-    [RequiresUnreferencedCode("JSON serialization and deserialization of ProblemDetails.Extensions might require types that cannot be statically analyzed.")]
-    [RequiresDynamicCode("JSON serialization and deserialization of ProblemDetails.Extensions might require types that cannot be statically analyzed.")]
-    [UnconditionalSuppressMessage("Trimming", "IL2046:'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "<Pending>")]
-    [UnconditionalSuppressMessage("AOT", "IL3051:'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "<Pending>")]
     public override HttpValidationProblemDetails Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         var problemDetails = new HttpValidationProblemDetails();
         return ReadProblemDetails(ref reader, options, problemDetails);
     }
 
-    [RequiresUnreferencedCode("JSON serialization and deserialization of ProblemDetails.Extensions might require types that cannot be statically analyzed.")]
-    [RequiresDynamicCode("JSON serialization and deserialization of ProblemDetails.Extensions might require types that cannot be statically analyzed.")]
     public static HttpValidationProblemDetails ReadProblemDetails(ref Utf8JsonReader reader, JsonSerializerOptions options, HttpValidationProblemDetails problemDetails)
     {
         if (reader.TokenType != JsonTokenType.StartObject)
@@ -34,15 +27,7 @@ internal sealed partial class HttpValidationProblemDetailsJsonConverter : JsonCo
         {
             if (reader.ValueTextEquals(Errors.EncodedUtf8Bytes))
             {
-                var context = new ErrorsJsonContext(options);
-                var errors = JsonSerializer.Deserialize(ref reader, context.DictionaryStringStringArray);
-                if (errors is not null)
-                {
-                    foreach (var item in errors)
-                    {
-                        problemDetails.Errors[item.Key] = item.Value;
-                    }
-                }
+                ReadErrors(ref reader, problemDetails.Errors);
             }
             else
             {
@@ -56,34 +41,88 @@ internal sealed partial class HttpValidationProblemDetailsJsonConverter : JsonCo
         }
 
         return problemDetails;
+
+        static void ReadErrors(ref Utf8JsonReader reader, IDictionary<string, string[]> errors)
+        {
+            if (!reader.Read())
+            {
+                throw new JsonException("Unexpected end when reading JSON.");
+            }
+
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.StartObject:
+                    while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
+                    {
+                        var name = reader.GetString()!;
+
+                        if (!reader.Read())
+                        {
+                            throw new JsonException("Unexpected end when reading JSON.");
+                        }
+
+                        if (reader.TokenType == JsonTokenType.Null)
+                        {
+                            errors[name] = null!;
+                        }
+                        else
+                        {
+                            var values = new List<string>();
+                            while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+                            {
+                                values.Add(reader.GetString()!);
+                            }
+                            errors[name] = values.ToArray();
+                        }
+                    }
+                    break;
+                case JsonTokenType.Null:
+                    return;
+                default:
+                    throw new JsonException($"Unexpected token when reading errors: {reader.TokenType}");
+            }
+        }
     }
 
-    [RequiresUnreferencedCode("JSON serialization and deserialization of ProblemDetails.Extensions might require types that cannot be statically analyzed.")]
-    [RequiresDynamicCode("JSON serialization and deserialization of ProblemDetails.Extensions might require types that cannot be statically analyzed.")]
-    [UnconditionalSuppressMessage("Trimming", "IL2046:'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "<Pending>")]
-    [UnconditionalSuppressMessage("AOT", "IL3051:'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "<Pending>")]
     public override void Write(Utf8JsonWriter writer, HttpValidationProblemDetails value, JsonSerializerOptions options)
     {
         WriteProblemDetails(writer, value, options);
     }
 
-    [RequiresUnreferencedCode("JSON serialization and deserialization of ProblemDetails.Extensions might require types that cannot be statically analyzed.")]
-    [RequiresDynamicCode("JSON serialization and deserialization of ProblemDetails.Extensions might require types that cannot be statically analyzed.")]
     public static void WriteProblemDetails(Utf8JsonWriter writer, HttpValidationProblemDetails value, JsonSerializerOptions options)
     {
         writer.WriteStartObject();
         ProblemDetailsJsonConverter.WriteProblemDetails(writer, value, options);
 
         writer.WritePropertyName(Errors);
-
-        var context = new ErrorsJsonContext(options);
-        JsonSerializer.Serialize(writer, value.Errors, context.IDictionaryStringStringArray);
+        WriteErrors(writer, value, options);
 
         writer.WriteEndObject();
-    }
 
-    [JsonSerializable(typeof(IDictionary<string, string[]>))]
-    [JsonSerializable(typeof(Dictionary<string, string[]>))]
-    private sealed partial class ErrorsJsonContext : JsonSerializerContext
-    { }
+        static void WriteErrors(Utf8JsonWriter writer, HttpValidationProblemDetails value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            foreach (var kvp in value.Errors)
+            {
+                var name = kvp.Key;
+                var errors = kvp.Value;
+
+                writer.WritePropertyName(options.DictionaryKeyPolicy?.ConvertName(name) ?? name);
+                if (errors is null)
+                {
+                    writer.WriteNullValue();
+                }
+                else
+                {
+                    writer.WriteStartArray();
+                    foreach (var error in errors)
+                    {
+                        writer.WriteStringValue(error);
+                    }
+                    writer.WriteEndArray();
+                }
+            }
+            writer.WriteEndObject();
+        }
+    }
 }

--- a/src/Shared/ProblemDetails/ProblemDetailsJsonConverter.cs
+++ b/src/Shared/ProblemDetails/ProblemDetailsJsonConverter.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 

--- a/src/Shared/ProblemDetails/ProblemDetailsJsonConverter.cs
+++ b/src/Shared/ProblemDetails/ProblemDetailsJsonConverter.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Microsoft.AspNetCore.Http;
 
-internal sealed partial class ProblemDetailsJsonConverter : JsonConverter<ProblemDetails>
+internal sealed class ProblemDetailsJsonConverter : JsonConverter<ProblemDetails>
 {
     private static readonly JsonEncodedText Type = JsonEncodedText.Encode("type");
     private static readonly JsonEncodedText Title = JsonEncodedText.Encode("title");

--- a/src/Shared/ProblemDetails/ProblemDetailsJsonConverter.cs
+++ b/src/Shared/ProblemDetails/ProblemDetailsJsonConverter.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -16,10 +17,6 @@ internal sealed partial class ProblemDetailsJsonConverter : JsonConverter<Proble
     private static readonly JsonEncodedText Detail = JsonEncodedText.Encode("detail");
     private static readonly JsonEncodedText Instance = JsonEncodedText.Encode("instance");
 
-    [RequiresUnreferencedCode("JSON serialization and deserialization of ProblemDetails.Extensions might require types that cannot be statically analyzed.")]
-    [RequiresDynamicCode("JSON serialization and deserialization of ProblemDetails.Extensions might require types that cannot be statically analyzed.")]
-    [UnconditionalSuppressMessage("Trimming", "IL2046:'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "<Pending>")]
-    [UnconditionalSuppressMessage("AOT", "IL3051:'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "<Pending>")]
     public override ProblemDetails Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         var problemDetails = new ProblemDetails();
@@ -42,10 +39,6 @@ internal sealed partial class ProblemDetailsJsonConverter : JsonConverter<Proble
         return problemDetails;
     }
 
-    [RequiresUnreferencedCode("JSON serialization and deserialization of ProblemDetails.Extensions might require types that cannot be statically analyzed.")]
-    [RequiresDynamicCode("JSON serialization and deserialization of ProblemDetails.Extensions might require types that cannot be statically analyzed.")]
-    [UnconditionalSuppressMessage("Trimming", "IL2046:'RequiresUnreferencedCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "<Pending>")]
-    [UnconditionalSuppressMessage("AOT", "IL3051:'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.", Justification = "<Pending>")]
     public override void Write(Utf8JsonWriter writer, ProblemDetails value, JsonSerializerOptions options)
     {
         writer.WriteStartObject();
@@ -53,8 +46,8 @@ internal sealed partial class ProblemDetailsJsonConverter : JsonConverter<Proble
         writer.WriteEndObject();
     }
 
-    [RequiresUnreferencedCode("JSON serialization and deserialization of ProblemDetails.Extensions might require types that cannot be statically analyzed.")]
-    [RequiresDynamicCode("JSON serialization and deserialization of ProblemDetails.Extensions might require types that cannot be statically analyzed.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "ProblemDetails.Extensions is annotated to expose this warning to callers.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "ProblemDetails.Extensions is annotated to expose this warning to callers.")]
     internal static void ReadValue(ref Utf8JsonReader reader, ProblemDetails value, JsonSerializerOptions options)
     {
         if (TryReadStringProperty(ref reader, Type, out var propertyValue))
@@ -106,8 +99,8 @@ internal sealed partial class ProblemDetailsJsonConverter : JsonConverter<Proble
         return true;
     }
 
-    [RequiresUnreferencedCode("JSON serialization and deserialization of ProblemDetails.Extensions might require types that cannot be statically analyzed.")]
-    [RequiresDynamicCode("JSON serialization and deserialization of ProblemDetails.Extensions might require types that cannot be statically analyzed.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "ProblemDetails.Extensions is annotated to expose this warning to callers.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "ProblemDetails.Extensions is annotated to expose this warning to callers.")]
     internal static void WriteProblemDetails(Utf8JsonWriter writer, ProblemDetails value, JsonSerializerOptions options)
     {
         if (value.Type != null)

--- a/src/Shared/ProblemDetails/ProblemDetailsJsonConverter.cs
+++ b/src/Shared/ProblemDetails/ProblemDetailsJsonConverter.cs
@@ -131,6 +131,7 @@ internal sealed partial class ProblemDetailsJsonConverter : JsonConverter<Proble
         foreach (var kvp in value.Extensions)
         {
             writer.WritePropertyName(kvp.Key);
+            // When AOT is enabled, Serialize will only work with values specified on the JsonContext.
             JsonSerializer.Serialize(writer, kvp.Value, kvp.Value?.GetType() ?? typeof(object), options);
         }
     }


### PR DESCRIPTION
`ProblemDetails.Extensions` is problematic. `Dictionary<string, object>` can contain any value, and the type needs to be serializable.

Simply annotating all places that use `ProblemDetails.Extensions` as unsafe isn't a good solution. The developer exception middleware serializes problem details with extensions, and the middleware is extremely commonly used and is registered by default in `WebApplication`: https://github.com/dotnet/aspnetcore/blob/d2f7bd0b37b7fed379d694b3231e6c5ddd177819/src/DefaultBuilder/src/WebApplicationBuilder.cs#L148
This PR tries to find a pragmatic middle ground that warns people about using extensions, but also makes some values safe so a user such as developer exception middleware can use it safely.

A short summary of what this PR tries to do:
* Warn when someone uses extensions
* Have a list of types that will work as extension values
* Update usage of extensions in aspnetcore to use compatible types.

Note: this PR builds on https://github.com/dotnet/aspnetcore/pull/45604. I split it out to make it clearer what changes are focused on `ProblemDetails`.

Changes in PR:
1. `ProblemDetails.Extensions` property now has warnings.
2. Warnings in converters are suppressed. These converters are in `[JsonConverter]` attributes on the types, so are never referenced in user code anyway.
3. Serialize/deserialize `Dictionary<string, string[]> Errors { get; }` in `HttpValidationProblemDetailsJsonConverter` manually. It's not difficult and avoids the problem of calling generated serialization inside a converter.
4. `DeveloperExceptionPageMiddlewareImpl` adds an anonymous type to extensions. This will never serialize, so it's been changed to a real type with a corresponding source generated serializer. It's converted into a `JsonElement` which is added to extensions. The problem details writer supports `JsonElement` extension values.
