### PR TITLE
consider escaped commas in LDAP distinguished name

### DIFF
--- a/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Authentication.Negotiate;
 
 internal static class LdapAdapter
 {
-    private static Regex DistinguishedNameSeparator = new Regex(@"(?<!\\),");
+    private static readonly Regex DistinguishedNameSeparator = new Regex(@"(?<!\\),");
     
     public static async Task RetrieveClaimsAsync(LdapSettings settings, ClaimsIdentity identity, ILogger logger)
     {

--- a/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Authentication.Negotiate;
 
 internal static partial class LdapAdapter
 {
-    [GeneratedRegex(@"(?<!\\),")]
+    [GeneratedRegex(@"(?<![^\\]\\),")]
     private static partial Regex DistinguishedNameSeparator();
     
     public static async Task RetrieveClaimsAsync(LdapSettings settings, ClaimsIdentity identity, ILogger logger)

--- a/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
@@ -12,9 +12,10 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Authentication.Negotiate;
 
-internal static class LdapAdapter
+internal static partial class LdapAdapter
 {
-    private static readonly Regex DistinguishedNameSeparator = new Regex(@"(?<!\\),");
+    [GeneratedRegex(@"(?<!\\),")]
+    private static partial Regex DistinguishedNameSeparator();
     
     public static async Task RetrieveClaimsAsync(LdapSettings settings, ClaimsIdentity identity, ILogger logger)
     {
@@ -65,7 +66,7 @@ internal static class LdapAdapter
             {
                 // Example distinguished name: CN=TestGroup,DC=KERB,DC=local
                 var groupDN = $"{Encoding.UTF8.GetString((byte[])group)}";
-                var groupCN = DistinguishedNameSeparator.Split(groupDN)[0].Substring("CN=".Length);
+                var groupCN = DistinguishedNameSeparator().Split(groupDN)[0].Substring("CN=".Length);
 
                 if (!settings.IgnoreNestedGroups)
                 {
@@ -123,7 +124,7 @@ internal static class LdapAdapter
                 foreach (var member in memberof)
                 {
                     var nestedGroupDN = $"{Encoding.UTF8.GetString((byte[])member)}";
-                    var nestedGroupCN = DistinguishedNameSeparator.Split(nestedGroupDN)[0].Substring("CN=".Length);
+                    var nestedGroupCN = DistinguishedNameSeparator().Split(nestedGroupDN)[0].Substring("CN=".Length);
 
                     if (processedGroups.Contains(nestedGroupDN))
                     {

--- a/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/LdapAdapter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Authentication.Negotiate;
 internal static partial class LdapAdapter
 {
     [GeneratedRegex(@"(?<![^\\]\\),")]
-    private static partial Regex DistinguishedNameSeparator();
+    internal static partial Regex DistinguishedNameSeparator();
     
     public static async Task RetrieveClaimsAsync(LdapSettings settings, ClaimsIdentity identity, ILogger logger)
     {

--- a/src/Security/Authentication/Negotiate/test/Negotiate.Test/LdapAdapterTests.cs
+++ b/src/Security/Authentication/Negotiate/test/Negotiate.Test/LdapAdapterTests.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Authentication.Negotiate.Test;
+
+public class LdapAdapterTests
+{
+    [Fact]
+    public void DistinguishedNameWithoutCommasSuccess()
+    {
+        var parts = LdapAdapter.DistinguishedNameSeparator.Split("Testing group - City")
+
+        Assert.Equal(new[] { "Testing group - City" }, parts);
+    }
+
+    [Fact]
+    public void DistinguishedNameWithEscapedCommaSuccess()
+    {
+        var parts = LdapAdapter.DistinguishedNameSeparator.Split("Testing group\,City")
+
+        Assert.Equal(new[] { "Testing group\,City" }, parts);
+    }
+
+    [Fact]
+    public void DistinguishedNameWithNotEscapedCommaSuccess()
+    {
+        var parts = LdapAdapter.DistinguishedNameSeparator.Split("Testing group,City")
+
+        Assert.Equal(new[] { "Testing group", "City" }, parts);
+    }
+
+    [Fact]
+    public void DistinguishedNameWithEscapedBackslashAndNotEscapedCommaSuccess()
+    {
+        var parts = LdapAdapter.DistinguishedNameSeparator.Split("Testing group\\,City")
+
+        Assert.Equal(new[] { "Testing group\\", "City" }, parts);
+    }
+}

--- a/src/Security/Authentication/Negotiate/test/Negotiate.Test/LdapAdapterTests.cs
+++ b/src/Security/Authentication/Negotiate/test/Negotiate.Test/LdapAdapterTests.cs
@@ -8,7 +8,7 @@ public class LdapAdapterTests
     [Fact]
     public void DistinguishedNameWithoutCommasSuccess()
     {
-        var parts = LdapAdapter.DistinguishedNameSeparator.Split("Testing group - City")
+        var parts = LdapAdapter.DistinguishedNameSeparator.Split("Testing group - City");
 
         Assert.Equal(new[] { "Testing group - City" }, parts);
     }
@@ -16,15 +16,15 @@ public class LdapAdapterTests
     [Fact]
     public void DistinguishedNameWithEscapedCommaSuccess()
     {
-        var parts = LdapAdapter.DistinguishedNameSeparator.Split("Testing group\,City")
+        var parts = LdapAdapter.DistinguishedNameSeparator.Split(@"Testing group\,City");
 
-        Assert.Equal(new[] { "Testing group\,City" }, parts);
+        Assert.Equal(new[] { @"Testing group\,City" }, parts);
     }
 
     [Fact]
     public void DistinguishedNameWithNotEscapedCommaSuccess()
     {
-        var parts = LdapAdapter.DistinguishedNameSeparator.Split("Testing group,City")
+        var parts = LdapAdapter.DistinguishedNameSeparator.Split("Testing group,City");
 
         Assert.Equal(new[] { "Testing group", "City" }, parts);
     }
@@ -32,8 +32,8 @@ public class LdapAdapterTests
     [Fact]
     public void DistinguishedNameWithEscapedBackslashAndNotEscapedCommaSuccess()
     {
-        var parts = LdapAdapter.DistinguishedNameSeparator.Split("Testing group\\,City")
+        var parts = LdapAdapter.DistinguishedNameSeparator.Split(@"Testing group\\,City");
 
-        Assert.Equal(new[] { "Testing group\\", "City" }, parts);
+        Assert.Equal(new[] { @"Testing group\\", "City" }, parts);
     }
 }

--- a/src/Security/Authentication/Negotiate/test/Negotiate.Test/LdapAdapterTests.cs
+++ b/src/Security/Authentication/Negotiate/test/Negotiate.Test/LdapAdapterTests.cs
@@ -8,7 +8,7 @@ public class LdapAdapterTests
     [Fact]
     public void DistinguishedNameWithoutCommasSuccess()
     {
-        var parts = LdapAdapter.DistinguishedNameSeparator.Split("Testing group - City");
+        var parts = LdapAdapter.DistinguishedNameSeparator().Split("Testing group - City");
 
         Assert.Equal(new[] { "Testing group - City" }, parts);
     }
@@ -16,7 +16,7 @@ public class LdapAdapterTests
     [Fact]
     public void DistinguishedNameWithEscapedCommaSuccess()
     {
-        var parts = LdapAdapter.DistinguishedNameSeparator.Split(@"Testing group\,City");
+        var parts = LdapAdapter.DistinguishedNameSeparator().Split(@"Testing group\,City");
 
         Assert.Equal(new[] { @"Testing group\,City" }, parts);
     }
@@ -24,7 +24,7 @@ public class LdapAdapterTests
     [Fact]
     public void DistinguishedNameWithNotEscapedCommaSuccess()
     {
-        var parts = LdapAdapter.DistinguishedNameSeparator.Split("Testing group,City");
+        var parts = LdapAdapter.DistinguishedNameSeparator().Split("Testing group,City");
 
         Assert.Equal(new[] { "Testing group", "City" }, parts);
     }
@@ -32,7 +32,7 @@ public class LdapAdapterTests
     [Fact]
     public void DistinguishedNameWithEscapedBackslashAndNotEscapedCommaSuccess()
     {
-        var parts = LdapAdapter.DistinguishedNameSeparator.Split(@"Testing group\\,City");
+        var parts = LdapAdapter.DistinguishedNameSeparator().Split(@"Testing group\\,City");
 
         Assert.Equal(new[] { @"Testing group\\", "City" }, parts);
     }


### PR DESCRIPTION
# Consider escaped commas in LDAP distinguished name

## Description

In real world DN can be like this: `CN=Testing group\,City,OU=Department,DC=contoso,DC=com`. We need to process this case correct - consider escaped comma and don't fail.
Without this fix DN parsing is incorrect -> we getting `Testing group\` as CN instead of  `Testing group`. Next, we try to resolve group with incorrect CN and getting exception.

Fixes #45648
