### PR TITLE
Add rate limiter context HttpContext feature

### DIFF
--- a/src/Middleware/RateLimiting/src/Features/IRateLimiterContextFeature.cs
+++ b/src/Middleware/RateLimiting/src/Features/IRateLimiterContextFeature.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Connections.Features;
+
+namespace Microsoft.AspNetCore.RateLimiting.Features;
+
+public interface IRateLimiterContextFeature
+{
+    RateLimiterContext Context { get; }
+}
+

--- a/src/Middleware/RateLimiting/src/Features/RateLimiterContext.cs
+++ b/src/Middleware/RateLimiting/src/Features/RateLimiterContext.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.RateLimiting.Features;
+
+public class RateLimiterContext
+{
+    public required HttpContext HttpContext { get; set; }
+
+    public required RateLimitLease Lease { get; set; }
+
+    public required PartitionedRateLimiter<HttpContext>? GlobalLimiter { get; set; }
+
+    public required PartitionedRateLimiter<HttpContext> EndpointLimiter { get; set; }
+}

--- a/src/Middleware/RateLimiting/src/Features/RateLimiterContextFeature.cs
+++ b/src/Middleware/RateLimiting/src/Features/RateLimiterContextFeature.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.RateLimiting.Features;
+
+public class RateLimiterContextFeature : IRateLimiterContextFeature
+{
+    private readonly RateLimiterContext _context;
+
+    public RateLimiterContextFeature(RateLimiterContext context)
+    {
+        _context = context;
+    }
+
+    public RateLimiterContext Context => _context;
+}

--- a/src/Middleware/RateLimiting/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/RateLimiting/src/PublicAPI.Unshipped.txt
@@ -6,6 +6,17 @@ Microsoft.AspNetCore.RateLimiting.DisableRateLimitingAttribute.DisableRateLimiti
 Microsoft.AspNetCore.RateLimiting.EnableRateLimitingAttribute
 Microsoft.AspNetCore.RateLimiting.EnableRateLimitingAttribute.EnableRateLimitingAttribute(string! policyName) -> void
 Microsoft.AspNetCore.RateLimiting.EnableRateLimitingAttribute.PolicyName.get -> string?
+Microsoft.AspNetCore.RateLimiting.Features.IRateLimiterContextFeature
+Microsoft.AspNetCore.RateLimiting.Features.IRateLimiterContextFeature.Context.get -> Microsoft.AspNetCore.RateLimiting.Features.RateLimiterContext!
+Microsoft.AspNetCore.RateLimiting.Features.RateLimiterContext
+Microsoft.AspNetCore.RateLimiting.Features.RateLimiterContext.EndpointLimiter.get -> System.Threading.RateLimiting.PartitionedRateLimiter<Microsoft.AspNetCore.Http.HttpContext!>!
+Microsoft.AspNetCore.RateLimiting.Features.RateLimiterContext.GlobalLimiter.get -> System.Threading.RateLimiting.PartitionedRateLimiter<Microsoft.AspNetCore.Http.HttpContext!>?
+Microsoft.AspNetCore.RateLimiting.Features.RateLimiterContext.HttpContext.get -> Microsoft.AspNetCore.Http.HttpContext!
+Microsoft.AspNetCore.RateLimiting.Features.RateLimiterContext.HttpContext.set -> void
+Microsoft.AspNetCore.RateLimiting.Features.RateLimiterContext.Lease.get -> System.Threading.RateLimiting.RateLimitLease!
+Microsoft.AspNetCore.RateLimiting.Features.RateLimiterContextFeature
+Microsoft.AspNetCore.RateLimiting.Features.RateLimiterContextFeature.Context.get -> Microsoft.AspNetCore.RateLimiting.Features.RateLimiterContext!
+Microsoft.AspNetCore.RateLimiting.Features.RateLimiterContextFeature.RateLimiterContextFeature(Microsoft.AspNetCore.RateLimiting.Features.RateLimiterContext! context) -> void
 Microsoft.AspNetCore.RateLimiting.IRateLimiterPolicy<TPartitionKey>
 Microsoft.AspNetCore.RateLimiting.IRateLimiterPolicy<TPartitionKey>.GetPartition(Microsoft.AspNetCore.Http.HttpContext! httpContext) -> System.Threading.RateLimiting.RateLimitPartition<TPartitionKey>
 Microsoft.AspNetCore.RateLimiting.IRateLimiterPolicy<TPartitionKey>.OnRejected.get -> System.Func<Microsoft.AspNetCore.RateLimiting.OnRejectedContext!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask>?


### PR DESCRIPTION
# Add rate limiter context HttpContext feature

Added HttpContext feature which has access to Global and Endpoint limiters with availability to fetch rate limiters statistics and get Lease metadata. Based on #44140

## Description

- Added new HttpContext feature, which allows to get access rate limiters and its statistics in custom middlewares or controllers
- Added unit tests for changes
- Still not sure about the API, so I didn't add any XML documentation yet

# Motivation

In #44140 issue, one of *The dream scenario for a better ASP.NET Core rate limiter middleware* as @maartenba says, would be able *Have a feature on the current HttpContext that gives access to the current rate limit context, so these details can also be returned on successful requests, or added to telemetry.*. This PR addresses this concern. 

I thought it would be much better to make multiple atomic, but feature-complete PR's to one issue, so it would be faster and easier to review


