### PR TITLE
Don't set the status code if the response has started

### DIFF
--- a/src/Http/Http/src/Builder/ApplicationBuilder.cs
+++ b/src/Http/Http/src/Builder/ApplicationBuilder.cs
@@ -132,7 +132,10 @@ public class ApplicationBuilder : IApplicationBuilder
                 throw new InvalidOperationException(message);
             }
 
-            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            if (!context.Response.HasStarted)
+            {
+                context.Response.StatusCode = StatusCodes.Status404NotFound;
+            }
             return Task.CompletedTask;
         };
 

--- a/src/Http/Http/test/ApplicationBuilderTests.cs
+++ b/src/Http/Http/test/ApplicationBuilderTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 
 namespace Microsoft.AspNetCore.Builder.Internal;
 
@@ -17,6 +18,23 @@ public class ApplicationBuilderTests
 
         app.Invoke(httpContext);
         Assert.Equal(404, httpContext.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task BuildReturnDelegateThatDoesNotSetStatusCodeIfResponseHasStarted()
+    {
+        var builder = new ApplicationBuilder(null);
+        var app = builder.Build();
+
+        var httpContext = new DefaultHttpContext();
+        var responseFeature = new TestHttpResponseFeature();
+        httpContext.Features.Set<IHttpResponseFeature>(responseFeature);
+        httpContext.Response.StatusCode = 200;
+
+        responseFeature.HasStarted = true;
+
+        await app.Invoke(httpContext);
+        Assert.Equal(200, httpContext.Response.StatusCode);
     }
 
     [Fact]
@@ -95,5 +113,33 @@ public class ApplicationBuilderTests
         builder2.Properties["test"] = "value2";
 
         Assert.Equal("value1", builder1.Properties["test"]);
+    }
+
+    private class TestHttpResponseFeature : IHttpResponseFeature
+    {
+        private int _statusCode = 200;
+        public int StatusCode
+        {
+            get => _statusCode;
+            set
+            {
+                _statusCode = HasStarted ? throw new NotSupportedException("The response has already started") : value;
+            }
+        }
+        public string ReasonPhrase { get; set; }
+        public IHeaderDictionary Headers { get; set; }
+        public Stream Body { get; set; } = Stream.Null;
+
+        public bool HasStarted { get; set; }
+
+        public void OnCompleted(Func<object, Task> callback, object state)
+        {
+
+        }
+
+        public void OnStarting(Func<object, Task> callback, object state)
+        {
+
+        }
     }
 }


### PR DESCRIPTION
- Middleware that writes then ends up at the terminal middleware ends up throwing an exception. This change doesn't set the status code if the response has started.
- Added a test

PS: I was answering a question on Stackoverflow and noticed this behavior.