### PR TITLE
Fix cookie null regression 

### DIFF
--- a/src/Http/Http/test/RequestCookiesCollectionTests.cs
+++ b/src/Http/Http/test/RequestCookiesCollectionTests.cs
@@ -44,4 +44,29 @@ public class RequestCookiesCollectionTests
 
         Assert.Equal(12, cookies.Count);
     }
+
+    [Theory]
+    [InlineData(",", null)]
+    [InlineData(";", null)]
+    [InlineData("er=dd,cc,bb", new[] { "dd" })]
+    [InlineData("er=dd,err=cc,errr=bb", new[] { "dd", "cc", "bb" })]
+    [InlineData("errorcookie=dd,:(\"sa;", new[] { "dd" })]
+    [InlineData("s;", null)]
+    public void ParseInvalidCookies(string cookieToParse, string[] expectedCookieValues)
+    {
+        var cookies = RequestCookieCollection.Parse(new StringValues(new[] { cookieToParse }));
+
+        if (expectedCookieValues == null)
+        {
+            Assert.Equal(0, cookies.Count);
+            return;
+        }
+
+        Assert.Equal(expectedCookieValues.Length, cookies.Count);
+        for (int i = 0; i < expectedCookieValues.Length; i++)
+        {
+            var value = expectedCookieValues[i];
+            Assert.Equal(value, cookies.ElementAt(i).Value);
+        }
+    }
 }

--- a/src/Http/Shared/CookieHeaderParserShared.cs
+++ b/src/Http/Shared/CookieHeaderParserShared.cs
@@ -29,9 +29,12 @@ internal static class CookieHeaderParserShared
                 if (TryParseValue(value, ref index, supportsMultipleValues, out var parsedName, out var parsedValue))
                 {
                     // The entry may not contain an actual value, like " , "
-                    var name = enableCookieNameEncoding ? Uri.UnescapeDataString(parsedName.Value.Value!) : parsedName.Value.Value!;
-                    store[name] = Uri.UnescapeDataString(parsedValue.Value.Value!);
-                    hasFoundValue = true;
+                    if (parsedName != null && parsedValue != null)
+                    {
+                        var name = enableCookieNameEncoding ? Uri.UnescapeDataString(parsedName.Value.Value!) : parsedName.Value.Value!;
+                        store[name] = Uri.UnescapeDataString(parsedValue.Value.Value!);
+                        hasFoundValue = true;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Fixes a regression in the cookie parser

## Description

The cookie parser is normally tolerant of bad data and skips over it. However, during 7.0 there was some nullability cleanup work that mistakenly removed some null checks. Now the code fails with InvalidOperationExceptions trying to access null nullable fields.

Fixes #45665

## Customer Impact

Requests that used to be accepted are currently throwing exceptions and rejected. These are often search engine indexing requests, so failures can impact a website's search coverage.

## Regression?

- [x] Yes
- [ ] No

7.0
https://github.com/dotnet/aspnetcore/pull/35547/files#diff-efd1128bc033953a7e2d1c7db7d700b5cda0e23e502eda76a94ff7bd3b066444

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Restoring prior behavior

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A