### PR TITLE
Update Helix.Common.props

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -47,7 +47,7 @@
         <HelixAvailableTargetQueue Include="$(HelixQueueArmDebian11)" Platform="Linux" />
 
         <!-- Mac -->
-        <HelixAvailableTargetQueue Include="OSX.1015.Amd64.Open" Platform="OSX" />
+        <HelixAvailableTargetQueue Include="OSX.1100.Amd64.Open" Platform="OSX" />
 
         <!-- Windows -->
         <HelixAvailableTargetQueue Include="Windows.Amd64.Server2022.Open" Platform="Windows" />

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -28,7 +28,7 @@
       <!-- aspnetcore-quarantined-pr (quarantined-pr.yml) -->
       <ItemGroup>
         <HelixAvailableTargetQueue Include="Ubuntu.2004.Amd64.Open" Platform="Linux" />
-        <HelixAvailableTargetQueue Include="OSX.1100.Amd64.Open" Platform="OSX" />
+        <HelixAvailableTargetQueue Include="OSX.13.Amd64.Open" Platform="OSX" />
         <HelixAvailableTargetQueue Include="Windows.11.Amd64.Client.Open" Platform="Windows" />
       </ItemGroup>
     </When>

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -28,7 +28,7 @@
       <!-- aspnetcore-quarantined-pr (quarantined-pr.yml) -->
       <ItemGroup>
         <HelixAvailableTargetQueue Include="Ubuntu.2004.Amd64.Open" Platform="Linux" />
-        <HelixAvailableTargetQueue Include="OSX.13.Amd64.Open" Platform="OSX" />
+        <HelixAvailableTargetQueue Include="OSX.1200.Amd64.Open" Platform="OSX" />
         <HelixAvailableTargetQueue Include="Windows.11.Amd64.Client.Open" Platform="Windows" />
       </ItemGroup>
     </When>


### PR DESCRIPTION
Fix build error:

> Helix queue osx.1015.amd64.open is set for estimated removal date of 2023-01-01. In most cases the queue will be removed permanently due to end-of-life; please contact dnceng for any questions or concerns, and we can help you decide how to proceed and discuss other options.

https://dev.azure.com/dnceng-public/public/_build/results?buildId=118949&view=results