### PR TITLE
Added copy parameters to enable parallel build

### DIFF
--- a/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
+++ b/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
@@ -66,8 +66,8 @@
     </ItemGroup>
     
     <PropertyGroup>
-        <_CreateHardLinksForMvcCopyDependencyFilesIfPossible Condition="'$(CreateHardLinksForMvcCopyDependencyFilesIfPossible)' == ''">false</_CreateHardLinksForMvcCopyDependencyFilesIfPossible>
-        <_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible Condition="'$(CreateSymbolicLinksMvcCopyDependencyFilesIfPossible)' == ''">false</_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible>
+        <_CreateHardLinksForMvcCopyDependencyFilesIfPossible Condition="'$(_CreateHardLinksForMvcCopyDependencyFilesIfPossible)' == ''">false</_CreateHardLinksForMvcCopyDependencyFilesIfPossible>
+        <_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible Condition="'$(_CreateSymbolicLinksMvcCopyDependencyFilesIfPossible)' == ''">false</_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible>
     </PropertyGroup>
 
     <Copy SourceFiles="%(DepsFilePaths.FullPath)"

--- a/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
+++ b/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
@@ -64,8 +64,17 @@
         Condition="'%(_ContentRootProjectReferences.Identity)' != ''"
         Include="$([System.IO.Path]::ChangeExtension('%(_ContentRootProjectReferences.ResolvedFrom)', '.deps.json'))" />
     </ItemGroup>
+    
+    <PropertyGroup>
+        <CreateHardLinksForMvcCopyDependencyFilesIfPossible Condition="'$(CreateHardLinksForMvcCopyDependencyFilesIfPossible)' == ''">false</CreateHardLinksForMvcCopyDependencyFilesIfPossible>
+        <CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible Condition="'$(CreateSymbolicLinksMvcCopyDependencyFilesIfPossible)' == ''">false</CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible>
+    </PropertyGroup>
 
-    <Copy SourceFiles="%(DepsFilePaths.FullPath)" DestinationFolder="$(OutDir)" Condition="Exists('%(DepsFilePaths.FullPath)')" />
+    <Copy SourceFiles="%(DepsFilePaths.FullPath)"
+       DestinationFolder="$(OutDir)"
+       UseHardlinksIfPossible="$(CreateHardLinksForMvcCopyDependencyFilesIfPossible)"
+       UseSymboliclinksIfPossible="$(CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible)"
+       Condition="Exists('%(DepsFilePaths.FullPath)')" />
   </Target>
 
 </Project>

--- a/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
+++ b/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
@@ -72,8 +72,8 @@
 
     <Copy SourceFiles="%(DepsFilePaths.FullPath)"
        DestinationFolder="$(OutDir)"
-       UseHardlinksIfPossible="$(CreateHardLinksForMvcCopyDependencyFilesIfPossible)"
-       UseSymboliclinksIfPossible="$(CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible)"
+       UseHardlinksIfPossible="$(_CreateHardLinksForMvcCopyDependencyFilesIfPossible)"
+       UseSymboliclinksIfPossible="$(_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible)"
        Condition="Exists('%(DepsFilePaths.FullPath)')" />
   </Target>
 

--- a/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
+++ b/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
@@ -66,8 +66,8 @@
     </ItemGroup>
     
     <PropertyGroup>
-        <CreateHardLinksForMvcCopyDependencyFilesIfPossible Condition="'$(CreateHardLinksForMvcCopyDependencyFilesIfPossible)' == ''">false</CreateHardLinksForMvcCopyDependencyFilesIfPossible>
-        <CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible Condition="'$(CreateSymbolicLinksMvcCopyDependencyFilesIfPossible)' == ''">false</CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible>
+        <_CreateHardLinksForMvcCopyDependencyFilesIfPossible Condition="'$(CreateHardLinksForMvcCopyDependencyFilesIfPossible)' == ''">false</_CreateHardLinksForMvcCopyDependencyFilesIfPossible>
+        <_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible Condition="'$(CreateSymbolicLinksMvcCopyDependencyFilesIfPossible)' == ''">false</_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible>
     </PropertyGroup>
 
     <Copy SourceFiles="%(DepsFilePaths.FullPath)"

--- a/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
+++ b/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
@@ -66,8 +66,8 @@
     </ItemGroup>
     
     <PropertyGroup>
-        <_CreateHardLinksForMvcCopyDependencyFilesIfPossible Condition="'$(_CreateHardLinksForMvcCopyDependencyFilesIfPossible)' == ''">false</_CreateHardLinksForMvcCopyDependencyFilesIfPossible>
-        <_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible Condition="'$(_CreateSymbolicLinksMvcCopyDependencyFilesIfPossible)' == ''">false</_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible>
+        <_CreateHardLinksForMvcCopyDependencyFilesIfPossible Condition="'$(_CreateHardLinksForMvcCopyDependencyFilesIfPossible)' == ''">$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)</_CreateHardLinksForMvcCopyDependencyFilesIfPossible>
+        <_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible Condition="'$(_CreateSymbolicLinksMvcCopyDependencyFilesIfPossible)' == ''">$(CreateSymbolicLinksForCopyFilesToOutputDirectoryIfPossible)</_CreateSymbolicLinksForMvcCopyDependencyFilesIfPossible>
     </PropertyGroup>
 
     <Copy SourceFiles="%(DepsFilePaths.FullPath)"


### PR DESCRIPTION
PR Title
Added parameters to Copy task that is executed for setting up correct dependency environment in the tests.

PR Description
When enabling multiple msbuild nodes it could fail due to locking "xxx.deps.json" files
We have faced with this issue using latest version of microsoft.aspnetcore.mvc.testing nuget package
C:\ZZZZ\nuget\microsoft.aspnetcore.mvc.testing\7.0.1\build\net7.0\Microsoft.AspNetCore.Mvc.Testing.targets(68, 5): error MSB3027: Unable to copy file "D:\XXXX\bin\Release\YYYY.deps.json" to "bin\Release\YYYY.deps.json". The process cannot access the file 'bin\Release\YYYY.deps.json' because it is being used by another process.

Addresses https://github.com/dotnet/aspnetcore/issues/33757