### PR TITLE
Update DeflateDecompressionProvider to use ZLibStream instead of DeflateStream

### DIFF
--- a/src/Middleware/RequestDecompression/src/DeflateDecompressionProvider.cs
+++ b/src/Middleware/RequestDecompression/src/DeflateDecompressionProvider.cs
@@ -13,6 +13,6 @@ internal sealed class DeflateDecompressionProvider : IDecompressionProvider
     /// <inheritdoc />
     public Stream GetDecompressionStream(Stream stream)
     {
-        return new DeflateStream(stream, CompressionMode.Decompress, leaveOpen: true);
+        return new ZLibStream(stream, CompressionMode.Decompress, leaveOpen: true);
     }
 }


### PR DESCRIPTION
Please see [this issue](https://github.com/dotnet/runtime/issues/38022), which describes the issue with using DeflateStream, and as the reason ZLibStream was introduced.

In a nutshell, refer to [RFC 2616, section 3.5](https://www.rfc-editor.org/rfc/rfc2616#section-3.5):

> **deflate**
> The "zlib" format defined in [RFC 1950](https://www.rfc-editor.org/rfc/rfc1950) [[31](https://www.rfc-editor.org/rfc/rfc2616#ref-31)] in combination with the "deflate" compression mechanism described in [RFC 1951](https://www.rfc-editor.org/rfc/rfc1951) [[29](https://www.rfc-editor.org/rfc/rfc2616#ref-29)].

That means deflate, in the context of HTTP, is comprised of the zlib header + deflate compression.
When using DeflateStream, it does **not** include the zlib header.
ZLibStream does include the zlib header, and is the correct stream to use in this case.

DeflateDecompressionProvider is using DeflateStream, meaning it is omitting the zlib header, which is required by the RFC.

See also: [This comment](https://github.com/stephentoub/runtime/blob/2a97cead437ee222408510aa080a601ce955544a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/DecompressionHandler.cs#L231)

**Breaking changes possibility:** .NET currently does not provide a built-in mechanism to compress HTTP bodies (is it currently suggested [here](https://github.com/dotnet/runtime/issues/46944)). Any compression would be done by the user in their own code. If they are not using the right stream type, then it's possible the decompression could fail on the server.