### PR TITLE
Add Tags property to OutputCache property.

### DIFF
--- a/src/Middleware/OutputCaching/src/OutputCacheAttribute.cs
+++ b/src/Middleware/OutputCaching/src/OutputCacheAttribute.cs
@@ -55,6 +55,11 @@ public sealed class OutputCacheAttribute : Attribute
     public string[]? VaryByRouteValueNames { get; init; }
 
     /// <summary>
+    /// Gets or sets tags to apply to the output cache.
+    /// </summary>
+    public string[]? Tags { get; init; }
+
+    /// <summary>
     /// Gets or sets the value of the cache policy name.
     /// </summary>
     public string? PolicyName { get; init; }
@@ -97,6 +102,11 @@ public sealed class OutputCacheAttribute : Attribute
         if (VaryByRouteValueNames != null)
         {
             builder.SetVaryByRouteValue(VaryByRouteValueNames);
+        }
+
+        if (Tags != null)
+        {
+            builder.Tag(Tags);
         }
 
         if (_duration != null)

--- a/src/Middleware/OutputCaching/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/OutputCaching/src/PublicAPI.Unshipped.txt
@@ -37,6 +37,8 @@ Microsoft.AspNetCore.OutputCaching.OutputCacheAttribute.VaryByQueryKeys.get -> s
 Microsoft.AspNetCore.OutputCaching.OutputCacheAttribute.VaryByQueryKeys.init -> void
 Microsoft.AspNetCore.OutputCaching.OutputCacheAttribute.VaryByRouteValueNames.get -> string![]?
 Microsoft.AspNetCore.OutputCaching.OutputCacheAttribute.VaryByRouteValueNames.init -> void
+Microsoft.AspNetCore.OutputCaching.OutputCacheAttribute.Tags.get -> string![]?
+Microsoft.AspNetCore.OutputCaching.OutputCacheAttribute.Tags.init -> void
 Microsoft.AspNetCore.OutputCaching.OutputCacheContext.EnableOutputCaching.get -> bool
 Microsoft.AspNetCore.OutputCaching.OutputCacheContext.EnableOutputCaching.set -> void
 Microsoft.AspNetCore.OutputCaching.OutputCacheContext.HttpContext.init -> void

--- a/src/Middleware/OutputCaching/test/OutputCacheAttributeTests.cs
+++ b/src/Middleware/OutputCaching/test/OutputCacheAttributeTests.cs
@@ -121,6 +121,18 @@ public class OutputCacheAttributeTests
         Assert.DoesNotContain("RouteB", (IEnumerable<string>)context.CacheVaryByRules.RouteValueNames);
     }
 
+    [Fact]
+    public async Task Attribute_CreatesTagsPolicy()
+    {
+        var context = TestUtils.CreateUninitializedContext();
+        var attribute = OutputCacheMethods.GetAttribute(nameof(OutputCacheMethods.Tags));
+        await attribute.BuildPolicy().CacheRequestAsync(context, cancellation: default);
+
+        Assert.True(context.EnableOutputCaching);
+        Assert.Contains("Tag1", (IEnumerable<string>)context.Tags);
+        Assert.Contains("Tag2", (IEnumerable<string>)context.Tags);
+    }
+
     private class OutputCacheMethods
     {
         public static OutputCacheAttribute GetAttribute(string methodName)
@@ -148,5 +160,8 @@ public class OutputCacheAttributeTests
 
         [OutputCache(VaryByRouteValueNames = new[] { "RouteA", "RouteC" })]
         public static void VaryByRouteValueNames() { }
+
+        [OutputCache(Tags = new[] { "Tag1", "Tag2" })]
+        public static void Tags() { }
     }
 }


### PR DESCRIPTION
# Add Tags property to OutputCache property

The ```[OutputCache]``` attribute does not have a tags property which means you either need to define tags in a policy in DI or append the ```OtuputCaching(...)```.

## Description

This just rounds out support for setting tags in the ```[OutputCache]``` attribute.

Addresses: #45842 
