### PR TITLE
Fix logout success log message (Blazor WebAssembly)

### DIFF
--- a/src/Components/WebAssembly/WebAssembly.Authentication/src/RemoteAuthenticatorViewCore.Log.cs
+++ b/src/Components/WebAssembly/WebAssembly.Authentication/src/RemoteAuthenticatorViewCore.Log.cs
@@ -37,7 +37,7 @@ public partial class RemoteAuthenticatorViewCore<TAuthenticationState> where TAu
         [LoggerMessage(9, LogLevel.Debug, "The logout was not initiated from within the page.", EventName = nameof(LogoutOperationInitiatedExternally))]
         public static partial void LogoutOperationInitiatedExternally(ILogger logger);
 
-        [LoggerMessage(10, LogLevel.Debug, "Login completed successfully.", EventName = nameof(LoginCompletedSuccessfully))]
+        [LoggerMessage(10, LogLevel.Debug, "Logout completed successfully.", EventName = nameof(LogoutCompletedSuccessfully))]
         public static partial void LogoutCompletedSuccessfully(ILogger logger);
 
         [LoggerMessage(11, LogLevel.Debug, "Logout requires redirect to the identity provider.", EventName = nameof(LogoutRequiresRedirect))]


### PR DESCRIPTION
# Correct the logout log message in Blazor WASM to read "logout" instead of "login"

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] ~You've included unit or integration tests for your change, where applicable.~
- [ ] N/A ~You've included inline docs for your change, where applicable.~
- [x] There's an open issue for the PR that you are making.
    - #45846

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Modifies _/src/Components/WebAssembly.Authentication/src/RemoteAuthenticatorViewCore.Log.cs_ to correct the log message and event name on successful logout.

## Description

Modifies the attribute decorating the `LogoutCompletedSuccessfully` method in  _RemoteAuthenticatorViewCore.Log.cs_ to refer to logout, not login.

Head:

https://github.com/dotnet/aspnetcore/blob/45fcfb75dd7ca6c548200dde4f7374a9a451039b/src/Components/WebAssembly/WebAssembly.Authentication/src/RemoteAuthenticatorViewCore.Log.cs#L40-L41

This PR:

```csharp
[LoggerMessage(10, LogLevel.Debug, "Logout completed successfully.", EventName = nameof(LogoutCompletedSuccessfully))]
public static partial void LogoutCompletedSuccessfully(ILogger logger);
```

Fixes #45846
