### PR TITLE
Use CachedFactoryContext

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -424,10 +424,34 @@ public static partial class RequestDelegateFactory
         //  When the `handler` returns a void or a void-returning Task, then we return an EmptyHttpResult
         //  to as a ValueTask<object?>
         // }
+
+        var argTypes = factoryContext.ArgumentTypes;
+        var contextArgAccess = new Expression[argTypes.Length];
+
+        for (int i = 0; i < argTypes.Length; i++)
+        {
+            if (RuntimeFeature.IsDynamicCodeSupported)
+            {
+                // Register expressions containing the boxed and unboxed variants
+                // of the route handler's arguments for use in EndpointFilterInvocationContext
+                // construction and route handler invocation.
+                // context.GetArgument<string>(0)
+                // (string, name_local), (int, int_local)
+                contextArgAccess[i] = Expression.Call(FilterContextExpr, EndpointFilterInvocationContextGetArgument.MakeGenericMethod(argTypes[i]), Expression.Constant(i));
+            }
+            else
+            {
+                // We box if dynamic code isn't supported
+                contextArgAccess[i] = Expression.Convert(
+                    Expression.Property(FilterContextArgumentsExpr, ListIndexer, Expression.Constant(i)),
+                argTypes[i]);
+            }
+        }
+
         var handlerReturnMapping = MapHandlerReturnTypeToValueTask(
                         targetExpression is null
-                            ? Expression.Call(methodInfo, factoryContext.ContextArgAccess)
-                            : Expression.Call(targetExpression, methodInfo, factoryContext.ContextArgAccess),
+                            ? Expression.Call(methodInfo, contextArgAccess)
+                            : Expression.Call(targetExpression, methodInfo, contextArgAccess),
                         methodInfo.ReturnType);
         var handlerInvocation = Expression.Block(
                     new[] { TargetExpr },
@@ -600,32 +624,9 @@ public static partial class RequestDelegateFactory
         factoryContext.BoxedArgs = new Expression[parameters.Length];
         factoryContext.Parameters = new List<ParameterInfo>(parameters);
 
-        var hasFilters = factoryContext.EndpointBuilder.FilterFactories.Count > 0;
-
         for (var i = 0; i < parameters.Length; i++)
         {
             args[i] = CreateArgument(parameters[i], factoryContext);
-
-            // Only populate the context args if there are filters for this handler
-            if (hasFilters)
-            {
-                if (RuntimeFeature.IsDynamicCodeSupported)
-                {
-                    // Register expressions containing the boxed and unboxed variants
-                    // of the route handler's arguments for use in EndpointFilterInvocationContext
-                    // construction and route handler invocation.
-                    // context.GetArgument<string>(0)
-                    // (string, name_local), (int, int_local)
-                    factoryContext.ContextArgAccess.Add(Expression.Call(FilterContextExpr, EndpointFilterInvocationContextGetArgument.MakeGenericMethod(parameters[i].ParameterType), Expression.Constant(i)));
-                }
-                else
-                {
-                    // We box if dynamic code isn't supported
-                    factoryContext.ContextArgAccess.Add(Expression.Convert(
-                        Expression.Property(FilterContextArgumentsExpr, ListIndexer, Expression.Constant(i)),
-                    parameters[i].ParameterType));
-                }
-            }
 
             factoryContext.ArgumentTypes[i] = parameters[i].ParameterType;
             factoryContext.BoxedArgs[i] = Expression.Convert(args[i], typeof(object));

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -428,7 +428,7 @@ public static partial class RequestDelegateFactory
         var argTypes = factoryContext.ArgumentTypes;
         var contextArgAccess = new Expression[argTypes.Length];
 
-        for (int i = 0; i < argTypes.Length; i++)
+        for (var i = 0; i < argTypes.Length; i++)
         {
             if (RuntimeFeature.IsDynamicCodeSupported)
             {

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -133,6 +133,7 @@ public static partial class RequestDelegateFactory
         return new RequestDelegateMetadataResult
         {
             EndpointMetadata = AsReadOnlyList(factoryContext.EndpointBuilder.Metadata),
+            CachedFactoryContext = factoryContext,
         };
     }
 

--- a/src/Http/Http.Extensions/src/RequestDelegateFactoryContext.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactoryContext.cs
@@ -49,7 +49,6 @@ internal sealed class RequestDelegateFactoryContext
     public bool ReadFormFile { get; set; }
     public ParameterInfo? FirstFormRequestBodyParameter { get; set; }
     // Properties for constructing and managing filters
-    public List<Expression> ContextArgAccess { get; } = new();
     public Expression? MethodCall { get; set; }
     public Type[] ArgumentTypes { get; set; } = Array.Empty<Type>();
     public Expression[]? ArgumentExpressions { get; set; }

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -6936,6 +6936,23 @@ public partial class RequestDelegateFactoryTests : LoggedTest
     }
 
     [Fact]
+    public void InferMetadata_PopulatesCachedContext()
+    {
+        // Arrange
+        var @delegate = void () => { };
+        var options = new RequestDelegateFactoryOptions
+        {
+            EndpointBuilder = CreateEndpointBuilder(),
+        };
+
+        // Act
+        var metadataResult = RequestDelegateFactory.InferMetadata(@delegate.Method, options);
+
+        // Assert
+        Assert.NotNull(metadataResult.CachedContext);
+    }
+
+    [Fact]
     public void Create_AllowsRemovalOfDefaultMetadata_ByReturnTypesImplementingIEndpointMetadataProvider()
     {
         // Arrange

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -6949,7 +6949,7 @@ public partial class RequestDelegateFactoryTests : LoggedTest
         var metadataResult = RequestDelegateFactory.InferMetadata(@delegate.Method, options);
 
         // Assert
-        Assert.NotNull(metadataResult.CachedContext);
+        Assert.NotNull(metadataResult.CachedFactoryContext);
     }
 
     [Fact]


### PR DESCRIPTION
# Fix `CachedFactoryContext` is unused

Stores the `RequestDelegateFactoryContext` created in `RequestDelegateFactory.InferMetadata()` on `RequestDelegateMetadataResult.CachedFactoryContext` so it can be reused in `RequestDelegateFactory.Create()`.

## Description

This was always the _expected_ behaviour, as caching the factory context prevents a lot of re-work building `Expression` trees for the handlers parameters.

Without the caching, the behaviour was still correct (as evidenced by the unit tests that assume the caching was taking place), it would just have an impact on startup time.

Fixes #45840