### PR TITLE
Fixed bug in NavigationManager.GetUriWithQueryParameter(s) to include uri with hash string

### DIFF
--- a/src/Components/Components/src/NavigationManagerExtensions.cs
+++ b/src/Components/Components/src/NavigationManagerExtensions.cs
@@ -140,8 +140,7 @@ public static class NavigationManagerExtensions
 
         public string GetUriWithQueryString()
         {
-            _builder.Append(_hash);
-            return _builder.ToString();
+            return _builder.ToString() + _hash;
         }
     }
 

--- a/src/Components/Components/src/NavigationManagerExtensions.cs
+++ b/src/Components/Components/src/NavigationManagerExtensions.cs
@@ -139,7 +139,7 @@ public static class NavigationManagerExtensions
         }
 
         public string GetUriWithQueryString()
-        {
+        {   
             return _builder.ToString() + _hash;
         }
     }
@@ -745,7 +745,7 @@ public static class NavigationManagerExtensions
         existingQueryStringEnumerable = new(query);
 
         var uriWithoutQueryString = uri.AsSpan(0, queryStartIndex);
-        newQueryStringBuilder = new(uriWithoutQueryString, query.Length + hash.Length, hash);
+        newQueryStringBuilder = new(uriWithoutQueryString, query.Length, hash);
 
         return true;
     }

--- a/src/Components/Components/src/NavigationManagerExtensions.cs
+++ b/src/Components/Components/src/NavigationManagerExtensions.cs
@@ -111,10 +111,10 @@ public static class NavigationManagerExtensions
 
         private readonly string _hash;
 
-        public QueryStringBuilder(ReadOnlySpan<char> uriWithoutQueryString, int additionalCapacity = 0, string hash = "")
+        public QueryStringBuilder(ReadOnlySpan<char> uriWithoutQueryStringAndHash, int additionalCapacity = 0, string hash = "")
         {
-            _builder = new(uriWithoutQueryString.Length + additionalCapacity);
-            _builder.Append(uriWithoutQueryString);
+            _builder = new(uriWithoutQueryStringAndHash.Length + additionalCapacity);
+            _builder.Append(uriWithoutQueryStringAndHash);
 
             _hash = hash;
 
@@ -744,8 +744,8 @@ public static class NavigationManagerExtensions
 
         existingQueryStringEnumerable = new(query);
 
-        var uriWithoutQueryString = uri.AsSpan(0, queryStartIndex);
-        newQueryStringBuilder = new(uriWithoutQueryString, query.Length, hash);
+        var uriWithoutQueryStringAndHash = uri.AsSpan(0, queryStartIndex);
+        newQueryStringBuilder = new(uriWithoutQueryStringAndHash, query.Length, hash);
 
         return true;
     }

--- a/src/Components/Components/test/NavigationManagerTest.cs
+++ b/src/Components/Components/test/NavigationManagerTest.cs
@@ -18,6 +18,8 @@ public class NavigationManagerTest
     [InlineData("scheme://host/path", "scheme://host/")]
     [InlineData("scheme://host/path/", "scheme://host/path/")]
     [InlineData("scheme://host/path/page?query=string&another=here", "scheme://host/path/")]
+    [InlineData("scheme://host/path/#hash", "scheme://host/path/")]
+    [InlineData("scheme://host/path/page?query=string&another=here#hash", "scheme://host/path/")]
     public void ComputesCorrectBaseUri(string baseUri, string expectedResult)
     {
         var actualResult = NavigationManager.NormalizeBaseUri(baseUri);
@@ -64,24 +66,6 @@ public class NavigationManagerTest
     [InlineData("scheme://host/", "otherscheme://host/")]
     [InlineData("scheme://host/", "scheme://otherhost/")]
     [InlineData("scheme://host/path/", "scheme://host/")]
-    public void Uri_ThrowsForInvalidBaseRelativePaths(string baseUri, string absoluteUri)
-    {
-        var navigationManager = new TestNavigationManager(baseUri);
-
-        var ex = Assert.Throws<ArgumentException>(() =>
-        {
-            navigationManager.ToBaseRelativePath(absoluteUri);
-        });
-
-        Assert.Equal(
-            $"The URI '{absoluteUri}' is not contained by the base URI '{baseUri}'.",
-            ex.Message);
-    }
-
-    [Theory]
-    [InlineData("scheme://host/", "otherscheme://host/")]
-    [InlineData("scheme://host/", "scheme://otherhost/")]
-    [InlineData("scheme://host/path/", "scheme://host/")]
     public void ToBaseRelativePath_ThrowsForInvalidBaseRelativePaths(string baseUri, string absoluteUri)
     {
         var navigationManager = new TestNavigationManager(baseUri);
@@ -102,6 +86,8 @@ public class NavigationManagerTest
     [InlineData("scheme://host/?full%20name=Sally%20Smith&age=42&full%20name=Emily", "scheme://host/?full%20name=John%20Doe&age=42&full%20name=John%20Doe")]
     [InlineData("scheme://host/?full%20name=&age=42", "scheme://host/?full%20name=John%20Doe&age=42")]
     [InlineData("scheme://host/?full%20name=", "scheme://host/?full%20name=John%20Doe")]
+    [InlineData("scheme://host/?full%20name=Bob%20Joe#hash", "scheme://host/?full%20name=John%20Doe#hash")]
+    [InlineData("scheme://host/?full%20name=Bob%20Joe&age=42#hash", "scheme://host/?full%20name=John%20Doe&age=42#hash")]
     public void GetUriWithQueryParameter_ReplacesWhenParameterExists(string baseUri, string expectedUri)
     {
         var navigationManager = new TestNavigationManager(baseUri);
@@ -114,6 +100,8 @@ public class NavigationManagerTest
     [InlineData("scheme://host/?age=42", "scheme://host/?age=42&name=John%20Doe")]
     [InlineData("scheme://host/", "scheme://host/?name=John%20Doe")]
     [InlineData("scheme://host/?", "scheme://host/?name=John%20Doe")]
+    [InlineData("scheme://host/#hash", "scheme://host/?name=John%20Doe#hash")]
+    [InlineData("scheme://host/?age=42#hash", "scheme://host/?age=42&name=John%20Doe#hash")]
     public void GetUriWithQueryParameter_AppendsWhenParameterDoesNotExist(string baseUri, string expectedUri)
     {
         var navigationManager = new TestNavigationManager(baseUri);
@@ -129,6 +117,9 @@ public class NavigationManagerTest
     [InlineData("scheme://host/?full%20name=&age=42", "scheme://host/?age=42")]
     [InlineData("scheme://host/?full%20name=", "scheme://host/")]
     [InlineData("scheme://host/", "scheme://host/")]
+    [InlineData("scheme://host/#hash", "scheme://host/#hash")]
+    [InlineData("scheme://host/?full%20name=&age=42#hash", "scheme://host/?age=42#hash")]
+    [InlineData("scheme://host/?full%20name=Bob#hash", "scheme://host/#hash")]
     public void GetUriWithQueryParameter_RemovesWhenParameterValueIsNull(string baseUri, string expectedUri)
     {
         var navigationManager = new TestNavigationManager(baseUri);
@@ -156,6 +147,8 @@ public class NavigationManagerTest
     [InlineData("scheme://host/?age=42&eye%20color=87", "scheme://host/?age=25&eye%20color=green")]
     [InlineData("scheme://host/?", "scheme://host/?age=25&eye%20color=green")]
     [InlineData("scheme://host/", "scheme://host/?age=25&eye%20color=green")]
+    [InlineData("scheme://host/#hash", "scheme://host/?age=25&eye%20color=green#hash")]
+    [InlineData("scheme://host/?name=Bob%20Joe&age=42#hash", "scheme://host/?age=25&eye%20color=green#hash")]
     public void GetUriWithQueryParameters_CanAddUpdateAndRemove(string baseUri, string expectedUri)
     {
         var navigationManager = new TestNavigationManager(baseUri);
@@ -173,6 +166,7 @@ public class NavigationManagerTest
     [InlineData("scheme://host/?full%20name=Bob%20Joe&ping=8&ping=300", "scheme://host/?full%20name=John%20Doe&ping=35&ping=16&ping=87&ping=240")]
     [InlineData("scheme://host/?ping=8&full%20name=Bob%20Joe&ping=300", "scheme://host/?ping=35&full%20name=John%20Doe&ping=16&ping=87&ping=240")]
     [InlineData("scheme://host/?ping=8&ping=300&ping=50&ping=68&ping=42", "scheme://host/?ping=35&ping=16&ping=87&ping=240&full%20name=John%20Doe")]
+    [InlineData("scheme://host/?full%20name=Bob%20Joe&ping=8&ping=300#hash", "scheme://host/?full%20name=John%20Doe&ping=35&ping=16&ping=87&ping=240#hash")]
     public void GetUriWithQueryParameters_SupportsEnumerableValues(string baseUri, string expectedUri)
     {
         var navigationManager = new TestNavigationManager(baseUri);


### PR DESCRIPTION
# Fixed bug in NavigationManager.GetUriWithQueryParameter(s) to include uri with hash string

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

1. Fixed NavigationManager.GetUriWithQueryParameter(s) methods: included case when uri has hash string
2. Added test cases where uri has hash string to NavigationManagerTests 
3. Removed duplicate test from NavigationManagerTests



Fixes #44204
