### PR TITLE
React to new HttpClient header size check #45811

### DIFF
--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
@@ -1345,7 +1345,6 @@ public class HttpClientHttp2InteropTests : LoggedTest
 
     [Theory]
     [MemberData(nameof(SupportedSchemes))]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/45811")]
     public async Task Settings_MaxHeaderListSize_Server(string scheme)
     {
         var oneKbString = new string('a', 1024);
@@ -1354,15 +1353,16 @@ public class HttpClientHttp2InteropTests : LoggedTest
             {
                 ConfigureKestrel(webHostBuilder, scheme);
                 webHostBuilder.ConfigureServices(AddTestLogging)
-                .Configure(app => app.Run(context => throw new NotImplementedException()));
+                .Configure(app => app.Run(context => context.Response.WriteAsync("Hello World")));
             });
         using var host = await hostBuilder.StartAsync().DefaultTimeout();
 
         var url = host.MakeUrl(scheme);
 
         using var client = CreateClient();
-        // There's no point in waiting for the settings to sync, the client doesn't check the header list size setting.
-        // https://github.com/dotnet/runtime/blob/48a78bfa13e9c710851690621fc2c0fe1637802c/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs#L467-L494
+        // Send an initial request to ensure the settings get synced before the real test.
+        var responseBody = await client.GetStringAsync(url).DefaultTimeout();
+        Assert.Equal("Hello World", responseBody);
 
         var request = CreateRequestMessage(HttpMethod.Get, url, content: null);
         // The default size limit is 32kb.
@@ -1370,10 +1370,10 @@ public class HttpClientHttp2InteropTests : LoggedTest
         {
             request.Headers.Add("header" + i, oneKbString + i);
         }
-        var response = await client.SendAsync(request).DefaultTimeout();
-        await host.StopAsync().DefaultTimeout();
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(request).DefaultTimeout());
+        Assert.Equal("The HTTP request headers length exceeded the server limit of 32768 bytes.", ex.Message);
 
-        Assert.Equal(HttpStatusCode.RequestHeaderFieldsTooLarge, response.StatusCode);
+        await host.StopAsync().DefaultTimeout();
     }
 
     [Theory]


### PR DESCRIPTION
Fixes #45811

HttpClient now checks the header size limit on the client, using the HTTP/2 setting advertised by the server.

@MihaZupan 