### PR TITLE
Unset MicrosoftNetCompilersToolsetVersion

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -159,9 +159,6 @@
     <MicrosoftNETCoreAppRuntimeVersion>$(MicrosoftNETCoreAppRuntimewinx64Version)</MicrosoftNETCoreAppRuntimeVersion>
   </PropertyGroup>
   <PropertyGroup Label="Manual">
-    <!-- Bumping the Roslyn version used in order to ingest the new runtime source generators -->
-    <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
-    <MicrosoftNetCompilersToolsetVersion>4.5.0-1.22517.9</MicrosoftNetCompilersToolsetVersion>
     <!-- DiagnosticAdapter package pinned temporarily (??) until migrated/deprecated -->
     <!-- This is the latest version found in dotnet-public. -->
     <MicrosoftExtensionsDiagnosticAdapterVersion>5.0.0-preview.3.20215.2</MicrosoftExtensionsDiagnosticAdapterVersion>

--- a/src/SignalR/common/Shared/ClientResultsManager.cs
+++ b/src/SignalR/common/Shared/ClientResultsManager.cs
@@ -23,7 +23,7 @@ internal sealed class ClientResultsManager : IInvocationBinder
             var tcs = (TaskCompletionSourceWithCancellation<T>)state;
             if (completionMessage.HasResult)
             {
-                tcs.SetResult((T)completionMessage.Result);
+                tcs.SetResult((T)completionMessage.Result!);
             }
             else
             {


### PR DESCRIPTION
This is older than what's in Arcade now: https://github.com/dotnet/arcade/blob/eae015fb1c92ceef69126164b3969447d0355c08/eng/Versions.props#L45. dotnet/SDK uses the Arcade version, so we can just fall back to that.

Fixes https://github.com/dotnet/aspnetcore/issues/45882