### PR TITLE
Add limit to length of IdentityUser.PhoneNumber.

### DIFF
--- a/src/Identity/EntityFrameworkCore/src/IdentityUserContext.cs
+++ b/src/Identity/EntityFrameworkCore/src/IdentityUserContext.cs
@@ -132,6 +132,7 @@ public abstract class IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, T
             b.Property(u => u.NormalizedUserName).HasMaxLength(256);
             b.Property(u => u.Email).HasMaxLength(256);
             b.Property(u => u.NormalizedEmail).HasMaxLength(256);
+            b.Property(u => u.PhoneNumber).HasMaxLength(50);
 
             if (encryptPersonalData)
             {


### PR DESCRIPTION
# Add limit to length of IdentityUser.PhoneNumber.

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Currently, the PhoneNumber of IdentityUser has an unlimited maximum length. The largest phone number in the world is composed of 15 digits according to https://en.wikipedia.org/wiki/E.164. For additional information such as "+, - , (,), space", a good length looks to be 50.
