### PR TITLE
Avoid deprecated `set-output` and bump action version

### DIFF
--- a/.github/workflows/runtime-sync.yml
+++ b/.github/workflows/runtime-sync.yml
@@ -60,11 +60,11 @@ jobs:
         # Test this script using an issue in the local forked repo
         $issue = 'https://api.github.com/repos/dotnet/aspnetcore/issues/18943'
         $sendpr = .\aspnetcore\.github\workflows\ReportDiff.ps1
-        echo "::set-output name=sendpr::$sendpr"
+        echo "sendpr=$sendpr" >> $GITHUB_OUTPUT
     - name: Send PR
       if: steps.check.outputs.sendpr == 'true'
       # https://github.com/marketplace/actions/create-pull-request
-      uses: dotnet/actions-create-pull-request@v3
+      uses: dotnet/actions-create-pull-request@v4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         path: .\aspnetcore


### PR DESCRIPTION
- see <https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/>
- bump to dotnet/actions-create-pull-request@v4 to avoid Node 12
  - see <https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/>