### PR TITLE
Add MVC ambiguous route analyzer

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -187,4 +187,13 @@ internal static class DiagnosticDescriptors
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: "https://aka.ms/aspnet/analyzers");
+
+    internal static readonly DiagnosticDescriptor AmbiguousActionRoute = new(
+        "ASP0023",
+        "Route conflict detected between controller actions",
+        "Route '{0}' conflicts with another action route. An HTTP request that matches multiple routes results in an ambiguous match error. Fix the conflict by changing the route's pattern, HTTP method, or route constraints.",
+        "Usage",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        helpLinkUri: "https://aka.ms/aspnet/analyzers");
 }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/WellKnownTypes.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/WellKnownTypes.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.AspNetCore.Analyzers.Infrastructure;
 using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
@@ -64,6 +65,48 @@ internal enum WellKnownType
     Microsoft_Extensions_DependencyInjection_OutputCacheConventionBuilderExtensions,
     Microsoft_AspNetCore_Builder_RateLimiterEndpointConventionBuilderExtensions,
     Microsoft_AspNetCore_Builder_RoutingEndpointConventionBuilderExtensions,
+    Microsoft_AspNetCore_Mvc_RouteAttribute,
+    Microsoft_AspNetCore_Mvc_HttpDeleteAttribute,
+    Microsoft_AspNetCore_Mvc_HttpGetAttribute,
+    Microsoft_AspNetCore_Mvc_HttpHeadAttribute,
+    Microsoft_AspNetCore_Mvc_HttpOptionsAttribute,
+    Microsoft_AspNetCore_Mvc_HttpPatchAttribute,
+    Microsoft_AspNetCore_Mvc_HttpPostAttribute,
+    Microsoft_AspNetCore_Mvc_HttpPutAttribute,
+    Microsoft_AspNetCore_Http_EndpointDescriptionAttribute,
+    Microsoft_AspNetCore_Http_EndpointSummaryAttribute,
+    Microsoft_AspNetCore_Http_TagsAttribute,
+    Microsoft_AspNetCore_Routing_EndpointGroupNameAttribute,
+    Microsoft_AspNetCore_Routing_EndpointNameAttribute,
+    Microsoft_AspNetCore_Routing_ExcludeFromDescriptionAttribute,
+    Microsoft_AspNetCore_Cors_DisableCorsAttribute,
+    Microsoft_AspNetCore_Cors_EnableCorsAttribute,
+    Microsoft_AspNetCore_OutputCaching_OutputCacheAttribute,
+    Microsoft_AspNetCore_RateLimiting_DisableRateLimitingAttribute,
+    Microsoft_AspNetCore_RateLimiting_EnableRateLimitingAttribute,
+    Microsoft_AspNetCore_Mvc_ActionNameAttribute,
+    Microsoft_AspNetCore_Mvc_DisableRequestSizeLimitAttribute,
+    Microsoft_AspNetCore_Mvc_FormatFilterAttribute,
+    Microsoft_AspNetCore_Mvc_ProducesAttribute,
+    Microsoft_AspNetCore_Mvc_ProducesDefaultResponseTypeAttribute,
+    Microsoft_AspNetCore_Mvc_ProducesErrorResponseTypeAttribute,
+    Microsoft_AspNetCore_Mvc_ProducesResponseTypeAttribute,
+    Microsoft_AspNetCore_Mvc_RequestFormLimitsAttribute,
+    Microsoft_AspNetCore_Mvc_RequestSizeLimitAttribute,
+    Microsoft_AspNetCore_Mvc_RequireHttpsAttribute,
+    Microsoft_AspNetCore_Mvc_ResponseCacheAttribute,
+    Microsoft_AspNetCore_Mvc_ServiceFilterAttribute,
+    Microsoft_AspNetCore_Mvc_TypeFilterAttribute,
+    Microsoft_AspNetCore_Mvc_ApiExplorer_ApiConventionNameMatchAttribute,
+    Microsoft_AspNetCore_Mvc_Filters_ResultFilterAttribute,
+    Microsoft_AspNetCore_Mvc_Infrastructure_DefaultStatusCodeAttribute,
+    Microsoft_AspNetCore_Mvc_AutoValidateAntiforgeryTokenAttribute,
+    Microsoft_AspNetCore_Mvc_IgnoreAntiforgeryTokenAttribute,
+    Microsoft_AspNetCore_Mvc_ViewFeatures_SaveTempDataAttribute,
+    Microsoft_AspNetCore_Mvc_SkipStatusCodePagesAttribute,
+    Microsoft_AspNetCore_Mvc_ValidateAntiForgeryTokenAttribute,
+    Microsoft_AspNetCore_Authorization_AllowAnonymousAttribute,
+    Microsoft_AspNetCore_Authorization_AuthorizeAttribute
 }
 
 internal sealed class WellKnownTypes
@@ -123,6 +166,48 @@ internal sealed class WellKnownTypes
         "Microsoft.Extensions.DependencyInjection.OutputCacheConventionBuilderExtensions",
         "Microsoft.AspNetCore.Builder.RateLimiterEndpointConventionBuilderExtensions",
         "Microsoft.AspNetCore.Builder.RoutingEndpointConventionBuilderExtensions",
+        "Microsoft.AspNetCore.Mvc.RouteAttribute",
+        "Microsoft.AspNetCore.Mvc.HttpDeleteAttribute",
+        "Microsoft.AspNetCore.Mvc.HttpGetAttribute",
+        "Microsoft.AspNetCore.Mvc.HttpHeadAttribute",
+        "Microsoft.AspNetCore.Mvc.HttpOptionsAttribute",
+        "Microsoft.AspNetCore.Mvc.HttpPatchAttribute",
+        "Microsoft.AspNetCore.Mvc.HttpPostAttribute",
+        "Microsoft.AspNetCore.Mvc.HttpPutAttribute",
+        "Microsoft.AspNetCore.Http.EndpointDescriptionAttribute",
+        "Microsoft.AspNetCore.Http.EndpointSummaryAttribute",
+        "Microsoft.AspNetCore.Http.TagsAttribute",
+        "Microsoft.AspNetCore.Routing.EndpointGroupNameAttribute",
+        "Microsoft.AspNetCore.Routing.EndpointNameAttribute",
+        "Microsoft.AspNetCore.Routing.ExcludeFromDescriptionAttribute",
+        "Microsoft.AspNetCore.Cors.DisableCorsAttribute",
+        "Microsoft.AspNetCore.Cors.EnableCorsAttribute",
+        "Microsoft.AspNetCore.OutputCaching.OutputCacheAttribute",
+        "Microsoft.AspNetCore.RateLimiting.DisableRateLimitingAttribute",
+        "Microsoft.AspNetCore.RateLimiting.EnableRateLimitingAttribute",
+        "Microsoft.AspNetCore.Mvc.ActionNameAttribute",
+        "Microsoft.AspNetCore.Mvc.DisableRequestSizeLimitAttribute",
+        "Microsoft.AspNetCore.Mvc.FormatFilterAttribute",
+        "Microsoft.AspNetCore.Mvc.ProducesAttribute",
+        "Microsoft.AspNetCore.Mvc.ProducesDefaultResponseTypeAttribute",
+        "Microsoft.AspNetCore.Mvc.ProducesErrorResponseTypeAttribute",
+        "Microsoft.AspNetCore.Mvc.ProducesResponseTypeAttribute",
+        "Microsoft.AspNetCore.Mvc.RequestFormLimitsAttribute",
+        "Microsoft.AspNetCore.Mvc.RequestSizeLimitAttribute",
+        "Microsoft.AspNetCore.Mvc.RequireHttpsAttribute",
+        "Microsoft.AspNetCore.Mvc.ResponseCacheAttribute",
+        "Microsoft.AspNetCore.Mvc.ServiceFilterAttribute",
+        "Microsoft.AspNetCore.Mvc.TypeFilterAttribute",
+        "Microsoft.AspNetCore.Mvc.ApiExplorer.ApiConventionNameMatchAttribute",
+        "Microsoft.AspNetCore.Mvc.Filters.ResultFilterAttribute",
+        "Microsoft.AspNetCore.Mvc.Infrastructure.DefaultStatusCodeAttribute",
+        "Microsoft.AspNetCore.Mvc.AutoValidateAntiforgeryTokenAttribute",
+        "Microsoft.AspNetCore.Mvc.IgnoreAntiforgeryTokenAttribute",
+        "Microsoft.AspNetCore.Mvc.ViewFeatures.SaveTempDataAttribute",
+        "Microsoft.AspNetCore.Mvc.SkipStatusCodePagesAttribute",
+        "Microsoft.AspNetCore.Mvc.ValidateAntiForgeryTokenAttribute",
+        "Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute",
+        "Microsoft.AspNetCore.Authorization.AuthorizeAttribute"
     };
 
     public static WellKnownTypes GetOrCreate(Compilation compilation) =>
@@ -164,6 +249,11 @@ internal sealed class WellKnownTypes
         _compilation = compilation;
     }
 
+    public INamedTypeSymbol Get(SpecialType type)
+    {
+        return _compilation.GetSpecialType(type);
+    }
+
     public INamedTypeSymbol Get(WellKnownType type)
     {
         var index = (int)type;
@@ -192,16 +282,20 @@ internal sealed class WellKnownTypes
         return _lazyWellKnownTypes[index]!;
     }
 
-    public bool IsType(ITypeSymbol type, WellKnownType[] wellKnownTypes)
+    public bool IsType(ITypeSymbol type, WellKnownType[] wellKnownTypes) => IsType(type, wellKnownTypes, out var _);
+
+    public bool IsType(ITypeSymbol type, WellKnownType[] wellKnownTypes, [NotNullWhen(true)] out WellKnownType? match)
     {
         foreach (var wellKnownType in wellKnownTypes)
         {
             if (SymbolEqualityComparer.Default.Equals(type, Get(wellKnownType)))
             {
+                match = wellKnownType;
                 return true;
             }
         }
 
+        match = null;
         return false;
     }
 

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Microsoft.AspNetCore.App.Analyzers.csproj
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Microsoft.AspNetCore.App.Analyzers.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)IsExternalInit.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Roslyn\CodeAnalysisExtensions.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Roslyn\MvcFacts.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Nullable\NullableAttributes.cs" />
   </ItemGroup>
 

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/DetectAmbiguousActionRoutes.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/DetectAmbiguousActionRoutes.cs
@@ -1,0 +1,196 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.AspNetCore.Analyzers.Infrastructure;
+using Microsoft.AspNetCore.Analyzers.Infrastructure.RoutePattern;
+using Microsoft.AspNetCore.App.Analyzers.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.AspNetCore.Analyzers.Mvc;
+
+public partial class MvcAnalyzer
+{
+    private static void DetectAmbiguousActionRoutes(SymbolAnalysisContext context, WellKnownTypes wellKnownTypes, List<ActionRoute> actionRoutes)
+    {
+        // Ambiguous action route detection is conservative in what it detects to avoid false positives.
+        //
+        // Successfully matched action routes must:
+        // 1. Be in the same controller.
+        // 2. Have an equivalent route.
+        // 3. Have a matching HTTP method.
+        // 4. Route either be the on the same action or the actions only have known safe attributes that don't impact matching.
+        if (actionRoutes.Count > 0)
+        {
+            // Group action routes together. When multiple match in a group, then report action routes to diagnostics.
+            var groupedByParent = actionRoutes
+                .GroupBy(ar => new ActionRouteGroupKey(ar.ActionSymbol, ar.RouteUsageModel.RoutePattern, ar.HttpMethods, wellKnownTypes));
+
+            foreach (var ambigiousGroup in groupedByParent.Where(g => g.Count() >= 2))
+            {
+                foreach (var ambigiousActionRoute in ambigiousGroup)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.AmbiguousActionRoute,
+                        ambigiousActionRoute.RouteUsageModel.UsageContext.RouteToken.GetLocation(),
+                        ambigiousActionRoute.RouteUsageModel.RoutePattern.Root.ToString()));
+                }
+            }
+        }
+    }
+
+    private readonly struct ActionRouteGroupKey : IEquatable<ActionRouteGroupKey>
+    {
+        public IMethodSymbol ActionSymbol { get; }
+        public RoutePatternTree RoutePattern { get; }
+        public ImmutableArray<string> HttpMethods { get; }
+        private readonly WellKnownTypes _wellKnownTypes;
+
+        public ActionRouteGroupKey(IMethodSymbol actionSymbol, RoutePatternTree routePattern, ImmutableArray<string> httpMethods, WellKnownTypes wellKnownTypes)
+        {
+            Debug.Assert(!httpMethods.IsDefault);
+
+            ActionSymbol = actionSymbol;
+            RoutePattern = routePattern;
+            HttpMethods = httpMethods;
+            _wellKnownTypes = wellKnownTypes;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ActionRouteGroupKey key)
+            {
+                return Equals(key);
+            }
+            return false;
+        }
+
+        public bool Equals(ActionRouteGroupKey other)
+        {
+            return
+                AmbiguousRoutePatternComparer.Instance.Equals(RoutePattern, other.RoutePattern) &&
+                HasMatchingHttpMethods(HttpMethods, other.HttpMethods) &&
+                CanMatchActions(_wellKnownTypes, ActionSymbol, other.ActionSymbol);
+        }
+
+        private static bool CanMatchActions(WellKnownTypes wellKnownTypes, IMethodSymbol actionSymbol1, IMethodSymbol actionSymbol2)
+        {
+            // Only match routes if either they are on the same action.
+            if (SymbolEqualityComparer.Default.Equals(actionSymbol1, actionSymbol2))
+            {
+                return true;
+            }
+
+            // Or all attributes on the actions are known to have no impact on routing.
+            // This ensures we don't detect routes that might have metadata added that impacts routing.
+            if (!HasUnknownAttribute(actionSymbol1, wellKnownTypes) && !HasUnknownAttribute(actionSymbol2, wellKnownTypes))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        // A collection of attributes in ASP.NET Core that don't have any impact on route matching and are safe.
+        // Note that route attributes such as [HttpGet] and friends are safe because we compare the route and HTTP method explicitly.
+        private static readonly WellKnownType[] KnownMethodAttributeTypes = new[]
+        {
+            WellKnownType.Microsoft_AspNetCore_Mvc_RouteAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_HttpDeleteAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_HttpGetAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_HttpHeadAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_HttpOptionsAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_HttpPatchAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_HttpPostAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_HttpPutAttribute,
+            WellKnownType.Microsoft_AspNetCore_Http_EndpointDescriptionAttribute,
+            WellKnownType.Microsoft_AspNetCore_Http_EndpointSummaryAttribute,
+            WellKnownType.Microsoft_AspNetCore_Http_TagsAttribute,
+            WellKnownType.Microsoft_AspNetCore_Routing_EndpointGroupNameAttribute,
+            WellKnownType.Microsoft_AspNetCore_Routing_EndpointNameAttribute,
+            WellKnownType.Microsoft_AspNetCore_Routing_ExcludeFromDescriptionAttribute,
+            WellKnownType.Microsoft_AspNetCore_Cors_DisableCorsAttribute,
+            WellKnownType.Microsoft_AspNetCore_Cors_EnableCorsAttribute,
+            WellKnownType.Microsoft_AspNetCore_OutputCaching_OutputCacheAttribute,
+            WellKnownType.Microsoft_AspNetCore_RateLimiting_DisableRateLimitingAttribute,
+            WellKnownType.Microsoft_AspNetCore_RateLimiting_EnableRateLimitingAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_ActionNameAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_DisableRequestSizeLimitAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_FormatFilterAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_ProducesAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_ProducesDefaultResponseTypeAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_ProducesErrorResponseTypeAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_ProducesResponseTypeAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_RequestFormLimitsAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_RequestSizeLimitAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_RequireHttpsAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_ResponseCacheAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_ServiceFilterAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_TypeFilterAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_ApiExplorer_ApiConventionNameMatchAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_Filters_ResultFilterAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_Infrastructure_DefaultStatusCodeAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_AutoValidateAntiforgeryTokenAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_IgnoreAntiforgeryTokenAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_ViewFeatures_SaveTempDataAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_SkipStatusCodePagesAttribute,
+            WellKnownType.Microsoft_AspNetCore_Mvc_ValidateAntiForgeryTokenAttribute,
+            WellKnownType.Microsoft_AspNetCore_Authorization_AllowAnonymousAttribute,
+            WellKnownType.Microsoft_AspNetCore_Authorization_AuthorizeAttribute
+        };
+
+        private static bool HasUnknownAttribute(IMethodSymbol actionSymbol, WellKnownTypes wellKnownTypes)
+        {
+            foreach (var attribute in actionSymbol.GetAttributes())
+            {
+                if (attribute.AttributeClass is null)
+                {
+                    return true;
+                }
+
+                if (!wellKnownTypes.IsType(attribute.AttributeClass, KnownMethodAttributeTypes))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool HasMatchingHttpMethods(ImmutableArray<string> httpMethods1, ImmutableArray<string> httpMethods2)
+        {
+            if (httpMethods1.IsEmpty || httpMethods2.IsEmpty)
+            {
+                return true;
+            }
+
+            foreach (var item1 in httpMethods1)
+            {
+                foreach (var item2 in httpMethods2)
+                {
+                    if (item2 == item1)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = 0;
+            foreach (var method in HttpMethods)
+            {
+                hashCode ^= StringComparer.OrdinalIgnoreCase.GetHashCode(method);
+            }
+            return hashCode ^ AmbiguousRoutePatternComparer.Instance.GetHashCode(RoutePattern);
+        }
+    }
+}

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/MvcAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/MvcAnalyzer.cs
@@ -38,8 +38,8 @@ public partial class MvcAnalyzer : DiagnosticAnalyzer
 
             context.RegisterSymbolAction(context =>
             {
-                if (context.Symbol is INamedTypeSymbol namedTypeSymbol &&
-                    MvcDetector.IsController(namedTypeSymbol, wellKnownTypes))
+                var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
+                if (MvcDetector.IsController(namedTypeSymbol, wellKnownTypes))
                 {
                     // Pool and reuse lists for each block.
                     if (!concurrentQueue.TryDequeue(out var actionRoutes))
@@ -79,7 +79,7 @@ public partial class MvcAnalyzer : DiagnosticAnalyzer
                         continue;
                     }
 
-                    var httpMethodsBuilder = ImmutableArray.CreateBuilder<string>();
+                    var httpMethods = ImmutableArray.Empty<string>();
 
                     switch (match.Value)
                     {
@@ -87,30 +87,30 @@ public partial class MvcAnalyzer : DiagnosticAnalyzer
                             // No HTTP method.
                             break;
                         case WellKnownType.Microsoft_AspNetCore_Mvc_HttpDeleteAttribute:
-                            httpMethodsBuilder.Add("DELETE");
+                            httpMethods = ImmutableArray.Create("DELETE");
                             break;
                         case WellKnownType.Microsoft_AspNetCore_Mvc_HttpGetAttribute:
-                            httpMethodsBuilder.Add("GET");
+                            httpMethods = ImmutableArray.Create("GET");
                             break;
                         case WellKnownType.Microsoft_AspNetCore_Mvc_HttpHeadAttribute:
-                            httpMethodsBuilder.Add("HEAD");
+                            httpMethods = ImmutableArray.Create("HEAD");
                             break;
                         case WellKnownType.Microsoft_AspNetCore_Mvc_HttpOptionsAttribute:
-                            httpMethodsBuilder.Add("OPTIONS");
+                            httpMethods = ImmutableArray.Create("OPTIONS");
                             break;
                         case WellKnownType.Microsoft_AspNetCore_Mvc_HttpPatchAttribute:
-                            httpMethodsBuilder.Add("PATCH");
+                            httpMethods = ImmutableArray.Create("PATCH");
                             break;
                         case WellKnownType.Microsoft_AspNetCore_Mvc_HttpPostAttribute:
-                            httpMethodsBuilder.Add("POST");
+                            httpMethods = ImmutableArray.Create("POST");
                             break;
                         case WellKnownType.Microsoft_AspNetCore_Mvc_HttpPutAttribute:
-                            httpMethodsBuilder.Add("PUT");
+                            httpMethods = ImmutableArray.Create("PUT");
                             break;
                         default:
                             throw new InvalidOperationException("Unexpected well known type:" + match);
                     }
-                    actionRoutes.Add(new ActionRoute(methodSymbol, routeUsage, httpMethodsBuilder.ToImmutable()));
+                    actionRoutes.Add(new ActionRoute(methodSymbol, routeUsage, httpMethods));
                 }
             }
         }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/MvcAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/MvcAnalyzer.cs
@@ -77,40 +77,35 @@ public partial class MvcAnalyzer : DiagnosticAnalyzer
                         continue;
                     }
 
-                    var httpMethods = ImmutableArray<string>.Empty;
-
-                    switch (match.Value)
-                    {
-                        case WellKnownType.Microsoft_AspNetCore_Mvc_RouteAttribute:
-                            // No HTTP method.
-                            break;
-                        case WellKnownType.Microsoft_AspNetCore_Mvc_HttpDeleteAttribute:
-                            httpMethods = ImmutableArray.Create("DELETE");
-                            break;
-                        case WellKnownType.Microsoft_AspNetCore_Mvc_HttpGetAttribute:
-                            httpMethods = ImmutableArray.Create("GET");
-                            break;
-                        case WellKnownType.Microsoft_AspNetCore_Mvc_HttpHeadAttribute:
-                            httpMethods = ImmutableArray.Create("HEAD");
-                            break;
-                        case WellKnownType.Microsoft_AspNetCore_Mvc_HttpOptionsAttribute:
-                            httpMethods = ImmutableArray.Create("OPTIONS");
-                            break;
-                        case WellKnownType.Microsoft_AspNetCore_Mvc_HttpPatchAttribute:
-                            httpMethods = ImmutableArray.Create("PATCH");
-                            break;
-                        case WellKnownType.Microsoft_AspNetCore_Mvc_HttpPostAttribute:
-                            httpMethods = ImmutableArray.Create("POST");
-                            break;
-                        case WellKnownType.Microsoft_AspNetCore_Mvc_HttpPutAttribute:
-                            httpMethods = ImmutableArray.Create("PUT");
-                            break;
-                        default:
-                            throw new InvalidOperationException("Unexpected well known type:" + match);
-                    }
-                    actionRoutes.Add(new ActionRoute(methodSymbol, routeUsage, httpMethods));
+                    actionRoutes.Add(new ActionRoute(methodSymbol, routeUsage, GetHttpMethods(match.Value)));
                 }
             }
+        }
+    }
+
+    private static ImmutableArray<string> GetHttpMethods(WellKnownType match)
+    {
+        switch (match)
+        {
+            case WellKnownType.Microsoft_AspNetCore_Mvc_RouteAttribute:
+                // No HTTP method.
+                return ImmutableArray<string>.Empty;
+            case WellKnownType.Microsoft_AspNetCore_Mvc_HttpDeleteAttribute:
+                return ImmutableArray.Create("DELETE");
+            case WellKnownType.Microsoft_AspNetCore_Mvc_HttpGetAttribute:
+                return ImmutableArray.Create("GET");
+            case WellKnownType.Microsoft_AspNetCore_Mvc_HttpHeadAttribute:
+                return ImmutableArray.Create("HEAD");
+            case WellKnownType.Microsoft_AspNetCore_Mvc_HttpOptionsAttribute:
+                return ImmutableArray.Create("OPTIONS");
+            case WellKnownType.Microsoft_AspNetCore_Mvc_HttpPatchAttribute:
+                return ImmutableArray.Create("PATCH");
+            case WellKnownType.Microsoft_AspNetCore_Mvc_HttpPostAttribute:
+                return ImmutableArray.Create("POST");
+            case WellKnownType.Microsoft_AspNetCore_Mvc_HttpPutAttribute:
+                return ImmutableArray.Create("PUT");
+            default:
+                throw new InvalidOperationException("Unexpected well known type:" + match);
         }
     }
 

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/MvcAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/MvcAnalyzer.cs
@@ -1,0 +1,152 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
+using Microsoft.AspNetCore.App.Analyzers.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.AspNetCore.Analyzers.Mvc;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public partial class MvcAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
+        DiagnosticDescriptors.AmbiguousActionRoute
+    );
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            var compilation = context.Compilation;
+            var wellKnownTypes = WellKnownTypes.GetOrCreate(compilation);
+            var routeUsageCache = RouteUsageCache.GetOrCreate(compilation);
+
+            // We want ConcurrentHashSet here in case RegisterOperationAction runs in parallel.
+            // Since ConcurrentHashSet doesn't exist, use ConcurrentDictionary and ignore the value.
+            var concurrentQueue = new ConcurrentQueue<List<ActionRoute>>();
+
+            context.RegisterSymbolAction(context =>
+            {
+                if (context.Symbol is INamedTypeSymbol namedTypeSymbol &&
+                    MvcDetector.IsController(namedTypeSymbol, wellKnownTypes))
+                {
+                    // Pool and reuse lists for each block.
+                    if (!concurrentQueue.TryDequeue(out var actionRoutes))
+                    {
+                        actionRoutes = new List<ActionRoute>();
+                    }
+
+                    PopulateActionRoutes(context, wellKnownTypes, routeUsageCache, namedTypeSymbol, actionRoutes);
+
+                    DetectAmbiguousActionRoutes(context, wellKnownTypes, actionRoutes);
+
+                    // Return to the pool.
+                    actionRoutes.Clear();
+                    concurrentQueue.Enqueue(actionRoutes);
+                }
+            }, SymbolKind.NamedType);
+        });
+    }
+
+    private static void PopulateActionRoutes(SymbolAnalysisContext context, WellKnownTypes wellKnownTypes, RouteUsageCache routeUsageCache, INamedTypeSymbol namedTypeSymbol, List<ActionRoute> actionRoutes)
+    {
+        foreach (var member in namedTypeSymbol.GetMembers())
+        {
+            if (member is IMethodSymbol methodSymbol &&
+                MvcDetector.IsAction(methodSymbol, wellKnownTypes))
+            {
+                foreach (var attribute in methodSymbol.GetAttributes())
+                {
+                    if (attribute.AttributeClass is null || !wellKnownTypes.IsType(attribute.AttributeClass, RouteAttributeTypes, out var match))
+                    {
+                        continue;
+                    }
+
+                    var routeUsage = GetRouteUsageModel(attribute, routeUsageCache, context.CancellationToken);
+                    if (routeUsage is null)
+                    {
+                        continue;
+                    }
+
+                    var httpMethodsBuilder = ImmutableArray.CreateBuilder<string>();
+
+                    switch (match.Value)
+                    {
+                        case WellKnownType.Microsoft_AspNetCore_Mvc_RouteAttribute:
+                            // No HTTP method.
+                            break;
+                        case WellKnownType.Microsoft_AspNetCore_Mvc_HttpDeleteAttribute:
+                            httpMethodsBuilder.Add("DELETE");
+                            break;
+                        case WellKnownType.Microsoft_AspNetCore_Mvc_HttpGetAttribute:
+                            httpMethodsBuilder.Add("GET");
+                            break;
+                        case WellKnownType.Microsoft_AspNetCore_Mvc_HttpHeadAttribute:
+                            httpMethodsBuilder.Add("HEAD");
+                            break;
+                        case WellKnownType.Microsoft_AspNetCore_Mvc_HttpOptionsAttribute:
+                            httpMethodsBuilder.Add("OPTIONS");
+                            break;
+                        case WellKnownType.Microsoft_AspNetCore_Mvc_HttpPatchAttribute:
+                            httpMethodsBuilder.Add("PATCH");
+                            break;
+                        case WellKnownType.Microsoft_AspNetCore_Mvc_HttpPostAttribute:
+                            httpMethodsBuilder.Add("POST");
+                            break;
+                        case WellKnownType.Microsoft_AspNetCore_Mvc_HttpPutAttribute:
+                            httpMethodsBuilder.Add("PUT");
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected well known type:" + match);
+                    }
+                    actionRoutes.Add(new ActionRoute(methodSymbol, routeUsage, httpMethodsBuilder.ToImmutable()));
+                }
+            }
+        }
+    }
+
+    private static readonly WellKnownType[] RouteAttributeTypes = new[]
+    {
+        WellKnownType.Microsoft_AspNetCore_Mvc_RouteAttribute,
+        WellKnownType.Microsoft_AspNetCore_Mvc_HttpDeleteAttribute,
+        WellKnownType.Microsoft_AspNetCore_Mvc_HttpGetAttribute,
+        WellKnownType.Microsoft_AspNetCore_Mvc_HttpHeadAttribute,
+        WellKnownType.Microsoft_AspNetCore_Mvc_HttpOptionsAttribute,
+        WellKnownType.Microsoft_AspNetCore_Mvc_HttpPatchAttribute,
+        WellKnownType.Microsoft_AspNetCore_Mvc_HttpPostAttribute,
+        WellKnownType.Microsoft_AspNetCore_Mvc_HttpPutAttribute
+    };
+
+    private static RouteUsageModel? GetRouteUsageModel(AttributeData attribute, RouteUsageCache routeUsageCache, CancellationToken cancellationToken)
+    {
+        if (attribute.ConstructorArguments.IsEmpty || attribute.ApplicationSyntaxReference is null)
+        {
+            return null;
+        }
+
+        if (attribute.ApplicationSyntaxReference.GetSyntax(cancellationToken) is AttributeSyntax attributeSyntax &&
+            attributeSyntax.ArgumentList is { } argumentList)
+        {
+            var attributeArgument = argumentList.Arguments[0];
+            if (attributeArgument.Expression is LiteralExpressionSyntax literalExpression)
+            {
+                return routeUsageCache.Get(literalExpression.Token, cancellationToken);
+            }
+        }
+
+        return null;
+    }
+
+    private record struct ActionRoute(IMethodSymbol ActionSymbol, RouteUsageModel RouteUsageModel, ImmutableArray<string> HttpMethods);
+}

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/MvcAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/MvcAnalyzer.cs
@@ -85,28 +85,18 @@ public partial class MvcAnalyzer : DiagnosticAnalyzer
 
     private static ImmutableArray<string> GetHttpMethods(WellKnownType match)
     {
-        switch (match)
+        return match switch
         {
-            case WellKnownType.Microsoft_AspNetCore_Mvc_RouteAttribute:
-                // No HTTP method.
-                return ImmutableArray<string>.Empty;
-            case WellKnownType.Microsoft_AspNetCore_Mvc_HttpDeleteAttribute:
-                return ImmutableArray.Create("DELETE");
-            case WellKnownType.Microsoft_AspNetCore_Mvc_HttpGetAttribute:
-                return ImmutableArray.Create("GET");
-            case WellKnownType.Microsoft_AspNetCore_Mvc_HttpHeadAttribute:
-                return ImmutableArray.Create("HEAD");
-            case WellKnownType.Microsoft_AspNetCore_Mvc_HttpOptionsAttribute:
-                return ImmutableArray.Create("OPTIONS");
-            case WellKnownType.Microsoft_AspNetCore_Mvc_HttpPatchAttribute:
-                return ImmutableArray.Create("PATCH");
-            case WellKnownType.Microsoft_AspNetCore_Mvc_HttpPostAttribute:
-                return ImmutableArray.Create("POST");
-            case WellKnownType.Microsoft_AspNetCore_Mvc_HttpPutAttribute:
-                return ImmutableArray.Create("PUT");
-            default:
-                throw new InvalidOperationException("Unexpected well known type:" + match);
-        }
+            WellKnownType.Microsoft_AspNetCore_Mvc_RouteAttribute => ImmutableArray<string>.Empty,// No HTTP method.
+            WellKnownType.Microsoft_AspNetCore_Mvc_HttpDeleteAttribute => ImmutableArray.Create("DELETE"),
+            WellKnownType.Microsoft_AspNetCore_Mvc_HttpGetAttribute => ImmutableArray.Create("GET"),
+            WellKnownType.Microsoft_AspNetCore_Mvc_HttpHeadAttribute => ImmutableArray.Create("HEAD"),
+            WellKnownType.Microsoft_AspNetCore_Mvc_HttpOptionsAttribute => ImmutableArray.Create("OPTIONS"),
+            WellKnownType.Microsoft_AspNetCore_Mvc_HttpPatchAttribute => ImmutableArray.Create("PATCH"),
+            WellKnownType.Microsoft_AspNetCore_Mvc_HttpPostAttribute => ImmutableArray.Create("POST"),
+            WellKnownType.Microsoft_AspNetCore_Mvc_HttpPutAttribute => ImmutableArray.Create("PUT"),
+            _ => throw new InvalidOperationException("Unexpected well known type:" + match),
+        };
     }
 
     private static readonly WellKnownType[] RouteAttributeTypes = new[]

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/MvcAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Mvc/MvcAnalyzer.cs
@@ -32,8 +32,6 @@ public partial class MvcAnalyzer : DiagnosticAnalyzer
             var wellKnownTypes = WellKnownTypes.GetOrCreate(compilation);
             var routeUsageCache = RouteUsageCache.GetOrCreate(compilation);
 
-            // We want ConcurrentHashSet here in case RegisterOperationAction runs in parallel.
-            // Since ConcurrentHashSet doesn't exist, use ConcurrentDictionary and ignore the value.
             var concurrentQueue = new ConcurrentQueue<List<ActionRoute>>();
 
             context.RegisterSymbolAction(context =>
@@ -79,7 +77,7 @@ public partial class MvcAnalyzer : DiagnosticAnalyzer
                         continue;
                     }
 
-                    var httpMethods = ImmutableArray.Empty<string>();
+                    var httpMethods = ImmutableArray<string>.Empty;
 
                     switch (match.Value)
                     {

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/MvcDetector.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/Infrastructure/MvcDetector.cs
@@ -3,16 +3,13 @@
 
 using System;
 using Microsoft.AspNetCore.App.Analyzers.Infrastructure;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
 
 internal static class MvcDetector
 {
-    private const string ControllerTypeNameSuffix = "Controller";
-
-    // Replicates logic from ControllerFeatureProvider.IsController.
-    // https://github.com/dotnet/aspnetcore/blob/785cf9bd845a8d28dce3a079c4fedf4a4c2afe57/src/Mvc/Mvc.Core/src/Controllers/ControllerFeatureProvider.cs#L39
     public static bool IsController(INamedTypeSymbol? typeSymbol, WellKnownTypes wellKnownTypes)
     {
         if (typeSymbol is null)
@@ -20,94 +17,21 @@ internal static class MvcDetector
             return false;
         }
 
-        if (!typeSymbol.IsReferenceType)
-        {
-            return false;
-        }
-
-        if (typeSymbol.IsAbstract)
-        {
-            return false;
-        }
-
-        // We only consider public top-level classes as controllers.
-        if (typeSymbol.DeclaredAccessibility != Accessibility.Public)
-        {
-            return false;
-        }
-        if (typeSymbol.ContainingType != null)
-        {
-            return false;
-        }
-
-        // Has generic arguments
-        if (typeSymbol.IsGenericType)
-        {
-            return false;
-        }
-
-        // Check name before attribute's for performance.
-        if (!typeSymbol.Name.EndsWith(ControllerTypeNameSuffix, StringComparison.OrdinalIgnoreCase) &&
-            !typeSymbol.HasAttribute(wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Mvc_ControllerAttribute)))
-        {
-            return false;
-        }
-
-        if (typeSymbol.HasAttribute(wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Mvc_NonControllerAttribute)))
-        {
-            return false;
-        }
-
-        return true;
+        return MvcFacts.IsController(
+            typeSymbol,
+            wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Mvc_ControllerAttribute),
+            wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Mvc_NonControllerAttribute));
     }
 
-    // Replicates logic from DefaultApplicationModelProvider.IsAction.
-    // https://github.com/dotnet/aspnetcore/blob/785cf9bd845a8d28dce3a079c4fedf4a4c2afe57/src/Mvc/Mvc.Core/src/ApplicationModels/DefaultApplicationModelProvider.cs#L393
     public static bool IsAction(IMethodSymbol methodSymbol, WellKnownTypes wellKnownTypes)
     {
-        if (methodSymbol == null)
-        {
-            throw new ArgumentNullException(nameof(methodSymbol));
-        }
+        var disposable = wellKnownTypes.Get(SpecialType.System_IDisposable);
+        var members = disposable.GetMembers(nameof(IDisposable.Dispose));
+        var idisposableDispose = (IMethodSymbol)members[0];
 
-        // The SpecialName bit is set to flag members that are treated in a special way by some compilers
-        // (such as property accessors and operator overloading methods).
-        if (methodSymbol.MethodKind is not (MethodKind.Ordinary or MethodKind.DeclareMethod))
-        {
-            return false;
-        }
-
-        // Overridden methods from Object class, e.g. Equals(Object), GetHashCode(), etc., are not valid.
-        if (methodSymbol.ContainingType.SpecialType is SpecialType.System_Object)
-        {
-            return false;
-        }
-
-        if (methodSymbol.IsStatic)
-        {
-            return false;
-        }
-
-        if (methodSymbol.IsAbstract)
-        {
-            return false;
-        }
-
-        if (methodSymbol.IsGenericMethod)
-        {
-            return false;
-        }
-
-        if (methodSymbol.DeclaredAccessibility != Accessibility.Public)
-        {
-            return false;
-        }
-
-        if (methodSymbol.HasAttribute(wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Mvc_NonControllerAttribute)))
-        {
-            return false;
-        }
-
-        return true;
+        return MvcFacts.IsControllerAction(
+            methodSymbol,
+            wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Mvc_NonActionAttribute),
+            idisposableDispose);
     }
 }

--- a/src/Framework/AspNetCoreAnalyzers/test/Mvc/DetectAmbiguousActionRoutesTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/Mvc/DetectAmbiguousActionRoutesTest.cs
@@ -1,0 +1,325 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis.Testing;
+using VerifyCS = Microsoft.AspNetCore.Analyzers.Verifiers.CSharpAnalyzerVerifier<Microsoft.AspNetCore.Analyzers.Mvc.MvcAnalyzer>;
+
+namespace Microsoft.AspNetCore.Analyzers.Mvc;
+
+public partial class DetectAmbiguousActionRoutesTest
+{
+    [Fact]
+    public async Task SameRoutes_DifferentAction_HasDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+public class WeatherForecastController : ControllerBase
+{
+    [Route({|#0:""/a""|})]
+    public object Get() => new object();
+
+    [Route({|#1:""/a""|})]
+    public object Get1() => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        var expectedDiagnostics = new[] {
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("/a").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("/a").WithLocation(1)
+        };
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source, expectedDiagnostics);
+    }
+
+    [Fact]
+    public async Task MixedRoutes_DifferentAction_HasDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+public class WeatherForecastController : ControllerBase
+{
+    [Route({|#0:""/a""|})]
+    public object Get() => new object();
+
+    [Route({|#1:""/a""|})]
+    public object Get1() => new object();
+
+    [Route({|#2:""/a""|})]
+    public object Get2() => new object();
+
+    [HttpGet({|#3:""/b""|})]
+    public object Get3() => new object();
+
+    [HttpGet({|#4:""/b""|})]
+    public object Get4() => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        var expectedDiagnostics = new[] {
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("/a").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("/a").WithLocation(1),
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("/a").WithLocation(2),
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("/b").WithLocation(3),
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("/b").WithLocation(4)
+        };
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source, expectedDiagnostics);
+    }
+
+    [Fact]
+    public async Task SameRoutes_DifferentAction_HostAttribute_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+public class WeatherForecastController : ControllerBase
+{
+    [Route(""/a"")]
+    public object Get() => new object();
+
+    [Route(""/a"")]
+    [Host(""consoto.com"")]
+    public object Get1() => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task SameRoutes_SameAction_HostAttribute_HasDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+public class WeatherForecastController : ControllerBase
+{
+    [Route({|#0:""/a""|})]
+    [Route({|#1:""/a""|})]
+    [Host(""consoto.com"")]
+    public object Get1() => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        var expectedDiagnostics = new[] {
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("/a").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("/a").WithLocation(1)
+        };
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source, expectedDiagnostics);
+    }
+
+    [Fact]
+    public async Task SameRoutes_DifferentAction_AuthorizeAttribute_HasDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+public class WeatherForecastController : ControllerBase
+{
+    [Route({|#0:""/a""|})]
+    public object Get() => new object();
+
+    [Route({|#1:""/a""|})]
+    [Authorize]
+    public object Get1() => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        var expectedDiagnostics = new[] {
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("/a").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("/a").WithLocation(1)
+        };
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source, expectedDiagnostics);
+    }
+
+    [Fact]
+    public async Task SameRoutes_SameAction_AuthorizeAttribute_HasDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+public class WeatherForecastController : ControllerBase
+{
+    [Route({|#0:""/a""|})]
+    [Route({|#1:""/a""|})]
+    [Authorize]
+    public object Get1() => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        var expectedDiagnostics = new[] {
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("/a").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("/a").WithLocation(1)
+        };
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source, expectedDiagnostics);
+    }
+
+    [Fact]
+    public async Task DifferentRoutes_DifferentAction_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+public class WeatherForecastController : ControllerBase
+{
+    [Route(""/a"")]
+    public object Get() => new object();
+
+    [Route(""/b"")]
+    public object Get1() => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task SameRoute_DifferentMethods_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+public class WeatherForecastController : ControllerBase
+{
+    [HttpGet(""/"")]
+    public object Get() => new object();
+
+    [HttpPost(""/"")]
+    public object Get1() => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task SameRoute_DifferentMethods_Route_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+public class WeatherForecastController : ControllerBase
+{
+    [HttpGet(""/"")]
+    public object Get() => new object();
+
+    [Route(""/"")]
+    public object Get1() => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task DuplicateRoutes_SameAction_HasDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+public class WeatherForecastController : ControllerBase
+{
+    [Route({|#0:""/""|})]
+    [Route({|#1:""/""|})]
+    public object Get() => new object();
+}
+internal class Program
+{
+    static void Main(string[] args)
+    {
+    }
+}
+";
+
+        var expectedDiagnostics = new[] {
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("/").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousActionRoute).WithArguments("/").WithLocation(1)
+        };
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source, expectedDiagnostics);
+    }
+}
+

--- a/src/Framework/AspNetCoreAnalyzers/test/Verifiers/CSharpAnalyzerVerifier.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/Verifiers/CSharpAnalyzerVerifier.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Testing;
@@ -76,6 +77,8 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
             TrimAssemblyExtension(typeof(Microsoft.Extensions.DependencyInjection.OutputCacheConventionBuilderExtensions).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Builder.AuthorizationEndpointConventionBuilderExtensions).Assembly.Location),
+            TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Mvc.AutoValidateAntiforgeryTokenAttribute).Assembly.Location),
+            TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Routing.RouteData).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Components.ComponentBase).Assembly.Location),
             TrimAssemblyExtension(typeof(Microsoft.AspNetCore.Components.ParameterAttribute).Assembly.Location),

--- a/src/Mvc/Mvc.Analyzers/src/Microsoft.AspNetCore.Mvc.Analyzers.csproj
+++ b/src/Mvc/Mvc.Analyzers/src/Microsoft.AspNetCore.Mvc.Analyzers.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)Roslyn\CodeAnalysisExtensions.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Roslyn\MvcFacts.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mvc/Mvc.Analyzers/src/TopLevelParameterNameAnalyzer.cs
+++ b/src/Mvc/Mvc.Analyzers/src/TopLevelParameterNameAnalyzer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 

--- a/src/Mvc/Mvc.Api.Analyzers/src/ApiControllerFacts.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/src/ApiControllerFacts.cs
@@ -1,7 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AspNetCore.Mvc.Analyzers;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers;

--- a/src/Mvc/Mvc.Api.Analyzers/src/Microsoft.AspNetCore.Mvc.Api.Analyzers.csproj
+++ b/src/Mvc/Mvc.Api.Analyzers/src/Microsoft.AspNetCore.Mvc.Api.Analyzers.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)Roslyn\CodeAnalysisExtensions.cs" LinkBase="Shared" />
-    <Compile Include="..\..\Mvc.Analyzers\src\MvcFacts.cs" />
+    <Compile Include="$(SharedSourceRoot)Roslyn\MvcFacts.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mvc/Mvc.Api.Analyzers/test/MvcFactsTest.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/MvcFactsTest.cs
@@ -1,7 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AspNetCore.Mvc.Analyzers;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Mvc.Api.Analyzers;

--- a/src/Shared/Roslyn/MvcFacts.cs
+++ b/src/Shared/Roslyn/MvcFacts.cs
@@ -1,10 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using Microsoft.CodeAnalysis;
 
-namespace Microsoft.AspNetCore.Mvc.Analyzers;
+namespace Microsoft.AspNetCore.Shared;
 
 internal static class MvcFacts
 {


### PR DESCRIPTION
Builds on https://github.com/dotnet/aspnetcore/pull/45582

Same idea, but for MVC.

This detection is conservative. Successfully matched action routes must:
1. Be in the same controller.
2. Have an equivalent route.
3. Have a matching HTTP method.
4. Route either be the on the same action or the actions only have known safe attributes that don't impact matching.
