### PR TITLE
Improve Win bundle installers' UI

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -39,10 +39,19 @@
   <!-- Properties which should be set after the project has been evaluated -->
 
   <PropertyGroup Label="Versioning settings">
-    <!-- The 'human friendly' version to display in installers. In pre-release builds, this might be "2.0.7 Preview 2 Build 12356". In final builds, it should be "2.0.7" -->
-    <BrandingVersionSuffix>$(PreReleaseBrandingLabel) Build $(VersionSuffix)</BrandingVersionSuffix>
-    <PackageBrandingVersion>$(VersionPrefix)</PackageBrandingVersion>
-    <PackageBrandingVersion Condition=" '$(VersionSuffix)' != '' ">$(PackageBrandingVersion) $(BrandingVersionSuffix.Trim())</PackageBrandingVersion>
+    <!--
+      The 'human friendly' versions to display in installers. In pre-release builds, these might be
+      "8.0.0 Alpha 1" and "8.0.0 Alpha 1 Build alpha.1.22616.7". In final builds, both should be "8.0.0".
+      ??? Thoughts on instead using $(VersionSuffixDateStamp).$(VersionSuffixBuildOfTheDay) when $(VersionSuffix) is
+      ??? non-empty? That would avoid repeating "Alpha 1" / "alpha.1" in $(PackageBrandingVersion). Seems this
+      ??? property is used only for display names, even in the registry (with the exception of e.g.
+      ??? "HKLM\SOFTWARE\WOW6432Node\Microsoft\Updates\.NET\Microsoft ASP.NET Core 8.0.0 Alpha 1 Build alpha.1.22616.7 - Shared Framework (x86)").
+    -->
+    <PackageBrandingVersionNoBuild>$(VersionPrefix)</PackageBrandingVersionNoBuild>
+    <PackageBrandingVersionNoBuild
+        Condition=" '$(PreReleaseBrandingLabel)' != '' ">$(PackageBrandingVersionNoBuild) $(PreReleaseBrandingLabel.Trim())</PackageBrandingVersionNoBuild>
+    <PackageBrandingVersion>$(PackageBrandingVersionNoBuild)</PackageBrandingVersion>
+    <PackageBrandingVersion Condition=" '$(VersionSuffix)' != '' ">$(PackageBrandingVersion) Build $(VersionSuffix.Trim())</PackageBrandingVersion>
 
     <SiteExtensionVersion>$(VersionPrefix)</SiteExtensionVersion>
     <SiteExtensionVersion Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix.Replace('.','-'))</SiteExtensionVersion>

--- a/src/Installers/Windows/SharedFrameworkBundle/1033/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/1033/thm.wxl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption"><!--_locComment_text="{Locked='[BundleNameFull]'}"-->[BundleNameFull] Setup</String>
-  <String Id="Title"><!--_locComment_text="{Locked}"-->[BundleNameShort]</String>
+  <String Id="Title"><!--_locComment_text="{Locked}"-->[BundleNameShortNoBuild]</String>
   <String Id="SubTitle"><!--_locComment_text="{Locked}"-->[BundleNameSub]</String>
   <String Id="InstallVersion"><!--_locComment_text="{Locked='[WixBundleVersion]'}"-->Version [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
@@ -50,6 +50,7 @@
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
 
+  <!-- Custom UI strings -->
   <String Id="Welcome"><!--_locComment_text="{Locked='[WixBundleName]'}"-->Welcome to the [WixBundleName] Setup.</String>
-  <String Id="EulaPrivacy"><!--_locComment_text="{Locked='[WixBundleName]'}"-->[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
+  <String Id="EulaPrivacy"><!--_locComment_text="{Locked='[BundleNameNoBuild]'}"-->[BundleNameNoBuild] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
+++ b/src/Installers/Windows/SharedFrameworkBundle/Bundle.wxs
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
-    <Bundle Name="$(var.BundleName)" Version="$(var.BundleVersion)" Manufacturer="Microsoft Corporation" UpgradeCode="$(var.BundleUpgradeCode)">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension"
+     xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
+    <Bundle Name="$(var.BundleName)" Version="$(var.BundleVersion)" Manufacturer="Microsoft Corporation"
+            UpgradeCode="$(var.BundleUpgradeCode)">
         <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense">
             <bal:WixStandardBootstrapperApplication LicenseUrl="https://go.microsoft.com/fwlink/?LinkId=329770"
                                                     LogoFile="DotNetLogo.bmp"
@@ -84,7 +87,10 @@
         <Log Prefix="dd_$(var.BundleLogPrefix)_" Extension=".log" />
         <OptionalUpdateRegistration Manufacturer="$(var.BundleRegManufacturer)" ProductFamily="$(var.BundleRegFamily)" Name="$(var.BundleRegName)" />
 
+        <!-- Bundle variables -->
+        <Variable Name="BundleNameNoBuild" Value="$(var.BundleNameNoBuild)"/>
         <Variable Name="BundleNameShort" Value="$(var.BundleNameShort)"/>
+        <Variable Name="BundleNameShortNoBuild" Value="$(var.BundleNameShortNoBuild)" />
         <Variable Name="BundleNameSub" Value="$(var.BundleNameSub)"/>
         <Variable Name="BundleNameFull" Value="$(var.BundleNameFull)"/>
 

--- a/src/Installers/Windows/SharedFrameworkBundle/SharedFrameworkBundle.wixproj
+++ b/src/Installers/Windows/SharedFrameworkBundle/SharedFrameworkBundle.wixproj
@@ -6,10 +6,12 @@
     <Name>AspNetCoreSharedFrameworkBundle</Name>
     <OutputName>$(Name)-$(Platform)</OutputName>
     <IsShipping>true</IsShipping>
-    <OutputType>Bundle</OutputType>
-    <NamespaceGuid>$(SharedFrameworkNamespaceGuid)</NamespaceGuid>
     <ProjectGuid>{D6C54D8B-043F-4877-B751-60E7390F9EC6}</ProjectGuid>
+    <OutputType>Bundle</OutputType>
     <SchemaVersion>2.0</SchemaVersion>
+
+    <!-- Namespace used to generate stable UUID3 GUIDs for MSI ProductCode, etc. DO NOT CHANGE THIS. -->
+    <NamespaceGuid>$(SharedFrameworkNamespaceGuid)</NamespaceGuid>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="thm.xml" />
     <Compile Include="Bundle.wxs" />
     <EmbeddedResource Include="thm.wxl" />
-    <Content Include="thm.xml" />
   </ItemGroup>
 
   <Choose>
@@ -65,8 +67,15 @@
     <PackageFileName>$(RuntimeInstallerBaseName)-$(PackageVersion)-win-$(Platform)$(TargetExt)</PackageFileName>
 
     <BundleNameShort>Microsoft ASP.NET Core $(PackageBrandingVersion)</BundleNameShort>
+    <!--
+      Title still truncated to e.g. "Microsoft ASP.NET Core 8.0.0 Release".
+      ??? Thoughts on sharing branding w/ the hosting bundle e.g. "Microsoft .NET 8.0.0 Release Candidate 1"?
+      ??? If we go that route, could make the subtitle "ASP.NET Shared Framework" or "ASP.NET Core...".
+    -->
+    <BundleNameShortNoBuild>Microsoft ASP.NET Core $(PackageBrandingVersionNoBuild)</BundleNameShortNoBuild>
     <BundleNameSub>Shared Framework</BundleNameSub>
     <BundleName>$(BundleNameShort) - $(BundleNameSub) ($(Platform))</BundleName>
+    <BundleNameNoBuild>$(BundleNameShortNoBuild) - $(BundleNameSub) ($(Platform))</BundleNameNoBuild>
     <BundleNameFull>$(BundleName)</BundleNameFull>
     <BundleRegName>$(BundleNameFull)</BundleRegName>
 
@@ -77,9 +86,11 @@
     <BundleRegManufacturer>Microsoft</BundleRegManufacturer>
     <BundleRegFamily>.NET</BundleRegFamily>
 
-    <DefineConstants>$(DefineConstants);BundleNameShort=$(BundleNameShort)</DefineConstants>
     <DefineConstants>$(DefineConstants);BundleName=$(BundleName)</DefineConstants>
+    <DefineConstants>$(DefineConstants);BundleNameNoBuild=$(BundleNameNoBuild)</DefineConstants>
     <DefineConstants>$(DefineConstants);BundleNameFull=$(BundleNameFull)</DefineConstants>
+    <DefineConstants>$(DefineConstants);BundleNameShort=$(BundleNameShort)</DefineConstants>
+    <DefineConstants>$(DefineConstants);BundleNameShortNoBuild=$(BundleNameShortNoBuild)</DefineConstants>
     <DefineConstants>$(DefineConstants);BundleNameSub=$(BundleNameSub)</DefineConstants>
     <DefineConstants>$(DefineConstants);BundleManufacturer=$(BundleManufacturer)</DefineConstants>
     <DefineConstants>$(DefineConstants);BundleLogPrefix=$(BundleLogPrefix)</DefineConstants>

--- a/src/Installers/Windows/SharedFrameworkBundle/thm.wxl
+++ b/src/Installers/Windows/SharedFrameworkBundle/thm.wxl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption"><!--_locComment_text="{Locked='[BundleNameFull]'}"-->[BundleNameFull] Setup</String>
-  <String Id="Title"><!--_locComment_text="{Locked}"-->[BundleNameShort]</String>
+  <String Id="Title"><!--_locComment_text="{Locked}"-->[BundleNameShortNoBuild]</String>
   <String Id="SubTitle"><!--_locComment_text="{Locked}"-->[BundleNameSub]</String>
   <String Id="InstallVersion"><!--_locComment_text="{Locked='[WixBundleVersion]'}"-->Version [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
@@ -50,6 +50,7 @@
   <String Id="FilesInUseOkButton">&amp;OK</String>
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
 
+  <!-- Custom UI strings -->
   <String Id="Welcome"><!--_locComment_text="{Locked='[WixBundleName]'}"-->Welcome to the [WixBundleName] Setup.</String>
-  <String Id="EulaPrivacy"><!--_locComment_text="{Locked='[WixBundleName]'}"-->[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
+  <String Id="EulaPrivacy"><!--_locComment_text="{Locked='[BundleNameNoBuild]'}"-->[BundleNameNoBuild] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/SharedFrameworkBundle/thm.xml
+++ b/src/Installers/Windows/SharedFrameworkBundle/thm.xml
@@ -18,7 +18,7 @@
     </Page>
     <Page Name="Install">
         <Text X="11" Y="90" Width="-11" Height="30" FontId="3">#(loc.Welcome)</Text>
-        <Hypertext Name="EulaAndPrivacyHyperlink" X="11" Y="131" Width="-11" Height="51" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.EulaPrivacy)</Hypertext>
+        <Hypertext Name="EulaAndPrivacyHyperlink" X="11" Y="131" Width="-11" Height="30" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.EulaPrivacy)</Hypertext>
         <Checkbox Name="EulaAcceptCheckbox" X="-11" Y="-41" Width="260" Height="34" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.InstallAcceptCheckbox)</Checkbox>
         <Button Name="InstallButton" X="-91" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.InstallInstallButton)</Button>
         <Button Name="WelcomeCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.InstallCloseButton)</Button>
@@ -48,10 +48,10 @@
         <Button Name="ModifyCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ModifyCloseButton)</Button>
     </Page>
     <Page Name="Success">
-        <Text Name="SuccessHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessHeader)</Text>
-        <Text Name="SuccessInstallHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessInstallHeader)</Text>
-        <Text Name="SuccessRepairHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRepairHeader)</Text> 	
-        <Text Name="SuccessUninstallHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessUninstallHeader)</Text> 
+        <Text Name="SuccessHeader" X="11" Y="80" Width="-11" Height="60" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessHeader)</Text>
+        <Text Name="SuccessInstallHeader" X="11" Y="80" Width="-11" Height="60" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessInstallHeader)</Text>
+        <Text Name="SuccessRepairHeader" X="11" Y="80" Width="-11" Height="60" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRepairHeader)</Text>
+        <Text Name="SuccessUninstallHeader" X="11" Y="80" Width="-11" Height="60" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessUninstallHeader)</Text>
         <Button Name="LaunchButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessLaunchButton)</Button>
         <Text Name="SuccessRestartText" X="-11" Y="-51" Width="400" Height="34" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRestartText)</Text>
         <Button Name="SuccessRestartButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessRestartButton)</Button>
@@ -61,7 +61,7 @@
         <Text Name="FailureHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureHeader)</Text>
         <Text Name="FailureInstallHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureInstallHeader)</Text>
         <Text Name="FailureUninstallHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureUninstallHeader)</Text>
-        <Text Name="FailureRepairHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureRepairHeader)</Text>	
+        <Text Name="FailureRepairHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureRepairHeader)</Text>
         <Hypertext Name="FailureLogFileLink" X="11" Y="121" Width="-11" Height="42" FontId="3" TabStop="yes" HideWhenDisabled="yes">#(loc.FailureHyperlinkLogText)</Hypertext>
         <Hypertext Name="FailureMessageText" X="22" Y="163" Width="-11" Height="51" FontId="3" TabStop="yes" HideWhenDisabled="yes" />
         <Text Name="FailureRestartText" X="-11" Y="-51" Width="400" Height="34" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureRestartText)</Text>

--- a/src/Installers/Windows/WindowsHostingBundle/1033/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/1033/thm.wxl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption"><!--_locComment_text="{Locked='[WixBundleName]'}"-->[WixBundleName] Setup</String>
-  <String Id="Title"><!--_locComment_text="{Locked}"-->[BundleNameShort]</String>
+  <String Id="Title"><!--_locComment_text="{Locked}"-->[BundleNameShortNoBuild]</String>
   <String Id="SubTitle"><!--_locComment_text="{Locked}"-->[BundleNameSub]</String>
   <String Id="InstallVersion"><!--_locComment_text="{Locked='[WixBundleVersion]'}"-->Version [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
@@ -54,7 +54,7 @@
   <String Id="Welcome"><!--_locComment_text="{Locked='[WixBundleName]'}"-->Welcome to the [WixBundleName] Setup.</String>
   <String Id="InstallResetIIS"><!--_locComment_text="'here' is to be translated"-->Please restart IIS after the installation completes. You can find additional information &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
   <String Id="InstallNoIIS"><!--_locComment_text="'here' is to be translated"-->IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
-  <String Id="EulaPrivacy"><!--_locComment_text="{Locked='[WixBundleName]'}"-->[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
+  <String Id="EulaPrivacy"><!--_locComment_text="{Locked='[BundleNameNoBuild]'}"-->[BundleNameNoBuild] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
   <String Id="ModifyResetIIS"><!--_locComment_text="'here' is to be translated"-->Please restart IIS after the installation completes. You can find additional information &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
   <String Id="ModifyNoIIS"><!--_locComment_text="'here' is to be translated"-->IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension"
-     xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
-    <Bundle Name="$(var.BundleName)" Version="$(var.BundleVersion)" Manufacturer="Microsoft Corporation" UpgradeCode="$(var.BundleUpgradeCode)"
-            dep:ProviderKey="$(var.BundleProviderKey)">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension"
+     xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension"
+     xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
+    <Bundle Name="$(var.BundleName)" Version="$(var.BundleVersion)" Manufacturer="Microsoft Corporation"
+            dep:ProviderKey="$(var.BundleProviderKey)"
+            UpgradeCode="$(var.BundleUpgradeCode)">
         <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense">
             <bal:WixStandardBootstrapperApplication LicenseUrl="https://go.microsoft.com/fwlink/?LinkId=329770"
                                                     LogoFile="DotNetLogo.bmp"
@@ -54,7 +57,9 @@
         <OptionalUpdateRegistration Manufacturer="$(var.BundleRegManufacturer)" ProductFamily="$(var.BundleRegFamily)" Name="$(var.BundleRegName)" />
 
         <!-- Bundle variables -->
-        <Variable Name="BundleNameShort" Value="$(var.BundleNameShort)"/>
+        <Variable Name="BundleNameNoBuild" Value="$(var.BundleNameNoBuild)" />
+        <Variable Name="BundleNameShort" Value="$(var.BundleNameShort)" />
+        <Variable Name="BundleNameShortNoBuild" Value="$(var.BundleNameShortNoBuild)" />
         <Variable Name="BundleNameSub" Value="$(var.BundleNameSub)"/>
         <Variable Name="OPT_NO_ANCM" bal:Overridable="yes"/>
         <Variable Name="OPT_NO_SHAREDFX" bal:Overridable="yes"/>
@@ -68,18 +73,18 @@
         <?define RegistrySeachCondition="NOT (OPT_NO_ANCM OR OPT_NO_ANCM=0 OR OPT_NO_SHAREDFX OR OPT_NO_SHAREDFX=0 OR OPT_NO_RUNTIME OR OPT_NO_RUNTIME=0 OR OPT_NO_X86 OR OPT_NO_X86=0 OR OPT_NO_SHARED_CONFIG_CHECK OR OPT_NO_SHARED_CONFIG_CHECK=0)" ?>
 
         <?foreach Option in $(var.Options) ?>
-            <util:RegistrySearch Id="$(var.Option)_should_be_set" 
+            <util:RegistrySearch Id="$(var.Option)_should_be_set"
                              Condition="$(var.RegistrySeachCondition)"
-                             Root="HKLM" 
-                             Key="Software\Microsoft\dotnet\host\options\$(var.MajorVersion).$(var.MinorVersion)" 
-                             Value="$(var.Option)" 
-                             Result="exists" 
+                             Root="HKLM"
+                             Key="Software\Microsoft\dotnet\host\options\$(var.MajorVersion).$(var.MinorVersion)"
+                             Value="$(var.Option)"
+                             Result="exists"
                              Variable="$(var.Option)_Exists"/>
 
-            <util:RegistrySearch Condition="$(var.Option)_Exists"     
+            <util:RegistrySearch Condition="$(var.Option)_Exists"
                              After="$(var.Option)_should_be_set"
-                             Root="HKLM" Key="Software\Microsoft\dotnet\host\options\$(var.MajorVersion).$(var.MinorVersion)" 
-                             Value="$(var.Option)" 
+                             Root="HKLM" Key="Software\Microsoft\dotnet\host\options\$(var.MajorVersion).$(var.MinorVersion)"
+                             Value="$(var.Option)"
                              Variable="$(var.Option)"
                              Result="value" />
         <?endforeach?>
@@ -98,7 +103,7 @@
                 <MsiProperty Name="OPT_NO_RUNTIME" Value="[OPT_NO_RUNTIME]"/>
                 <MsiProperty Name="OPT_NO_X86" Value="[OPT_NO_X86]"/>
                 <MsiProperty Name="OPT_NO_SHARED_CONFIG_CHECK" Value="[OPT_NO_SHARED_CONFIG_CHECK]"/>
-            </MsiPackage> 
+            </MsiPackage>
             <PackageGroupRef Id="PG_ANCM" />
             <PackageGroupRef Id="PG_DOTNET_REDIST_LTS_BUNDLE" />
             <!--<PackageGroupRef Id="PG_DOTNET_REDIST_FTS_BUNDLE" />-->

--- a/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
+++ b/src/Installers/Windows/WindowsHostingBundle/WindowsHostingBundle.wixproj
@@ -83,6 +83,7 @@
     <PackageFileName>dotnet-hosting-$(PackageVersion)-win$(TargetExt)</PackageFileName>
 
     <BundleNameShort>Microsoft .NET $(PackageBrandingVersion)</BundleNameShort>
+    <BundleNameShortNoBuild>Microsoft .NET $(PackageBrandingVersionNoBuild)</BundleNameShortNoBuild>
     <SharedFxPackageVersion>$(PackageVersion)</SharedFxPackageVersion>
     <SharedFxMsiVersion>$(PackageVersion)</SharedFxMsiVersion>
     <SharedFxMsiVersion
@@ -92,15 +93,16 @@
   <PropertyGroup>
     <BundleNameSub>Windows Server Hosting</BundleNameSub>
     <BundleName>$(BundleNameShort) - $(BundleNameSub)</BundleName>
+    <BundleNameNoBuild>$(BundleNameShortNoBuild) - $(BundleNameSub)</BundleNameNoBuild>
     <BundleNameFull>$(BundleName) ($(Platform))</BundleNameFull>
+    <BundleRegName>$(BundleNameFull)</BundleRegName>
+
     <BundleManufacturer>Microsoft Corporation</BundleManufacturer>
     <BundleLogPrefix>dd_DotNetCoreWinSvrHosting</BundleLogPrefix>
 
     <!-- Registration -->
     <BundleRegManufacturer>Microsoft</BundleRegManufacturer>
     <BundleRegFamily>.NET</BundleRegFamily>
-    <BundleRegName>Microsoft .NET $(PackageBrandingVersion) - Windows Server Hosting</BundleRegName>
-    <BundleRegName>$(BundleNameFull)</BundleRegName>
   </PropertyGroup>
 
   <ItemGroup>
@@ -123,8 +125,9 @@
 
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);BundleName=$(BundleName)</DefineConstants>
-    <DefineConstants>$(DefineConstants);BundleNameFull=$(BundleNameFull)</DefineConstants>
+    <DefineConstants>$(DefineConstants);BundleNameNoBuild=$(BundleNameNoBuild)</DefineConstants>
     <DefineConstants>$(DefineConstants);BundleNameShort=$(BundleNameShort)</DefineConstants>
+    <DefineConstants>$(DefineConstants);BundleNameShortNoBuild=$(BundleNameShortNoBuild)</DefineConstants>
     <DefineConstants>$(DefineConstants);BundleNameSub=$(BundleNameSub)</DefineConstants>
     <DefineConstants>$(DefineConstants);BundleManufacturer=$(BundleManufacturer)</DefineConstants>
     <DefineConstants>$(DefineConstants);BundleLogPrefix=$(BundleLogPrefix)</DefineConstants>

--- a/src/Installers/Windows/WindowsHostingBundle/thm.wxl
+++ b/src/Installers/Windows/WindowsHostingBundle/thm.wxl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="Caption"><!--_locComment_text="{Locked='[WixBundleName]'}"-->[WixBundleName] Setup</String>
-  <String Id="Title"><!--_locComment_text="{Locked}"-->[BundleNameShort]</String>
+  <String Id="Title"><!--_locComment_text="{Locked}"-->[BundleNameShortNoBuild]</String>
   <String Id="SubTitle"><!--_locComment_text="{Locked}"-->[BundleNameSub]</String>
   <String Id="InstallVersion"><!--_locComment_text="{Locked='[WixBundleVersion]'}"-->Version [WixBundleVersion]</String>
   <String Id="ConfirmCancelMessage">Are you sure you want to cancel?</String>
@@ -54,7 +54,7 @@
   <String Id="Welcome"><!--_locComment_text="{Locked='[WixBundleName]'}"-->Welcome to the [WixBundleName] Setup.</String>
   <String Id="InstallResetIIS"><!--_locComment_text="'here' is to be translated"-->Please restart IIS after the installation completes. You can find additional information &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
   <String Id="InstallNoIIS"><!--_locComment_text="'here' is to be translated"-->IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
-  <String Id="EulaPrivacy"><!--_locComment_text="{Locked='[WixBundleName]'}"-->[WixBundleName] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
+  <String Id="EulaPrivacy"><!--_locComment_text="{Locked='[BundleNameNoBuild]'}"-->[BundleNameNoBuild] &lt;a href="https://go.microsoft.com/fwlink/?LinkId=329770"&gt;license terms&lt;/a&gt; and &lt;a href="https://go.microsoft.com/fwlink/?LinkId=786378"&gt;privacy statement&lt;/a&gt;.</String>
   <String Id="ModifyResetIIS"><!--_locComment_text="'here' is to be translated"-->Please restart IIS after the installation completes. You can find additional information &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
   <String Id="ModifyNoIIS"><!--_locComment_text="'here' is to be translated"-->IIS is not enabled on this machine. If you intend to run ASP.NET Core applications with IIS, you must install IIS before running this installer. You can find additional information &lt;a href="https://aka.ms/aspnet/8.0/host-and-deploy-with-iis"&gt;here&lt;/a&gt;.</String>
 </WixLocalization>

--- a/src/Installers/Windows/WindowsHostingBundle/thm.xml
+++ b/src/Installers/Windows/WindowsHostingBundle/thm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Theme xmlns="http://wixtoolset.org/schemas/thmutil/2010">
-    <Window Width="485" Height="347" HexStyle="100a0000" FontId="0">#(loc.Caption)</Window>
+    <Window Width="585" Height="347" HexStyle="100a0000" FontId="0">#(loc.Caption)</Window>
     <Font Id="0" Height="-12" Weight="500" Foreground="000000" Background="FFFFFF">Segoe UI</Font>
     <Font Id="1" Height="-24" Weight="500" Foreground="000000">Segoe UI</Font>
     <Font Id="2" Height="-22" Weight="500" Foreground="666666">Segoe UI</Font>
@@ -17,10 +17,10 @@
         <Button Name="HelpCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.HelpCloseButton)</Button>
     </Page>
     <Page Name="Install">
-        <Hypertext X="11" Y="90" Width="-11" Height="15" FontId="3">#(loc.Welcome)</Hypertext>
-        <Hypertext X="11" Y="119" Width="-11" Height="45" FontId="3" Name="InstallResetIIS" HideWhenDisabled="yes">#(loc.InstallResetIIS)</Hypertext>
-        <Hypertext X="11" Y="119" Width="-11" Height="45" FontId="3" Name="InstallNoIIS" HideWhenDisabled="yes">#(loc.InstallNoIIS)</Hypertext>
-        <Hypertext Name="EulaAndPrivacyHyperlink" X="11" Y="178" Width="-11" Height="51" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.EulaPrivacy)</Hypertext>
+        <Text X="11" Y="90" Width="-11" Height="30" FontId="3">#(loc.Welcome)</Text>
+        <Hypertext Name="EulaAndPrivacyHyperlink" X="11" Y="131" Width="-11" Height="30" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.EulaPrivacy)</Hypertext>
+        <Hypertext X="11" Y="172" Width="-11" Height="45" FontId="3" Name="InstallResetIIS" HideWhenDisabled="yes">#(loc.InstallResetIIS)</Hypertext>
+        <Hypertext X="11" Y="172" Width="-11" Height="45" FontId="3" Name="InstallNoIIS" HideWhenDisabled="yes">#(loc.InstallNoIIS)</Hypertext>
         <Checkbox Name="EulaAcceptCheckbox" X="-11" Y="-41" Width="260" Height="34" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.InstallAcceptCheckbox)</Checkbox>
         <Button Name="InstallButton" X="-91" Y="-11" Width="95" Height="23" TabStop="yes" FontId="0">#(loc.InstallInstallButton)</Button>
         <Button Name="WelcomeCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.InstallCloseButton)</Button>
@@ -54,8 +54,8 @@
     <Page Name="Success">
         <Text Name="SuccessHeader" X="11" Y="80" Width="-11" Height="60" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessHeader)</Text>
         <Text Name="SuccessInstallHeader" X="11" Y="80" Width="-11" Height="60" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessInstallHeader)</Text>
-        <Text Name="SuccessRepairHeader" X="11" Y="80" Width="-11" Height="60" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRepairHeader)</Text> 	
-        <Text Name="SuccessUninstallHeader" X="11" Y="80" Width="-11" Height="60" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessUninstallHeader)</Text> 
+        <Text Name="SuccessRepairHeader" X="11" Y="80" Width="-11" Height="60" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRepairHeader)</Text>
+        <Text Name="SuccessUninstallHeader" X="11" Y="80" Width="-11" Height="60" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessUninstallHeader)</Text>
         <Button Name="LaunchButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessLaunchButton)</Button>
         <Text Name="SuccessRestartText" X="-11" Y="-51" Width="400" Height="34" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRestartText)</Text>
         <Button Name="SuccessRestartButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessRestartButton)</Button>
@@ -65,7 +65,7 @@
         <Text Name="FailureHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureHeader)</Text>
         <Text Name="FailureInstallHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureInstallHeader)</Text>
         <Text Name="FailureUninstallHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureUninstallHeader)</Text>
-        <Text Name="FailureRepairHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureRepairHeader)</Text>	
+        <Text Name="FailureRepairHeader" X="11" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureRepairHeader)</Text>
         <Hypertext Name="FailureLogFileLink" X="11" Y="121" Width="-11" Height="42" FontId="3" TabStop="yes" HideWhenDisabled="yes">#(loc.FailureHyperlinkLogText)</Hypertext>
         <Hypertext Name="FailureMessageText" X="22" Y="163" Width="-11" Height="51" FontId="3" TabStop="yes" HideWhenDisabled="yes" />
         <Text Name="FailureRestartText" X="-11" Y="-51" Width="400" Height="34" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureRestartText)</Text>


### PR DESCRIPTION
- part of #44582
  - see the "Sizes and verbosity" section
- enlarge Windows Hosting bundle frame
- heighten Shared Framework bundle success headers
- add and use `$(PackageBrandingVersionNoBuild)` to reduce text overflow in bundles
  - reduce length of installer title and don't repeat full name in EULA hypertext
- nit: align bundle files to make comparisons easier
- !temporary! add a few questions for reviewers