### PR TITLE
Update sourceIndexPackageVersion

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -87,7 +87,7 @@ variables:
            /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
   # Variables for source indexing afterBuild step and job.
   - name: sourceIndexPackageVersion
-    value: 1.0.1-20210614.1
+    value: 1.0.1-20221220.2
   - name: sourceIndexPackageSource
     value: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   - group: source-dot-net stage1 variables


### PR DESCRIPTION
Fixing the official build break introduced by https://github.com/dotnet/aspnetcore/pull/45879. We can't get rid of these SourceIndex properties and use the arcade defaults, because these are used directly later in this file.