### PR TITLE
Move to latest .NET SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "8.0.100-alpha.1.23055.1"
+    "version": "8.0.100-alpha.1.23059.8"
   },
   "tools": {
-    "dotnet": "8.0.100-alpha.1.23055.1",
+    "dotnet": "8.0.100-alpha.1.23059.8",
     "runtimes": {
       "dotnet/x86": [
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"

--- a/src/Mvc/test/WebSites/TagHelpersWebSite/Views/Home/ViewComponentTagHelpers.cshtml
+++ b/src/Mvc/test/WebSites/TagHelpersWebSite/Views/Home/ViewComponentTagHelpers.cshtml
@@ -10,5 +10,5 @@
 <vc:generic items-foo="items"></vc:generic>
 <vc:dan jacket-color="Green" /><br />
 <div>
-    <vc:copyright website="example.com" year="year" bold></vc:copyright>
+    <vc:copyright website="example.com" year="@year" bold></vc:copyright>
 </div>


### PR DESCRIPTION
- 8.0.100-alpha.1.23055.1 -> 8.0.100-alpha.1.23059.8
- not a big jump because #45879 went in just this morning
  - that PR was relatively up to date