### PR TITLE
[SignalR] Avoid Http2 when negotiate auth is used

### DIFF
--- a/src/SignalR/SignalR.slnf
+++ b/src/SignalR/SignalR.slnf
@@ -33,6 +33,7 @@
       "src\\Security\\Authentication\\Cookies\\src\\Microsoft.AspNetCore.Authentication.Cookies.csproj",
       "src\\Security\\Authentication\\Core\\src\\Microsoft.AspNetCore.Authentication.csproj",
       "src\\Security\\Authentication\\JwtBearer\\src\\Microsoft.AspNetCore.Authentication.JwtBearer.csproj",
+      "src\\Security\\Authentication\\Negotiate\\src\\Microsoft.AspNetCore.Authentication.Negotiate.csproj",
       "src\\Security\\Authorization\\Core\\src\\Microsoft.AspNetCore.Authorization.csproj",
       "src\\Security\\Authorization\\Policy\\src\\Microsoft.AspNetCore.Authorization.Policy.csproj",
       "src\\Servers\\Connections.Abstractions\\src\\Microsoft.AspNetCore.Connections.Abstractions.csproj",

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -1788,7 +1788,7 @@ public class HubConnectionTests : FunctionalTestBase
         Assert.Contains(TestSink.Writes, context => context.Message.Contains("Request finished HTTP/2 CONNECT"));
     }
 
-    [Theory]
+    [ConditionalTheory]
     [MemberData(nameof(TransportTypes))]
     // Negotiate auth on non-windows requires a lot of setup which is out of scope for these tests
     [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux)]

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -1790,13 +1790,15 @@ public class HubConnectionTests : FunctionalTestBase
 
     [Theory]
     [MemberData(nameof(TransportTypes))]
+    // Negotiate auth on non-windows requires a lot of setup which is out of scope for these tests
+    [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux)]
     public async Task TransportFallsbackFromHttp2WhenUsingCredentials(HttpTransportType httpTransportType)
     {
         await using (var server = await StartServer<Startup>(configureKestrelServerOptions: o =>
         {
             o.ConfigureEndpointDefaults(o2 =>
             {
-                o2.Protocols = Server.Kestrel.Core.HttpProtocols.Http1AndHttp2;
+                o2.Protocols = Server.Kestrel.Core.HttpProtocols.Http1;
                 o2.UseHttps();
             });
             o.ConfigureHttpsDefaults(httpsOptions =>
@@ -1847,6 +1849,8 @@ public class HubConnectionTests : FunctionalTestBase
 
     [ConditionalFact]
     [WebSocketsSupportedCondition]
+    // Negotiate auth on non-windows requires a lot of setup which is out of scope for these tests
+    [OSSkipCondition(OperatingSystems.MacOSX | OperatingSystems.Linux)]
     public async Task WebSocketsFailsWhenHttp1NotAllowedAndUsingCredentials()
     {
         await using (var server = await StartServer<Startup>(context => context.EventId.Name == "ErrorStartingTransport",

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -1788,6 +1788,106 @@ public class HubConnectionTests : FunctionalTestBase
         Assert.Contains(TestSink.Writes, context => context.Message.Contains("Request finished HTTP/2 CONNECT"));
     }
 
+    [Theory]
+    [MemberData(nameof(TransportTypes))]
+    public async Task TransportFallsbackFromHttp2WhenUsingCredentials(HttpTransportType httpTransportType)
+    {
+        await using (var server = await StartServer<Startup>(configureKestrelServerOptions: o =>
+        {
+            o.ConfigureEndpointDefaults(o2 =>
+            {
+                o2.Protocols = Server.Kestrel.Core.HttpProtocols.Http1AndHttp2;
+                o2.UseHttps();
+            });
+            o.ConfigureHttpsDefaults(httpsOptions =>
+            {
+                httpsOptions.ServerCertificate = TestCertificateHelper.GetTestCert();
+            });
+        }))
+        {
+            var hubConnection = new HubConnectionBuilder()
+                .WithLoggerFactory(LoggerFactory)
+                .WithUrl(server.Url + "/windowsauthhub", httpTransportType, options =>
+                {
+                    options.HttpMessageHandlerFactory = h =>
+                    {
+                        ((HttpClientHandler)h).ServerCertificateCustomValidationCallback = (_, _, _, _) => true;
+                        return h;
+                    };
+                    options.WebSocketConfiguration = o =>
+                    {
+                        o.RemoteCertificateValidationCallback = (_, _, _, _) => true;
+                        o.HttpVersion = HttpVersion.Version20;
+                    };
+                    options.UseDefaultCredentials = true;
+                })
+                .Build();
+            try
+            {
+                await hubConnection.StartAsync().DefaultTimeout();
+                var echoResponse = await hubConnection.InvokeAsync<string>(nameof(HubWithAuthorization2.Echo), "Foo").DefaultTimeout();
+                Assert.Equal("Foo", echoResponse);
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                await hubConnection.DisposeAsync().DefaultTimeout();
+            }
+        }
+
+        // Check that HTTP/1.1 was used instead of the configured HTTP/2 since Windows Auth is being used
+        Assert.Contains(TestSink.Writes, context => context.Message.Contains("Request starting HTTP/1.1 POST"));
+        Assert.Contains(TestSink.Writes, context => context.Message.Contains("Request starting HTTP/1.1 GET"));
+        Assert.Contains(TestSink.Writes, context => context.Message.Contains("Request finished HTTP/1.1 GET"));
+    }
+
+    [ConditionalFact]
+    [WebSocketsSupportedCondition]
+    public async Task WebSocketsFailsWhenHttp1NotAllowedAndUsingCredentials()
+    {
+        await using (var server = await StartServer<Startup>(context => context.EventId.Name == "ErrorStartingTransport",
+            configureKestrelServerOptions: o =>
+        {
+            o.ConfigureEndpointDefaults(o2 =>
+            {
+                o2.Protocols = Server.Kestrel.Core.HttpProtocols.Http1AndHttp2;
+                o2.UseHttps();
+            });
+            o.ConfigureHttpsDefaults(httpsOptions =>
+            {
+                httpsOptions.ServerCertificate = TestCertificateHelper.GetTestCert();
+            });
+        }))
+        {
+            var hubConnection = new HubConnectionBuilder()
+                .WithLoggerFactory(LoggerFactory)
+                .WithUrl(server.Url + "/windowsauthhub", HttpTransportType.WebSockets, options =>
+                {
+                    options.HttpMessageHandlerFactory = h =>
+                    {
+                        ((HttpClientHandler)h).ServerCertificateCustomValidationCallback = (_, _, _, _) => true;
+                        return h;
+                    };
+                    options.WebSocketConfiguration = o =>
+                    {
+                        o.RemoteCertificateValidationCallback = (_, _, _, _) => true;
+                        o.HttpVersion = HttpVersion.Version20;
+                        o.HttpVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+                    };
+                    options.UseDefaultCredentials = true;
+                })
+                .Build();
+
+            var ex = await Assert.ThrowsAsync<AggregateException>(() => hubConnection.StartAsync().DefaultTimeout());
+            Assert.Contains("Negotiate Authentication doesn't work with HTTP/2 or higher.", ex.Message);
+            await hubConnection.DisposeAsync().DefaultTimeout();
+        }
+    }
+
     [ConditionalFact]
     [WebSocketsSupportedCondition]
     public async Task WebSocketsWithAccessTokenOverHttp2()

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Microsoft.AspNetCore.SignalR.Client.FunctionalTests.csproj
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Microsoft.AspNetCore.SignalR.Client.FunctionalTests.csproj
@@ -7,6 +7,7 @@
     <ProjectReference Include="$(SignalRTestUtilsProject)" />
 
     <Reference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <Reference Include="Microsoft.AspNetCore.Authentication.Negotiate" />
     <Reference Include="Microsoft.AspNetCore.Diagnostics" />
     <Reference Include="Microsoft.AspNetCore.Http" />
     <Reference Include="Microsoft.AspNetCore.SignalR.Client" />

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -538,7 +538,7 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
         HttpMessageHandler httpMessageHandler = httpClientHandler;
 
         var isBrowser = OperatingSystem.IsBrowser();
-        var useHttp2 = true;
+        var allowHttp2 = true;
 
         if (_httpConnectionOptions != null)
         {
@@ -578,7 +578,7 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
                     httpClientHandler.UseDefaultCredentials = _httpConnectionOptions.UseDefaultCredentials.Value;
                     // Negotiate Auth isn't supported over HTTP/2 and HttpClient does not gracefully fallback to HTTP/1.1 in that case
                     // https://github.com/dotnet/runtime/issues/1582
-                    useHttp2 = !_httpConnectionOptions.UseDefaultCredentials.Value;
+                    allowHttp2 = !_httpConnectionOptions.UseDefaultCredentials.Value;
                 }
 
                 if (_httpConnectionOptions.Credentials != null)
@@ -586,7 +586,7 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
                     httpClientHandler.Credentials = _httpConnectionOptions.Credentials;
                     // Negotiate Auth isn't supported over HTTP/2 and HttpClient does not gracefully fallback to HTTP/1.1 in that case
                     // https://github.com/dotnet/runtime/issues/1582
-                    useHttp2 = false;
+                    allowHttp2 = false;
                 }
             }
 
@@ -607,7 +607,7 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
         // Wrap message handler after HttpMessageHandlerFactory to ensure not overridden
         httpMessageHandler = new LoggingHttpMessageHandler(httpMessageHandler, _loggerFactory);
 
-        if (useHttp2)
+        if (allowHttp2)
         {
             httpMessageHandler = new Http2HttpMessageHandler(httpMessageHandler);
         }

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/Http2HttpMessageHandler.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/Http2HttpMessageHandler.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Http.Connections.Client.Internal;
+
+internal class Http2HttpMessageHandler : DelegatingHandler
+{
+    public Http2HttpMessageHandler(HttpMessageHandler inner) : base(inner) { }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+#if NETSTANDARD2_1_OR_GREATER || NET7_0_OR_GREATER
+        // HttpClient gracefully falls back to HTTP/1.1,
+        // so it's fine to set the preferred version to a higher version
+        request.Version = HttpVersion.Version20;
+#endif
+
+        return base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/Http2HttpMessageHandler.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/Http2HttpMessageHandler.cs
@@ -20,9 +20,13 @@ internal class Http2HttpMessageHandler : DelegatingHandler
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
 #if NETSTANDARD2_1_OR_GREATER || NET7_0_OR_GREATER
-        // HttpClient gracefully falls back to HTTP/1.1,
-        // so it's fine to set the preferred version to a higher version
-        request.Version = HttpVersion.Version20;
+        // Check just in case HttpRequestMessage defaults to 3 or higher for some reason
+        if (request.Version == HttpVersion.Version11)
+        {
+            // HttpClient gracefully falls back to HTTP/1.1,
+            // so it's fine to set the preferred version to a higher version
+            request.Version = HttpVersion.Version20;
+        }
 #endif
 
         return base.SendAsync(request, cancellationToken);

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/LongPollingTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/LongPollingTransport.cs
@@ -50,12 +50,7 @@ internal sealed partial class LongPollingTransport : ITransport
 
         // Make initial long polling request
         // Server uses first long polling request to finish initializing connection and it returns without data
-        var request = new HttpRequestMessage(HttpMethod.Get, url)
-        {
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
-            Version = HttpVersion.Version20,
-#endif
-        };
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
         using (var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false))
         {
             response.EnsureSuccessStatusCode();
@@ -153,12 +148,7 @@ internal sealed partial class LongPollingTransport : ITransport
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                var request = new HttpRequestMessage(HttpMethod.Get, pollUrl)
-                {
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
-                    Version = HttpVersion.Version20,
-#endif
-                };
+                var request = new HttpRequestMessage(HttpMethod.Get, pollUrl);
 
                 HttpResponseMessage response;
 
@@ -237,12 +227,7 @@ internal sealed partial class LongPollingTransport : ITransport
         try
         {
             Log.SendingDeleteRequest(_logger, url);
-            var request = new HttpRequestMessage(HttpMethod.Delete, url)
-            {
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
-                Version = HttpVersion.Version20,
-#endif
-            };
+            var request = new HttpRequestMessage(HttpMethod.Delete, url);
             var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
 
             if (response.StatusCode == HttpStatusCode.NotFound)

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/SendUtils.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/SendUtils.cs
@@ -41,11 +41,6 @@ internal static partial class SendUtils
                         // Send them in a single post
                         var request = new HttpRequestMessage(HttpMethod.Post, sendUrl);
 
-#if NETSTANDARD2_1_OR_GREATER || NET7_0_OR_GREATER
-                        // HttpClient gracefully falls back to HTTP/1.1, so it's fine to set the preferred version to a higher version
-                        request.Version = HttpVersion.Version20;
-#endif
-
                         request.Content = new ReadOnlySequenceContent(buffer);
 
                         // ResponseHeadersRead instructs SendAsync to return once headers are read

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/ServerSentEventsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/ServerSentEventsTransport.cs
@@ -55,12 +55,7 @@ internal sealed partial class ServerSentEventsTransport : ITransport
 
         Log.StartTransport(_logger, transferFormat);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, url)
-        {
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
-            Version = HttpVersion.Version20,
-#endif
-        };
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
 
         HttpResponseMessage? response = null;

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
@@ -91,6 +91,8 @@ internal sealed partial class WebSocketsTransport : ITransport
                 }
             }
 
+            var allowHttp2 = true;
+
             if (!isBrowser)
             {
                 if (context.Options.Cookies != null)
@@ -106,6 +108,9 @@ internal sealed partial class WebSocketsTransport : ITransport
                 if (context.Options.Credentials != null)
                 {
                     webSocket.Options.Credentials = context.Options.Credentials;
+                    // Negotiate Auth isn't supported over HTTP/2 and HttpClient does not gracefully fallback to HTTP/1.1 in that case
+                    // https://github.com/dotnet/runtime/issues/1582
+                    allowHttp2 = false;
                 }
 
                 var originalProxy = webSocket.Options.Proxy;
@@ -117,12 +122,18 @@ internal sealed partial class WebSocketsTransport : ITransport
                 if (context.Options.UseDefaultCredentials != null)
                 {
                     webSocket.Options.UseDefaultCredentials = context.Options.UseDefaultCredentials.Value;
+                    if (context.Options.UseDefaultCredentials.Value)
+                    {
+                        // Negotiate Auth isn't supported over HTTP/2 and HttpClient does not gracefully fallback to HTTP/1.1 in that case
+                        // https://github.com/dotnet/runtime/issues/1582
+                        allowHttp2 = false;
+                    }
                 }
 
                 context.Options.WebSocketConfiguration?.Invoke(webSocket.Options);
 
 #if NET7_0_OR_GREATER
-                if (webSocket.Options.HttpVersion >= HttpVersion.Version20)
+                if (webSocket.Options.HttpVersion >= HttpVersion.Version20 && allowHttp2)
                 {
                     // Reset options we set on the users' behalf since they are already on the HttpClient that we're passing to ConnectAsync
                     // And ConnectAsync will throw if these options are set on the ClientWebSocketOptions
@@ -145,6 +156,19 @@ internal sealed partial class WebSocketsTransport : ITransport
                     if (ReferenceEquals(webSocket.Options.Proxy, context.Options.Proxy))
                     {
                         webSocket.Options.Proxy = originalProxy;
+                    }
+                }
+
+                if (!allowHttp2 && webSocket.Options.HttpVersion >= HttpVersion.Version20)
+                {
+                    // We shouldn't fallback to HTTP/1.1 if the user explicitly states
+                    if (webSocket.Options.HttpVersionPolicy == HttpVersionPolicy.RequestVersionOrLower)
+                    {
+                        webSocket.Options.HttpVersion = HttpVersion.Version11;
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException("Negotiate Authentication doesn't work with HTTP/2 or higher.");
                     }
                 }
 

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
@@ -91,7 +91,9 @@ internal sealed partial class WebSocketsTransport : ITransport
                 }
             }
 
+#if NET7_0_OR_GREATER
             var allowHttp2 = true;
+#endif
 
             if (!isBrowser)
             {
@@ -110,7 +112,9 @@ internal sealed partial class WebSocketsTransport : ITransport
                     webSocket.Options.Credentials = context.Options.Credentials;
                     // Negotiate Auth isn't supported over HTTP/2 and HttpClient does not gracefully fallback to HTTP/1.1 in that case
                     // https://github.com/dotnet/runtime/issues/1582
+#if NET7_0_OR_GREATER
                     allowHttp2 = false;
+#endif
                 }
 
                 var originalProxy = webSocket.Options.Proxy;
@@ -126,7 +130,9 @@ internal sealed partial class WebSocketsTransport : ITransport
                     {
                         // Negotiate Auth isn't supported over HTTP/2 and HttpClient does not gracefully fallback to HTTP/1.1 in that case
                         // https://github.com/dotnet/runtime/issues/1582
+#if NET7_0_OR_GREATER
                         allowHttp2 = false;
+#endif
                     }
                 }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/45371

https://github.com/dotnet/aspnetcore/blob/c096dbbbe652f03be926502d790eb499682eea13/src/Security/Authentication/Negotiate/src/NegotiateHandler.cs#L54