### PR TITLE
Use dotnet 6 instead of 3.1 for BinLogToSln

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -379,8 +379,8 @@ stages:
             inputs:
               packageType: sdk
               version: 6.0.x
-              installationPath: $(Agent.TempDirectory)/dotnet
-              workingDirectory: $(Agent.TempDirectory)
+              installationPath: $(Build.SourcesDirectory)/.dotnet
+              workingDirectory: $(Build.SourcesDirectory)
           - powershell: . $(Build.SourcesDirectory)/activate.ps1;
               dotnet tool install BinLogToSln
               --version $(SourceIndexPackageVersion)

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -375,12 +375,12 @@ stages:
         ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(parameters.testSourceIndexing, 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))) }}:
           afterBuild:
           - task: UseDotNet@2
-            displayName: Use .NET Core sdk 3.1
+            displayName: Use .NET Core SDK 6
             inputs:
               packageType: sdk
-              version: 3.1.x
-              installationPath: $(Build.SourcesDirectory)/.dotnet
-              workingDirectory: $(Build.SourcesDirectory)
+              version: 6.0.x
+              installationPath: $(Agent.TempDirectory)/dotnet
+              workingDirectory: $(Agent.TempDirectory)
           - powershell: . $(Build.SourcesDirectory)/activate.ps1;
               dotnet tool install BinLogToSln
               --version $(SourceIndexPackageVersion)


### PR DESCRIPTION
Arm builds are still failing because the new BinLogToSln tool needs .net 6 instead of 3.1 - see related change in Arcade: https://github.com/dotnet/arcade/pull/12096/files#diff-c3f9d56d86d82b8f03164b31f36f8b8fad72c8c186c612c03b4c1d24157d00ddR43