### PR TITLE
Use dotnet 6 for uploading indexable solution

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -881,10 +881,10 @@ stages:
                 cleanDestinationFolder: true
             # Ignore repository's global.json and any existing .NET SDK.
             - task: UseDotNet@2
-              displayName: Use .NET Core sdk 3.1
+              displayName: Use .NET Core SDK 6
               inputs:
                 packageType: sdk
-                version: 3.1.x
+                version: 6.0.x
                 installationPath: $(Agent.TempDirectory)/.dotnet
                 workingDirectory: $(Agent.TempDirectory)
             - script: $(Agent.TempDirectory)/.dotnet/dotnet tool install UploadIndexStage1


### PR DESCRIPTION
More fallout from the latest arcade/SDK update w.r.t BinLogToSln. I believe this is the last one that needs to be updated.

Related: https://github.com/dotnet/aspnetcore/pull/45986