### PR TITLE
Force update of the npm package with dotnet.d.ts

### DIFF
--- a/eng/targets/Npm.Common.targets
+++ b/eng/targets/Npm.Common.targets
@@ -8,7 +8,7 @@
     <PackageJson>$(MSBuildProjectDirectory)\package.json</PackageJson>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$(MSBuildProjectDirectory)\obj\</BaseIntermediateOutputPath>
     <IntermediateOutputPath>$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)'))$(Configuration)\</IntermediateOutputPath>
-    <InstallArgs>--frozen-lockfile</InstallArgs>
+    <InstallArgs>$(InstallArgs) --frozen-lockfile</InstallArgs>
     <_BackupPackageJson>$(IntermediateOutputPath)$(MSBuildProjectName).package.json.bak</_BackupPackageJson>
     <BuildDependsOn>
       PrepareForBuild;

--- a/src/Components/Web.JS/Microsoft.AspNetCore.Components.Web.JS.npmproj
+++ b/src/Components/Web.JS/Microsoft.AspNetCore.Components.Web.JS.npmproj
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <InstallArgs>--check-files</InstallArgs>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
force update of the `src\Components\Web.JS\@types\dotnet` npm package

in order to fix stale files in `src\Components\Web.JS\node_modules\@types\dotnet` as reported in https://github.com/dotnet/aspnetcore/pull/45993

note that just bumping the version in `src\Components\Web.JS\@types\dotnet\package.json` would not help as it's only refered to by `src\Components\Web.JS\package.json` as path to directory, not a versioned module.