### PR TITLE
Call CloseAsync instead of CloseOutputAsync in the browser

### DIFF
--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
@@ -463,8 +463,17 @@ internal sealed partial class WebSocketsTransport : ITransport
             {
                 try
                 {
-                    // We're done sending, send the close frame to the client if the websocket is still open
-                    await socket.CloseOutputAsync(error != null ? WebSocketCloseStatus.InternalServerError : WebSocketCloseStatus.NormalClosure, "", _stopCts.Token).ConfigureAwait(false);
+                    if (!OperatingSystem.IsBrowser())
+                    {
+                        // We're done sending, send the close frame to the client if the websocket is still open
+                        await socket.CloseOutputAsync(error != null ? WebSocketCloseStatus.InternalServerError : WebSocketCloseStatus.NormalClosure, "", _stopCts.Token).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        // WebSocket in the browser doesn't have an equivalent to CloseOutputAsync, it just calls CloseAsync and logs a warning
+                        // So let's just call CloseAsync to avoid the warning
+                        await socket.CloseAsync(error != null ? WebSocketCloseStatus.InternalServerError : WebSocketCloseStatus.NormalClosure, "", _stopCts.Token).ConfigureAwait(false);
+                    }
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Warning seen in https://github.com/aspnet/AspNetCore-ManualTests/issues/1781
Not sure if it's new in 7.0, or no one noticed before?