### PR TITLE
[AOT] Add expression free request filter pipeline for RequestDelegate

### DIFF
--- a/src/Http/Http.Extensions/src/Microsoft.AspNetCore.Http.Extensions.csproj
+++ b/src/Http/Http.Extensions/src/Microsoft.AspNetCore.Http.Extensions.csproj
@@ -23,6 +23,7 @@
     <Compile Include="$(SharedSourceRoot)ProblemDetails\ProblemDetailsDefaults.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)ValueStringBuilder\**\*.cs" LinkBase="Shared"/>
     <Compile Include="$(SharedSourceRoot)Json\JsonSerializerExtensions.cs" LinkBase="Shared"/>
+    <Compile Include="$(SharedSourceRoot)RouteHandlers\ExecuteHandlerHelper.cs" LinkBase="Shared"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Http/Http.Extensions/src/RequestDelegateMetadataResult.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateMetadataResult.cs
@@ -19,5 +19,6 @@ public sealed class RequestDelegateMetadataResult
 
     // This internal cached context avoids redoing unnecessary reflection in Create that was already done in InferMetadata.
     // InferMetadata currently does more work than it needs to building up expression trees, but the expectation is that InferMetadata will usually be followed by Create.
-    internal RequestDelegateFactoryContext? CachedFactoryContext { get; set; }
+    // The property typed as object to avoid having a dependency System.Linq.Expressions. The value is RequestDelegateFactoryContext.
+    internal object? CachedFactoryContext { get; set; }
 }

--- a/src/Http/Http.Extensions/src/RequestDelegateMetadataResult.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateMetadataResult.cs
@@ -19,6 +19,6 @@ public sealed class RequestDelegateMetadataResult
 
     // This internal cached context avoids redoing unnecessary reflection in Create that was already done in InferMetadata.
     // InferMetadata currently does more work than it needs to building up expression trees, but the expectation is that InferMetadata will usually be followed by Create.
-    // The property typed as object to avoid having a dependency System.Linq.Expressions. The value is RequestDelegateFactoryContext.
+    // The property is typed as object to avoid having a dependency System.Linq.Expressions. The value is RequestDelegateFactoryContext.
     internal object? CachedFactoryContext { get; set; }
 }

--- a/src/Http/Routing/src/Builder/EndpointRouteBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/EndpointRouteBuilderExtensions.cs
@@ -211,7 +211,7 @@ public static class EndpointRouteBuilderExtensions
             }
 
             var metadata = new List<object>(options.EndpointBuilder?.Metadata ?? Array.Empty<object>());
-            return new RequestDelegateResult(RequestDelegateFilterPipelineBuilder.Create(requestDelegate, options), metadata);
+            return new RequestDelegateResult(requestDelegate, metadata);
         }
     }
 

--- a/src/Http/Routing/src/Builder/EndpointRouteBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/EndpointRouteBuilderExtensions.cs
@@ -210,7 +210,9 @@ public static class EndpointRouteBuilderExtensions
                 requestDelegate = RequestDelegateFilterPipelineBuilder.Create(requestDelegate, options);
             }
 
-            var metadata = new List<object>(options.EndpointBuilder?.Metadata ?? Array.Empty<object>());
+            IReadOnlyList<object> metadata = options.EndpointBuilder?.Metadata is not null ?
+                new List<object>(options.EndpointBuilder.Metadata) :
+                Array.Empty<object>();
             return new RequestDelegateResult(requestDelegate, metadata);
         }
     }

--- a/src/Http/Routing/src/Builder/RouteHandlerBuilder.cs
+++ b/src/Http/Routing/src/Builder/RouteHandlerBuilder.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AspNetCore.Routing;
-
 namespace Microsoft.AspNetCore.Builder;
 
 /// <summary>
@@ -14,12 +12,6 @@ public sealed class RouteHandlerBuilder : IEndpointConventionBuilder
     private readonly ICollection<Action<EndpointBuilder>>? _conventions;
     private readonly ICollection<Action<EndpointBuilder>>? _finallyConventions;
 
-    /// <summary>
-    /// Instantiates a new <see cref="RouteHandlerBuilder" /> given a ThrowOnAddAfterEndpointBuiltConventionCollection from
-    /// <see cref="RouteEndpointDataSource.AddRouteHandler(Routing.Patterns.RoutePattern, Delegate, IEnumerable{string}?, bool)"/>.
-    /// </summary>
-    /// <param name="conventions">The convention list returned from <see cref="RouteEndpointDataSource"/>.</param>
-    /// <param name="finallyConventions">The final convention list returned from <see cref="RouteEndpointDataSource"/>.</param>
     internal RouteHandlerBuilder(ICollection<Action<EndpointBuilder>> conventions, ICollection<Action<EndpointBuilder>> finallyConventions)
     {
         _conventions = conventions;

--- a/src/Http/Routing/src/Microsoft.AspNetCore.Routing.csproj
+++ b/src/Http/Routing/src/Microsoft.AspNetCore.Routing.csproj
@@ -31,6 +31,8 @@
     <Compile Include="$(SharedSourceRoot)MediaType\HttpTokenParsingRule.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)ApiExplorerTypes\*.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)RoutingMetadata\AcceptsMetadata.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Json\JsonSerializerExtensions.cs" LinkBase="Shared"/>
+    <Compile Include="$(SharedSourceRoot)RouteHandlers\ExecuteHandlerHelper.cs" LinkBase="Shared"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Http/Routing/src/RequestDelegateFilterPipelineBuilder.cs
+++ b/src/Http/Routing/src/RequestDelegateFilterPipelineBuilder.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Json;
+using Microsoft.AspNetCore.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Routing;
+
+internal static class RequestDelegateFilterPipelineBuilder
+{
+    // Due to https://github.com/dotnet/aspnetcore/issues/41330 we cannot reference the EmptyHttpResult type
+    // but users still need to assert on it as in https://github.com/dotnet/aspnetcore/issues/45063
+    // so we temporarily work around this here by using reflection to get the actual type.
+    private static readonly object? EmptyHttpResultInstance = Type.GetType("Microsoft.AspNetCore.Http.HttpResults.EmptyHttpResult, Microsoft.AspNetCore.Http.Results")?.GetProperty("Instance")?.GetValue(null, null);
+
+    public static RequestDelegate Create(RequestDelegate requestDelegate, RequestDelegateFactoryOptions options)
+    {
+        Debug.Assert(options.EndpointBuilder != null);
+
+        var serviceProvider = options.ServiceProvider ?? options.EndpointBuilder.ApplicationServices;
+        var jsonOptions = serviceProvider?.GetService<IOptions<JsonOptions>>()?.Value ?? new JsonOptions();
+        var jsonSerializerOptions = jsonOptions.SerializerOptions;
+
+        var factoryContext = new EndpointFilterFactoryContext
+        {
+            MethodInfo = requestDelegate.Method,
+            ApplicationServices = options.EndpointBuilder.ApplicationServices
+        };
+        var jsonTypeInfo = (JsonTypeInfo<object>)jsonSerializerOptions.GetTypeInfo(typeof(object));
+
+        EndpointFilterDelegate filteredInvocation = async (EndpointFilterInvocationContext context) =>
+        {
+            if (context.HttpContext.Response.StatusCode >= 400)
+            {
+                return EmptyHttpResultInstance;
+            }
+            else
+            {
+                await requestDelegate(context.HttpContext);
+                return EmptyHttpResultInstance;
+            }
+        };
+
+        var initialFilteredInvocation = filteredInvocation;
+        for (var i = options.EndpointBuilder.FilterFactories.Count - 1; i >= 0; i--)
+        {
+            var currentFilterFactory = options.EndpointBuilder.FilterFactories[i];
+            filteredInvocation = currentFilterFactory(factoryContext, filteredInvocation);
+        }
+
+        // The filter factories have run without modifying per-request behavior, we can skip running the pipeline.
+        if (ReferenceEquals(initialFilteredInvocation, filteredInvocation))
+        {
+            return requestDelegate;
+        }
+
+        return async (HttpContext httpContext) =>
+        {
+            var obj = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext, new object[] { httpContext }));
+            if (obj is not null)
+            {
+                await ExecuteHandlerHelper.ExecuteReturnAsync(obj, httpContext, jsonSerializerOptions, jsonTypeInfo);
+            }
+        };
+    }
+}

--- a/src/Http/Routing/src/RequestDelegateFilterPipelineBuilder.cs
+++ b/src/Http/Routing/src/RequestDelegateFilterPipelineBuilder.cs
@@ -31,7 +31,7 @@ internal static class RequestDelegateFilterPipelineBuilder
             MethodInfo = requestDelegate.Method,
             ApplicationServices = options.EndpointBuilder.ApplicationServices
         };
-        var jsonTypeInfo = (JsonTypeInfo<object>)jsonSerializerOptions.GetTypeInfo(typeof(object));
+        var jsonTypeInfo = (JsonTypeInfo<object>)jsonSerializerOptions.GetReadOnlyTypeInfo(typeof(object));
 
         EndpointFilterDelegate filteredInvocation = async (EndpointFilterInvocationContext context) =>
         {

--- a/src/Http/Routing/src/RequestDelegateFilterPipelineBuilder.cs
+++ b/src/Http/Routing/src/RequestDelegateFilterPipelineBuilder.cs
@@ -36,15 +36,11 @@ internal static class RequestDelegateFilterPipelineBuilder
         EndpointFilterDelegate filteredInvocation = async (EndpointFilterInvocationContext context) =>
         {
             Debug.Assert(EmptyHttpResultInstance != null, "Unable to get EmptyHttpResult instance via reflection.");
-            if (context.HttpContext.Response.StatusCode >= 400)
-            {
-                return EmptyHttpResultInstance;
-            }
-            else
+            if (context.HttpContext.Response.StatusCode < 400)
             {
                 await requestDelegate(context.HttpContext);
-                return EmptyHttpResultInstance;
             }
+            return EmptyHttpResultInstance;
         };
 
         var initialFilteredInvocation = filteredInvocation;

--- a/src/Http/Routing/src/RequestDelegateFilterPipelineBuilder.cs
+++ b/src/Http/Routing/src/RequestDelegateFilterPipelineBuilder.cs
@@ -35,6 +35,7 @@ internal static class RequestDelegateFilterPipelineBuilder
 
         EndpointFilterDelegate filteredInvocation = async (EndpointFilterInvocationContext context) =>
         {
+            Debug.Assert(EmptyHttpResultInstance != null, "Unable to get EmptyHttpResult instance via reflection.");
             if (context.HttpContext.Response.StatusCode >= 400)
             {
                 return EmptyHttpResultInstance;

--- a/src/Http/Routing/src/RouteEndpointDataSource.cs
+++ b/src/Http/Routing/src/RouteEndpointDataSource.cs
@@ -35,7 +35,6 @@ internal sealed class RouteEndpointDataSource : EndpointDataSource
         RequestDelegate requestDelegate,
         IEnumerable<string>? httpMethods)
     {
-
         var conventions = new ThrowOnAddAfterEndpointBuiltConventionCollection();
         var finallyConventions = new ThrowOnAddAfterEndpointBuiltConventionCollection();
 

--- a/src/Http/Routing/src/RouteEndpointDataSource.cs
+++ b/src/Http/Routing/src/RouteEndpointDataSource.cs
@@ -69,6 +69,8 @@ internal sealed class RouteEndpointDataSource : EndpointDataSource
 
     private static RequestDelegate BuildFilterPipeline(RequestDelegate requestDelegate, RequestDelegateFactoryOptions options)
     {
+        Debug.Assert(options.EndpointBuilder != null);
+
         var serviceProvider = options.ServiceProvider ?? options.EndpointBuilder.ApplicationServices;
         var jsonOptions = serviceProvider?.GetService<IOptions<JsonOptions>>()?.Value ?? new JsonOptions();
         var jsonSerializerOptions = jsonOptions.SerializerOptions;

--- a/src/Http/Routing/test/UnitTests/Builder/RequestDelegateEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/RequestDelegateEndpointRouteBuilderExtensionsTest.cs
@@ -29,28 +29,28 @@ public class RequestDelegateEndpointRouteBuilderExtensionsTest
     {
         get
         {
-            IEndpointConventionBuilder MapGet(IEndpointRouteBuilder routes, string template, Delegate action) =>
+            IEndpointConventionBuilder MapGet(IEndpointRouteBuilder routes, string template, RequestDelegate action) =>
                 routes.MapGet(template, action);
 
-            IEndpointConventionBuilder MapPost(IEndpointRouteBuilder routes, string template, Delegate action) =>
+            IEndpointConventionBuilder MapPost(IEndpointRouteBuilder routes, string template, RequestDelegate action) =>
                 routes.MapPost(template, action);
 
-            IEndpointConventionBuilder MapPut(IEndpointRouteBuilder routes, string template, Delegate action) =>
+            IEndpointConventionBuilder MapPut(IEndpointRouteBuilder routes, string template, RequestDelegate action) =>
                 routes.MapPut(template, action);
 
-            IEndpointConventionBuilder MapDelete(IEndpointRouteBuilder routes, string template, Delegate action) =>
+            IEndpointConventionBuilder MapDelete(IEndpointRouteBuilder routes, string template, RequestDelegate action) =>
                 routes.MapDelete(template, action);
 
-            IEndpointConventionBuilder Map(IEndpointRouteBuilder routes, string template, Delegate action) =>
+            IEndpointConventionBuilder Map(IEndpointRouteBuilder routes, string template, RequestDelegate action) =>
                 routes.Map(template, action);
 
             return new object[][]
             {
-                    new object[] { (Func<IEndpointRouteBuilder, string, Delegate, IEndpointConventionBuilder>)MapGet },
-                    new object[] { (Func<IEndpointRouteBuilder, string, Delegate, IEndpointConventionBuilder>)MapPost },
-                    new object[] { (Func<IEndpointRouteBuilder, string, Delegate, IEndpointConventionBuilder>)MapPut },
-                    new object[] { (Func<IEndpointRouteBuilder, string, Delegate, IEndpointConventionBuilder>)MapDelete },
-                    new object[] { (Func<IEndpointRouteBuilder, string, Delegate, IEndpointConventionBuilder>)Map },
+                new object[] { (Func<IEndpointRouteBuilder, string, RequestDelegate, IEndpointConventionBuilder>)MapGet },
+                new object[] { (Func<IEndpointRouteBuilder, string, RequestDelegate, IEndpointConventionBuilder>)MapPost },
+                new object[] { (Func<IEndpointRouteBuilder, string, RequestDelegate, IEndpointConventionBuilder>)MapPut },
+                new object[] { (Func<IEndpointRouteBuilder, string, RequestDelegate, IEndpointConventionBuilder>)MapDelete },
+                new object[] { (Func<IEndpointRouteBuilder, string, RequestDelegate, IEndpointConventionBuilder>)Map },
             };
         }
     }
@@ -75,7 +75,7 @@ public class RequestDelegateEndpointRouteBuilderExtensionsTest
 
     [Theory]
     [MemberData(nameof(MapMethods))]
-    public async Task MapEndpoint_ReturnGenericTypeTask_GeneratedDelegate(Func<IEndpointRouteBuilder, string, Delegate, IEndpointConventionBuilder> map)
+    public async Task MapEndpoint_ReturnGenericTypeTask_GeneratedDelegate(Func<IEndpointRouteBuilder, string, RequestDelegate, IEndpointConventionBuilder> map)
     {
         var httpContext = new DefaultHttpContext();
         var responseBodyStream = new MemoryStream();
@@ -83,7 +83,11 @@ public class RequestDelegateEndpointRouteBuilderExtensionsTest
 
         // Arrange
         var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(EmptyServiceProvider.Instance));
-        static async Task<string> GenericTypeTaskDelegate(HttpContext context) => await Task.FromResult("String Test");
+        static async Task<string> GenericTypeTaskDelegate(HttpContext context)
+        {
+            await context.Response.WriteAsync("Response string text");
+            return await Task.FromResult("String Test");
+        }
 
         // Act
         var endpointBuilder = map(builder, "/", GenericTypeTaskDelegate);
@@ -98,12 +102,12 @@ public class RequestDelegateEndpointRouteBuilderExtensionsTest
 
         var responseBody = Encoding.UTF8.GetString(responseBodyStream.ToArray());
 
-        Assert.Equal("String Test", responseBody);
+        Assert.Equal("Response string text", responseBody);
     }
 
     [Theory]
     [MemberData(nameof(MapMethods))]
-    public async Task MapEndpoint_CanBeFiltered_ByEndpointFilters(Func<IEndpointRouteBuilder, string, RequestDelegate, IEndpointConventionBuilder> map)
+    public async Task MapEndpoint_CanBeFiltered_EndpointFilterFactory(Func<IEndpointRouteBuilder, string, RequestDelegate, IEndpointConventionBuilder> map)
     {
         var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(EmptyServiceProvider.Instance));
         var httpContext = new DefaultHttpContext();
@@ -111,7 +115,6 @@ public class RequestDelegateEndpointRouteBuilderExtensionsTest
         httpContext.Response.Body = responseBodyStream;
 
         RequestDelegate initialRequestDelegate = static (context) => Task.CompletedTask;
-        var filterTag = new TagsAttribute("filter");
 
         var endpointBuilder = map(builder, "/", initialRequestDelegate).AddEndpointFilterFactory(filterFactory: (routeHandlerContext, next) =>
         {
@@ -119,7 +122,7 @@ public class RequestDelegateEndpointRouteBuilderExtensionsTest
             {
                 Assert.IsAssignableFrom<HttpContext>(Assert.Single(invocationContext.Arguments));
                 // Ignore thre result and write filtered because we can!
-                await next(invocationContext);
+                _ = await next(invocationContext);
                 return "filtered!";
             };
         });
@@ -136,6 +139,119 @@ public class RequestDelegateEndpointRouteBuilderExtensionsTest
         var responseBody = Encoding.UTF8.GetString(responseBodyStream.ToArray());
 
         Assert.Equal("filtered!", responseBody);
+    }
+
+    [Fact]
+    public async Task MapEndpoint_CanBeFiltered_EndpointFilter()
+    {
+        var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(EmptyServiceProvider.Instance));
+        var httpContext = new DefaultHttpContext();
+        var responseBodyStream = new MemoryStream();
+        httpContext.Response.Body = responseBodyStream;
+
+        RequestDelegate initialRequestDelegate = static (context) => Task.CompletedTask;
+
+        var endpointBuilder = builder.Map("/", initialRequestDelegate)
+            .AddEndpointFilter(new HttpContextArgFilter("First"))
+            .AddEndpointFilter(new HttpContextArgFilter("Second"));
+
+        var dataSource = GetBuilderEndpointDataSource(builder);
+        var endpoint = Assert.Single(dataSource.Endpoints);
+
+        Assert.NotSame(initialRequestDelegate, endpoint.RequestDelegate);
+
+        Assert.NotNull(endpoint.RequestDelegate);
+        var requestDelegate = endpoint.RequestDelegate!;
+        await requestDelegate(httpContext);
+
+        var responseBody = Encoding.UTF8.GetString(responseBodyStream.ToArray());
+
+        Assert.Equal("filtered!", responseBody);
+        Assert.Equal(1, (int)httpContext.Items["First-Order"]!);
+        Assert.Equal(2, (int)httpContext.Items["Second-Order"]!);
+    }
+
+    [Fact]
+    public async Task MapEndpoint_Filtered_DontExecuteEndpointWhenErrorResponseStatus()
+    {
+        var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(EmptyServiceProvider.Instance));
+        var httpContext = new DefaultHttpContext();
+        var responseBodyStream = new MemoryStream();
+        httpContext.Response.Body = responseBodyStream;
+
+        RequestDelegate initialRequestDelegate = static (context) =>
+        {
+            context.Items["ExecutedEndpoint"] = true;
+            throw new Exception("Shouldn't reach here.");
+        };
+
+        var endpointBuilder = builder.Map("/", initialRequestDelegate)
+            .AddEndpointFilterFactory(filterFactory: (routeHandlerContext, next) =>
+            {
+                return async invocationContext =>
+                {
+                    var httpContext = Assert.IsAssignableFrom<HttpContext>(Assert.Single(invocationContext.Arguments));
+                    httpContext.Items["First"] = true;
+                    httpContext.Response.StatusCode = 400;
+                    return await next(invocationContext);
+                };
+            })
+            .AddEndpointFilterFactory(filterFactory: (routeHandlerContext, next) =>
+            {
+                return invocationContext =>
+                {
+                    var httpContext = Assert.IsAssignableFrom<HttpContext>(Assert.Single(invocationContext.Arguments));
+                    httpContext.Items["Second"] = true;
+                    return next(invocationContext);
+                };
+            });
+
+        var dataSource = GetBuilderEndpointDataSource(builder);
+        var endpoint = Assert.Single(dataSource.Endpoints);
+
+        Assert.NotSame(initialRequestDelegate, endpoint.RequestDelegate);
+
+        Assert.NotNull(endpoint.RequestDelegate);
+        var requestDelegate = endpoint.RequestDelegate!;
+        await requestDelegate(httpContext);
+
+        Assert.True((bool)httpContext.Items["First"]!);
+        Assert.True((bool)httpContext.Items["Second"]!);
+        Assert.False(httpContext.Items.ContainsKey("ExecutedEndpoint"));
+    }
+
+    private sealed class HttpContextArgFilter : IEndpointFilter
+    {
+        private readonly string _name;
+
+        public HttpContextArgFilter(string name)
+        {
+            _name = name;
+        }
+
+        public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+        {
+            if (context.Arguments[0] is HttpContext httpContext)
+            {
+                int order;
+                if (httpContext.Items["CurrentOrder"] is int)
+                {
+                    order = (int)httpContext.Items["CurrentOrder"]!;
+                    order++;
+                    httpContext.Items["CurrentOrder"] = order;
+                }
+                else
+                {
+                    order = 1;
+                    httpContext.Items["CurrentOrder"] = order;
+                }
+                httpContext.Items[$"{_name}-Order"] = order;
+            }
+
+            // Ignore thre result and write filtered because we can!
+            _ = await next(context);
+            return "filtered!";
+        }
     }
 
     [Theory]
@@ -316,6 +432,22 @@ public class RequestDelegateEndpointRouteBuilderExtensionsTest
             m => Assert.Equal("System.Runtime.CompilerServices.NullableContextAttribute", m.ToString()),
             m => Assert.IsAssignableFrom<Attribute1>(m),
             m => Assert.IsAssignableFrom<Attribute2>(m));
+    }
+
+    [Fact]
+    public void MapEndpoint_Filter()
+    {
+        // Arrange
+        var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(EmptyServiceProvider.Instance));
+
+        // Act
+        var endpointBuilder = builder
+            .Map(RoutePatternFactory.Parse("/"), context => Task.CompletedTask)
+            .AddEndpointFilter(new HttpContextArgFilter(""));
+
+        // Assert
+        var endpointBuilder1 = GetRouteEndpointBuilder(builder);
+        Assert.Equal("/", endpointBuilder1.RoutePattern.RawText);
     }
 
     [Attribute1]

--- a/src/Http/Routing/test/UnitTests/Builder/RequestDelegateEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/RequestDelegateEndpointRouteBuilderExtensionsTest.cs
@@ -265,15 +265,15 @@ public class RequestDelegateEndpointRouteBuilderExtensionsTest
         var responseBodyStream = new MemoryStream();
         httpContext.Response.Body = responseBodyStream;
 
-        var @delegate = (HttpContext context) => Task.CompletedTask;
+        RequestDelegate requestDelegate = (HttpContext context) => Task.CompletedTask;
 
-        var endpointBuilder = builder.Map("/", @delegate)
+        var endpointBuilder = builder.Map("/", requestDelegate)
             .AddEndpointFilterFactory(filterFactory: (routeHandlerContext, next) =>
             {
                 return async invocationContext =>
                 {
                     await next(invocationContext);
-                    return new MyCoolType(Name: "Jason"); // serialized as JSON
+                    return new MyCoolType(Name: "你好"); // serialized as JSON
                 };
             });
 
@@ -283,7 +283,7 @@ public class RequestDelegateEndpointRouteBuilderExtensionsTest
         await endpoint.RequestDelegate!(httpContext);
 
         var responseBody = Encoding.UTF8.GetString(responseBodyStream.ToArray());
-        Assert.Equal(@"{""name"":""Jason""}", responseBody);
+        Assert.Equal(@"{""name"":""你好""}", responseBody);
     }
 
     private record struct MyCoolType(string Name);

--- a/src/Http/Routing/test/UnitTests/Microsoft.AspNetCore.Routing.Tests.csproj
+++ b/src/Http/Routing/test/UnitTests/Microsoft.AspNetCore.Routing.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Http" />
     <Reference Include="Microsoft.AspNetCore.Routing" />
+    <Reference Include="Microsoft.AspNetCore.Http.Results" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
     <Reference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <Reference Include="Microsoft.Extensions.Logging" />

--- a/src/Shared/RouteHandlers/ExecuteHandlerHelper.cs
+++ b/src/Shared/RouteHandlers/ExecuteHandlerHelper.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http;
+using System.Text.Json.Serialization.Metadata;
+using System.Text.Json;
+
+namespace Microsoft.AspNetCore.Internal;
+
+internal static class ExecuteHandlerHelper
+{
+    public static Task ExecuteReturnAsync(object obj, HttpContext httpContext, JsonSerializerOptions options, JsonTypeInfo<object> jsonTypeInfo)
+    {
+        // Terminal built ins
+        if (obj is IResult result)
+        {
+            return result.ExecuteAsync(httpContext);
+        }
+        else if (obj is string stringValue)
+        {
+            SetPlaintextContentType(httpContext);
+            return httpContext.Response.WriteAsync(stringValue);
+        }
+        else
+        {
+            // Otherwise, we JSON serialize when we reach the terminal state
+            return WriteJsonResponseAsync(httpContext.Response, obj, options, jsonTypeInfo);
+        }
+    }
+
+    public static void SetPlaintextContentType(HttpContext httpContext)
+    {
+        httpContext.Response.ContentType ??= "text/plain; charset=utf-8";
+    }
+
+    public static Task WriteJsonResponseAsync<T>(HttpResponse response, T? value, JsonSerializerOptions options, JsonTypeInfo<T> jsonTypeInfo)
+    {
+        var runtimeType = value?.GetType();
+
+        if (runtimeType is null || jsonTypeInfo.Type == runtimeType || jsonTypeInfo.IsPolymorphicSafe())
+        {
+            // In this case the polymorphism is not
+            // relevant for us and will be handled by STJ, if needed.
+            return HttpResponseJsonExtensions.WriteAsJsonAsync(response, value!, jsonTypeInfo, default);
+        }
+
+        // Call WriteAsJsonAsync() with the runtime type to serialize the runtime type rather than the declared type
+        // and avoid source generators issues.
+        // https://github.com/dotnet/aspnetcore/issues/43894
+        // https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-polymorphism
+        var runtimeTypeInfo = options.GetTypeInfo(runtimeType);
+        return HttpResponseJsonExtensions.WriteAsJsonAsync(response, value!, runtimeTypeInfo, default);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/46014

The goal here is to remove `System.Linq.Expressions` dependency from mapping `RequestDelegate` endpoints (i.e. basic, non-minimal API endpoints). This allows apps that map basic endpoints to avoid warnings from expressions, and reduce publish size by trimming away expressions assembly.

Changes:

* Add `InferMetadataFunc` and `CreateHandlerRequestDelegateFunc` to `RouteEntry`.
* `RequestDelegate` now registers its own func for building request filter factory pipeline. It doesn't use `System.Linq.Expressions`.
* There is some messiness in sharing code because mapping `RequestDelegate` routes lives in `Microsoft.AspNetCore.Routing`. All of `RequestDelegateFactory` lives in `Microsoft.AspNetCore.Http.Extensions`. I tried to share code using source file linking, but a cleaner solution would be to add a public `RequestDelegateFactory.Create(RequestDelegate, ...)` overload that `Microsoft.AspNetCore.Routing` can call. Thoughts? Edit: API proposal - https://github.com/dotnet/aspnetcore/issues/46024

@halter73 @davidfowl This is a start to the changes you discussed making. The next step after this PR is to make public API to configure `InferMetadataFunc` and `CreateHandlerRequestDelegateFunc`. Then source generated code can inject its own logic.