### PR TITLE
GenericWebHostService should not ignore SuppressStatusMessages

### DIFF
--- a/src/Hosting/Hosting/src/GenericHost/GenericWebHostService.cs
+++ b/src/Hosting/Hosting/src/GenericHost/GenericWebHostService.cs
@@ -158,7 +158,7 @@ internal sealed partial class GenericWebHostService : IHostedService
         await Server.StartAsync(httpApplication, cancellationToken);
         HostingEventSource.Log.ServerReady();
 
-        if (addresses != null)
+        if (addresses != null && !Options.WebHostOptions.SuppressStatusMessages)
         {
             foreach (var address in addresses)
             {


### PR DESCRIPTION
# `GenericWebHostService` respects `WebHostOptions.SuppressStatusMessages` now

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Check `WebHostOptions.SuppressStatusMessages` before log `Now listening on...`

## Description

see https://github.com/dotnet/aspnetcore/issues/46022

Fixes #46022 (in this specific format)
