### PR TITLE
Remove legacy check to fix Runtime SiteExtension

### DIFF
--- a/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
+++ b/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
@@ -45,7 +45,7 @@
 
   <Target Name="ResolveReferenceItemsForPackage" DependsOnTargets="ResolveReferences" BeforeTargets="_GetPackageFiles">
     <ItemGroup>
-      <Content Include="$(DotNetUnpackFolder)\**\*.*" Exclude="$(DotNetUnpackFolder)\**\.*" Condition="'$(DotNetAssetRootUrl)' != ''" PackagePath="content\%(RecursiveDir)" />
+      <Content Include="$(DotNetUnpackFolder)\**\*.*" Exclude="$(DotNetUnpackFolder)\**\.*" PackagePath="content\%(RecursiveDir)" />
       <Content Include="%(ShimComponents.DllLocation)"
             Pack="true"
             Condition="'%(ShimComponents.Platform)' == '$(TargetArchitecture)'"


### PR DESCRIPTION
DotNetAssetRootUrl started not being set in 7.0.1 which means the Runtime is no longer copied into the Nupkgs output. This variable is from ProdCon days and shouldn't be used anymore.