### PR TITLE
Get EmptyHttpResult in RDF via reflection (#45878)

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -91,8 +91,17 @@ public static partial class RequestDelegateFactory
     private static readonly MemberExpression FormFilesExpr = Expression.Property(FormExpr, typeof(IFormCollection).GetProperty(nameof(IFormCollection.Files))!);
     private static readonly MemberExpression StatusCodeExpr = Expression.Property(HttpResponseExpr, typeof(HttpResponse).GetProperty(nameof(HttpResponse.StatusCode))!);
     private static readonly MemberExpression CompletedTaskExpr = Expression.Property(null, (PropertyInfo)GetMemberInfo<Func<Task>>(() => Task.CompletedTask));
-    private static readonly NewExpression EmptyHttpResultValueTaskExpr = Expression.New(typeof(ValueTask<object>).GetConstructor(new[] { typeof(EmptyHttpResult) })!, Expression.Property(null, typeof(EmptyHttpResult), nameof(EmptyHttpResult.Instance)));
-
+    // Due to https://github.com/dotnet/aspnetcore/issues/41330 we cannot reference the EmptyHttpResult type
+    // but users still need to assert on it as in https://github.com/dotnet/aspnetcore/issues/45063
+    // so we temporarily work around this here by using reflection to get the actual type.
+    private static readonly object? EmptyHttpResultInstance = Type.GetType("Microsoft.AspNetCore.Http.HttpResults.EmptyHttpResult, Microsoft.AspNetCore.Http.Results")?.GetProperty("Instance")?.GetValue(null, null);
+#if DEBUG
+    private static readonly NewExpression EmptyHttpResultValueTaskExpr = EmptyHttpResultInstance is not null
+            ? Expression.New(typeof(ValueTask<object>).GetConstructor(new[] { typeof(IResult) })!, Expression.Constant(EmptyHttpResultInstance))
+            : throw new UnreachableException("The EmptyHttpResult type could not be found.");
+#else
+    private static readonly NewExpression EmptyHttpResultValueTaskExpr = Expression.New(typeof(ValueTask<object>).GetConstructor(new[] { typeof(IResult) })!, Expression.Constant(EmptyHttpResultInstance));
+#endif
     private static readonly ParameterExpression TempSourceStringExpr = ParameterBindingMethodCache.TempSourceStringExpr;
     private static readonly BinaryExpression TempSourceStringNotNullExpr = Expression.NotEqual(TempSourceStringExpr, Expression.Constant(null));
     private static readonly BinaryExpression TempSourceStringNullExpr = Expression.Equal(TempSourceStringExpr, Expression.Constant(null));
@@ -389,6 +398,7 @@ public static partial class RequestDelegateFactory
     private static EndpointFilterDelegate? CreateFilterPipeline(MethodInfo methodInfo, Expression? targetExpression, RequestDelegateFactoryContext factoryContext, Expression<Func<HttpContext, object?>>? targetFactory)
     {
         Debug.Assert(factoryContext.EndpointBuilder.FilterFactories.Count > 0);
+        Debug.Assert(EmptyHttpResultInstance is not null, "The EmptyHttpResult type could not be found.");
         // httpContext.Response.StatusCode >= 400
         // ? Task.CompletedTask
         // : {
@@ -453,6 +463,7 @@ public static partial class RequestDelegateFactory
 
     private static Expression MapHandlerReturnTypeToValueTask(Expression methodCall, Type returnType)
     {
+        Debug.Assert(EmptyHttpResultInstance is not null, "The EmptyHttpResult type could not be found.");
         if (returnType == typeof(void))
         {
             return Expression.Block(methodCall, EmptyHttpResultValueTaskExpr);
@@ -2097,15 +2108,16 @@ public static partial class RequestDelegateFactory
 
     private static ValueTask<object?> ExecuteTaskWithEmptyResult(Task task)
     {
+        Debug.Assert(EmptyHttpResultInstance is not null, "The EmptyHttpResult type could not be found.");
         static async ValueTask<object?> ExecuteAwaited(Task task)
         {
             await task;
-            return EmptyHttpResult.Instance;
+            return EmptyHttpResultInstance;
         }
 
         if (task.IsCompletedSuccessfully)
         {
-            return new ValueTask<object?>(EmptyHttpResult.Instance);
+            return new ValueTask<object?>(EmptyHttpResultInstance);
         }
 
         return ExecuteAwaited(task);
@@ -2113,16 +2125,17 @@ public static partial class RequestDelegateFactory
 
     private static ValueTask<object?> ExecuteValueTaskWithEmptyResult(ValueTask valueTask)
     {
+        Debug.Assert(EmptyHttpResultInstance is not null, "The EmptyHttpResult type could not be found.");
         static async ValueTask<object?> ExecuteAwaited(ValueTask task)
         {
             await task;
-            return EmptyHttpResult.Instance;
+            return EmptyHttpResultInstance;
         }
 
         if (valueTask.IsCompletedSuccessfully)
         {
             valueTask.GetAwaiter().GetResult();
-            return new ValueTask<object?>(EmptyHttpResult.Instance);
+            return new ValueTask<object?>(EmptyHttpResultInstance);
         }
 
         return ExecuteAwaited(valueTask);
@@ -2439,24 +2452,6 @@ public static partial class RequestDelegateFactory
         foreach (var kv in factoryContext.TrackedParameters)
         {
             errorMessage.AppendLine(FormattableString.Invariant($"{kv.Key,-19} | {kv.Value,-15}"));
-        }
-    }
-
-    // Due to cyclic references between Http.Extensions and
-    // Http.Results, we define our own instance of the `EmptyHttpResult`
-    // type here.
-    private sealed class EmptyHttpResult : IResult
-    {
-        private EmptyHttpResult()
-        {
-        }
-
-        public static EmptyHttpResult Instance { get; } = new();
-
-        /// <inheritdoc/>
-        public Task ExecuteAsync(HttpContext httpContext)
-        {
-            return Task.CompletedTask;
         }
     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -97,7 +97,18 @@ public partial class RequestDelegateFactoryTests : LoggedTest
     {
         var httpContext = CreateHttpContext();
 
-        var factoryResult = RequestDelegateFactory.Create(@delegate);
+        var factoryResult = RequestDelegateFactory.Create(@delegate, new RequestDelegateFactoryOptions()
+        {
+            EndpointBuilder = CreateEndpointBuilderFromFilterFactories(new List<Func<EndpointFilterFactoryContext, EndpointFilterDelegate, EndpointFilterDelegate>>()
+            {
+                (routeHandlerContext, next) => async (context) =>
+                {
+                    var response = await next(context);
+                    Assert.IsType<EmptyHttpResult>(response);
+                    return response;
+                }
+            }),
+        });
         var requestDelegate = factoryResult.RequestDelegate;
 
         await requestDelegate(httpContext);
@@ -6602,6 +6613,34 @@ public partial class RequestDelegateFactoryTests : LoggedTest
 
         Assert.Same(options.EndpointBuilder.RequestDelegate, result.RequestDelegate);
         Assert.Same(options.EndpointBuilder.Metadata, result.EndpointMetadata);
+    }
+
+    [Fact]
+    public async Task RDF_CanAssertOnEmptyResult()
+    {
+        var @delegate = (string name, HttpContext context) => context.Items.Add("param", name);
+
+        var result = RequestDelegateFactory.Create(@delegate, new RequestDelegateFactoryOptions()
+        {
+            EndpointBuilder = CreateEndpointBuilderFromFilterFactories(new List<Func<EndpointFilterFactoryContext, EndpointFilterDelegate, EndpointFilterDelegate>>()
+            {
+                (routeHandlerContext, next) => async (context) =>
+                {
+                    var response = await next(context);
+                    Assert.IsType<EmptyHttpResult>(response);
+                    Assert.Same(Results.Empty, response);
+                    return response;
+                }
+            }),
+        });
+
+        var httpContext = CreateHttpContext();
+        httpContext.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+        {
+            ["name"] = "Tester"
+        });
+
+        await result.RequestDelegate(httpContext);
     }
 
     private DefaultHttpContext CreateHttpContext()

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -23,6 +23,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
Backport of #45878 to `release/7.0`.

## Description

This PR updates the `RequestDelegateFactory` to access the `EmptyHttpResult` type via reflection instead of defining and emitting its own `EmptyHttpResult` as part of the runtime code generation.

Fixes https://github.com/dotnet/aspnetcore/issues/45063

## Customer Impact

Without this change, users cannot adequately write test cases for applications that leverage filters and happen to return an empty result because the internal `EmptyHttpResult` was not public to assert on. This change provides a quality of life improvement and allows users to write more complete test cases for their applications.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Low risk because the surface area of the change is small (minimal APIs with endpoint filters).

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A
