### PR TITLE
Annotate QueryString.HasValue for nullability

### DIFF
--- a/src/Http/Http.Abstractions/src/QueryString.cs
+++ b/src/Http/Http.Abstractions/src/QueryString.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Encodings.Web;
 using Microsoft.Extensions.Primitives;
@@ -39,6 +40,7 @@ public readonly struct QueryString : IEquatable<QueryString>
     /// <summary>
     /// True if the query string is not empty
     /// </summary>
+    [MemberNotNullWhen(true, nameof(Value))]
     public bool HasValue => !string.IsNullOrEmpty(Value);
 
     /// <summary>
@@ -61,7 +63,7 @@ public readonly struct QueryString : IEquatable<QueryString>
     public string ToUriComponent()
     {
         // Escape things properly so System.Uri doesn't mis-interpret the data.
-        return !string.IsNullOrEmpty(Value) ? Value!.Replace("#", "%23") : string.Empty;
+        return HasValue ? Value.Replace("#", "%23") : string.Empty;
     }
 
     /// <summary>
@@ -168,11 +170,11 @@ public readonly struct QueryString : IEquatable<QueryString>
     /// <returns>The concatenated <see cref="QueryString"/>.</returns>
     public QueryString Add(QueryString other)
     {
-        if (!HasValue || Value!.Equals("?", StringComparison.Ordinal))
+        if (!HasValue || Value.Equals("?", StringComparison.Ordinal))
         {
             return other;
         }
-        if (!other.HasValue || other.Value!.Equals("?", StringComparison.Ordinal))
+        if (!other.HasValue || other.Value.Equals("?", StringComparison.Ordinal))
         {
             return this;
         }
@@ -192,7 +194,7 @@ public readonly struct QueryString : IEquatable<QueryString>
     {
         ArgumentNullException.ThrowIfNull(name);
 
-        if (!HasValue || Value!.Equals("?", StringComparison.Ordinal))
+        if (!HasValue || Value.Equals("?", StringComparison.Ordinal))
         {
             return Create(name, value);
         }
@@ -236,7 +238,7 @@ public readonly struct QueryString : IEquatable<QueryString>
     /// <returns>The hash code as an <see cref="int"/>.</returns>
     public override int GetHashCode()
     {
-        return (HasValue ? Value!.GetHashCode() : 0);
+        return (HasValue ? Value.GetHashCode() : 0);
     }
 
     /// <summary>


### PR DESCRIPTION
Added `[MemberNotNullWhen(true, nameof(Value))]` to `QueryString.HasValue` to avoid having to spam `!` everywhere.
This matches `PathString.HasValue` which already has the attribute.
https://github.com/dotnet/aspnetcore/blob/d194f5091ffa2ebd450845edf30721d623d848dd/src/Http/Http.Abstractions/src/PathString.cs#L48-L49
