### PR TITLE
[release/6.0] Remove legacy check to fix Runtime SiteExtension

### DIFF
--- a/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
+++ b/src/SiteExtensions/Runtime/Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj
@@ -42,7 +42,7 @@
 
   <Target Name="ResolveReferenceItemsForPackage" DependsOnTargets="ResolveReferences" BeforeTargets="_GetPackageFiles">
     <ItemGroup>
-      <Content Include="$(DotNetUnpackFolder)\**\*.*" Exclude="$(DotNetUnpackFolder)\**\.*" Condition="$(DotNetAssetRootUrl) != ''" PackagePath="content\%(RecursiveDir)" />
+      <Content Include="$(DotNetUnpackFolder)\**\*.*" Exclude="$(DotNetUnpackFolder)\**\.*" PackagePath="content\%(RecursiveDir)" />
       <Content Include="%(ShimComponents.DllLocation)"
             Pack="true"
             Condition="'%(ShimComponents.Platform)' == '$(TargetArchitecture)'"


### PR DESCRIPTION
Backport of #46033 to release/6.0

# Remove legacy check to fix Runtime SiteExtension

Summary of the changes (Less than 80 chars)

## Description

This package bundles the Runtime and ANCM and then modifies the web.config in App Service to use the bundled versions. A change in infrastructure in 7.0.1 caused the package to no longer bundle the Runtime.

## Customer Impact

Azure App Service reported a customer complaining about the 7.0.1 package no longer functioning.

## Regression?

- [x] Yes
- [ ] No

7.0.0 builds set a legacy setting, starting in 7.0.1 the setting was no longer set. Something about arcade changes that removed the legacy variable.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

We were just getting lucky before that a legacy setting was set in our builds that allowed the package to be built correctly. This removes the reliance on the setting, nothing else about the package being built changed.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [x] Yes
- [ ] No
- [ ] N/A
