### PR TITLE
Set StaticFileOptions.OnPrepareResponse = CacheHeaderSettings.SetCacheHeaders for Blazor static files endpoint

### DIFF
--- a/src/Components/Server/src/Builder/ComponentEndpointRouteBuilderExtensions.cs
+++ b/src/Components/Server/src/Builder/ComponentEndpointRouteBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.AspNetCore.Builder;
@@ -96,7 +97,8 @@ public static class ComponentEndpointRouteBuilderExtensions
     {
         var options = new StaticFileOptions
         {
-            FileProvider = new ManifestEmbeddedFileProvider(typeof(ComponentEndpointRouteBuilderExtensions).Assembly)
+            FileProvider = new ManifestEmbeddedFileProvider(typeof(ComponentEndpointRouteBuilderExtensions).Assembly),
+            OnPrepareResponse = CacheHeaderSettings.SetCacheHeaders
         };
 
         var app = endpoints.CreateApplicationBuilder();


### PR DESCRIPTION
# Set StaticFileOptions.OnPrepareResponse = CacheHeaderSettings.SetCacheHeaders for Blazor static files endpoint

 In the [PR](https://github.com/dotnet/aspnetcore/pull/45897) forgot to set StaticFileOptions.OnPrepareResponse = CacheHeaderSettings.SetCacheHeaders for Blazor static files endpoint. 
By doing this now, we're allowing the browser to store a cached copy of the response, but telling it that it must check with the server for modifications (based on Etag) before using that cached copy.

