### PR TITLE
Enumerate paramnames on startup

### DIFF
--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -277,7 +277,7 @@ public static partial class RequestDelegateFactory
             Handler = handler,
             ServiceProvider = serviceProvider,
             ServiceProviderIsService = serviceProvider.GetService<IServiceProviderIsService>(),
-            RouteParameters = options?.RouteParameterNames?.ToList(),
+            RouteParameters = options?.RouteParameterNames,
             ThrowOnBadRequest = options?.ThrowOnBadRequest ?? false,
             DisableInferredFromBody = options?.DisableInferBodyFromParameters ?? false,
             EndpointBuilder = endpointBuilder,

--- a/src/Http/Http.Extensions/src/RequestDelegateFactoryContext.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactoryContext.cs
@@ -14,7 +14,7 @@ internal sealed class RequestDelegateFactoryContext
     // Options
     public required IServiceProvider ServiceProvider { get; init; }
     public required IServiceProviderIsService? ServiceProviderIsService { get; init; }
-    public required List<string>? RouteParameters { get; init; }
+    public required IEnumerable<string>? RouteParameters { get; init; }
     public required bool ThrowOnBadRequest { get; init; }
     public required bool DisableInferredFromBody { get; init; }
     public required EndpointBuilder EndpointBuilder { get; init; }

--- a/src/Http/Routing/src/RouteEndpointDataSource.cs
+++ b/src/Http/Routing/src/RouteEndpointDataSource.cs
@@ -277,20 +277,22 @@ internal sealed class RouteEndpointDataSource : EndpointDataSource
 
     private RequestDelegateFactoryOptions CreateRdfOptions(RouteEntry entry, RoutePattern pattern, RouteEndpointBuilder builder)
     {
-        var routeParamNames = new List<string>(pattern.Parameters.Count);
-        foreach (var parameter in pattern.Parameters)
-        {
-            routeParamNames.Add(parameter.Name);
-        }
-
         return new()
         {
             ServiceProvider = _applicationServices,
-            RouteParameterNames = routeParamNames,
+            RouteParameterNames = ProduceRouteParamNames(),
             ThrowOnBadRequest = _throwOnBadRequest,
             DisableInferBodyFromParameters = ShouldDisableInferredBodyParameters(entry.HttpMethods),
             EndpointBuilder = builder,
         };
+
+        IEnumerable<string> ProduceRouteParamNames()
+        {
+            foreach (var routePatternPart in pattern.Parameters)
+            {
+                yield return routePatternPart.Name;
+            }
+        }
     }
 
     private static bool ShouldDisableInferredBodyParameters(IEnumerable<string>? httpMethods)


### PR DESCRIPTION
# Enumerate endpoint parameter names on startup instead of allocating a list.


- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.


Summary of the changes 

## Use Enumerable instead of List to save allocation

Use of `IEnumerable<string>` when getting the endpoint parameters names from the collection, which then gets used to create the `RequestDelegateFactoryContext`

Fixes https://github.com/dotnet/aspnetcore/issues/46010

