### PR TITLE
Fix Blazor PageContext disposal

### DIFF
--- a/src/Components/WebView/WebView/src/PageContext.cs
+++ b/src/Components/WebView/WebView/src/PageContext.cs
@@ -48,9 +48,9 @@ internal sealed class PageContext : IAsyncDisposable
         Renderer = new WebViewRenderer(services, dispatcher, ipcSender, loggerFactory, JSRuntime, jsComponents);
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-        Renderer.Dispose();
-        return _serviceScope.DisposeAsync();
+        await Renderer.DisposeAsync();
+        await _serviceScope.DisposeAsync();
     }
 }


### PR DESCRIPTION
# Fix Blazor PageContext disposal

The `PageContext.DisposeAsync()` method was invoking `Renderer.Dispose()`, which does not wait for asynchronous component disposal logic to complete. This PR fixes this issue by awaiting `Renderer.DisposeAsync()` instead.

## Description

Without this fix, asynchronous Blazor Hybrid component disposal logic may throw exceptions if Blazor services are accessed. See https://github.com/dotnet/maui/issues/7997#issuecomment-1258681003 for additional context and details.

Fixes https://github.com/dotnet/maui/issues/7997
