### PR TITLE
string.Split to Span.Split

### DIFF
--- a/src/Http/Routing/src/Matching/HostMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/HostMatcherPolicy.cs
@@ -154,25 +154,27 @@ public sealed class HostMatcherPolicy : MatcherPolicy, IEndpointComparerPolicy, 
             return EdgeKey.WildcardEdgeKey;
         }
 
-        var hostParts = host.Split(':');
-        if (hostParts.Length == 1)
+        Span<Range> hostParts = stackalloc Range[3];
+        var hostSpan = host.AsSpan();
+        var length = hostSpan.Split(hostParts, ':');
+        if (length == 1)
         {
-            if (!string.IsNullOrEmpty(hostParts[0]))
+            if (!hostSpan[hostParts[0]].IsEmpty)
             {
-                return new EdgeKey(hostParts[0], null);
+                return new EdgeKey(hostSpan[hostParts[0]].ToString(), null);
             }
         }
-        if (hostParts.Length == 2)
+        if (length == 2)
         {
-            if (!string.IsNullOrEmpty(hostParts[0]))
+            if (!hostSpan[hostParts[0]].IsEmpty)
             {
-                if (int.TryParse(hostParts[1], out var port))
+                if (int.TryParse(hostSpan[hostParts[1]], out var port))
                 {
-                    return new EdgeKey(hostParts[0], port);
+                    return new EdgeKey(hostSpan[hostParts[0]].ToString(), port);
                 }
-                else if (string.Equals(hostParts[1], WildcardHost, StringComparison.Ordinal))
+                else if (hostSpan[hostParts[1]].Equals(WildcardHost, StringComparison.Ordinal))
                 {
-                    return new EdgeKey(hostParts[0], null);
+                    return new EdgeKey(hostSpan[hostParts[0]].ToString(), null);
                 }
             }
         }

--- a/src/Identity/Extensions.Stores/src/UserStoreBase.cs
+++ b/src/Identity/Extensions.Stores/src/UserStoreBase.cs
@@ -920,7 +920,20 @@ public abstract class UserStoreBase<TUser, [DynamicallyAccessedMembers(Dynamical
         var mergedCodes = await GetTokenAsync(user, InternalLoginProvider, RecoveryCodeTokenName, cancellationToken).ConfigureAwait(false) ?? "";
         if (mergedCodes.Length > 0)
         {
-            return mergedCodes.Split(';').Length;
+            // non-allocating version of mergedCodes.Split(';').Length
+            var count = 1;
+            var index = 0;
+            while (index < mergedCodes.Length)
+            {
+                var semiColonIndex = mergedCodes.IndexOf(';', index);
+                if (semiColonIndex < 0)
+                {
+                    break;
+                }
+                count++;
+                index = semiColonIndex + 1;
+            }
+            return count;
         }
         return 0;
     }

--- a/src/Middleware/Localization/src/CookieRequestCultureProvider.cs
+++ b/src/Middleware/Localization/src/CookieRequestCultureProvider.cs
@@ -69,15 +69,16 @@ public class CookieRequestCultureProvider : RequestCultureProvider
             return null;
         }
 
-        var parts = value.Split(_cookieSeparator, StringSplitOptions.RemoveEmptyEntries);
-
-        if (parts.Length != 2)
+        //var parts = value.Split(_cookieSeparator, StringSplitOptions.RemoveEmptyEntries);
+        Span<Range> parts = stackalloc Range[3];
+        var valueSpan = value.AsSpan();
+        if (valueSpan.Split(parts, _cookieSeparator, StringSplitOptions.RemoveEmptyEntries) != 2)
         {
             return null;
         }
 
-        var potentialCultureName = parts[0];
-        var potentialUICultureName = parts[1];
+        var potentialCultureName = valueSpan[parts[0]];
+        var potentialUICultureName = valueSpan[parts[1]];
 
         if (!potentialCultureName.StartsWith(_culturePrefix, StringComparison.Ordinal) || !
             potentialUICultureName.StartsWith(_uiCulturePrefix, StringComparison.Ordinal))
@@ -85,8 +86,8 @@ public class CookieRequestCultureProvider : RequestCultureProvider
             return null;
         }
 
-        var cultureName = potentialCultureName.Substring(_culturePrefix.Length);
-        var uiCultureName = potentialUICultureName.Substring(_uiCulturePrefix.Length);
+        var cultureName = potentialCultureName.Slice(_culturePrefix.Length);
+        var uiCultureName = potentialUICultureName.Slice(_uiCulturePrefix.Length);
 
         if (cultureName == null && uiCultureName == null)
         {
@@ -105,6 +106,6 @@ public class CookieRequestCultureProvider : RequestCultureProvider
             cultureName = uiCultureName;
         }
 
-        return new ProviderCultureResult(cultureName, uiCultureName);
+        return new ProviderCultureResult(cultureName.ToString(), uiCultureName.ToString());
     }
 }

--- a/src/Middleware/Localization/src/CookieRequestCultureProvider.cs
+++ b/src/Middleware/Localization/src/CookieRequestCultureProvider.cs
@@ -69,7 +69,6 @@ public class CookieRequestCultureProvider : RequestCultureProvider
             return null;
         }
 
-        //var parts = value.Split(_cookieSeparator, StringSplitOptions.RemoveEmptyEntries);
         Span<Range> parts = stackalloc Range[3];
         var valueSpan = value.AsSpan();
         if (valueSpan.Split(parts, _cookieSeparator, StringSplitOptions.RemoveEmptyEntries) != 2)
@@ -89,18 +88,18 @@ public class CookieRequestCultureProvider : RequestCultureProvider
         var cultureName = potentialCultureName.Slice(_culturePrefix.Length);
         var uiCultureName = potentialUICultureName.Slice(_uiCulturePrefix.Length);
 
-        if (cultureName == null && uiCultureName == null)
+        if (cultureName.IsEmpty && uiCultureName.IsEmpty)
         {
             // No values specified for either so no match
             return null;
         }
 
-        if (cultureName != null && uiCultureName == null)
+        if (!cultureName.IsEmpty && uiCultureName.IsEmpty)
         {
             // Value for culture but not for UI culture so default to culture value for both
             uiCultureName = cultureName;
         }
-        else if (cultureName == null && uiCultureName != null)
+        else if (cultureName.IsEmpty && !uiCultureName.IsEmpty)
         {
             // Value for UI culture but not for culture so default to UI culture value for both
             cultureName = uiCultureName;

--- a/src/Middleware/Rewrite/src/ApacheModRewrite/FileParser.cs
+++ b/src/Middleware/Rewrite/src/ApacheModRewrite/FileParser.cs
@@ -12,9 +12,6 @@ internal sealed class FileParser
         var builder = new RuleBuilder();
         var lineNum = 0;
 
-        // parsers
-        var flagsParser = new FlagParser();
-
         while ((line = input.ReadLine()) != null)
         {
             lineNum++;
@@ -48,7 +45,7 @@ internal sealed class FileParser
                         var flags = new Flags();
                         if (tokens.Count == 4)
                         {
-                            flags = flagsParser.Parse(tokens[3]);
+                            flags = FlagParser.Parse(tokens[3]);
                         }
 
                         builder.AddConditionFromParts(pattern, condActionParsed, flags);
@@ -67,7 +64,7 @@ internal sealed class FileParser
                         Flags flags;
                         if (tokens.Count == 4)
                         {
-                            flags = flagsParser.Parse(tokens[3]);
+                            flags = FlagParser.Parse(tokens[3]);
                         }
                         else
                         {

--- a/src/Middleware/Rewrite/src/ApacheModRewrite/FlagParser.cs
+++ b/src/Middleware/Rewrite/src/ApacheModRewrite/FlagParser.cs
@@ -3,9 +3,9 @@
 
 namespace Microsoft.AspNetCore.Rewrite.ApacheModRewrite;
 
-internal sealed class FlagParser
+internal static class FlagParser
 {
-    private readonly IDictionary<string, FlagType> _ruleFlagLookup = new Dictionary<string, FlagType>(StringComparer.OrdinalIgnoreCase) {
+    private static readonly IDictionary<string, FlagType> _ruleFlagLookup = new Dictionary<string, FlagType>(StringComparer.OrdinalIgnoreCase) {
             { "b", FlagType.EscapeBackreference},
             { "c", FlagType.Chain },
             { "chain", FlagType.Chain},
@@ -52,7 +52,7 @@ internal sealed class FlagParser
             { "type", FlagType.Type },
         };
 
-    public Flags Parse(string flagString)
+    public static Flags Parse(string flagString)
     {
         if (string.IsNullOrEmpty(flagString))
         {
@@ -70,19 +70,21 @@ internal sealed class FlagParser
         // Invalid syntax to have any spaces.
         var tokens = flagString.Substring(1, flagString.Length - 2).Split(',');
         var flags = new Flags();
+        Span<Range> hasPayload = stackalloc Range[3];
         foreach (var token in tokens)
         {
-            var hasPayload = token.Split('=');
+            var tokenSpan = token.AsSpan();
+            var length = tokenSpan.Split(hasPayload, '=');
 
             FlagType flag;
-            if (!_ruleFlagLookup.TryGetValue(hasPayload[0], out flag))
+            if (!_ruleFlagLookup.TryGetValue(tokenSpan[hasPayload[0]].ToString(), out flag))
             {
-                throw new FormatException($"Unrecognized flag: '{hasPayload[0]}'");
+                throw new FormatException($"Unrecognized flag: '{tokenSpan[hasPayload[0]]}'");
             }
 
-            if (hasPayload.Length == 2)
+            if (length == 2)
             {
-                flags.SetFlag(flag, hasPayload[1]);
+                flags.SetFlag(flag, tokenSpan[hasPayload[1]].ToString());
             }
             else
             {

--- a/src/Middleware/Rewrite/src/ApacheModRewrite/RuleBuilder.cs
+++ b/src/Middleware/Rewrite/src/ApacheModRewrite/RuleBuilder.cs
@@ -36,7 +36,7 @@ internal sealed class RuleBuilder
         Flags flags;
         if (tokens.Count == 4)
         {
-            flags = new FlagParser().Parse(tokens[3]);
+            flags = FlagParser.Parse(tokens[3]);
         }
         else
         {

--- a/src/Middleware/Rewrite/test/ApacheModRewrite/FlagParserTest.cs
+++ b/src/Middleware/Rewrite/test/ApacheModRewrite/FlagParserTest.cs
@@ -10,7 +10,7 @@ public class FlagParserTest
     [Fact]
     public void FlagParser_CheckSingleTerm()
     {
-        var results = new FlagParser().Parse("[NC]");
+        var results = FlagParser.Parse("[NC]");
         var dict = new Dictionary<FlagType, string>();
         dict.Add(FlagType.NoCase, string.Empty);
         var expected = new Flags(dict);
@@ -21,7 +21,7 @@ public class FlagParserTest
     [Fact]
     public void FlagParser_CheckManyTerms()
     {
-        var results = new FlagParser().Parse("[NC,F,L]");
+        var results = FlagParser.Parse("[NC,F,L]");
         var dict = new Dictionary<FlagType, string>();
         dict.Add(FlagType.NoCase, string.Empty);
         dict.Add(FlagType.Forbidden, string.Empty);
@@ -34,7 +34,7 @@ public class FlagParserTest
     [Fact]
     public void FlagParser_CheckManyTermsWithEquals()
     {
-        var results = new FlagParser().Parse("[NC,F,R=301]");
+        var results = FlagParser.Parse("[NC,F,R=301]");
         var dict = new Dictionary<FlagType, string>();
         dict.Add(FlagType.NoCase, string.Empty);
         dict.Add(FlagType.Forbidden, string.Empty);
@@ -51,15 +51,15 @@ public class FlagParserTest
     [InlineData("[RL]", "Unrecognized flag: 'RL'")]
     public void FlagParser_AssertFormatErrorWhenFlagsArePoorlyConstructed(string input, string expected)
     {
-        var ex = Assert.Throws<FormatException>(() => new FlagParser().Parse(input));
+        var ex = Assert.Throws<FormatException>(() => FlagParser.Parse(input));
         Assert.Equal(expected, ex.Message);
     }
 
     [Fact]
     public void FlagParser_AssertArgumentExceptionWhenFlagsAreNullOrEmpty()
     {
-        Assert.Throws<ArgumentException>(() => new FlagParser().Parse(null));
-        Assert.Throws<ArgumentException>(() => new FlagParser().Parse(string.Empty));
+        Assert.Throws<ArgumentException>(() => FlagParser.Parse(null));
+        Assert.Throws<ArgumentException>(() => FlagParser.Parse(string.Empty));
     }
 
     [Theory]
@@ -68,7 +68,7 @@ public class FlagParserTest
     [InlineData("[CO=;NAME:VALUE;ABC:123]", ";NAME:VALUE;ABC:123")]
     public void Flag_ParserHandlesComplexFlags(string flagString, string expected)
     {
-        var results = new FlagParser().Parse(flagString);
+        var results = FlagParser.Parse(flagString);
         string value;
         Assert.True(results.GetValue(FlagType.Cookie, out value));
         Assert.Equal(expected, value);

--- a/src/Middleware/StaticFiles/src/HtmlDirectoryFormatter.cs
+++ b/src/Middleware/StaticFiles/src/HtmlDirectoryFormatter.cs
@@ -103,7 +103,7 @@ public class HtmlDirectoryFormatter : IDirectoryFormatter
     <header><h1>{0} <a href=""/"">/</a>", HtmlEncode(Resources.HtmlDir_IndexOf));
 
         string cumulativePath = "/";
-        foreach (var segment in requestPath.Value!.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries))
+        foreach (var segment in requestPath.Value!.Split('/', StringSplitOptions.RemoveEmptyEntries))
         {
             cumulativePath = cumulativePath + segment + "/";
             builder.AppendFormat(

--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -563,8 +563,7 @@ internal sealed partial class Request
         }
 
         var index = transferEncoding.LastIndexOf(',');
-        index = index == -1 ? 0 : index + 1;
-        if (transferEncoding.AsSpan().Slice(index).Trim().Equals("chunked", StringComparison.OrdinalIgnoreCase))
+        if (transferEncoding.AsSpan().Slice(index + 1).Trim().Equals("chunked", StringComparison.OrdinalIgnoreCase))
         {
             return true;
         }

--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -205,7 +205,7 @@ internal sealed partial class Request
             {
                 // Note Http.Sys adds the Transfer-Encoding: chunked header to HTTP/2 requests with bodies for back compat.
                 var transferEncoding = Headers[HeaderNames.TransferEncoding].ToString();
-                if (transferEncoding != null && string.Equals("chunked", transferEncoding.Split(',')[^1].Trim(), StringComparison.OrdinalIgnoreCase))
+                if (IsChunked(transferEncoding))
                 {
                     _contentBoundaryType = BoundaryType.Chunked;
                 }
@@ -532,7 +532,7 @@ internal sealed partial class Request
         if (StringValues.IsNullOrEmpty(Headers.ContentLength)) { return; }
 
         var transferEncoding = Headers[HeaderNames.TransferEncoding].ToString();
-        if (transferEncoding == null || !string.Equals("chunked", transferEncoding.Split(',')[^1].Trim(), StringComparison.OrdinalIgnoreCase))
+        if (!IsChunked(transferEncoding))
         {
             return;
         }
@@ -553,5 +553,21 @@ internal sealed partial class Request
         IHeaderDictionary headerDictionary = Headers;
         headerDictionary.Add("X-Content-Length", headerDictionary[HeaderNames.ContentLength]);
         Headers.ContentLength = StringValues.Empty;
+    }
+
+    private static bool IsChunked(string? transferEncoding)
+    {
+        if (transferEncoding is null)
+        {
+            return false;
+        }
+
+        var index = transferEncoding.LastIndexOf(',');
+        index = index == -1 ? 0 : index + 1;
+        if (transferEncoding.AsSpan().Slice(index).Trim().Equals("chunked", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -345,7 +345,7 @@ internal abstract partial class IISHttpContext : NativeRequestContext, IThreadPo
         // Note Http.Sys adds the Transfer-Encoding: chunked header to HTTP/2 requests with bodies for back compat.
         // Transfer-Encoding takes priority over Content-Length.
         string transferEncoding = RequestHeaders.TransferEncoding.ToString();
-        if (transferEncoding != null && string.Equals("chunked", transferEncoding.Split(',')[^1].Trim(), StringComparison.OrdinalIgnoreCase))
+        if (IsChunked(transferEncoding))
         {
             // https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
             // A sender MUST NOT send a Content-Length header field in any message
@@ -829,5 +829,21 @@ internal abstract partial class IISHttpContext : NativeRequestContext, IThreadPo
     {
         return success ? NativeMethods.REQUEST_NOTIFICATION_STATUS.RQ_NOTIFICATION_CONTINUE
                        : NativeMethods.REQUEST_NOTIFICATION_STATUS.RQ_NOTIFICATION_FINISH_REQUEST;
+    }
+
+    private static bool IsChunked(string? transferEncoding)
+    {
+        if (transferEncoding is null)
+        {
+            return false;
+        }
+
+        var index = transferEncoding.LastIndexOf(',');
+        index = index == -1 ? 0 : index + 1;
+        if (transferEncoding.AsSpan().Slice(index).Trim().Equals("chunked", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -839,8 +839,7 @@ internal abstract partial class IISHttpContext : NativeRequestContext, IThreadPo
         }
 
         var index = transferEncoding.LastIndexOf(',');
-        index = index == -1 ? 0 : index + 1;
-        if (transferEncoding.AsSpan().Slice(index).Trim().Equals("chunked", StringComparison.OrdinalIgnoreCase))
+        if (transferEncoding.AsSpan().Slice(index + 1).Trim().Equals("chunked", StringComparison.OrdinalIgnoreCase))
         {
             return true;
         }


### PR DESCRIPTION
New `ReadOnlySpan<char>.Split` methods introduced in https://github.com/dotnet/runtime/issues/76186 can avoid the string+array allocations from `string.Split` in some cases. Went through our code base and found where we can use the new methods.