### PR TITLE
Support SkipStatusCodePages when not using WebApplication builder and UseStatusCodePagesWithReExecute

### DIFF
--- a/src/Middleware/Diagnostics/src/StatusCodePage/StatusCodePagesMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/StatusCodePage/StatusCodePagesMiddleware.cs
@@ -41,9 +41,9 @@ public class StatusCodePagesMiddleware
         var statusCodeFeature = new StatusCodePagesFeature();
         context.Features.Set<IStatusCodePagesFeature>(statusCodeFeature);
         var endpoint = context.GetEndpoint();
-        var skipStatusCodePageMetadata = endpoint?.Metadata.GetMetadata<ISkipStatusCodePagesMetadata>();
+        var shouldCheckEndpointAgain= endpoint is null;
 
-        if (skipStatusCodePageMetadata is not null)
+        if (HasSkipStatusCodePagesMetadata(endpoint))
         {
             statusCodeFeature.Enabled = false;
         }
@@ -54,6 +54,12 @@ public class StatusCodePagesMiddleware
         {
             // Check if the feature is still available because other middleware (such as a web API written in MVC) could
             // have disabled the feature to prevent HTML status code responses from showing up to an API client.
+            return;
+        }
+
+        if (shouldCheckEndpointAgain && HasSkipStatusCodePagesMetadata(context.GetEndpoint()))
+        {
+            // If the endpoint was null check the endpoint again since it could have been set by another middleware.
             return;
         }
 
@@ -69,5 +75,12 @@ public class StatusCodePagesMiddleware
 
         var statusCodeContext = new StatusCodeContext(context, _options, _next);
         await _options.HandleAsync(statusCodeContext);
+    }
+
+    private static bool HasSkipStatusCodePagesMetadata(Endpoint? endpoint)
+    {
+        var skipStatusCodePageMetadata = endpoint?.Metadata.GetMetadata<ISkipStatusCodePagesMetadata>();
+
+        return skipStatusCodePageMetadata is not null;
     }
 }

--- a/src/Middleware/Diagnostics/src/StatusCodePage/StatusCodePagesMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/StatusCodePage/StatusCodePagesMiddleware.cs
@@ -41,7 +41,7 @@ public class StatusCodePagesMiddleware
         var statusCodeFeature = new StatusCodePagesFeature();
         context.Features.Set<IStatusCodePagesFeature>(statusCodeFeature);
         var endpoint = context.GetEndpoint();
-        var shouldCheckEndpointAgain= endpoint is null;
+        var shouldCheckEndpointAgain = endpoint is null;
 
         if (HasSkipStatusCodePagesMetadata(endpoint))
         {

--- a/src/Middleware/Diagnostics/test/UnitTests/StatusCodeMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/StatusCodeMiddlewareTest.cs
@@ -313,4 +313,80 @@ public class StatusCodeMiddlewareTest
         var content = await response.Content.ReadAsStringAsync();
         Assert.Empty(content);
     }
+
+    [Fact]
+    public async Task SkipStatusCodePages_SupportsSkipIfUsedBeforeRouting()
+    {
+        using var host = new HostBuilder()
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseTestServer()
+                .ConfigureServices(services => services.AddRouting())
+                .Configure(app =>
+                {
+                    app.UseStatusCodePagesWithReExecute("/status");
+                    app.UseRouting();
+
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapGet("/skip", [SkipStatusCodePages](c) =>
+                        {
+                            c.Response.StatusCode = 400;
+                            return Task.CompletedTask;
+                        });
+
+                        endpoints.MapGet("/status", (HttpResponse response) => $"Status: {response.StatusCode}");
+                    });
+
+                    app.Run(_ => throw new InvalidOperationException("Invalid input provided."));
+                });
+            }).Build();
+
+        await host.StartAsync();
+
+        using var server = host.GetTestServer();
+        var client = server.CreateClient();
+        var response = await client.GetAsync("/skip");
+        var content = await response.Content.ReadAsStringAsync();
+
+        Assert.Empty(content);
+    }
+
+    [Fact]
+    public async Task SkipStatusCodePages_WorksIfUsedBeforeRouting()
+    {
+        using var host = new HostBuilder()
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseTestServer()
+                .ConfigureServices(services => services.AddRouting())
+                .Configure(app =>
+                {
+                    app.UseStatusCodePagesWithReExecute("/status");
+                    app.UseRouting();
+
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapGet("/", (c) =>
+                        {
+                            c.Response.StatusCode = 400;
+                            return Task.CompletedTask;
+                        });
+
+                        endpoints.MapGet("/status", (HttpResponse response) => $"Status: {response.StatusCode}");
+                    });
+
+                    app.Run(_ => throw new InvalidOperationException("Invalid input provided."));
+                });
+            }).Build();
+
+        await host.StartAsync();
+
+        using var server = host.GetTestServer();
+        var client = server.CreateClient();
+        var response = await client.GetAsync("/");
+        var content = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal("Status: 400", content);
+    }
 }


### PR DESCRIPTION
Add support for SkipStatusCodePages attribute when using minimal APIs with a non WebApplication builder and UseRouting.

I have implemented the suggested fix as stated in the issue.

Fixes #39472