### PR TITLE
Add token to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,44 @@
 version: 2
+registries:
+  azure.com:
+    token: ${{secrets.DEPENDABOT_NPM_TOKEN}}
+    type: npm-registry
+    url: https://pkgs.dev.azure.com/
+
 updates:
-  # Keep submodules up to date in 'main'.
-  - package-ecosystem: "gitsubmodule"
+  - package-ecosystem: npm
+    directory: "/"
+    # Perform only security updates of our npm dependencies.
+    open-pull-requests-limit: 0
+    registries:
+    - azure.com
+    # Schedule should be ignored for security updates.
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Weekly interval opens PRs on Monday.
+      day: monday
       interval: "weekly"
-    allow:
-      - dependency-type: "all"
+      time: 05:00
+      timezone: "America/Los_Angeles"
     commit-message:
       prefix: "[main] "
       include: scope
     labels:
       - area-infrastructure
-  - package-ecosystem: "github-actions"
+
+  # Keep submodules up to date in 'main'.
+  - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      # Weekly interval opens PRs on Monday.
+      day: monday
       interval: "weekly"
+      time: 05:00
+      timezone: "America/Los_Angeles"
+    allow:
+      - dependency-type: "all"
     commit-message:
       prefix: "[main] "
       include: scope
@@ -38,18 +59,6 @@ updates:
     labels:
       - area-infrastructure
     target-branch: "release/2.1"
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    allow:
-      - dependency-type: "all"
-    commit-message:
-      prefix: "[release/3.1] "
-      include: scope
-    labels:
-      - area-infrastructure
-    target-branch: "release/3.1"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+# yarn lockfile v1
+registry "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/"


### PR DESCRIPTION
- use new `DEPENDABOT_NPM_TOKEN` token
- add a .yarnrc file enforcing our registry choice globally
  - might not be necessary now but will help if we add new `npm` projects
- remove submodule update configuration for release/3.1

nits:
- add explicit day and time for our weekly updates
- move submodule update configurations together
  - Monday is the default but configuration takes less words than previous comments