### PR TITLE
Use a fresh execution context for application logic

### DIFF
--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -598,7 +598,6 @@ internal sealed partial class HttpConnectionContext : ConnectionContext,
         }
     }
 
-
     internal void StartSendCancellation()
     {
         if (!_options.TransportSendTimeoutEnabled)


### PR DESCRIPTION
Discard the execution context when running the user application in the http transport. This stops all async locals from flowing from the initial request that establishes the SignalR connection from flowing into the connection delegate pipeline. 

- This officially breaks the IHttpContextAccessor in both blazor and SignalR applications (HttpContext will be null)
- The activity will no longer flow from the initial request into *all* SignalR invocations from that 
- Logging scopes from the original request will not flow to application logic 
- It breaks the current culture flowing from the request localization middleware 

"Fixes" https://github.com/dotnet/aspnetcore/issues/29846. Blazor server will no longer get an activity.

cc @javiercn @SteveSandersonMS 