### PR TITLE
Wait for Request to finish

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocesshandler.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocesshandler.cpp
@@ -25,7 +25,8 @@ IN_PROCESS_HANDLER::IN_PROCESS_HANDLER(
    m_pRequestHandlerContext(pRequestHandlerContext),
    m_pAsyncCompletionHandler(pAsyncCompletion),
    m_pDisconnectHandler(pDisconnectHandler),
-   m_disconnectFired(false)
+   m_disconnectFired(false),
+   m_queueNotified(false)
 {
     InitializeSRWLock(&m_srwDisconnectLock);
 }

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocesshandler.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocesshandler.h
@@ -7,6 +7,8 @@
 #include <memory>
 #include "iapplication.h"
 #include "inprocessapplication.h"
+#include <mutex>
+#include <condition_variable>
 
 class IN_PROCESS_APPLICATION;
 
@@ -88,4 +90,8 @@ private:
     static ALLOC_CACHE_HANDLER *   sm_pAlloc;
     bool m_disconnectFired;
     SRWLOCK m_srwDisconnectLock;
+
+    std::mutex m_lockQueue;
+    std::condition_variable m_queueCheck;
+    bool m_queueNotified;
 };

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -807,6 +807,7 @@ internal abstract partial class IISHttpContext : NativeRequestContext, IThreadPo
         finally
         {
             // Post completion after completing the request to resume the state machine
+            // This must be called before freeing the GCHandle _thisHandle, see comment in IndicateManagedRequestComplete for details
             PostCompletion(ConvertRequestCompletionResults(successfulRequest));
 
             // After disposing a safe handle, Dispose() will not block waiting for the pinvokes to finish.


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/40498

<h2>The problem</h2>

IIS can detect a request disconnection and calls our `NotifyDisconnect` method which will notify our managed code which aborts the managed side of the request
https://github.com/dotnet/aspnetcore/blob/e67e77d85e74c94fd72a942b3b8e77c74c228cd6/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocesshandler.cpp#L116
https://github.com/dotnet/aspnetcore/blob/e67e77d85e74c94fd72a942b3b8e77c74c228cd6/src/Servers/IIS/IIS/src/Core/IISHttpContext.IO.cs#L226

At the same time the request could be completing because it finished writing a response in which case it will tell native code
https://github.com/dotnet/aspnetcore/blob/1dd6f451a0df2ee8e4575dd8dca9df77fda129b1/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/inprocesshandler.cpp#L121
and free the GCHandle pointing at the managed IISHttpContext
https://github.com/dotnet/aspnetcore/blob/e67e77d85e74c94fd72a942b3b8e77c74c228cd6/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs#L801-L821

The problem is that once a `GCHandle` has been freed, the next `GCHandle` allocated can point to the same address. What this means is that if native code is still running and pointing at a `GCHandle` that has been freed and re-allocated, the native code will now be operating on a different object. In the original issue the `GCHandle` was replaced by the next request and `NotifyDisconnect` is still running and will end up aborting the next request.

<h2>The fix</h2>

The proposed fix blocks the managed->native call that tells the native side that the request completed **if** the native side is already attempting to abort the request.

Blocking this call means that the managed side will not free the `GCHandle` until we know the native side is done using the managed request object, preventing the `GCHandle` from pointing to a new request while the native side is still using it.

Blocking **does not** occur if the managed->native call happens first, because it nulls out the managed pointer which prevents any future `NotifyDisconnect` calls from doing anything. And it avoids running the blocking code via the `m_disconnectFired` bool being false.

The potential deadlock described at the top of `NotifyDisconnect` is still avoided because we _didn't_ change the disconnect handler callback to run in a lock.

<h2>The testing</h2>

We haven't reproduced this issue ourselves, so it's mostly an educated guess that we fixed the issue. I will be trying to force the issue to occur by using thread freezing in the debugger and make sure the fix behaves as intended. Since it's a race we generally can't write a targeted unit/functional test to verify the fix, and we rely on other tests to make sure we don't regress anything.

@antmjones would it be possible for you to test the fix since you've been able to reproduce the issue multiple times?