### PR TITLE
Skip Source Build for now

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -783,19 +783,20 @@ stages:
             publishOnError: true
             includeForks: true
 
-    # Source build
-    - template: /eng/common/templates/job/source-build.yml
-      parameters:
-        platform:
-          name: 'Managed'
-          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
-          buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks'
-          skipPublishValidation: true
-          jobProperties:
-            timeoutInMinutes: 120
-            variables:
-              # Log environment variables in binary logs to ease debugging
-              MSBUILDLOGALLENVIRONMENTVARIABLES: true
+    # Source build - skip until https://github.com/dotnet/source-build/issues/3111 is resolved
+    - ${{ if False }}:
+      - template: /eng/common/templates/job/source-build.yml
+        parameters:
+          platform:
+            name: 'Managed'
+            container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
+            buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks'
+            skipPublishValidation: true
+            jobProperties:
+              timeoutInMinutes: 120
+              variables:
+                # Log environment variables in binary logs to ease debugging
+                MSBUILDLOGALLENVIRONMENTVARIABLES: true
 
     # Publish to the BAR and perform source indexing. Wait until everything else is done.
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
Source Build failures are blocking CI & Official builds until https://github.com/dotnet/source-build/issues/3111 is resolved - let's skip that job until it's fixed

Related - https://github.com/dotnet/aspnetcore/issues/46191