### PR TITLE
Remove now-redundant properties from AOT template

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "8.0.100-alpha.1.23061.8"
+    "version": "8.0.100-alpha.1.23070.2"
   },
   "tools": {
-    "dotnet": "8.0.100-alpha.1.23061.8",
+    "dotnet": "8.0.100-alpha.1.23070.2",
     "runtimes": {
       "dotnet/x86": [
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"

--- a/src/ProjectTemplates/Web.ProjectTemplates/Api-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/Api-CSharp.csproj.in
@@ -9,8 +9,6 @@
     <ServerGarbageCollection>False</ServerGarbageCollection>
     <!--#if (NativeAot) -->
     <PublishAot>true</PublishAot>
-    <TrimMode>full</TrimMode>
-    <PublishIISAssets>false</PublishIISAssets>
     <!--#endif -->
   </PropertyGroup>
 


### PR DESCRIPTION
This is a reaction to https://github.com/dotnet/sdk/pull/29984 which makes `TrimMode` and `PublishIISAssets` default to "full" and "false" respectively when `PublishAot` is "true".