### PR TITLE
Make it easy to produce a 2.1 build without prodcon

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -57,6 +57,8 @@ variables:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - name: PB_ISFINALBUILD
     value: ${{ coalesce(variables.PB_ISFINALBUILD, 'true') }}
+  - name: PB_SignType
+    value: ${{ coalesce(variables.PB_SignType, 'real') }}
 
 jobs:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), eq(variables.runCodeQL3000, 'true')) }}:

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -426,7 +426,7 @@ jobs:
             parallel: true
 
     # Only run the publish job if this is a prodcon build
-    - ${{ if ne(variables['ProductBuildId'], null) }}:
+    - ${{ if not(variables['ProductBuildId']) }}:
       - job: Publish
         displayName: Publish
         dependsOn:

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -426,7 +426,7 @@ jobs:
             parallel: true
 
     # Only run the publish job if this is a prodcon build
-    - ${{ if gt(length(variables['ProductBuildId']), 0) }}:
+    - ${{ if ne(variables['ProductBuildId'], Null) }}:
       - job: Publish
         displayName: Publish
         dependsOn:

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -426,7 +426,7 @@ jobs:
             parallel: true
 
     # Only run the publish job if this is a prodcon build
-    - ${{ if not(variables['ProductBuildId']) }}:
+    - ${{ if variables['ProductBuildId'] }}:
       - job: Publish
         displayName: Publish
         dependsOn:

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -426,7 +426,7 @@ jobs:
             parallel: true
 
     # Only run the publish job if this is a prodcon build
-    - ${{ if ne(variables['ProductBuildId'], Null) }}:
+    - ${{ if ne(variables['ProductBuildId'], null) }}:
       - job: Publish
         displayName: Publish
         dependsOn:

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -56,7 +56,7 @@ variables:
   value: ${{ or(eq(variables['Build.Reason'], 'Schedule'), and(eq(variables['Build.Reason'], 'Manual'), eq(parameters.runCodeQL3000, 'true'))) }}
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - name: PB_ISFINALBUILD
-    value: ${{ coalesce(variables.PB_SKIPTESTS, 'true') }}
+    value: ${{ coalesce(variables.PB_ISFINALBUILD, 'true') }}
 
 jobs:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), eq(variables.runCodeQL3000, 'true')) }}:

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -54,6 +54,9 @@ variables:
             $(BuildNumberArg)'
 - name: runCodeQL3000
   value: ${{ or(eq(variables['Build.Reason'], 'Schedule'), and(eq(variables['Build.Reason'], 'Manual'), eq(parameters.runCodeQL3000, 'true'))) }}
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - name: PB_ISFINALBUILD
+    value: ${{ coalesce(variables.PB_SKIPTESTS, 'true') }}
 
 jobs:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), eq(variables.runCodeQL3000, 'true')) }}:

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -425,126 +425,128 @@ jobs:
             artifactType: Container
             parallel: true
 
-    - job: Publish
-      displayName: Publish
-      dependsOn:
-        - Windows_Installers
-        - SharedFX_Installers
-        - Package_Archive
-      timeoutInMinutes: 90
-      workspace:
-        clean: all
-      pool:
-        name: NetCore1ESPool-Svc-Internal
-        demands: ImageOverride -equals 1es-windows-2019
-      variables:
-        _SignType: real
-        JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
-        PB_SKIPTESTS: 'true'
-      steps:
-      - checkout: self
-        clean: true
-      - task: NuGetCommand@2
-        displayName: 'Clear NuGet caches'
-        inputs:
-          command: custom
-          arguments: 'locals all -clear'
-      - task: DownloadBuildArtifacts@0
-        displayName: Download Windows artifacts
-        inputs:
-          artifactName: artifacts-Windows-Release
-          downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
-      - task: DownloadBuildArtifacts@0
-        displayName: Download Windows SharedFx artifacts
-        inputs:
-          artifactName: artifacts-Windows-SharedFx
-          downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
-      - task: DownloadBuildArtifacts@0
-        displayName: Download Package Archive artifacts
-        inputs:
-          artifactName: artifacts-Package-Archive
-          downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
-      - task: DownloadBuildArtifacts@0
-        displayName: Download SharedFx installer artifacts
-        inputs:
-          artifactName: artifacts-SharedFx-Installers
-          downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
-      - task: DownloadBuildArtifacts@0
-        displayName: Download Windows installer artifacts
-        inputs:
-          artifactName: artifacts-Windows-Installers
-          downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
-      - task: CopyFiles@2
-        displayName: Copy Windows artifacts to .deps/assets
-        inputs:
-          sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-Release/build/
-          contents: '**/*.tgz'
-          targetFolder: $(Build.SourcesDirectory)/.deps/assets/
-          flattenFolders: true
-      - task: CopyFiles@2
-        displayName: Copy Windows SharedFx artifacts to .deps/assets
-        inputs:
-          sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/
-          contents: |
-            SharedFx/**
-            OobArchives/**
-          targetFolder: $(Build.SourcesDirectory)/.deps/assets/
-          flattenFolders: true
-      - task: CopyFiles@2
-        displayName: Copy Package Archive artifacts to .deps/assets
-        inputs:
-          sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Package-Archive/lzma/
-          contents: '**'
-          targetFolder: $(Build.SourcesDirectory)/.deps/assets/
-      - task: CopyFiles@2
-        displayName: Copy SharedFx Installer artifacts to .deps/assets
-        inputs:
-          sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-SharedFx-Installers/installers/
-          contents: '**'
-          targetFolder: $(Build.SourcesDirectory)/.deps/assets/
-      - task: CopyFiles@2
-        displayName: Copy Windows Installer artifacts to .deps/assets
-        inputs:
-          sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-Installers/bin/Release/installers/
-          contents: |
-            en-US/*.msi
-            **/*.exe
-            **/*.wixlib
-            **/*.nupkg
-          targetFolder: $(Build.SourcesDirectory)/.deps/assets/
-          flattenFolders: true
-      - task: CopyFiles@2
-        displayName: Copy Windows SharedFx artifacts to .deps/packages
-        inputs:
-          sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/Packages/
-          contents: '**'
-          targetFolder: $(Build.SourcesDirectory)/.deps/packages/
-      - task: DeleteFiles@1
-        displayName: Delete korebuild.json
-        inputs:
-          contents: korebuild.json
-      - script: .\build.cmd
-                -ci
-                $(BuildNumberArg)
-                /t:Publish
-                /p:BuildBranch=$(Build.SourceBranchName)
-                /bl:artifacts/logs/Publish.binlog
-        env:
-          PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
-          PB_ASSETROOTURL: $(PB_AssetRootUrl)
-          PB_RESTORESOURCE: $(PB_RestoreSource)
-          PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
+    # Only run the publish job if this is a prodcon build
+    - ${{ if gt(length(variables['ProductBuildId']), 0) }}:
+      - job: Publish
         displayName: Publish
-      - powershell: eng\scripts\KillProcesses.ps1
-        displayName: Kill processes
-        condition: always()
-      - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
-        - task: PublishBuildArtifacts@1
-          displayName: Upload logs
-          condition: always()
-          continueOnError: true
+        dependsOn:
+          - Windows_Installers
+          - SharedFX_Installers
+          - Package_Archive
+        timeoutInMinutes: 90
+        workspace:
+          clean: all
+        pool:
+          name: NetCore1ESPool-Svc-Internal
+          demands: ImageOverride -equals 1es-windows-2019
+        variables:
+          _SignType: real
+          JAVA_HOME: $(Agent.BuildDirectory)\.tools\jdk
+          PB_SKIPTESTS: 'true'
+        steps:
+        - checkout: self
+          clean: true
+        - task: NuGetCommand@2
+          displayName: 'Clear NuGet caches'
           inputs:
-            pathtoPublish: artifacts/logs
-            artifactName: artifacts-Publish
-            artifactType: Container
-            parallel: true
+            command: custom
+            arguments: 'locals all -clear'
+        - task: DownloadBuildArtifacts@0
+          displayName: Download Windows artifacts
+          inputs:
+            artifactName: artifacts-Windows-Release
+            downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+        - task: DownloadBuildArtifacts@0
+          displayName: Download Windows SharedFx artifacts
+          inputs:
+            artifactName: artifacts-Windows-SharedFx
+            downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+        - task: DownloadBuildArtifacts@0
+          displayName: Download Package Archive artifacts
+          inputs:
+            artifactName: artifacts-Package-Archive
+            downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+        - task: DownloadBuildArtifacts@0
+          displayName: Download SharedFx installer artifacts
+          inputs:
+            artifactName: artifacts-SharedFx-Installers
+            downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+        - task: DownloadBuildArtifacts@0
+          displayName: Download Windows installer artifacts
+          inputs:
+            artifactName: artifacts-Windows-Installers
+            downloadPath: $(Build.StagingDirectory)/downloaded_artifacts/
+        - task: CopyFiles@2
+          displayName: Copy Windows artifacts to .deps/assets
+          inputs:
+            sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-Release/build/
+            contents: '**/*.tgz'
+            targetFolder: $(Build.SourcesDirectory)/.deps/assets/
+            flattenFolders: true
+        - task: CopyFiles@2
+          displayName: Copy Windows SharedFx artifacts to .deps/assets
+          inputs:
+            sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/
+            contents: |
+              SharedFx/**
+              OobArchives/**
+            targetFolder: $(Build.SourcesDirectory)/.deps/assets/
+            flattenFolders: true
+        - task: CopyFiles@2
+          displayName: Copy Package Archive artifacts to .deps/assets
+          inputs:
+            sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Package-Archive/lzma/
+            contents: '**'
+            targetFolder: $(Build.SourcesDirectory)/.deps/assets/
+        - task: CopyFiles@2
+          displayName: Copy SharedFx Installer artifacts to .deps/assets
+          inputs:
+            sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-SharedFx-Installers/installers/
+            contents: '**'
+            targetFolder: $(Build.SourcesDirectory)/.deps/assets/
+        - task: CopyFiles@2
+          displayName: Copy Windows Installer artifacts to .deps/assets
+          inputs:
+            sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-Installers/bin/Release/installers/
+            contents: |
+              en-US/*.msi
+              **/*.exe
+              **/*.wixlib
+              **/*.nupkg
+            targetFolder: $(Build.SourcesDirectory)/.deps/assets/
+            flattenFolders: true
+        - task: CopyFiles@2
+          displayName: Copy Windows SharedFx artifacts to .deps/packages
+          inputs:
+            sourceFolder: $(Build.StagingDirectory)/downloaded_artifacts/artifacts-Windows-SharedFx/Signed/Packages/
+            contents: '**'
+            targetFolder: $(Build.SourcesDirectory)/.deps/packages/
+        - task: DeleteFiles@1
+          displayName: Delete korebuild.json
+          inputs:
+            contents: korebuild.json
+        - script: .\build.cmd
+                  -ci
+                  $(BuildNumberArg)
+                  /t:Publish
+                  /p:BuildBranch=$(Build.SourceBranchName)
+                  /bl:artifacts/logs/Publish.binlog
+          env:
+            PB_PACKAGEVERSIONPROPSURL: $(PB_PackageVersionPropsUrl)
+            PB_ASSETROOTURL: $(PB_AssetRootUrl)
+            PB_RESTORESOURCE: $(PB_RestoreSource)
+            PB_PUBLISHBLOBFEEDKEY: $(PB_PublishBlobFeedKey)
+          displayName: Publish
+        - powershell: eng\scripts\KillProcesses.ps1
+          displayName: Kill processes
+          condition: always()
+        - ${{ if eq(variables['system.pullrequest.isfork'], false) }}:
+          - task: PublishBuildArtifacts@1
+            displayName: Upload logs
+            condition: always()
+            continueOnError: true
+            inputs:
+              pathtoPublish: artifacts/logs
+              artifactName: artifacts-Publish
+              artifactType: Container
+              parallel: true

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -199,7 +199,7 @@
     <SystemRuntimeCompilerServicesUnsafePackageVersion>4.5.3</SystemRuntimeCompilerServicesUnsafePackageVersion>
     <SystemRuntimeInteropServicesRuntimeInformationPackageVersion>4.3.0</SystemRuntimeInteropServicesRuntimeInformationPackageVersion>
     <SystemSecurityCryptographyCngPackageVersion>4.5.2</SystemSecurityCryptographyCngPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>4.5.0</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>4.5.1</SystemSecurityCryptographyXmlPackageVersion>
     <SystemSecurityPermissionsPackageVersion>4.5.0</SystemSecurityPermissionsPackageVersion>
     <SystemSecurityPrincipalWindowsPackageVersion>4.5.1</SystemSecurityPrincipalWindowsPackageVersion>
     <SystemServiceProcessServiceControllerPackageVersion>4.5.0</SystemServiceProcessServiceControllerPackageVersion>


### PR DESCRIPTION
Allows you to produce a useable 2.1 build by just queuing a build of the branch, without removing the ability to do a full prodcon build (in the unfortunate event that we need to do another one of those). Will restore the latest OOB packages from public feeds, and the 2.1.30 (last full public build) runtime .zips from public blob storage.

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2093448&view=results

CC @mmitche 