### PR TITLE
Avoid UnobservedTaskExceptions when getting an error in server to client streaming

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -616,9 +616,8 @@ public partial class HubConnection : IAsyncDisposable
         }
         finally
         {
-            // If WaitToReadAsync threw, this will replace that and throw the same Exception
             // Needed to avoid UnobservedTaskExceptions
-            await reader.Completion.ConfigureAwait(false);
+            _ = reader.Completion.Exception;
         }
     }
 

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.StreamAsChannelAsync.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.StreamAsChannelAsync.cs
@@ -312,14 +312,8 @@ public static partial class HubConnectionExtensions
             // This will safely no-op if the catch block above ran.
             outputChannel.Writer.TryComplete();
 
-            try
-            {
-                // Needed to avoid UnobservedTaskExceptions
-                await inputChannel.Completion.ConfigureAwait(false);
-            }
-            // This exception should already have been thrown by WaitToReadAsync and that exception was used to complete the channel
-            // we pass to the user so they can see the exception.
-            catch { }
+            // Needed to avoid UnobservedTaskExceptions
+            _ = inputChannel.Completion.Exception;
         }
     }
 }

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.StreamAsChannelAsync.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnectionExtensions.StreamAsChannelAsync.cs
@@ -302,9 +302,6 @@ public static partial class HubConnectionExtensions
                     }
                 }
             }
-
-            // Manifest any errors in the completion task
-            await inputChannel.Completion.ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -314,6 +311,15 @@ public static partial class HubConnectionExtensions
         {
             // This will safely no-op if the catch block above ran.
             outputChannel.Writer.TryComplete();
+
+            try
+            {
+                // Needed to avoid UnobservedTaskExceptions
+                await inputChannel.Completion.ConfigureAwait(false);
+            }
+            // This exception should already have been thrown by WaitToReadAsync and that exception was used to complete the channel
+            // we pass to the user so they can see the exception.
+            catch { }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/46169

Filed https://github.com/dotnet/runtime/issues/80885 on the Runtime side since this is an unfortunate usage pattern. 