### PR TITLE
Fix route syntax highlighting parameter color

### DIFF
--- a/src/Framework/App.Ref/src/CompatibilitySuppressions.xml
+++ b/src/Framework/App.Ref/src/CompatibilitySuppressions.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
-<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<Suppressions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Suppression>
     <DiagnosticId>PKV004</DiagnosticId>
     <Target>net7.0</Target>

--- a/src/Framework/App.Runtime/src/CompatibilitySuppressions.xml
+++ b/src/Framework/App.Runtime/src/CompatibilitySuppressions.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
-<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<Suppressions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Suppression>
     <DiagnosticId>PKV0001</DiagnosticId>
     <Target>net7.0</Target>

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternClassifier.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternClassifier.cs
@@ -95,8 +95,10 @@ internal sealed class RoutePatternClassifier : IAspNetCoreEmbeddedLanguageClassi
         public void Visit(RoutePatternNameParameterPartNode node)
         {
             // Parameter name should look like a regular parameter.
-            // ClassificationTypeNames.ParameterName isn't working so temporarily reuse color from JSON syntax.
-            // TODO: Fix with https://github.com/dotnet/aspnetcore/issues/46207
+            // ClassificationTypeNames.ParameterName isn't working so temporarily reuse color from JSON syntax:
+            // https://github.com/dotnet/roslyn/blob/e1ee2f544a7a4f8d536278bed4e180c54919276e/src/Workspaces/Core/Portable/Classification/ClassificationTypeNames.cs#L181
+            //
+            // TODO: Fix properly with https://github.com/dotnet/aspnetcore/issues/46207
             AddClassification(node.ParameterNameToken, "json - object");
         }
 

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternClassifier.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternClassifier.cs
@@ -94,7 +94,10 @@ internal sealed class RoutePatternClassifier : IAspNetCoreEmbeddedLanguageClassi
 
         public void Visit(RoutePatternNameParameterPartNode node)
         {
-            AddClassification(node.ParameterNameToken, ClassificationTypeNames.ParameterName);
+            // Parameter name should look like a regular parameter.
+            // ClassificationTypeNames.ParameterName isn't working so temporarily reuse color from JSON syntax.
+            // TODO: Fix with https://github.com/dotnet/aspnetcore/issues/46207
+            AddClassification(node.ParameterNameToken, "json - object");
         }
 
         public void Visit(RoutePatternPolicyParameterPartNode node)

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternClassifierTests.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteEmbeddedLanguage/RoutePatternClassifierTests.cs
@@ -152,4 +152,6 @@ Regex.CharacterClass("["),
 Regex.CharacterClass("one"),
 Regex.CharacterClass("]"));
     }
+
+    private static FormattedClassification Parameter(string name) => new FormattedClassification(name, "json - object");
 }


### PR DESCRIPTION
For some reason, the `parameter name` classification has stopped working in VS. Reuse JSON classification (hacky) until property colors are added to VS for route patterns that we can depend on. Issue for that: https://github.com/dotnet/aspnetcore/issues/46207

Before:

![image](https://user-images.githubusercontent.com/303201/213903141-755818bc-8816-4285-a751-1f86783f4037.png)

After:

![image](https://user-images.githubusercontent.com/303201/213903194-a50d086c-444d-4b85-a8e6-63a04161ef49.png)
