### PR TITLE
Don't depend on source-build job while it isn't running

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -831,7 +831,6 @@ stages:
                 - MacOS_Test
                 - Linux_Test
                 - Helix_x64
-            - Source_Build_Managed
           pool:
             name: NetCore1ESPool-Internal
             demands: ImageOverride -equals 1es-windows-2019
@@ -870,7 +869,6 @@ stages:
                 - MacOS_Test
                 - Linux_Test
                 - Helix_x64
-            - Source_Build_Managed
           pool:
             name: NetCore1ESPool-Internal
             # Visual Studio Enterprise - no BuildTools agents exist internally and job must run on Windows


### PR DESCRIPTION
Missed this in the last PR for https://github.com/dotnet/aspnetcore/issues/46191 - internal builds are failing because the job doesn't exist. Need to revert this as part of that issue