### PR TITLE
Consistently return StringValues.Empty instead of default for missing headers

### DIFF
--- a/src/Http/Http/src/HeaderDictionary.cs
+++ b/src/Http/Http/src/HeaderDictionary.cs
@@ -73,6 +73,7 @@ public class HeaderDictionary : IHeaderDictionary
             {
                 return value;
             }
+
             return StringValues.Empty;
         }
         set
@@ -94,7 +95,15 @@ public class HeaderDictionary : IHeaderDictionary
 
     StringValues IDictionary<string, StringValues>.this[string key]
     {
-        get { return this[key]; }
+        get
+        {
+            if (Store == null)
+            {
+                ThrowKeyNotFoundException();
+            }
+
+            return Store[key];
+        }
         set
         {
             ThrowIfReadOnly();
@@ -359,6 +368,12 @@ public class HeaderDictionary : IHeaderDictionary
         {
             throw new InvalidOperationException("The response headers cannot be modified because the response has already started.");
         }
+    }
+
+    [DoesNotReturn]
+    private static void ThrowKeyNotFoundException()
+    {
+        throw new KeyNotFoundException();
     }
 
     /// <summary>

--- a/src/Http/Http/test/HeaderDictionaryTests.cs
+++ b/src/Http/Http/test/HeaderDictionaryTests.cs
@@ -112,4 +112,29 @@ public class HeaderDictionaryTests
 
         Assert.Equal(new[] { "value " }, result);
     }
+
+    [Fact]
+    public void PublicIndexerReturnsStringValuesEmptyForMissingHeaders()
+    {
+        var headers = new HeaderDictionary();
+
+        // StringValues.Empty.Equals(default(StringValues)), so we check if the implicit conversion
+        // to string[] returns null or Array.Empty<string>() to tell the difference.
+        Assert.Same(Array.Empty<string>(), (string[])headers["Header1"]);
+    }
+
+    [Fact]
+    public void IHeaderDictionaryMembersReturnStringValuesEmptyForMissingHeaders()
+    {
+        IHeaderDictionary headers = new HeaderDictionary();
+        Assert.Same(Array.Empty<string>(), (string[])headers["Header1"]);
+        Assert.Same(Array.Empty<string>(), (string[])headers.Host);
+    }
+
+    [Fact]
+    public void IDictionaryIndexerThrowsForMissingHeaders()
+    {
+        IDictionary<string, StringValues> headers = new HeaderDictionary();
+        Assert.Throws<KeyNotFoundException>(() => headers["Header1"]);
+    }
 }

--- a/src/Http/Http/test/HeaderDictionaryTests.cs
+++ b/src/Http/Http/test/HeaderDictionaryTests.cs
@@ -113,28 +113,23 @@ public class HeaderDictionaryTests
         Assert.Equal(new[] { "value " }, result);
     }
 
-    [Fact]
-    public void PublicIndexerReturnsStringValuesEmptyForMissingHeaders()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ReturnsCorrectStringValuesEmptyForMissingHeaders(bool withStore)
     {
-        var headers = new HeaderDictionary();
+        // Test both with and without HeaderDictionary.Store set.
+        var emptyHeaders = withStore ? new HeaderDictionary(1) : new HeaderDictionary();
 
         // StringValues.Empty.Equals(default(StringValues)), so we check if the implicit conversion
         // to string[] returns null or Array.Empty<string>() to tell the difference.
-        Assert.Same(Array.Empty<string>(), (string[])headers["Header1"]);
-    }
+        Assert.Same(Array.Empty<string>(), (string[])emptyHeaders["Header1"]);
 
-    [Fact]
-    public void IHeaderDictionaryMembersReturnStringValuesEmptyForMissingHeaders()
-    {
-        IHeaderDictionary headers = new HeaderDictionary();
-        Assert.Same(Array.Empty<string>(), (string[])headers["Header1"]);
-        Assert.Same(Array.Empty<string>(), (string[])headers.Host);
-    }
+        IHeaderDictionary asIHeaderDictionary = emptyHeaders;
+        Assert.Same(Array.Empty<string>(), (string[])asIHeaderDictionary["Header1"]);
+        Assert.Same(Array.Empty<string>(), (string[])asIHeaderDictionary.Host);
 
-    [Fact]
-    public void IDictionaryIndexerThrowsForMissingHeaders()
-    {
-        IDictionary<string, StringValues> headers = new HeaderDictionary();
-        Assert.Throws<KeyNotFoundException>(() => headers["Header1"]);
+        IDictionary<string, StringValues> asIDictionary = emptyHeaders;
+        Assert.Throws<KeyNotFoundException>(() => asIDictionary["Header1"]);
     }
 }

--- a/src/Http/Http/test/QueryCollectionTests.cs
+++ b/src/Http/Http/test/QueryCollectionTests.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.AspNetCore.Http.Tests;
+
+public class QueryCollectionTests
+{
+    [Fact]
+    public void ReturnStringValuesEmptyForMissingQueryKeys()
+    {
+        IQueryCollection query = new QueryCollection(new Dictionary<string, StringValues>());
+
+        // StringValues.Empty.Equals(default(StringValues)), so we check if the implicit conversion
+        // to string[] returns null or Array.Empty<string>() to tell the difference.
+        Assert.Same(Array.Empty<string>(), (string[])query["query1"]);
+
+        // Test the null-dictionary code path too.
+        Assert.Same(Array.Empty<string>(), (string[])QueryCollection.Empty["query1"]);
+    }
+}

--- a/src/Servers/HttpSys/test/FunctionalTests/RequestBodyTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/RequestBodyTests.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using Xunit;
 
@@ -263,7 +264,7 @@ public class RequestBodyTests
             httpContext.Request.Headers[HeaderNames.ContentLength] = "456";
             CheckHeadersCount(HeaderNames.ContentLength, 1, httpContext.Request);
             Assert.Equal(456, httpContext.Request.ContentLength);
-            httpContext.Request.Headers[HeaderNames.ContentLength] = "";
+            httpContext.Request.Headers[HeaderNames.ContentLength] = StringValues.Empty;
             CheckHeadersCount(HeaderNames.ContentLength, 0, httpContext.Request);
             Assert.Null(httpContext.Request.ContentLength);
             Assert.Equal("", httpContext.Request.Headers[HeaderNames.ContentLength].ToString());
@@ -276,7 +277,7 @@ public class RequestBodyTests
             CheckHeadersCount("Custom-Header", 1, httpContext.Request);
             httpContext.Request.Headers["Custom-Header"] = "bar";
             CheckHeadersCount("Custom-Header", 1, httpContext.Request);
-            httpContext.Request.Headers["Custom-Header"] = "";
+            httpContext.Request.Headers["Custom-Header"] = StringValues.Empty;
             CheckHeadersCount("Custom-Header", 0, httpContext.Request);
             Assert.Equal("", httpContext.Request.Headers["Custom-Header"].ToString());
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/RequestResponseTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/RequestResponseTests.cs
@@ -440,6 +440,13 @@ public class RequestResponseTests
     }
 
     [ConditionalFact]
+    public async Task TestStringValuesEmptyForMissingHeaders()
+    {
+        var result = await _fixture.Client.GetStringAsync($"/TestRequestHeaders");
+        Assert.Equal("Success", result);
+    }
+
+    [ConditionalFact]
     public async Task TestReadOffsetWorks()
     {
         var result = await _fixture.Client.PostAsync($"/TestReadOffsetWorks", new StringContent("Hello World"));

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -389,12 +389,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = StringValues.Empty;
                 if ((_bits & 0x2L) != 0)
                 {
-                    value = _headers._Connection;
+                    return _headers._Connection;
                 }
-                return value;
+                return StringValues.Empty;
             }
             set
             {
@@ -414,12 +413,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = StringValues.Empty;
                 if ((_bits & 0x4L) != 0)
                 {
-                    value = _headers._Host;
+                    return _headers._Host;
                 }
-                return value;
+                return StringValues.Empty;
             }
             set
             {
@@ -439,12 +437,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = StringValues.Empty;
                 if ((_bits & 0x10L) != 0)
                 {
-                    value = _headers._Authority;
+                    return _headers._Authority;
                 }
-                return value;
+                return StringValues.Empty;
             }
             set
             {
@@ -464,12 +461,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = StringValues.Empty;
                 if ((_bits & 0x20L) != 0)
                 {
-                    value = _headers._Method;
+                    return _headers._Method;
                 }
-                return value;
+                return StringValues.Empty;
             }
             set
             {
@@ -489,12 +485,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = StringValues.Empty;
                 if ((_bits & 0x40L) != 0)
                 {
-                    value = _headers._Path;
+                    return _headers._Path;
                 }
-                return value;
+                return StringValues.Empty;
             }
             set
             {
@@ -514,12 +509,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = StringValues.Empty;
                 if ((_bits & 0x80L) != 0)
                 {
-                    value = _headers._Protocol;
+                    return _headers._Protocol;
                 }
-                return value;
+                return StringValues.Empty;
             }
             set
             {
@@ -539,12 +533,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = StringValues.Empty;
                 if ((_bits & 0x100L) != 0)
                 {
-                    value = _headers._Scheme;
+                    return _headers._Scheme;
                 }
-                return value;
+                return StringValues.Empty;
             }
             set
             {
@@ -564,12 +557,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = StringValues.Empty;
                 if ((_bits & 0x80000000000L) != 0)
                 {
-                    value = _headers._TransferEncoding;
+                    return _headers._TransferEncoding;
                 }
-                return value;
+                return StringValues.Empty;
             }
             set
             {
@@ -589,12 +581,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = StringValues.Empty;
                 if (_contentLength.HasValue)
                 {
-                    value = new StringValues(HeaderUtilities.FormatNonNegativeInt64(_contentLength.Value));
+                    return new StringValues(HeaderUtilities.FormatNonNegativeInt64(_contentLength.Value));
                 }
-                return value;
+                return StringValues.Empty;
             }
             set
             {
@@ -8701,12 +8692,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = StringValues.Empty;
                 if ((_bits & 0x1L) != 0)
                 {
-                    value = _headers._Connection;
+                    return _headers._Connection;
                 }
-                return value;
+                return StringValues.Empty;
             }
             set
             {
@@ -8727,12 +8717,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = StringValues.Empty;
                 if ((_bits & 0x1000L) != 0)
                 {
-                    value = _headers._Allow;
+                    return _headers._Allow;
                 }
-                return value;
+                return StringValues.Empty;
             }
             set
             {
@@ -8752,12 +8741,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = StringValues.Empty;
                 if ((_bits & 0x2000L) != 0)
                 {
-                    value = _headers._AltSvc;
+                    return _headers._AltSvc;
                 }
-                return value;
+                return StringValues.Empty;
             }
             set
             {
@@ -8778,12 +8766,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = StringValues.Empty;
                 if ((_bits & 0x100000000L) != 0)
                 {
-                    value = _headers._TransferEncoding;
+                    return _headers._TransferEncoding;
                 }
-                return value;
+                return StringValues.Empty;
             }
             set
             {
@@ -8804,12 +8791,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = StringValues.Empty;
                 if (_contentLength.HasValue)
                 {
-                    value = new StringValues(HeaderUtilities.FormatNonNegativeInt64(_contentLength.Value));
+                    return new StringValues(HeaderUtilities.FormatNonNegativeInt64(_contentLength.Value));
                 }
-                return value;
+                return StringValues.Empty;
             }
             set
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs
@@ -389,7 +389,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = default;
+                StringValues value = StringValues.Empty;
                 if ((_bits & 0x2L) != 0)
                 {
                     value = _headers._Connection;
@@ -401,19 +401,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (!StringValues.IsNullOrEmpty(value))
                 {
                     _bits |= 0x2L;
+                    _headers._Connection = value; 
                 }
                 else
                 {
                     _bits &= ~0x2L;
+                    _headers._Connection = default; 
                 }
-                _headers._Connection = value; 
             }
         }
         public StringValues HeaderHost
         {
             get
             {
-                StringValues value = default;
+                StringValues value = StringValues.Empty;
                 if ((_bits & 0x4L) != 0)
                 {
                     value = _headers._Host;
@@ -425,19 +426,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (!StringValues.IsNullOrEmpty(value))
                 {
                     _bits |= 0x4L;
+                    _headers._Host = value; 
                 }
                 else
                 {
                     _bits &= ~0x4L;
+                    _headers._Host = default; 
                 }
-                _headers._Host = value; 
             }
         }
         public StringValues HeaderAuthority
         {
             get
             {
-                StringValues value = default;
+                StringValues value = StringValues.Empty;
                 if ((_bits & 0x10L) != 0)
                 {
                     value = _headers._Authority;
@@ -449,19 +451,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (!StringValues.IsNullOrEmpty(value))
                 {
                     _bits |= 0x10L;
+                    _headers._Authority = value; 
                 }
                 else
                 {
                     _bits &= ~0x10L;
+                    _headers._Authority = default; 
                 }
-                _headers._Authority = value; 
             }
         }
         public StringValues HeaderMethod
         {
             get
             {
-                StringValues value = default;
+                StringValues value = StringValues.Empty;
                 if ((_bits & 0x20L) != 0)
                 {
                     value = _headers._Method;
@@ -473,19 +476,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (!StringValues.IsNullOrEmpty(value))
                 {
                     _bits |= 0x20L;
+                    _headers._Method = value; 
                 }
                 else
                 {
                     _bits &= ~0x20L;
+                    _headers._Method = default; 
                 }
-                _headers._Method = value; 
             }
         }
         public StringValues HeaderPath
         {
             get
             {
-                StringValues value = default;
+                StringValues value = StringValues.Empty;
                 if ((_bits & 0x40L) != 0)
                 {
                     value = _headers._Path;
@@ -497,19 +501,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (!StringValues.IsNullOrEmpty(value))
                 {
                     _bits |= 0x40L;
+                    _headers._Path = value; 
                 }
                 else
                 {
                     _bits &= ~0x40L;
+                    _headers._Path = default; 
                 }
-                _headers._Path = value; 
             }
         }
         public StringValues HeaderProtocol
         {
             get
             {
-                StringValues value = default;
+                StringValues value = StringValues.Empty;
                 if ((_bits & 0x80L) != 0)
                 {
                     value = _headers._Protocol;
@@ -521,19 +526,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (!StringValues.IsNullOrEmpty(value))
                 {
                     _bits |= 0x80L;
+                    _headers._Protocol = value; 
                 }
                 else
                 {
                     _bits &= ~0x80L;
+                    _headers._Protocol = default; 
                 }
-                _headers._Protocol = value; 
             }
         }
         public StringValues HeaderScheme
         {
             get
             {
-                StringValues value = default;
+                StringValues value = StringValues.Empty;
                 if ((_bits & 0x100L) != 0)
                 {
                     value = _headers._Scheme;
@@ -545,19 +551,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (!StringValues.IsNullOrEmpty(value))
                 {
                     _bits |= 0x100L;
+                    _headers._Scheme = value; 
                 }
                 else
                 {
                     _bits &= ~0x100L;
+                    _headers._Scheme = default; 
                 }
-                _headers._Scheme = value; 
             }
         }
         public StringValues HeaderTransferEncoding
         {
             get
             {
-                StringValues value = default;
+                StringValues value = StringValues.Empty;
                 if ((_bits & 0x80000000000L) != 0)
                 {
                     value = _headers._TransferEncoding;
@@ -569,19 +576,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (!StringValues.IsNullOrEmpty(value))
                 {
                     _bits |= 0x80000000000L;
+                    _headers._TransferEncoding = value; 
                 }
                 else
                 {
                     _bits &= ~0x80000000000L;
+                    _headers._TransferEncoding = default; 
                 }
-                _headers._TransferEncoding = value; 
             }
         }
         public StringValues HeaderContentLength
         {
             get
             {
-                StringValues value = default;
+                StringValues value = StringValues.Empty;
                 if (_contentLength.HasValue)
                 {
                     value = new StringValues(HeaderUtilities.FormatNonNegativeInt64(_contentLength.Value));
@@ -603,7 +611,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -631,7 +639,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -659,7 +667,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -687,7 +695,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -715,7 +723,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -743,7 +751,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -771,7 +779,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -799,7 +807,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -827,7 +835,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -855,7 +863,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -883,7 +891,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -911,7 +919,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -939,7 +947,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -967,7 +975,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -995,7 +1003,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1023,7 +1031,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1051,7 +1059,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1079,7 +1087,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1107,7 +1115,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1135,7 +1143,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1163,7 +1171,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1191,7 +1199,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1219,7 +1227,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1247,7 +1255,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1275,7 +1283,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1303,7 +1311,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1331,7 +1339,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1359,7 +1367,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1387,7 +1395,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1415,7 +1423,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1443,7 +1451,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1471,7 +1479,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1499,7 +1507,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1527,7 +1535,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1555,7 +1563,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1583,7 +1591,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1611,7 +1619,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1639,7 +1647,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1667,7 +1675,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1695,7 +1703,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1723,7 +1731,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1751,7 +1759,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1779,7 +1787,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -1806,7 +1814,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AcceptRanges, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -1823,7 +1831,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AccessControlAllowCredentials, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -1840,7 +1848,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AccessControlAllowHeaders, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -1857,7 +1865,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AccessControlAllowMethods, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -1874,7 +1882,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AccessControlAllowOrigin, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -1891,7 +1899,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AccessControlExposeHeaders, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -1908,7 +1916,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AccessControlMaxAge, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -1925,7 +1933,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Age, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -1942,7 +1950,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Allow, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -1959,7 +1967,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AltSvc, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -1976,7 +1984,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentDisposition, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -1993,7 +2001,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentEncoding, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2010,7 +2018,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentLanguage, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2027,7 +2035,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentLocation, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2044,7 +2052,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentMD5, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2061,7 +2069,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentRange, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2078,7 +2086,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentSecurityPolicy, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2095,7 +2103,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentSecurityPolicyReportOnly, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2112,7 +2120,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ETag, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2129,7 +2137,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Expires, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2146,7 +2154,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.GrpcMessage, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2163,7 +2171,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.GrpcStatus, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2180,7 +2188,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.LastModified, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2197,7 +2205,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Link, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2214,7 +2222,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Location, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2231,7 +2239,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ProxyAuthenticate, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2248,7 +2256,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ProxyConnection, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2265,7 +2273,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.RetryAfter, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2282,7 +2290,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.SecWebSocketAccept, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2299,7 +2307,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.SecWebSocketKey, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2316,7 +2324,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.SecWebSocketProtocol, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2333,7 +2341,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.SecWebSocketVersion, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2350,7 +2358,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.SecWebSocketExtensions, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2367,7 +2375,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Server, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2384,7 +2392,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.SetCookie, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2401,7 +2409,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.StrictTransportSecurity, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2418,7 +2426,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Trailer, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2435,7 +2443,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Vary, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2452,7 +2460,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.WebSocketSubProtocols, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2469,7 +2477,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.WWWAuthenticate, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2486,7 +2494,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.XContentTypeOptions, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2503,7 +2511,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.XFrameOptions, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2520,7 +2528,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.XPoweredBy, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2537,7 +2545,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.XRequestedWith, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2554,7 +2562,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.XUACompatible, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -2571,7 +2579,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.XXSSProtection, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -8693,7 +8701,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = default;
+                StringValues value = StringValues.Empty;
                 if ((_bits & 0x1L) != 0)
                 {
                     value = _headers._Connection;
@@ -8705,12 +8713,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (!StringValues.IsNullOrEmpty(value))
                 {
                     _bits |= 0x1L;
+                    _headers._Connection = value; 
                 }
                 else
                 {
                     _bits &= ~0x1L;
+                    _headers._Connection = default; 
                 }
-                _headers._Connection = value; 
                 _headers._rawConnection = null;
             }
         }
@@ -8718,7 +8727,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = default;
+                StringValues value = StringValues.Empty;
                 if ((_bits & 0x1000L) != 0)
                 {
                     value = _headers._Allow;
@@ -8730,19 +8739,20 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (!StringValues.IsNullOrEmpty(value))
                 {
                     _bits |= 0x1000L;
+                    _headers._Allow = value; 
                 }
                 else
                 {
                     _bits &= ~0x1000L;
+                    _headers._Allow = default; 
                 }
-                _headers._Allow = value; 
             }
         }
         public StringValues HeaderAltSvc
         {
             get
             {
-                StringValues value = default;
+                StringValues value = StringValues.Empty;
                 if ((_bits & 0x2000L) != 0)
                 {
                     value = _headers._AltSvc;
@@ -8754,12 +8764,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (!StringValues.IsNullOrEmpty(value))
                 {
                     _bits |= 0x2000L;
+                    _headers._AltSvc = value; 
                 }
                 else
                 {
                     _bits &= ~0x2000L;
+                    _headers._AltSvc = default; 
                 }
-                _headers._AltSvc = value; 
                 _headers._rawAltSvc = null;
             }
         }
@@ -8767,7 +8778,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = default;
+                StringValues value = StringValues.Empty;
                 if ((_bits & 0x100000000L) != 0)
                 {
                     value = _headers._TransferEncoding;
@@ -8779,12 +8790,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (!StringValues.IsNullOrEmpty(value))
                 {
                     _bits |= 0x100000000L;
+                    _headers._TransferEncoding = value; 
                 }
                 else
                 {
                     _bits &= ~0x100000000L;
+                    _headers._TransferEncoding = default; 
                 }
-                _headers._TransferEncoding = value; 
                 _headers._rawTransferEncoding = null;
             }
         }
@@ -8792,7 +8804,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {
             get
             {
-                StringValues value = default;
+                StringValues value = StringValues.Empty;
                 if (_contentLength.HasValue)
                 {
                     value = new StringValues(HeaderUtilities.FormatNonNegativeInt64(_contentLength.Value));
@@ -8814,7 +8826,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -8844,7 +8856,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -8873,7 +8885,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -8903,7 +8915,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -8933,7 +8945,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -8962,7 +8974,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -8991,7 +9003,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9020,7 +9032,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9049,7 +9061,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9078,7 +9090,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9107,7 +9119,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9136,7 +9148,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9165,7 +9177,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9194,7 +9206,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9224,7 +9236,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9253,7 +9265,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9282,7 +9294,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9311,7 +9323,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9340,7 +9352,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9369,7 +9381,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9398,7 +9410,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9427,7 +9439,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9456,7 +9468,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9485,7 +9497,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9514,7 +9526,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9543,7 +9555,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9572,7 +9584,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9601,7 +9613,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9630,7 +9642,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9659,7 +9671,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9688,7 +9700,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9717,7 +9729,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9746,7 +9758,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9776,7 +9788,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9805,7 +9817,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9834,7 +9846,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9863,7 +9875,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9892,7 +9904,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -9920,7 +9932,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Accept, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -9938,7 +9950,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AcceptCharset, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -9956,7 +9968,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AcceptEncoding, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -9974,7 +9986,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AcceptLanguage, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -9992,7 +10004,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AccessControlRequestHeaders, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10010,7 +10022,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AccessControlRequestMethod, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10028,7 +10040,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Authorization, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10046,7 +10058,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Baggage, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10064,7 +10076,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentDisposition, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10082,7 +10094,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentSecurityPolicy, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10100,7 +10112,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentSecurityPolicyReportOnly, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10118,7 +10130,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.CorrelationContext, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10136,7 +10148,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Cookie, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10154,7 +10166,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Expect, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10172,7 +10184,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.From, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10190,7 +10202,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.GrpcAcceptEncoding, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10208,7 +10220,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.GrpcMessage, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10226,7 +10238,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.GrpcStatus, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10244,7 +10256,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.GrpcTimeout, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10262,7 +10274,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Host, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10280,7 +10292,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.IfMatch, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10298,7 +10310,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.IfModifiedSince, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10316,7 +10328,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.IfNoneMatch, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10334,7 +10346,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.IfRange, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10352,7 +10364,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.IfUnmodifiedSince, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10370,7 +10382,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Link, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10388,7 +10400,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.MaxForwards, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10406,7 +10418,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Origin, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10424,7 +10436,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ProxyAuthorization, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10442,7 +10454,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Range, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10460,7 +10472,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Referer, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10478,7 +10490,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.RequestId, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10496,7 +10508,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.SecWebSocketAccept, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10514,7 +10526,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.SecWebSocketKey, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10532,7 +10544,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.SecWebSocketProtocol, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10550,7 +10562,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.SecWebSocketVersion, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10568,7 +10580,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.SecWebSocketExtensions, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10586,7 +10598,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.StrictTransportSecurity, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10604,7 +10616,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.TE, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10622,7 +10634,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Translate, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10640,7 +10652,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.TraceParent, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10658,7 +10670,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.TraceState, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10676,7 +10688,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.UpgradeInsecureRequests, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10694,7 +10706,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.UserAgent, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10712,7 +10724,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.WebSocketSubProtocols, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10730,7 +10742,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.XContentTypeOptions, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10748,7 +10760,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.XFrameOptions, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10766,7 +10778,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.XPoweredBy, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10784,7 +10796,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.XRequestedWith, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10802,7 +10814,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.XUACompatible, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -10820,7 +10832,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.XXSSProtection, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15524,7 +15536,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -15553,7 +15565,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -15582,7 +15594,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {
                     return value;
                 }
-                return default;
+                return StringValues.Empty;
             }
             set
             {
@@ -15610,7 +15622,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Accept, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15628,7 +15640,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AcceptCharset, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15646,7 +15658,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AcceptEncoding, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15664,7 +15676,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AcceptLanguage, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15682,7 +15694,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AcceptRanges, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15700,7 +15712,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AccessControlAllowCredentials, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15718,7 +15730,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AccessControlAllowHeaders, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15736,7 +15748,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AccessControlAllowMethods, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15754,7 +15766,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AccessControlAllowOrigin, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15772,7 +15784,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AccessControlExposeHeaders, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15790,7 +15802,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AccessControlMaxAge, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15808,7 +15820,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AccessControlRequestHeaders, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15826,7 +15838,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AccessControlRequestMethod, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15844,7 +15856,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Age, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15862,7 +15874,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Allow, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15880,7 +15892,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.AltSvc, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15898,7 +15910,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Authorization, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15916,7 +15928,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Baggage, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15934,7 +15946,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.CacheControl, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15952,7 +15964,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Connection, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15970,7 +15982,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentDisposition, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -15988,7 +16000,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentEncoding, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16006,7 +16018,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentLanguage, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16024,7 +16036,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentLocation, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16042,7 +16054,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentMD5, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16060,7 +16072,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentRange, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16078,7 +16090,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentSecurityPolicy, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16096,7 +16108,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentSecurityPolicyReportOnly, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16114,7 +16126,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ContentType, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16132,7 +16144,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.CorrelationContext, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16150,7 +16162,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Cookie, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16168,7 +16180,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Date, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16186,7 +16198,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Expires, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16204,7 +16216,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Expect, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16222,7 +16234,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.From, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16240,7 +16252,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.GrpcAcceptEncoding, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16258,7 +16270,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.GrpcEncoding, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16276,7 +16288,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.GrpcTimeout, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16294,7 +16306,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Host, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16312,7 +16324,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.KeepAlive, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16330,7 +16342,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.IfMatch, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16348,7 +16360,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.IfModifiedSince, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16366,7 +16378,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.IfNoneMatch, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16384,7 +16396,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.IfRange, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16402,7 +16414,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.IfUnmodifiedSince, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16420,7 +16432,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.LastModified, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16438,7 +16450,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Link, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16456,7 +16468,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Location, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16474,7 +16486,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.MaxForwards, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16492,7 +16504,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Origin, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16510,7 +16522,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Pragma, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16528,7 +16540,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ProxyAuthenticate, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16546,7 +16558,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ProxyAuthorization, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16564,7 +16576,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.ProxyConnection, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16582,7 +16594,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Range, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16600,7 +16612,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Referer, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16618,7 +16630,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.RetryAfter, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16636,7 +16648,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.RequestId, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16654,7 +16666,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.SecWebSocketAccept, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16672,7 +16684,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.SecWebSocketKey, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16690,7 +16702,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.SecWebSocketProtocol, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16708,7 +16720,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.SecWebSocketVersion, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16726,7 +16738,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.SecWebSocketExtensions, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16744,7 +16756,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Server, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16762,7 +16774,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.SetCookie, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16780,7 +16792,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.StrictTransportSecurity, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16798,7 +16810,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.TE, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16816,7 +16828,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Trailer, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16834,7 +16846,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.TransferEncoding, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16852,7 +16864,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Translate, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16870,7 +16882,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.TraceParent, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16888,7 +16900,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.TraceState, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16906,7 +16918,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Upgrade, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16924,7 +16936,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.UpgradeInsecureRequests, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16942,7 +16954,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.UserAgent, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16960,7 +16972,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Vary, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16978,7 +16990,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Via, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -16996,7 +17008,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.Warning, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -17014,7 +17026,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.WebSocketSubProtocols, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -17032,7 +17044,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.WWWAuthenticate, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -17050,7 +17062,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.XContentTypeOptions, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -17068,7 +17080,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.XFrameOptions, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -17086,7 +17098,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.XPoweredBy, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -17104,7 +17116,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.XRequestedWith, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -17122,7 +17134,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.XUACompatible, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }
@@ -17140,7 +17152,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.XXSSProtection, ref value))
                 {
-                    value = default;
+                    value = StringValues.Empty;
                 }
                 return value;
             }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
@@ -98,7 +98,7 @@ internal abstract partial class HttpHeaders : IHeaderDictionary
         throw new ArgumentException();
     }
 
-    protected static void ThrowKeyNotFoundException()
+    private static void ThrowKeyNotFoundException()
     {
         throw new KeyNotFoundException();
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
@@ -44,8 +44,11 @@ internal abstract partial class HttpHeaders : IHeaderDictionary
     {
         get
         {
-            TryGetValueFast(key, out var value);
-            return value;
+            if (TryGetValueFast(key, out var value))
+            {
+                return value;
+            }
+            return StringValues.Empty;
         }
         set
         {

--- a/src/Servers/Kestrel/Core/test/HttpRequestHeadersTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpRequestHeadersTests.cs
@@ -100,6 +100,22 @@ public class HttpRequestHeadersTests
     }
 
     [Fact]
+    public void IHeaderDictionaryMembersReturnStringValuesEmptyForMissingHeaders()
+    {
+        IHeaderDictionary headers = new HttpRequestHeaders();
+
+        // StringValues.Empty.Equals(default(StringValues)), so we check if the implicit conversion
+        // to string[] returns null or Array.Empty<string>() to tell the difference.
+        Assert.Same(Array.Empty<string>(), (string[])headers["custom"]);
+        Assert.Same(Array.Empty<string>(), (string[])headers["host"]);
+        Assert.Same(Array.Empty<string>(), (string[])headers["Content-Length"]);
+
+        // Test both optimized and non-optimized properties.
+        Assert.Same(Array.Empty<string>(), (string[])headers.Host);
+        Assert.Same(Array.Empty<string>(), (string[])headers.AltSvc);
+    }
+
+    [Fact]
     public void EntriesCanBeEnumeratedAfterResets()
     {
         HttpRequestHeaders headers = new HttpRequestHeaders();

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -859,12 +859,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {{{(header.Name == HeaderNames.ContentLength ? $@"
             get
             {{
-                StringValues value = StringValues.Empty;
                 if (_contentLength.HasValue)
                 {{
-                    value = new StringValues(HeaderUtilities.FormatNonNegativeInt64(_contentLength.Value));
+                    return new StringValues(HeaderUtilities.FormatNonNegativeInt64(_contentLength.Value));
                 }}
-                return value;
+                return StringValues.Empty;
             }}
             set
             {{
@@ -872,12 +871,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }}" : $@"
             get
             {{
-                StringValues value = StringValues.Empty;
                 if ({header.TestBit()})
                 {{
-                    value = _headers._{header.Identifier};
+                    return _headers._{header.Identifier};
                 }}
-                return value;
+                return StringValues.Empty;
             }}
             set
             {{

--- a/src/Servers/Kestrel/shared/KnownHeaders.cs
+++ b/src/Servers/Kestrel/shared/KnownHeaders.cs
@@ -859,7 +859,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
         {{{(header.Name == HeaderNames.ContentLength ? $@"
             get
             {{
-                StringValues value = default;
+                StringValues value = StringValues.Empty;
                 if (_contentLength.HasValue)
                 {{
                     value = new StringValues(HeaderUtilities.FormatNonNegativeInt64(_contentLength.Value));
@@ -872,7 +872,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
             }}" : $@"
             get
             {{
-                StringValues value = default;
+                StringValues value = StringValues.Empty;
                 if ({header.TestBit()})
                 {{
                     value = _headers._{header.Identifier};
@@ -884,12 +884,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 if (!StringValues.IsNullOrEmpty(value))
                 {{
                     {header.SetBit()};
+                    _headers._{header.Identifier} = value; 
                 }}
                 else
                 {{
                     {header.ClearBit()};
-                }}
-                _headers._{header.Identifier} = value; {(header.EnhancedSetter == false ? "" : $@"
+                    _headers._{header.Identifier} = default; 
+                }}{(header.EnhancedSetter == false ? "" : $@"
                 _headers._raw{header.Identifier} = null;")}
             }}")}
         }}")}
@@ -903,7 +904,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 {{
                     return value;
                 }}
-                return default;
+                return StringValues.Empty;
             }}
             set
             {{
@@ -932,7 +933,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
                 StringValues value = default;
                 if (!TryGetUnknown(HeaderNames.{header}, ref value))
                 {{
-                    value = default;
+                    value = StringValues.Empty;
                 }}
                 return value;
             }}

--- a/src/Shared/HttpSys/RequestProcessing/RequestHeaders.Generated.cs
+++ b/src/Shared/HttpSys/RequestProcessing/RequestHeaders.Generated.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x1u) != 0))
+                if (((_flag0 & 0x1u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Accept);
                     if (nativeValue != null)
@@ -72,12 +72,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x1u;
                 }
-                return _Accept;
+
+                if (_Accept.Count > 0)
+                {
+                    return _Accept;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x1u;
-                _Accept = value;
+
+                if (value.Count > 0)
+                {
+                    _Accept = value;
+                }
+                else
+                {
+                    _Accept = default;
+                }
             }
         }
 
@@ -85,7 +98,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x2u) != 0))
+                if (((_flag0 & 0x2u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.AcceptCharset);
                     if (nativeValue != null)
@@ -94,12 +107,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x2u;
                 }
-                return _AcceptCharset;
+
+                if (_AcceptCharset.Count > 0)
+                {
+                    return _AcceptCharset;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x2u;
-                _AcceptCharset = value;
+
+                if (value.Count > 0)
+                {
+                    _AcceptCharset = value;
+                }
+                else
+                {
+                    _AcceptCharset = default;
+                }
             }
         }
 
@@ -107,7 +133,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x4u) != 0))
+                if (((_flag0 & 0x4u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.AcceptEncoding);
                     if (nativeValue != null)
@@ -116,12 +142,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x4u;
                 }
-                return _AcceptEncoding;
+
+                if (_AcceptEncoding.Count > 0)
+                {
+                    return _AcceptEncoding;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x4u;
-                _AcceptEncoding = value;
+
+                if (value.Count > 0)
+                {
+                    _AcceptEncoding = value;
+                }
+                else
+                {
+                    _AcceptEncoding = default;
+                }
             }
         }
 
@@ -129,7 +168,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x8u) != 0))
+                if (((_flag0 & 0x8u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.AcceptLanguage);
                     if (nativeValue != null)
@@ -138,12 +177,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x8u;
                 }
-                return _AcceptLanguage;
+
+                if (_AcceptLanguage.Count > 0)
+                {
+                    return _AcceptLanguage;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x8u;
-                _AcceptLanguage = value;
+
+                if (value.Count > 0)
+                {
+                    _AcceptLanguage = value;
+                }
+                else
+                {
+                    _AcceptLanguage = default;
+                }
             }
         }
 
@@ -151,7 +203,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x10u) != 0))
+                if (((_flag0 & 0x10u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Allow);
                     if (nativeValue != null)
@@ -160,12 +212,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x10u;
                 }
-                return _Allow;
+
+                if (_Allow.Count > 0)
+                {
+                    return _Allow;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x10u;
-                _Allow = value;
+
+                if (value.Count > 0)
+                {
+                    _Allow = value;
+                }
+                else
+                {
+                    _Allow = default;
+                }
             }
         }
 
@@ -173,7 +238,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x20u) != 0))
+                if (((_flag0 & 0x20u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Authorization);
                     if (nativeValue != null)
@@ -182,12 +247,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x20u;
                 }
-                return _Authorization;
+
+                if (_Authorization.Count > 0)
+                {
+                    return _Authorization;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x20u;
-                _Authorization = value;
+
+                if (value.Count > 0)
+                {
+                    _Authorization = value;
+                }
+                else
+                {
+                    _Authorization = default;
+                }
             }
         }
 
@@ -195,7 +273,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x40u) != 0))
+                if (((_flag0 & 0x40u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.CacheControl);
                     if (nativeValue != null)
@@ -204,12 +282,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x40u;
                 }
-                return _CacheControl;
+
+                if (_CacheControl.Count > 0)
+                {
+                    return _CacheControl;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x40u;
-                _CacheControl = value;
+
+                if (value.Count > 0)
+                {
+                    _CacheControl = value;
+                }
+                else
+                {
+                    _CacheControl = default;
+                }
             }
         }
 
@@ -217,7 +308,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x80u) != 0))
+                if (((_flag0 & 0x80u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Connection);
                     if (nativeValue != null)
@@ -226,12 +317,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x80u;
                 }
-                return _Connection;
+
+                if (_Connection.Count > 0)
+                {
+                    return _Connection;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x80u;
-                _Connection = value;
+
+                if (value.Count > 0)
+                {
+                    _Connection = value;
+                }
+                else
+                {
+                    _Connection = default;
+                }
             }
         }
 
@@ -239,7 +343,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x100u) != 0))
+                if (((_flag0 & 0x100u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.ContentEncoding);
                     if (nativeValue != null)
@@ -248,12 +352,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x100u;
                 }
-                return _ContentEncoding;
+
+                if (_ContentEncoding.Count > 0)
+                {
+                    return _ContentEncoding;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x100u;
-                _ContentEncoding = value;
+
+                if (value.Count > 0)
+                {
+                    _ContentEncoding = value;
+                }
+                else
+                {
+                    _ContentEncoding = default;
+                }
             }
         }
 
@@ -261,7 +378,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x200u) != 0))
+                if (((_flag0 & 0x200u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.ContentLanguage);
                     if (nativeValue != null)
@@ -270,12 +387,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x200u;
                 }
-                return _ContentLanguage;
+
+                if (_ContentLanguage.Count > 0)
+                {
+                    return _ContentLanguage;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x200u;
-                _ContentLanguage = value;
+
+                if (value.Count > 0)
+                {
+                    _ContentLanguage = value;
+                }
+                else
+                {
+                    _ContentLanguage = default;
+                }
             }
         }
 
@@ -283,7 +413,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x400u) != 0))
+                if (((_flag0 & 0x400u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.ContentLength);
                     if (nativeValue != null)
@@ -292,12 +422,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x400u;
                 }
-                return _ContentLength;
+
+                if (_ContentLength.Count > 0)
+                {
+                    return _ContentLength;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x400u;
-                _ContentLength = value;
+
+                if (value.Count > 0)
+                {
+                    _ContentLength = value;
+                }
+                else
+                {
+                    _ContentLength = default;
+                }
             }
         }
 
@@ -305,7 +448,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x800u) != 0))
+                if (((_flag0 & 0x800u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.ContentLocation);
                     if (nativeValue != null)
@@ -314,12 +457,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x800u;
                 }
-                return _ContentLocation;
+
+                if (_ContentLocation.Count > 0)
+                {
+                    return _ContentLocation;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x800u;
-                _ContentLocation = value;
+
+                if (value.Count > 0)
+                {
+                    _ContentLocation = value;
+                }
+                else
+                {
+                    _ContentLocation = default;
+                }
             }
         }
 
@@ -327,7 +483,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x1000u) != 0))
+                if (((_flag0 & 0x1000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.ContentMd5);
                     if (nativeValue != null)
@@ -336,12 +492,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x1000u;
                 }
-                return _ContentMD5;
+
+                if (_ContentMD5.Count > 0)
+                {
+                    return _ContentMD5;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x1000u;
-                _ContentMD5 = value;
+
+                if (value.Count > 0)
+                {
+                    _ContentMD5 = value;
+                }
+                else
+                {
+                    _ContentMD5 = default;
+                }
             }
         }
 
@@ -349,7 +518,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x2000u) != 0))
+                if (((_flag0 & 0x2000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.ContentRange);
                     if (nativeValue != null)
@@ -358,12 +527,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x2000u;
                 }
-                return _ContentRange;
+
+                if (_ContentRange.Count > 0)
+                {
+                    return _ContentRange;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x2000u;
-                _ContentRange = value;
+
+                if (value.Count > 0)
+                {
+                    _ContentRange = value;
+                }
+                else
+                {
+                    _ContentRange = default;
+                }
             }
         }
 
@@ -371,7 +553,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x4000u) != 0))
+                if (((_flag0 & 0x4000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.ContentType);
                     if (nativeValue != null)
@@ -380,12 +562,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x4000u;
                 }
-                return _ContentType;
+
+                if (_ContentType.Count > 0)
+                {
+                    return _ContentType;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x4000u;
-                _ContentType = value;
+
+                if (value.Count > 0)
+                {
+                    _ContentType = value;
+                }
+                else
+                {
+                    _ContentType = default;
+                }
             }
         }
 
@@ -393,7 +588,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x8000u) != 0))
+                if (((_flag0 & 0x8000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Cookie);
                     if (nativeValue != null)
@@ -402,12 +597,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x8000u;
                 }
-                return _Cookie;
+
+                if (_Cookie.Count > 0)
+                {
+                    return _Cookie;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x8000u;
-                _Cookie = value;
+
+                if (value.Count > 0)
+                {
+                    _Cookie = value;
+                }
+                else
+                {
+                    _Cookie = default;
+                }
             }
         }
 
@@ -415,7 +623,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x10000u) != 0))
+                if (((_flag0 & 0x10000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Date);
                     if (nativeValue != null)
@@ -424,12 +632,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x10000u;
                 }
-                return _Date;
+
+                if (_Date.Count > 0)
+                {
+                    return _Date;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x10000u;
-                _Date = value;
+
+                if (value.Count > 0)
+                {
+                    _Date = value;
+                }
+                else
+                {
+                    _Date = default;
+                }
             }
         }
 
@@ -437,7 +658,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x20000u) != 0))
+                if (((_flag0 & 0x20000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Expect);
                     if (nativeValue != null)
@@ -446,12 +667,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x20000u;
                 }
-                return _Expect;
+
+                if (_Expect.Count > 0)
+                {
+                    return _Expect;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x20000u;
-                _Expect = value;
+
+                if (value.Count > 0)
+                {
+                    _Expect = value;
+                }
+                else
+                {
+                    _Expect = default;
+                }
             }
         }
 
@@ -459,7 +693,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x40000u) != 0))
+                if (((_flag0 & 0x40000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Expires);
                     if (nativeValue != null)
@@ -468,12 +702,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x40000u;
                 }
-                return _Expires;
+
+                if (_Expires.Count > 0)
+                {
+                    return _Expires;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x40000u;
-                _Expires = value;
+
+                if (value.Count > 0)
+                {
+                    _Expires = value;
+                }
+                else
+                {
+                    _Expires = default;
+                }
             }
         }
 
@@ -481,7 +728,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x80000u) != 0))
+                if (((_flag0 & 0x80000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.From);
                     if (nativeValue != null)
@@ -490,12 +737,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x80000u;
                 }
-                return _From;
+
+                if (_From.Count > 0)
+                {
+                    return _From;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x80000u;
-                _From = value;
+
+                if (value.Count > 0)
+                {
+                    _From = value;
+                }
+                else
+                {
+                    _From = default;
+                }
             }
         }
 
@@ -503,7 +763,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x100000u) != 0))
+                if (((_flag0 & 0x100000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Host);
                     if (nativeValue != null)
@@ -512,12 +772,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x100000u;
                 }
-                return _Host;
+
+                if (_Host.Count > 0)
+                {
+                    return _Host;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x100000u;
-                _Host = value;
+
+                if (value.Count > 0)
+                {
+                    _Host = value;
+                }
+                else
+                {
+                    _Host = default;
+                }
             }
         }
 
@@ -525,7 +798,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x200000u) != 0))
+                if (((_flag0 & 0x200000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.IfMatch);
                     if (nativeValue != null)
@@ -534,12 +807,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x200000u;
                 }
-                return _IfMatch;
+
+                if (_IfMatch.Count > 0)
+                {
+                    return _IfMatch;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x200000u;
-                _IfMatch = value;
+
+                if (value.Count > 0)
+                {
+                    _IfMatch = value;
+                }
+                else
+                {
+                    _IfMatch = default;
+                }
             }
         }
 
@@ -547,7 +833,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x400000u) != 0))
+                if (((_flag0 & 0x400000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.IfModifiedSince);
                     if (nativeValue != null)
@@ -556,12 +842,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x400000u;
                 }
-                return _IfModifiedSince;
+
+                if (_IfModifiedSince.Count > 0)
+                {
+                    return _IfModifiedSince;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x400000u;
-                _IfModifiedSince = value;
+
+                if (value.Count > 0)
+                {
+                    _IfModifiedSince = value;
+                }
+                else
+                {
+                    _IfModifiedSince = default;
+                }
             }
         }
 
@@ -569,7 +868,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x800000u) != 0))
+                if (((_flag0 & 0x800000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.IfNoneMatch);
                     if (nativeValue != null)
@@ -578,12 +877,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x800000u;
                 }
-                return _IfNoneMatch;
+
+                if (_IfNoneMatch.Count > 0)
+                {
+                    return _IfNoneMatch;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x800000u;
-                _IfNoneMatch = value;
+
+                if (value.Count > 0)
+                {
+                    _IfNoneMatch = value;
+                }
+                else
+                {
+                    _IfNoneMatch = default;
+                }
             }
         }
 
@@ -591,7 +903,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x1000000u) != 0))
+                if (((_flag0 & 0x1000000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.IfRange);
                     if (nativeValue != null)
@@ -600,12 +912,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x1000000u;
                 }
-                return _IfRange;
+
+                if (_IfRange.Count > 0)
+                {
+                    return _IfRange;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x1000000u;
-                _IfRange = value;
+
+                if (value.Count > 0)
+                {
+                    _IfRange = value;
+                }
+                else
+                {
+                    _IfRange = default;
+                }
             }
         }
 
@@ -613,7 +938,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x2000000u) != 0))
+                if (((_flag0 & 0x2000000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.IfUnmodifiedSince);
                     if (nativeValue != null)
@@ -622,12 +947,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x2000000u;
                 }
-                return _IfUnmodifiedSince;
+
+                if (_IfUnmodifiedSince.Count > 0)
+                {
+                    return _IfUnmodifiedSince;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x2000000u;
-                _IfUnmodifiedSince = value;
+
+                if (value.Count > 0)
+                {
+                    _IfUnmodifiedSince = value;
+                }
+                else
+                {
+                    _IfUnmodifiedSince = default;
+                }
             }
         }
 
@@ -635,7 +973,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x4000000u) != 0))
+                if (((_flag0 & 0x4000000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.KeepAlive);
                     if (nativeValue != null)
@@ -644,12 +982,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x4000000u;
                 }
-                return _KeepAlive;
+
+                if (_KeepAlive.Count > 0)
+                {
+                    return _KeepAlive;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x4000000u;
-                _KeepAlive = value;
+
+                if (value.Count > 0)
+                {
+                    _KeepAlive = value;
+                }
+                else
+                {
+                    _KeepAlive = default;
+                }
             }
         }
 
@@ -657,7 +1008,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x8000000u) != 0))
+                if (((_flag0 & 0x8000000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.LastModified);
                     if (nativeValue != null)
@@ -666,12 +1017,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x8000000u;
                 }
-                return _LastModified;
+
+                if (_LastModified.Count > 0)
+                {
+                    return _LastModified;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x8000000u;
-                _LastModified = value;
+
+                if (value.Count > 0)
+                {
+                    _LastModified = value;
+                }
+                else
+                {
+                    _LastModified = default;
+                }
             }
         }
 
@@ -679,7 +1043,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x10000000u) != 0))
+                if (((_flag0 & 0x10000000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.MaxForwards);
                     if (nativeValue != null)
@@ -688,12 +1052,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x10000000u;
                 }
-                return _MaxForwards;
+
+                if (_MaxForwards.Count > 0)
+                {
+                    return _MaxForwards;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x10000000u;
-                _MaxForwards = value;
+
+                if (value.Count > 0)
+                {
+                    _MaxForwards = value;
+                }
+                else
+                {
+                    _MaxForwards = default;
+                }
             }
         }
 
@@ -701,7 +1078,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x20000000u) != 0))
+                if (((_flag0 & 0x20000000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Pragma);
                     if (nativeValue != null)
@@ -710,12 +1087,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x20000000u;
                 }
-                return _Pragma;
+
+                if (_Pragma.Count > 0)
+                {
+                    return _Pragma;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x20000000u;
-                _Pragma = value;
+
+                if (value.Count > 0)
+                {
+                    _Pragma = value;
+                }
+                else
+                {
+                    _Pragma = default;
+                }
             }
         }
 
@@ -723,7 +1113,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x40000000u) != 0))
+                if (((_flag0 & 0x40000000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.ProxyAuthorization);
                     if (nativeValue != null)
@@ -732,12 +1122,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x40000000u;
                 }
-                return _ProxyAuthorization;
+
+                if (_ProxyAuthorization.Count > 0)
+                {
+                    return _ProxyAuthorization;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x40000000u;
-                _ProxyAuthorization = value;
+
+                if (value.Count > 0)
+                {
+                    _ProxyAuthorization = value;
+                }
+                else
+                {
+                    _ProxyAuthorization = default;
+                }
             }
         }
 
@@ -745,7 +1148,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag0 & 0x80000000u) != 0))
+                if (((_flag0 & 0x80000000u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Range);
                     if (nativeValue != null)
@@ -754,12 +1157,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag0 |= 0x80000000u;
                 }
-                return _Range;
+
+                if (_Range.Count > 0)
+                {
+                    return _Range;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag0 |= 0x80000000u;
-                _Range = value;
+
+                if (value.Count > 0)
+                {
+                    _Range = value;
+                }
+                else
+                {
+                    _Range = default;
+                }
             }
         }
 
@@ -767,7 +1183,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag1 & 0x1u) != 0))
+                if (((_flag1 & 0x1u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Referer);
                     if (nativeValue != null)
@@ -776,12 +1192,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag1 |= 0x1u;
                 }
-                return _Referer;
+
+                if (_Referer.Count > 0)
+                {
+                    return _Referer;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag1 |= 0x1u;
-                _Referer = value;
+
+                if (value.Count > 0)
+                {
+                    _Referer = value;
+                }
+                else
+                {
+                    _Referer = default;
+                }
             }
         }
 
@@ -789,7 +1218,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag1 & 0x2u) != 0))
+                if (((_flag1 & 0x2u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Te);
                     if (nativeValue != null)
@@ -798,12 +1227,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag1 |= 0x2u;
                 }
-                return _TE;
+
+                if (_TE.Count > 0)
+                {
+                    return _TE;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag1 |= 0x2u;
-                _TE = value;
+
+                if (value.Count > 0)
+                {
+                    _TE = value;
+                }
+                else
+                {
+                    _TE = default;
+                }
             }
         }
 
@@ -811,7 +1253,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag1 & 0x4u) != 0))
+                if (((_flag1 & 0x4u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Trailer);
                     if (nativeValue != null)
@@ -820,12 +1262,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag1 |= 0x4u;
                 }
-                return _Trailer;
+
+                if (_Trailer.Count > 0)
+                {
+                    return _Trailer;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag1 |= 0x4u;
-                _Trailer = value;
+
+                if (value.Count > 0)
+                {
+                    _Trailer = value;
+                }
+                else
+                {
+                    _Trailer = default;
+                }
             }
         }
 
@@ -833,7 +1288,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag1 & 0x8u) != 0))
+                if (((_flag1 & 0x8u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.TransferEncoding);
                     if (nativeValue != null)
@@ -842,12 +1297,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag1 |= 0x8u;
                 }
-                return _TransferEncoding;
+
+                if (_TransferEncoding.Count > 0)
+                {
+                    return _TransferEncoding;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag1 |= 0x8u;
-                _TransferEncoding = value;
+
+                if (value.Count > 0)
+                {
+                    _TransferEncoding = value;
+                }
+                else
+                {
+                    _TransferEncoding = default;
+                }
             }
         }
 
@@ -855,7 +1323,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag1 & 0x10u) != 0))
+                if (((_flag1 & 0x10u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Translate);
                     if (nativeValue != null)
@@ -864,12 +1332,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag1 |= 0x10u;
                 }
-                return _Translate;
+
+                if (_Translate.Count > 0)
+                {
+                    return _Translate;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag1 |= 0x10u;
-                _Translate = value;
+
+                if (value.Count > 0)
+                {
+                    _Translate = value;
+                }
+                else
+                {
+                    _Translate = default;
+                }
             }
         }
 
@@ -877,7 +1358,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag1 & 0x20u) != 0))
+                if (((_flag1 & 0x20u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Upgrade);
                     if (nativeValue != null)
@@ -886,12 +1367,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag1 |= 0x20u;
                 }
-                return _Upgrade;
+
+                if (_Upgrade.Count > 0)
+                {
+                    return _Upgrade;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag1 |= 0x20u;
-                _Upgrade = value;
+
+                if (value.Count > 0)
+                {
+                    _Upgrade = value;
+                }
+                else
+                {
+                    _Upgrade = default;
+                }
             }
         }
 
@@ -899,7 +1393,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag1 & 0x40u) != 0))
+                if (((_flag1 & 0x40u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.UserAgent);
                     if (nativeValue != null)
@@ -908,12 +1402,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag1 |= 0x40u;
                 }
-                return _UserAgent;
+
+                if (_UserAgent.Count > 0)
+                {
+                    return _UserAgent;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag1 |= 0x40u;
-                _UserAgent = value;
+
+                if (value.Count > 0)
+                {
+                    _UserAgent = value;
+                }
+                else
+                {
+                    _UserAgent = default;
+                }
             }
         }
 
@@ -921,7 +1428,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag1 & 0x80u) != 0))
+                if (((_flag1 & 0x80u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Via);
                     if (nativeValue != null)
@@ -930,12 +1437,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag1 |= 0x80u;
                 }
-                return _Via;
+
+                if (_Via.Count > 0)
+                {
+                    return _Via;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag1 |= 0x80u;
-                _Via = value;
+
+                if (value.Count > 0)
+                {
+                    _Via = value;
+                }
+                else
+                {
+                    _Via = default;
+                }
             }
         }
 
@@ -943,7 +1463,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!((_flag1 & 0x100u) != 0))
+                if (((_flag1 & 0x100u)) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Warning);
                     if (nativeValue != null)
@@ -952,12 +1472,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     _flag1 |= 0x100u;
                 }
-                return _Warning;
+
+                if (_Warning.Count > 0)
+                {
+                    return _Warning;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 _flag1 |= 0x100u;
-                _Warning = value;
+
+                if (value.Count > 0)
+                {
+                    _Warning = value;
+                }
+                else
+                {
+                    _Warning = default;
+                }
             }
         }
 
@@ -1411,7 +1944,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     break;
             }
-            value = StringValues.Empty;
+            value = default;
             return false;
         }
 
@@ -1422,7 +1955,6 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 case 2:
                     if (string.Equals(key, HeaderNames.TE, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag1 |= 0x2u;
                         TE = value;
                         return true;
                     }
@@ -1430,7 +1962,6 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 case 3:
                     if (string.Equals(key, HeaderNames.Via, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag1 |= 0x80u;
                         Via = value;
                         return true;
                     }
@@ -1438,19 +1969,16 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 case 4:
                     if (string.Equals(key, HeaderNames.Date, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x10000u;
                         Date = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.From, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x80000u;
                         From = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.Host, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x100000u;
                         Host = value;
                         return true;
                     }
@@ -1458,13 +1986,11 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 case 5:
                     if (string.Equals(key, HeaderNames.Allow, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x10u;
                         Allow = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.Range, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x80000000u;
                         Range = value;
                         return true;
                     }
@@ -1472,25 +1998,21 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 case 6:
                     if (string.Equals(key, HeaderNames.Accept, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x1u;
                         Accept = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.Cookie, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x8000u;
                         Cookie = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.Expect, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x20000u;
                         Expect = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.Pragma, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x20000000u;
                         Pragma = value;
                         return true;
                     }
@@ -1498,31 +2020,26 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 case 7:
                     if (string.Equals(key, HeaderNames.Expires, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x40000u;
                         Expires = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.Referer, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag1 |= 0x1u;
                         Referer = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.Trailer, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag1 |= 0x4u;
                         Trailer = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.Upgrade, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag1 |= 0x20u;
                         Upgrade = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.Warning, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag1 |= 0x100u;
                         Warning = value;
                         return true;
                     }
@@ -1530,13 +2047,11 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 case 8:
                     if (string.Equals(key, HeaderNames.IfMatch, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x200000u;
                         IfMatch = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.IfRange, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x1000000u;
                         IfRange = value;
                         return true;
                     }
@@ -1544,7 +2059,6 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 case 9:
                     if (string.Equals(key, HeaderNames.Translate, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag1 |= 0x10u;
                         Translate = value;
                         return true;
                     }
@@ -1552,19 +2066,16 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 case 10:
                     if (string.Equals(key, HeaderNames.Connection, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x80u;
                         Connection = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.KeepAlive, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x4000000u;
                         KeepAlive = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.UserAgent, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag1 |= 0x40u;
                         UserAgent = value;
                         return true;
                     }
@@ -1572,7 +2083,6 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 case 11:
                     if (string.Equals(key, HeaderNames.ContentMD5, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x1000u;
                         ContentMD5 = value;
                         return true;
                     }
@@ -1580,13 +2090,11 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 case 12:
                     if (string.Equals(key, HeaderNames.ContentType, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x4000u;
                         ContentType = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.MaxForwards, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x10000000u;
                         MaxForwards = value;
                         return true;
                     }
@@ -1594,31 +2102,26 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 case 13:
                     if (string.Equals(key, HeaderNames.Authorization, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x20u;
                         Authorization = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.CacheControl, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x40u;
                         CacheControl = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.ContentRange, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x2000u;
                         ContentRange = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.IfNoneMatch, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x800000u;
                         IfNoneMatch = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.LastModified, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x8000000u;
                         LastModified = value;
                         return true;
                     }
@@ -1626,13 +2129,11 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 case 14:
                     if (string.Equals(key, HeaderNames.AcceptCharset, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x2u;
                         AcceptCharset = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.ContentLength, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x400u;
                         ContentLength = value;
                         return true;
                     }
@@ -1640,13 +2141,11 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 case 15:
                     if (string.Equals(key, HeaderNames.AcceptEncoding, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x4u;
                         AcceptEncoding = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.AcceptLanguage, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x8u;
                         AcceptLanguage = value;
                         return true;
                     }
@@ -1654,19 +2153,16 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 case 16:
                     if (string.Equals(key, HeaderNames.ContentEncoding, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x100u;
                         ContentEncoding = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.ContentLanguage, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x200u;
                         ContentLanguage = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.ContentLocation, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x800u;
                         ContentLocation = value;
                         return true;
                     }
@@ -1674,13 +2170,11 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 case 17:
                     if (string.Equals(key, HeaderNames.IfModifiedSince, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x400000u;
                         IfModifiedSince = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.TransferEncoding, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag1 |= 0x8u;
                         TransferEncoding = value;
                         return true;
                     }
@@ -1688,13 +2182,11 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                 case 19:
                     if (string.Equals(key, HeaderNames.IfUnmodifiedSince, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x2000000u;
                         IfUnmodifiedSince = value;
                         return true;
                     }
                     if (string.Equals(key, HeaderNames.ProxyAuthorization, StringComparison.OrdinalIgnoreCase))
                     {
-                        _flag0 |= 0x40000000u;
                         ProxyAuthorization = value;
                         return true;
                     }
@@ -1712,7 +2204,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.Te))
                         {
-                            TE = StringValues.Empty;
+                            TE = default;
                             return true;
                         }
                         return false;
@@ -1724,7 +2216,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.Via))
                         {
-                            Via = StringValues.Empty;
+                            Via = default;
                             return true;
                         }
                         return false;
@@ -1736,7 +2228,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.Date))
                         {
-                            Date = StringValues.Empty;
+                            Date = default;
                             return true;
                         }
                         return false;
@@ -1746,7 +2238,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.From))
                         {
-                            From = StringValues.Empty;
+                            From = default;
                             return true;
                         }
                         return false;
@@ -1756,7 +2248,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.Host))
                         {
-                            Host = StringValues.Empty;
+                            Host = default;
                             return true;
                         }
                         return false;
@@ -1768,7 +2260,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.Allow))
                         {
-                            Allow = StringValues.Empty;
+                            Allow = default;
                             return true;
                         }
                         return false;
@@ -1778,7 +2270,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.Range))
                         {
-                            Range = StringValues.Empty;
+                            Range = default;
                             return true;
                         }
                         return false;
@@ -1790,7 +2282,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.Accept))
                         {
-                            Accept = StringValues.Empty;
+                            Accept = default;
                             return true;
                         }
                         return false;
@@ -1800,7 +2292,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.Cookie))
                         {
-                            Cookie = StringValues.Empty;
+                            Cookie = default;
                             return true;
                         }
                         return false;
@@ -1810,7 +2302,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.Expect))
                         {
-                            Expect = StringValues.Empty;
+                            Expect = default;
                             return true;
                         }
                         return false;
@@ -1820,7 +2312,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.Pragma))
                         {
-                            Pragma = StringValues.Empty;
+                            Pragma = default;
                             return true;
                         }
                         return false;
@@ -1832,7 +2324,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.Expires))
                         {
-                            Expires = StringValues.Empty;
+                            Expires = default;
                             return true;
                         }
                         return false;
@@ -1842,7 +2334,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.Referer))
                         {
-                            Referer = StringValues.Empty;
+                            Referer = default;
                             return true;
                         }
                         return false;
@@ -1852,7 +2344,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.Trailer))
                         {
-                            Trailer = StringValues.Empty;
+                            Trailer = default;
                             return true;
                         }
                         return false;
@@ -1862,7 +2354,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.Upgrade))
                         {
-                            Upgrade = StringValues.Empty;
+                            Upgrade = default;
                             return true;
                         }
                         return false;
@@ -1872,7 +2364,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.Warning))
                         {
-                            Warning = StringValues.Empty;
+                            Warning = default;
                             return true;
                         }
                         return false;
@@ -1884,7 +2376,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.IfMatch))
                         {
-                            IfMatch = StringValues.Empty;
+                            IfMatch = default;
                             return true;
                         }
                         return false;
@@ -1894,7 +2386,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.IfRange))
                         {
-                            IfRange = StringValues.Empty;
+                            IfRange = default;
                             return true;
                         }
                         return false;
@@ -1906,7 +2398,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.Translate))
                         {
-                            Translate = StringValues.Empty;
+                            Translate = default;
                             return true;
                         }
                         return false;
@@ -1918,7 +2410,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.Connection))
                         {
-                            Connection = StringValues.Empty;
+                            Connection = default;
                             return true;
                         }
                         return false;
@@ -1928,7 +2420,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.KeepAlive))
                         {
-                            KeepAlive = StringValues.Empty;
+                            KeepAlive = default;
                             return true;
                         }
                         return false;
@@ -1938,7 +2430,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.UserAgent))
                         {
-                            UserAgent = StringValues.Empty;
+                            UserAgent = default;
                             return true;
                         }
                         return false;
@@ -1950,7 +2442,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.ContentMd5))
                         {
-                            ContentMD5 = StringValues.Empty;
+                            ContentMD5 = default;
                             return true;
                         }
                         return false;
@@ -1962,7 +2454,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.ContentType))
                         {
-                            ContentType = StringValues.Empty;
+                            ContentType = default;
                             return true;
                         }
                         return false;
@@ -1972,7 +2464,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.MaxForwards))
                         {
-                            MaxForwards = StringValues.Empty;
+                            MaxForwards = default;
                             return true;
                         }
                         return false;
@@ -1984,7 +2476,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.Authorization))
                         {
-                            Authorization = StringValues.Empty;
+                            Authorization = default;
                             return true;
                         }
                         return false;
@@ -1994,7 +2486,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.CacheControl))
                         {
-                            CacheControl = StringValues.Empty;
+                            CacheControl = default;
                             return true;
                         }
                         return false;
@@ -2004,7 +2496,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.ContentRange))
                         {
-                            ContentRange = StringValues.Empty;
+                            ContentRange = default;
                             return true;
                         }
                         return false;
@@ -2014,7 +2506,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.IfNoneMatch))
                         {
-                            IfNoneMatch = StringValues.Empty;
+                            IfNoneMatch = default;
                             return true;
                         }
                         return false;
@@ -2024,7 +2516,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.LastModified))
                         {
-                            LastModified = StringValues.Empty;
+                            LastModified = default;
                             return true;
                         }
                         return false;
@@ -2036,7 +2528,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.AcceptCharset))
                         {
-                            AcceptCharset = StringValues.Empty;
+                            AcceptCharset = default;
                             return true;
                         }
                         return false;
@@ -2046,7 +2538,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.ContentLength))
                         {
-                            ContentLength = StringValues.Empty;
+                            ContentLength = default;
                             return true;
                         }
                         return false;
@@ -2058,7 +2550,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.AcceptEncoding))
                         {
-                            AcceptEncoding = StringValues.Empty;
+                            AcceptEncoding = default;
                             return true;
                         }
                         return false;
@@ -2068,7 +2560,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.AcceptLanguage))
                         {
-                            AcceptLanguage = StringValues.Empty;
+                            AcceptLanguage = default;
                             return true;
                         }
                         return false;
@@ -2080,7 +2572,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.ContentEncoding))
                         {
-                            ContentEncoding = StringValues.Empty;
+                            ContentEncoding = default;
                             return true;
                         }
                         return false;
@@ -2090,7 +2582,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.ContentLanguage))
                         {
-                            ContentLanguage = StringValues.Empty;
+                            ContentLanguage = default;
                             return true;
                         }
                         return false;
@@ -2100,7 +2592,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.ContentLocation))
                         {
-                            ContentLocation = StringValues.Empty;
+                            ContentLocation = default;
                             return true;
                         }
                         return false;
@@ -2112,7 +2604,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.IfModifiedSince))
                         {
-                            IfModifiedSince = StringValues.Empty;
+                            IfModifiedSince = default;
                             return true;
                         }
                         return false;
@@ -2122,7 +2614,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.TransferEncoding))
                         {
-                            TransferEncoding = StringValues.Empty;
+                            TransferEncoding = default;
                             return true;
                         }
                         return false;
@@ -2134,7 +2626,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.IfUnmodifiedSince))
                         {
-                            IfUnmodifiedSince = StringValues.Empty;
+                            IfUnmodifiedSince = default;
                             return true;
                         }
                         return false;
@@ -2144,7 +2636,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(HttpSysRequestHeader.ProxyAuthorization))
                         {
-                            ProxyAuthorization = StringValues.Empty;
+                            ProxyAuthorization = default;
                             return true;
                         }
                         return false;
@@ -2752,47 +3244,47 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 
         private bool HasKnownHeader(HttpSysRequestHeader header) => header switch
         {
-            HttpSysRequestHeader.Accept => ((_flag0 & 0x1u) != 0) ? _Accept.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Accept),
-            HttpSysRequestHeader.AcceptCharset => ((_flag0 & 0x2u) != 0) ? _AcceptCharset.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.AcceptCharset),
-            HttpSysRequestHeader.AcceptEncoding => ((_flag0 & 0x4u) != 0) ? _AcceptEncoding.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.AcceptEncoding),
-            HttpSysRequestHeader.AcceptLanguage => ((_flag0 & 0x8u) != 0) ? _AcceptLanguage.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.AcceptLanguage),
-            HttpSysRequestHeader.Allow => ((_flag0 & 0x10u) != 0) ? _Allow.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Allow),
-            HttpSysRequestHeader.Authorization => ((_flag0 & 0x20u) != 0) ? _Authorization.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Authorization),
-            HttpSysRequestHeader.CacheControl => ((_flag0 & 0x40u) != 0) ? _CacheControl.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.CacheControl),
-            HttpSysRequestHeader.Connection => ((_flag0 & 0x80u) != 0) ? _Connection.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Connection),
-            HttpSysRequestHeader.ContentEncoding => ((_flag0 & 0x100u) != 0) ? _ContentEncoding.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentEncoding),
-            HttpSysRequestHeader.ContentLanguage => ((_flag0 & 0x200u) != 0) ? _ContentLanguage.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentLanguage),
-            HttpSysRequestHeader.ContentLength => ((_flag0 & 0x400u) != 0) ? _ContentLength.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentLength),
-            HttpSysRequestHeader.ContentLocation => ((_flag0 & 0x800u) != 0) ? _ContentLocation.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentLocation),
-            HttpSysRequestHeader.ContentMd5 => ((_flag0 & 0x1000u) != 0) ? _ContentMD5.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentMd5),
-            HttpSysRequestHeader.ContentRange => ((_flag0 & 0x2000u) != 0) ? _ContentRange.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentRange),
-            HttpSysRequestHeader.ContentType => ((_flag0 & 0x4000u) != 0) ? _ContentType.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentType),
-            HttpSysRequestHeader.Cookie => ((_flag0 & 0x8000u) != 0) ? _Cookie.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Cookie),
-            HttpSysRequestHeader.Date => ((_flag0 & 0x10000u) != 0) ? _Date.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Date),
-            HttpSysRequestHeader.Expect => ((_flag0 & 0x20000u) != 0) ? _Expect.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Expect),
-            HttpSysRequestHeader.Expires => ((_flag0 & 0x40000u) != 0) ? _Expires.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Expires),
-            HttpSysRequestHeader.From => ((_flag0 & 0x80000u) != 0) ? _From.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.From),
-            HttpSysRequestHeader.Host => ((_flag0 & 0x100000u) != 0) ? _Host.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Host),
-            HttpSysRequestHeader.IfMatch => ((_flag0 & 0x200000u) != 0) ? _IfMatch.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfMatch),
-            HttpSysRequestHeader.IfModifiedSince => ((_flag0 & 0x400000u) != 0) ? _IfModifiedSince.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfModifiedSince),
-            HttpSysRequestHeader.IfNoneMatch => ((_flag0 & 0x800000u) != 0) ? _IfNoneMatch.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfNoneMatch),
-            HttpSysRequestHeader.IfRange => ((_flag0 & 0x1000000u) != 0) ? _IfRange.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfRange),
-            HttpSysRequestHeader.IfUnmodifiedSince => ((_flag0 & 0x2000000u) != 0) ? _IfUnmodifiedSince.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfUnmodifiedSince),
-            HttpSysRequestHeader.KeepAlive => ((_flag0 & 0x4000000u) != 0) ? _KeepAlive.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.KeepAlive),
-            HttpSysRequestHeader.LastModified => ((_flag0 & 0x8000000u) != 0) ? _LastModified.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.LastModified),
-            HttpSysRequestHeader.MaxForwards => ((_flag0 & 0x10000000u) != 0) ? _MaxForwards.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.MaxForwards),
-            HttpSysRequestHeader.Pragma => ((_flag0 & 0x20000000u) != 0) ? _Pragma.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Pragma),
-            HttpSysRequestHeader.ProxyAuthorization => ((_flag0 & 0x40000000u) != 0) ? _ProxyAuthorization.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ProxyAuthorization),
-            HttpSysRequestHeader.Range => ((_flag0 & 0x80000000u) != 0) ? _Range.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Range),
-            HttpSysRequestHeader.Referer => ((_flag1 & 0x1u) != 0) ? _Referer.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Referer),
-            HttpSysRequestHeader.Te => ((_flag1 & 0x2u) != 0) ? _TE.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Te),
-            HttpSysRequestHeader.Trailer => ((_flag1 & 0x4u) != 0) ? _Trailer.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Trailer),
-            HttpSysRequestHeader.TransferEncoding => ((_flag1 & 0x8u) != 0) ? _TransferEncoding.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.TransferEncoding),
-            HttpSysRequestHeader.Translate => ((_flag1 & 0x10u) != 0) ? _Translate.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Translate),
-            HttpSysRequestHeader.Upgrade => ((_flag1 & 0x20u) != 0) ? _Upgrade.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Upgrade),
-            HttpSysRequestHeader.UserAgent => ((_flag1 & 0x40u) != 0) ? _UserAgent.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.UserAgent),
-            HttpSysRequestHeader.Via => ((_flag1 & 0x80u) != 0) ? _Via.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Via),
-            HttpSysRequestHeader.Warning => ((_flag1 & 0x100u) != 0) ? _Warning.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Warning),
+            HttpSysRequestHeader.Accept => ((_flag0 & 0x1u)) != 0 ? _Accept.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Accept),
+            HttpSysRequestHeader.AcceptCharset => ((_flag0 & 0x2u)) != 0 ? _AcceptCharset.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.AcceptCharset),
+            HttpSysRequestHeader.AcceptEncoding => ((_flag0 & 0x4u)) != 0 ? _AcceptEncoding.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.AcceptEncoding),
+            HttpSysRequestHeader.AcceptLanguage => ((_flag0 & 0x8u)) != 0 ? _AcceptLanguage.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.AcceptLanguage),
+            HttpSysRequestHeader.Allow => ((_flag0 & 0x10u)) != 0 ? _Allow.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Allow),
+            HttpSysRequestHeader.Authorization => ((_flag0 & 0x20u)) != 0 ? _Authorization.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Authorization),
+            HttpSysRequestHeader.CacheControl => ((_flag0 & 0x40u)) != 0 ? _CacheControl.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.CacheControl),
+            HttpSysRequestHeader.Connection => ((_flag0 & 0x80u)) != 0 ? _Connection.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Connection),
+            HttpSysRequestHeader.ContentEncoding => ((_flag0 & 0x100u)) != 0 ? _ContentEncoding.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentEncoding),
+            HttpSysRequestHeader.ContentLanguage => ((_flag0 & 0x200u)) != 0 ? _ContentLanguage.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentLanguage),
+            HttpSysRequestHeader.ContentLength => ((_flag0 & 0x400u)) != 0 ? _ContentLength.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentLength),
+            HttpSysRequestHeader.ContentLocation => ((_flag0 & 0x800u)) != 0 ? _ContentLocation.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentLocation),
+            HttpSysRequestHeader.ContentMd5 => ((_flag0 & 0x1000u)) != 0 ? _ContentMD5.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentMd5),
+            HttpSysRequestHeader.ContentRange => ((_flag0 & 0x2000u)) != 0 ? _ContentRange.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentRange),
+            HttpSysRequestHeader.ContentType => ((_flag0 & 0x4000u)) != 0 ? _ContentType.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentType),
+            HttpSysRequestHeader.Cookie => ((_flag0 & 0x8000u)) != 0 ? _Cookie.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Cookie),
+            HttpSysRequestHeader.Date => ((_flag0 & 0x10000u)) != 0 ? _Date.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Date),
+            HttpSysRequestHeader.Expect => ((_flag0 & 0x20000u)) != 0 ? _Expect.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Expect),
+            HttpSysRequestHeader.Expires => ((_flag0 & 0x40000u)) != 0 ? _Expires.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Expires),
+            HttpSysRequestHeader.From => ((_flag0 & 0x80000u)) != 0 ? _From.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.From),
+            HttpSysRequestHeader.Host => ((_flag0 & 0x100000u)) != 0 ? _Host.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Host),
+            HttpSysRequestHeader.IfMatch => ((_flag0 & 0x200000u)) != 0 ? _IfMatch.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfMatch),
+            HttpSysRequestHeader.IfModifiedSince => ((_flag0 & 0x400000u)) != 0 ? _IfModifiedSince.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfModifiedSince),
+            HttpSysRequestHeader.IfNoneMatch => ((_flag0 & 0x800000u)) != 0 ? _IfNoneMatch.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfNoneMatch),
+            HttpSysRequestHeader.IfRange => ((_flag0 & 0x1000000u)) != 0 ? _IfRange.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfRange),
+            HttpSysRequestHeader.IfUnmodifiedSince => ((_flag0 & 0x2000000u)) != 0 ? _IfUnmodifiedSince.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfUnmodifiedSince),
+            HttpSysRequestHeader.KeepAlive => ((_flag0 & 0x4000000u)) != 0 ? _KeepAlive.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.KeepAlive),
+            HttpSysRequestHeader.LastModified => ((_flag0 & 0x8000000u)) != 0 ? _LastModified.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.LastModified),
+            HttpSysRequestHeader.MaxForwards => ((_flag0 & 0x10000000u)) != 0 ? _MaxForwards.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.MaxForwards),
+            HttpSysRequestHeader.Pragma => ((_flag0 & 0x20000000u)) != 0 ? _Pragma.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Pragma),
+            HttpSysRequestHeader.ProxyAuthorization => ((_flag0 & 0x40000000u)) != 0 ? _ProxyAuthorization.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ProxyAuthorization),
+            HttpSysRequestHeader.Range => ((_flag0 & 0x80000000u)) != 0 ? _Range.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Range),
+            HttpSysRequestHeader.Referer => ((_flag1 & 0x1u)) != 0 ? _Referer.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Referer),
+            HttpSysRequestHeader.Te => ((_flag1 & 0x2u)) != 0 ? _TE.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Te),
+            HttpSysRequestHeader.Trailer => ((_flag1 & 0x4u)) != 0 ? _Trailer.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Trailer),
+            HttpSysRequestHeader.TransferEncoding => ((_flag1 & 0x8u)) != 0 ? _TransferEncoding.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.TransferEncoding),
+            HttpSysRequestHeader.Translate => ((_flag1 & 0x10u)) != 0 ? _Translate.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Translate),
+            HttpSysRequestHeader.Upgrade => ((_flag1 & 0x20u)) != 0 ? _Upgrade.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Upgrade),
+            HttpSysRequestHeader.UserAgent => ((_flag1 & 0x40u)) != 0 ? _UserAgent.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.UserAgent),
+            HttpSysRequestHeader.Via => ((_flag1 & 0x80u)) != 0 ? _Via.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Via),
+            HttpSysRequestHeader.Warning => ((_flag1 & 0x100u)) != 0 ? _Warning.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Warning),
             _ => throw new NotImplementedException()
         };
     }

--- a/src/Shared/HttpSys/RequestProcessing/RequestHeaders.Generated.cs
+++ b/src/Shared/HttpSys/RequestProcessing/RequestHeaders.Generated.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x1u)) == 0)
+                if ((_flag0 & 0x1u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Accept);
                     if (nativeValue != null)
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x2u)) == 0)
+                if ((_flag0 & 0x2u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.AcceptCharset);
                     if (nativeValue != null)
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x4u)) == 0)
+                if ((_flag0 & 0x4u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.AcceptEncoding);
                     if (nativeValue != null)
@@ -168,7 +168,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x8u)) == 0)
+                if ((_flag0 & 0x8u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.AcceptLanguage);
                     if (nativeValue != null)
@@ -203,7 +203,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x10u)) == 0)
+                if ((_flag0 & 0x10u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Allow);
                     if (nativeValue != null)
@@ -238,7 +238,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x20u)) == 0)
+                if ((_flag0 & 0x20u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Authorization);
                     if (nativeValue != null)
@@ -273,7 +273,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x40u)) == 0)
+                if ((_flag0 & 0x40u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.CacheControl);
                     if (nativeValue != null)
@@ -308,7 +308,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x80u)) == 0)
+                if ((_flag0 & 0x80u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Connection);
                     if (nativeValue != null)
@@ -343,7 +343,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x100u)) == 0)
+                if ((_flag0 & 0x100u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.ContentEncoding);
                     if (nativeValue != null)
@@ -378,7 +378,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x200u)) == 0)
+                if ((_flag0 & 0x200u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.ContentLanguage);
                     if (nativeValue != null)
@@ -413,7 +413,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x400u)) == 0)
+                if ((_flag0 & 0x400u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.ContentLength);
                     if (nativeValue != null)
@@ -448,7 +448,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x800u)) == 0)
+                if ((_flag0 & 0x800u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.ContentLocation);
                     if (nativeValue != null)
@@ -483,7 +483,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x1000u)) == 0)
+                if ((_flag0 & 0x1000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.ContentMd5);
                     if (nativeValue != null)
@@ -518,7 +518,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x2000u)) == 0)
+                if ((_flag0 & 0x2000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.ContentRange);
                     if (nativeValue != null)
@@ -553,7 +553,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x4000u)) == 0)
+                if ((_flag0 & 0x4000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.ContentType);
                     if (nativeValue != null)
@@ -588,7 +588,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x8000u)) == 0)
+                if ((_flag0 & 0x8000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Cookie);
                     if (nativeValue != null)
@@ -623,7 +623,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x10000u)) == 0)
+                if ((_flag0 & 0x10000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Date);
                     if (nativeValue != null)
@@ -658,7 +658,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x20000u)) == 0)
+                if ((_flag0 & 0x20000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Expect);
                     if (nativeValue != null)
@@ -693,7 +693,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x40000u)) == 0)
+                if ((_flag0 & 0x40000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Expires);
                     if (nativeValue != null)
@@ -728,7 +728,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x80000u)) == 0)
+                if ((_flag0 & 0x80000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.From);
                     if (nativeValue != null)
@@ -763,7 +763,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x100000u)) == 0)
+                if ((_flag0 & 0x100000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Host);
                     if (nativeValue != null)
@@ -798,7 +798,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x200000u)) == 0)
+                if ((_flag0 & 0x200000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.IfMatch);
                     if (nativeValue != null)
@@ -833,7 +833,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x400000u)) == 0)
+                if ((_flag0 & 0x400000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.IfModifiedSince);
                     if (nativeValue != null)
@@ -868,7 +868,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x800000u)) == 0)
+                if ((_flag0 & 0x800000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.IfNoneMatch);
                     if (nativeValue != null)
@@ -903,7 +903,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x1000000u)) == 0)
+                if ((_flag0 & 0x1000000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.IfRange);
                     if (nativeValue != null)
@@ -938,7 +938,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x2000000u)) == 0)
+                if ((_flag0 & 0x2000000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.IfUnmodifiedSince);
                     if (nativeValue != null)
@@ -973,7 +973,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x4000000u)) == 0)
+                if ((_flag0 & 0x4000000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.KeepAlive);
                     if (nativeValue != null)
@@ -1008,7 +1008,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x8000000u)) == 0)
+                if ((_flag0 & 0x8000000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.LastModified);
                     if (nativeValue != null)
@@ -1043,7 +1043,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x10000000u)) == 0)
+                if ((_flag0 & 0x10000000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.MaxForwards);
                     if (nativeValue != null)
@@ -1078,7 +1078,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x20000000u)) == 0)
+                if ((_flag0 & 0x20000000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Pragma);
                     if (nativeValue != null)
@@ -1113,7 +1113,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x40000000u)) == 0)
+                if ((_flag0 & 0x40000000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.ProxyAuthorization);
                     if (nativeValue != null)
@@ -1148,7 +1148,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag0 & 0x80000000u)) == 0)
+                if ((_flag0 & 0x80000000u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Range);
                     if (nativeValue != null)
@@ -1183,7 +1183,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag1 & 0x1u)) == 0)
+                if ((_flag1 & 0x1u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Referer);
                     if (nativeValue != null)
@@ -1218,7 +1218,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag1 & 0x2u)) == 0)
+                if ((_flag1 & 0x2u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Te);
                     if (nativeValue != null)
@@ -1253,7 +1253,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag1 & 0x4u)) == 0)
+                if ((_flag1 & 0x4u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Trailer);
                     if (nativeValue != null)
@@ -1288,7 +1288,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag1 & 0x8u)) == 0)
+                if ((_flag1 & 0x8u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.TransferEncoding);
                     if (nativeValue != null)
@@ -1323,7 +1323,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag1 & 0x10u)) == 0)
+                if ((_flag1 & 0x10u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Translate);
                     if (nativeValue != null)
@@ -1358,7 +1358,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag1 & 0x20u)) == 0)
+                if ((_flag1 & 0x20u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Upgrade);
                     if (nativeValue != null)
@@ -1393,7 +1393,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag1 & 0x40u)) == 0)
+                if ((_flag1 & 0x40u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.UserAgent);
                     if (nativeValue != null)
@@ -1428,7 +1428,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag1 & 0x80u)) == 0)
+                if ((_flag1 & 0x80u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Via);
                     if (nativeValue != null)
@@ -1463,7 +1463,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (((_flag1 & 0x100u)) == 0)
+                if ((_flag1 & 0x100u) == 0)
                 {
                     string nativeValue = GetKnownHeader(HttpSysRequestHeader.Warning);
                     if (nativeValue != null)
@@ -3244,47 +3244,47 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 
         private bool HasKnownHeader(HttpSysRequestHeader header) => header switch
         {
-            HttpSysRequestHeader.Accept => ((_flag0 & 0x1u)) != 0 ? _Accept.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Accept),
-            HttpSysRequestHeader.AcceptCharset => ((_flag0 & 0x2u)) != 0 ? _AcceptCharset.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.AcceptCharset),
-            HttpSysRequestHeader.AcceptEncoding => ((_flag0 & 0x4u)) != 0 ? _AcceptEncoding.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.AcceptEncoding),
-            HttpSysRequestHeader.AcceptLanguage => ((_flag0 & 0x8u)) != 0 ? _AcceptLanguage.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.AcceptLanguage),
-            HttpSysRequestHeader.Allow => ((_flag0 & 0x10u)) != 0 ? _Allow.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Allow),
-            HttpSysRequestHeader.Authorization => ((_flag0 & 0x20u)) != 0 ? _Authorization.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Authorization),
-            HttpSysRequestHeader.CacheControl => ((_flag0 & 0x40u)) != 0 ? _CacheControl.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.CacheControl),
-            HttpSysRequestHeader.Connection => ((_flag0 & 0x80u)) != 0 ? _Connection.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Connection),
-            HttpSysRequestHeader.ContentEncoding => ((_flag0 & 0x100u)) != 0 ? _ContentEncoding.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentEncoding),
-            HttpSysRequestHeader.ContentLanguage => ((_flag0 & 0x200u)) != 0 ? _ContentLanguage.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentLanguage),
-            HttpSysRequestHeader.ContentLength => ((_flag0 & 0x400u)) != 0 ? _ContentLength.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentLength),
-            HttpSysRequestHeader.ContentLocation => ((_flag0 & 0x800u)) != 0 ? _ContentLocation.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentLocation),
-            HttpSysRequestHeader.ContentMd5 => ((_flag0 & 0x1000u)) != 0 ? _ContentMD5.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentMd5),
-            HttpSysRequestHeader.ContentRange => ((_flag0 & 0x2000u)) != 0 ? _ContentRange.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentRange),
-            HttpSysRequestHeader.ContentType => ((_flag0 & 0x4000u)) != 0 ? _ContentType.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentType),
-            HttpSysRequestHeader.Cookie => ((_flag0 & 0x8000u)) != 0 ? _Cookie.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Cookie),
-            HttpSysRequestHeader.Date => ((_flag0 & 0x10000u)) != 0 ? _Date.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Date),
-            HttpSysRequestHeader.Expect => ((_flag0 & 0x20000u)) != 0 ? _Expect.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Expect),
-            HttpSysRequestHeader.Expires => ((_flag0 & 0x40000u)) != 0 ? _Expires.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Expires),
-            HttpSysRequestHeader.From => ((_flag0 & 0x80000u)) != 0 ? _From.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.From),
-            HttpSysRequestHeader.Host => ((_flag0 & 0x100000u)) != 0 ? _Host.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Host),
-            HttpSysRequestHeader.IfMatch => ((_flag0 & 0x200000u)) != 0 ? _IfMatch.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfMatch),
-            HttpSysRequestHeader.IfModifiedSince => ((_flag0 & 0x400000u)) != 0 ? _IfModifiedSince.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfModifiedSince),
-            HttpSysRequestHeader.IfNoneMatch => ((_flag0 & 0x800000u)) != 0 ? _IfNoneMatch.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfNoneMatch),
-            HttpSysRequestHeader.IfRange => ((_flag0 & 0x1000000u)) != 0 ? _IfRange.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfRange),
-            HttpSysRequestHeader.IfUnmodifiedSince => ((_flag0 & 0x2000000u)) != 0 ? _IfUnmodifiedSince.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfUnmodifiedSince),
-            HttpSysRequestHeader.KeepAlive => ((_flag0 & 0x4000000u)) != 0 ? _KeepAlive.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.KeepAlive),
-            HttpSysRequestHeader.LastModified => ((_flag0 & 0x8000000u)) != 0 ? _LastModified.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.LastModified),
-            HttpSysRequestHeader.MaxForwards => ((_flag0 & 0x10000000u)) != 0 ? _MaxForwards.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.MaxForwards),
-            HttpSysRequestHeader.Pragma => ((_flag0 & 0x20000000u)) != 0 ? _Pragma.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Pragma),
-            HttpSysRequestHeader.ProxyAuthorization => ((_flag0 & 0x40000000u)) != 0 ? _ProxyAuthorization.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ProxyAuthorization),
-            HttpSysRequestHeader.Range => ((_flag0 & 0x80000000u)) != 0 ? _Range.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Range),
-            HttpSysRequestHeader.Referer => ((_flag1 & 0x1u)) != 0 ? _Referer.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Referer),
-            HttpSysRequestHeader.Te => ((_flag1 & 0x2u)) != 0 ? _TE.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Te),
-            HttpSysRequestHeader.Trailer => ((_flag1 & 0x4u)) != 0 ? _Trailer.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Trailer),
-            HttpSysRequestHeader.TransferEncoding => ((_flag1 & 0x8u)) != 0 ? _TransferEncoding.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.TransferEncoding),
-            HttpSysRequestHeader.Translate => ((_flag1 & 0x10u)) != 0 ? _Translate.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Translate),
-            HttpSysRequestHeader.Upgrade => ((_flag1 & 0x20u)) != 0 ? _Upgrade.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Upgrade),
-            HttpSysRequestHeader.UserAgent => ((_flag1 & 0x40u)) != 0 ? _UserAgent.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.UserAgent),
-            HttpSysRequestHeader.Via => ((_flag1 & 0x80u)) != 0 ? _Via.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Via),
-            HttpSysRequestHeader.Warning => ((_flag1 & 0x100u)) != 0 ? _Warning.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Warning),
+            HttpSysRequestHeader.Accept => (_flag0 & 0x1u) != 0 ? _Accept.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Accept),
+            HttpSysRequestHeader.AcceptCharset => (_flag0 & 0x2u) != 0 ? _AcceptCharset.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.AcceptCharset),
+            HttpSysRequestHeader.AcceptEncoding => (_flag0 & 0x4u) != 0 ? _AcceptEncoding.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.AcceptEncoding),
+            HttpSysRequestHeader.AcceptLanguage => (_flag0 & 0x8u) != 0 ? _AcceptLanguage.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.AcceptLanguage),
+            HttpSysRequestHeader.Allow => (_flag0 & 0x10u) != 0 ? _Allow.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Allow),
+            HttpSysRequestHeader.Authorization => (_flag0 & 0x20u) != 0 ? _Authorization.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Authorization),
+            HttpSysRequestHeader.CacheControl => (_flag0 & 0x40u) != 0 ? _CacheControl.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.CacheControl),
+            HttpSysRequestHeader.Connection => (_flag0 & 0x80u) != 0 ? _Connection.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Connection),
+            HttpSysRequestHeader.ContentEncoding => (_flag0 & 0x100u) != 0 ? _ContentEncoding.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentEncoding),
+            HttpSysRequestHeader.ContentLanguage => (_flag0 & 0x200u) != 0 ? _ContentLanguage.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentLanguage),
+            HttpSysRequestHeader.ContentLength => (_flag0 & 0x400u) != 0 ? _ContentLength.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentLength),
+            HttpSysRequestHeader.ContentLocation => (_flag0 & 0x800u) != 0 ? _ContentLocation.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentLocation),
+            HttpSysRequestHeader.ContentMd5 => (_flag0 & 0x1000u) != 0 ? _ContentMD5.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentMd5),
+            HttpSysRequestHeader.ContentRange => (_flag0 & 0x2000u) != 0 ? _ContentRange.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentRange),
+            HttpSysRequestHeader.ContentType => (_flag0 & 0x4000u) != 0 ? _ContentType.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ContentType),
+            HttpSysRequestHeader.Cookie => (_flag0 & 0x8000u) != 0 ? _Cookie.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Cookie),
+            HttpSysRequestHeader.Date => (_flag0 & 0x10000u) != 0 ? _Date.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Date),
+            HttpSysRequestHeader.Expect => (_flag0 & 0x20000u) != 0 ? _Expect.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Expect),
+            HttpSysRequestHeader.Expires => (_flag0 & 0x40000u) != 0 ? _Expires.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Expires),
+            HttpSysRequestHeader.From => (_flag0 & 0x80000u) != 0 ? _From.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.From),
+            HttpSysRequestHeader.Host => (_flag0 & 0x100000u) != 0 ? _Host.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Host),
+            HttpSysRequestHeader.IfMatch => (_flag0 & 0x200000u) != 0 ? _IfMatch.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfMatch),
+            HttpSysRequestHeader.IfModifiedSince => (_flag0 & 0x400000u) != 0 ? _IfModifiedSince.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfModifiedSince),
+            HttpSysRequestHeader.IfNoneMatch => (_flag0 & 0x800000u) != 0 ? _IfNoneMatch.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfNoneMatch),
+            HttpSysRequestHeader.IfRange => (_flag0 & 0x1000000u) != 0 ? _IfRange.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfRange),
+            HttpSysRequestHeader.IfUnmodifiedSince => (_flag0 & 0x2000000u) != 0 ? _IfUnmodifiedSince.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.IfUnmodifiedSince),
+            HttpSysRequestHeader.KeepAlive => (_flag0 & 0x4000000u) != 0 ? _KeepAlive.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.KeepAlive),
+            HttpSysRequestHeader.LastModified => (_flag0 & 0x8000000u) != 0 ? _LastModified.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.LastModified),
+            HttpSysRequestHeader.MaxForwards => (_flag0 & 0x10000000u) != 0 ? _MaxForwards.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.MaxForwards),
+            HttpSysRequestHeader.Pragma => (_flag0 & 0x20000000u) != 0 ? _Pragma.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Pragma),
+            HttpSysRequestHeader.ProxyAuthorization => (_flag0 & 0x40000000u) != 0 ? _ProxyAuthorization.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.ProxyAuthorization),
+            HttpSysRequestHeader.Range => (_flag0 & 0x80000000u) != 0 ? _Range.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Range),
+            HttpSysRequestHeader.Referer => (_flag1 & 0x1u) != 0 ? _Referer.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Referer),
+            HttpSysRequestHeader.Te => (_flag1 & 0x2u) != 0 ? _TE.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Te),
+            HttpSysRequestHeader.Trailer => (_flag1 & 0x4u) != 0 ? _Trailer.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Trailer),
+            HttpSysRequestHeader.TransferEncoding => (_flag1 & 0x8u) != 0 ? _TransferEncoding.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.TransferEncoding),
+            HttpSysRequestHeader.Translate => (_flag1 & 0x10u) != 0 ? _Translate.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Translate),
+            HttpSysRequestHeader.Upgrade => (_flag1 & 0x20u) != 0 ? _Upgrade.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Upgrade),
+            HttpSysRequestHeader.UserAgent => (_flag1 & 0x40u) != 0 ? _UserAgent.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.UserAgent),
+            HttpSysRequestHeader.Via => (_flag1 & 0x80u) != 0 ? _Via.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Via),
+            HttpSysRequestHeader.Warning => (_flag1 & 0x100u) != 0 ? _Warning.Count > 0 : _requestMemoryBlob.HasKnownHeader(HttpSysRequestHeader.Warning),
             _ => throw new NotImplementedException()
         };
     }

--- a/src/Shared/HttpSys/RequestProcessing/RequestHeaders.Generated.tt
+++ b/src/Shared/HttpSys/RequestProcessing/RequestHeaders.Generated.tt
@@ -92,24 +92,13 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     <#=MarkRead(prop.Index)#>;
                 }
 
-                if (_<#=prop.Name#>.Count > 0)
-                {
-                    return _<#=prop.Name#>;
-                }
-                return StringValues.Empty;
+                return _<#=prop.Name#>.Count > 0 ? _<#=prop.Name#> : StringValues.Empty;
             }
             set
             {
                 <#=MarkRead(prop.Index)#>;
 
-                if (value.Count > 0)
-                {
-                    _<#=prop.Name#> = value;
-                }
-                else
-                {
-                    _<#=prop.Name#> = default;
-                }
+                _<#=prop.Name#> = value.Count > 0 ? value : default;
             }
         }
 

--- a/src/Shared/HttpSys/RequestProcessing/RequestHeaders.Generated.tt
+++ b/src/Shared/HttpSys/RequestProcessing/RequestHeaders.Generated.tt
@@ -50,7 +50,7 @@ var props = new[]
 var lengths = props.GroupBy(prop=>prop.Key.Length).OrderBy(prop=>prop.Key);
 
 
-Func<int,string> IsReadMask = Index => "((_flag" + (Index / 32) + " & 0x" + (1<<(Index % 32)).ToString("x") + "u))";
+Func<int,string> IsReadMask = Index => "(_flag" + (Index / 32) + " & 0x" + (1<<(Index % 32)).ToString("x") + "u)";
 Func<int,string> MarkRead = Index => "_flag" + (Index / 32) + " |= 0x" + (1<<(Index % 32)).ToString("x") + "u";
 Func<int,string> Clear = Index => "_flag" + (Index / 32) + " &= ~0x" + (1<<(Index % 32)).ToString("x") + "u";
 #>

--- a/src/Shared/HttpSys/RequestProcessing/RequestHeaders.Generated.tt
+++ b/src/Shared/HttpSys/RequestProcessing/RequestHeaders.Generated.tt
@@ -50,7 +50,7 @@ var props = new[]
 var lengths = props.GroupBy(prop=>prop.Key.Length).OrderBy(prop=>prop.Key);
 
 
-Func<int,string> IsRead = Index => "((_flag" + (Index / 32) + " & 0x" + (1<<(Index % 32)).ToString("x") + "u) != 0)";
+Func<int,string> IsReadMask = Index => "((_flag" + (Index / 32) + " & 0x" + (1<<(Index % 32)).ToString("x") + "u))";
 Func<int,string> MarkRead = Index => "_flag" + (Index / 32) + " |= 0x" + (1<<(Index % 32)).ToString("x") + "u";
 Func<int,string> Clear = Index => "_flag" + (Index / 32) + " &= ~0x" + (1<<(Index % 32)).ToString("x") + "u";
 #>
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         {
             get
             {
-                if (!<#=IsRead(prop.Index)#>)
+                if (<#=IsReadMask(prop.Index)#> == 0)
                 {
                     string nativeValue = GetKnownHeader(<#=prop.ID#>);
                     if (nativeValue != null)
@@ -91,12 +91,25 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     }
                     <#=MarkRead(prop.Index)#>;
                 }
-                return _<#=prop.Name#>;
+
+                if (_<#=prop.Name#>.Count > 0)
+                {
+                    return _<#=prop.Name#>;
+                }
+                return StringValues.Empty;
             }
             set
             {
                 <#=MarkRead(prop.Index)#>;
-                _<#=prop.Name#> = value;
+
+                if (value.Count > 0)
+                {
+                    _<#=prop.Name#> = value;
+                }
+                else
+                {
+                    _<#=prop.Name#> = default;
+                }
             }
         }
 
@@ -135,7 +148,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     break;
 <# } #>
             }
-            value = StringValues.Empty;
+            value = default;
             return false;
         }
 
@@ -148,7 +161,6 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 <# foreach(var prop in length) { #>
                     if (string.Equals(key, HeaderNames.<#=prop.Name#>, StringComparison.OrdinalIgnoreCase))
                     {
-                        <#=MarkRead(prop.Index)#>;
                         <#=prop.Name#> = value;
                         return true;
                     }
@@ -170,7 +182,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
                     {
                         if (HasKnownHeader(<#=prop.ID#>))
                         {
-                            <#=prop.Name#> = StringValues.Empty;
+                            <#=prop.Name#> = default;
                             return true;
                         }
                         return false;
@@ -231,7 +243,7 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
         private bool HasKnownHeader(HttpSysRequestHeader header) => header switch
         {
 <# foreach(var prop in props) { #>
-            <#=prop.ID#> => <#=IsRead(prop.Index)#> ? _<#=prop.Name#>.Count > 0 : _requestMemoryBlob.HasKnownHeader(<#=prop.ID#>),
+            <#=prop.ID#> => <#=IsReadMask(prop.Index)#> != 0 ? _<#=prop.Name#>.Count > 0 : _requestMemoryBlob.HasKnownHeader(<#=prop.ID#>),
 <# } #>
             _ => throw new NotImplementedException()
         };

--- a/src/Shared/HttpSys/RequestProcessing/RequestHeaders.cs
+++ b/src/Shared/HttpSys/RequestProcessing/RequestHeaders.cs
@@ -66,6 +66,11 @@ internal sealed partial class RequestHeaders : IHeaderDictionary
 
     void IDictionary<string, StringValues>.Add(string key, StringValues value)
     {
+        if (ContainsKey(key))
+        {
+            ThrowDuplicateKeyException();
+        }
+
         if (!PropertiesTrySetValue(key, value))
         {
             Extra.Add(key, value);
@@ -216,7 +221,7 @@ internal sealed partial class RequestHeaders : IHeaderDictionary
         }
         set
         {
-            if (StringValues.IsNullOrEmpty(value))
+            if (value.Count == 0)
             {
                 Remove(key);
             }
@@ -249,6 +254,11 @@ internal sealed partial class RequestHeaders : IHeaderDictionary
         {
             throw new InvalidOperationException("The response headers cannot be modified because the response has already started.");
         }
+    }
+
+    private static void ThrowDuplicateKeyException()
+    {
+        throw new ArgumentException("An item with the same key has already been added.");
     }
 
     public IEnumerable<string> GetValues(string key)


### PR DESCRIPTION
Fixes #44509