### PR TITLE
[Named Pipe] Check for pipe broken on WaitConnectionAsync

### DIFF
--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
@@ -94,6 +94,15 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
                         }
                     }
                 }
+                catch (IOException ex) when (!_listeningToken.IsCancellationRequested)
+                {
+                    // WaitForConnectionAsync can throw IOException when the pipe is broken.
+                    NamedPipeLog.ConnectionListenerBrokenPipe(_log, ex);
+
+                    // Dispose existing pipe, create a new one and continue accepting.
+                    nextStream.Dispose();
+                    nextStream = CreateServerStream();
+                }
                 catch (OperationCanceledException ex) when (_listeningToken.IsCancellationRequested)
                 {
                     // Cancelled the current token

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeLog.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeLog.cs
@@ -77,4 +77,6 @@ internal static partial class NamedPipeLog
         }
     }
 
+    [LoggerMessage(8, LogLevel.Debug, "Named pipe listener received broken pipe while waiting for a connection.", EventName = "ConnectionListenerBrokenPipe")]
+    public static partial void ConnectionListenerBrokenPipe(ILogger logger, Exception ex);
 }


### PR DESCRIPTION
Changes from https://github.com/dotnet/aspnetcore/pull/46182

I looked up situations that can cause a broken pipe and most sources mention a broken pipe can happen when the other side has disconnected. I'm unsure how that could apply to `WaitForConnectionAsync` because we're waiting for a client to connect. Perhaps the client can request a connection, then disconnect before `WaitForConnectionAsync` returns the stream.

No test, as I could not create a situation where a broken pipe exception was thrown.

@simonferquel I added logging because I'm wary of catching an error and continuing without any record of what is happening. If there is a situation where a server keeps getting broken pipes and goes into an infinite loop, there is logging to explain what the server is doing. I'm not sure if that can happen, just being cautious.