### PR TITLE
UseBlazorFrameworkFiles: add webcil mime type mapping

### DIFF
--- a/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
+++ b/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs
@@ -86,6 +86,7 @@ public static class ComponentsWebAssemblyApplicationBuilderExtensions
         options.FileProvider = webRootFileProvider;
         var contentTypeProvider = new FileExtensionContentTypeProvider();
         AddMapping(contentTypeProvider, ".dll", MediaTypeNames.Application.Octet);
+        AddMapping(contentTypeProvider, ".webcil", MediaTypeNames.Application.Octet);
         // We unconditionally map pdbs as there will be no pdbs in the output folder for
         // release builds unless BlazorEnableDebugging is explicitly set to true.
         AddMapping(contentTypeProvider, ".pdb", MediaTypeNames.Application.Octet);


### PR DESCRIPTION

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

WebCIL is a new container format for .NET assemblies when publishing to webassembly.  (See https://github.com/dotnet/runtime/pull/79416)

Related to https://github.com/dotnet/runtime/issues/80807

