### PR TITLE
Improve IIS error when wrong application path

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
@@ -321,10 +321,21 @@ try
                 errorContext.generalErrorType = "Failed to load ASP.NET Core runtime";
                 errorContext.errorReason = "The specified version of Microsoft.NetCore.App or Microsoft.AspNetCore.App was not found.";
 
-                EventLog::Error(
-                    ASPNETCORE_EVENT_GENERAL_ERROR,
-                    ASPNETCORE_EVENT_HOSTFXR_FAILURE_MSG
-                );
+                if (intHostFxrExitCode == APPARGNOTRUNNABLE)
+                {
+                    errorContext.detailedErrorContent = "Provided application path does not exist, or isn't a .dll or .exe.";
+                    EventLog::Error(
+                        ASPNETCORE_EVENT_GENERAL_ERROR,
+                        ASPNETCORE_EVENT_HOSTFXR_BAD_APPLICATION_FAILURE_MSG
+                    );
+                }
+                else
+                {
+                    EventLog::Error(
+                        ASPNETCORE_EVENT_GENERAL_ERROR,
+                        ASPNETCORE_EVENT_HOSTFXR_FAILURE_MSG
+                    );
+                }
 
                 return E_UNEXPECTED;
             }

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
@@ -321,7 +321,7 @@ try
                 errorContext.generalErrorType = "Failed to load ASP.NET Core runtime";
                 errorContext.errorReason = "The specified version of Microsoft.NetCore.App or Microsoft.AspNetCore.App was not found.";
 
-                if (intHostFxrExitCode == APPARGNOTRUNNABLE)
+                if (intHostFxrExitCode == AppArgNotRunnable)
                 {
                     errorContext.detailedErrorContent = "Provided application path does not exist, or isn't a .dll or .exe.";
                     EventLog::Error(

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
@@ -30,7 +30,7 @@ typedef int(*hostfxr_get_runtime_property_value_fn)(void* host_context_handle, P
 typedef int(*hostfxr_run_app_fn)(void* host_context_handle);
 typedef int(*hostfxr_close_fn)(void* hostfxr_context_handle);
 
-#define APPARGNOTRUNNABLE 0x80008094
+const int AppArgNotRunnable = 0x80008094;
 
 class HostFxrErrorRedirector: NonCopyable
 {

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/HostFxr.h
@@ -30,6 +30,8 @@ typedef int(*hostfxr_get_runtime_property_value_fn)(void* host_context_handle, P
 typedef int(*hostfxr_run_app_fn)(void* host_context_handle);
 typedef int(*hostfxr_close_fn)(void* hostfxr_context_handle);
 
+#define APPARGNOTRUNNABLE 0x80008094
+
 class HostFxrErrorRedirector: NonCopyable
 {
 public:

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/resources.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/resources.h
@@ -41,6 +41,7 @@
 #define ASPNETCORE_EVENT_HOSTFXR_DLL_INVALID_VERSION_MSG     L"Hostfxr version used does not support 'hostfxr_get_native_search_directories', update the version of hostfxr to a higher version. Path to hostfxr: '%s'."
 #define ASPNETCORE_EVENT_HOSTFXR_DLL_UNABLE_TO_LOAD_MSG      L"Unable to load '%s'. This might be caused by a bitness mismatch between IIS application pool and published application."
 #define ASPNETCORE_EVENT_HOSTFXR_FAILURE_MSG                 L"Unable to locate application dependencies. Ensure that the versions of Microsoft.NetCore.App and Microsoft.AspNetCore.App targeted by the application are installed."
+#define ASPNETCORE_EVENT_HOSTFXR_BAD_APPLICATION_FAILURE_MSG L"Provided application path does not exist, or isn't a .dll or .exe."
 #define ASPNETCORE_EVENT_INPROCESS_THREAD_EXCEPTION_MSG      L"Application '%s' with physical root '%s' hit unexpected managed exception, exception code = '0x%x'. Please check the stderr logs for more information."
 #define ASPNETCORE_EVENT_INPROCESS_THREAD_EXCEPTION_STDOUT_MSG L"Application '%s' with physical root '%s' hit unexpected managed exception, exception code = '0x%x'. First 30KB characters of captured stdout and stderr logs:\r\n%s"
 #define ASPNETCORE_EVENT_INPROCESS_RH_ERROR_MSG              L"Could not find 'aspnetcorev2_inprocess.dll'. Exception message:\r\n%s"

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/EventLogHelpers.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/EventLogHelpers.cs
@@ -262,6 +262,11 @@ public class EventLogHelpers
         }
     }
 
+    public static string InProcessFailedToFindApplication()
+    {
+        return "Provided application path does not exist, or isn't a .dll or .exe.";
+    }
+
     public static string InProcessFailedToFindRequestHandler(IISDeploymentResult deploymentResult)
     {
         if (DeployerSelector.HasNewShim)


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/46021 by using the hostfxr error code to detect when the application either is missing or not a .dll or .exe file.

Not sure if we should use 500.31 here or add a new error code, or reuse [500.38 Application DLL Not Found](https://learn.microsoft.com/aspnet/core/test/troubleshoot-azure-iis?view=aspnetcore-7.0#50038-ancm-application-dll-not-found).

The error code is defined at https://github.com/dotnet/runtime/blob/fd9b3d101096bf0d8b65fa2cc7ebe6e84d2d280a/src/native/corehost/error_codes.h#L35 and used by hostfxr at https://github.com/dotnet/runtime/blob/fd9b3d101096bf0d8b65fa2cc7ebe6e84d2d280a/src/native/corehost/fxr/command_line.cpp#L161-L181