### PR TITLE
Multiple accept loops in named pipes transport

### DIFF
--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
@@ -58,7 +58,7 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
     {
         Debug.Assert(_listeningTasks == null, "Already started");
 
-        _listeningTasks = new Task[_options.AcceptQueueCount];
+        _listeningTasks = new Task[_options.ListenerQueueCount];
 
         for (var i = 0; i < _listeningTasks.Length; i++)
         {

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
@@ -65,13 +65,13 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
             // Start first stream inline to catch creation errors.
             var initialStream = CreateServerStream();
 
-            _listeningTasks[i] = Task.Run(() => StartAsync(initialStream, i));
+            _listeningTasks[i] = Task.Run(() => StartAsync(initialStream));
         }
     }
 
     public EndPoint EndPoint => _endpoint;
 
-    private async Task StartAsync(NamedPipeServerStream nextStream, int index)
+    private async Task StartAsync(NamedPipeServerStream nextStream)
     {
         try
         {
@@ -82,8 +82,6 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
                     var stream = nextStream;
 
                     await stream.WaitForConnectionAsync(_listeningToken);
-
-                    _log.LogInformation("Connection accepted on " + index);
 
                     var connection = new NamedPipeConnection(stream, _endpoint, _log, _memoryPool, _inputOptions, _outputOptions);
                     connection.Start();

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
@@ -65,7 +65,7 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
             // Start first stream inline to catch creation errors.
             var initialStream = CreateServerStream();
 
-            _listeningTasks[i] = StartAsync(initialStream, i);
+            _listeningTasks[i] = Task.Run(() => StartAsync(initialStream, i));
         }
     }
 

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
@@ -14,7 +14,7 @@ public sealed class NamedPipeTransportOptions
     /// <summary>
     /// 
     /// </summary>
-    public int AcceptQueueCount { get; set; } = Math.Clamp(Environment.ProcessorCount, 1, 16);
+    public int AcceptQueueCount { get; set; } = Math.Min(Environment.ProcessorCount, 16);
 
     /// <summary>
     /// Gets or sets the maximum unconsumed incoming bytes the transport will buffer.

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
@@ -12,6 +12,11 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes;
 public sealed class NamedPipeTransportOptions
 {
     /// <summary>
+    /// 
+    /// </summary>
+    public int AcceptQueueCount { get; set; } = Math.Clamp(Environment.ProcessorCount, 1, 16);
+
+    /// <summary>
     /// Gets or sets the maximum unconsumed incoming bytes the transport will buffer.
     /// <para>
     /// A value of <see langword="null"/> or 0 disables backpressure entirely allowing unlimited buffering.

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
@@ -12,9 +12,12 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes;
 public sealed class NamedPipeTransportOptions
 {
     /// <summary>
-    /// 
+    /// The number of listener queues used to accept name pipe connections.
     /// </summary>
-    public int AcceptQueueCount { get; set; } = Math.Min(Environment.ProcessorCount, 16);
+    /// <remarks>
+    /// Defaults to <see cref="Environment.ProcessorCount" /> rounded down and clamped between 1 and 16.
+    /// </remarks>
+    public int ListenerQueueCount { get; set; } = Math.Min(Environment.ProcessorCount, 16);
 
     /// <summary>
     /// Gets or sets the maximum unconsumed incoming bytes the transport will buffer.

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 Microsoft.AspNetCore.Hosting.WebHostBuilderNamedPipeExtensions
 Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions
+Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions.AcceptQueueCount.get -> int
+Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions.AcceptQueueCount.set -> void
 Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions.CurrentUserOnly.get -> bool
 Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions.CurrentUserOnly.set -> void
 Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions.MaxReadBufferSize.get -> long?

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/PublicAPI.Unshipped.txt
@@ -1,10 +1,10 @@
 #nullable enable
 Microsoft.AspNetCore.Hosting.WebHostBuilderNamedPipeExtensions
 Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions
-Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions.AcceptQueueCount.get -> int
-Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions.AcceptQueueCount.set -> void
 Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions.CurrentUserOnly.get -> bool
 Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions.CurrentUserOnly.set -> void
+Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions.ListenerQueueCount.get -> int
+Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions.ListenerQueueCount.set -> void
 Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions.MaxReadBufferSize.get -> long?
 Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions.MaxReadBufferSize.set -> void
 Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.NamedPipeTransportOptions.MaxWriteBufferSize.get -> long?

--- a/src/Servers/Kestrel/Transport.NamedPipes/test/NamedPipeConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/test/NamedPipeConnectionListenerTests.cs
@@ -78,7 +78,7 @@ public class NamedPipeConnectionListenerTests : TestApplicationErrorLoggerLogged
 
         var currentCallCount = 0;
         var options = new NamedPipeTransportOptions();
-        options.AcceptQueueCount = 16;
+        options.AcceptQueueCount = 1;
         await using var connectionListener = await NamedPipeTestHelpers.CreateConnectionListenerFactory(LoggerFactory, options: options);
 
         // Act
@@ -86,8 +86,7 @@ public class NamedPipeConnectionListenerTests : TestApplicationErrorLoggerLogged
         {
             while (currentCallCount < TotalCallCount)
             {
-                var connection = await connectionListener.AcceptAsync().DefaultTimeout();
-                await connection.DisposeAsync();
+                _ = await connectionListener.AcceptAsync();
 
                 currentCallCount++;
 
@@ -111,7 +110,7 @@ public class NamedPipeConnectionListenerTests : TestApplicationErrorLoggerLogged
                         await clientStream.ConnectAsync();
 
                         await clientStream.WriteAsync(new byte[1]);
-                        await clientStream.ReadAsync(new byte[1]);
+                        await clientStream.DisposeAsync();
                         clientStreamCount++;
                     }
                     catch (IOException ex)

--- a/src/Servers/Kestrel/Transport.NamedPipes/test/NamedPipeConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/test/NamedPipeConnectionListenerTests.cs
@@ -68,6 +68,63 @@ public class NamedPipeConnectionListenerTests : TestApplicationErrorLoggerLogged
         Assert.Contains(LogMessages, m => m.EventId.Name == "ConnectionListenerAborted");
     }
 
+    [Fact]
+    public async Task AcceptAsync_ParallelConnections_ClientConnectionsSuccessfullyAccepted()
+    {
+        // Arrange
+        const int ParallelCount = 10;
+        const int ParallelCallCount = 5000;
+        const int TotalCallCount = ParallelCount * ParallelCallCount;
+
+        var currentCallCount = 0;
+        var options = new NamedPipeTransportOptions();
+        options.AcceptQueueCount = 16;
+        await using var connectionListener = await NamedPipeTestHelpers.CreateConnectionListenerFactory(LoggerFactory, options: options);
+
+        // Act
+        var serverTask = Task.Run(async () =>
+        {
+            while (currentCallCount < TotalCallCount)
+            {
+                var connection = await connectionListener.AcceptAsync().DefaultTimeout();
+                await connection.DisposeAsync();
+
+                currentCallCount++;
+
+                Logger.LogInformation($"Server accepted {currentCallCount} calls.");
+            }
+
+            Logger.LogInformation($"Server task complete.");
+        });
+
+        var parallelTasks = new List<Task>();
+        for (var i = 0; i < ParallelCount; i++)
+        {
+            parallelTasks.Add(Task.Run(async () =>
+            {
+                var clientStreamCount = 0;
+                while (clientStreamCount < ParallelCallCount)
+                {
+                    try
+                    {
+                        var clientStream = NamedPipeTestHelpers.CreateClientStream(connectionListener.EndPoint);
+                        await clientStream.ConnectAsync();
+
+                        await clientStream.WriteAsync(new byte[1]);
+                        await clientStream.ReadAsync(new byte[1]);
+                        clientStreamCount++;
+                    }
+                    catch (IOException ex)
+                    {
+                        Logger.LogInformation(ex, "Client exception.");
+                    }
+                }
+            }));
+        }
+
+        await serverTask.DefaultTimeout();
+    }
+
     [ConditionalFact]
     [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX, SkipReason = "Non-OS implementations use UDS with an unlimited accept limit.")]
     public async Task AcceptAsync_HitBacklogLimit_ClientConnectionsSuccessfullyAccepted()

--- a/src/Servers/Kestrel/Transport.NamedPipes/test/NamedPipeConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/test/NamedPipeConnectionListenerTests.cs
@@ -78,7 +78,7 @@ public class NamedPipeConnectionListenerTests : TestApplicationErrorLoggerLogged
 
         var currentCallCount = 0;
         var options = new NamedPipeTransportOptions();
-        options.AcceptQueueCount = 16;
+        options.ListenerQueueCount = 16;
         await using var connectionListener = await NamedPipeTestHelpers.CreateConnectionListenerFactory(LoggerFactory, options: options);
 
         // Act

--- a/src/Servers/Kestrel/Transport.NamedPipes/test/NamedPipeConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/test/NamedPipeConnectionListenerTests.cs
@@ -78,7 +78,7 @@ public class NamedPipeConnectionListenerTests : TestApplicationErrorLoggerLogged
 
         var currentCallCount = 0;
         var options = new NamedPipeTransportOptions();
-        options.AcceptQueueCount = 1;
+        options.AcceptQueueCount = 16;
         await using var connectionListener = await NamedPipeTestHelpers.CreateConnectionListenerFactory(LoggerFactory, options: options);
 
         // Act


### PR DESCRIPTION
Feedback from https://github.com/dotnet/aspnetcore/issues/14207

PR adds multiple accept queues. I did some very cursory benchmarks via a unit test and found an improvement when 2 or more queues were used.

Creating 50,000 connections.

* 1 accept queue: 6.1 sec
* 2 accept queues: 4.7 sec

I didn't notice any improvement from increasing the queue count above 2, but in other places in transports, we are using `Environment.ProcessorCount`, so I followed that.