### PR TITLE
Adding ILLink.Substituions.xml EmbeddedResource

### DIFF
--- a/src/Http/Http.Extensions/src/Microsoft.AspNetCore.Http.Extensions.csproj
+++ b/src/Http/Http.Extensions/src/Microsoft.AspNetCore.Http.Extensions.csproj
@@ -25,6 +25,10 @@
     <Compile Include="$(SharedSourceRoot)Json\JsonSerializerExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)TrimmingAppContextSwitches.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)RouteHandlers\ExecuteHandlerHelper.cs" LinkBase="Shared"/>
+  </ItemGroup>  
+  
+  <ItemGroup>
+    <EmbeddedResource Include="Properties\ILLink.Substitutions.xml" LogicalName="ILLink.Substitutions.xml" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`ILLink` substitutions are not working for `Microsoft.Http.Extensions` due to this unexpected change while merging:

https://github.com/dotnet/aspnetcore/pull/45886/commits/e160ba95538b13db93797c110540c9eb257dbadb

Adding the `EmbeddedResource` item back.