### PR TITLE
Avoid a state machine allocation in EndpointMiddleware

### DIFF
--- a/src/Http/Routing/src/EndpointMiddleware.cs
+++ b/src/Http/Routing/src/EndpointMiddleware.cs
@@ -50,6 +50,12 @@ internal sealed partial class EndpointMiddleware
 
             if (endpoint.RequestDelegate is not null)
             {
+                if (!_logger.IsEnabled(LogLevel.Information))
+                {
+                    // Avoid the AwaitRequestTask state machine allocation if logging is disabled.
+                    return endpoint.RequestDelegate(httpContext);
+                }
+
                 Log.ExecutingEndpoint(_logger, endpoint);
 
                 try


### PR DESCRIPTION
If logging is not enabled, we don't have to await the RequestDelegate task.

I am looking through YARP allocations and this shows up as a 136-byte allocation on every request.