### PR TITLE
Defer search for dev cert until build bind time

### DIFF
--- a/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
+++ b/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
@@ -73,12 +73,6 @@ public class HttpsConnectionAdapterOptions
     public SslProtocols SslProtocols { get; set; }
 
     /// <summary>
-    /// The protocols enabled on this endpoint.
-    /// </summary>
-    /// <remarks>Defaults to HTTP/1.x only.</remarks>
-    internal HttpProtocols HttpProtocols { get; set; }
-
-    /// <summary>
     /// Specifies whether the certificate revocation list is checked during authentication.
     /// </summary>
     public bool CheckCertificateRevocation { get; set; }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TransportManager.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TransportManager.cs
@@ -77,7 +77,7 @@ internal sealed class TransportManager
         // The QUIC transport will check if TlsConnectionCallbackOptions is missing.
         if (listenOptions.HttpsOptions != null)
         {
-            var sslServerAuthenticationOptions = HttpsConnectionMiddleware.CreateHttp3Options(listenOptions.HttpsOptions);
+            var sslServerAuthenticationOptions = HttpsConnectionMiddleware.CreateHttp3Options(listenOptions.HttpsOptions.Value);
             features.Set(new TlsConnectionCallbackOptions
             {
                 ApplicationProtocols = sslServerAuthenticationOptions.ApplicationProtocols ?? new List<SslApplicationProtocol> { SslApplicationProtocol.Http3 },

--- a/src/Servers/Kestrel/Core/src/ListenOptions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptions.cs
@@ -140,7 +140,8 @@ public class ListenOptions : IConnectionBuilder, IMultiplexedConnectionBuilder
     }
 
     internal bool IsTls { get; set; }
-    internal HttpsConnectionAdapterOptions? HttpsOptions { get; set; }
+    /// <remarks>Should not be inspected until the configuration has been loaded.</remarks>
+    internal Lazy<HttpsConnectionAdapterOptions>? HttpsOptions { get; set; }
     internal TlsHandshakeCallbackOptions? HttpsCallbackOptions { get; set; }
 
     /// <summary>

--- a/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
@@ -163,21 +163,24 @@ public static class ListenOptionsHttpsExtensions
     {
         ArgumentNullException.ThrowIfNull(configureOptions);
 
-        return listenOptions.UseHttps(() =>
+        return listenOptions.UseHttps(new Lazy<HttpsConnectionAdapterOptions>(() =>
         {
-            var httpsOptions = new HttpsConnectionAdapterOptions();
-            listenOptions.KestrelServerOptions.ApplyHttpsDefaults(httpsOptions);
-            configureOptions(httpsOptions);
-            listenOptions.KestrelServerOptions.ApplyDefaultCert(httpsOptions);
-            httpsOptions.HttpProtocols = listenOptions.Protocols;
+            // We defer configuration of the https options until build time so that the IConfiguration will be available.
+            // This is particularly important in docker containers, where the docker tools use IConfiguration to tell
+            // us where the development certificates have been mounted.
 
-            if (httpsOptions.ServerCertificate == null && httpsOptions.ServerCertificateSelector == null)
+            var options = new HttpsConnectionAdapterOptions();
+            listenOptions.KestrelServerOptions.ApplyHttpsDefaults(options);
+            configureOptions(options);
+            listenOptions.KestrelServerOptions.ApplyDefaultCert(options);
+
+            if (options.ServerCertificate == null && options.ServerCertificateSelector == null)
             {
                 throw new InvalidOperationException(CoreStrings.NoCertSpecifiedNoDevelopmentCertificateFound);
             }
 
-            return httpsOptions;
-        });
+            return options;
+        }));
     }
 
     /// <summary>
@@ -189,7 +192,7 @@ public static class ListenOptionsHttpsExtensions
     /// <returns>The <see cref="ListenOptions"/>.</returns>
     public static ListenOptions UseHttps(this ListenOptions listenOptions, HttpsConnectionAdapterOptions httpsOptions)
     {
-        return listenOptions.UseHttps(() => httpsOptions);
+        return listenOptions.UseHttps(new Lazy<HttpsConnectionAdapterOptions>(httpsOptions));
     }
 
     /// <summary>
@@ -197,23 +200,20 @@ public static class ListenOptionsHttpsExtensions
     /// <see cref="KestrelServerOptions.ConfigureHttpsDefaults(Action{HttpsConnectionAdapterOptions})"/>.
     /// </summary>
     /// <param name="listenOptions">The <see cref="ListenOptions"/> to configure.</param>
-    /// <param name="getHttpsOptions">A function returning options to configure HTTPS.</param>
+    /// <param name="lazyHttpsOptions">Options to configure HTTPS.</param>
     /// <returns>The <see cref="ListenOptions"/>.</returns>
-    private static ListenOptions UseHttps(this ListenOptions listenOptions, Func<HttpsConnectionAdapterOptions> getHttpsOptions)
+    private static ListenOptions UseHttps(this ListenOptions listenOptions, Lazy<HttpsConnectionAdapterOptions> lazyHttpsOptions)
     {
-        // Set this outside the lambda, which might not be invoked
         listenOptions.IsTls = true;
+        listenOptions.HttpsOptions = lazyHttpsOptions;
 
         // NB: This lambda will only be invoked if either HTTP/1.* or HTTP/2 is being used
         listenOptions.Use(next =>
         {
-            // We defer configuration of the https options until build time so that the IConfiguration will be available.
-            // This is particularly important in docker containers, where the docker tools use IConfiguration to tell
-            // us where the development certificates have been mounted.
-
-            var httpsOptions = getHttpsOptions();
-
-            listenOptions.HttpsOptions = httpsOptions;
+            // Evaluate the HttpsConnectionAdapterOptions, now that the configuration, if any, has been loaded
+            var httpsOptions = listenOptions.HttpsOptions.Value;
+            // Set the list of protocols from listen options
+            httpsOptions.HttpProtocols = listenOptions.Protocols;
 
             var loggerFactory = listenOptions.KestrelServerOptions?.ApplicationServices.GetRequiredService<ILoggerFactory>() ?? NullLoggerFactory.Instance;
 

--- a/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
@@ -201,6 +201,10 @@ public static class ListenOptionsHttpsExtensions
     /// <returns>The <see cref="ListenOptions"/>.</returns>
     private static ListenOptions UseHttps(this ListenOptions listenOptions, Func<HttpsConnectionAdapterOptions> getHttpsOptions)
     {
+        // Set this outside the lambda, which might not be invoked
+        listenOptions.IsTls = true;
+
+        // NB: This lambda will only be invoked if either HTTP/1.* or HTTP/2 is being used
         listenOptions.Use(next =>
         {
             // We defer configuration of the https options until build time so that the IConfiguration will be available.
@@ -209,7 +213,6 @@ public static class ListenOptionsHttpsExtensions
 
             var httpsOptions = getHttpsOptions();
 
-            listenOptions.IsTls = true;
             listenOptions.HttpsOptions = httpsOptions;
 
             var loggerFactory = listenOptions.KestrelServerOptions?.ApplicationServices.GetRequiredService<ILoggerFactory>() ?? NullLoggerFactory.Instance;
@@ -274,6 +277,7 @@ public static class ListenOptionsHttpsExtensions
         listenOptions.IsTls = true;
         listenOptions.HttpsCallbackOptions = callbackOptions;
 
+        // NB: This lambda will only be invoked if either HTTP/1.* or HTTP/2 is being used
         listenOptions.Use(next =>
         {
             // Set the list of protocols from listen options.

--- a/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
@@ -173,7 +173,6 @@ public static class ListenOptionsHttpsExtensions
             listenOptions.KestrelServerOptions.ApplyHttpsDefaults(options);
             configureOptions(options);
             listenOptions.KestrelServerOptions.ApplyDefaultCert(options);
-            options.HttpProtocols = listenOptions.Protocols;
 
             if (options.ServerCertificate == null && options.ServerCertificateSelector == null)
             {
@@ -193,11 +192,7 @@ public static class ListenOptionsHttpsExtensions
     /// <returns>The <see cref="ListenOptions"/>.</returns>
     public static ListenOptions UseHttps(this ListenOptions listenOptions, HttpsConnectionAdapterOptions httpsOptions)
     {
-        return listenOptions.UseHttps(new Lazy<HttpsConnectionAdapterOptions>(() =>
-        {
-            httpsOptions.HttpProtocols = listenOptions.Protocols;
-            return httpsOptions;
-        }));
+        return listenOptions.UseHttps(new Lazy<HttpsConnectionAdapterOptions>(httpsOptions));
     }
 
     /// <summary>
@@ -218,7 +213,7 @@ public static class ListenOptionsHttpsExtensions
             // Evaluate the HttpsConnectionAdapterOptions, now that the configuration, if any, has been loaded
             var httpsOptions = listenOptions.HttpsOptions.Value;
             var loggerFactory = listenOptions.KestrelServerOptions?.ApplicationServices.GetRequiredService<ILoggerFactory>() ?? NullLoggerFactory.Instance;
-            var middleware = new HttpsConnectionMiddleware(next, httpsOptions, loggerFactory);
+            var middleware = new HttpsConnectionMiddleware(next, httpsOptions, listenOptions.Protocols, loggerFactory);
             return middleware.OnConnectionAsync;
         });
 

--- a/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
@@ -176,22 +176,6 @@ public static class ListenOptionsHttpsExtensions
         return listenOptions.UseHttps(options);
     }
 
-    // Use Https if a default cert is available
-    internal static bool TryUseHttps(this ListenOptions listenOptions)
-    {
-        var options = new HttpsConnectionAdapterOptions();
-        listenOptions.KestrelServerOptions.ApplyHttpsDefaults(options);
-        listenOptions.KestrelServerOptions.ApplyDefaultCert(options);
-
-        if (options.ServerCertificate == null && options.ServerCertificateSelector == null)
-        {
-            return false;
-        }
-
-        listenOptions.UseHttps(options);
-        return true;
-    }
-
     /// <summary>
     /// Configure Kestrel to use HTTPS. This does not use default certificates or other defaults specified via config or
     /// <see cref="KestrelServerOptions.ConfigureHttpsDefaults(Action{HttpsConnectionAdapterOptions})"/>.

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -33,6 +33,9 @@ internal sealed class HttpsConnectionMiddleware
     private readonly ILogger<HttpsConnectionMiddleware> _logger;
     private readonly Func<Stream, SslStream> _sslStreamFactory;
 
+    // Internal for testing
+    internal readonly HttpProtocols _httpProtocols;
+
     // The following fields are only set by HttpsConnectionAdapterOptions ctor.
     private readonly HttpsConnectionAdapterOptions? _options;
     private readonly SslStreamCertificateContext? _serverCertificateContext;
@@ -42,17 +45,16 @@ internal sealed class HttpsConnectionMiddleware
     // The following fields are only set by TlsHandshakeCallbackOptions ctor.
     private readonly Func<TlsHandshakeCallbackContext, ValueTask<SslServerAuthenticationOptions>>? _tlsCallbackOptions;
     private readonly object? _tlsCallbackOptionsState;
-    private readonly HttpProtocols _httpProtocols;
 
     // Pool for cancellation tokens that cancel the handshake
     private readonly CancellationTokenSourcePool _ctsPool = new();
 
-    public HttpsConnectionMiddleware(ConnectionDelegate next, HttpsConnectionAdapterOptions options)
-      : this(next, options, loggerFactory: NullLoggerFactory.Instance)
+    public HttpsConnectionMiddleware(ConnectionDelegate next, HttpsConnectionAdapterOptions options, HttpProtocols httpProtocols)
+      : this(next, options, httpProtocols, loggerFactory: NullLoggerFactory.Instance)
     {
     }
 
-    public HttpsConnectionMiddleware(ConnectionDelegate next, HttpsConnectionAdapterOptions options, ILoggerFactory loggerFactory)
+    public HttpsConnectionMiddleware(ConnectionDelegate next, HttpsConnectionAdapterOptions options, HttpProtocols httpProtocols, ILoggerFactory loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(options);
 
@@ -72,7 +74,7 @@ internal sealed class HttpsConnectionMiddleware
         //_sslStreamFactory = s => new SslStream(s);
 
         _options = options;
-        _options.HttpProtocols = ValidateAndNormalizeHttpProtocols(_options.HttpProtocols, _logger);
+        _httpProtocols = ValidateAndNormalizeHttpProtocols(httpProtocols, _logger);
 
         // capture the certificate now so it can't be switched after validation
         _serverCertificate = options.ServerCertificate;
@@ -320,7 +322,7 @@ internal sealed class HttpsConnectionMiddleware
             CertificateRevocationCheckMode = _options.CheckCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
         };
 
-        ConfigureAlpn(sslOptions, _options.HttpProtocols);
+        ConfigureAlpn(sslOptions, _httpProtocols);
 
         _options.OnAuthenticate?.Invoke(context, sslOptions);
 

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -296,9 +296,9 @@ public class KestrelConfigurationLoaderTests
             Assert.NotEmpty(serverOptions.CodeBackedListenOptions);
             Assert.All(serverOptions.CodeBackedListenOptions, listenOptions =>
             {
-                Assert.Null(listenOptions.HttpsOptions);
+                Assert.False(listenOptions.HttpsOptions.IsValueCreated);
                 listenOptions.Build();
-                Assert.Equal(listenOptions.HttpsOptions?.ServerCertificate?.SerialNumber, certificate.SerialNumber);
+                Assert.Equal(listenOptions.HttpsOptions?.Value.ServerCertificate?.SerialNumber, certificate.SerialNumber);
             });
         }
         finally
@@ -348,9 +348,9 @@ public class KestrelConfigurationLoaderTests
             Assert.NotEmpty(serverOptions.CodeBackedListenOptions);
             Assert.All(serverOptions.CodeBackedListenOptions, listenOptions =>
             {
-                Assert.Null(listenOptions.HttpsOptions);
+                Assert.False(listenOptions.HttpsOptions.IsValueCreated);
                 listenOptions.Build();
-                Assert.Equal(listenOptions.HttpsOptions?.ServerCertificate?.SerialNumber, certificate.SerialNumber);
+                Assert.Equal(listenOptions.HttpsOptions?.Value.ServerCertificate?.SerialNumber, certificate.SerialNumber);
             });
         }
         finally

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -166,10 +166,7 @@ public class KestrelConfigurationLoaderTests
         Assert.True(ran1);
         Assert.True(ran2);
 
-        serverOptions.ConfigurationBackedListenOptions[0].Build();
         Assert.True(serverOptions.ConfigurationBackedListenOptions[0].IsTls);
-
-        serverOptions.CodeBackedListenOptions[0].Build();
         Assert.False(serverOptions.CodeBackedListenOptions[0].IsTls);
     }
 
@@ -211,10 +208,7 @@ public class KestrelConfigurationLoaderTests
         Assert.True(ran2);
 
         // You only get Https once per endpoint.
-        serverOptions.ConfigurationBackedListenOptions[0].Build();
         Assert.True(serverOptions.ConfigurationBackedListenOptions[0].IsTls);
-
-        serverOptions.CodeBackedListenOptions[0].Build();
         Assert.True(serverOptions.CodeBackedListenOptions[0].IsTls);
     }
 
@@ -298,7 +292,8 @@ public class KestrelConfigurationLoaderTests
             {
                 Assert.False(listenOptions.HttpsOptions.IsValueCreated);
                 listenOptions.Build();
-                Assert.Equal(listenOptions.HttpsOptions?.Value.ServerCertificate?.SerialNumber, certificate.SerialNumber);
+                Assert.True(listenOptions.HttpsOptions.IsValueCreated);
+                Assert.Equal(listenOptions.HttpsOptions.Value.ServerCertificate?.SerialNumber, certificate.SerialNumber);
             });
         }
         finally
@@ -350,7 +345,8 @@ public class KestrelConfigurationLoaderTests
             {
                 Assert.False(listenOptions.HttpsOptions.IsValueCreated);
                 listenOptions.Build();
-                Assert.Equal(listenOptions.HttpsOptions?.Value.ServerCertificate?.SerialNumber, certificate.SerialNumber);
+                Assert.True(listenOptions.HttpsOptions.IsValueCreated);
+                Assert.Equal(listenOptions.HttpsOptions.Value.ServerCertificate?.SerialNumber, certificate.SerialNumber);
             });
         }
         finally
@@ -840,7 +836,7 @@ public class KestrelConfigurationLoaderTests
             });
         });
 
-        serverOptions.CodeBackedListenOptions[0].Build();
+        _ = serverOptions.CodeBackedListenOptions[0].HttpsOptions.Value; // Force evaluation
 
         Assert.True(ranDefault);
         Assert.True(ran1);
@@ -977,7 +973,7 @@ public class KestrelConfigurationLoaderTests
             });
         });
 
-        serverOptions.CodeBackedListenOptions[0].Build();
+        _ = serverOptions.CodeBackedListenOptions[0].HttpsOptions.Value; // Force evaluation
 
         Assert.True(ranDefault);
         Assert.True(ran1);

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -253,6 +253,110 @@ public class KestrelConfigurationLoaderTests
     }
 
     [Fact]
+    public void LoadDevelopmentCertificate_ConfigureFirst()
+    {
+        try
+        {
+            var serverOptions = CreateServerOptions();
+            var certificate = new X509Certificate2(TestResources.GetCertPath("aspnetdevcert.pfx"), "testPassword", X509KeyStorageFlags.Exportable);
+            var bytes = certificate.Export(X509ContentType.Pkcs12, "1234");
+            var path = GetCertificatePath();
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            File.WriteAllBytes(path, bytes);
+
+            var config = new ConfigurationBuilder().AddInMemoryCollection(new[]
+            {
+                new KeyValuePair<string, string>("Certificates:Development:Password", "1234"),
+            }).Build();
+
+            serverOptions.Configure(config);
+
+            Assert.Null(serverOptions.DefaultCertificate);
+
+            serverOptions.ConfigurationLoader.Load();
+
+            Assert.NotNull(serverOptions.DefaultCertificate);
+            Assert.Equal(serverOptions.DefaultCertificate.SerialNumber, certificate.SerialNumber);
+
+            var ran1 = false;
+            serverOptions.ListenAnyIP(4545, listenOptions =>
+            {
+                ran1 = true;
+                listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
+                listenOptions.UseHttps();
+            });
+            Assert.True(ran1);
+
+            Assert.NotEmpty(serverOptions.CodeBackedListenOptions);
+            Assert.All(serverOptions.CodeBackedListenOptions, listenOptions =>
+            {
+                Assert.Null(listenOptions.HttpsOptions);
+                listenOptions.Build();
+                Assert.Equal(listenOptions.HttpsOptions?.ServerCertificate?.SerialNumber, certificate.SerialNumber);
+            });
+        }
+        finally
+        {
+            if (File.Exists(GetCertificatePath()))
+            {
+                File.Delete(GetCertificatePath());
+            }
+        }
+    }
+
+    [Fact]
+    public void LoadDevelopmentCertificate_UseHttpsFirst()
+    {
+        try
+        {
+            var serverOptions = CreateServerOptions();
+            var certificate = new X509Certificate2(TestResources.GetCertPath("aspnetdevcert.pfx"), "testPassword", X509KeyStorageFlags.Exportable);
+            var bytes = certificate.Export(X509ContentType.Pkcs12, "1234");
+            var path = GetCertificatePath();
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            File.WriteAllBytes(path, bytes);
+
+            var ran1 = false;
+            serverOptions.ListenAnyIP(4545, listenOptions =>
+            {
+                ran1 = true;
+                listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
+                listenOptions.UseHttps();
+            });
+            Assert.True(ran1);
+
+            var config = new ConfigurationBuilder().AddInMemoryCollection(new[]
+            {
+                new KeyValuePair<string, string>("Certificates:Development:Password", "1234"),
+            }).Build();
+
+            serverOptions.Configure(config);
+
+            Assert.Null(serverOptions.DefaultCertificate);
+
+            serverOptions.ConfigurationLoader.Load();
+
+            Assert.NotNull(serverOptions.DefaultCertificate);
+            Assert.Equal(serverOptions.DefaultCertificate.SerialNumber, certificate.SerialNumber);
+
+            Assert.NotEmpty(serverOptions.CodeBackedListenOptions);
+            Assert.All(serverOptions.CodeBackedListenOptions, listenOptions =>
+            {
+                Assert.Null(listenOptions.HttpsOptions);
+                listenOptions.Build();
+                Assert.Equal(listenOptions.HttpsOptions?.ServerCertificate?.SerialNumber, certificate.SerialNumber);
+            });
+        }
+        finally
+        {
+            if (File.Exists(GetCertificatePath()))
+            {
+                File.Delete(GetCertificatePath());
+            }
+        }
+    }
+
+    [Fact]
     public void ConfigureEndpoint_ThrowsWhen_The_PasswordIsMissing()
     {
         var serverOptions = CreateServerOptions();

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -166,7 +166,10 @@ public class KestrelConfigurationLoaderTests
         Assert.True(ran1);
         Assert.True(ran2);
 
+        serverOptions.ConfigurationBackedListenOptions[0].Build();
         Assert.True(serverOptions.ConfigurationBackedListenOptions[0].IsTls);
+
+        serverOptions.CodeBackedListenOptions[0].Build();
         Assert.False(serverOptions.CodeBackedListenOptions[0].IsTls);
     }
 
@@ -208,7 +211,10 @@ public class KestrelConfigurationLoaderTests
         Assert.True(ran2);
 
         // You only get Https once per endpoint.
+        serverOptions.ConfigurationBackedListenOptions[0].Build();
         Assert.True(serverOptions.ConfigurationBackedListenOptions[0].IsTls);
+
+        serverOptions.CodeBackedListenOptions[0].Build();
         Assert.True(serverOptions.CodeBackedListenOptions[0].IsTls);
     }
 
@@ -834,6 +840,8 @@ public class KestrelConfigurationLoaderTests
             });
         });
 
+        serverOptions.CodeBackedListenOptions[0].Build();
+
         Assert.True(ranDefault);
         Assert.True(ran1);
         Assert.True(ran2);
@@ -968,6 +976,8 @@ public class KestrelConfigurationLoaderTests
                 ran2 = true;
             });
         });
+
+        serverOptions.CodeBackedListenOptions[0].Build();
 
         Assert.True(ranDefault);
         Assert.True(ran1);

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -286,14 +286,11 @@ public class KestrelConfigurationLoaderTests
             });
             Assert.True(ran1);
 
-            Assert.NotEmpty(serverOptions.CodeBackedListenOptions);
-            Assert.All(serverOptions.CodeBackedListenOptions, listenOptions =>
-            {
-                Assert.False(listenOptions.HttpsOptions.IsValueCreated);
-                listenOptions.Build();
-                Assert.True(listenOptions.HttpsOptions.IsValueCreated);
-                Assert.Equal(listenOptions.HttpsOptions.Value.ServerCertificate?.SerialNumber, certificate.SerialNumber);
-            });
+            var listenOptions = serverOptions.CodeBackedListenOptions.Single();
+            Assert.False(listenOptions.HttpsOptions.IsValueCreated);
+            listenOptions.Build();
+            Assert.True(listenOptions.HttpsOptions.IsValueCreated);
+            Assert.Equal(listenOptions.HttpsOptions.Value.ServerCertificate?.SerialNumber, certificate.SerialNumber);
         }
         finally
         {
@@ -338,14 +335,11 @@ public class KestrelConfigurationLoaderTests
             Assert.NotNull(serverOptions.DefaultCertificate);
             Assert.Equal(serverOptions.DefaultCertificate.SerialNumber, certificate.SerialNumber);
 
-            Assert.NotEmpty(serverOptions.CodeBackedListenOptions);
-            Assert.All(serverOptions.CodeBackedListenOptions, listenOptions =>
-            {
-                Assert.False(listenOptions.HttpsOptions.IsValueCreated);
-                listenOptions.Build();
-                Assert.True(listenOptions.HttpsOptions.IsValueCreated);
-                Assert.Equal(listenOptions.HttpsOptions.Value.ServerCertificate?.SerialNumber, certificate.SerialNumber);
-            });
+            var listenOptions = serverOptions.CodeBackedListenOptions.Single();
+            Assert.False(listenOptions.HttpsOptions.IsValueCreated);
+            listenOptions.Build();
+            Assert.True(listenOptions.HttpsOptions.IsValueCreated);
+            Assert.Equal(listenOptions.HttpsOptions.Value.ServerCertificate?.SerialNumber, certificate.SerialNumber);
         }
         finally
         {

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -282,7 +282,6 @@ public class KestrelConfigurationLoaderTests
             serverOptions.ListenAnyIP(4545, listenOptions =>
             {
                 ran1 = true;
-                listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
                 listenOptions.UseHttps();
             });
             Assert.True(ran1);
@@ -321,7 +320,6 @@ public class KestrelConfigurationLoaderTests
             serverOptions.ListenAnyIP(4545, listenOptions =>
             {
                 ran1 = true;
-                listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
                 listenOptions.UseHttps();
             });
             Assert.True(ran1);
@@ -836,7 +834,7 @@ public class KestrelConfigurationLoaderTests
             });
         });
 
-        _ = serverOptions.CodeBackedListenOptions[0].HttpsOptions.Value; // Force evaluation
+        _ = serverOptions.CodeBackedListenOptions.Single().HttpsOptions.Value; // Force evaluation
 
         Assert.True(ranDefault);
         Assert.True(ran1);
@@ -973,7 +971,7 @@ public class KestrelConfigurationLoaderTests
             });
         });
 
-        _ = serverOptions.CodeBackedListenOptions[0].HttpsOptions.Value; // Force evaluation
+        _ = serverOptions.CodeBackedListenOptions.Single().HttpsOptions.Value; // Force evaluation
 
         Assert.True(ranDefault);
         Assert.True(ran1);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -228,7 +228,8 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
     public void ThrowsWhenNoServerCertificateIsProvided()
     {
         Assert.Throws<ArgumentException>(() => new HttpsConnectionMiddleware(context => Task.CompletedTask,
-            new HttpsConnectionAdapterOptions())
+            new HttpsConnectionAdapterOptions(),
+            ListenOptions.DefaultHttpProtocols)
             );
     }
 
@@ -1268,7 +1269,8 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         new HttpsConnectionMiddleware(context => Task.CompletedTask, new HttpsConnectionAdapterOptions
         {
             ServerCertificate = cert,
-        });
+        },
+        ListenOptions.DefaultHttpProtocols);
     }
 
     [Theory]
@@ -1286,7 +1288,8 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         new HttpsConnectionMiddleware(context => Task.CompletedTask, new HttpsConnectionAdapterOptions
         {
             ServerCertificate = cert,
-        });
+        },
+        ListenOptions.DefaultHttpProtocols);
     }
 
     [Theory]
@@ -1305,7 +1308,7 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
             new HttpsConnectionMiddleware(context => Task.CompletedTask, new HttpsConnectionAdapterOptions
             {
                 ServerCertificate = cert,
-            }));
+            }, ListenOptions.DefaultHttpProtocols));
 
         Assert.Equal(CoreStrings.FormatInvalidServerCertificateEku(cert.Thumbprint), ex.Message);
     }
@@ -1352,11 +1355,10 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         var httpConnectionAdapterOptions = new HttpsConnectionAdapterOptions
         {
             ServerCertificate = _x509Certificate2,
-            HttpProtocols = HttpProtocols.Http1AndHttp2
         };
-        new HttpsConnectionMiddleware(context => Task.CompletedTask, httpConnectionAdapterOptions);
+        var middleware = new HttpsConnectionMiddleware(context => Task.CompletedTask, httpConnectionAdapterOptions, HttpProtocols.Http1AndHttp2);
 
-        Assert.Equal(HttpProtocols.Http1, httpConnectionAdapterOptions.HttpProtocols);
+        Assert.Equal(HttpProtocols.Http1, middleware._httpProtocols);
     }
 
     [ConditionalFact]
@@ -1367,11 +1369,10 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         var httpConnectionAdapterOptions = new HttpsConnectionAdapterOptions
         {
             ServerCertificate = _x509Certificate2,
-            HttpProtocols = HttpProtocols.Http1AndHttp2
         };
-        new HttpsConnectionMiddleware(context => Task.CompletedTask, httpConnectionAdapterOptions);
+        var middleware = new HttpsConnectionMiddleware(context => Task.CompletedTask, httpConnectionAdapterOptions, HttpProtocols.Http1AndHttp2);
 
-        Assert.Equal(HttpProtocols.Http1AndHttp2, httpConnectionAdapterOptions.HttpProtocols);
+        Assert.Equal(HttpProtocols.Http1AndHttp2, middleware._httpProtocols);
     }
 
     [ConditionalFact]
@@ -1382,10 +1383,9 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         var httpConnectionAdapterOptions = new HttpsConnectionAdapterOptions
         {
             ServerCertificate = _x509Certificate2,
-            HttpProtocols = HttpProtocols.Http2
         };
 
-        Assert.Throws<NotSupportedException>(() => new HttpsConnectionMiddleware(context => Task.CompletedTask, httpConnectionAdapterOptions));
+        Assert.Throws<NotSupportedException>(() => new HttpsConnectionMiddleware(context => Task.CompletedTask, httpConnectionAdapterOptions, HttpProtocols.Http2));
     }
 
     [ConditionalFact]
@@ -1396,11 +1396,10 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         var httpConnectionAdapterOptions = new HttpsConnectionAdapterOptions
         {
             ServerCertificate = _x509Certificate2,
-            HttpProtocols = HttpProtocols.Http2
         };
 
         // Does not throw
-        new HttpsConnectionMiddleware(context => Task.CompletedTask, httpConnectionAdapterOptions);
+        new HttpsConnectionMiddleware(context => Task.CompletedTask, httpConnectionAdapterOptions, HttpProtocols.Http2);
     }
 
     private static async Task App(HttpContext httpContext)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
@@ -53,14 +53,18 @@ public class HttpsTests : LoggedTest
 
         Assert.False(serverOptions.IsDevCertLoaded);
 
+        var ranUseHttpsAction = false;
         serverOptions.ListenLocalhost(5001, options =>
         {
             options.UseHttps(opt =>
             {
                 // The default cert is applied after UseHttps.
                 Assert.Null(opt.ServerCertificate);
+                ranUseHttpsAction = true;
             });
         });
+        _ = serverOptions.CodeBackedListenOptions.Single().HttpsOptions.Value; // Force evaluation
+        Assert.True(ranUseHttpsAction);
         Assert.False(serverOptions.IsDevCertLoaded);
     }
 
@@ -106,14 +110,20 @@ public class HttpsTests : LoggedTest
             options.ServerCertificate = _x509Certificate2;
             options.ClientCertificateMode = ClientCertificateMode.RequireCertificate;
         });
+        var ranUseHttpsAction = false;
         serverOptions.ListenLocalhost(5000, options =>
         {
             options.UseHttps(opt =>
             {
                 Assert.Equal(_x509Certificate2, opt.ServerCertificate);
                 Assert.Equal(ClientCertificateMode.RequireCertificate, opt.ClientCertificateMode);
+                ranUseHttpsAction = true;
             });
         });
+
+        _ = serverOptions.CodeBackedListenOptions.Single().HttpsOptions.Value; // Force evaluation
+        Assert.True(ranUseHttpsAction);
+
         // Never lazy loaded
         Assert.False(serverOptions.IsDevCertLoaded);
         Assert.Null(serverOptions.DefaultCertificate);
@@ -133,6 +143,7 @@ public class HttpsTests : LoggedTest
             };
             options.ClientCertificateMode = ClientCertificateMode.RequireCertificate;
         });
+        var ranUseHttpsAction = false;
         serverOptions.ListenLocalhost(5000, options =>
         {
             options.UseHttps(opt =>
@@ -140,8 +151,13 @@ public class HttpsTests : LoggedTest
                 Assert.Null(opt.ServerCertificate);
                 Assert.NotNull(opt.ServerCertificateSelector);
                 Assert.Equal(ClientCertificateMode.RequireCertificate, opt.ClientCertificateMode);
+                ranUseHttpsAction = true;
             });
         });
+
+        _ = serverOptions.CodeBackedListenOptions.Single().HttpsOptions.Value; // Force evaluation
+        Assert.True(ranUseHttpsAction);
+
         // Never lazy loaded
         Assert.False(serverOptions.IsDevCertLoaded);
         Assert.Null(serverOptions.DefaultCertificate);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
@@ -63,7 +63,7 @@ public class HttpsTests : LoggedTest
                 ranUseHttpsAction = true;
             });
         });
-        _ = serverOptions.CodeBackedListenOptions.Single().HttpsOptions.Value; // Force evaluation
+        _ = serverOptions.CodeBackedListenOptions[1].HttpsOptions.Value; // Force evaluation
         Assert.True(ranUseHttpsAction);
         Assert.False(serverOptions.IsDevCertLoaded);
     }

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
@@ -23,6 +23,7 @@ public class Http3TlsTests : LoggedTest
     [MsQuicSupported]
     public async Task ServerCertificateSelector_Invoked()
     {
+        var serverCertificateSelectorActionCalled = false;
         var builder = CreateHostBuilder(async context =>
         {
             await context.Response.WriteAsync("Hello World");
@@ -35,6 +36,7 @@ public class Http3TlsTests : LoggedTest
                 {
                     httpsOptions.ServerCertificateSelector = (context, host) =>
                     {
+                        serverCertificateSelectorActionCalled = true;
                         Assert.Null(context); // The context isn't available durring the quic handshake.
                         Assert.Equal("testhost", host);
                         return TestResources.GetTestCertificate();
@@ -58,6 +60,8 @@ public class Http3TlsTests : LoggedTest
         var result = await response.Content.ReadAsStringAsync();
         Assert.Equal(HttpVersion.Version30, response.Version);
         Assert.Equal("Hello World", result);
+
+        Assert.True(serverCertificateSelectorActionCalled);
 
         await host.StopAsync().DefaultTimeout();
     }


### PR DESCRIPTION
...so that it can occur after `IConfiguration` is read.  (In particular, so that it occurs during `AddressBinder.BindAsync` which happens strictly after `KestrelConfigurationLoader.Load`.)  This is important in Docker scenarios since the Docker tools use `IConfiguration` to tell us where the dev cert directory is mounted.
    
Fixes #45801