### PR TITLE
Source-build should also use the release runtime.

### DIFF
--- a/src/Tools/Directory.Build.targets
+++ b/src/Tools/Directory.Build.targets
@@ -8,7 +8,7 @@
       Target the default version of .NET Core in tool projects to maximize the compatible environments. Must be set
       before importing root Directory.Build.targets.
     -->
-    <TargetLatestDotNetRuntime Condition=" '$(IsServicingBuild)' == 'true' ">false</TargetLatestDotNetRuntime>
+    <TargetLatestDotNetRuntime Condition=" '$(IsServicingBuild)' == 'true' '$(DotNetSourceBuild))' != 'true'">false</TargetLatestDotNetRuntime>
     <!-- Tool projects publish before packing. Packages should contain the latest bits. -->
     <UseLatestPackageReferences>true</UseLatestPackageReferences>
   </PropertyGroup>
@@ -18,4 +18,5 @@
   <Target Name="CleanPublishDir" AfterTargets="CoreClean">
     <RemoveDir Directories="$(PublishDir)" />
   </Target>
+
 </Project>

--- a/src/Tools/Directory.Build.targets
+++ b/src/Tools/Directory.Build.targets
@@ -8,7 +8,7 @@
       Target the default version of .NET Core in tool projects to maximize the compatible environments. Must be set
       before importing root Directory.Build.targets.
     -->
-    <TargetLatestDotNetRuntime Condition=" '$(IsServicingBuild)' == 'true' '$(DotNetSourceBuild))' != 'true'">false</TargetLatestDotNetRuntime>
+    <TargetLatestDotNetRuntime Condition=" '$(IsServicingBuild)' == 'true' ">false</TargetLatestDotNetRuntime>
     <!-- Tool projects publish before packing. Packages should contain the latest bits. -->
     <UseLatestPackageReferences>true</UseLatestPackageReferences>
   </PropertyGroup>
@@ -18,5 +18,4 @@
   <Target Name="CleanPublishDir" AfterTargets="CoreClean">
     <RemoveDir Directories="$(PublishDir)" />
   </Target>
-
 </Project>

--- a/src/Tools/dotnet-dev-certs/src/dotnet-dev-certs.csproj
+++ b/src/Tools/dotnet-dev-certs/src/dotnet-dev-certs.csproj
@@ -10,6 +10,7 @@
     <!-- This package is for internal use only. It contains a CLI which is bundled in the .NET Core SDK. -->
     <IsShippingPackage>false</IsShippingPackage>
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
+    <TargetLatestDotNetRuntime Condition=" '$(IsServicingBuild)' == 'true' and '$(DotNetSourceBuild))' != 'true'">false</TargetLatestDotNetRuntime>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/dotnet-user-jwts/src/dotnet-user-jwts.csproj
+++ b/src/Tools/dotnet-user-jwts/src/dotnet-user-jwts.csproj
@@ -10,6 +10,7 @@
     <!-- This package is for internal use only. It contains a CLI which is bundled in the .NET Core SDK. -->
     <IsShippingPackage>false</IsShippingPackage>
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
+    <TargetLatestDotNetRuntime Condition=" '$(IsServicingBuild)' == 'true' and '$(DotNetSourceBuild))' != 'true'">false</TargetLatestDotNetRuntime>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj
+++ b/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj
@@ -11,6 +11,7 @@
     <!-- This package is for internal use only. It contains a CLI which is bundled in the .NET Core SDK. -->
     <IsShippingPackage>false</IsShippingPackage>
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
+    <TargetLatestDotNetRuntime Condition=" '$(IsServicingBuild)' == 'true' and '$(DotNetSourceBuild))' != 'true'">false</TargetLatestDotNetRuntime>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is attempting to fix https://github.com/dotnet/source-build/issues/3146.  Source-build produces a stabilized runtime version which should filter down into ASP.NET and other repos.  In https://github.com/dotnet/aspnetcore/pull/43937 we made changes in ASP.NET to support using only the non-portable (i.e. RID-specific) version of this runtime but this doesn't appear to have worked for the projects in `src/Tools`:

```
  /src/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj : error NU1102: Unable to find package Microsoft.NETCore.App.Host.centos.8-x64 with version (= 7.0.2-servicing.22606.5) [/src/.dotnet/sdk/7.0.102/NuGet.targets]
  /src/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj : error NU1102:   - Found 1 version(s) in source-built [ Nearest version: 7.0.2 ] [/src/.dotnet/sdk/7.0.102/NuGet.targets]
  /src/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj : error NU1102:   - Found 1 version(s) in previously-source-built [ Nearest version: 7.0.2 ] [/src/.dotnet/sdk/7.0.102/NuGet.targets]
  /src/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj : error NU1102:   - Found 0 version(s) in prebuilt [/src/.dotnet/sdk/7.0.102/NuGet.targets]
  /src/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj : error NU1102:   - Found 0 version(s) in reference-packages [/src/.dotnet/sdk/7.0.102/NuGet.targets]
  /src/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-user-jwts/src/dotnet-user-jwts.csproj : error NU1102: Unable to find package Microsoft.NETCore.App.Host.centos.8-x64 with version (= 7.0.2-servicing.22606.5) [/src/.dotnet/sdk/7.0.102/NuGet.targets]
  /src/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-user-jwts/src/dotnet-user-jwts.csproj : error NU1102:   - Found 1 version(s) in source-built [ Nearest version: 7.0.2 ] [/src/.dotnet/sdk/7.0.102/NuGet.targets]
  /src/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-user-jwts/src/dotnet-user-jwts.csproj : error NU1102:   - Found 1 version(s) in previously-source-built [ Nearest version: 7.0.2 ] [/src/.dotnet/sdk/7.0.102/NuGet.targets]
  /src/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-user-jwts/src/dotnet-user-jwts.csproj : error NU1102:   - Found 0 version(s) in prebuilt [/src/.dotnet/sdk/7.0.102/NuGet.targets]
  /src/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-user-jwts/src/dotnet-user-jwts.csproj : error NU1102:   - Found 0 version(s) in reference-packages [/src/.dotnet/sdk/7.0.102/NuGet.targets]
  /src/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-dev-certs/src/dotnet-dev-certs.csproj : error NU1102: Unable to find package Microsoft.NETCore.App.Host.centos.8-x64 with version (= 7.0.2-servicing.22606.5) [/src/.dotnet/sdk/7.0.102/NuGet.targets]
  /src/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-dev-certs/src/dotnet-dev-certs.csproj : error NU1102:   - Found 1 version(s) in source-built [ Nearest version: 7.0.2 ] [/src/.dotnet/sdk/7.0.102/NuGet.targets]
  /src/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-dev-certs/src/dotnet-dev-certs.csproj : error NU1102:   - Found 1 version(s) in previously-source-built [ Nearest version: 7.0.2 ] [/src/.dotnet/sdk/7.0.102/NuGet.targets]
  /src/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-dev-certs/src/dotnet-dev-certs.csproj : error NU1102:   - Found 0 version(s) in prebuilt [/src/.dotnet/sdk/7.0.102/NuGet.targets]
  /src/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-dev-certs/src/dotnet-dev-certs.csproj : error NU1102:   - Found 0 version(s) in reference-packages [/src/.dotnet/sdk/7.0.102/NuGet.targets]
```

I wanted to open this as a draft to get any advice and also to make sure that I don't break the non-source-build ASP.NET with my source-build fix.