### PR TITLE
Add schema support infrastructure

### DIFF
--- a/src/Identity/EntityFrameworkCore/src/IdentityDbContext.cs
+++ b/src/Identity/EntityFrameworkCore/src/IdentityDbContext.cs
@@ -119,6 +119,60 @@ public abstract class IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRol
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);
+    }
+
+    /// <summary>
+    /// Configures the schema needed for the identity framework for schema version 2.0
+    /// </summary>
+    /// <param name="builder">
+    /// The builder being used to construct the model for this context.
+    /// </param>
+    protected override void OnModelCreatingVersion2(ModelBuilder builder)
+    {
+        base.OnModelCreatingVersion2(builder);
+
+        // Current no differences between Version 2 and Version 1
+        builder.Entity<TUser>(b =>
+        {
+            b.HasMany<TUserRole>().WithOne().HasForeignKey(ur => ur.UserId).IsRequired();
+        });
+
+        builder.Entity<TRole>(b =>
+        {
+            b.HasKey(r => r.Id);
+            b.HasIndex(r => r.NormalizedName).HasDatabaseName("RoleNameIndex").IsUnique();
+            b.ToTable("AspNetRoles");
+            b.Property(r => r.ConcurrencyStamp).IsConcurrencyToken();
+
+            b.Property(u => u.Name).HasMaxLength(256);
+            b.Property(u => u.NormalizedName).HasMaxLength(256);
+
+            b.HasMany<TUserRole>().WithOne().HasForeignKey(ur => ur.RoleId).IsRequired();
+            b.HasMany<TRoleClaim>().WithOne().HasForeignKey(rc => rc.RoleId).IsRequired();
+        });
+
+        builder.Entity<TRoleClaim>(b =>
+        {
+            b.HasKey(rc => rc.Id);
+            b.ToTable("AspNetRoleClaims");
+        });
+
+        builder.Entity<TUserRole>(b =>
+        {
+            b.HasKey(r => new { r.UserId, r.RoleId });
+            b.ToTable("AspNetUserRoles");
+        });
+    }
+
+    /// <summary>
+    /// Configures the schema needed for the identity framework for schema version 1.0
+    /// </summary>
+    /// <param name="builder">
+    /// The builder being used to construct the model for this context.
+    /// </param>
+    protected override void OnModelCreatingVersion1(ModelBuilder builder)
+    {
+        base.OnModelCreatingVersion1(builder);
         builder.Entity<TUser>(b =>
         {
             b.HasMany<TUserRole>().WithOne().HasForeignKey(ur => ur.UserId).IsRequired();

--- a/src/Identity/EntityFrameworkCore/src/IdentityDbContext.cs
+++ b/src/Identity/EntityFrameworkCore/src/IdentityDbContext.cs
@@ -127,7 +127,7 @@ public abstract class IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRol
     /// <param name="builder">
     /// The builder being used to construct the model for this context.
     /// </param>
-    protected override void OnModelCreatingVersion2(ModelBuilder builder)
+    internal override void OnModelCreatingVersion2(ModelBuilder builder)
     {
         base.OnModelCreatingVersion2(builder);
 
@@ -170,7 +170,7 @@ public abstract class IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRol
     /// <param name="builder">
     /// The builder being used to construct the model for this context.
     /// </param>
-    protected override void OnModelCreatingVersion1(ModelBuilder builder)
+    internal override void OnModelCreatingVersion1(ModelBuilder builder)
     {
         base.OnModelCreatingVersion1(builder);
         builder.Entity<TUser>(b =>

--- a/src/Identity/EntityFrameworkCore/src/IdentityUserContext.cs
+++ b/src/Identity/EntityFrameworkCore/src/IdentityUserContext.cs
@@ -95,6 +95,11 @@ public abstract class IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, T
     /// </summary>
     public virtual DbSet<TUserToken> UserTokens { get; set; } = default!;
 
+    /// <summary>
+    /// Gets the schema version used for versioning.
+    /// </summary>
+    protected virtual Version SchemaVersion { get => GetStoreOptions()?.SchemaVersion ?? IdentityVersions.Version1; }
+
     private StoreOptions? GetStoreOptions() => this.GetService<IDbContextOptions>()
                         .Extensions.OfType<CoreOptionsExtension>()
                         .FirstOrDefault()?.ApplicationServiceProvider
@@ -126,7 +131,7 @@ public abstract class IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, T
     /// The builder being used to construct the model for this context.
     /// </param>
     /// <param name="schemaVersion">The schema version.</param>
-    protected virtual void OnModelCreatingVersion(ModelBuilder builder, Version schemaVersion)
+    internal virtual void OnModelCreatingVersion(ModelBuilder builder, Version schemaVersion)
     {
         if (schemaVersion >= IdentityVersions.Version2)
         {
@@ -144,7 +149,7 @@ public abstract class IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, T
     /// <param name="builder">
     /// The builder being used to construct the model for this context.
     /// </param>
-    protected virtual void OnModelCreatingVersion2(ModelBuilder builder)
+    internal virtual void OnModelCreatingVersion2(ModelBuilder builder)
     {
         // Differences from Version 1:
         // - maxKeyLength defaults to 128
@@ -246,7 +251,7 @@ public abstract class IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, T
     /// <param name="builder">
     /// The builder being used to construct the model for this context.
     /// </param>
-    protected virtual void OnModelCreatingVersion1(ModelBuilder builder)
+    internal virtual void OnModelCreatingVersion1(ModelBuilder builder)
     {
         var storeOptions = GetStoreOptions();
         var maxKeyLength = storeOptions?.MaxLengthForKeys ?? 0;

--- a/src/Identity/EntityFrameworkCore/src/IdentityUserContext.cs
+++ b/src/Identity/EntityFrameworkCore/src/IdentityUserContext.cs
@@ -98,7 +98,7 @@ public abstract class IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, T
     /// <summary>
     /// Gets the schema version used for versioning.
     /// </summary>
-    protected virtual Version SchemaVersion { get => GetStoreOptions()?.SchemaVersion ?? IdentityVersions.Version1; }
+    protected virtual Version SchemaVersion { get => GetStoreOptions()?.SchemaVersion ?? IdentitySchemaVersions.Version1; }
 
     private StoreOptions? GetStoreOptions() => this.GetService<IDbContextOptions>()
                         .Extensions.OfType<CoreOptionsExtension>()
@@ -120,7 +120,7 @@ public abstract class IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, T
     /// </param>
     protected override void OnModelCreating(ModelBuilder builder)
     {
-        var version = GetStoreOptions()?.SchemaVersion ?? IdentityVersions.Version1;
+        var version = GetStoreOptions()?.SchemaVersion ?? IdentitySchemaVersions.Version1;
         OnModelCreatingVersion(builder, version);
     }
 
@@ -133,7 +133,7 @@ public abstract class IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, T
     /// <param name="schemaVersion">The schema version.</param>
     internal virtual void OnModelCreatingVersion(ModelBuilder builder, Version schemaVersion)
     {
-        if (schemaVersion >= IdentityVersions.Version2)
+        if (schemaVersion >= IdentitySchemaVersions.Version2)
         {
             OnModelCreatingVersion2(builder);
         }

--- a/src/Identity/EntityFrameworkCore/src/PublicAPI.Unshipped.txt
+++ b/src/Identity/EntityFrameworkCore/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+override Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>.OnModelCreatingVersion1(Microsoft.EntityFrameworkCore.ModelBuilder! builder) -> void
+override Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>.OnModelCreatingVersion2(Microsoft.EntityFrameworkCore.ModelBuilder! builder) -> void
+virtual Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, TUserToken>.OnModelCreatingVersion(Microsoft.EntityFrameworkCore.ModelBuilder! builder, System.Version! schemaVersion) -> void
+virtual Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, TUserToken>.OnModelCreatingVersion1(Microsoft.EntityFrameworkCore.ModelBuilder! builder) -> void
+virtual Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, TUserToken>.OnModelCreatingVersion2(Microsoft.EntityFrameworkCore.ModelBuilder! builder) -> void

--- a/src/Identity/EntityFrameworkCore/src/PublicAPI.Unshipped.txt
+++ b/src/Identity/EntityFrameworkCore/src/PublicAPI.Unshipped.txt
@@ -1,6 +1,2 @@
 #nullable enable
-override Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>.OnModelCreatingVersion1(Microsoft.EntityFrameworkCore.ModelBuilder! builder) -> void
-override Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>.OnModelCreatingVersion2(Microsoft.EntityFrameworkCore.ModelBuilder! builder) -> void
-virtual Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, TUserToken>.OnModelCreatingVersion(Microsoft.EntityFrameworkCore.ModelBuilder! builder, System.Version! schemaVersion) -> void
-virtual Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, TUserToken>.OnModelCreatingVersion1(Microsoft.EntityFrameworkCore.ModelBuilder! builder) -> void
-virtual Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, TUserToken>.OnModelCreatingVersion2(Microsoft.EntityFrameworkCore.ModelBuilder! builder) -> void
+virtual Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserContext<TUser, TKey, TUserClaim, TUserLogin, TUserToken>.SchemaVersion.get -> System.Version!

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/CustomSchemaTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/CustomSchemaTest.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test;
+
+public class CustomSchemaTest : IClassFixture<ScratchDatabaseFixture>
+{
+    private readonly ApplicationBuilder _builder;
+
+    public CustomSchemaTest(ScratchDatabaseFixture fixture)
+    {
+        var services = new ServiceCollection();
+
+        services
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
+            .AddDbContext<CustomVersionDbContext>(o =>
+                o.UseSqlite(fixture.Connection)
+                    .ConfigureWarnings(b => b.Log(CoreEventId.ManyServiceProvidersCreatedWarning)))
+            .AddIdentity<IdentityUser, IdentityRole>(o =>
+            {
+                // Versions >= 3 are custom
+                o.Stores.SchemaVersion = new Version(3, 0);
+            })
+            .AddEntityFrameworkStores<CustomVersionDbContext>();
+
+        services.AddLogging();
+
+        _builder = new ApplicationBuilder(services.BuildServiceProvider());
+
+        using (var scope = _builder.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<CustomVersionDbContext>();
+            db.Database.EnsureCreated();
+        }
+    }
+
+    [Fact]
+    public void CanAddCustomColumn()
+    {
+        using (var scope = _builder.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<CustomVersionDbContext>();
+
+            VersionTwoSchemaTest.VerifyVersion2Schema(db);
+
+            var sqlConn = (SqliteConnection)db.Database.GetDbConnection();
+            try
+            {
+                sqlConn.Open();
+                Assert.True(DbUtil.VerifyColumns(sqlConn, "CustomColumns", "Id"));
+            }
+            finally
+            {
+                sqlConn.Close();
+            }
+        }
+    }
+
+}
+

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/CustomSchemaTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/CustomSchemaTest.cs
@@ -62,6 +62,4 @@ public class CustomSchemaTest : IClassFixture<ScratchDatabaseFixture>
             }
         }
     }
-
 }
-

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/EmptySchemaTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/EmptySchemaTest.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test;
+
+public class EmptySchemaTest : IClassFixture<ScratchDatabaseFixture>
+{
+    private readonly ApplicationBuilder _builder;
+
+    public EmptySchemaTest(ScratchDatabaseFixture fixture)
+    {
+        var services = new ServiceCollection();
+
+        services
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
+            .AddDbContext<EmptyDbContext>(o =>
+                o.UseSqlite(fixture.Connection)
+                    .ConfigureWarnings(b => b.Log(CoreEventId.ManyServiceProvidersCreatedWarning)))
+            .AddIdentity<IdentityUser, IdentityRole>(o =>
+            {
+                // Versions >= 10 are empty
+                o.Stores.SchemaVersion = new Version(11, 0);
+            })
+            .AddEntityFrameworkStores<EmptyDbContext>();
+
+        services.AddLogging();
+
+        _builder = new ApplicationBuilder(services.BuildServiceProvider());
+
+        using (var scope = _builder.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<EmptyDbContext>();
+            db.Database.EnsureCreated();
+            Assert.False(db.OnModelCreatingVersion2Called);
+            Assert.False(db.OnModelCreatingVersion1Called);
+        }
+    }
+
+    [Fact]
+    public void CanIgnoreEverything()
+    {
+        using (var scope = _builder.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<EmptyDbContext>();
+
+            VerifyEmptySchema(db);
+        }
+    }
+
+    private static void VerifyEmptySchema(EmptyDbContext dbContext)
+    {
+        var sqlConn = (SqliteConnection)dbContext.Database.GetDbConnection();
+
+        try
+        {
+            sqlConn.Open();
+            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUsers"));
+            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetRoles"));
+            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserRoles"));
+            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserClaims"));
+            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserLogins"));
+            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserTokens"));
+        }
+        finally
+        {
+            sqlConn.Close();
+        }
+    }
+}
+

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/EmptySchemaTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/EmptySchemaTest.cs
@@ -46,32 +46,21 @@ public class EmptySchemaTest : IClassFixture<ScratchDatabaseFixture>
     [Fact]
     public void CanIgnoreEverything()
     {
-        using (var scope = _builder.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope())
-        {
-            var db = scope.ServiceProvider.GetRequiredService<EmptyDbContext>();
-
-            VerifyEmptySchema(db);
-        }
+        using var scope = _builder.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<EmptyDbContext>();
+        VerifyEmptySchema(db);
     }
 
     private static void VerifyEmptySchema(EmptyDbContext dbContext)
     {
-        var sqlConn = (SqliteConnection)dbContext.Database.GetDbConnection();
-
-        try
-        {
-            sqlConn.Open();
-            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUsers"));
-            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetRoles"));
-            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserRoles"));
-            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserClaims"));
-            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserLogins"));
-            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserTokens"));
-        }
-        finally
-        {
-            sqlConn.Close();
-        }
+        using var sqlConn = (SqliteConnection)dbContext.Database.GetDbConnection();
+        sqlConn.Open();
+        Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUsers"));
+        Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetRoles"));
+        Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserRoles"));
+        Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserClaims"));
+        Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserLogins"));
+        Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserTokens"));
     }
 }
 

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/EmptySchemaTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/EmptySchemaTest.cs
@@ -17,8 +17,8 @@ public class EmptySchemaTest : IClassFixture<ScratchDatabaseFixture>
     public EmptySchemaTest(ScratchDatabaseFixture fixture)
     {
         var services = new ServiceCollection();
-
         services
+            .AddLogging()
             .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
             .AddDbContext<EmptyDbContext>(o =>
                 o.UseSqlite(fixture.Connection)
@@ -30,17 +30,10 @@ public class EmptySchemaTest : IClassFixture<ScratchDatabaseFixture>
             })
             .AddEntityFrameworkStores<EmptyDbContext>();
 
-        services.AddLogging();
-
         _builder = new ApplicationBuilder(services.BuildServiceProvider());
-
-        using (var scope = _builder.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope())
-        {
-            var db = scope.ServiceProvider.GetRequiredService<EmptyDbContext>();
-            db.Database.EnsureCreated();
-            Assert.False(db.OnModelCreatingVersion2Called);
-            Assert.False(db.OnModelCreatingVersion1Called);
-        }
+        using var scope = _builder.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<EmptyDbContext>();
+        db.Database.EnsureCreated();
     }
 
     [Fact]
@@ -63,4 +56,3 @@ public class EmptySchemaTest : IClassFixture<ScratchDatabaseFixture>
         Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserTokens"));
     }
 }
-

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/VersionOneSchemaTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/VersionOneSchemaTest.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test;
+
+public class VersionOneSchemaTest : IClassFixture<ScratchDatabaseFixture>
+{
+    private readonly ApplicationBuilder _builder;
+
+    public VersionOneSchemaTest(ScratchDatabaseFixture fixture)
+    {
+        var services = new ServiceCollection();
+
+        services
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
+            .AddDbContext<VersionOneDbContext>(o =>
+                o.UseSqlite(fixture.Connection)
+                    .ConfigureWarnings(b => b.Log(CoreEventId.ManyServiceProvidersCreatedWarning)))
+            .AddIdentity<IdentityUser, IdentityRole>(o =>
+            {
+                o.Stores.MaxLengthForKeys = 128;
+            })
+            .AddEntityFrameworkStores<VersionOneDbContext>();
+
+        services.AddLogging();
+
+        _builder = new ApplicationBuilder(services.BuildServiceProvider());
+
+        using (var scope = _builder.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<VersionOneDbContext>();
+            db.Database.EnsureCreated();
+            Assert.True(db.OnModelCreatingVersion1Called);
+            Assert.False(db.OnModelCreatingVersion2Called);
+        }
+    }
+
+    [Fact]
+    public void EnsureDefaultSchema()
+    {
+        using (var scope = _builder.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<VersionOneDbContext>();
+
+            VerifyVersion1Schema(db);
+        }
+    }
+
+    private static void VerifyVersion1Schema(VersionOneDbContext dbContext)
+    {
+        var sqlConn = (SqliteConnection)dbContext.Database.GetDbConnection();
+
+        try
+        {
+            sqlConn.Open();
+            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUsers", "Id", "UserName", "Email", "PasswordHash", "SecurityStamp",
+                "EmailConfirmed", "PhoneNumber", "PhoneNumberConfirmed", "TwoFactorEnabled", "LockoutEnabled",
+                "LockoutEnd", "AccessFailedCount", "ConcurrencyStamp", "NormalizedUserName", "NormalizedEmail"));
+            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetRoles", "Id", "Name", "NormalizedName", "ConcurrencyStamp"));
+            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserRoles", "UserId", "RoleId"));
+            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserClaims", "Id", "UserId", "ClaimType", "ClaimValue"));
+            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserLogins", "UserId", "ProviderKey", "LoginProvider", "ProviderDisplayName"));
+            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserTokens", "UserId", "LoginProvider", "Name", "Value"));
+
+            Assert.True(DbUtil.VerifyMaxLength(dbContext, "AspNetUsers", 256, "UserName", "Email", "NormalizedUserName", "NormalizedEmail"));
+            Assert.True(DbUtil.VerifyMaxLength(dbContext, "AspNetRoles", 256, "Name", "NormalizedName"));
+            Assert.True(DbUtil.VerifyMaxLength(dbContext, "AspNetUserLogins", 128, "LoginProvider", "ProviderKey"));
+            Assert.True(DbUtil.VerifyMaxLength(dbContext, "AspNetUserTokens", 128, "LoginProvider", "Name"));
+
+            DbUtil.VerifyIndex(sqlConn, "AspNetRoles", "RoleNameIndex", isUnique: true);
+            DbUtil.VerifyIndex(sqlConn, "AspNetUsers", "UserNameIndex", isUnique: true);
+            DbUtil.VerifyIndex(sqlConn, "AspNetUsers", "EmailIndex");
+        }
+        finally
+        {
+            sqlConn.Close();
+        }
+    }
+}

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/VersionOneSchemaTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/VersionOneSchemaTest.cs
@@ -37,8 +37,6 @@ public class VersionOneSchemaTest : IClassFixture<ScratchDatabaseFixture>
         {
             var db = scope.ServiceProvider.GetRequiredService<VersionOneDbContext>();
             db.Database.EnsureCreated();
-            Assert.True(db.OnModelCreatingVersion1Called);
-            Assert.False(db.OnModelCreatingVersion2Called);
         }
     }
 

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/VersionOneSchemaTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/VersionOneSchemaTest.cs
@@ -33,52 +33,39 @@ public class VersionOneSchemaTest : IClassFixture<ScratchDatabaseFixture>
 
         _builder = new ApplicationBuilder(services.BuildServiceProvider());
 
-        using (var scope = _builder.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope())
-        {
-            var db = scope.ServiceProvider.GetRequiredService<VersionOneDbContext>();
-            db.Database.EnsureCreated();
-        }
+        using var scope = _builder.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<VersionOneDbContext>();
+        db.Database.EnsureCreated();
     }
 
     [Fact]
     public void EnsureDefaultSchema()
     {
-        using (var scope = _builder.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope())
-        {
-            var db = scope.ServiceProvider.GetRequiredService<VersionOneDbContext>();
-
-            VerifyVersion1Schema(db);
-        }
+        using var scope = _builder.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<VersionOneDbContext>();
+        VerifyVersion1Schema(db);
     }
 
     private static void VerifyVersion1Schema(VersionOneDbContext dbContext)
     {
-        var sqlConn = (SqliteConnection)dbContext.Database.GetDbConnection();
+        using var sqlConn = (SqliteConnection)dbContext.Database.GetDbConnection();
+        sqlConn.Open();
+        Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUsers", "Id", "UserName", "Email", "PasswordHash", "SecurityStamp",
+            "EmailConfirmed", "PhoneNumber", "PhoneNumberConfirmed", "TwoFactorEnabled", "LockoutEnabled",
+            "LockoutEnd", "AccessFailedCount", "ConcurrencyStamp", "NormalizedUserName", "NormalizedEmail"));
+        Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetRoles", "Id", "Name", "NormalizedName", "ConcurrencyStamp"));
+        Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserRoles", "UserId", "RoleId"));
+        Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserClaims", "Id", "UserId", "ClaimType", "ClaimValue"));
+        Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserLogins", "UserId", "ProviderKey", "LoginProvider", "ProviderDisplayName"));
+        Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserTokens", "UserId", "LoginProvider", "Name", "Value"));
 
-        try
-        {
-            sqlConn.Open();
-            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUsers", "Id", "UserName", "Email", "PasswordHash", "SecurityStamp",
-                "EmailConfirmed", "PhoneNumber", "PhoneNumberConfirmed", "TwoFactorEnabled", "LockoutEnabled",
-                "LockoutEnd", "AccessFailedCount", "ConcurrencyStamp", "NormalizedUserName", "NormalizedEmail"));
-            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetRoles", "Id", "Name", "NormalizedName", "ConcurrencyStamp"));
-            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserRoles", "UserId", "RoleId"));
-            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserClaims", "Id", "UserId", "ClaimType", "ClaimValue"));
-            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserLogins", "UserId", "ProviderKey", "LoginProvider", "ProviderDisplayName"));
-            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserTokens", "UserId", "LoginProvider", "Name", "Value"));
+        Assert.True(DbUtil.VerifyMaxLength(dbContext, "AspNetUsers", 256, "UserName", "Email", "NormalizedUserName", "NormalizedEmail"));
+        Assert.True(DbUtil.VerifyMaxLength(dbContext, "AspNetRoles", 256, "Name", "NormalizedName"));
+        Assert.True(DbUtil.VerifyMaxLength(dbContext, "AspNetUserLogins", 128, "LoginProvider", "ProviderKey"));
+        Assert.True(DbUtil.VerifyMaxLength(dbContext, "AspNetUserTokens", 128, "LoginProvider", "Name"));
 
-            Assert.True(DbUtil.VerifyMaxLength(dbContext, "AspNetUsers", 256, "UserName", "Email", "NormalizedUserName", "NormalizedEmail"));
-            Assert.True(DbUtil.VerifyMaxLength(dbContext, "AspNetRoles", 256, "Name", "NormalizedName"));
-            Assert.True(DbUtil.VerifyMaxLength(dbContext, "AspNetUserLogins", 128, "LoginProvider", "ProviderKey"));
-            Assert.True(DbUtil.VerifyMaxLength(dbContext, "AspNetUserTokens", 128, "LoginProvider", "Name"));
-
-            DbUtil.VerifyIndex(sqlConn, "AspNetRoles", "RoleNameIndex", isUnique: true);
-            DbUtil.VerifyIndex(sqlConn, "AspNetUsers", "UserNameIndex", isUnique: true);
-            DbUtil.VerifyIndex(sqlConn, "AspNetUsers", "EmailIndex");
-        }
-        finally
-        {
-            sqlConn.Close();
-        }
+        DbUtil.VerifyIndex(sqlConn, "AspNetRoles", "RoleNameIndex", isUnique: true);
+        DbUtil.VerifyIndex(sqlConn, "AspNetUsers", "UserNameIndex", isUnique: true);
+        DbUtil.VerifyIndex(sqlConn, "AspNetUsers", "EmailIndex");
     }
 }

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/VersionTestDbContext.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/VersionTestDbContext.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test;
+
+// Need a different context type here since EF model is changing by having MaxLengthForKeys
+public class VersionOneDbContext : IdentityDbContext<IdentityUser, IdentityRole, string>
+{
+    public VersionOneDbContext(DbContextOptions options)
+        : base(options)
+    {
+    }
+
+    public bool OnModelCreatingVersion1Called = false;
+    public bool OnModelCreatingVersion2Called = false;
+
+    protected override void OnModelCreatingVersion1(ModelBuilder builder)
+    {
+        base.OnModelCreatingVersion1(builder);
+        OnModelCreatingVersion1Called = true;
+    }
+
+    protected override void OnModelCreatingVersion2(ModelBuilder builder)
+    {
+        base.OnModelCreatingVersion2(builder);
+        OnModelCreatingVersion2Called = true;
+    }
+}
+
+public class VersionTwoDbContext : IdentityDbContext<IdentityUser, IdentityRole, string>
+{
+    public VersionTwoDbContext(DbContextOptions options)
+        : base(options)
+    {
+    }
+
+    public bool OnModelCreatingVersion1Called = false;
+    public bool OnModelCreatingVersion2Called = false;
+
+    protected override void OnModelCreatingVersion1(ModelBuilder builder)
+    {
+        base.OnModelCreatingVersion1(builder);
+        OnModelCreatingVersion1Called = true;
+    }
+
+    protected override void OnModelCreatingVersion2(ModelBuilder builder)
+    {
+        base.OnModelCreatingVersion2(builder);
+        OnModelCreatingVersion2Called = true;
+    }
+}

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/VersionTestDbContext.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/VersionTestDbContext.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test;
 
@@ -49,5 +51,85 @@ public class VersionTwoDbContext : IdentityDbContext<IdentityUser, IdentityRole,
     {
         base.OnModelCreatingVersion2(builder);
         OnModelCreatingVersion2Called = true;
+    }
+}
+
+public class EmptyDbContext : IdentityDbContext<IdentityUser, IdentityRole, string>
+{
+    public EmptyDbContext(DbContextOptions options)
+        : base(options)
+    {
+    }
+
+    public bool OnModelCreatingVersion1Called = false;
+    public bool OnModelCreatingVersion2Called = false;
+
+    protected override void OnModelCreatingVersion(ModelBuilder builder, Version schemaVersion)
+    {
+        if (schemaVersion >= new Version(10, 0))
+        {
+            builder.Ignore<IdentityUser>();
+
+            builder.Ignore<IdentityUserClaim<string>>();
+
+            builder.Ignore<IdentityUserLogin<string>>();
+
+            builder.Ignore<IdentityUserToken<string>>();
+
+            builder.Ignore<IdentityRole>();
+
+            builder.Ignore<IdentityRoleClaim<string>>();
+
+            builder.Ignore<IdentityUserRole<string>>();
+
+        }
+        else
+        {
+            base.OnModelCreatingVersion(builder, schemaVersion);
+        }
+    }
+
+    protected override void OnModelCreatingVersion1(ModelBuilder builder)
+    {
+        base.OnModelCreatingVersion1(builder);
+        OnModelCreatingVersion1Called = true;
+    }
+
+    protected override void OnModelCreatingVersion2(ModelBuilder builder)
+    {
+        base.OnModelCreatingVersion2(builder);
+        OnModelCreatingVersion2Called = true;
+    }
+}
+
+public class CustomColumn
+{
+    public string Id { get; set; }
+}
+
+public class CustomVersionDbContext : IdentityDbContext<IdentityUser, IdentityRole, string>
+{
+    public CustomVersionDbContext(DbContextOptions options)
+        : base(options)
+    {
+    }
+
+    public DbSet<CustomColumn> CustomColumns { get; set; }
+
+    protected override void OnModelCreatingVersion(ModelBuilder builder, Version schemaVersion)
+    {
+        if (schemaVersion >= new Version(3, 0))
+        {
+            base.OnModelCreatingVersion2(builder);
+
+            builder.Entity<CustomColumn>(b =>
+            {
+                b.HasKey(b => b.Id);
+            });
+        }
+        else
+        {
+            base.OnModelCreatingVersion(builder, schemaVersion);
+        }
     }
 }

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/VersionTestDbContext.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/VersionTestDbContext.cs
@@ -31,9 +31,6 @@ public class EmptyDbContext : IdentityDbContext<IdentityUser, IdentityRole, stri
     {
     }
 
-    public bool OnModelCreatingVersion1Called = false;
-    public bool OnModelCreatingVersion2Called = false;
-
     protected override void OnModelCreating(ModelBuilder builder)
     {
         if (SchemaVersion >= new Version(10, 0))

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/VersionTestDbContext.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/VersionTestDbContext.cs
@@ -14,21 +14,6 @@ public class VersionOneDbContext : IdentityDbContext<IdentityUser, IdentityRole,
         : base(options)
     {
     }
-
-    public bool OnModelCreatingVersion1Called = false;
-    public bool OnModelCreatingVersion2Called = false;
-
-    protected override void OnModelCreatingVersion1(ModelBuilder builder)
-    {
-        base.OnModelCreatingVersion1(builder);
-        OnModelCreatingVersion1Called = true;
-    }
-
-    protected override void OnModelCreatingVersion2(ModelBuilder builder)
-    {
-        base.OnModelCreatingVersion2(builder);
-        OnModelCreatingVersion2Called = true;
-    }
 }
 
 public class VersionTwoDbContext : IdentityDbContext<IdentityUser, IdentityRole, string>
@@ -36,21 +21,6 @@ public class VersionTwoDbContext : IdentityDbContext<IdentityUser, IdentityRole,
     public VersionTwoDbContext(DbContextOptions options)
         : base(options)
     {
-    }
-
-    public bool OnModelCreatingVersion1Called = false;
-    public bool OnModelCreatingVersion2Called = false;
-
-    protected override void OnModelCreatingVersion1(ModelBuilder builder)
-    {
-        base.OnModelCreatingVersion1(builder);
-        OnModelCreatingVersion1Called = true;
-    }
-
-    protected override void OnModelCreatingVersion2(ModelBuilder builder)
-    {
-        base.OnModelCreatingVersion2(builder);
-        OnModelCreatingVersion2Called = true;
     }
 }
 
@@ -64,9 +34,9 @@ public class EmptyDbContext : IdentityDbContext<IdentityUser, IdentityRole, stri
     public bool OnModelCreatingVersion1Called = false;
     public bool OnModelCreatingVersion2Called = false;
 
-    protected override void OnModelCreatingVersion(ModelBuilder builder, Version schemaVersion)
+    protected override void OnModelCreating(ModelBuilder builder)
     {
-        if (schemaVersion >= new Version(10, 0))
+        if (SchemaVersion >= new Version(10, 0))
         {
             builder.Ignore<IdentityUser>();
 
@@ -85,20 +55,8 @@ public class EmptyDbContext : IdentityDbContext<IdentityUser, IdentityRole, stri
         }
         else
         {
-            base.OnModelCreatingVersion(builder, schemaVersion);
+            base.OnModelCreating(builder);
         }
-    }
-
-    protected override void OnModelCreatingVersion1(ModelBuilder builder)
-    {
-        base.OnModelCreatingVersion1(builder);
-        OnModelCreatingVersion1Called = true;
-    }
-
-    protected override void OnModelCreatingVersion2(ModelBuilder builder)
-    {
-        base.OnModelCreatingVersion2(builder);
-        OnModelCreatingVersion2Called = true;
     }
 }
 
@@ -116,20 +74,16 @@ public class CustomVersionDbContext : IdentityDbContext<IdentityUser, IdentityRo
 
     public DbSet<CustomColumn> CustomColumns { get; set; }
 
-    protected override void OnModelCreatingVersion(ModelBuilder builder, Version schemaVersion)
+    protected override void OnModelCreating(ModelBuilder builder)
     {
-        if (schemaVersion >= new Version(3, 0))
-        {
-            base.OnModelCreatingVersion2(builder);
+        base.OnModelCreating(builder);
 
+        if (SchemaVersion >= new Version(3, 0))
+        {
             builder.Entity<CustomColumn>(b =>
             {
                 b.HasKey(b => b.Id);
             });
-        }
-        else
-        {
-            base.OnModelCreatingVersion(builder, schemaVersion);
         }
     }
 }

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/VersionTwoSchemaTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/VersionTwoSchemaTest.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Identity.EntityFrameworkCore.Test;
+
+public class VersionTwoSchemaTest : IClassFixture<ScratchDatabaseFixture>
+{
+    private readonly ApplicationBuilder _builder;
+
+    public VersionTwoSchemaTest(ScratchDatabaseFixture fixture)
+    {
+        var services = new ServiceCollection();
+
+        services
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
+            .AddDbContext<VersionTwoDbContext>(o =>
+                o.UseSqlite(fixture.Connection)
+                    .ConfigureWarnings(b => b.Log(CoreEventId.ManyServiceProvidersCreatedWarning)))
+            .AddIdentity<IdentityUser, IdentityRole>(o =>
+            {
+                // MaxKeyLength does not need to be set in version 2
+                o.Stores.SchemaVersion = IdentityVersions.Version2;
+            })
+            .AddEntityFrameworkStores<VersionTwoDbContext>();
+
+        services.AddLogging();
+
+        _builder = new ApplicationBuilder(services.BuildServiceProvider());
+
+        using (var scope = _builder.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<VersionTwoDbContext>();
+            db.Database.EnsureCreated();
+            Assert.True(db.OnModelCreatingVersion2Called);
+            Assert.False(db.OnModelCreatingVersion1Called);
+        }
+    }
+
+    [Fact]
+    public void EnsureDefaultSchema()
+    {
+        using (var scope = _builder.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<VersionTwoDbContext>();
+
+            VerifyVersion2Schema(db);
+        }
+    }
+
+    private static void VerifyVersion2Schema(VersionTwoDbContext dbContext)
+    {
+        var sqlConn = (SqliteConnection)dbContext.Database.GetDbConnection();
+
+        try
+        {
+            sqlConn.Open();
+            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUsers", "Id", "UserName", "Email", "PasswordHash", "SecurityStamp",
+                "EmailConfirmed", "PhoneNumber", "PhoneNumberConfirmed", "TwoFactorEnabled", "LockoutEnabled",
+                "LockoutEnd", "AccessFailedCount", "ConcurrencyStamp", "NormalizedUserName", "NormalizedEmail"));
+            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetRoles", "Id", "Name", "NormalizedName", "ConcurrencyStamp"));
+            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserRoles", "UserId", "RoleId"));
+            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserClaims", "Id", "UserId", "ClaimType", "ClaimValue"));
+            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserLogins", "UserId", "ProviderKey", "LoginProvider", "ProviderDisplayName"));
+            Assert.True(DbUtil.VerifyColumns(sqlConn, "AspNetUserTokens", "UserId", "LoginProvider", "Name", "Value"));
+
+            Assert.True(DbUtil.VerifyMaxLength(dbContext, "AspNetUsers", 256, "UserName", "Email", "NormalizedUserName", "NormalizedEmail", "PhoneNumber"));
+            Assert.True(DbUtil.VerifyMaxLength(dbContext, "AspNetRoles", 256, "Name", "NormalizedName"));
+            Assert.True(DbUtil.VerifyMaxLength(dbContext, "AspNetUserLogins", 128, "LoginProvider", "ProviderKey"));
+            Assert.True(DbUtil.VerifyMaxLength(dbContext, "AspNetUserTokens", 128, "LoginProvider", "Name"));
+
+            DbUtil.VerifyIndex(sqlConn, "AspNetRoles", "RoleNameIndex", isUnique: true);
+            DbUtil.VerifyIndex(sqlConn, "AspNetUsers", "UserNameIndex", isUnique: true);
+            DbUtil.VerifyIndex(sqlConn, "AspNetUsers", "EmailIndex");
+        }
+        finally
+        {
+            sqlConn.Close();
+        }
+    }
+}

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/VersionTwoSchemaTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/VersionTwoSchemaTest.cs
@@ -54,7 +54,7 @@ public class VersionTwoSchemaTest : IClassFixture<ScratchDatabaseFixture>
         }
     }
 
-    private static void VerifyVersion2Schema(VersionTwoDbContext dbContext)
+    internal static void VerifyVersion2Schema(DbContext dbContext)
     {
         var sqlConn = (SqliteConnection)dbContext.Database.GetDbConnection();
 

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/VersionTwoSchemaTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/VersionTwoSchemaTest.cs
@@ -33,13 +33,10 @@ public class VersionTwoSchemaTest : IClassFixture<ScratchDatabaseFixture>
         services.AddLogging();
 
         _builder = new ApplicationBuilder(services.BuildServiceProvider());
-
         using (var scope = _builder.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope())
         {
             var db = scope.ServiceProvider.GetRequiredService<VersionTwoDbContext>();
             db.Database.EnsureCreated();
-            Assert.True(db.OnModelCreatingVersion2Called);
-            Assert.False(db.OnModelCreatingVersion1Called);
         }
     }
 
@@ -49,7 +46,6 @@ public class VersionTwoSchemaTest : IClassFixture<ScratchDatabaseFixture>
         using (var scope = _builder.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope())
         {
             var db = scope.ServiceProvider.GetRequiredService<VersionTwoDbContext>();
-
             VerifyVersion2Schema(db);
         }
     }

--- a/src/Identity/EntityFrameworkCore/test/EF.Test/VersionTwoSchemaTest.cs
+++ b/src/Identity/EntityFrameworkCore/test/EF.Test/VersionTwoSchemaTest.cs
@@ -26,7 +26,7 @@ public class VersionTwoSchemaTest : IClassFixture<ScratchDatabaseFixture>
             .AddIdentity<IdentityUser, IdentityRole>(o =>
             {
                 // MaxKeyLength does not need to be set in version 2
-                o.Stores.SchemaVersion = IdentityVersions.Version2;
+                o.Stores.SchemaVersion = IdentitySchemaVersions.Version2;
             })
             .AddEntityFrameworkStores<VersionTwoDbContext>();
 

--- a/src/Identity/Extensions.Core/src/IdentitySchemaVersions.cs
+++ b/src/Identity/Extensions.Core/src/IdentitySchemaVersions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Identity;
 /// <summary>
 /// Contains various identity version constants.
 /// </summary>
-public static class IdentityVersions
+public static class IdentitySchemaVersions
 {
     /// <summary>
     /// Represents the default version of the identity schema 

--- a/src/Identity/Extensions.Core/src/IdentityVersions.cs
+++ b/src/Identity/Extensions.Core/src/IdentityVersions.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.AspNetCore.Identity;
+
+/// <summary>
+/// Contains various identity version constants.
+/// </summary>
+public static class IdentityVersions
+{
+    /// <summary>
+    /// Represents the initial 1.0 version of the identity schema 
+    /// </summary>
+    public static readonly Version Version1 = new Version(1, 0);
+
+    /// <summary>
+    /// Represents the 2.0 version of the identity schema
+    /// </summary>
+    public static readonly Version Version2 = new Version(2, 0);
+
+}

--- a/src/Identity/Extensions.Core/src/IdentityVersions.cs
+++ b/src/Identity/Extensions.Core/src/IdentityVersions.cs
@@ -11,6 +11,11 @@ namespace Microsoft.AspNetCore.Identity;
 public static class IdentityVersions
 {
     /// <summary>
+    /// Represents the default version of the identity schema 
+    /// </summary>
+    public static readonly Version Default = new Version(0, 0);
+
+    /// <summary>
     /// Represents the initial 1.0 version of the identity schema 
     /// </summary>
     public static readonly Version Version1 = new Version(1, 0);

--- a/src/Identity/Extensions.Core/src/PublicAPI.Unshipped.txt
+++ b/src/Identity/Extensions.Core/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+Microsoft.AspNetCore.Identity.IdentityVersions
+Microsoft.AspNetCore.Identity.StoreOptions.SchemaVersion.get -> System.Version!
+Microsoft.AspNetCore.Identity.StoreOptions.SchemaVersion.set -> void
+static readonly Microsoft.AspNetCore.Identity.IdentityVersions.Version1 -> System.Version!
+static readonly Microsoft.AspNetCore.Identity.IdentityVersions.Version2 -> System.Version!

--- a/src/Identity/Extensions.Core/src/PublicAPI.Unshipped.txt
+++ b/src/Identity/Extensions.Core/src/PublicAPI.Unshipped.txt
@@ -2,5 +2,6 @@
 Microsoft.AspNetCore.Identity.IdentityVersions
 Microsoft.AspNetCore.Identity.StoreOptions.SchemaVersion.get -> System.Version!
 Microsoft.AspNetCore.Identity.StoreOptions.SchemaVersion.set -> void
+static readonly Microsoft.AspNetCore.Identity.IdentityVersions.Default -> System.Version!
 static readonly Microsoft.AspNetCore.Identity.IdentityVersions.Version1 -> System.Version!
 static readonly Microsoft.AspNetCore.Identity.IdentityVersions.Version2 -> System.Version!

--- a/src/Identity/Extensions.Core/src/PublicAPI.Unshipped.txt
+++ b/src/Identity/Extensions.Core/src/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
-Microsoft.AspNetCore.Identity.IdentityVersions
+Microsoft.AspNetCore.Identity.IdentitySchemaVersions
 Microsoft.AspNetCore.Identity.StoreOptions.SchemaVersion.get -> System.Version!
 Microsoft.AspNetCore.Identity.StoreOptions.SchemaVersion.set -> void
-static readonly Microsoft.AspNetCore.Identity.IdentityVersions.Default -> System.Version!
-static readonly Microsoft.AspNetCore.Identity.IdentityVersions.Version1 -> System.Version!
-static readonly Microsoft.AspNetCore.Identity.IdentityVersions.Version2 -> System.Version!
+static readonly Microsoft.AspNetCore.Identity.IdentitySchemaVersions.Default -> System.Version!
+static readonly Microsoft.AspNetCore.Identity.IdentitySchemaVersions.Version1 -> System.Version!
+static readonly Microsoft.AspNetCore.Identity.IdentitySchemaVersions.Version2 -> System.Version!

--- a/src/Identity/Extensions.Core/src/StoreOptions.cs
+++ b/src/Identity/Extensions.Core/src/StoreOptions.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.AspNetCore.Identity;
 
+using System;
+
 /// <summary>
 /// Used for store specific options
 /// </summary>
@@ -19,4 +21,10 @@ public class StoreOptions
     /// This will be enforced by requiring the store to implement <see cref="IProtectedUserStore{TUser}"/>.
     /// </summary>
     public bool ProtectPersonalData { get; set; }
+
+    /// <summary>
+    /// The schema version for the store, the default is 0.0 which leaves it up to the store
+    /// to determine what version should be used.
+    /// </summary>
+    public Version SchemaVersion { get; set; } = new Version(0, 0);
 }

--- a/src/Identity/Extensions.Core/src/StoreOptions.cs
+++ b/src/Identity/Extensions.Core/src/StoreOptions.cs
@@ -26,5 +26,5 @@ public class StoreOptions
     /// The schema version for the store, the default is 0.0 which leaves it up to the store
     /// to determine what version should be used.
     /// </summary>
-    public Version SchemaVersion { get; set; } = IdentityVersions.Default;
+    public Version SchemaVersion { get; set; } = IdentitySchemaVersions.Default;
 }

--- a/src/Identity/Extensions.Core/src/StoreOptions.cs
+++ b/src/Identity/Extensions.Core/src/StoreOptions.cs
@@ -26,5 +26,5 @@ public class StoreOptions
     /// The schema version for the store, the default is 0.0 which leaves it up to the store
     /// to determine what version should be used.
     /// </summary>
-    public Version SchemaVersion { get; set; } = new Version(0, 0);
+    public Version SchemaVersion { get; set; } = IdentityVersions.Default;
 }


### PR DESCRIPTION
Introduce the concept of SchemaVersion so we can target different table schemas and make breaking changes in the default EF store.

Example usage:
```C#
            .AddIdentity<IdentityUser, IdentityRole>(o =>
            {
                // Opting into the new schema explicitly
                o.Stores.SchemaVersion = IdentityVersions.Version2;

                // Opting into the old schema explicitly
                o.Stores.SchemaVersion = IdentityVersions.Version1;

                // Default is 0.0 and left to the stores to interpret appropriately
            })
```

Added a few basic tests to exercise the functionality, one that ignores all of the entities, one that adds a custom column, and made some minor tweaks in the 2.0 schema adjusting some key lengths etc.

Wanted to get the review process started on this at this checkpoint
