### PR TITLE
Improve DFA matcher builder startup perf with many constraints

### DIFF
--- a/src/Http/Routing/perf/Microbenchmarks/Matching/CreateMatcherRegexConstraintBenchmark.cs
+++ b/src/Http/Routing/perf/Microbenchmarks/Matching/CreateMatcherRegexConstraintBenchmark.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.AspNetCore.Routing.Matching;
+
+public class CreateMatcherRegexConstraintBenchmark : EndpointRoutingBenchmarkBase
+{
+    [Params(true, false)]
+    public bool RegexSame { get; set; }
+
+    private const int EndpointCount = 1_000;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Endpoints = new RouteEndpoint[EndpointCount];
+        for (var i = 0; i < Endpoints.Length; i++)
+        {
+            Endpoints[i] = RegexSame
+                ? CreateEndpoint("/plaintext" + i + "/{param:regex(^\\d{{7}}|(SI[[PG]]|JPA|DEM)\\d{{4}})}")
+                : CreateEndpoint("/plaintext" + i + "/{param:regex(^" + i + "\\d{{7}}|(SI[[PG]]|JPA|DEM)\\d{{4}})}");
+        }
+
+    }
+
+    [Benchmark]
+    public void Build()
+    {
+        var builder = CreateDfaMatcherBuilder();
+        for (var i = 0; i < Endpoints.Length; i++)
+        {
+            builder.AddEndpoint(Endpoints[i]);
+        }
+
+        builder.Build();
+    }
+}

--- a/src/Http/Routing/src/Constraints/AlphaRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/AlphaRouteConstraint.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Routing.Matching;
 
 namespace Microsoft.AspNetCore.Routing.Constraints;
 
 /// <summary>
 /// Constrains a route parameter to contain only lowercase or uppercase letters A through Z in the English alphabet.
 /// </summary>
-public partial class AlphaRouteConstraint : RegexRouteConstraint
+public partial class AlphaRouteConstraint : RegexRouteConstraint, ICachableParameterPolicy
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="AlphaRouteConstraint" /> class.

--- a/src/Http/Routing/src/Constraints/BoolRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/BoolRouteConstraint.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints;
 /// <summary>
 /// Constrains a route parameter to represent only Boolean values.
 /// </summary>
-public class BoolRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy
+public class BoolRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy, ICachableParameterPolicy
 {
     /// <inheritdoc />
     public bool Match(

--- a/src/Http/Routing/src/Constraints/DateTimeRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/DateTimeRouteConstraint.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints;
 /// For a sample on how to list all formats which are considered, please visit
 /// http://msdn.microsoft.com/en-us/library/aszyst2c(v=vs.110).aspx
 /// </remarks>
-public class DateTimeRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy
+public class DateTimeRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy, ICachableParameterPolicy
 {
     /// <inheritdoc />
     public bool Match(

--- a/src/Http/Routing/src/Constraints/DecimalRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/DecimalRouteConstraint.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints;
 /// <summary>
 /// Constrains a route parameter to represent only decimal values.
 /// </summary>
-public class DecimalRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy
+public class DecimalRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy, ICachableParameterPolicy
 {
     /// <inheritdoc />
     public bool Match(

--- a/src/Http/Routing/src/Constraints/DoubleRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/DoubleRouteConstraint.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints;
 /// <summary>
 /// Constrains a route parameter to represent only 64-bit floating-point values.
 /// </summary>
-public class DoubleRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy
+public class DoubleRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy, ICachableParameterPolicy
 {
     /// <inheritdoc />
     public bool Match(

--- a/src/Http/Routing/src/Constraints/FileNameRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/FileNameRouteConstraint.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints;
 /// </list>
 /// </para>
 /// </remarks>
-public class FileNameRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy
+public class FileNameRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy, ICachableParameterPolicy
 {
     /// <inheritdoc />
     public bool Match(

--- a/src/Http/Routing/src/Constraints/FloatRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/FloatRouteConstraint.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints;
 /// <summary>
 /// Constrains a route parameter to represent only 32-bit floating-point values.
 /// </summary>
-public class FloatRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy
+public class FloatRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy, ICachableParameterPolicy
 {
     /// <inheritdoc />
     public bool Match(

--- a/src/Http/Routing/src/Constraints/GuidRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/GuidRouteConstraint.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints;
 /// Matches values specified in any of the five formats "N", "D", "B", "P", or "X",
 /// supported by Guid.ToString(string) and Guid.ToString(String, IFormatProvider) methods.
 /// </summary>
-public class GuidRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy
+public class GuidRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy, ICachableParameterPolicy
 {
     /// <inheritdoc />
     public bool Match(

--- a/src/Http/Routing/src/Constraints/IntRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/IntRouteConstraint.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints;
 /// <summary>
 /// Constrains a route parameter to represent only 32-bit integer values.
 /// </summary>
-public class IntRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy
+public class IntRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy, ICachableParameterPolicy
 {
     /// <inheritdoc />
     public bool Match(

--- a/src/Http/Routing/src/Constraints/LengthRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/LengthRouteConstraint.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints;
 /// <summary>
 /// Constrains a route parameter to be a string of a given length or within a given range of lengths.
 /// </summary>
-public class LengthRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy
+public class LengthRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy, ICachableParameterPolicy
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="LengthRouteConstraint" /> class that constrains

--- a/src/Http/Routing/src/Constraints/LongRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/LongRouteConstraint.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints;
 /// <summary>
 /// Constrains a route parameter to represent only 64-bit integer values.
 /// </summary>
-public class LongRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy
+public class LongRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy, ICachableParameterPolicy
 {
     /// <inheritdoc />
     public bool Match(

--- a/src/Http/Routing/src/Constraints/MaxLengthRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/MaxLengthRouteConstraint.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints;
 /// <summary>
 /// Constrains a route parameter to be a string with a maximum length.
 /// </summary>
-public class MaxLengthRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy
+public class MaxLengthRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy, ICachableParameterPolicy
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="MaxLengthRouteConstraint" /> class.

--- a/src/Http/Routing/src/Constraints/MaxRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/MaxRouteConstraint.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints;
 /// <summary>
 /// Constrains a route parameter to be an integer with a maximum value.
 /// </summary>
-public class MaxRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy
+public class MaxRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy, ICachableParameterPolicy
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="MaxRouteConstraint" /> class.

--- a/src/Http/Routing/src/Constraints/MinLengthRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/MinLengthRouteConstraint.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints;
 /// <summary>
 /// Constrains a route parameter to be a string with a minimum length.
 /// </summary>
-public class MinLengthRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy
+public class MinLengthRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy, ICachableParameterPolicy
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="MinLengthRouteConstraint" /> class.

--- a/src/Http/Routing/src/Constraints/MinRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/MinRouteConstraint.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints;
 /// <summary>
 /// Constrains a route parameter to be a long with a minimum value.
 /// </summary>
-public class MinRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy
+public class MinRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy, ICachableParameterPolicy
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="MinRouteConstraint" /> class.

--- a/src/Http/Routing/src/Constraints/NonFileNameRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/NonFileNameRouteConstraint.cs
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints;
 /// </list>
 /// </para>
 /// </remarks>
-public class NonFileNameRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy
+public class NonFileNameRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy, ICachableParameterPolicy
 {
     /// <inheritdoc />
     public bool Match(

--- a/src/Http/Routing/src/Constraints/RangeRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/RangeRouteConstraint.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints;
 /// <summary>
 /// Constraints a route parameter to be an integer within a given range of values.
 /// </summary>
-public class RangeRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy
+public class RangeRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy, ICachableParameterPolicy
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="RangeRouteConstraint" /> class.

--- a/src/Http/Routing/src/Constraints/RegexInlineRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/RegexInlineRouteConstraint.cs
@@ -3,13 +3,14 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Routing.Matching;
 
 namespace Microsoft.AspNetCore.Routing.Constraints;
 
 /// <summary>
 /// Represents a regex constraint which can be used as an inlineConstraint.
 /// </summary>
-public class RegexInlineRouteConstraint : RegexRouteConstraint
+public class RegexInlineRouteConstraint : RegexRouteConstraint, ICachableParameterPolicy
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="RegexInlineRouteConstraint" /> class.

--- a/src/Http/Routing/src/Constraints/RegexRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/RegexRouteConstraint.cs
@@ -50,7 +50,8 @@ public class RegexRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatch
     {
         get
         {
-            // Not thread safe. No side effect but could have multiple instances of Regex created.
+            // Create regex instance lazily to avoid compiling regexes at app startup. Delay creation until constraint is first evaluation.
+            // Not thread safe. No side effect but multiple instances of a regex instance could be created from a burst of requests.
             _constraint ??= new Regex(
                 _regexPattern,
                 RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.IgnoreCase,

--- a/src/Http/Routing/src/Constraints/RegexRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/RegexRouteConstraint.cs
@@ -50,7 +50,7 @@ public class RegexRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatch
     {
         get
         {
-            // Create regex instance lazily to avoid compiling regexes at app startup. Delay creation until constraint is first evaluation.
+            // Create regex instance lazily to avoid compiling regexes at app startup. Delay creation until constraint is first evaluated.
             // This is not thread safe. No side effect but multiple instances of a regex instance could be created from a burst of requests.
             _constraint ??= new Regex(
                 _regexPattern,

--- a/src/Http/Routing/src/Constraints/RegexRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/RegexRouteConstraint.cs
@@ -15,6 +15,8 @@ namespace Microsoft.AspNetCore.Routing.Constraints;
 public class RegexRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy
 {
     private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromSeconds(10);
+    private readonly string _regexPattern;
+    private Regex? _constraint;
 
     /// <summary>
     /// Constructor for a <see cref="RegexRouteConstraint"/> given a <paramref name="regex"/>.
@@ -24,7 +26,8 @@ public class RegexRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatch
     {
         ArgumentNullException.ThrowIfNull(regex);
 
-        Constraint = regex;
+        _constraint = regex;
+        _regexPattern = regex.ToString();
     }
 
     /// <summary>
@@ -37,16 +40,25 @@ public class RegexRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatch
     {
         ArgumentNullException.ThrowIfNull(regexPattern);
 
-        Constraint = new Regex(
-            regexPattern,
-            RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.IgnoreCase,
-            RegexMatchTimeout);
+        _regexPattern = regexPattern;
     }
 
     /// <summary>
     /// Gets the regular expression used in the route constraint.
     /// </summary>
-    public Regex Constraint { get; private set; }
+    public Regex Constraint
+    {
+        get
+        {
+            // Not thread safe. No side effect but could have multiple instances of Regex created.
+            _constraint ??= new Regex(
+                _regexPattern,
+                RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.IgnoreCase,
+                RegexMatchTimeout);
+
+            return _constraint;
+        }
+    }
 
     /// <inheritdoc />
     public bool Match(

--- a/src/Http/Routing/src/Constraints/RegexRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/RegexRouteConstraint.cs
@@ -51,7 +51,7 @@ public class RegexRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatch
         get
         {
             // Create regex instance lazily to avoid compiling regexes at app startup. Delay creation until constraint is first evaluation.
-            // Not thread safe. No side effect but multiple instances of a regex instance could be created from a burst of requests.
+            // This is not thread safe. No side effect but multiple instances of a regex instance could be created from a burst of requests.
             _constraint ??= new Regex(
                 _regexPattern,
                 RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.IgnoreCase,

--- a/src/Http/Routing/src/Constraints/StringRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/StringRouteConstraint.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints;
 /// <summary>
 /// Constrains a route parameter to contain only a specified string.
 /// </summary>
-public class StringRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy
+public class StringRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatchingPolicy, ICachableParameterPolicy
 {
     private readonly string _value;
 

--- a/src/Http/Routing/src/Matching/DfaMatcherBuilder.cs
+++ b/src/Http/Routing/src/Matching/DfaMatcherBuilder.cs
@@ -130,7 +130,7 @@ internal sealed class DfaMatcherBuilder : MatcherBuilder
             // Only cachable parameter policies are in the cache, so a match will only be available if the parameter policy key is configured to a cachable parameter policy.
             if (_cachedParameters.TryGetValue(inlineText, out var parameterPolicy))
             {
-                return Create(parameter, parameterPolicy);
+                return _inner.Create(parameter, parameterPolicy);
             }
 
             parameterPolicy = _inner.Create(parameter, inlineText);

--- a/src/Http/Routing/src/Matching/DfaMatcherBuilder.cs
+++ b/src/Http/Routing/src/Matching/DfaMatcherBuilder.cs
@@ -139,6 +139,9 @@ internal sealed class DfaMatcherBuilder : MatcherBuilder
             var createdParameterPolicy = (parameterPolicy is OptionalRouteConstraint optionalRouteConstraint)
                 ? optionalRouteConstraint.InnerConstraint
                 : parameterPolicy;
+
+            // For know, only cache policies in a known allow list. This is indicated by implementing ICachableParameterPolicy.
+            // There is a chance that a user-defined constraint has state, such as an evaluation count. That would break if the constraint is shared between routes, so don't cache.
             if (createdParameterPolicy is ICachableParameterPolicy)
             {
                 _cachedParameters[inlineText] = createdParameterPolicy;

--- a/src/Http/Routing/src/Matching/DfaMatcherBuilder.cs
+++ b/src/Http/Routing/src/Matching/DfaMatcherBuilder.cs
@@ -121,13 +121,15 @@ internal sealed class DfaMatcherBuilder : MatcherBuilder
         public CachingParameterPolicyFactory(ParameterPolicyFactory inner)
         {
             _inner = inner;
-            _cachedParameters = new Dictionary<string, IParameterPolicy>();
+            _cachedParameters = new Dictionary<string, IParameterPolicy>(StringComparer.Ordinal);
         }
 
         public override IParameterPolicy Create(RoutePatternParameterPart parameter, string inlineText)
         {
             // Blindly check the cache to see if it contains a match.
             // Only cachable parameter policies are in the cache, so a match will only be available if the parameter policy key is configured to a cachable parameter policy.
+            //
+            // Note: Cache key is case sensitive. While the route prefix, e.g. "regex", is case-insensitive, the constraint could care about the case of the argument.
             if (_cachedParameters.TryGetValue(inlineText, out var parameterPolicy))
             {
                 return _inner.Create(parameter, parameterPolicy);

--- a/src/Http/Routing/src/Matching/DfaMatcherBuilder.cs
+++ b/src/Http/Routing/src/Matching/DfaMatcherBuilder.cs
@@ -142,7 +142,7 @@ internal sealed class DfaMatcherBuilder : MatcherBuilder
                 ? optionalRouteConstraint.InnerConstraint
                 : parameterPolicy;
 
-            // For know, only cache policies in a known allow list. This is indicated by implementing ICachableParameterPolicy.
+            // Only cache policies in a known allow list. This is indicated by implementing ICachableParameterPolicy.
             // There is a chance that a user-defined constraint has state, such as an evaluation count. That would break if the constraint is shared between routes, so don't cache.
             if (createdParameterPolicy is ICachableParameterPolicy)
             {

--- a/src/Http/Routing/src/Matching/DfaMatcherBuilder.cs
+++ b/src/Http/Routing/src/Matching/DfaMatcherBuilder.cs
@@ -6,6 +6,7 @@
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing.Constraints;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.AspNetCore.Routing.Template;
 using Microsoft.Extensions.Logging;
@@ -39,7 +40,8 @@ internal sealed class DfaMatcherBuilder : MatcherBuilder
         IEnumerable<MatcherPolicy> policies)
     {
         _loggerFactory = loggerFactory;
-        _parameterPolicyFactory = parameterPolicyFactory;
+        // DfaMatcherBuilder is a transient service. Each instance has its own cache of parameter policies.
+        _parameterPolicyFactory = new CachingParameterPolicyFactory(parameterPolicyFactory);
         _selector = selector;
 
         var (nodeBuilderPolicies, endpointComparerPolicies, endpointSelectorPolicies) = ExtractPolicies(policies.OrderBy(p => p.Order));
@@ -109,6 +111,46 @@ internal sealed class DfaMatcherBuilder : MatcherBuilder
         root.Visit(ApplyPolicies);
 
         return root;
+    }
+
+    private sealed class CachingParameterPolicyFactory : ParameterPolicyFactory
+    {
+        private readonly ParameterPolicyFactory _inner;
+        private readonly Dictionary<string, IParameterPolicy> _cachedParameters;
+
+        public CachingParameterPolicyFactory(ParameterPolicyFactory inner)
+        {
+            _inner = inner;
+            _cachedParameters = new Dictionary<string, IParameterPolicy>();
+        }
+
+        public override IParameterPolicy Create(RoutePatternParameterPart parameter, string inlineText)
+        {
+            // Blindly check the cache to see if it contains a match.
+            // Only cachable parameter policies are in the cache, so a match will only be available if the parameter policy key is configured to a cachable parameter policy.
+            if (_cachedParameters.TryGetValue(inlineText, out var parameterPolicy))
+            {
+                return Create(parameter, parameterPolicy);
+            }
+
+            parameterPolicy = _inner.Create(parameter, inlineText);
+
+            // The created parameter policy can be wrapped in an OptionalRouteConstraint if RoutePatternParameterPart.IsOptional is true.
+            var createdParameterPolicy = (parameterPolicy is OptionalRouteConstraint optionalRouteConstraint)
+                ? optionalRouteConstraint.InnerConstraint
+                : parameterPolicy;
+            if (createdParameterPolicy is ICachableParameterPolicy)
+            {
+                _cachedParameters[inlineText] = createdParameterPolicy;
+            }
+
+            return parameterPolicy;
+        }
+
+        public override IParameterPolicy Create(RoutePatternParameterPart parameter, IParameterPolicy parameterPolicy)
+        {
+            return _inner.Create(parameter, parameterPolicy);
+        }
     }
 
     private sealed class DfaBuilderWorker

--- a/src/Http/Routing/src/Matching/ICachableParameterPolicy.cs
+++ b/src/Http/Routing/src/Matching/ICachableParameterPolicy.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Routing.Matching;
+
+/// <summary>
+/// A marker interface for parameter policies that can be shared.
+/// </summary>
+internal interface ICachableParameterPolicy
+{
+}

--- a/src/Http/Routing/test/UnitTests/Matching/DfaMatcherBuilderTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/DfaMatcherBuilderTest.cs
@@ -3374,6 +3374,75 @@ public class DfaMatcherBuilderTest
     }
 
     [Fact]
+    public void CreateCandidate_InlineRouteConstraints_Duplicate_SameInstance()
+    {
+        // Arrange
+        var endpoint1 = CreateEndpoint("/a/b/{c:int}");
+        var endpoint2 = CreateEndpoint("/d/e/{f:int}");
+
+        var builder = CreateDfaMatcherBuilder();
+
+        // Act
+        var candidate1 = builder.CreateCandidate(endpoint1, score: 0);
+        var candidate2 = builder.CreateCandidate(endpoint2, score: 0);
+
+        // Assert
+        Assert.Equal(Candidate.CandidateFlags.HasConstraints | Candidate.CandidateFlags.HasCaptures, candidate1.Flags);
+        var constraint1 = Assert.Single(candidate1.Constraints);
+
+        Assert.Equal(Candidate.CandidateFlags.HasConstraints | Candidate.CandidateFlags.HasCaptures, candidate2.Flags);
+        var constraint2 = Assert.Single(candidate2.Constraints);
+
+        Assert.Same(constraint1.Value, constraint2.Value);
+    }
+
+    [Fact]
+    public void CreateCandidate_InlineRouteConstraintsWithArgument_Duplicate_SameInstance()
+    {
+        // Arrange
+        var endpoint1 = CreateEndpoint("/a/b/{c:regex([A-Z])}");
+        var endpoint2 = CreateEndpoint("/d/e/{f:regex([A-Z])}");
+
+        var builder = CreateDfaMatcherBuilder();
+
+        // Act
+        var candidate1 = builder.CreateCandidate(endpoint1, score: 0);
+        var candidate2 = builder.CreateCandidate(endpoint2, score: 0);
+
+        // Assert
+        Assert.Equal(Candidate.CandidateFlags.HasConstraints | Candidate.CandidateFlags.HasCaptures, candidate1.Flags);
+        var constraint1 = Assert.Single(candidate1.Constraints);
+
+        Assert.Equal(Candidate.CandidateFlags.HasConstraints | Candidate.CandidateFlags.HasCaptures, candidate2.Flags);
+        var constraint2 = Assert.Single(candidate2.Constraints);
+
+        Assert.Same(constraint1.Value, constraint2.Value);
+    }
+
+    [Fact]
+    public void CreateCandidate_InlineRouteConstraintsWithArgument_DifferentArgument_DifferentInstance()
+    {
+        // Arrange
+        var endpoint1 = CreateEndpoint("/a/b/{c:regex([A-Z])}");
+        var endpoint2 = CreateEndpoint("/d/e/{f:regex([a-z])}");
+
+        var builder = CreateDfaMatcherBuilder();
+
+        // Act
+        var candidate1 = builder.CreateCandidate(endpoint1, score: 0);
+        var candidate2 = builder.CreateCandidate(endpoint2, score: 0);
+
+        // Assert
+        Assert.Equal(Candidate.CandidateFlags.HasConstraints | Candidate.CandidateFlags.HasCaptures, candidate1.Flags);
+        var constraint1 = Assert.Single(candidate1.Constraints);
+
+        Assert.Equal(Candidate.CandidateFlags.HasConstraints | Candidate.CandidateFlags.HasCaptures, candidate2.Flags);
+        var constraint2 = Assert.Single(candidate2.Constraints);
+
+        Assert.NotSame(constraint1.Value, constraint2.Value);
+    }
+
+    [Fact]
     public void CreateCandidate_CustomParameterPolicy()
     {
         // Arrange


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/46154

* Adds a cache to the matcher builder to reuse constraints marked as cachable.
* `RegexRouteConstraint` creates its `Regex` instance lazily. Still important in situations where the web app has many non-duplicate regexes.