### PR TITLE
Prerender value of textarea element as text content

### DIFF
--- a/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/HtmlRenderer.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/HtmlRenderer.cs
@@ -213,12 +213,8 @@ internal sealed class HtmlRenderer : Renderer
             result.Append(capturedValueAttribute);
         }
 
-        var afterElement = position + frame.ElementSubtreeLength; // Skip descendants
-        result.AppendHtml("</");
-        result.AppendHtml(frame.ElementName);
-        result.AppendHtml(">");
-        Debug.Assert(afterElement == position + frame.ElementSubtreeLength);
-        return afterElement;
+        result.AppendHtml("</textarea>");
+        return position + frame.ElementSubtreeLength; // Skip descendants
     }
 
     private int RenderChildren(HtmlRenderingContext context, ArrayRange<RenderTreeFrame> frames, int position, int maxElements)

--- a/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/HtmlRenderer.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/HtmlRenderer.cs
@@ -134,7 +134,7 @@ internal sealed class HtmlRenderer : Renderer
         result.AppendHtml(frame.ElementName);
         int afterElement;
         var isTextArea = string.Equals(frame.ElementName, "textarea", StringComparison.OrdinalIgnoreCase);
-        //
+        // We don't want to include value attribute of textarea element.
         var afterAttributes = RenderAttributes(context, frames, position + 1, frame.ElementSubtreeLength - 1, !isTextArea, out var capturedValueAttribute);
 
         // When we see an <option> as a descendant of a <select>, and the option's "value" attribute matches the

--- a/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/HtmlRenderer.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/HtmlRenderer.cs
@@ -202,8 +202,7 @@ internal sealed class HtmlRenderer : Renderer
         ref var frame = ref frames.Array[position];
         var result = context.HtmlContentBuilder;
 
-        result.AppendHtml("<");
-        result.AppendHtml(frame.ElementName);
+        result.AppendHtml("<textarea");
         _ = RenderAttributes(context, frames, position + 1, frame.ElementSubtreeLength - 1, false, out var capturedValueAttribute);
         result.AppendHtml(">");
 

--- a/src/Mvc/Mvc.ViewFeatures/test/RazorComponents/HtmlRendererTest.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/RazorComponents/HtmlRendererTest.cs
@@ -320,11 +320,11 @@ public class HtmlRendererTest
     public void RenderComponentAsync_RendersValueAttributeAsTextContentOfTextareaElement()
     {
         // Arrange
-        var expectedHtml = "<textarea rows=\"10\" cols=\"20\">Hello World!</textarea>";
+        var expectedHtml = "<textarea rows=\"10\" cols=\"20\">Hello &lt;html&gt;-encoded content!</textarea>";
         var serviceProvider = new ServiceCollection().AddSingleton(new RenderFragment(rtb =>
         {
             rtb.OpenElement(0, "textarea");
-            rtb.AddAttribute(1, "value", "Hello World!");
+            rtb.AddAttribute(1, "value", "Hello <html>-encoded content!");
             rtb.AddAttribute(2, "rows", "10");
             rtb.AddAttribute(3, "cols", "20");
             rtb.CloseElement();

--- a/src/Mvc/Mvc.ViewFeatures/test/RazorComponents/HtmlRendererTest.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/RazorComponents/HtmlRendererTest.cs
@@ -339,6 +339,70 @@ public class HtmlRendererTest
     }
 
     [Fact]
+    public void RenderComponentAsync_RendersTextareaElementWithoutValueAttribute()
+    {
+        // Arrange
+        var expectedHtml = "<textarea rows=\"10\" cols=\"20\">Hello &lt;html&gt;-encoded content!</textarea>";
+        var serviceProvider = new ServiceCollection().AddSingleton(new RenderFragment(rtb =>
+        {
+            rtb.OpenElement(0, "textarea");
+            rtb.AddAttribute(1, "rows", "10");
+            rtb.AddAttribute(2, "cols", "20");
+            rtb.AddContent(3, "Hello <html>-encoded content!");
+            rtb.CloseElement();
+        })).BuildServiceProvider();
+        var htmlRenderer = GetHtmlRenderer(serviceProvider);
+
+        // Act
+        var result = GetResult(htmlRenderer.Dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterView.Empty)));
+
+        // Assert
+        AssertHtmlContentEquals(expectedHtml, result);
+    }
+
+    [Fact]
+    public void RenderComponentAsync_RendersTextareaElementWithoutValueAttributeOrTextContent()
+    {
+        // Arrange
+        var expectedHtml = "<textarea rows=\"10\" cols=\"20\"></textarea>";
+        var serviceProvider = new ServiceCollection().AddSingleton(new RenderFragment(rtb =>
+        {
+            rtb.OpenElement(0, "textarea");
+            rtb.AddAttribute(1, "rows", "10");
+            rtb.AddAttribute(2, "cols", "20");
+            rtb.CloseElement();
+        })).BuildServiceProvider();
+        var htmlRenderer = GetHtmlRenderer(serviceProvider);
+
+        // Act
+        var result = GetResult(htmlRenderer.Dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterView.Empty)));
+
+        // Assert
+        AssertHtmlContentEquals(expectedHtml, result);
+    }
+
+    [Fact]
+    public void RenderComponentAsync_ValueAttributeOfTextareaElementOverridesTextContent()
+    {
+        // Arrange
+        var expectedHtml = "<textarea>Hello World!</textarea>";
+        var serviceProvider = new ServiceCollection().AddSingleton(new RenderFragment(rtb =>
+        {
+            rtb.OpenElement(0, "textarea");
+            rtb.AddAttribute(1, "value", "Hello World!");
+            rtb.AddContent(3, "Some content");
+            rtb.CloseElement();
+        })).BuildServiceProvider();
+        var htmlRenderer = GetHtmlRenderer(serviceProvider);
+
+        // Act
+        var result = GetResult(htmlRenderer.Dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterView.Empty)));
+
+        // Assert
+        AssertHtmlContentEquals(expectedHtml, result);
+    }
+
+    [Fact]
     public void RenderComponentAsync_MarksSelectedOptionsAsSelected_WithOptGroups()
     {
         // Arrange

--- a/src/Mvc/Mvc.ViewFeatures/test/RazorComponents/HtmlRendererTest.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/RazorComponents/HtmlRendererTest.cs
@@ -317,6 +317,28 @@ public class HtmlRendererTest
     }
 
     [Fact]
+    public void RenderComponentAsync_RendersValueAttributeAsTextContentOfTextareaElement()
+    {
+        // Arrange
+        var expectedHtml = "<textarea rows=\"10\" cols=\"20\">Hello World!</textarea>";
+        var serviceProvider = new ServiceCollection().AddSingleton(new RenderFragment(rtb =>
+        {
+            rtb.OpenElement(0, "textarea");
+            rtb.AddAttribute(1, "value", "Hello World!");
+            rtb.AddAttribute(2, "rows", "10");
+            rtb.AddAttribute(3, "cols", "20");
+            rtb.CloseElement();
+        })).BuildServiceProvider();
+        var htmlRenderer = GetHtmlRenderer(serviceProvider);
+
+        // Act
+        var result = GetResult(htmlRenderer.Dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterView.Empty)));
+
+        // Assert
+        AssertHtmlContentEquals(expectedHtml, result);
+    }
+
+    [Fact]
     public void RenderComponentAsync_MarksSelectedOptionsAsSelected_WithOptGroups()
     {
         // Arrange


### PR DESCRIPTION
# Prerender value of textarea element as text content

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description
```csharp
<textarea @bind="@value"></textarea> 
@code 
{
    string value = "Hello";
}
```

This prerenders as `<textarea value="Hello"></textarea>`,  it should be `<textarea>Hello</textarea>`.

Fixes #45967
