### PR TITLE
Fixed rendering of self closing elements

### DIFF
--- a/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/HtmlRenderer.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/HtmlRenderer.cs
@@ -228,10 +228,12 @@ internal sealed class HtmlRenderer : Renderer
         {
             var candidateIndex = position + i;
             ref var frame = ref frames.Array[candidateIndex];
+
             if (frame.FrameType == RenderTreeFrameType.ElementReferenceCapture)
             {
                 continue;
             }
+
             if (frame.FrameType != RenderTreeFrameType.Attribute)
             {
                 return candidateIndex;

--- a/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/HtmlRenderer.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/HtmlRenderer.cs
@@ -147,11 +147,14 @@ internal sealed class HtmlRenderer : Renderer
             result.AppendHtml(" selected");
         }
 
+        if (!SelfClosingElements.Contains(frame.ElementName))
+        {
+            result.AppendHtml(">");
+        }
+
         var remainingElements = frame.ElementSubtreeLength + position - afterAttributes;
         if (remainingElements > 0 || isTextArea)
         {
-            result.AppendHtml(">");
-
             var isSelect = string.Equals(frame.ElementName, "select", StringComparison.OrdinalIgnoreCase);
             if (isSelect)
             {
@@ -176,29 +179,24 @@ internal sealed class HtmlRenderer : Renderer
                 // we can safely say there is no longer any value for this
                 context.ClosestSelectValueAsString = null;
             }
-
-            result.AppendHtml("</");
-            result.AppendHtml(frame.ElementName);
-            result.AppendHtml(">");
-            Debug.Assert(afterElement == position + frame.ElementSubtreeLength);
-            return afterElement;
         }
         else
         {
-            if (SelfClosingElements.Contains(frame.ElementName))
-            {
-                result.AppendHtml(" />");
-            }
-            else
-            {
-                result.AppendHtml(">");
-                result.AppendHtml("</");
-                result.AppendHtml(frame.ElementName);
-                result.AppendHtml(">");
-            }
-            Debug.Assert(afterAttributes == position + frame.ElementSubtreeLength);
-            return afterAttributes;
+            afterElement = afterAttributes;
         }
+
+        if (SelfClosingElements.Contains(frame.ElementName))
+        {
+            result.AppendHtml(" />");
+        }
+        else
+        {
+            result.AppendHtml("</");
+            result.AppendHtml(frame.ElementName);
+            result.AppendHtml(">");
+        }
+        Debug.Assert(afterElement == position + frame.ElementSubtreeLength);
+        return afterElement;
     }
 
     private int RenderChildren(HtmlRenderingContext context, ArrayRange<RenderTreeFrame> frames, int position, int maxElements)

--- a/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/HtmlRenderer.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/HtmlRenderer.cs
@@ -229,13 +229,13 @@ internal sealed class HtmlRenderer : Renderer
             var candidateIndex = position + i;
             ref var frame = ref frames.Array[candidateIndex];
 
-            if (frame.FrameType == RenderTreeFrameType.ElementReferenceCapture)
-            {
-                continue;
-            }
-
             if (frame.FrameType != RenderTreeFrameType.Attribute)
             {
+                if (frame.FrameType == RenderTreeFrameType.ElementReferenceCapture)
+                {
+                    continue;
+                }
+
                 return candidateIndex;
             }
 

--- a/src/Mvc/Mvc.ViewFeatures/test/RazorComponents/HtmlRendererTest.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/RazorComponents/HtmlRendererTest.cs
@@ -403,7 +403,7 @@ public class HtmlRendererTest
     }
 
     [Fact]
-    public void RenderComponentAsync_RendersSelfClosingElementWithoutTextComponentAsSelfClosingElement()
+    public void RenderComponentAsync_RendersSelfClosingElement()
     {
         // Arrange
         var expectedHtml = "<input value=\"Hello &lt;html&gt;-encoded content!\" id=\"Test\" />";
@@ -412,6 +412,26 @@ public class HtmlRendererTest
             rtb.OpenElement(0, "input");
             rtb.AddAttribute(1, "value", "Hello <html>-encoded content!");
             rtb.AddAttribute(2, "id", "Test");
+            rtb.CloseElement();
+        })).BuildServiceProvider();
+        var htmlRenderer = GetHtmlRenderer(serviceProvider);
+
+        // Act
+        var result = GetResult(htmlRenderer.Dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterView.Empty)));
+
+        // Assert
+        AssertHtmlContentEquals(expectedHtml, result);
+    }   
+
+    [Fact]
+    public void RenderComponentAsync_RendersSelfClosingElementWithTextComponentAsNormalElement()
+    {
+        // Arrange
+        var expectedHtml = "<meta>Something</meta>";
+        var serviceProvider = new ServiceCollection().AddSingleton(new RenderFragment(rtb =>
+        {
+            rtb.OpenElement(0, "meta");
+            rtb.AddContent(1, "Something");
             rtb.CloseElement();
         })).BuildServiceProvider();
         var htmlRenderer = GetHtmlRenderer(serviceProvider);
@@ -434,26 +454,6 @@ public class HtmlRendererTest
             rtb.AddAttribute(1, "value", "Hello <html>-encoded content!");
             rtb.AddAttribute(2, "id", "Test");
             rtb.AddElementReferenceCapture(3, inputReference => _ = inputReference);
-            rtb.CloseElement();
-        })).BuildServiceProvider();
-        var htmlRenderer = GetHtmlRenderer(serviceProvider);
-
-        // Act
-        var result = GetResult(htmlRenderer.Dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterView.Empty)));
-
-        // Assert
-        AssertHtmlContentEquals(expectedHtml, result);
-    }
-
-    [Fact]
-    public void RenderComponentAsync_RendersSelfClosingElementWithTextComponentAsNormalElement()
-    {
-        // Arrange
-        var expectedHtml = "<meta>Something</meta>";
-        var serviceProvider = new ServiceCollection().AddSingleton(new RenderFragment(rtb =>
-        {
-            rtb.OpenElement(0, "meta");
-            rtb.AddContent(1, "Something");
             rtb.CloseElement();
         })).BuildServiceProvider();
         var htmlRenderer = GetHtmlRenderer(serviceProvider);

--- a/src/Mvc/Mvc.ViewFeatures/test/RazorComponents/HtmlRendererTest.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/RazorComponents/HtmlRendererTest.cs
@@ -4,13 +4,11 @@
 using System.Globalization;
 using System.Runtime.ExceptionServices;
 using System.Text.Encodings.Web;
-using System.Xml.Linq;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace Microsoft.AspNetCore.Components.Rendering;
 

--- a/src/Mvc/Mvc.ViewFeatures/test/RazorComponents/HtmlRendererTest.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/RazorComponents/HtmlRendererTest.cs
@@ -4,11 +4,13 @@
 using System.Globalization;
 using System.Runtime.ExceptionServices;
 using System.Text.Encodings.Web;
+using System.Xml.Linq;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace Microsoft.AspNetCore.Components.Rendering;
 
@@ -391,6 +393,27 @@ public class HtmlRendererTest
             rtb.OpenElement(0, "textarea");
             rtb.AddAttribute(1, "value", "Hello World!");
             rtb.AddContent(3, "Some content");
+            rtb.CloseElement();
+        })).BuildServiceProvider();
+        var htmlRenderer = GetHtmlRenderer(serviceProvider);
+
+        // Act
+        var result = GetResult(htmlRenderer.Dispatcher.InvokeAsync(() => htmlRenderer.RenderComponentAsync<TestComponent>(ParameterView.Empty)));
+
+        // Assert
+        AssertHtmlContentEquals(expectedHtml, result);
+    }
+
+    [Fact]
+    public void RenderComponentAsync_RendersSelfClosingElement()
+    {
+        // Arrange
+        var expectedHtml = "<input value=\"Hello &lt;html&gt;-encoded content!\" id=\"Test\" />";
+        var serviceProvider = new ServiceCollection().AddSingleton(new RenderFragment(rtb =>
+        {
+            rtb.OpenElement(0, "input");
+            rtb.AddAttribute(1, "value", "Hello <html>-encoded content!");
+            rtb.AddAttribute(1, "id", "Test");
             rtb.CloseElement();
         })).BuildServiceProvider();
         var htmlRenderer = GetHtmlRenderer(serviceProvider);


### PR DESCRIPTION
# Fixed rendering of self closing elements

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->


## Description

Self closing elements were rendering incorrectly.
Example `<input value=""some value"></input>` but should be `<input value=""some value" />`

Fixes #46183
