### PR TITLE
Don't close connection on MacOS when getting client certificate

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
@@ -129,6 +129,12 @@ internal sealed class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicat
             await _sslStream.NegotiateClientCertificateAsync(cancellationToken);
 #pragma warning restore CA1416 // Validate platform compatibility
         }
+        catch (PlatformNotSupportedException)
+        {
+            // NegotiateClientCertificateAsync might not be supported on all platforms.
+            // Don't attempt to recover by creating a new connection. Instead, just throw error directly to the app.
+            throw;
+        }
         catch
         {
             // We can't tell which exceptions are fatal or recoverable. Consider them all recoverable only given a new connection

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -595,6 +595,11 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
 
             await Assert.ThrowsAsync<PlatformNotSupportedException>(() => context.Connection.GetClientCertificateAsync());
 
+            var lifetimeNotificationFeature = context.Features.Get<IConnectionLifetimeNotificationFeature>();
+            Assert.False(
+                lifetimeNotificationFeature.ConnectionClosedRequested.IsCancellationRequested,
+                "GetClientCertificateAsync shouldn't cause the connection to be closed.");
+
             await context.Response.WriteAsync("hello world");
         }, new TestServiceContext(LoggerFactory), ConfigureListenOptions);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/46294

I think throwing `PlatformNotSupportedException` is the right thing to do. Silently returning a null client cert might create developer confusion about what is going on. An exception is very clear.

I attempted to add a unit test for this. I don't have a Mac, so no idea if it will work. 