### PR TITLE
Update Debian11 Arm64 queue to Debian12

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -5,7 +5,7 @@
     <HelixQueueDebian11>(Debian.11.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64</HelixQueueDebian11>
     <HelixQueueFedora34>(Fedora.34.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-helix</HelixQueueFedora34>
     <HelixQueueMariner>(Mariner)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix</HelixQueueMariner>
-    <HelixQueueArmDebian11>(Debian.11.Arm64.Open)ubuntu.2004.armarch.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-arm64v8</HelixQueueArmDebian11>
+    <HelixQueueArmDebian12>(Debian.12.Arm64.Open)ubuntu.2004.armarch.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-arm64v8-staging</HelixQueueArmDebian12>
 
     <!-- Do not attempt to override global property. -->
     <RunQuarantinedTests Condition=" '$(RunQuarantinedTests)' == '' ">false</RunQuarantinedTests>
@@ -44,7 +44,7 @@
         <HelixAvailableTargetQueue Include="$(HelixQueueDebian11)" Platform="Linux" />
         <HelixAvailableTargetQueue Include="$(HelixQueueFedora34)" Platform="Linux" />
         <HelixAvailableTargetQueue Include="$(HelixQueueMariner)" Platform="Linux" />
-        <HelixAvailableTargetQueue Include="$(HelixQueueArmDebian11)" Platform="Linux" />
+        <HelixAvailableTargetQueue Include="$(HelixQueueArmDebian12)" Platform="Linux" />
 
         <!-- Mac -->
         <HelixAvailableTargetQueue Include="OSX.1100.Amd64.Open" Platform="OSX" />

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -5,7 +5,7 @@
     <HelixQueueDebian11>(Debian.11.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64</HelixQueueDebian11>
     <HelixQueueFedora34>(Fedora.34.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-helix</HelixQueueFedora34>
     <HelixQueueMariner>(Mariner)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix</HelixQueueMariner>
-    <HelixQueueArmDebian12>(Debian.12.Arm64.Open)ubuntu.2004.armarch.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-arm64v8-staging</HelixQueueArmDebian12>
+    <HelixQueueArmDebian12>(Debian.12.Arm64.Open)ubuntu.2004.armarch.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-arm64v8</HelixQueueArmDebian12>
 
     <!-- Do not attempt to override global property. -->
     <RunQuarantinedTests Condition=" '$(RunQuarantinedTests)' == '' ">false</RunQuarantinedTests>

--- a/src/ProjectTemplates/README.md
+++ b/src/ProjectTemplates/README.md
@@ -87,7 +87,7 @@ An entire test project can be configured to skip specific platforms using the `<
 
 ```xml
 <SkipHelixQueues>
-    $(HelixQueueArmDebian11);
+    $(HelixQueueArmDebian12);
 </SkipHelixQueues>
 ```
 

--- a/src/ProjectTemplates/test/Templates.Blazor.Server.Tests/Templates.Blazor.Server.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Blazor.Server.Tests/Templates.Blazor.Server.Tests.csproj
@@ -20,7 +20,7 @@
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
     <HelixTimeout>01:00:00</HelixTimeout>
     <SkipHelixQueues>
-      $(HelixQueueArmDebian11);
+      $(HelixQueueArmDebian12);
     </SkipHelixQueues>
   </PropertyGroup>
 

--- a/src/ProjectTemplates/test/Templates.Blazor.Server.Tests/Templates.Blazor.Server.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Blazor.Server.Tests/Templates.Blazor.Server.Tests.csproj
@@ -19,9 +19,6 @@
     <RestoreFolderName>Server</RestoreFolderName>
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
     <HelixTimeout>01:00:00</HelixTimeout>
-    <SkipHelixQueues>
-      $(HelixQueueArmDebian12);
-    </SkipHelixQueues>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Auth.Tests/Templates.Blazor.WebAssembly.Auth.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Auth.Tests/Templates.Blazor.WebAssembly.Auth.Tests.csproj
@@ -20,7 +20,7 @@
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
     <HelixTimeout>01:00:00</HelixTimeout>
     <SkipHelixQueues>
-      $(HelixQueueArmDebian11);
+      $(HelixQueueArmDebian12);
     </SkipHelixQueues>
   </PropertyGroup>
 

--- a/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Auth.Tests/Templates.Blazor.WebAssembly.Auth.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Auth.Tests/Templates.Blazor.WebAssembly.Auth.Tests.csproj
@@ -19,9 +19,6 @@
     <RestoreFolderName>WebAssembly</RestoreFolderName>
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
     <HelixTimeout>01:00:00</HelixTimeout>
-    <SkipHelixQueues>
-      $(HelixQueueArmDebian12);
-    </SkipHelixQueues>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Tests/Templates.Blazor.WebAssembly.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Tests/Templates.Blazor.WebAssembly.Tests.csproj
@@ -19,7 +19,7 @@
     <RestoreFolderName>WebAssembly</RestoreFolderName>
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
     <SkipHelixQueues>
-      $(HelixQueueArmDebian11);
+      $(HelixQueueArmDebian12);
     </SkipHelixQueues>
   </PropertyGroup>
 

--- a/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Tests/Templates.Blazor.WebAssembly.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Blazor.WebAssembly.Tests/Templates.Blazor.WebAssembly.Tests.csproj
@@ -18,9 +18,6 @@
     <TestTemplateCreationFolder>TestTemplates\</TestTemplateCreationFolder>
     <RestoreFolderName>WebAssembly</RestoreFolderName>
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
-    <SkipHelixQueues>
-      $(HelixQueueArmDebian12);
-    </SkipHelixQueues>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
@@ -19,9 +19,6 @@
     <RestoreFolderName>Mvc</RestoreFolderName>
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
     <HelixTimeout>01:00:00</HelixTimeout>
-    <SkipHelixQueues>
-      $(HelixQueueArmDebian12);
-    </SkipHelixQueues>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
@@ -20,7 +20,7 @@
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
     <HelixTimeout>01:00:00</HelixTimeout>
     <SkipHelixQueues>
-      $(HelixQueueArmDebian11);
+      $(HelixQueueArmDebian12);
     </SkipHelixQueues>
   </PropertyGroup>
 

--- a/src/ProjectTemplates/test/Templates.Tests/Templates.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Tests/Templates.Tests.csproj
@@ -20,7 +20,7 @@
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
     <HelixTimeout>01:00:00</HelixTimeout>
     <SkipHelixQueues>
-      $(HelixQueueArmDebian11);
+      $(HelixQueueArmDebian12);
     </SkipHelixQueues>
   </PropertyGroup>
 

--- a/src/ProjectTemplates/test/Templates.Tests/Templates.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Tests/Templates.Tests.csproj
@@ -19,9 +19,6 @@
     <RestoreFolderName>Other</RestoreFolderName>
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
     <HelixTimeout>01:00:00</HelixTimeout>
-    <SkipHelixQueues>
-      $(HelixQueueArmDebian12);
-    </SkipHelixQueues>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We'll keep the Amd64 image on Debian11 until msquic is available (https://github.com/dotnet/aspnetcore/issues/46418)