### PR TITLE
Re-enable ChromeTests in Interop.FunctionalTests

### DIFF
--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/ChromeTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/ChromeTests.cs
@@ -63,7 +63,7 @@ public class ChromeTests : LoggedTest
             };
     }
 
-    [ConditionalTheory(Skip = "Disabling while debugging. https://github.com/dotnet/aspnetcore-internal/issues/1363")]
+    [ConditionalTheory]
     [TlsAlpnSupported]
     [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win81, SkipReason = "Missing Windows ALPN support: https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation#Support")]
     [InlineData("", "Interop HTTP/2 GET")]

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/SkipIfChromeUnavailableAttribute.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/SkipIfChromeUnavailableAttribute.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.IO;
 using Microsoft.AspNetCore.Testing;
 
 namespace Interop.FunctionalTests;
@@ -10,21 +8,37 @@ namespace Interop.FunctionalTests;
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false)]
 public class SkipIfChromeUnavailableAttribute : Attribute, ITestCondition
 {
-    public bool IsMet => string.IsNullOrEmpty(Environment.GetEnvironmentVariable("JENKINS_HOME")) && (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI")) || File.Exists(ResolveChromeExecutablePath()));
+    public bool IsMet
+    {
+        get
+        {
+            // Skip if Jenkins
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("JENKINS_HOME")))
+            {
+                return false;
+            }
+
+            // Otherwise, run in all CI scenarios
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI")))
+            {
+                return true;
+            }
+
+            // That just leaves local runs - check if chrome is available
+            if (OperatingSystem.IsLinux())
+            {
+                return File.Exists(Path.Combine("/usr", "bin", "google-chrome"));
+            }
+
+            if (OperatingSystem.IsWindows())
+            {
+                return File.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Google", "Chrome", "Application", "chrome.exe")) ||
+                    File.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Google", "Chrome", "Application", "chrome.exe"));
+            }
+            
+            throw new PlatformNotSupportedException();
+        }
+    }
 
     public string SkipReason => "This is running on Jenkins or Chrome/Chromium is not installed and this is a dev environment.";
-
-    private static string ResolveChromeExecutablePath()
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Google", "Chrome", "Application", "chrome.exe");
-        }
-        else if (OperatingSystem.IsLinux())
-        {
-            return Path.Combine("/usr", "bin", "google-chrome");
-        }
-
-        throw new PlatformNotSupportedException();
-    }
 }


### PR DESCRIPTION
The bug explaining why it's skipped has been closed (though apparently with the reason that we have enough coverage without these tests).

To get it passing again, `SkipIfChromeUnavailableAttribute` has to be updated to also look for 64-bit Chrome on Windows.