### PR TITLE
Bump up the MIN_PORT for ANCM out of process

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.cpp
@@ -113,13 +113,13 @@ SERVER_PROCESS::GetRandomPort
     BOOL    fPortInUse = FALSE;
     DWORD   dwActualProcessId = 0;
 
-    std::uniform_int_distribution<> dist(MIN_PORT, MAX_PORT);
+    std::uniform_int_distribution<> dist(MIN_PORT_RANDOM, MAX_PORT);
 
     if (g_fNsiApiNotSupported)
     {
         //
         // the default value for optional parameter dwExcludedPort is 0 which is reserved
-        // a random number between MIN_PORT and MAX_PORT
+        // a random number between MIN_PORT_RANDOM and MAX_PORT
         //
         while ((*pdwPickedPort = dist(m_randomGenerator)) == dwExcludedPort);
     }
@@ -224,7 +224,7 @@ Finished:
             m_struAppFullPath.QueryStr(),
             m_struPhysicalPath.QueryStr(),
             m_dwPort,
-            MIN_PORT,
+            MIN_PORT_RANDOM,
             MAX_PORT,
             hr);
     }

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.h
@@ -6,7 +6,10 @@
 #include <random>
 #include <map>
 
-#define MIN_PORT                                    10025
+// This value is somewhat arbitrary. Fixed-port services tend to
+// use ports near the minimum (1025) so this number is much higher
+// to reduce the chance of collisions.
+#define MIN_PORT                                    10000
 #define MAX_PORT                                    48000
 #define MAX_RETRY                                   10
 #define MAX_ACTIVE_CHILD_PROCESSES                  16

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.h
@@ -6,10 +6,13 @@
 #include <random>
 #include <map>
 
+// Keep using 1025 to avoid breaking existing services that are choosing
+// a port lower than 10000 via the ASPNETCORE_PORT environment variable
+#define MIN_PORT                                    1025
 // This value is somewhat arbitrary. Fixed-port services tend to
 // use ports near the minimum (1025) so this number is much higher
 // to reduce the chance of collisions.
-#define MIN_PORT                                    10000
+#define MIN_PORT_RANDOM                             10000
 #define MAX_PORT                                    48000
 #define MAX_RETRY                                   10
 #define MAX_ACTIVE_CHILD_PROCESSES                  16

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.h
@@ -6,7 +6,9 @@
 #include <random>
 #include <map>
 
-// Keep using 1025 to avoid breaking existing services that are choosing
+// Minimum port number that can be used.
+// This is lower than 'MIN_PORT_RANDOM' since we allow people to choose
+// low-numbered ports when they are not using random assignment.
 // a port lower than 10000 via the ASPNETCORE_PORT environment variable
 #define MIN_PORT                                    1025
 // Minimum number used for automatic random port assignment.

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.h
@@ -9,6 +9,7 @@
 // Keep using 1025 to avoid breaking existing services that are choosing
 // a port lower than 10000 via the ASPNETCORE_PORT environment variable
 #define MIN_PORT                                    1025
+// Minimum number used for automatic random port assignment.
 // This value is somewhat arbitrary. Fixed-port services tend to
 // use ports near the minimum (1025) so this number is much higher
 // to reduce the chance of collisions.

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.h
@@ -6,7 +6,7 @@
 #include <random>
 #include <map>
 
-#define MIN_PORT                                    1025
+#define MIN_PORT                                    10025
 #define MAX_PORT                                    48000
 #define MAX_RETRY                                   10
 #define MAX_ACTIVE_CHILD_PROCESSES                  16

--- a/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/OutOfProcessRequestHandler/serverprocess.h
@@ -9,7 +9,6 @@
 // Minimum port number that can be used.
 // This is lower than 'MIN_PORT_RANDOM' since we allow people to choose
 // low-numbered ports when they are not using random assignment.
-// a port lower than 10000 via the ASPNETCORE_PORT environment variable
 #define MIN_PORT                                    1025
 // Minimum number used for automatic random port assignment.
 // This value is somewhat arbitrary. Fixed-port services tend to

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.h
@@ -32,8 +32,6 @@
 
 #define MAX_RAPID_FAILS_PER_MINUTE 100
 #define MILLISECONDS_IN_ONE_SECOND 1000
-#define MIN_PORT                   10025
-#define MAX_PORT                   48000
 
 #define TIMESPAN_IN_MILLISECONDS(x)  ((x)/((LONGLONG)(10000)))
 #define TIMESPAN_IN_SECONDS(x)       ((TIMESPAN_IN_MILLISECONDS(x))/((LONGLONG)(1000)))

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/requesthandler_config.h
@@ -32,7 +32,7 @@
 
 #define MAX_RAPID_FAILS_PER_MINUTE 100
 #define MILLISECONDS_IN_ONE_SECOND 1000
-#define MIN_PORT                   1025
+#define MIN_PORT                   10025
 #define MAX_PORT                   48000
 
 #define TIMESPAN_IN_MILLISECONDS(x)  ((x)/((LONGLONG)(10000)))

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/AspNetCorePortTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/AspNetCorePortTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 public class AspNetCorePortTests : IISFunctionalTestBase
 {
     // Port range allowed by ANCM config
-    private const int _minPort = 10025;
+    private const int _minPort = 10000;
     private const int _maxPort = 48000;
 
     public AspNetCorePortTests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/AspNetCorePortTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/AspNetCorePortTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 public class AspNetCorePortTests : IISFunctionalTestBase
 {
     // Port range allowed by ANCM config
-    private const int _minPort = 10000;
+    private const int _minPort = 1025;
     private const int _maxPort = 48000;
 
     public AspNetCorePortTests(PublishedSitesFixture fixture) : base(fixture)

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/AspNetCorePortTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/AspNetCorePortTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 public class AspNetCorePortTests : IISFunctionalTestBase
 {
     // Port range allowed by ANCM config
-    private const int _minPort = 1025;
+    private const int _minPort = 10025;
     private const int _maxPort = 48000;
 
     public AspNetCorePortTests(PublishedSitesFixture fixture) : base(fixture)


### PR DESCRIPTION
# Bump up the MIN_PORT for ANCM out of process

Bump the MIN port from 1025 to 10025.

## Description

What to fix: avoid occupying static ports used by other services running on the same machine
Why 10025? it does not necessarily to start from 1025. 10025~48000 should be fine. It is better to choose a even larger number?

Fixes #46431
