### PR TITLE
[blazor] Use JSImport for lazy loading assemblies

### DIFF
--- a/src/Components/Web.JS/src/GlobalExports.ts
+++ b/src/Components/Web.JS/src/GlobalExports.ts
@@ -53,11 +53,9 @@ interface IBlazor {
     renderBatch?: (browserRendererId: number, batchAddress: Pointer) => void,
     getConfig?: (dotNetFileName: System_String) => System_Object | undefined,
     getApplicationEnvironment?: () => System_String,
-    readLazyAssemblies?: () => System_Array<System_Object>,
-    readLazyPdbs?: () => System_Array<System_Object>,
     readSatelliteAssemblies?: () => System_Array<System_Object>,
-    getLazyAssemblies?: any
     dotNetCriticalError?: any
+    loadLazyAssembly?: any,
     getSatelliteAssemblies?: any,
     sendJSDataStream?: (data: any, streamId: number, chunkSize: number) => void,
     getJSDataStreamChunk?: (data: any, position: number, chunkSize: number) => Promise<Uint8Array>,

--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -12,7 +12,7 @@ import { Platform, System_Array, Pointer, System_Object, System_String, HeapLock
 import { WebAssemblyBootResourceType } from '../WebAssemblyStartOptions';
 import { BootJsonData, ICUDataMode } from '../BootConfig';
 import { Blazor } from '../../GlobalExports';
-import { RuntimeAPI, CreateDotnetRuntimeType, DotnetModuleConfig, EmscriptenModule, AssetEntry, ResourceRequest } from 'dotnet';
+import { RuntimeAPI, CreateDotnetRuntimeType, DotnetModuleConfig, EmscriptenModule, AssetEntry } from 'dotnet';
 import { BINDINGType, MONOType } from 'dotnet/dotnet-legacy';
 
 // initially undefined and only fully initialized after createEmscriptenModuleInstance()
@@ -144,13 +144,13 @@ export const monoPlatform: Platform = {
     return ((baseAddress as any as number) + (fieldOffset || 0)) as any as T;
   },
 
-  beginHeapLock: function() {
+  beginHeapLock: function () {
     assertHeapIsNotLocked();
     currentHeapLock = new MonoHeapLock();
     return currentHeapLock;
   },
 
-  invokeWhenHeapUnlocked: function(callback) {
+  invokeWhenHeapUnlocked: function (callback) {
     // This is somewhat like a sync context. If we're not locked, just pass through the call directly.
     if (!currentHeapLock) {
       callback();
@@ -225,7 +225,7 @@ async function createEmscriptenModuleInstance(resourceLoader: WebAssemblyResourc
     // If anything writes to stderr, treat it as a critical exception. The underlying runtime writes
     // to stderr if a truly critical problem occurs outside .NET code. Note that .NET unhandled
     // exceptions also reach this, but via a different code path - see dotNetCriticalError below.
-    console.error(line);
+    console.error(line || '(null)');
     showErrorNotification();
   };
   const existingPreRun = moduleConfig.preRun || [] as any;
@@ -233,12 +233,12 @@ async function createEmscriptenModuleInstance(resourceLoader: WebAssemblyResourc
   (moduleConfig as any).preloadPlugins = [];
 
   let resourcesLoaded = 0;
-  function setProgress(){
-      resourcesLoaded++;
-      const percentage = resourcesLoaded / totalResources.length * 100;
-      document.documentElement.style.setProperty('--blazor-load-percentage', `${percentage}%`);
-      document.documentElement.style.setProperty('--blazor-load-percentage-text', `"${Math.floor(percentage)}%"`);
-    }
+  function setProgress() {
+    resourcesLoaded++;
+    const percentage = resourcesLoaded / totalResources.length * 100;
+    document.documentElement.style.setProperty('--blazor-load-percentage', `${percentage}%`);
+    document.documentElement.style.setProperty('--blazor-load-percentage-text', `"${Math.floor(percentage)}%"`);
+  }
 
   const monoToBlazorAssetTypeMap: { [key: string]: WebAssemblyBootResourceType | undefined } = {
     'assembly': 'assembly',
@@ -280,7 +280,9 @@ async function createEmscriptenModuleInstance(resourceLoader: WebAssemblyResourc
 
   // Begin loading the .dll/.pdb/.wasm files, but don't block here. Let other loading processes run in parallel.
   const assembliesBeingLoaded = resourceLoader.loadResources(resources.assembly, filename => `_framework/${filename}`, 'assembly');
-  const pdbsBeingLoaded = resourceLoader.loadResources(resources.pdb || {}, filename => `_framework/${filename}`, 'pdb');
+  const pdbsBeingLoaded = hasDebuggingEnabled()
+    ? resourceLoader.loadResources(resources.pdb || {}, filename => `_framework/${filename}`, 'pdb')
+    : [];
   const totalResources = assembliesBeingLoaded.concat(pdbsBeingLoaded, runtimeAssetsBeingLoaded);
 
   const dotnetTimeZoneResourceName = 'dotnet.timezones.blat';
@@ -340,7 +342,8 @@ async function createEmscriptenModuleInstance(resourceLoader: WebAssemblyResourc
       assembliesBeingLoaded.forEach(r => addResourceAsAssembly(r, changeExtension(r.name, '.dll')));
       pdbsBeingLoaded.forEach(r => addResourceAsAssembly(r, r.name));
 
-      Blazor._internal.dotNetCriticalError = (message) => printErr(message || '(null)');
+      Blazor._internal.dotNetCriticalError = printErr;
+      Blazor._internal.loadLazyAssembly = loadLazyAssembly;
 
       // Wire-up callbacks for satellite assemblies. Blazor will call these as part of the application
       // startup sequence to load satellite assemblies for the application's culture.
@@ -372,76 +375,37 @@ async function createEmscriptenModuleInstance(resourceLoader: WebAssemblyResourc
         return BINDING.js_to_mono_obj(Promise.resolve(0));
       };
 
-      const lazyResources: {
-        assemblies?: (ArrayBuffer | null)[],
-        pdbs?: (ArrayBuffer | null)[]
-      } = {};
-      Blazor._internal.getLazyAssemblies = (assembliesToLoadDotNetArray) => {
-        const assembliesToLoad = BINDING.mono_array_to_js_array(assembliesToLoadDotNetArray);
-        const lazyAssemblies = resourceLoader.bootConfig.resources.lazyAssembly;
-
-        if (!lazyAssemblies) {
-          throw new Error("No assemblies have been marked as lazy-loadable. Use the 'BlazorWebAssemblyLazyLoad' item group in your project file to enable lazy loading an assembly.");
-        }
-
-        const assembliesMarkedAsLazy = assembliesToLoad!.filter(assembly => lazyAssemblies.hasOwnProperty(assembly));
-
-        if (assembliesMarkedAsLazy.length !== assembliesToLoad!.length) {
-          const notMarked = assembliesToLoad!.filter(assembly => !assembliesMarkedAsLazy.includes(assembly));
-          throw new Error(`${notMarked.join()} must be marked with 'BlazorWebAssemblyLazyLoad' item group in your project file to allow lazy-loading.`);
-        }
-
-        let pdbPromises: Promise<(ArrayBuffer | null)[]> | undefined;
-        if (hasDebuggingEnabled()) {
-          const pdbs = resourceLoader.bootConfig.resources.pdb;
-          const pdbsToLoad = assembliesMarkedAsLazy.map(a => changeExtension(a, '.pdb'));
-          if (pdbs) {
-            pdbPromises = Promise.all(pdbsToLoad
-              .map(pdb => lazyAssemblies.hasOwnProperty(pdb) ? resourceLoader.loadResource(pdb, `_framework/${pdb}`, lazyAssemblies[pdb], 'pdb') : null)
-              .map(async resource => resource ? (await resource.response).arrayBuffer() : null));
-          }
-        }
-
-        const resourcePromises = Promise.all(assembliesMarkedAsLazy
-          .map(assembly => resourceLoader.loadResource(assembly, `_framework/${assembly}`, lazyAssemblies[assembly], 'assembly'))
-          .map(async resource => (await resource.response).arrayBuffer()));
-
-
-        return BINDING.js_to_mono_obj(Promise.all([resourcePromises, pdbPromises]).then(values => {
-          lazyResources['assemblies'] = values[0];
-          lazyResources['pdbs'] = values[1];
-          if (lazyResources['assemblies'].length) {
-            Blazor._internal.readLazyAssemblies = () => {
-              const { assemblies } = lazyResources;
-              if (!assemblies) {
-                return BINDING.mono_obj_array_new(0);
-              }
-              const assemblyBytes = BINDING.mono_obj_array_new(assemblies.length);
-              for (let i = 0; i < assemblies.length; i++) {
-                const assembly = assemblies[i] as ArrayBuffer;
-                BINDING.mono_obj_array_set(assemblyBytes, i, BINDING.js_typed_array_to_array(new Uint8Array(assembly)));
-              }
-              return assemblyBytes as any;
-            };
-
-            Blazor._internal.readLazyPdbs = () => {
-              const { assemblies, pdbs } = lazyResources;
-              if (!assemblies) {
-                return BINDING.mono_obj_array_new(0);
-              }
-              const pdbBytes = BINDING.mono_obj_array_new(assemblies.length);
-              for (let i = 0; i < assemblies.length; i++) {
-                const pdb = pdbs && pdbs[i] ? new Uint8Array(pdbs[i] as ArrayBufferLike) : new Uint8Array();
-                BINDING.mono_obj_array_set(pdbBytes, i, BINDING.js_typed_array_to_array(pdb));
-              }
-              return pdbBytes as any;
-            };
-          }
-
-          return lazyResources['assemblies'].length;
-        }));
-      };
     };
+
+    async function loadLazyAssembly(assemblyNameToLoad: string, allocator: (dllLength: number, pdbLength: number) => number, loader: (dllLength: number, pdbLength: number) => void): Promise<void> {
+      const lazyAssemblies = resources.lazyAssembly;
+      if (!lazyAssemblies) {
+        throw new Error("No assemblies have been marked as lazy-loadable. Use the 'BlazorWebAssemblyLazyLoad' item group in your project file to enable lazy loading an assembly.");
+      }
+
+      const assemblyMarkedAsLazy = lazyAssemblies.hasOwnProperty(assemblyNameToLoad);
+      if (!assemblyMarkedAsLazy) {
+        throw new Error(`${assemblyNameToLoad} must be marked with 'BlazorWebAssemblyLazyLoad' item group in your project file to allow lazy-loading.`);
+      }
+      const dllNameToLoad = changeExtension(assemblyNameToLoad, '.dll');
+      const pdbNameToLoad = changeExtension(assemblyNameToLoad, '.pdb');
+      const shouldLoadPdb = hasDebuggingEnabled() && resources.pdb && lazyAssemblies.hasOwnProperty(pdbNameToLoad);
+
+      const dllBytesPromise = resourceLoader.loadResource(dllNameToLoad, `_framework/${dllNameToLoad}`, lazyAssemblies[dllNameToLoad], 'assembly').response.then(response => response.arrayBuffer());
+      if (shouldLoadPdb) {
+        const pdbBytesPromise = await resourceLoader.loadResource(pdbNameToLoad, `_framework/${pdbNameToLoad}`, lazyAssemblies[pdbNameToLoad], 'pdb').response.then(response => response.arrayBuffer());
+        const [dllBytes, pdbBytes] = await Promise.all([dllBytesPromise, pdbBytesPromise]);
+        const pinnedBuffer = allocator(dllBytes.byteLength, pdbBytes.byteLength);
+        Module.HEAPU8.set(new Uint8Array(dllBytes), pinnedBuffer);
+        Module.HEAPU8.set(new Uint8Array(pdbBytes), pinnedBuffer + dllBytes.byteLength);
+        loader(dllBytes.byteLength, pdbBytes.byteLength);
+      } else {
+        const dllBytes = await dllBytesPromise;
+        const pinnedBuffer = allocator(dllBytes.byteLength, 0);
+        Module.HEAPU8.set(new Uint8Array(dllBytes), pinnedBuffer);
+        loader(dllBytes.byteLength, 0);
+      }
+    }
 
     const postRun = () => {
       if (resourceLoader.bootConfig.debugBuild && resourceLoader.bootConfig.cacheBootResources) {

--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -144,13 +144,13 @@ export const monoPlatform: Platform = {
     return ((baseAddress as any as number) + (fieldOffset || 0)) as any as T;
   },
 
-  beginHeapLock: function () {
+  beginHeapLock: function() {
     assertHeapIsNotLocked();
     currentHeapLock = new MonoHeapLock();
     return currentHeapLock;
   },
 
-  invokeWhenHeapUnlocked: function (callback) {
+  invokeWhenHeapUnlocked: function(callback) {
     // This is somewhat like a sync context. If we're not locked, just pass through the call directly.
     if (!currentHeapLock) {
       callback();

--- a/src/Components/WebAssembly/WebAssembly/src/Services/LazyAssemblyLoader.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/LazyAssemblyLoader.cs
@@ -124,7 +124,6 @@ public sealed partial class LazyAssemblyLoader
         loadedAssemblies.Add(loadedAssembly);
         _loadedAssemblyCache!.Add(assemblyToLoad);
 
-        files.Dispose();
     }
 
     private partial class LazyAssemblyLoaderInterop

--- a/src/Components/WebAssembly/WebAssembly/src/Services/LazyAssemblyLoader.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/LazyAssemblyLoader.cs
@@ -115,8 +115,8 @@ public sealed partial class LazyAssemblyLoader
     {
         using var files = await LazyAssemblyLoaderInterop.LoadLazyAssembly(assemblyToLoad);
 
-        byte[] dllBytes = files.GetPropertyAsByteArray("dll")!;
-        byte[]? pdbBytes = files.GetPropertyAsByteArray("pdb");
+        var dllBytes = files.GetPropertyAsByteArray("dll")!;
+        var pdbBytes = files.GetPropertyAsByteArray("pdb");
         Assembly loadedAssembly = pdbBytes == null
                     ? AssemblyLoadContext.Default.LoadFromStream(new MemoryStream(dllBytes))
                     : AssemblyLoadContext.Default.LoadFromStream(new MemoryStream(dllBytes), new MemoryStream(pdbBytes));

--- a/src/Components/WebAssembly/WebAssembly/src/Services/LazyAssemblyLoader.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/LazyAssemblyLoader.cs
@@ -113,7 +113,7 @@ public sealed partial class LazyAssemblyLoader
     [SupportedOSPlatform("browser")]
     private async Task LoadAssembly(string assemblyToLoad, List<Assembly> loadedAssemblies)
     {
-        JSObject files = await LazyAssemblyLoaderInterop.LoadLazyAssembly(assemblyToLoad);
+        using var files = await LazyAssemblyLoaderInterop.LoadLazyAssembly(assemblyToLoad);
 
         byte[] dllBytes = files.GetPropertyAsByteArray("dll")!;
         byte[]? pdbBytes = files.GetPropertyAsByteArray("pdb");


### PR DESCRIPTION
## Motivation

- The current `getLazyAssemblies` is implemented using legacy/obsolete JS interop.  
- legacy interop has problems with multi-threading and uses unsupported API.
- legacy interop is not CSP compliant

Contributes to https://github.com/dotnet/aspnetcore/issues/37787

## Description
- use new generated JavaScript interop with `[JSImport]`
- moved async parallel download to C# side
- only one allocation & copy of the DLL bytes from fetch buffer directly to wasm memory.
- the new implementation is loading DLLs asynchronously as they arrive, which should be faster overall
