### PR TITLE
Update gRPC template dependencies for AOT

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -258,11 +258,11 @@
     <FSharpCoreVersion>6.0.0</FSharpCoreVersion>
     <GoogleApiCommonProtosVersion>2.5.0</GoogleApiCommonProtosVersion>
     <GoogleProtobufVersion>3.21.6</GoogleProtobufVersion>
-    <GrpcAspNetCoreVersion>2.49.0</GrpcAspNetCoreVersion>
-    <GrpcAspNetCoreServerVersion>2.49.0</GrpcAspNetCoreServerVersion>
-    <GrpcAuthVersion>2.49.0</GrpcAuthVersion>
-    <GrpcNetClientVersion>2.49.0</GrpcNetClientVersion>
-    <GrpcToolsVersion>2.49.0</GrpcToolsVersion>
+    <GrpcAspNetCoreVersion>2.51.0</GrpcAspNetCoreVersion>
+    <GrpcAspNetCoreServerVersion>2.51.0</GrpcAspNetCoreServerVersion>
+    <GrpcAuthVersion>2.51.0</GrpcAuthVersion>
+    <GrpcNetClientVersion>2.51.0</GrpcNetClientVersion>
+    <GrpcToolsVersion>2.51.0</GrpcToolsVersion>
     <DuendeIdentityServerAspNetIdentityVersion>6.0.4</DuendeIdentityServerAspNetIdentityVersion>
     <DuendeIdentityServerEntityFrameworkVersion>6.0.4</DuendeIdentityServerEntityFrameworkVersion>
     <DuendeIdentityServerVersion>6.0.4</DuendeIdentityServerVersion>

--- a/src/ProjectTemplates/Web.ProjectTemplates/GrpcService-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/GrpcService-CSharp.csproj.in
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="${GrpcAspNetCoreVersion}" />
+    <PackageReference Include="Google.Protobuf" Version="3.22.0-rc2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Grpc.* 2.51.0 fixes a couple of AOT warnings

Google.Protobuf also fixes warnings. It's not possible to get a full version in time for preview 2. I have added an RC version directly to the project template as a temporary measure. It overrides what is referenced by Grpc.AspNetCore.