### PR TITLE
Cache and reuse NamedPipeServerStream instances

### DIFF
--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnection.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnection.cs
@@ -294,9 +294,13 @@ internal sealed class NamedPipeConnection : TransportConnection, IConnectionName
             return;
         }
 
-        if (!_streamDisconnected || !_connectionListener.TryCacheStream(_stream))
+        if (!_streamDisconnected)
         {
             _stream.Dispose();
+        }
+        else
+        {
+            _connectionListener.ReturnStream(_stream);
         }
     }
 }

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnection.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnection.cs
@@ -13,15 +13,17 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.Internal;
 
 internal sealed class NamedPipeConnection : TransportConnection, IConnectionNamedPipeFeature
 {
+    private static readonly ConnectionAbortedException SendGracefullyCompletedException = new ConnectionAbortedException("The named pipe transport's send loop completed gracefully.");
     private const int MinAllocBufferSize = 4096;
-
+    private readonly NamedPipeConnectionListener _connectionListener;
     private readonly NamedPipeServerStream _stream;
     private readonly ILogger _log;
     private readonly IDuplexPipe _originalTransport;
 
     private readonly CancellationTokenSource _connectionClosedTokenSource = new CancellationTokenSource();
     private bool _connectionClosed;
-    private bool _connectionDisposed;
+    private bool _connectionShutdown;
+    private bool _streamDisconnected;
     private Exception? _shutdownReason;
     private readonly object _shutdownLock = new object();
 
@@ -30,6 +32,7 @@ internal sealed class NamedPipeConnection : TransportConnection, IConnectionName
     internal Task _sendingTask = Task.CompletedTask;
 
     public NamedPipeConnection(
+        NamedPipeConnectionListener connectionListener,
         NamedPipeServerStream stream,
         NamedPipeEndPoint endPoint,
         ILogger logger,
@@ -37,6 +40,7 @@ internal sealed class NamedPipeConnection : TransportConnection, IConnectionName
         PipeOptions inputOptions,
         PipeOptions outputOptions)
     {
+        _connectionListener = connectionListener;
         _stream = stream;
         _log = logger;
         MemoryPool = memoryPool;
@@ -120,7 +124,7 @@ internal sealed class NamedPipeConnection : TransportConnection, IConnectionName
             // This exception should always be ignored because _shutdownReason should be set.
             error = ex;
 
-            if (!_connectionDisposed)
+            if (!_connectionShutdown)
             {
                 // This is unexpected if the socket hasn't been disposed yet.
                 NamedPipeLog.ConnectionError(_log, this, error);
@@ -206,7 +210,7 @@ internal sealed class NamedPipeConnection : TransportConnection, IConnectionName
     {
         lock (_shutdownLock)
         {
-            if (_connectionDisposed)
+            if (_connectionShutdown)
             {
                 return;
             }
@@ -214,25 +218,24 @@ internal sealed class NamedPipeConnection : TransportConnection, IConnectionName
             // Make sure to close the connection only after the _aborted flag is set.
             // Without this, the RequestsCanBeAbortedMidRead test will sometimes fail when
             // a BadHttpRequestException is thrown instead of a TaskCanceledException.
-            _connectionDisposed = true;
+            _connectionShutdown = true;
 
             // shutdownReason should only be null if the output was completed gracefully, so no one should ever
             // ever observe the nondescript ConnectionAbortedException except for connection middleware attempting
             // to half close the connection which is currently unsupported.
-            _shutdownReason = shutdownReason ?? new ConnectionAbortedException("The Socket transport's send loop completed gracefully.");
+            _shutdownReason = shutdownReason ?? SendGracefullyCompletedException;
             NamedPipeLog.ConnectionDisconnect(_log, this, _shutdownReason.Message);
 
             try
             {
                 // Try to gracefully close the socket even for aborts to match libuv behavior.
                 _stream.Disconnect();
+                _streamDisconnected = true;
             }
             catch
             {
                 // Ignore any errors from NamedPipeStream.Disconnect() since we're tearing down the connection anyway.
             }
-
-            _stream.Dispose();
         }
     }
 
@@ -287,8 +290,13 @@ internal sealed class NamedPipeConnection : TransportConnection, IConnectionName
         catch (Exception ex)
         {
             _log.LogError(0, ex, $"Unexpected exception in {nameof(NamedPipeConnection)}.{nameof(Start)}.");
+            _stream.Dispose();
+            return;
         }
-        
-        await _stream.DisposeAsync();
+
+        if (!_streamDisconnected || !_connectionListener.TryCacheStream(_stream))
+        {
+            _stream.Dispose();
+        }
     }
 }

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO.Pipelines;
 using System.IO.Pipes;
@@ -10,6 +9,7 @@ using System.Net;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ObjectPool;
 using NamedPipeOptions = System.IO.Pipes.PipeOptions;
 using PipeOptions = System.IO.Pipelines.PipeOptions;
 
@@ -20,6 +20,7 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
     private readonly ILogger _log;
     private readonly NamedPipeEndPoint _endpoint;
     private readonly NamedPipeTransportOptions _options;
+    private readonly ObjectPool<NamedPipeServerStream> _namedPipeServerStreamPool;
     private readonly CancellationTokenSource _listeningTokenSource = new CancellationTokenSource();
     private readonly CancellationToken _listeningToken;
     private readonly Channel<ConnectionContext> _acceptedQueue;
@@ -27,7 +28,6 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
     private readonly PipeOptions _inputOptions;
     private readonly PipeOptions _outputOptions;
     private readonly Mutex _mutex;
-    private readonly ConcurrentQueue<NamedPipeServerStream> _streamsCache = new ConcurrentQueue<NamedPipeServerStream>();
     private Task[]? _listeningTasks;
     private int _disposed;
 
@@ -40,6 +40,7 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
         _log = loggerFactory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes");
         _endpoint = endpoint;
         _options = options;
+        _namedPipeServerStreamPool = new DefaultObjectPoolProvider().Create(new NamedPipeServerStreamPoolPolicy(this));
         _mutex = mutex;
         _memoryPool = options.MemoryPoolFactory();
         _listeningToken = _listeningTokenSource.Token;
@@ -56,17 +57,10 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
         _outputOptions = new PipeOptions(_memoryPool, PipeScheduler.Inline, PipeScheduler.ThreadPool, maxWriteBufferSize, maxWriteBufferSize / 2, useSynchronizationContext: false);
     }
 
-    internal bool TryCacheStream(NamedPipeServerStream namedPipeServerStream)
+    internal void ReturnStream(NamedPipeServerStream namedPipeServerStream)
     {
-        // Limit the number of cached named pipe server streams.
-        // This isn't thread safe so it's possible for Count and Enqueue to race and slightly exceed this limit.
-        if (_streamsCache.Count <= 50)
-        {
-            _streamsCache.Enqueue(namedPipeServerStream);
-            return true;
-        }
-
-        return false;
+        // The stream is automatically disposed if there isn't space in the pool.
+        _namedPipeServerStreamPool.Return(namedPipeServerStream);
     }
 
     public void Start()
@@ -78,7 +72,7 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
         for (var i = 0; i < _listeningTasks.Length; i++)
         {
             // Start first stream inline to catch creation errors.
-            var initialStream = CreateServerStream();
+            var initialStream = _namedPipeServerStreamPool.Get();
 
             _listeningTasks[i] = Task.Run(() => StartAsync(initialStream));
         }
@@ -104,7 +98,7 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
                     // Create the next stream before writing connected stream to the channel.
                     // This ensures there is always a created stream and another process can't
                     // create a stream with the same name with different a access policy.
-                    nextStream = GetOrCreateServerStream();
+                    nextStream = _namedPipeServerStreamPool.Get();
 
                     while (!_acceptedQueue.Writer.TryWrite(connection))
                     {
@@ -121,7 +115,7 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
 
                     // Dispose existing pipe, create a new one and continue accepting.
                     nextStream.Dispose();
-                    nextStream = GetOrCreateServerStream();
+                    nextStream = _namedPipeServerStreamPool.Get();
                 }
                 catch (OperationCanceledException ex) when (_listeningToken.IsCancellationRequested)
                 {
@@ -138,52 +132,6 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
         {
             _acceptedQueue.Writer.TryComplete(ex);
         }
-    }
-
-    private NamedPipeServerStream GetOrCreateServerStream()
-    {
-        if (!_streamsCache.TryDequeue(out var stream))
-        {
-            // Cache is empty. Create a new server stream.
-            stream = CreateServerStream();
-        }
-
-        return stream;
-    }
-
-    private NamedPipeServerStream CreateServerStream()
-    {
-        NamedPipeServerStream stream;
-        var pipeOptions = NamedPipeOptions.Asynchronous | NamedPipeOptions.WriteThrough;
-        if (_options.CurrentUserOnly)
-        {
-            pipeOptions |= NamedPipeOptions.CurrentUserOnly;
-        }
-
-        if (_options.PipeSecurity != null)
-        {
-            stream = NamedPipeServerStreamAcl.Create(
-                _endpoint.PipeName,
-                PipeDirection.InOut,
-                NamedPipeServerStream.MaxAllowedServerInstances,
-                PipeTransmissionMode.Byte,
-                pipeOptions,
-                inBufferSize: 0, // Buffer in System.IO.Pipelines
-                outBufferSize: 0, // Buffer in System.IO.Pipelines
-                _options.PipeSecurity);
-        }
-        else
-        {
-            stream = new NamedPipeServerStream(
-                _endpoint.PipeName,
-                PipeDirection.InOut,
-                NamedPipeServerStream.MaxAllowedServerInstances,
-                PipeTransmissionMode.Byte,
-                pipeOptions,
-                inBufferSize: 0,
-                outBufferSize: 0);
-        }
-        return stream;
     }
 
     public async ValueTask<ConnectionContext?> AcceptAsync(CancellationToken cancellationToken = default)
@@ -217,5 +165,56 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
         {
             await Task.WhenAll(_listeningTasks);
         }
+
+        // Dispose pool after listening tasks are complete so there is no chance a stream
+        // is fetched from the pool after the pool is disposed.
+        ((IDisposable)_namedPipeServerStreamPool).Dispose();
+    }
+
+    private sealed class NamedPipeServerStreamPoolPolicy : IPooledObjectPolicy<NamedPipeServerStream>
+    {
+        public NamedPipeConnectionListener _listener;
+
+        public NamedPipeServerStreamPoolPolicy(NamedPipeConnectionListener listener)
+        {
+            _listener = listener;
+        }
+
+        public NamedPipeServerStream Create()
+        {
+            NamedPipeServerStream stream;
+            var pipeOptions = NamedPipeOptions.Asynchronous | NamedPipeOptions.WriteThrough;
+            if (_listener._options.CurrentUserOnly)
+            {
+                pipeOptions |= NamedPipeOptions.CurrentUserOnly;
+            }
+
+            if (_listener._options.PipeSecurity != null)
+            {
+                stream = NamedPipeServerStreamAcl.Create(
+                    _listener._endpoint.PipeName,
+                    PipeDirection.InOut,
+                    NamedPipeServerStream.MaxAllowedServerInstances,
+                    PipeTransmissionMode.Byte,
+                    pipeOptions,
+                    inBufferSize: 0, // Buffer in System.IO.Pipelines
+                    outBufferSize: 0, // Buffer in System.IO.Pipelines
+                    _listener._options.PipeSecurity);
+            }
+            else
+            {
+                stream = new NamedPipeServerStream(
+                    _listener._endpoint.PipeName,
+                    PipeDirection.InOut,
+                    NamedPipeServerStream.MaxAllowedServerInstances,
+                    PipeTransmissionMode.Byte,
+                    pipeOptions,
+                    inBufferSize: 0,
+                    outBufferSize: 0);
+            }
+            return stream;
+        }
+
+        public bool Return(NamedPipeServerStream obj) => true;
     }
 }

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
@@ -166,8 +166,8 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
             await Task.WhenAll(_listeningTasks);
         }
 
-        // Dispose pool after listening tasks are complete so there is no chance a stream
-        // is fetched from the pool after the pool is disposed.
+        // Dispose pool after listening tasks are complete so there is no chance a stream is fetched from the pool after the pool is disposed.
+        // Important to dispose because this empties and disposes streams in the pool.
         ((IDisposable)_namedPipeServerStreamPool).Dispose();
     }
 

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.csproj
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
     <Reference Include="Microsoft.AspNetCore.Connections.Abstractions" />
+    <Reference Include="Microsoft.Extensions.ObjectPool" />
     <Reference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 


### PR DESCRIPTION
`NamedPipeServerStream` instances can be reused between connections:

```csharp
// End connection
_stream.Disconnect();

// Start new connection
await _stream.WaitForConnectionAsync();
```

This PR adds a cache to the connection listener, allowing streams to be reused between connections.

A further improvement could be to completely reuse `NamedPipeConnection` (the implementation of `ConnectionContext` that wraps the stream). However, caching a connection context is harder because it has to determine whether anyone else is still using it. `NamedPipeServerStream` is private, making it relatively simple to detect whether it is still in use.

Before:
```
|    Method | ListenerQueueCount |     Mean |    Error |   StdDev |     Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |------------------- |---------:|---------:|---------:|---------:|------:|------:|------:|----------:|
| Plaintext |                  1 | 59.16 us | 1.130 us | 1.257 us | 16,902.9 |     - |     - |     - |     11 KB |
| Plaintext |                  2 | 59.62 us | 1.055 us | 0.935 us | 16,772.6 |     - |     - |     - |     11 KB |
| Plaintext |                  8 | 34.49 us | 0.508 us | 0.450 us | 28,997.5 |     - |     - |     - |     11 KB |
| Plaintext |                 16 | 35.30 us | 0.401 us | 0.335 us | 28,329.2 |     - |     - |     - |     11 KB |
```
After:
```
|    Method | ListenerQueueCount |     Mean |    Error |   StdDev |     Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |------------------- |---------:|---------:|---------:|---------:|------:|------:|------:|----------:|
| Plaintext |                  1 | 44.40 us | 0.644 us | 0.602 us | 22,522.2 |     - |     - |     - |      9 KB |
| Plaintext |                  2 | 29.90 us | 0.488 us | 0.433 us | 33,449.5 |     - |     - |     - |      9 KB |
| Plaintext |                  8 | 24.09 us | 0.219 us | 0.194 us | 41,509.1 |     - |     - |     - |      9 KB |
| Plaintext |                 16 | 23.98 us | 0.249 us | 0.221 us | 41,706.7 |     - |     - |     - |      9 KB |
```
(update) ObjectPool:
```
|    Method | ListenerQueueCount |     Mean |    Error |   StdDev |     Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |------------------- |---------:|---------:|---------:|---------:|------:|------:|------:|----------:|
| Plaintext |                  1 | 43.11 us | 0.714 us | 0.668 us | 23,199.0 |     - |     - |     - |      9 KB |
| Plaintext |                  2 | 29.24 us | 0.403 us | 0.377 us | 34,204.9 |     - |     - |     - |      9 KB |
| Plaintext |                  8 | 23.53 us | 0.366 us | 0.343 us | 42,503.3 |     - |     - |     - |      9 KB |
| Plaintext |                 16 | 23.74 us | 0.349 us | 0.326 us | 42,128.1 |     - |     - |     - |      9 KB |
```