### PR TITLE
Use Arcade's pool-providers.yml

### DIFF
--- a/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
+++ b/.azure/pipelines/azure-pipelines-mirror-within-azdo.yml
@@ -13,7 +13,8 @@ parameters:
   type: boolean
 
 variables:
-  - group: Mirror-Credentials
+- group: Mirror-Credentials
+- template: /eng/common/templates/variables/pool-providers.yml
 
 # Merges code from one AzDO branch into another
 jobs:
@@ -26,7 +27,7 @@ jobs:
       - job: Merge_Azure_DevOps_Branches
         enableSBOM: false
         pool:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals 1es-windows-2019
         variables:
         - name: WorkingDirectoryName

--- a/.azure/pipelines/benchmarks.yml
+++ b/.azure/pipelines/benchmarks.yml
@@ -6,6 +6,9 @@ trigger: none
 pr:
 - '*'
 
+variables:
+- template: /eng/common/templates/variables/pool-providers.yml
+
 jobs:
 - template: jobs/default-build.yml
   parameters:

--- a/.azure/pipelines/blazor-daily-tests.yml
+++ b/.azure/pipelines/blazor-daily-tests.yml
@@ -17,6 +17,7 @@ variables:
     value: 'blazor-e2e-sc-proxy-tunnel'
   - name: E2ETESTS_Sauce__HostName
     value: 'sauce.local'
+  - template: /eng/common/templates/variables/pool-providers.yml
 
 jobs:
 - template: jobs/default-build.yml

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -152,6 +152,7 @@ variables:
       value: test
 - name: runCodeQL3000
   value: ${{ or(eq(variables['Build.Reason'], 'Schedule'), and(eq(variables['Build.Reason'], 'Manual'), eq(parameters.runCodeQL3000, 'true'))) }}
+- template: /eng/common/templates/variables/pool-providers.yml
 
 stages:
 - stage: build
@@ -832,7 +833,7 @@ stages:
                 - Helix_x64
             - Source_Build_Managed
           pool:
-            name: NetCore1ESPool-Internal
+            name: $(DncEngInternalBuildPool)
             demands: ImageOverride -equals 1es-windows-2019
           publishUsingPipelines: ${{ variables._PublishUsingPipelines }}
           enablePublishBuildArtifacts: true # publish artifacts/log files
@@ -871,7 +872,7 @@ stages:
                 - Helix_x64
             - Source_Build_Managed
           pool:
-            name: NetCore1ESPool-Internal
+            name: $(DncEngInternalBuildPool)
             # Visual Studio Enterprise - no BuildTools agents exist internally and job must run on Windows
             demands: ImageOverride -equals 1es-windows-2019
           steps:

--- a/.azure/pipelines/components-e2e-tests.yml
+++ b/.azure/pipelines/components-e2e-tests.yml
@@ -25,6 +25,7 @@ variables:
   value: true
 - name: _TeamName
   value:  AspNetCore
+- template: /eng/common/templates/variables/pool-providers.yml
 
 jobs:
 - template: jobs/default-build.yml

--- a/.azure/pipelines/devBuilds.yml
+++ b/.azure/pipelines/devBuilds.yml
@@ -8,6 +8,9 @@ trigger: none
 # no PR builds
 pr: none
 
+variables:
+- template: /eng/common/templates/variables/pool-providers.yml
+
 stages:
 - stage: build_components
   displayName: Build Components

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -20,6 +20,7 @@ variables:
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-HelixApi-Access
+- template: /eng/common/templates/variables/pool-providers.yml
 
 jobs:
 - template: jobs/default-build.yml

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -116,17 +116,17 @@ jobs:
           vmImage: ubuntu-20.04
         ${{ if or(eq(parameters.useHostedUbuntu, false), and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'Manual', 'PullRequest', 'Schedule'))) }}:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: NetCore-Public
+            name: $(DncEngPublicBuildPool)
             demands: ImageOverride -equals Build.Ubuntu.2004.Amd64.Open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            name: NetCore1ESPool-Internal
+            name: $(DncEngInternalBuildPool)
             demands: ImageOverride -equals Build.Ubuntu.2004.Amd64
       ${{ if eq(parameters.agentOs, 'Windows') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCore-Public
+          name: $(DncEngPublicBuildPool)
           demands: ImageOverride -equals 1es-windows-2022-open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: NetCore1ESPool-Internal
+          name: $(DncEngInternalBuildPool)
           # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
           demands: ImageOverride -equals 1es-windows-2022
     ${{ if ne(parameters.container, '') }}:

--- a/.azure/pipelines/localization.yml
+++ b/.azure/pipelines/localization.yml
@@ -25,6 +25,7 @@ parameters:
 variables:
 - name: _TeamName
   value: AspNetCore
+- template: /eng/common/templates/variables/pool-providers.yml
 
 jobs:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.Reason'], 'Manual'))) }}:

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -45,6 +45,7 @@ variables:
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-HelixApi-Access
+- template: /eng/common/templates/variables/pool-providers.yml
 
 jobs:
 - template: jobs/default-build.yml

--- a/.azure/pipelines/quarantined-tests.yml
+++ b/.azure/pipelines/quarantined-tests.yml
@@ -15,6 +15,7 @@ variables:
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-HelixApi-Access
+- template: /eng/common/templates/variables/pool-providers.yml
 
 jobs:
 - template: jobs/default-build.yml

--- a/.azure/pipelines/richnav.yml
+++ b/.azure/pipelines/richnav.yml
@@ -17,6 +17,7 @@ variables:
   value: '/p:SkipTestBuild=true'
 - name: WindowsNonX64LogArgs
   value: -ExcludeCIBinaryLog
+- template: /eng/common/templates/variables/pool-providers.yml
 
 stages:
 - stage: build

--- a/.azure/pipelines/signalr-daily-tests.yml
+++ b/.azure/pipelines/signalr-daily-tests.yml
@@ -8,6 +8,7 @@ variables:
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - group: DotNet-MSRC-Storage
     - group: AzureDevOps-Artifact-Feeds-Pats
+  - template: /eng/common/templates/variables/pool-providers.yml
 
 # The only Daily Tests we have run in Sauce Labs and only need to run on one machine (because they just trigger SauceLabs)
 # Hence we use the 'default-build.yml' template because it represents a single phase

--- a/.azure/pipelines/stress.yml
+++ b/.azure/pipelines/stress.yml
@@ -16,6 +16,8 @@ variables:
 - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
   - name: _BuildArgs
     value: ''
+- template: /eng/common/templates/variables/pool-providers.yml
+
 jobs:
 - template: jobs/default-build.yml
   parameters:


### PR DESCRIPTION
- import the variable template
- use the two variables it provides wherever we name the pool
  - future release branches will now automatically switch to the -Svc pools