### PR TITLE
Greater than 1 FromBody analyzer.

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -199,7 +199,7 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor AtMostOneFromBodyAttribute = new(
         "ASP0024",
-        "At most one parameter can have a [FromBody] attribute.",
+        "Route handler has multiple parameters with the [FromBody] attribute.",
         "Two or more parameters are declared with a [FromBody] attribute. Only one parameter can have a [FromBody] attribute.",
         "Usage",
         DiagnosticSeverity.Error,

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -199,8 +199,8 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor AtMostOneFromBodyAttribute = new(
         "ASP0024",
-        "Route handler has multiple parameters with the [FromBody] attribute.",
-        "Route handler has multiple parameters with the [FromBody] attribute. Only one parameter can have a [FromBody] attribute.",
+        new LocalizableResourceString(nameof(Resources.Analyzer_MultipleFromBody_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_MultipleFromBody_Message), Resources.ResourceManager, typeof(Resources)),
         "Usage",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -200,7 +200,7 @@ internal static class DiagnosticDescriptors
     internal static readonly DiagnosticDescriptor AtMostOneFromBodyAttribute = new(
         "ASP0024",
         "Route handler has multiple parameters with the [FromBody] attribute.",
-        "Two or more parameters are declared with a [FromBody] attribute. Only one parameter can have a [FromBody] attribute.",
+        "Route handler has multiple parameters with the [FromBody] attribute. Only one parameter can have a [FromBody] attribute.",
         "Usage",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -196,4 +196,13 @@ internal static class DiagnosticDescriptors
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: "https://aka.ms/aspnet/analyzers");
+
+    internal static readonly DiagnosticDescriptor AtMostOneFromBodyAttribute = new(
+        "ASP0024",
+        "At most one parameter can have a [FromBody] attribute.",
+        "Two or more parameters are declared with a [FromBody] attribute. Only one parameter can have a [FromBody] attribute.",
+        "Usage",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        helpLinkUri: "https://aka.ms/aspnet/analyzers");
 }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
@@ -207,4 +207,10 @@
   <data name="Analyzer_HeaderDictionaryAdd_Title" xml:space="preserve">
     <value>Suggest using IHeaderDictionary.Append or the indexer</value>
   </data>
+  <data name="Analyzer_MultipleFromBody_Message" xml:space="preserve">
+    <value>Route handler has multiple parameters with the [FromBody] attribute. Only one parameter can have a [FromBody] attribute.</value>
+  </data>
+  <data name="Analyzer_MultipleFromBody_Title" xml:space="preserve">
+    <value>Route handler has multiple parameters with the [FromBody] attribute.</value>
+  </data>
 </root>

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
@@ -208,7 +208,7 @@
     <value>Suggest using IHeaderDictionary.Append or the indexer</value>
   </data>
   <data name="Analyzer_MultipleFromBody_Message" xml:space="preserve">
-    <value>Route handler has multiple parameters with the [FromBody] attribute. Only one parameter can have a [FromBody] attribute.</value>
+    <value>Route handler has multiple parameters with the [FromBody] attribute or a parameter with an [AsParameters] attribute where the parameter type contains multiple members with [FromBody] attributes. Only one parameter can have a [FromBody] attribute.</value>
   </data>
   <data name="Analyzer_MultipleFromBody_Title" xml:space="preserve">
     <value>Route handler has multiple parameters with the [FromBody] attribute.</value>

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/AtMostOneFromBodyAttribute.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/AtMostOneFromBodyAttribute.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
-using Microsoft.AspNetCore.Analyzers.Infrastructure;
 using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
 using Microsoft.AspNetCore.App.Analyzers.Infrastructure;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.AspNetCore.Analyzers.RouteHandlers;
@@ -17,10 +15,9 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
 {
     private static void AtMostOneFromBodyAttribute(
         in OperationAnalysisContext context,
+        WellKnownTypes wellKnownTypes,
         IMethodSymbol methodSymbol)
     {
-        var wellKnownTypes = WellKnownTypes.GetOrCreate(context.Compilation);
-
         var fromBodyMetadataInterfaceType = wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Http_Metadata_IFromBodyMetadata);
 
         var fromBodyMetadataInterfaceParameters = methodSymbol.Parameters.Where(p => p.HasAttributeImplementingInterface(fromBodyMetadataInterfaceType));
@@ -29,12 +26,16 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
         {
             foreach (var parameterSymbol in fromBodyMetadataInterfaceParameters)
             {
-                var syntax = parameterSymbol.DeclaringSyntaxReferences[0].GetSyntax(context.CancellationToken);
-                var location = syntax.GetLocation();
-                context.ReportDiagnostic(Diagnostic.Create(
-                    DiagnosticDescriptors.AtMostOneFromBodyAttribute,
-                    location
-                    ));
+                if (parameterSymbol.DeclaringSyntaxReferences.Length > 0)
+                {
+                    var syntax = parameterSymbol.DeclaringSyntaxReferences[0].GetSyntax(context.CancellationToken);
+                    var location = syntax.GetLocation();
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        DiagnosticDescriptors.AtMostOneFromBodyAttribute,
+                        location
+                        ));
+                }
+
             }
         }
     }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/AtMostOneFromBodyAttribute.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/AtMostOneFromBodyAttribute.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
 using Microsoft.AspNetCore.App.Analyzers.Infrastructure;
@@ -19,23 +20,42 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
         IMethodSymbol methodSymbol)
     {
         var fromBodyMetadataInterfaceType = wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Http_Metadata_IFromBodyMetadata);
+        var asParametersAttributeType = wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Http_AsParametersAttribute);
+
+        var asParametersDecoratedParameters = methodSymbol.Parameters.Where(p => p.HasAttribute(asParametersAttributeType));
+
+        foreach (var asParameterDecoratedParameter in asParametersDecoratedParameters)
+        {
+            var fromBodyMetadataInterfaceMembers = asParameterDecoratedParameter.Type.GetMembers().Where(
+                m => m.HasAttributeImplementingInterface(fromBodyMetadataInterfaceType)
+                );
+
+            if (fromBodyMetadataInterfaceMembers.Count() >= 2)
+            {
+                ReportDiagnostics(context, fromBodyMetadataInterfaceMembers);
+            }
+        }
 
         var fromBodyMetadataInterfaceParameters = methodSymbol.Parameters.Where(p => p.HasAttributeImplementingInterface(fromBodyMetadataInterfaceType));
 
         if (fromBodyMetadataInterfaceParameters.Count() >= 2)
         {
-            foreach (var parameterSymbol in fromBodyMetadataInterfaceParameters)
+            ReportDiagnostics(context, fromBodyMetadataInterfaceParameters);
+        }
+
+        static void ReportDiagnostics(OperationAnalysisContext context, IEnumerable<ISymbol> symbols)
+        {
+            foreach (var symbol in symbols)
             {
-                if (parameterSymbol.DeclaringSyntaxReferences.Length > 0)
+                if (symbol.DeclaringSyntaxReferences.Length > 0)
                 {
-                    var syntax = parameterSymbol.DeclaringSyntaxReferences[0].GetSyntax(context.CancellationToken);
+                    var syntax = symbol.DeclaringSyntaxReferences[0].GetSyntax(context.CancellationToken);
                     var location = syntax.GetLocation();
                     context.ReportDiagnostic(Diagnostic.Create(
                         DiagnosticDescriptors.AtMostOneFromBodyAttribute,
                         location
                         ));
                 }
-
             }
         }
     }

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/AtMostOneFromBodyAttribute.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/AtMostOneFromBodyAttribute.cs
@@ -17,7 +17,6 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
 {
     private static void AtMostOneFromBodyAttribute(
         in OperationAnalysisContext context,
-        RouteUsageModel routeUsage,
         IMethodSymbol methodSymbol)
     {
         var wellKnownTypes = WellKnownTypes.GetOrCreate(context.Compilation);

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/AtMostOneFromBodyAttribute.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/AtMostOneFromBodyAttribute.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using Microsoft.AspNetCore.Analyzers.Infrastructure;
+using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
+using Microsoft.AspNetCore.App.Analyzers.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.AspNetCore.Analyzers.RouteHandlers;
+
+using WellKnownType = WellKnownTypeData.WellKnownType;
+
+public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
+{
+    private static void AtMostOneFromBodyAttribute(
+        in OperationAnalysisContext context,
+        RouteUsageModel routeUsage,
+        IMethodSymbol methodSymbol)
+    {
+        var wellKnownTypes = WellKnownTypes.GetOrCreate(context.Compilation);
+
+        var fromBodyMetadataInterfaceType = wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Http_Metadata_IFromBodyMetadata);
+
+        var fromBodyMetadataInterfaceParameters = methodSymbol.Parameters.Where(p => p.HasAttributeImplementingInterface(fromBodyMetadataInterfaceType));
+
+        if (fromBodyMetadataInterfaceParameters.Count() >= 2)
+        {
+            foreach (var parameterSymbol in fromBodyMetadataInterfaceParameters)
+            {
+                var syntax = parameterSymbol.DeclaringSyntaxReferences[0].GetSyntax(context.CancellationToken);
+                var location = syntax.GetLocation();
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.AtMostOneFromBodyAttribute,
+                    location
+                    ));
+            }
+        }
+    }
+}

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DisallowNonParsableComplexTypesOnParameters.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DisallowNonParsableComplexTypesOnParameters.cs
@@ -17,11 +17,10 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
 {
     private static void DisallowNonParsableComplexTypesOnParameters(
         in OperationAnalysisContext context,
+        WellKnownTypes wellKnownTypes,
         RouteUsageModel routeUsage,
         IMethodSymbol methodSymbol)
     {
-        var wellKnownTypes = WellKnownTypes.GetOrCreate(context.Compilation);
-
         foreach (var handlerDelegateParameter in methodSymbol.Parameters)
         {
             // If the parameter is decorated with a FromServices attribute then we can skip it.

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
@@ -106,19 +106,19 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
                 {
                     var lambda = (IAnonymousFunctionOperation)delegateCreation.Target;
                     DisallowMvcBindArgumentsOnParameters(in context, wellKnownTypes, invocation, lambda.Symbol);
-                    DisallowNonParsableComplexTypesOnParameters(in context, routeUsage, lambda.Symbol);
+                    DisallowNonParsableComplexTypesOnParameters(in context, wellKnownTypes, routeUsage, lambda.Symbol);
                     DisallowReturningActionResultFromMapMethods(in context, wellKnownTypes, invocation, lambda, delegateCreation.Syntax);
                     DetectMisplacedLambdaAttribute(context, lambda);
                     DetectMismatchedParameterOptionality(in context, routeUsage, lambda.Symbol);
-                    AtMostOneFromBodyAttribute(in context, lambda.Symbol);
+                    AtMostOneFromBodyAttribute(in context, wellKnownTypes, lambda.Symbol);
                 }
                 else if (delegateCreation.Target.Kind == OperationKind.MethodReference)
                 {
                     var methodReference = (IMethodReferenceOperation)delegateCreation.Target;
                     DisallowMvcBindArgumentsOnParameters(in context, wellKnownTypes, invocation, methodReference.Method);
-                    DisallowNonParsableComplexTypesOnParameters(in context, routeUsage, methodReference.Method);
+                    DisallowNonParsableComplexTypesOnParameters(in context, wellKnownTypes, routeUsage, methodReference.Method);
                     DetectMismatchedParameterOptionality(in context, routeUsage, methodReference.Method);
-                    AtMostOneFromBodyAttribute(in context, methodReference.Method);
+                    AtMostOneFromBodyAttribute(in context, wellKnownTypes, methodReference.Method);
 
                     var foundMethodReferenceBody = false;
                     if (!methodReference.Method.DeclaringSyntaxReferences.IsEmpty)

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
@@ -27,7 +27,8 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
         DiagnosticDescriptors.DetectMismatchedParameterOptionality,
         DiagnosticDescriptors.RouteParameterComplexTypeIsNotParsableOrBindable,
         DiagnosticDescriptors.BindAsyncSignatureMustReturnValueTaskOfT,
-        DiagnosticDescriptors.AmbiguousRouteHandlerRoute
+        DiagnosticDescriptors.AmbiguousRouteHandlerRoute,
+        DiagnosticDescriptors.AtMostOneFromBodyAttribute
     );
 
     public override void Initialize(AnalysisContext context)
@@ -109,6 +110,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
                     DisallowReturningActionResultFromMapMethods(in context, wellKnownTypes, invocation, lambda, delegateCreation.Syntax);
                     DetectMisplacedLambdaAttribute(context, lambda);
                     DetectMismatchedParameterOptionality(in context, routeUsage, lambda.Symbol);
+                    AtMostOneFromBodyAttribute(in context, routeUsage, lambda.Symbol);
                 }
                 else if (delegateCreation.Target.Kind == OperationKind.MethodReference)
                 {
@@ -116,6 +118,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
                     DisallowMvcBindArgumentsOnParameters(in context, wellKnownTypes, invocation, methodReference.Method);
                     DisallowNonParsableComplexTypesOnParameters(in context, routeUsage, methodReference.Method);
                     DetectMismatchedParameterOptionality(in context, routeUsage, methodReference.Method);
+                    AtMostOneFromBodyAttribute(in context, routeUsage, methodReference.Method);
 
                     var foundMethodReferenceBody = false;
                     if (!methodReference.Method.DeclaringSyntaxReferences.IsEmpty)

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
@@ -110,7 +110,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
                     DisallowReturningActionResultFromMapMethods(in context, wellKnownTypes, invocation, lambda, delegateCreation.Syntax);
                     DetectMisplacedLambdaAttribute(context, lambda);
                     DetectMismatchedParameterOptionality(in context, routeUsage, lambda.Symbol);
-                    AtMostOneFromBodyAttribute(in context, routeUsage, lambda.Symbol);
+                    AtMostOneFromBodyAttribute(in context, lambda.Symbol);
                 }
                 else if (delegateCreation.Target.Kind == OperationKind.MethodReference)
                 {
@@ -118,7 +118,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
                     DisallowMvcBindArgumentsOnParameters(in context, wellKnownTypes, invocation, methodReference.Method);
                     DisallowNonParsableComplexTypesOnParameters(in context, routeUsage, methodReference.Method);
                     DetectMismatchedParameterOptionality(in context, routeUsage, methodReference.Method);
-                    AtMostOneFromBodyAttribute(in context, routeUsage, methodReference.Method);
+                    AtMostOneFromBodyAttribute(in context, methodReference.Method);
 
                     var foundMethodReferenceBody = false;
                     if (!methodReference.Method.DeclaringSyntaxReferences.IsEmpty)

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/AtMostOneFromBodyAttributeTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/AtMostOneFromBodyAttributeTest.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Policy;
+using Microsoft.CodeAnalysis.Testing;
+using VerifyCS = Microsoft.AspNetCore.Analyzers.Verifiers.CSharpAnalyzerVerifier<Microsoft.AspNetCore.Analyzers.RouteHandlers.RouteHandlerAnalyzer>;
+
+namespace Microsoft.AspNetCore.Analyzers.RouteHandlers;
+
+public partial class AtMostOneFromBodyAttributeTest
+{
+    private TestDiagnosticAnalyzerRunner Runner { get; } = new(new RouteHandlerAnalyzer());
+
+    [Fact]
+    public async Task Handler_With_No_FromBody_Attributes_Works()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+var webApp = WebApplication.Create();
+webApp.MapPost(""/products/{productId}"", (string productId, Product product) => {});
+
+public class Product
+{
+}
+";
+
+        // Act
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task Handler_With_One_FromBody_Attributes_Works()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Builder;
+var webApp = WebApplication.Create();
+webApp.MapPost(""/products/{productId}"", (string productId, [FromBody]Product product) => {});
+
+public class Product
+{
+}
+";
+
+        // Act
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task Handler_With_Two_FromBody_Attributes_Fails()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Builder;
+var webApp = WebApplication.Create();
+webApp.MapPost(""/products/{productId}"", (string productId, {|#0:[FromBody]Product product1|}, {|#1:[FromBody]Product product2|}) => {});
+
+public class Product
+{
+}
+";
+
+        var expectedDiagnostic1 = new DiagnosticResult(DiagnosticDescriptors.AtMostOneFromBodyAttribute).WithLocation(0);
+        var expectedDiagnostic2 = new DiagnosticResult(DiagnosticDescriptors.AtMostOneFromBodyAttribute).WithLocation(1);
+
+        // Act
+        await VerifyCS.VerifyAnalyzerAsync(
+            source,
+            expectedDiagnostic1,
+            expectedDiagnostic2
+            );
+    }
+}

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/AtMostOneFromBodyAttributeTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/AtMostOneFromBodyAttributeTest.cs
@@ -106,4 +106,68 @@ public class Product
             expectedDiagnostic2
             );
     }
+
+    [Fact]
+    public async Task Handler_Handler_With_AsParameters_Argument_With_TwoFromBody_Attributes_Fails()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Builder;
+var webApp = WebApplication.Create();
+webApp.MapPost(""/products/{productId}"", ([AsParameters]GetProductRequest request) => {});
+
+public class GetProductRequest
+{
+    {|#0:[FromBody]
+    public Product Product1 { get; set; }|}
+
+    {|#1:[FromBody]
+    public Product Product2 { get; set; }|}
+}
+
+public class Product
+{
+}
+";
+
+        var expectedDiagnostic1 = new DiagnosticResult(DiagnosticDescriptors.AtMostOneFromBodyAttribute).WithLocation(0);
+        var expectedDiagnostic2 = new DiagnosticResult(DiagnosticDescriptors.AtMostOneFromBodyAttribute).WithLocation(1);
+
+        // Act
+        await VerifyCS.VerifyAnalyzerAsync(
+            source,
+            expectedDiagnostic1,
+            expectedDiagnostic2
+            );
+    }
+
+    [Fact]
+    public async Task Handler_Handler_With_AsParameters_Argument_With_OneFromBody_Attributes_Works()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Builder;
+var webApp = WebApplication.Create();
+webApp.MapPost(""/products/{productId}"", ([AsParameters]GetProductRequest request) => {});
+
+public class GetProductRequest
+{
+    {|#0:[FromBody]
+    public Product Product1 { get; set; }|}
+
+    public Product Product2 { get; set; }
+}
+
+public class Product
+{
+}
+";
+
+        // Act
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
 }

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/AtMostOneFromBodyAttributeTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/AtMostOneFromBodyAttributeTest.cs
@@ -73,4 +73,37 @@ public class Product
             expectedDiagnostic2
             );
     }
+
+    [Fact]
+    public async Task MethodGroup_Handler_With_Two_FromBody_Attributes_Fails()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Builder;
+var webApp = WebApplication.Create();
+webApp.MapPost(""/products/{productId}"", MyHandlers.ProcessRequest);
+
+public static class MyHandlers
+{
+    public static void ProcessRequest(string productId, {|#0:[FromBody]Product product1|}, {|#1:[FromBody]Product product2|})
+    {
+    }
+}
+
+public class Product
+{
+}
+";
+
+        var expectedDiagnostic1 = new DiagnosticResult(DiagnosticDescriptors.AtMostOneFromBodyAttribute).WithLocation(0);
+        var expectedDiagnostic2 = new DiagnosticResult(DiagnosticDescriptors.AtMostOneFromBodyAttribute).WithLocation(1);
+
+        // Act
+        await VerifyCS.VerifyAnalyzerAsync(
+            source,
+            expectedDiagnostic1,
+            expectedDiagnostic2
+            );
+    }
 }


### PR DESCRIPTION
This PR addresses #45382.

# Detect when two or more [FromBody] attributes are used

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

This PR ads another diagnostic for when two ```[FromBody]``` attributes are used on a single handler function. It ads a diagnostic for each parameter which is decorated with ```[FromBody]```.