### PR TITLE
HttpSys - clear overlapped handle to prevent multiple release in fault scenario

### DIFF
--- a/src/Servers/HttpSys/src/AsyncAcceptContext.cs
+++ b/src/Servers/HttpSys/src/AsyncAcceptContext.cs
@@ -167,6 +167,7 @@ internal sealed unsafe class AsyncAcceptContext : IValueTaskSource<RequestContex
         if (_overlapped != null)
         {
             boundHandle.FreeNativeOverlapped(_overlapped);
+            _overlapped = null;
         }
 
         _requestContext = _requestContextFactory.CreateRequestContext(size, requestId);


### PR DESCRIPTION
# HttpSys - clear overlapped handle to prevent multiple release in fault scenario

## Description

As [discussed here](https://github.com/dotnet/aspnetcore/issues/46439#issuecomment-1420791920), it is possible (from symptoms) that we are over-releasing the overlapped handle; one possible cause of this is that in any scenario where any of

```
        _requestContext = _requestContextFactory.CreateRequestContext(size, requestId);
        _overlapped = boundHandle.AllocateNativeOverlapped(_preallocatedOverlapped);
```

throws, we aren't resetting `_overlapped`, hence we will release the *previous* overlapped handle multiple times (this path is called in the accept loop - if accept fails, it tries again); once it has fully released, all future release will be doomed, but we'll still keep trying it every time

I'm still investigating whether we can prove this, but the change itself is sensible and safe.

Note: the only concrete request context factory in play here is [very simple](https://github.com/dotnet/aspnetcore/blob/0588658400c1531c89f830cfaf39fa99568103f1/src/Servers/HttpSys/src/ApplicationRequestContextFactory.cs#L21), so I can't give rational causes for a request-context creation failure other than OOM.

If we think there could be *another* cause of the incorrect additional release, we could strengthen the release loop further, so that if we have a doomed handle we at least don't get stuck:

``` c#
        var overlapped = _overlapped;
        if (overlapped != null)
        {
            _overlapped = null; // release eagerly in case of failure
            boundHandle.FreeNativeOverlapped(overlapped);
        }
```

Fixes #46439 (speculative)
