### PR TITLE
ServerComparison.FunctionalTests: extend nginx configuration so nginx starts on RHEL and Fedora.

### DIFF
--- a/src/Servers/test/FunctionalTests/NoCompression.conf
+++ b/src/Servers/test/FunctionalTests/NoCompression.conf
@@ -14,6 +14,15 @@ http {
     keepalive_timeout 10;
     types_hash_max_size 2048;
 
+    # nginx fails start on Fedora/RHEL as non-root with permission errors when
+    # trying to create these paths at their default location under /var/lib/nginx/tmp.
+    # Set them to a writable location.
+    client_body_temp_path /tmp/client_body;
+    proxy_temp_path /tmp/proxy;
+    fastcgi_temp_path /tmp/fastcgi;
+    uwsgi_temp_path /tmp/uwsgi;
+    scgi_temp_path /tmp/scgi;
+
     default_type application/octet-stream;
 
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;

--- a/src/Servers/test/FunctionalTests/nginx.conf
+++ b/src/Servers/test/FunctionalTests/nginx.conf
@@ -13,6 +13,15 @@ http {
     keepalive_timeout 10;
     types_hash_max_size 2048;
 
+    # nginx fails start on Fedora/RHEL as non-root with permission errors when
+    # trying to create these paths at their default location under /var/lib/nginx/tmp.
+    # Set them to a writable location.
+    client_body_temp_path /tmp/client_body;
+    proxy_temp_path /tmp/proxy;
+    fastcgi_temp_path /tmp/fastcgi;
+    uwsgi_temp_path /tmp/uwsgi;
+    scgi_temp_path /tmp/scgi;
+
     default_type application/octet-stream;
 
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;


### PR DESCRIPTION
Without this additional configuration, all nginx based tests fail on RHEL/Fedora while trying to start nginx.

@dougbu @Tratcher ptal.

cc @omajid 