### PR TITLE
Reduce allocations caused by Range operators on arrays and strings

### DIFF
--- a/src/Http/Http/src/Internal/ResponseCookies.cs
+++ b/src/Http/Http/src/Internal/ResponseCookies.cs
@@ -87,7 +87,7 @@ internal sealed partial class ResponseCookies : IResponseCookies
             }
         }
 
-        var cookieSuffix = options.CreateCookieHeader(string.Empty, string.Empty).ToString()[1..];
+        var cookieSuffix = options.CreateCookieHeader(string.Empty, string.Empty).ToString().AsSpan(1);
         var cookies = new string[keyValuePairs.Length];
         var position = 0;
 
@@ -98,7 +98,7 @@ internal sealed partial class ResponseCookies : IResponseCookies
         }
 
         // Can't use += as StringValues does not override operator+
-        // and the implict conversions will cause an incorrect string concat https://github.com/dotnet/runtime/issues/52507
+        // and the implicit conversions will cause an incorrect string concat https://github.com/dotnet/runtime/issues/52507
         Headers.SetCookie = StringValues.Concat(Headers.SetCookie, cookies);
     }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -841,7 +841,7 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
             if (string.Equals(HttpRequestHeaders.HeaderProtocol, WebTransportSession.WebTransportProtocolValue, StringComparison.Ordinal))
             {
                 // if the client supports the same version of WebTransport as Kestrel, make this a WebTransport request
-                if (((AspNetCore.Http.IHeaderDictionary)HttpRequestHeaders).TryGetValue(WebTransportSession.CurrentSuppportedVersion, out var version) && string.Equals(version, WebTransportSession.VersionEnabledIndicator, StringComparison.Ordinal))
+                if (((AspNetCore.Http.IHeaderDictionary)HttpRequestHeaders).TryGetValue(WebTransportSession.CurrentSupportedVersion, out var version) && string.Equals(version, WebTransportSession.VersionEnabledIndicator, StringComparison.Ordinal))
                 {
                     IsWebTransportRequest = true;
                 }
@@ -1201,13 +1201,13 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
 
         if (!IsWebTransportRequest)
         {
-            throw new InvalidOperationException(CoreStrings.FormatFailedToNegotiateCommonWebTransportVersion(WebTransportSession.CurrentSuppportedVersion));
+            throw new InvalidOperationException(CoreStrings.FormatFailedToNegotiateCommonWebTransportVersion(WebTransportSession.CurrentSupportedVersion));
         }
 
         _isWebTransportSessionAccepted = true;
 
         // version negotiation
-        var version = WebTransportSession.CurrentSuppportedVersion[WebTransportSession.SecPrefix.Length..];
+        var version = WebTransportSession.CurrentSupportedVersionSuffix;
 
         _context.WebTransportSession = _context.Connection!.OpenNewWebTransportSession(this);
 

--- a/src/Servers/Kestrel/Core/src/Internal/WebTransport/WebTransportSession.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/WebTransport/WebTransportSession.cs
@@ -38,7 +38,8 @@ internal sealed class WebTransportSession : IWebTransportSession
     internal const string VersionEnabledIndicator = "1";
     internal const string SecPrefix = "sec-webtransport-http3-";
     internal const string VersionHeaderPrefix = $"{SecPrefix}draft";
-    internal const string CurrentSuppportedVersion = $"{VersionHeaderPrefix}02";
+    internal const string CurrentSupportedVersionSuffix = "draft02";
+    internal const string CurrentSupportedVersion = $"{SecPrefix}{CurrentSupportedVersionSuffix}";
 
     public long SessionId => _connectStream.StreamId;
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/WebTransport/WebTransportHandshakeTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/WebTransport/WebTransportHandshakeTests.cs
@@ -71,7 +71,7 @@ public class WebTransportHandshakeTests : Http3TestBase
             new KeyValuePair<string, string>(InternalHeaderNames.Path, "/"),
             new KeyValuePair<string, string>(InternalHeaderNames.Authority, "server.example.com"),
             new KeyValuePair<string, string>(HeaderNames.Origin, "server.example.com"),
-            new KeyValuePair<string, string>(WebTransportSession.CurrentSuppportedVersion, "1")
+            new KeyValuePair<string, string>(WebTransportSession.CurrentSupportedVersion, "1")
         });
 
         var response2 = await requestStream.ExpectHeadersAsync();

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/WebTransport/WebTransportTestUtilities.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/WebTransport/WebTransportTestUtilities.cs
@@ -65,7 +65,7 @@ internal class WebTransportTestUtilities
             new KeyValuePair<string, string>(InternalHeaderNames.Path, "/"),
             new KeyValuePair<string, string>(InternalHeaderNames.Authority, "server.example.com"),
             new KeyValuePair<string, string>(HeaderNames.Origin, "server.example.com"),
-            new KeyValuePair<string, string>(WebTransportSession.CurrentSuppportedVersion, "1")
+            new KeyValuePair<string, string>(WebTransportSession.CurrentSupportedVersion, "1")
         });
 
         return (WebTransportSession)await appCompletedTcs.Task;

--- a/src/Shared/PropertyAsParameterInfo.cs
+++ b/src/Shared/PropertyAsParameterInfo.cs
@@ -87,7 +87,7 @@ internal sealed class PropertyAsParameterInfo : ParameterInfo
                 // to keep the same parameter ordering
                 static List<ParameterInfo> InitializeList(ParameterInfo[] parameters, int i)
                 {
-                    // will add the rest of the parameters to this list, so set initial capacity to reducing growing the list
+                    // will add the rest of the parameters to this list, so set initial capacity to reduce growing the list
                     List<ParameterInfo> list = new(parameters.Length);
                     list.AddRange(parameters.AsSpan(0, i));
                     return list;

--- a/src/Shared/PropertyAsParameterInfo.cs
+++ b/src/Shared/PropertyAsParameterInfo.cs
@@ -85,7 +85,14 @@ internal sealed class PropertyAsParameterInfo : ParameterInfo
             {
                 // Initialize the list with all parameter already processed
                 // to keep the same parameter ordering
-                flattenedParameters ??= new(parameters[0..i]);
+                static List<ParameterInfo> InitializeList(ParameterInfo[] parameters, int i)
+                {
+                    // will add the rest of the parameters to this list, so set initial capacity to reducing growing the list
+                    List<ParameterInfo> list = new(parameters.Length);
+                    list.AddRange(parameters.AsSpan(0, i));
+                    return list;
+                }
+                flattenedParameters ??= InitializeList(parameters, i);
                 nullabilityContext ??= new();
 
                 var isNullable = Nullable.GetUnderlyingType(parameters[i].ParameterType) != null ||


### PR DESCRIPTION
Using the Range operator on an array or string causes a new array or string allocation, which may not be necessary. In these cases, we don't need to allocate an intermediate array or string, and can just use a span instead.

Fixed minor spelling mistakes in adjacent code.
