### PR TITLE
Refactor named pipes connection listener completion

### DIFF
--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
@@ -131,7 +131,7 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
             }
             catch (OperationCanceledException) when (_listeningToken.IsCancellationRequested)
             {
-                // Cancelled the current token
+                // Token was canceled. The listener is shutting down.
                 break;
             }
         }

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeLog.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeLog.cs
@@ -30,7 +30,7 @@ internal static partial class NamedPipeLog
         }
     }
 
-    [LoggerMessage(3, LogLevel.Debug, "Named pipe listener aborted.", EventName = "ConnectionListenerAborted")]
+    [LoggerMessage(3, LogLevel.Error, "Named pipe listener aborted.", EventName = "ConnectionListenerAborted")]
     public static partial void ConnectionListenerAborted(ILogger logger, Exception exception);
 
     [LoggerMessage(4, LogLevel.Debug, @"Connection id ""{ConnectionId}"" paused.", EventName = "ConnectionPause", SkipEnabledCheck = true)]
@@ -79,4 +79,7 @@ internal static partial class NamedPipeLog
 
     [LoggerMessage(8, LogLevel.Debug, "Named pipe listener received broken pipe while waiting for a connection.", EventName = "ConnectionListenerBrokenPipe")]
     public static partial void ConnectionListenerBrokenPipe(ILogger logger, Exception ex);
+
+    [LoggerMessage(9, LogLevel.Trace, "Named pipe listener queue exited.", EventName = "ConnectionListenerQueueExited")]
+    public static partial void ConnectionListenerQueueExited(ILogger logger);
 }

--- a/src/Servers/Kestrel/Transport.NamedPipes/test/NamedPipeConnectionListenerTests.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/test/NamedPipeConnectionListenerTests.cs
@@ -52,7 +52,7 @@ public class NamedPipeConnectionListenerTests : TestApplicationErrorLoggerLogged
     }
 
     [ConditionalFact]
-    public async Task AcceptAsync_UnbindAfterCall_CleanExitAndLog()
+    public async Task AcceptAsync_UnbindAfterCall_CleanExit()
     {
         // Arrange
         await using var connectionListener = await NamedPipeTestHelpers.CreateConnectionListenerFactory(LoggerFactory);
@@ -65,7 +65,7 @@ public class NamedPipeConnectionListenerTests : TestApplicationErrorLoggerLogged
         // Assert
         Assert.Null(await acceptTask.AsTask().DefaultTimeout());
 
-        Assert.Contains(LogMessages, m => m.EventId.Name == "ConnectionListenerAborted");
+        Assert.DoesNotContain(LogMessages, m => m.LogLevel >= LogLevel.Error);
     }
 
     [Theory]
@@ -192,7 +192,7 @@ public class NamedPipeConnectionListenerTests : TestApplicationErrorLoggerLogged
     }
 
     [ConditionalFact]
-    public async Task AcceptAsync_DisposeAfterCall_CleanExitAndLog()
+    public async Task AcceptAsync_DisposeAfterCall_CleanExit()
     {
         // Arrange
         await using var connectionListener = await NamedPipeTestHelpers.CreateConnectionListenerFactory(LoggerFactory);
@@ -205,7 +205,7 @@ public class NamedPipeConnectionListenerTests : TestApplicationErrorLoggerLogged
         // Assert
         Assert.Null(await acceptTask.AsTask().DefaultTimeout());
 
-        Assert.Contains(LogMessages, m => m.EventId.Name == "ConnectionListenerAborted");
+        Assert.DoesNotContain(LogMessages, m => m.LogLevel >= LogLevel.Error);
     }
 
     [ConditionalFact]


### PR DESCRIPTION
Two changes:

1. Move completion of the channel out of listener queues. Previously the first queue to exit would complete the channel. There is the chance another queue has just accepted a connection and attempts to put it on the channel and fails.
2. The `ConnectionListenerAborted` log was written inside each listener queue. That means when the transport was disposed of, it was logged 16 times. Move the log to completion, and only log if there was an error. This more closely matches sockets transport.