### PR TITLE
Expose the original status code in StatusCodeReExecuteFeature

### DIFF
--- a/src/Middleware/Diagnostics.Abstractions/src/IStatusCodeReExecuteFeature.cs
+++ b/src/Middleware/Diagnostics.Abstractions/src/IStatusCodeReExecuteFeature.cs
@@ -29,6 +29,11 @@ public interface IStatusCodeReExecuteFeature
     string? OriginalQueryString { get; set; }
 
     /// <summary>
+    /// The <see cref="HttpResponse.StatusCode"/> of the original response.
+    /// </summary>
+    int OriginalStatusCode { get; set; }
+
+    /// <summary>
     /// Gets the selected <see cref="Http.Endpoint"/> for the original request.
     /// </summary>
     Endpoint? Endpoint => null;

--- a/src/Middleware/Diagnostics.Abstractions/src/IStatusCodeReExecuteFeature.cs
+++ b/src/Middleware/Diagnostics.Abstractions/src/IStatusCodeReExecuteFeature.cs
@@ -31,7 +31,7 @@ public interface IStatusCodeReExecuteFeature
     /// <summary>
     /// The <see cref="HttpResponse.StatusCode"/> of the original response.
     /// </summary>
-    int OriginalStatusCode { get; set; }
+    int OriginalStatusCode => throw new NotImplementedException();
 
     /// <summary>
     /// Gets the selected <see cref="Http.Endpoint"/> for the original request.

--- a/src/Middleware/Diagnostics.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/Diagnostics.Abstractions/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,2 @@
 #nullable enable
 Microsoft.AspNetCore.Diagnostics.IStatusCodeReExecuteFeature.OriginalStatusCode.get -> int
-Microsoft.AspNetCore.Diagnostics.IStatusCodeReExecuteFeature.OriginalStatusCode.set -> void

--- a/src/Middleware/Diagnostics.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/Diagnostics.Abstractions/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Diagnostics.IStatusCodeReExecuteFeature.OriginalStatusCode.get -> int
+Microsoft.AspNetCore.Diagnostics.IStatusCodeReExecuteFeature.OriginalStatusCode.set -> void

--- a/src/Middleware/Diagnostics/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/Diagnostics/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Diagnostics.StatusCodeReExecuteFeature.OriginalStatusCode.get -> int
+Microsoft.AspNetCore.Diagnostics.StatusCodeReExecuteFeature.OriginalStatusCode.set -> void

--- a/src/Middleware/Diagnostics/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/Diagnostics/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,2 @@
 #nullable enable
 Microsoft.AspNetCore.Diagnostics.StatusCodeReExecuteFeature.OriginalStatusCode.get -> int
-Microsoft.AspNetCore.Diagnostics.StatusCodeReExecuteFeature.OriginalStatusCode.set -> void

--- a/src/Middleware/Diagnostics/src/StatusCodePage/StatusCodePagesExtensions.cs
+++ b/src/Middleware/Diagnostics/src/StatusCodePage/StatusCodePagesExtensions.cs
@@ -164,10 +164,12 @@ public static class StatusCodePagesExtensions
     {
         var handler = async (StatusCodeContext context) =>
         {
+            var originalStatusCode = context.HttpContext.Response.StatusCode;
+
             var newPath = new PathString(
-                string.Format(CultureInfo.InvariantCulture, pathFormat, context.HttpContext.Response.StatusCode));
+                string.Format(CultureInfo.InvariantCulture, pathFormat, originalStatusCode));
             var formatedQueryString = queryFormat == null ? null :
-                string.Format(CultureInfo.InvariantCulture, queryFormat, context.HttpContext.Response.StatusCode);
+                string.Format(CultureInfo.InvariantCulture, queryFormat, originalStatusCode);
             var newQueryString = queryFormat == null ? QueryString.Empty : new QueryString(formatedQueryString);
 
             var originalPath = context.HttpContext.Request.Path;
@@ -181,6 +183,7 @@ public static class StatusCodePagesExtensions
                 OriginalPathBase = context.HttpContext.Request.PathBase.Value!,
                 OriginalPath = originalPath.Value!,
                 OriginalQueryString = originalQueryString.HasValue ? originalQueryString.Value : null,
+                OriginalStatusCode = originalStatusCode,
                 Endpoint = context.HttpContext.GetEndpoint(),
                 RouteValues = routeValuesFeature?.RouteValues
             });

--- a/src/Middleware/Diagnostics/src/StatusCodePage/StatusCodeReExecuteFeature.cs
+++ b/src/Middleware/Diagnostics/src/StatusCodePage/StatusCodeReExecuteFeature.cs
@@ -19,6 +19,9 @@ public class StatusCodeReExecuteFeature : IStatusCodeReExecuteFeature
     public string? OriginalQueryString { get; set; }
 
     /// <inheritdoc/>
+    public int OriginalStatusCode { get; set; }
+
+    /// <inheritdoc/>
     public Endpoint? Endpoint { get; set; }
 
     /// <inheritdoc/>

--- a/src/Middleware/Diagnostics/src/StatusCodePage/StatusCodeReExecuteFeature.cs
+++ b/src/Middleware/Diagnostics/src/StatusCodePage/StatusCodeReExecuteFeature.cs
@@ -19,7 +19,7 @@ public class StatusCodeReExecuteFeature : IStatusCodeReExecuteFeature
     public string? OriginalQueryString { get; set; }
 
     /// <inheritdoc/>
-    public int OriginalStatusCode { get; set; }
+    public int OriginalStatusCode { get; internal set; }
 
     /// <inheritdoc/>
     public Endpoint? Endpoint { get; set; }


### PR DESCRIPTION
# Expose the original status code in StatusCodeReExecuteFeature

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Expose the original status code in `StatusCodeReExecuteFeature`

## Description

Expose the original status code in `StatusCodeReExecuteFeature` so that it can be used in places like `StaticFileOptions.OnPrepareResponse`.

With this change it will be possible to write code like

```csharp
app.UseStaticFiles(new StaticFileOptions
{
    OnPrepareResponse = responseContext =>
    {
        var context = responseContext.Context;
        if (context.Response.StatusCode == StatusCodes.Status200OK &&
            context.Features[typeof(IStatusCodeReExecuteFeature)] is IStatusCodeReExecuteFeature statusCodeFeature)
        {
            context.Response.StatusCode = statusCodeFeature.OriginalStatusCode;
        }
    }
});
```

Fixes #46538
