### PR TITLE
fix typo in log message

### DIFF
--- a/src/Middleware/RequestDecompression/src/RequestDecompressionMiddleware.cs
+++ b/src/Middleware/RequestDecompression/src/RequestDecompressionMiddleware.cs
@@ -124,7 +124,7 @@ internal sealed partial class RequestDecompressionMiddleware
         [LoggerMessage(4, LogLevel.Debug, "The maximum request body size has been set to {RequestSize}.", EventName = "MaxRequestBodySizeSet")]
         public static partial void MaxRequestBodySizeSet(ILogger logger, string requestSize);
 
-        [LoggerMessage(5, LogLevel.Debug, "The maximum request body size as been disabled.", EventName = "MaxRequestBodySizeDisabled")]
+        [LoggerMessage(5, LogLevel.Debug, "The maximum request body size has been disabled.", EventName = "MaxRequestBodySizeDisabled")]
         public static partial void MaxRequestBodySizeDisabled(ILogger logger);
     }
 }

--- a/src/Middleware/RequestDecompression/test/RequestDecompressionMiddlewareTests.cs
+++ b/src/Middleware/RequestDecompression/test/RequestDecompressionMiddlewareTests.cs
@@ -737,7 +737,7 @@ public class RequestDecompressionMiddlewareTests
         if (isRequestSizeLimitDisabled)
         {
             AssertLog(Assert.Single(logMessages), LogLevel.Debug,
-                "The maximum request body size as been disabled.");
+                "The maximum request body size has been disabled.");
         }
         else
         {


### PR DESCRIPTION
Fix typo

----

I was looking for a way to disable this middleware for particular endpoint (pass-through scenario), but seems there is no way for partial opt out.
Are you willing to accept PR for something like this?
```c#
class DisableRequestDecompressionAttribute : Attribute, IRequestDecompressionMetadata
{
    bool Enabled { get; set; }
}
```