### PR TITLE
Updated Microsoft.AspNetCore.Identity.UserOptions.RequireUniqueEmail flag description.

### DIFF
--- a/src/Identity/Extensions.Core/src/UserOptions.cs
+++ b/src/Identity/Extensions.Core/src/UserOptions.cs
@@ -20,7 +20,7 @@ public class UserOptions
     /// Gets or sets a flag indicating whether the application requires unique emails for its users. Defaults to false.
     /// </summary>
     /// <value>
-    /// True if the application requires each user to have their own, unique email, otherwise false.
+    /// True if the application requires each user to have their own, unique, not null, not blank email, otherwise false.
     /// </value>
     public bool RequireUniqueEmail { get; set; }
 }


### PR DESCRIPTION
### Updated Microsoft.AspNetCore.Identity.UserOptions.RequireUniqueEmail flag XML docs description.

Clarified what happens if we set this flag true.

### Note

Wanted to simply write **valid email**, but it wouldn't be true as long as `System.ComponentModel.DataAnnotations.EmailAddressAttribute.IsValid()` is used to "validate" email value in `Microsoft.AspNetCore.Identity.UserValidator`

Fixes #46435
