### PR TITLE
Avoid accessing RequestServices & creating a logger in Utf8ContentHttpResult if no logging is being performed

### DIFF
--- a/src/Http/Http.Results/src/Utf8ContentHttpResult.cs
+++ b/src/Http/Http.Results/src/Utf8ContentHttpResult.cs
@@ -50,12 +50,14 @@ public sealed partial class Utf8ContentHttpResult : IResult, IStatusCodeHttpResu
     {
         ArgumentNullException.ThrowIfNull(httpContext);
 
-        // Creating the logger with a string to preserve the category after the refactoring.
-        var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
-        var logger = loggerFactory.CreateLogger("Microsoft.AspNetCore.Http.Result.Utf8ContentHttpResult");
-
         if (StatusCode is { } statusCode)
         {
+            // Creating the logger with a string to preserve the category after the refactoring.
+            // It's important to only access RequestServices & create the logger if we're actually going to use it
+            // to avoid the costs when they're not necessary.
+            var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
+            var logger = loggerFactory.CreateLogger("Microsoft.AspNetCore.Http.Result.Utf8ContentHttpResult");
+
             HttpResultsHelper.Log.WritingResultAsStatusCode(logger, statusCode);
             httpContext.Response.StatusCode = statusCode;
         }


### PR DESCRIPTION
`Utf8ContentHttpResult` is always incurring the cost of accessing `HttpContext.RequestServices`, resolving the `ILoggerFactory`, and creating an `ILogger`, even in cases when it doesn't log anything. This has a significant cost in benchmarking scenarios, dropping RPS from ~991K to ~798K.

This change simply avoids the cost of getting an `ILogger` if no logging is to be performed.
