### PR TITLE
Introduce 'RenderTreeBuilder.AddComponentParameter()'

### DIFF
--- a/src/Components/Authorization/src/AuthorizeRouteView.cs
+++ b/src/Components/Authorization/src/AuthorizeRouteView.cs
@@ -79,7 +79,7 @@ public sealed class AuthorizeRouteView : RouteView
         {
             // Otherwise, implicitly wrap the output in a <CascadingAuthenticationState>
             builder.OpenComponent<CascadingAuthenticationState>(0);
-            builder.AddAttribute(1, nameof(CascadingAuthenticationState.ChildContent), _renderAuthorizeRouteViewCoreDelegate);
+            builder.AddComponentParameter(1, nameof(CascadingAuthenticationState.ChildContent), _renderAuthorizeRouteViewCoreDelegate);
             builder.CloseComponent();
         }
     }
@@ -87,11 +87,11 @@ public sealed class AuthorizeRouteView : RouteView
     private void RenderAuthorizeRouteViewCore(RenderTreeBuilder builder)
     {
         builder.OpenComponent<AuthorizeRouteViewCore>(0);
-        builder.AddAttribute(1, nameof(AuthorizeRouteViewCore.RouteData), RouteData);
-        builder.AddAttribute(2, nameof(AuthorizeRouteViewCore.Authorized), _renderAuthorizedDelegate);
-        builder.AddAttribute(3, nameof(AuthorizeRouteViewCore.Authorizing), _renderAuthorizingDelegate);
-        builder.AddAttribute(4, nameof(AuthorizeRouteViewCore.NotAuthorized), _renderNotAuthorizedDelegate);
-        builder.AddAttribute(5, nameof(AuthorizeRouteViewCore.Resource), Resource);
+        builder.AddComponentParameter(1, nameof(AuthorizeRouteViewCore.RouteData), RouteData);
+        builder.AddComponentParameter(2, nameof(AuthorizeRouteViewCore.Authorized), _renderAuthorizedDelegate);
+        builder.AddComponentParameter(3, nameof(AuthorizeRouteViewCore.Authorizing), _renderAuthorizingDelegate);
+        builder.AddComponentParameter(4, nameof(AuthorizeRouteViewCore.NotAuthorized), _renderNotAuthorizedDelegate);
+        builder.AddComponentParameter(5, nameof(AuthorizeRouteViewCore.Resource), Resource);
         builder.CloseComponent();
     }
 
@@ -104,8 +104,8 @@ public sealed class AuthorizeRouteView : RouteView
     private void RenderContentInDefaultLayout(RenderTreeBuilder builder, RenderFragment content)
     {
         builder.OpenComponent<LayoutView>(0);
-        builder.AddAttribute(1, nameof(LayoutView.Layout), DefaultLayout);
-        builder.AddAttribute(2, nameof(LayoutView.ChildContent), content);
+        builder.AddComponentParameter(1, nameof(LayoutView.Layout), DefaultLayout);
+        builder.AddComponentParameter(2, nameof(LayoutView.ChildContent), content);
         builder.CloseComponent();
     }
 

--- a/src/Components/Authorization/test/AuthorizeRouteViewTest.cs
+++ b/src/Components/Authorization/test/AuthorizeRouteViewTest.cs
@@ -411,11 +411,11 @@ public class AuthorizeRouteViewTest
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
             builder.OpenComponent<CascadingValue<Task<AuthenticationState>>>(0);
-            builder.AddAttribute(1, nameof(CascadingValue<object>.Value), _authenticationState);
-            builder.AddAttribute(2, nameof(CascadingValue<object>.ChildContent), (RenderFragment)(builder =>
+            builder.AddComponentParameter(1, nameof(CascadingValue<object>.Value), _authenticationState);
+            builder.AddComponentParameter(2, nameof(CascadingValue<object>.ChildContent), (RenderFragment)(builder =>
             {
                 builder.OpenComponent<AuthorizeRouteView>(0);
-                builder.AddAttribute(1, nameof(AuthorizeRouteView.RouteData), _routeData);
+                builder.AddComponentParameter(1, nameof(AuthorizeRouteView.RouteData), _routeData);
                 builder.CloseComponent();
             }));
             builder.CloseComponent();

--- a/src/Components/Authorization/test/AuthorizeViewTest.cs
+++ b/src/Components/Authorization/test/AuthorizeViewTest.cs
@@ -505,13 +505,13 @@ public class AuthorizeViewTest
         return new TestAuthStateProviderComponent(builder =>
         {
             builder.OpenComponent<AuthorizeView>(0);
-            builder.AddAttribute(1, nameof(AuthorizeView.ChildContent), childContent);
-            builder.AddAttribute(2, nameof(AuthorizeView.Authorized), authorized);
-            builder.AddAttribute(3, nameof(AuthorizeView.NotAuthorized), notAuthorized);
-            builder.AddAttribute(4, nameof(AuthorizeView.Authorizing), authorizing);
-            builder.AddAttribute(5, nameof(AuthorizeView.Policy), policy);
-            builder.AddAttribute(6, nameof(AuthorizeView.Roles), roles);
-            builder.AddAttribute(7, nameof(AuthorizeView.Resource), resource);
+            builder.AddComponentParameter(1, nameof(AuthorizeView.ChildContent), childContent);
+            builder.AddComponentParameter(2, nameof(AuthorizeView.Authorized), authorized);
+            builder.AddComponentParameter(3, nameof(AuthorizeView.NotAuthorized), notAuthorized);
+            builder.AddComponentParameter(4, nameof(AuthorizeView.Authorizing), authorizing);
+            builder.AddComponentParameter(5, nameof(AuthorizeView.Policy), policy);
+            builder.AddComponentParameter(6, nameof(AuthorizeView.Roles), roles);
+            builder.AddComponentParameter(7, nameof(AuthorizeView.Resource), resource);
             builder.CloseComponent();
         });
     }
@@ -531,11 +531,11 @@ public class AuthorizeViewTest
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
             builder.OpenComponent<CascadingValue<Task<AuthenticationState>>>(0);
-            builder.AddAttribute(1, nameof(CascadingValue<Task<AuthenticationState>>.Value), AuthenticationState);
-            builder.AddAttribute(2, "ChildContent", (RenderFragment)(builder =>
+            builder.AddComponentParameter(1, nameof(CascadingValue<Task<AuthenticationState>>.Value), AuthenticationState);
+            builder.AddComponentParameter(2, "ChildContent", (RenderFragment)(builder =>
             {
                 builder.OpenComponent<NeverReRenderComponent>(0);
-                builder.AddAttribute(1, "ChildContent", _childContent);
+                builder.AddComponentParameter(1, "ChildContent", _childContent);
                 builder.CloseComponent();
             }));
             builder.CloseComponent();

--- a/src/Components/Authorization/test/CascadingAuthenticationStateTest.cs
+++ b/src/Components/Authorization/test/CascadingAuthenticationStateTest.cs
@@ -177,7 +177,7 @@ public class CascadingAuthenticationStateTest
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
             builder.OpenComponent<CascadingAuthenticationState>(0);
-            builder.AddAttribute(1, "ChildContent", new RenderFragment(childBuilder =>
+            builder.AddComponentParameter(1, "ChildContent", new RenderFragment(childBuilder =>
             {
                 childBuilder.OpenComponent<ReceiveAuthStateComponent>(0);
                 childBuilder.CloseComponent();

--- a/src/Components/Components/src/DynamicComponent.cs
+++ b/src/Components/Components/src/DynamicComponent.cs
@@ -98,7 +98,7 @@ public class DynamicComponent : IComponent
         {
             foreach (var entry in Parameters)
             {
-                builder.AddAttribute(1, entry.Key, entry.Value);
+                builder.AddComponentParameter(1, entry.Key, entry.Value);
             }
         }
 

--- a/src/Components/Components/src/LayoutView.cs
+++ b/src/Components/Components/src/LayoutView.cs
@@ -69,7 +69,7 @@ public class LayoutView : IComponent
         void Render(RenderTreeBuilder builder)
         {
             builder.OpenComponent(0, layoutType);
-            builder.AddAttribute(1, LayoutComponentBase.BodyPropertyName, bodyParam);
+            builder.AddComponentParameter(1, LayoutComponentBase.BodyPropertyName, bodyParam);
             builder.CloseComponent();
         };
 

--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -3,5 +3,4 @@ Microsoft.AspNetCore.Components.ComponentBase.DispatchExceptionAsync(System.Exce
 Microsoft.AspNetCore.Components.RenderHandle.DispatchExceptionAsync(System.Exception! exception) -> System.Threading.Tasks.Task!
 *REMOVED*Microsoft.AspNetCore.Components.NavigationManager.ToAbsoluteUri(string! relativeUri) -> System.Uri!
 Microsoft.AspNetCore.Components.NavigationManager.ToAbsoluteUri(string? relativeUri) -> System.Uri!
-Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddComponentParameter(int sequence, string! name, bool value) -> void
 Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddComponentParameter(int sequence, string! name, object? value) -> void

--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ Microsoft.AspNetCore.Components.ComponentBase.DispatchExceptionAsync(System.Exce
 Microsoft.AspNetCore.Components.RenderHandle.DispatchExceptionAsync(System.Exception! exception) -> System.Threading.Tasks.Task!
 *REMOVED*Microsoft.AspNetCore.Components.NavigationManager.ToAbsoluteUri(string! relativeUri) -> System.Uri!
 Microsoft.AspNetCore.Components.NavigationManager.ToAbsoluteUri(string? relativeUri) -> System.Uri!
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddComponentParameter(int sequence, string! name, bool value) -> void
+Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddComponentParameter(int sequence, string! name, object? value) -> void

--- a/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
+++ b/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
@@ -506,6 +506,30 @@ public sealed class RenderTreeBuilder : IDisposable
     }
 
     /// <summary>
+    /// Appends a frame representing a component parameter.
+    /// </summary>
+    /// <param name="sequence">An integer that represents the position of the instruction in the source code.</param>
+    /// <param name="name">The name of the attribute.</param>
+    /// <param name="value">The value of the attribute.</param>
+    public void AddComponentParameter(int sequence, string name, bool value)
+    {
+        AssertCanAddComponentParameter();
+        _entries.AppendAttribute(sequence, name, value ? BoxedTrue : BoxedFalse);
+    }
+
+    /// <summary>
+    /// Appends a frame representing a component parameter.
+    /// </summary>
+    /// <param name="sequence">An integer that represents the position of the instruction in the source code.</param>
+    /// <param name="name">The name of the attribute.</param>
+    /// <param name="value">The value of the attribute.</param>
+    public void AddComponentParameter(int sequence, string name, object? value)
+    {
+        AssertCanAddComponentParameter();
+        _entries.AppendAttribute(sequence, name, value);
+    }
+
+    /// <summary>
     /// Assigns the specified key value to the current element or component.
     /// </summary>
     /// <param name="value">The value for the key.</param>
@@ -646,6 +670,14 @@ public sealed class RenderTreeBuilder : IDisposable
             && _lastNonAttributeFrameType != RenderTreeFrameType.Component)
         {
             throw new InvalidOperationException($"Attributes may only be added immediately after frames of type {RenderTreeFrameType.Element} or {RenderTreeFrameType.Component}");
+        }
+    }
+
+    private void AssertCanAddComponentParameter()
+    {
+        if (_lastNonAttributeFrameType != RenderTreeFrameType.Component)
+        {
+            throw new InvalidOperationException($"Component parameters may only be added immediately after frames of type {RenderTreeFrameType.Component}");
         }
     }
 

--- a/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
+++ b/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
@@ -511,18 +511,6 @@ public sealed class RenderTreeBuilder : IDisposable
     /// <param name="sequence">An integer that represents the position of the instruction in the source code.</param>
     /// <param name="name">The name of the attribute.</param>
     /// <param name="value">The value of the attribute.</param>
-    public void AddComponentParameter(int sequence, string name, bool value)
-    {
-        AssertCanAddComponentParameter();
-        _entries.AppendAttribute(sequence, name, value ? BoxedTrue : BoxedFalse);
-    }
-
-    /// <summary>
-    /// Appends a frame representing a component parameter.
-    /// </summary>
-    /// <param name="sequence">An integer that represents the position of the instruction in the source code.</param>
-    /// <param name="name">The name of the attribute.</param>
-    /// <param name="value">The value of the attribute.</param>
     public void AddComponentParameter(int sequence, string name, object? value)
     {
         AssertCanAddComponentParameter();

--- a/src/Components/Components/src/RouteView.cs
+++ b/src/Components/Components/src/RouteView.cs
@@ -81,8 +81,8 @@ public class RouteView : IComponent
             ?? DefaultLayout;
 
         builder.OpenComponent<LayoutView>(0);
-        builder.AddAttribute(1, nameof(LayoutView.Layout), pageLayoutType);
-        builder.AddAttribute(2, nameof(LayoutView.ChildContent), _renderPageWithParametersDelegate);
+        builder.AddComponentParameter(1, nameof(LayoutView.Layout), pageLayoutType);
+        builder.AddComponentParameter(2, nameof(LayoutView.ChildContent), _renderPageWithParametersDelegate);
         builder.CloseComponent();
     }
 
@@ -92,7 +92,7 @@ public class RouteView : IComponent
 
         foreach (var kvp in RouteData.RouteValues)
         {
-            builder.AddAttribute(1, kvp.Key, kvp.Value);
+            builder.AddComponentParameter(1, kvp.Key, kvp.Value);
         }
 
         var queryParameterSupplier = QueryParameterValueSupplier.ForType(RouteData.PageType);

--- a/src/Components/Components/src/Routing/QueryParameterValueSupplier.cs
+++ b/src/Components/Components/src/Routing/QueryParameterValueSupplier.cs
@@ -58,7 +58,7 @@ internal sealed class QueryParameterValueSupplier
             {
                 ref var destination = ref _destinations[destinationIndex];
                 var blankValue = destination.IsArray ? destination.Parser.ParseMultiple(default, string.Empty) : null;
-                builder.AddAttribute(0, destination.ComponentParameterName, blankValue);
+                builder.AddComponentParameter(0, destination.ComponentParameterName, blankValue);
             }
             return;
         }
@@ -101,7 +101,7 @@ internal sealed class QueryParameterValueSupplier
                         ? default
                         : destination.Parser.Parse(values[0].Span, destination.ComponentParameterName);
 
-                builder.AddAttribute(0, destination.ComponentParameterName, parsedValue);
+                builder.AddComponentParameter(0, destination.ComponentParameterName, parsedValue);
             }
         }
         finally

--- a/src/Components/Components/test/CascadingParameterTest.cs
+++ b/src/Components/Components/test/CascadingParameterTest.cs
@@ -17,11 +17,11 @@ public class CascadingParameterTest
         var component = new TestComponent(builder =>
         {
             builder.OpenComponent<CascadingValue<string>>(0);
-            builder.AddAttribute(1, "Value", "Hello");
-            builder.AddAttribute(2, "ChildContent", new RenderFragment(childBuilder =>
+            builder.AddComponentParameter(1, "Value", "Hello");
+            builder.AddComponentParameter(2, "ChildContent", new RenderFragment(childBuilder =>
             {
                 childBuilder.OpenComponent<CascadingParameterConsumerComponent<string>>(0);
-                childBuilder.AddAttribute(1, "RegularParameter", "Goodbye");
+                childBuilder.AddComponentParameter(1, "RegularParameter", "Goodbye");
                 childBuilder.CloseComponent();
             }));
             builder.CloseComponent();
@@ -55,11 +55,11 @@ public class CascadingParameterTest
         var component = new TestComponent(builder =>
         {
             builder.OpenComponent<CascadingValue<string>>(0);
-            builder.AddAttribute(1, "Value", "Hello");
-            builder.AddAttribute(2, "ChildContent", new RenderFragment(childBuilder =>
+            builder.AddComponentParameter(1, "Value", "Hello");
+            builder.AddComponentParameter(2, "ChildContent", new RenderFragment(childBuilder =>
             {
                 childBuilder.OpenComponent<CascadingParameterConsumerComponent<string>>(0);
-                childBuilder.AddAttribute(1, "RegularParameter", regularParameterValue);
+                childBuilder.AddComponentParameter(1, "RegularParameter", regularParameterValue);
                 childBuilder.CloseComponent();
             }));
             builder.CloseComponent();
@@ -103,11 +103,11 @@ public class CascadingParameterTest
         var component = new TestComponent(builder =>
         {
             builder.OpenComponent<CascadingValue<string>>(0);
-            builder.AddAttribute(1, "Value", providedValue);
-            builder.AddAttribute(2, "ChildContent", new RenderFragment(childBuilder =>
+            builder.AddComponentParameter(1, "Value", providedValue);
+            builder.AddComponentParameter(2, "ChildContent", new RenderFragment(childBuilder =>
             {
                 childBuilder.OpenComponent<CascadingParameterConsumerComponent<string>>(0);
-                childBuilder.AddAttribute(1, "RegularParameter", "Goodbye");
+                childBuilder.AddComponentParameter(1, "RegularParameter", "Goodbye");
                 childBuilder.CloseComponent();
             }));
             builder.CloseComponent();
@@ -148,11 +148,11 @@ public class CascadingParameterTest
         var component = new TestComponent(builder =>
         {
             builder.OpenComponent<CascadingValue<string>>(0);
-            builder.AddAttribute(1, "Value", "Unchanging value");
-            builder.AddAttribute(2, "ChildContent", new RenderFragment(childBuilder =>
+            builder.AddComponentParameter(1, "Value", "Unchanging value");
+            builder.AddComponentParameter(2, "ChildContent", new RenderFragment(childBuilder =>
             {
                 childBuilder.OpenComponent<CascadingParameterConsumerComponent<string>>(0);
-                childBuilder.AddAttribute(1, "RegularParameter", "Goodbye");
+                childBuilder.AddComponentParameter(1, "RegularParameter", "Goodbye");
                 childBuilder.CloseComponent();
             }));
             builder.CloseComponent();
@@ -187,19 +187,19 @@ public class CascadingParameterTest
         {
             // At the outer level, have an unrelated fixed cascading value to show we can deal with combining both types
             builder.OpenComponent<CascadingValue<int>>(0);
-            builder.AddAttribute(1, "Value", 123);
-            builder.AddAttribute(2, "IsFixed", true);
-            builder.AddAttribute(3, "ChildContent", new RenderFragment(builder2 =>
+            builder.AddComponentParameter(1, "Value", 123);
+            builder.AddComponentParameter(2, "IsFixed", true);
+            builder.AddComponentParameter(3, "ChildContent", new RenderFragment(builder2 =>
             {
                 // Then also have a non-fixed cascading value so we can show that unsubscription works
                 builder2.OpenComponent<CascadingValue<string>>(0);
-                builder2.AddAttribute(1, "Value", providedValue);
-                builder2.AddAttribute(2, "ChildContent", new RenderFragment(builder3 =>
+                builder2.AddComponentParameter(1, "Value", providedValue);
+                builder2.AddComponentParameter(2, "ChildContent", new RenderFragment(builder3 =>
                 {
                     if (displayNestedComponent)
                     {
                         builder3.OpenComponent<SecondCascadingParameterConsumerComponent<string, int>>(0);
-                        builder3.AddAttribute(1, "RegularParameter", "Goodbye");
+                        builder3.AddComponentParameter(1, "RegularParameter", "Goodbye");
                         builder3.CloseComponent();
                     }
                 }));
@@ -253,14 +253,14 @@ public class CascadingParameterTest
         var component = new TestComponent(builder =>
         {
             builder.OpenComponent<CascadingValue<string>>(0);
-            builder.AddAttribute(1, "Value", providedValue);
-            builder.AddAttribute(2, "IsFixed", true);
-            builder.AddAttribute(3, "ChildContent", new RenderFragment(childBuilder =>
+            builder.AddComponentParameter(1, "Value", providedValue);
+            builder.AddComponentParameter(2, "IsFixed", true);
+            builder.AddComponentParameter(3, "ChildContent", new RenderFragment(childBuilder =>
             {
                 if (shouldIncludeChild)
                 {
                     childBuilder.OpenComponent<CascadingParameterConsumerComponent<string>>(0);
-                    childBuilder.AddAttribute(1, "RegularParameter", "Goodbye");
+                    childBuilder.AddComponentParameter(1, "RegularParameter", "Goodbye");
                     childBuilder.CloseComponent();
                 }
             }));
@@ -312,8 +312,8 @@ public class CascadingParameterTest
         var component = new TestComponent(builder =>
         {
             builder.OpenComponent<CascadingValue<object>>(0);
-            builder.AddAttribute(1, "IsFixed", isFixed);
-            builder.AddAttribute(2, "Value", new object());
+            builder.AddComponentParameter(1, "IsFixed", isFixed);
+            builder.AddComponentParameter(2, "Value", new object());
             builder.CloseComponent();
         });
         renderer.AssignRootComponentId(component);
@@ -336,9 +336,9 @@ public class CascadingParameterTest
             builder.OpenComponent<CascadingValue<object>>(0);
             if (isFixed) // Showing also that "unset" is treated as "false"
             {
-                builder.AddAttribute(1, "IsFixed", true);
+                builder.AddComponentParameter(1, "IsFixed", true);
             }
-            builder.AddAttribute(2, "Value", new object());
+            builder.AddComponentParameter(2, "Value", new object());
             builder.CloseComponent();
         });
         renderer.AssignRootComponentId(component);
@@ -359,8 +359,8 @@ public class CascadingParameterTest
         var component = new TestComponent(builder =>
         {
             builder.OpenComponent<CascadingValue<string>>(0);
-            builder.AddAttribute(1, "Value", providedValue);
-            builder.AddAttribute(2, "ChildContent", new RenderFragment(childBuilder =>
+            builder.AddComponentParameter(1, "Value", providedValue);
+            builder.AddComponentParameter(2, "ChildContent", new RenderFragment(childBuilder =>
             {
                 childBuilder.OpenComponent<CascadingParameterConsumerComponent<string>>(0);
                 childBuilder.CloseComponent();

--- a/src/Components/Components/test/ParameterViewTest.Assignment.cs
+++ b/src/Components/Components/test/ParameterViewTest.Assignment.cs
@@ -664,7 +664,7 @@ public partial class ParameterViewTest
             {
                 if (!kvp.Cascading)
                 {
-                    builder.AddAttribute(1, kvp.Name, kvp.Value);
+                    builder.AddComponentParameter(1, kvp.Name, kvp.Value);
                 }
             }
             builder.CloseComponent();

--- a/src/Components/Components/test/RenderTreeDiffBuilderTest.cs
+++ b/src/Components/Components/test/RenderTreeDiffBuilderTest.cs
@@ -210,7 +210,7 @@ public class RenderTreeDiffBuilderTest : IDisposable
         // Arrange
         oldTree.OpenComponent<CaptureSetParametersComponent>(0);
         oldTree.SetKey("retained key");
-        oldTree.AddAttribute(1, "ParamName", "Param old value");
+        oldTree.AddComponentParameter(1, "ParamName", "Param old value");
         oldTree.CloseComponent();
         using var initial = new RenderTreeBuilder();
         GetRenderedBatch(initial, oldTree, false); // Assign initial IDs
@@ -218,12 +218,12 @@ public class RenderTreeDiffBuilderTest : IDisposable
 
         newTree.OpenComponent<CaptureSetParametersComponent>(0);
         newTree.SetKey("new key");
-        newTree.AddAttribute(1, "ParamName", "New component param value");
+        newTree.AddComponentParameter(1, "ParamName", "New component param value");
         newTree.CloseComponent();
 
         newTree.OpenComponent<CaptureSetParametersComponent>(0);
         newTree.SetKey("retained key");
-        newTree.AddAttribute(1, "ParamName", "Param new value");
+        newTree.AddComponentParameter(1, "ParamName", "Param new value");
         newTree.CloseComponent();
 
         // Without the key, it would modify the param on the first component,
@@ -251,12 +251,12 @@ public class RenderTreeDiffBuilderTest : IDisposable
         // Arrange
         oldTree.OpenComponent<FakeComponent>(0);
         oldTree.SetKey("will delete");
-        oldTree.AddAttribute(1, nameof(FakeComponent.StringProperty), "Anything");
+        oldTree.AddComponentParameter(1, nameof(FakeComponent.StringProperty), "Anything");
         oldTree.CloseComponent();
 
         oldTree.OpenComponent<FakeComponent>(0);
         oldTree.SetKey("will retain");
-        oldTree.AddAttribute(1, nameof(FakeComponent.StringProperty), "Retained param value");
+        oldTree.AddComponentParameter(1, nameof(FakeComponent.StringProperty), "Retained param value");
         oldTree.CloseComponent();
 
         // Instantiate initial components
@@ -266,7 +266,7 @@ public class RenderTreeDiffBuilderTest : IDisposable
 
         newTree.OpenComponent<FakeComponent>(0);
         newTree.SetKey("will retain");
-        newTree.AddAttribute(1, nameof(FakeComponent.StringProperty), "Retained param value");
+        newTree.AddComponentParameter(1, nameof(FakeComponent.StringProperty), "Retained param value");
         newTree.CloseComponent();
 
         // Without the key, it updates the param on the first component, then
@@ -289,11 +289,11 @@ public class RenderTreeDiffBuilderTest : IDisposable
         // Arrange
         oldTree.OpenComponent<FakeComponent>(0);
         oldTree.SetKey("will delete");
-        oldTree.AddAttribute(1, nameof(FakeComponent.StringProperty), "Will delete");
+        oldTree.AddComponentParameter(1, nameof(FakeComponent.StringProperty), "Will delete");
         oldTree.CloseComponent();
 
         oldTree.OpenComponent<FakeComponent>(2);
-        oldTree.AddAttribute(3, nameof(FakeComponent.StringProperty), "Retained param value");
+        oldTree.AddComponentParameter(3, nameof(FakeComponent.StringProperty), "Retained param value");
         oldTree.CloseComponent();
 
         // Instantiate initial components
@@ -302,7 +302,7 @@ public class RenderTreeDiffBuilderTest : IDisposable
         var oldComponents = GetComponents(oldTree);
 
         newTree.OpenComponent<FakeComponent>(2);
-        newTree.AddAttribute(3, nameof(FakeComponent.StringProperty), "Retained param value");
+        newTree.AddComponentParameter(3, nameof(FakeComponent.StringProperty), "Retained param value");
         newTree.CloseComponent();
 
         // Act
@@ -1587,9 +1587,9 @@ public class RenderTreeDiffBuilderTest : IDisposable
         // Arrange
         var testObject = new object();
         newTree.OpenComponent<FakeComponent>(0);
-        newTree.AddAttribute(1, nameof(FakeComponent.IntProperty), 123);
-        newTree.AddAttribute(2, nameof(FakeComponent.StringProperty), "some string");
-        newTree.AddAttribute(3, nameof(FakeComponent.ObjectProperty), testObject);
+        newTree.AddComponentParameter(1, nameof(FakeComponent.IntProperty), 123);
+        newTree.AddComponentParameter(2, nameof(FakeComponent.StringProperty), "some string");
+        newTree.AddComponentParameter(3, nameof(FakeComponent.ObjectProperty), testObject);
         newTree.CloseComponent();
 
         // Act
@@ -1703,12 +1703,12 @@ public class RenderTreeDiffBuilderTest : IDisposable
         // Arrange
         var objectWillNotChange = new object();
         oldTree.OpenComponent<FakeComponent>(12);
-        oldTree.AddAttribute(13, nameof(FakeComponent.StringProperty), "String will change");
-        oldTree.AddAttribute(14, nameof(FakeComponent.ObjectProperty), objectWillNotChange);
+        oldTree.AddComponentParameter(13, nameof(FakeComponent.StringProperty), "String will change");
+        oldTree.AddComponentParameter(14, nameof(FakeComponent.ObjectProperty), objectWillNotChange);
         oldTree.CloseComponent();
         newTree.OpenComponent<FakeComponent>(12);
-        newTree.AddAttribute(13, nameof(FakeComponent.StringProperty), "String did change");
-        newTree.AddAttribute(14, nameof(FakeComponent.ObjectProperty), objectWillNotChange);
+        newTree.AddComponentParameter(13, nameof(FakeComponent.StringProperty), "String did change");
+        newTree.AddComponentParameter(14, nameof(FakeComponent.ObjectProperty), objectWillNotChange);
         newTree.CloseComponent();
 
         using var batchBuilder = new RenderBatchBuilder();
@@ -1739,16 +1739,16 @@ public class RenderTreeDiffBuilderTest : IDisposable
         foreach (var tree in new[] { oldTree, newTree })
         {
             tree.OpenComponent<CaptureSetParametersComponent>(0);
-            tree.AddAttribute(1, "MyString", "Some fixed string");
-            tree.AddAttribute(1, "MyByte", (byte)123);
-            tree.AddAttribute(1, "MyInt", int.MaxValue);
-            tree.AddAttribute(1, "MyLong", long.MaxValue);
-            tree.AddAttribute(1, "MyBool", true);
-            tree.AddAttribute(1, "MyFloat", float.MaxValue);
-            tree.AddAttribute(1, "MyDouble", double.MaxValue);
-            tree.AddAttribute(1, "MyDecimal", decimal.MinusOne);
-            tree.AddAttribute(1, "MyDate", dateTimeWillNotChange);
-            tree.AddAttribute(1, "MyGuid", Guid.Empty);
+            tree.AddComponentParameter(1, "MyString", "Some fixed string");
+            tree.AddComponentParameter(1, "MyByte", (byte)123);
+            tree.AddComponentParameter(1, "MyInt", int.MaxValue);
+            tree.AddComponentParameter(1, "MyLong", long.MaxValue);
+            tree.AddComponentParameter(1, "MyBool", true);
+            tree.AddComponentParameter(1, "MyFloat", float.MaxValue);
+            tree.AddComponentParameter(1, "MyDouble", double.MaxValue);
+            tree.AddComponentParameter(1, "MyDecimal", decimal.MinusOne);
+            tree.AddComponentParameter(1, "MyDate", dateTimeWillNotChange);
+            tree.AddComponentParameter(1, "MyGuid", Guid.Empty);
             tree.CloseComponent();
         }
 
@@ -1778,7 +1778,7 @@ public class RenderTreeDiffBuilderTest : IDisposable
         foreach (var tree in new[] { oldTree, newTree })
         {
             tree.OpenComponent<CaptureSetParametersComponent>(0);
-            tree.AddAttribute(1, "MyFragment", fragmentWillNotChange);
+            tree.AddComponentParameter(1, "MyFragment", fragmentWillNotChange);
             tree.CloseComponent();
         }
 
@@ -2009,14 +2009,14 @@ public class RenderTreeDiffBuilderTest : IDisposable
         // Arrange
         oldTree.OpenComponent<CaptureSetParametersComponent>(0);
         oldTree.SetKey("first key");
-        oldTree.AddAttribute(1, nameof(FakeComponent.StringProperty), "First param");
+        oldTree.AddComponentParameter(1, nameof(FakeComponent.StringProperty), "First param");
         oldTree.CloseComponent();
 
         oldTree.AddContent(2, "Unkeyed item");
 
         oldTree.OpenComponent<CaptureSetParametersComponent>(0);
         oldTree.SetKey("second key");
-        oldTree.AddAttribute(1, nameof(FakeComponent.StringProperty), "Second param");
+        oldTree.AddComponentParameter(1, nameof(FakeComponent.StringProperty), "Second param");
         oldTree.CloseComponent();
 
         using var renderTreeBuilder = new RenderTreeBuilder();
@@ -2025,14 +2025,14 @@ public class RenderTreeDiffBuilderTest : IDisposable
 
         newTree.OpenComponent<CaptureSetParametersComponent>(0);
         newTree.SetKey("second key");
-        newTree.AddAttribute(1, nameof(FakeComponent.StringProperty), "Second param");
+        newTree.AddComponentParameter(1, nameof(FakeComponent.StringProperty), "Second param");
         newTree.CloseComponent();
 
         newTree.AddContent(2, "Unkeyed item");
 
         newTree.OpenComponent<CaptureSetParametersComponent>(0);
         newTree.SetKey("first key");
-        newTree.AddAttribute(1, nameof(FakeComponent.StringProperty), "First param modified");
+        newTree.AddComponentParameter(1, nameof(FakeComponent.StringProperty), "First param modified");
         newTree.CloseComponent();
 
         // Without the key, it changes the parameter on both

--- a/src/Components/Components/test/RendererTest.cs
+++ b/src/Components/Components/test/RendererTest.cs
@@ -63,7 +63,7 @@ public class RendererTest
         {
             builder.AddContent(0, "Hello");
             builder.OpenComponent<MessageComponent>(1);
-            builder.AddAttribute(2, nameof(MessageComponent.Message), "Nested component output");
+            builder.AddComponentParameter(2, nameof(MessageComponent.Message), "Nested component output");
             builder.CloseComponent();
         });
 
@@ -1018,7 +1018,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickAction), (Action)parentComponent.SomeMethod);
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickAction), (Action)parentComponent.SomeMethod);
             builder.CloseComponent();
         };
         parentComponent.OnEvent = () =>
@@ -1059,7 +1059,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickAction), (Action)(() =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickAction), (Action)(() =>
             {
                 parentComponent.SomeMethod();
             }));
@@ -1101,7 +1101,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickEventCallback), EventCallback.Factory.Create(parentComponent, (Action)parentComponent.SomeMethod));
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickEventCallback), EventCallback.Factory.Create(parentComponent, (Action)parentComponent.SomeMethod));
             builder.CloseComponent();
         };
         parentComponent.OnEvent = () =>
@@ -1139,7 +1139,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickEventCallback), EventCallback.Factory.Create(parentComponent, (Action)(() =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickEventCallback), EventCallback.Factory.Create(parentComponent, (Action)(() =>
             {
                 parentComponent.SomeMethod();
             })));
@@ -1180,7 +1180,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickEventCallback), EventCallback.Factory.Create(parentComponent, (Func<Task>)(() =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickEventCallback), EventCallback.Factory.Create(parentComponent, (Func<Task>)(() =>
             {
                 parentComponent.SomeMethod();
                 return Task.CompletedTask;
@@ -1220,7 +1220,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickEventCallbackOfT), EventCallback.Factory.Create<DerivedEventArgs>(parentComponent, (Action)parentComponent.SomeMethod));
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickEventCallbackOfT), EventCallback.Factory.Create<DerivedEventArgs>(parentComponent, (Action)parentComponent.SomeMethod));
             builder.CloseComponent();
         };
         parentComponent.OnEvent = () =>
@@ -1258,7 +1258,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickEventCallbackOfT), EventCallback.Factory.Create<DerivedEventArgs>(parentComponent, (Action)(() =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickEventCallbackOfT), EventCallback.Factory.Create<DerivedEventArgs>(parentComponent, (Action)(() =>
             {
                 parentComponent.SomeMethod();
             })));
@@ -1299,7 +1299,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickEventCallbackOfT), EventCallback.Factory.Create<DerivedEventArgs>(parentComponent, (Func<Task>)(() =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickEventCallbackOfT), EventCallback.Factory.Create<DerivedEventArgs>(parentComponent, (Func<Task>)(() =>
             {
                 parentComponent.SomeMethod();
                 return Task.CompletedTask;
@@ -1337,7 +1337,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickAction), (Action)(() =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickAction), (Action)(() =>
             {
                 // Do nothing.
             }));
@@ -1369,7 +1369,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickEventCallback), EventCallback.Factory.Create(parentComponent, (Action)(() =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickEventCallback), EventCallback.Factory.Create(parentComponent, (Action)(() =>
             {
                 // Do nothing.
             })));
@@ -1403,7 +1403,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickEventCallbackOfT), EventCallback.Factory.Create(parentComponent, (Action<DerivedEventArgs>)((e) =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickEventCallbackOfT), EventCallback.Factory.Create(parentComponent, (Action<DerivedEventArgs>)((e) =>
             {
                 arg = e;
             })));
@@ -1436,7 +1436,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickAction), (Action)(() =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickAction), (Action)(() =>
             {
                 throw new OperationCanceledException();
             }));
@@ -1468,7 +1468,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickEventCallback), EventCallback.Factory.Create(parentComponent, (Action)(() =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickEventCallback), EventCallback.Factory.Create(parentComponent, (Action)(() =>
             {
                 throw new OperationCanceledException();
             })));
@@ -1502,7 +1502,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickEventCallbackOfT), EventCallback.Factory.Create(parentComponent, (Action<DerivedEventArgs>)((e) =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickEventCallbackOfT), EventCallback.Factory.Create(parentComponent, (Action<DerivedEventArgs>)((e) =>
             {
                 arg = e;
                 throw new OperationCanceledException();
@@ -1536,7 +1536,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickAction), (Action)(() =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickAction), (Action)(() =>
             {
                 throw new InvalidTimeZoneException();
             }));
@@ -1568,7 +1568,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickEventCallback), EventCallback.Factory.Create(parentComponent, (Action)(() =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickEventCallback), EventCallback.Factory.Create(parentComponent, (Action)(() =>
             {
                 throw new InvalidTimeZoneException();
             })));
@@ -1602,7 +1602,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickEventCallbackOfT), EventCallback.Factory.Create<DerivedEventArgs>(parentComponent, (Action<DerivedEventArgs>)((e) =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickEventCallbackOfT), EventCallback.Factory.Create<DerivedEventArgs>(parentComponent, (Action<DerivedEventArgs>)((e) =>
             {
                 arg = e;
                 throw new InvalidTimeZoneException();
@@ -1638,7 +1638,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickAsyncAction), (Func<Task>)(async () =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickAsyncAction), (Func<Task>)(async () =>
             {
                 await tcs.Task;
             }));
@@ -1673,7 +1673,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickEventCallback), EventCallback.Factory.Create(parentComponent, async () =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickEventCallback), EventCallback.Factory.Create(parentComponent, async () =>
             {
                 await tcs.Task;
             }));
@@ -1710,7 +1710,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickEventCallbackOfT), EventCallback.Factory.Create<DerivedEventArgs>(parentComponent, async (e) =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickEventCallbackOfT), EventCallback.Factory.Create<DerivedEventArgs>(parentComponent, async (e) =>
             {
                 arg = e;
                 await tcs.Task;
@@ -1747,7 +1747,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickAsyncAction), (Func<Task>)(async () =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickAsyncAction), (Func<Task>)(async () =>
             {
                 await tcs.Task;
                 throw new TaskCanceledException();
@@ -1785,7 +1785,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickEventCallback), EventCallback.Factory.Create(parentComponent, async () =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickEventCallback), EventCallback.Factory.Create(parentComponent, async () =>
             {
                 await tcs.Task;
                 throw new TaskCanceledException();
@@ -1825,7 +1825,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickEventCallbackOfT), EventCallback.Factory.Create<DerivedEventArgs>(parentComponent, async (e) =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickEventCallbackOfT), EventCallback.Factory.Create<DerivedEventArgs>(parentComponent, async (e) =>
             {
                 arg = e;
                 await tcs.Task;
@@ -1865,7 +1865,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickAsyncAction), (Func<Task>)(async () =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickAsyncAction), (Func<Task>)(async () =>
             {
                 await tcs.Task;
                 throw new InvalidTimeZoneException();
@@ -1902,7 +1902,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickEventCallback), EventCallback.Factory.Create(parentComponent, async () =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickEventCallback), EventCallback.Factory.Create(parentComponent, async () =>
             {
                 await tcs.Task;
                 throw new InvalidTimeZoneException();
@@ -1941,7 +1941,7 @@ public class RendererTest
         parentComponent.RenderFragment = (builder) =>
         {
             builder.OpenComponent<EventComponent>(0);
-            builder.AddAttribute(1, nameof(EventComponent.OnClickEventCallbackOfT), EventCallback.Factory.Create<DerivedEventArgs>(parentComponent, async (e) =>
+            builder.AddComponentParameter(1, nameof(EventComponent.OnClickEventCallbackOfT), EventCallback.Factory.Create<DerivedEventArgs>(parentComponent, async (e) =>
             {
                 arg = e;
                 await tcs.Task;
@@ -2064,9 +2064,9 @@ public class RendererTest
         var component = new TestComponent(builder =>
         {
             builder.OpenComponent<FakeComponent>(1);
-            builder.AddAttribute(2, nameof(FakeComponent.IntProperty), firstRender ? 123 : 256);
-            builder.AddAttribute(3, nameof(FakeComponent.ObjectProperty), objectThatWillNotChange);
-            builder.AddAttribute(4, nameof(FakeComponent.StringProperty), firstRender ? "String that will change" : "String that did change");
+            builder.AddComponentParameter(2, nameof(FakeComponent.IntProperty), firstRender ? 123 : 256);
+            builder.AddComponentParameter(3, nameof(FakeComponent.ObjectProperty), objectThatWillNotChange);
+            builder.AddComponentParameter(4, nameof(FakeComponent.StringProperty), firstRender ? "String that will change" : "String that did change");
             builder.CloseComponent();
         });
 
@@ -2102,7 +2102,7 @@ public class RendererTest
         var component = new TestComponent(builder =>
         {
             builder.OpenComponent<MessageComponent>(1);
-            builder.AddAttribute(2, nameof(MessageComponent.Message), firstRender ? "first" : "second");
+            builder.AddComponentParameter(2, nameof(MessageComponent.Message), firstRender ? "first" : "second");
             builder.CloseComponent();
         });
 
@@ -2138,9 +2138,9 @@ public class RendererTest
         var component = new TestComponent(builder =>
         {
             builder.OpenComponent<MyStrongComponent>(1);
-            builder.AddAttribute(1, "class", firstRender ? "first" : "second");
-            builder.AddAttribute(2, "id", "some_text");
-            builder.AddAttribute(3, nameof(MyStrongComponent.Text), "hi there.");
+            builder.AddComponentParameter(1, "class", firstRender ? "first" : "second");
+            builder.AddComponentParameter(2, "id", "some_text");
+            builder.AddComponentParameter(3, nameof(MyStrongComponent.Text), "hi there.");
             builder.CloseComponent();
         });
 
@@ -2178,9 +2178,9 @@ public class RendererTest
         var component = new TestComponent(builder =>
         {
             builder.OpenComponent<MyStrongComponent>(1);
-            builder.AddAttribute(1, "class", "cool-beans");
-            builder.AddAttribute(2, "id", "some_text");
-            builder.AddAttribute(3, nameof(MyStrongComponent.Text), "hi there.");
+            builder.AddComponentParameter(1, "class", "cool-beans");
+            builder.AddComponentParameter(2, "id", "some_text");
+            builder.AddComponentParameter(3, nameof(MyStrongComponent.Text), "hi there.");
             builder.CloseComponent();
         });
 
@@ -2211,7 +2211,7 @@ public class RendererTest
             {
                 // Nested descendants
                 builder.OpenComponent<ConditionalParentComponent<FakeComponent>>(100);
-                builder.AddAttribute(101, nameof(ConditionalParentComponent<FakeComponent>.IncludeChild), true);
+                builder.AddComponentParameter(101, nameof(ConditionalParentComponent<FakeComponent>.IncludeChild), true);
                 builder.CloseComponent();
             }
             builder.OpenComponent<FakeComponent>(200);
@@ -2265,11 +2265,11 @@ public class RendererTest
             {
                 builder.AddContent(0, "Hello");
                 builder.OpenComponent<DisposableComponent>(1);
-                builder.AddAttribute(1, nameof(DisposableComponent.DisposeAction), (Action)(() => throw exception1));
+                builder.AddComponentParameter(1, nameof(DisposableComponent.DisposeAction), (Action)(() => throw exception1));
                 builder.CloseComponent();
 
                 builder.OpenComponent<DisposableComponent>(2);
-                builder.AddAttribute(1, nameof(DisposableComponent.DisposeAction), (Action)(() => throw exception2));
+                builder.AddComponentParameter(1, nameof(DisposableComponent.DisposeAction), (Action)(() => throw exception2));
                 builder.CloseComponent();
             }
         });
@@ -2305,7 +2305,7 @@ public class RendererTest
             {
                 builder.AddContent(0, "Hello");
                 builder.OpenComponent<AsyncDisposableComponent>(1);
-                builder.AddAttribute(1, nameof(AsyncDisposableComponent.AsyncDisposeAction), (Func<ValueTask>)(() => throw exception1));
+                builder.AddComponentParameter(1, nameof(AsyncDisposableComponent.AsyncDisposeAction), (Func<ValueTask>)(() => throw exception1));
                 builder.CloseComponent();
             }
         });
@@ -2340,7 +2340,7 @@ public class RendererTest
             {
                 builder.AddContent(0, "Hello");
                 builder.OpenComponent<AsyncDisposableComponent>(1);
-                builder.AddAttribute(1, nameof(AsyncDisposableComponent.AsyncDisposeAction), (Func<ValueTask>)(() => default));
+                builder.AddComponentParameter(1, nameof(AsyncDisposableComponent.AsyncDisposeAction), (Func<ValueTask>)(() => default));
                 builder.CloseComponent();
             }
         });
@@ -2377,7 +2377,7 @@ public class RendererTest
             {
                 builder.AddContent(0, "Hello");
                 builder.OpenComponent<AsyncDisposableComponent>(1);
-                builder.AddAttribute(1, nameof(AsyncDisposableComponent.AsyncDisposeAction), (Func<ValueTask>)(async () => { await tcs.Task; }));
+                builder.AddComponentParameter(1, nameof(AsyncDisposableComponent.AsyncDisposeAction), (Func<ValueTask>)(async () => { await tcs.Task; }));
                 builder.CloseComponent();
             }
         });
@@ -2419,7 +2419,7 @@ public class RendererTest
             {
                 builder.AddContent(0, "Hello");
                 builder.OpenComponent<AsyncDisposableComponent>(1);
-                builder.AddAttribute(1, nameof(AsyncDisposableComponent.AsyncDisposeAction), (Func<ValueTask>)(async () => { await tcs.Task; throw exception1; }));
+                builder.AddComponentParameter(1, nameof(AsyncDisposableComponent.AsyncDisposeAction), (Func<ValueTask>)(async () => { await tcs.Task; throw exception1; }));
                 builder.CloseComponent();
             }
         });
@@ -2458,7 +2458,7 @@ public class RendererTest
             {
                 builder.AddContent(0, "Hello");
                 builder.OpenComponent<AsyncDisposableComponent>(1);
-                builder.AddAttribute(1, nameof(AsyncDisposableComponent.AsyncDisposeAction), (Func<ValueTask>)(() => throw new TaskCanceledException()));
+                builder.AddComponentParameter(1, nameof(AsyncDisposableComponent.AsyncDisposeAction), (Func<ValueTask>)(() => throw new TaskCanceledException()));
                 builder.CloseComponent();
             }
         });
@@ -2494,7 +2494,7 @@ public class RendererTest
             {
                 builder.AddContent(0, "Hello");
                 builder.OpenComponent<AsyncDisposableComponent>(1);
-                builder.AddAttribute(
+                builder.AddComponentParameter(
                     1,
                     nameof(AsyncDisposableComponent.AsyncDisposeAction),
                     (Func<ValueTask>)(() => new ValueTask(tcs.Task)));
@@ -2544,24 +2544,24 @@ public class RendererTest
             {
                 builder.AddContent(0, "Hello");
                 builder.OpenComponent<DisposableComponent>(1);
-                builder.AddAttribute(1, nameof(DisposableComponent.DisposeAction), (Action)(() => { count1++; }));
+                builder.AddComponentParameter(1, nameof(DisposableComponent.DisposeAction), (Action)(() => { count1++; }));
                 builder.CloseComponent();
 
                 builder.OpenComponent<DisposableComponent>(2);
-                builder.AddAttribute(1, nameof(DisposableComponent.DisposeAction), (Action)(() => { count2++; throw exception1; }));
+                builder.AddComponentParameter(1, nameof(DisposableComponent.DisposeAction), (Action)(() => { count2++; throw exception1; }));
                 builder.CloseComponent();
 
                 builder.OpenComponent<DisposableComponent>(3);
-                builder.AddAttribute(1, nameof(DisposableComponent.DisposeAction), (Action)(() => { count3++; }));
+                builder.AddComponentParameter(1, nameof(DisposableComponent.DisposeAction), (Action)(() => { count3++; }));
                 builder.CloseComponent();
             }
 
             builder.OpenComponent<DisposableComponent>(4);
-            builder.AddAttribute(1, nameof(DisposableComponent.DisposeAction), (Action)(() => { count4++; throw exception2; }));
+            builder.AddComponentParameter(1, nameof(DisposableComponent.DisposeAction), (Action)(() => { count4++; throw exception2; }));
             builder.CloseComponent();
 
             builder.OpenComponent<DisposableComponent>(5);
-            builder.AddAttribute(1, nameof(DisposableComponent.DisposeAction), (Action)(() => { count5++; }));
+            builder.AddComponentParameter(1, nameof(DisposableComponent.DisposeAction), (Action)(() => { count5++; }));
             builder.CloseComponent();
         });
         var componentId = renderer.AssignRootComponentId(component);
@@ -2779,7 +2779,7 @@ public class RendererTest
         {
             builder.AddContent(0, "Child event count: " + eventCount);
             builder.OpenComponent<EventComponent>(1);
-            builder.AddAttribute(2, nameof(EventComponent.OnTest), new Action<EventArgs>(args =>
+            builder.AddComponentParameter(2, nameof(EventComponent.OnTest), new Action<EventArgs>(args =>
             {
                 eventCount++;
                 rootComponent.TriggerRender();
@@ -2901,7 +2901,7 @@ public class RendererTest
         parent = new TestComponent(builder =>
         {
             builder.OpenComponent<ReRendersParentComponent>(0);
-            builder.AddAttribute(1, nameof(ReRendersParentComponent.Parent), parent);
+            builder.AddComponentParameter(1, nameof(ReRendersParentComponent.Parent), parent);
             builder.CloseComponent();
             builder.AddContent(2, $"Parent render count: {++parentRenderCount}");
         });
@@ -2967,7 +2967,7 @@ public class RendererTest
             if (shouldRenderChild)
             {
                 builder.OpenComponent<RendersSelfAfterEventComponent>(1);
-                builder.AddAttribute(2, "onclick", (Action<object>)((object obj) =>
+                builder.AddComponentParameter(2, "onclick", (Action<object>)((object obj) =>
                 {
                     // First we queue (1) a re-render of the root component, then the child component
                     // will queue (2) its own re-render. But by the time (1) completes, the child will
@@ -3329,7 +3329,7 @@ public class RendererTest
         {
             // First child will be re-rendered because we'll change its param
             builder.OpenComponent<AfterRenderCaptureComponent>(0);
-            builder.AddAttribute(1, "some param", showComponent3);
+            builder.AddComponentParameter(1, "some param", showComponent3);
             builder.CloseComponent();
 
             // Second child will not be re-rendered because nothing changes
@@ -3645,7 +3645,7 @@ public class RendererTest
         var component = new TestComponent(builder =>
         {
             builder.OpenComponent<ComponentThatAwaitsTask>(0);
-            builder.AddAttribute(1, nameof(ComponentThatAwaitsTask.TaskToAwait), taskToAwait);
+            builder.AddComponentParameter(1, nameof(ComponentThatAwaitsTask.TaskToAwait), taskToAwait);
             builder.CloseComponent();
         });
         var componentId = renderer.AssignRootComponentId(component);
@@ -4173,11 +4173,11 @@ public class RendererTest
         {
             builder.AddContent(0, "Hello");
             builder.OpenComponent<DisposableComponent>(1);
-            builder.AddAttribute(1, nameof(DisposableComponent.DisposeAction), (Action)(() => throw exception1));
+            builder.AddComponentParameter(1, nameof(DisposableComponent.DisposeAction), (Action)(() => throw exception1));
             builder.CloseComponent();
 
             builder.OpenComponent<DisposableComponent>(2);
-            builder.AddAttribute(1, nameof(DisposableComponent.DisposeAction), (Action)(() => throw exception2));
+            builder.AddComponentParameter(1, nameof(DisposableComponent.DisposeAction), (Action)(() => throw exception2));
             builder.CloseComponent();
         });
         var componentId = renderer.AssignRootComponentId(component);
@@ -4205,7 +4205,7 @@ public class RendererTest
         {
             builder.AddContent(0, "Hello");
             builder.OpenComponent<AsyncDisposableComponent>(1);
-            builder.AddAttribute(1, nameof(AsyncDisposableComponent.AsyncDisposeAction), (Func<ValueTask>)(() => { disposed = true; throw exception1; }));
+            builder.AddComponentParameter(1, nameof(AsyncDisposableComponent.AsyncDisposeAction), (Func<ValueTask>)(() => { disposed = true; throw exception1; }));
             builder.CloseComponent();
         });
         var componentId = renderer.AssignRootComponentId(component);
@@ -4233,7 +4233,7 @@ public class RendererTest
         {
             builder.AddContent(0, "Hello");
             builder.OpenComponent<AsyncDisposableComponent>(1);
-            builder.AddAttribute(1, nameof(AsyncDisposableComponent.AsyncDisposeAction), (Func<ValueTask>)(async () => { await tcs.Task; disposed = true; throw exception1; }));
+            builder.AddComponentParameter(1, nameof(AsyncDisposableComponent.AsyncDisposeAction), (Func<ValueTask>)(async () => { await tcs.Task; disposed = true; throw exception1; }));
             builder.CloseComponent();
         });
         var componentId = renderer.AssignRootComponentId(component);
@@ -4381,7 +4381,7 @@ public class RendererTest
         var rootComponent = new TestComponent(builder =>
         {
             builder.OpenComponent<ParameterViewIllegalCapturingComponent>(0);
-            builder.AddAttribute(1, nameof(ParameterViewIllegalCapturingComponent.SomeParam), 0);
+            builder.AddComponentParameter(1, nameof(ParameterViewIllegalCapturingComponent.SomeParam), 0);
             builder.CloseComponent();
         });
         var rootComponentId = renderer.AssignRootComponentId(rootComponent);
@@ -4468,7 +4468,7 @@ public class RendererTest
             TestErrorBoundary.RenderNestedErrorBoundaries(builder, builder =>
             {
                 builder.OpenComponent<ErrorThrowingComponent>(0);
-                builder.AddAttribute(1, nameof(ErrorThrowingComponent.ThrowDuringRender), exception);
+                builder.AddComponentParameter(1, nameof(ErrorThrowingComponent.ThrowDuringRender), exception);
                 builder.CloseComponent();
             });
         }));
@@ -4499,7 +4499,7 @@ public class RendererTest
             TestErrorBoundary.RenderNestedErrorBoundaries(builder, builder =>
             {
                 builder.OpenComponent<ErrorThrowingComponent>(0);
-                builder.AddAttribute(1, nameof(ErrorThrowingComponent.ThrowDuringParameterSettingSync), exception);
+                builder.AddComponentParameter(1, nameof(ErrorThrowingComponent.ThrowDuringParameterSettingSync), exception);
                 builder.CloseComponent();
             });
         });
@@ -4536,7 +4536,7 @@ public class RendererTest
             TestErrorBoundary.RenderNestedErrorBoundaries(builder, builder =>
             {
                 builder.OpenComponent<ErrorThrowingComponent>(0);
-                builder.AddAttribute(1, nameof(ErrorThrowingComponent.ThrowDuringParameterSettingAsync), exceptionTcs?.Task);
+                builder.AddComponentParameter(1, nameof(ErrorThrowingComponent.ThrowDuringParameterSettingAsync), exceptionTcs?.Task);
                 builder.CloseComponent();
             });
         });
@@ -4575,7 +4575,7 @@ public class RendererTest
             TestErrorBoundary.RenderNestedErrorBoundaries(builder, builder =>
             {
                 builder.OpenComponent<ErrorThrowingComponent>(0);
-                builder.AddAttribute(1, nameof(ErrorThrowingComponent.ThrowDuringEventSync), exception);
+                builder.AddComponentParameter(1, nameof(ErrorThrowingComponent.ThrowDuringEventSync), exception);
                 builder.CloseComponent();
             });
         }));
@@ -4614,7 +4614,7 @@ public class RendererTest
             TestErrorBoundary.RenderNestedErrorBoundaries(builder, builder =>
             {
                 builder.OpenComponent<ErrorThrowingComponent>(0);
-                builder.AddAttribute(1, nameof(ErrorThrowingComponent.ThrowDuringEventAsync), exceptionTcs.Task);
+                builder.AddComponentParameter(1, nameof(ErrorThrowingComponent.ThrowDuringEventAsync), exceptionTcs.Task);
                 builder.CloseComponent();
             });
         }));
@@ -4661,7 +4661,7 @@ public class RendererTest
                 TestErrorBoundary.RenderNestedErrorBoundaries(builder, builder =>
                 {
                     builder.OpenComponent<ErrorThrowingComponent>(0);
-                    builder.AddAttribute(1, nameof(ErrorThrowingComponent.ThrowDuringEventAsync), exceptionTcs.Task);
+                    builder.AddComponentParameter(1, nameof(ErrorThrowingComponent.ThrowDuringEventAsync), exceptionTcs.Task);
                     builder.CloseComponent();
                 });
             }
@@ -4820,11 +4820,11 @@ public class RendererTest
         {
             builder.AddContent(0, "Hello");
             builder.OpenComponent<DisposableComponent>(1);
-            builder.AddAttribute(1, nameof(DisposableComponent.DisposeAction), (Action)(() => throw exception1));
+            builder.AddComponentParameter(1, nameof(DisposableComponent.DisposeAction), (Action)(() => throw exception1));
             builder.CloseComponent();
 
             builder.OpenComponent<AsyncDisposableComponent>(2);
-            builder.AddAttribute(1, nameof(AsyncDisposableComponent.AsyncDisposeAction), (Func<ValueTask>)(async () => await exception2Tcs.Task));
+            builder.AddComponentParameter(1, nameof(AsyncDisposableComponent.AsyncDisposeAction), (Func<ValueTask>)(async () => await exception2Tcs.Task));
             builder.CloseComponent();
         });
         var rootComponentId = renderer.AssignRootComponentId(rootComponent);
@@ -5176,7 +5176,7 @@ public class RendererTest
                 {
                     foreach (var kvp in ChildParameters)
                     {
-                        builder.AddAttribute(2, kvp.Key, kvp.Value);
+                        builder.AddComponentParameter(2, kvp.Key, kvp.Value);
                     }
                 }
                 builder.CloseComponent();
@@ -5477,10 +5477,10 @@ public class RendererTest
             foreach (var child in childrenToRender)
             {
                 builder.OpenComponent<NestedAsyncComponent>(2);
-                builder.AddAttribute(3, eventActionsName, component.EventActions);
-                builder.AddAttribute(4, whatToRenderName, component.WhatToRender);
-                builder.AddAttribute(5, testIdName, child);
-                builder.AddAttribute(6, logName, component.Log);
+                builder.AddComponentParameter(3, eventActionsName, component.EventActions);
+                builder.AddComponentParameter(4, whatToRenderName, component.WhatToRender);
+                builder.AddComponentParameter(5, testIdName, child);
+                builder.AddComponentParameter(6, logName, component.Log);
                 builder.CloseComponent();
             }
 
@@ -5777,11 +5777,11 @@ public class RendererTest
         {
             // Create an error boundary
             builder.OpenComponent<TestErrorBoundary>(0);
-            builder.AddAttribute(1, nameof(TestErrorBoundary.ChildContent), (RenderFragment)(builder =>
+            builder.AddComponentParameter(1, nameof(TestErrorBoundary.ChildContent), (RenderFragment)(builder =>
             {
                 // ... containing another error boundary, containing the content
                 builder.OpenComponent<TestErrorBoundary>(0);
-                builder.AddAttribute(1, nameof(TestErrorBoundary.ChildContent), innerContent);
+                builder.AddComponentParameter(1, nameof(TestErrorBoundary.ChildContent), innerContent);
                 builder.CloseComponent();
             }));
             builder.CloseComponent();

--- a/src/Components/Web/src/Forms/EditForm.cs
+++ b/src/Components/Web/src/Forms/EditForm.cs
@@ -123,9 +123,9 @@ public class EditForm : ComponentBase
         builder.AddMultipleAttributes(1, AdditionalAttributes);
         builder.AddAttribute(2, "onsubmit", _handleSubmitDelegate);
         builder.OpenComponent<CascadingValue<EditContext>>(3);
-        builder.AddAttribute(4, "IsFixed", true);
-        builder.AddAttribute(5, "Value", _editContext);
-        builder.AddAttribute(6, "ChildContent", ChildContent?.Invoke(_editContext));
+        builder.AddComponentParameter(4, "IsFixed", true);
+        builder.AddComponentParameter(5, "Value", _editContext);
+        builder.AddComponentParameter(6, "ChildContent", ChildContent?.Invoke(_editContext));
         builder.CloseComponent();
         builder.CloseElement();
 

--- a/src/Components/Web/src/Forms/InputRadioGroup.cs
+++ b/src/Components/Web/src/Forms/InputRadioGroup.cs
@@ -57,8 +57,8 @@ public class InputRadioGroup<[DynamicallyAccessedMembers(DynamicallyAccessedMemb
         // Note that we must not set IsFixed=true on the CascadingValue, because the mutations to _context
         // are what cause the descendant InputRadio components to re-render themselves
         builder.OpenComponent<CascadingValue<InputRadioContext>>(0);
-        builder.AddAttribute(2, "Value", _context);
-        builder.AddAttribute(3, "ChildContent", ChildContent);
+        builder.AddComponentParameter(2, "Value", _context);
+        builder.AddComponentParameter(3, "ChildContent", ChildContent);
         builder.CloseComponent();
     }
 

--- a/src/Components/Web/src/Head/HeadContent.cs
+++ b/src/Components/Web/src/Head/HeadContent.cs
@@ -21,8 +21,8 @@ public sealed class HeadContent : ComponentBase
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         builder.OpenComponent<SectionContent>(0);
-        builder.AddAttribute(1, nameof(SectionContent.Name), HeadOutlet.HeadSectionOutletName);
-        builder.AddAttribute(2, nameof(SectionContent.ChildContent), ChildContent);
+        builder.AddComponentParameter(1, nameof(SectionContent.Name), HeadOutlet.HeadSectionOutletName);
+        builder.AddComponentParameter(2, nameof(SectionContent.ChildContent), ChildContent);
         builder.CloseComponent();
     }
 }

--- a/src/Components/Web/src/Head/HeadOutlet.cs
+++ b/src/Components/Web/src/Head/HeadOutlet.cs
@@ -37,22 +37,22 @@ public sealed class HeadOutlet : ComponentBase
     {
         // Render the title content
         builder.OpenComponent<SectionOutlet>(0);
-        builder.AddAttribute(1, nameof(SectionOutlet.Name), TitleSectionOutletName);
+        builder.AddComponentParameter(1, nameof(SectionOutlet.Name), TitleSectionOutletName);
         builder.CloseComponent();
 
         // Render the default title if it exists
         if (!string.IsNullOrEmpty(_defaultTitle))
         {
             builder.OpenComponent<SectionContent>(2);
-            builder.AddAttribute(3, nameof(SectionContent.Name), TitleSectionOutletName);
-            builder.AddAttribute(4, nameof(SectionContent.IsDefaultContent), true);
-            builder.AddAttribute(5, nameof(SectionContent.ChildContent), (RenderFragment)BuildDefaultTitleRenderTree);
+            builder.AddComponentParameter(3, nameof(SectionContent.Name), TitleSectionOutletName);
+            builder.AddComponentParameter(4, nameof(SectionContent.IsDefaultContent), true);
+            builder.AddComponentParameter(5, nameof(SectionContent.ChildContent), (RenderFragment)BuildDefaultTitleRenderTree);
             builder.CloseComponent();
         }
 
         // Render the rest of the head metadata
         builder.OpenComponent<SectionOutlet>(6);
-        builder.AddAttribute(7, nameof(SectionOutlet.Name), HeadSectionOutletName);
+        builder.AddComponentParameter(7, nameof(SectionOutlet.Name), HeadSectionOutletName);
         builder.CloseComponent();
     }
 

--- a/src/Components/Web/src/Head/PageTitle.cs
+++ b/src/Components/Web/src/Head/PageTitle.cs
@@ -21,8 +21,8 @@ public sealed class PageTitle : ComponentBase
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         builder.OpenComponent<SectionContent>(0);
-        builder.AddAttribute(1, nameof(SectionContent.Name), HeadOutlet.TitleSectionOutletName);
-        builder.AddAttribute(2, nameof(SectionContent.ChildContent), (RenderFragment)BuildTitleRenderTree);
+        builder.AddComponentParameter(1, nameof(SectionContent.Name), HeadOutlet.TitleSectionOutletName);
+        builder.AddComponentParameter(2, nameof(SectionContent.ChildContent), (RenderFragment)BuildTitleRenderTree);
         builder.CloseComponent();
     }
 

--- a/src/Components/Web/test/Forms/EditFormTest.cs
+++ b/src/Components/Web/test/Forms/EditFormTest.cs
@@ -107,8 +107,8 @@ public class EditFormTest
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
             builder.OpenComponent<EditForm>(0);
-            builder.AddAttribute(1, "Model", Model);
-            builder.AddAttribute(2, "EditContext", EditContext);
+            builder.AddComponentParameter(1, "Model", Model);
+            builder.AddComponentParameter(2, "EditContext", EditContext);
             builder.CloseComponent();
         }
     }

--- a/src/Components/Web/test/Forms/InputRadioTest.cs
+++ b/src/Components/Web/test/Forms/InputRadioTest.cs
@@ -75,8 +75,8 @@ public class InputRadioTest
         foreach (var selectedValue in (TestEnum[])Enum.GetValues(typeof(TestEnum)))
         {
             builder.OpenComponent<TestInputRadio>(0);
-            builder.AddAttribute(1, "Name", name);
-            builder.AddAttribute(2, "Value", selectedValue);
+            builder.AddComponentParameter(1, "Name", name);
+            builder.AddComponentParameter(2, "Value", selectedValue);
             builder.CloseComponent();
         }
     };
@@ -84,14 +84,14 @@ public class InputRadioTest
     private static RenderFragment RadioButtonsWithGroup(string name, Expression<Func<TestEnum>> valueExpression) => (builder) =>
     {
         builder.OpenComponent<InputRadioGroup<TestEnum>>(0);
-        builder.AddAttribute(1, "Name", name);
-        builder.AddAttribute(2, "ValueExpression", valueExpression);
-        builder.AddAttribute(2, "ChildContent", new RenderFragment((childBuilder) =>
+        builder.AddComponentParameter(1, "Name", name);
+        builder.AddComponentParameter(2, "ValueExpression", valueExpression);
+        builder.AddComponentParameter(2, "ChildContent", new RenderFragment((childBuilder) =>
         {
             foreach (var value in (TestEnum[])Enum.GetValues(typeof(TestEnum)))
             {
                 childBuilder.OpenComponent<TestInputRadio>(0);
-                childBuilder.AddAttribute(1, "Value", value);
+                childBuilder.AddComponentParameter(1, "Value", value);
                 childBuilder.CloseComponent();
             }
         }));
@@ -139,8 +139,8 @@ public class InputRadioTest
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
             builder.OpenComponent<CascadingValue<EditContext>>(0);
-            builder.AddAttribute(1, "Value", EditContext);
-            builder.AddAttribute(2, "ChildContent", InnerContent);
+            builder.AddComponentParameter(1, "Value", EditContext);
+            builder.AddComponentParameter(2, "ChildContent", InnerContent);
             builder.CloseComponent();
         }
     }

--- a/src/Components/Web/test/Forms/TestInputHostComponent.cs
+++ b/src/Components/Web/test/Forms/TestInputHostComponent.cs
@@ -22,14 +22,14 @@ internal class TestInputHostComponent<TValue, TComponent> : AutoRenderComponent 
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         builder.OpenComponent<CascadingValue<EditContext>>(0);
-        builder.AddAttribute(1, "Value", EditContext);
-        builder.AddAttribute(2, "ChildContent", new RenderFragment(childBuilder =>
+        builder.AddComponentParameter(1, "Value", EditContext);
+        builder.AddComponentParameter(2, "ChildContent", new RenderFragment(childBuilder =>
         {
             childBuilder.OpenComponent<TComponent>(0);
-            childBuilder.AddAttribute(0, "Value", Value);
-            childBuilder.AddAttribute(1, "ValueChanged",
+            childBuilder.AddComponentParameter(0, "Value", Value);
+            childBuilder.AddComponentParameter(1, "ValueChanged",
                 EventCallback.Factory.Create(this, ValueChanged));
-            childBuilder.AddAttribute(2, "ValueExpression", ValueExpression);
+            childBuilder.AddComponentParameter(2, "ValueExpression", ValueExpression);
             childBuilder.AddMultipleAttributes(3, AdditionalAttributes);
             childBuilder.CloseComponent();
         }));

--- a/src/Components/Web/test/Virtualization/VirtualizeTest.cs
+++ b/src/Components/Web/test/Virtualization/VirtualizeTest.cs
@@ -113,9 +113,9 @@ public class VirtualizeTest
         => builder =>
     {
         builder.OpenComponent<Virtualize<TItem>>(0);
-        builder.AddAttribute(1, "ItemSize", itemSize);
-        builder.AddAttribute(2, "ItemsProvider", itemsProvider);
-        builder.AddAttribute(3, "Items", items);
+        builder.AddComponentParameter(1, "ItemSize", itemSize);
+        builder.AddComponentParameter(2, "ItemsProvider", itemsProvider);
+        builder.AddComponentParameter(3, "Items", items);
 
         if (captureRenderedVirtualize != null)
         {


### PR DESCRIPTION
# Introduce `RenderTreeBuilder.AddComponentParameter()`

Fixes an issue where user-defined implicit conversion operators may cause undesirable `RenderTreeBuilder.AddAttribute()` overloads to be resolved.

## Description

Suppose you have defined the following class:

```csharp
public class Foo
{
    public string Value { get; set; } = string.Empty;
    public static implicit operator string(Foo foo) => foo.Value;
}
```

Now let's say you have a Blazor component `MyComponent` that has a parameter of type `Foo`. The generated `RenderTreeBuilder.AddAttribute(...)` call to set the parameter value will look something like this:

```csharp
// ...
__builder.AddAttribute(1, "Foo", _foo); // '_foo' is of type 'Foo' here
```

We want the `AddAttribute(int sequence, string name, object? value)` overload to be resolved, but since `Foo` defines an implicit conversion to `string`, the `AddAttribute(int sequence, string name, string value)` overload gets resolved instead. As a result, the framework later tries to set the component parameter of type `Foo` to a value of type `string`, and an exception is thrown. 

To solve this problem, this PR adds an `AddComponentParameter(int sequence, string name, object? value)` method to `RenderTreeBuilder`. There is only one overload to choose from, so we don't experience the same problem as we did with `AddAttribute()`. Also, since component parameter values always get boxed eventually (to be added to a `RenderTreeFrame`), we're not losing anything by performing the boxing earlier.

A corresponding change will have to be made in the Razor compiler so that generated code makes use of the new `AddComponentParameter()` method.

## Validation

- [X] Manual
- [X] Automated tests

Contributes to #18042
