### PR TITLE
Don't clobber non-default status codes in static files middleware

### DIFF
--- a/src/Middleware/StaticFiles/src/StaticFileContext.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileContext.cs
@@ -242,7 +242,11 @@ internal struct StaticFileContext
 
     public Task ApplyResponseHeadersAsync(int statusCode)
     {
-        _response.StatusCode = statusCode;
+        // Only clobber the default status (e.g. in cases this a status code pages retry)
+        if (_response.StatusCode == StatusCodes.Status200OK)
+        {
+            _response.StatusCode = statusCode;
+        }
         if (statusCode < 400)
         {
             // these headers are returned for 200, 206, and 304

--- a/src/Middleware/StaticFiles/test/UnitTests/StaticFileMiddlewareTests.cs
+++ b/src/Middleware/StaticFiles/test/UnitTests/StaticFileMiddlewareTests.cs
@@ -414,6 +414,55 @@ public class StaticFileMiddlewareTests : LoggedTest
         }
     }
 
+    [Fact]
+    public async Task OverrideDefaultStatusCode()
+    {
+        using var host = await StaticFilesTestServer.Create(app =>
+        {
+            app.Use(next => context => 
+            {
+                context.Response.StatusCode = StatusCodes.Status200OK;
+                return next(context);
+            });
+            app.UseStaticFiles();
+        });
+
+        using var server = host.GetTestServer();
+        var response = await server.CreateClient().GetAsync("/");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    /// <remarks>
+    /// Note that the status code *might* be overridden if the static files middleware
+    /// delegates to `next` (e.g. if the file isn't found and hits the 404 middleware).
+    /// </remarks>
+    [Fact]
+    public async Task DontOverrideNonDefaultStatusCode()
+    {
+        const HttpStatusCode errorCode = HttpStatusCode.InsufficientStorage;
+
+        using var fileProvider = new PhysicalFileProvider(Path.Combine(AppContext.BaseDirectory, "."));
+
+        using var host = await StaticFilesTestServer.Create(app =>
+        {
+            app.Use(next => context =>
+            {
+                context.Response.StatusCode = (int)errorCode;
+                return next(context);
+            });
+
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                RequestPath = new PathString(),
+                FileProvider = fileProvider
+            });
+        });
+
+        using var server = host.GetTestServer();
+        var response = await server.CreateClient().GetAsync("/TestDocument.txt");
+        Assert.Equal(errorCode, response.StatusCode);
+    }
+
     [Theory]
     [MemberData(nameof(ExistingFiles))]
     public async Task HeadFile_HeadersButNotBodyServed(string baseUrl, string baseDir, string requestUrl)


### PR DESCRIPTION
# Don't clobber non-default status codes in static files middleware

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

If the static files middleware sees a status code of 200, it can set its own - otherwise, it should leave it as-is.

## Description

When the status code page middleware requests a static error page, it's important that the overall status code remain unchanged, rather than being set to 200 to indicate that the _error page_ was retrieved correctly.

Fixes #40518
