### PR TITLE
Update CreateSlimBuilder to use Host.CreateEmptyApplicationBuilder.

### DIFF
--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -565,24 +565,22 @@ public class WebApplicationTests
     public void ContentRootIsDefaultedToCurrentDirectory()
     {
         var tmpDir = Directory.CreateTempSubdirectory();
-        // On macOS /tmp is a symlink to /private/tmp. Resolve any links so the path comparison works correctly.
-        var tmpDirectoryPath = tmpDir.LinkTarget ?? tmpDir.FullName;
 
         try
         {
             var options = new RemoteInvokeOptions();
-            options.StartInfo.WorkingDirectory = tmpDirectoryPath;
+            options.StartInfo.WorkingDirectory = tmpDir.FullName;
 
-            using var remoteHandle = RemoteExecutor.Invoke(static (string currentDirectory) =>
+            using var remoteHandle = RemoteExecutor.Invoke(static () =>
             {
                 foreach (object[] data in CreateBuilderFuncs)
                 {
                     var createBuilder = (CreateBuilderFunc)data[0];
                     var builder = createBuilder();
 
-                    Assert.Equal(NormalizePath(currentDirectory), NormalizePath(builder.Environment.ContentRootPath));
+                    Assert.Equal(NormalizePath(Environment.CurrentDirectory), NormalizePath(builder.Environment.ContentRootPath));
                 }
-            }, tmpDirectoryPath, options);
+            }, options);
         }
         finally
         {

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -565,11 +565,13 @@ public class WebApplicationTests
     public void ContentRootIsDefaultedToCurrentDirectory()
     {
         var tmpDir = Directory.CreateTempSubdirectory();
+        // On macOS /tmp is a symlink to /private/tmp. Resolve any links so the path comparison works correctly.
+        var tmpDirectoryPath = tmpDir.LinkTarget ?? tmpDir.FullName;
 
         try
         {
             var options = new RemoteInvokeOptions();
-            options.StartInfo.WorkingDirectory = tmpDir.FullName;
+            options.StartInfo.WorkingDirectory = tmpDirectoryPath;
 
             using var remoteHandle = RemoteExecutor.Invoke(static (string currentDirectory) =>
             {
@@ -580,7 +582,7 @@ public class WebApplicationTests
 
                     Assert.Equal(NormalizePath(currentDirectory), NormalizePath(builder.Environment.ContentRootPath));
                 }
-            }, tmpDir.FullName, options);
+            }, tmpDirectoryPath, options);
         }
         finally
         {


### PR DESCRIPTION
Also fix 2 existing bugs:
1. ContentRootPath is set to the app's BaseDirectory, and not CurrentWorkingDirectory. Default to CWD by using the same logic as HostApplicationBuilder.
2. Add un-prefixed environment variables to the configuration, and ensure the configuration order is the same as WebApplication.CreateBuilder.

Fix #46293