### PR TITLE
Framework.Tests: support running against Linux build artifacts.

### DIFF
--- a/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
+++ b/src/Framework/test/Microsoft.AspNetCore.App.UnitTests.csproj
@@ -18,15 +18,15 @@
     <!-- Ignore aspnetcorev2_inprocess because tests expect only managed assemblies in this item group. -->
     <_SharedFrameworkBinariesFromRepo Include="@(AspNetCoreAppReference);@(AspNetCoreAppReferenceAndPackage)" />
 
+    <_ExpectedSharedFrameworkBinaries Include="@(_SharedFrameworkBinariesFromRepo);
+        @(ExternalAspNetCoreAppReference);
+        @(_TransitiveExternalAspNetCoreAppReference)" />
     <!--
       Special-case System.Diagnostics.EventLog.Messages.dll because that assembly name does _not_ match a
       package. Can't mention it in @(ExternalAspNetCoreAppReference) or underlying
       @(_TransitiveExternalAspNetCoreAppReference) without thoroughly confusing eng/targets/ResolveReferences.targets.
     -->
-    <_ExpectedSharedFrameworkBinaries Include="@(_SharedFrameworkBinariesFromRepo);
-        @(ExternalAspNetCoreAppReference);
-        @(_TransitiveExternalAspNetCoreAppReference);
-        System.Diagnostics.EventLog.Messages" />
+    <_ExpectedSharedFrameworkBinaries Condition="'$(TargetOsName)' == 'win'" Include="System.Diagnostics.EventLog.Messages" />
     <_ExpectedSharedFrameworkBinaries Condition="'$(TargetOsName)' == 'win' AND '$(TargetArchitecture)' != 'arm'" Include="aspnetcorev2_inprocess" />
 
     <AssemblyAttribute Include="Microsoft.AspNetCore.TestData">

--- a/src/Framework/test/SharedFxTests.cs
+++ b/src/Framework/test/SharedFxTests.cs
@@ -324,10 +324,8 @@ public class SharedFxTests
         var packageFolder = SkipOnHelixAttribute.OnHelix() ?
             Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") :
             TestData.GetPackagesFolder();
-        var sharedFxPath = Path.Combine(
-            packageFolder,
-            "Microsoft.AspNetCore.App.Runtime.win-x64." + TestData.GetSharedFxVersion() + ".nupkg");
-        AssertEx.FileExists(sharedFxPath);
+        var sharedFxPath = Directory.GetFiles(packageFolder, "Microsoft.AspNetCore.App.Runtime.*-x64." + TestData.GetSharedFxVersion() + ".nupkg").FirstOrDefault();
+        Assert.NotNull(sharedFxPath);
 
         ZipArchive archive = ZipFile.OpenRead(sharedFxPath);
 

--- a/src/Framework/test/SharedFxTests.cs
+++ b/src/Framework/test/SharedFxTests.cs
@@ -324,7 +324,7 @@ public class SharedFxTests
         var packageFolder = SkipOnHelixAttribute.OnHelix() ?
             Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") :
             TestData.GetPackagesFolder();
-        var sharedFxPath = Directory.GetFiles(packageFolder, "Microsoft.AspNetCore.App.Runtime.*-x64." + TestData.GetSharedFxVersion() + ".nupkg").FirstOrDefault();
+        var sharedFxPath = Directory.GetFiles(packageFolder, "Microsoft.AspNetCore.App.Runtime.*-*." + TestData.GetSharedFxVersion() + ".nupkg").FirstOrDefault();
         Assert.NotNull(sharedFxPath);
 
         ZipArchive archive = ZipFile.OpenRead(sharedFxPath);

--- a/src/Framework/test/TestData.cs
+++ b/src/Framework/test/TestData.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Microsoft.AspNetCore.Testing;
 
 namespace Microsoft.AspNetCore;
 
@@ -156,7 +157,8 @@ public static class TestData
             };
 
         // System.Diagnostics.EventLog.Messages is only present in the Windows build.
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+            !SkipOnHelixAttribute.OnHelix()) // Helix tests always run against the Windows assets (even on non-Windows)
         {
             ListedSharedFxAssemblies.Remove("System.Diagnostics.EventLog.Messages");
         }

--- a/src/Framework/test/TestData.cs
+++ b/src/Framework/test/TestData.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.AspNetCore;
 
@@ -153,6 +154,12 @@ public static class TestData
                 "System.Security.Cryptography.Xml",
                 "System.Threading.RateLimiting",
             };
+
+        // System.Diagnostics.EventLog.Messages is only present in the Windows build.
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            ListedSharedFxAssemblies.Remove("System.Diagnostics.EventLog.Messages");
+        }
 
         ListedTargetingPackAssemblies = new List<string>
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/46524.

@dougbu ptal.

These are the changes that make the tests pass for a local build.

Can we make it so that the aspnetcore CI when running on X will consume the binaries built for X?
Or will CI keep on running these tests against Windows build artifacts only?

In what files should I make the changes for `HELIX_WORKITEM_ROOT`?

cc @omajid 