### PR TITLE
Skip test until Debian12 supports msquic

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
@@ -26,6 +26,7 @@ public class WebHostTests : LoggedTest
     [ConditionalFact]
     [SkipOnAlpine("https://github.com/dotnet/aspnetcore/issues/46537")]
     [SkipOnMariner("https://github.com/dotnet/aspnetcore/issues/46537")]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/46418", Queues = "Debian.12.Arm64.Open;")]
     [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "HTTP/3 isn't supported on MacOS.")]
     [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win11_21H2)]
     public async Task PlatformSmoketest_HelloWorld_ClientSuccess()

--- a/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
@@ -26,7 +26,7 @@ public class WebHostTests : LoggedTest
     [ConditionalFact]
     [SkipOnAlpine("https://github.com/dotnet/aspnetcore/issues/46537")]
     [SkipOnMariner("https://github.com/dotnet/aspnetcore/issues/46537")]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/46418", Queues = "Debian.12.Arm64.Open;")]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/46616", Queues = "Debian.12.Arm64.Open;")]
     [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "HTTP/3 isn't supported on MacOS.")]
     [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win11_21H2)]
     public async Task PlatformSmoketest_HelloWorld_ClientSuccess()


### PR DESCRIPTION
# Skip test until Debian12 supports msquic

The addition of https://github.com/dotnet/aspnetcore/pull/46523 missed Debian12, which does not currently support msquic. Updating the test so that it skips that queue until msquic is available.

Related: https://github.com/dotnet/aspnetcore/issues/46418