### PR TITLE
Fix Blazor WebAssembly load percentage

### DIFF
--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -295,7 +295,6 @@ async function createEmscriptenModuleInstance(resourceLoader: WebAssemblyResourc
       'globalization'
     );
     totalResources.push(timeZoneResource);
-    timeZoneResource.response.then(_ => setProgress());
   }
 
   let icuDataResource: LoadingResource | undefined;
@@ -309,7 +308,6 @@ async function createEmscriptenModuleInstance(resourceLoader: WebAssemblyResourc
       'globalization'
     );
     totalResources.push(icuDataResource);
-    icuDataResource.response.then(_ => setProgress());
   }
 
   totalResources.forEach(loadingResource => loadingResource.response.then(_ => setProgress()));

--- a/src/Components/test/testassets/BasicTestApp/wwwroot/index.html
+++ b/src/Components/test/testassets/BasicTestApp/wwwroot/index.html
@@ -16,7 +16,9 @@
 </head>
 
 <body>
-    <root>Loading...</root>
+    <root>
+        <span class="loading-progress-text">Loading...</span>
+    </root>
 
     <!-- Explicit display:none required so StartupErrorNotificationTest can observe it change -->
     <div id="blazor-error-ui" style="display: none;">

--- a/src/Components/test/testassets/BasicTestApp/wwwroot/style.css
+++ b/src/Components/test/testassets/BasicTestApp/wwwroot/style.css
@@ -39,3 +39,7 @@
     .blazor-error-boundary::after {
         content: "An error has occurred."
     }
+
+.loading-progress-text::after {
+    content: var(--blazor-load-percentage-text);
+}


### PR DESCRIPTION
# Fix Blazor WebAssembly load percentage

Fixes an issue where the `--blazor-load-percentage` CSS variable exceeded 100%. This was caused by ICU and time zone resources getting double-counted when calculating loading progress.

This PR also updates the test app to utilize `--blazor-load-percentage-text` to make it easier to identify if this bug is reintroduced.

Fixes https://github.com/aspnet/AspNetCore-ManualTests/issues/1874
