### PR TITLE
gRPC JSON transcoding: Fix not supporting JSON name in querystring names

### DIFF
--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Binding/JsonTranscodingProviderServiceBinder.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Binding/JsonTranscodingProviderServiceBinder.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Google.Api;
 using Google.Protobuf.Reflection;
 using Grpc.AspNetCore.Server;

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonRequestHelpers.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonRequestHelpers.cs
@@ -335,7 +335,7 @@ internal static class JsonRequestHelpers
     {
         return serverCallContext.DescriptorInfo.PathDescriptorsCache.GetOrAdd(path, p =>
         {
-            ServiceDescriptorHelpers.TryResolveDescriptors(requestMessage.Descriptor, p.Split('.'), out var pathDescriptors);
+            ServiceDescriptorHelpers.TryResolveDescriptors(requestMessage.Descriptor, p.Split('.'), allowJsonName: true, out var pathDescriptors);
             return pathDescriptors;
         });
     }

--- a/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
@@ -104,6 +104,7 @@ internal static class ServiceDescriptorHelpers
     {
         // Search fields by field name and JSON name.
         // JSON name takes precedence. If there are conflicts then the last field with a name wins.
+        // This logic matches how properties are used in JSON serialization's MessageTypeInfoResolver.
         var fields = messageDescriptor.Fields.InFieldNumberOrder();
 
         FieldDescriptor? fieldDescriptor = null;

--- a/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
@@ -74,7 +74,7 @@ internal static class ServiceDescriptorHelpers
             if (currentDescriptor != null)
             {
                 field = allowJsonName
-                    ? GetFieldByName(messageDescriptor, fieldName)
+                    ? GetFieldByName(currentDescriptor, fieldName)
                     : currentDescriptor.FindFieldByName(fieldName);
             }
 

--- a/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
@@ -102,13 +102,15 @@ internal static class ServiceDescriptorHelpers
 
     private static FieldDescriptor? GetFieldByName(MessageDescriptor messageDescriptor, string fieldName)
     {
-        // JSON name takes precedence. Last field wins.
+        // Search fields by field name and JSON name.
+        // JSON name takes precedence. If there are conflicts then the last field with a name wins.
         var fields = messageDescriptor.Fields.InFieldNumberOrder();
 
         FieldDescriptor? fieldDescriptor = null;
         for (var i = fields.Count - 1; i >= 0; i--)
         {
-            // Exit early on match because we're checking JSON name first, in reverse order through fields.
+            // We're checking JSON name first, in reverse order through fields.
+            // That means the method can exit early on match because the match has the highest precedence.
             var field = fields[i];
             if (field.JsonName == fieldName)
             {

--- a/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
@@ -25,7 +25,6 @@ using Google.Api;
 using Google.Protobuf;
 using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
-using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;
 using Microsoft.Extensions.Primitives;
 using Type = System.Type;
 

--- a/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
@@ -102,8 +102,8 @@ internal static class ServiceDescriptorHelpers
 
     private static FieldDescriptor? GetFieldByName(MessageDescriptor messageDescriptor, string fieldName)
     {
-        // Search fields by field name and JSON name.
-        // JSON name takes precedence. If there are conflicts then the last field with a name wins.
+        // Search fields by field name and JSON name. Both names can be referenced.
+        // If there are conflicts, then the last field with a name wins.
         // This logic matches how properties are used in JSON serialization's MessageTypeInfoResolver.
         var fields = messageDescriptor.Fields.InFieldNumberOrder();
 

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
@@ -27,11 +27,23 @@ public class JsonConverterReadTests
     public void NonJsonName()
     {
         var json = @"{
+  ""hiding_field_name"": ""A field name""
+}";
+
+        var m = AssertReadJson<HelloRequest>(json);
+        Assert.Equal("A field name", m.HidingFieldName);
+    }
+
+    [Fact]
+    public void HidingJsonName()
+    {
+        var json = @"{
   ""field_name"": ""A field name""
 }";
 
         var m = AssertReadJson<HelloRequest>(json);
-        Assert.Equal("A field name", m.FieldName);
+        Assert.Equal("", m.FieldName);
+        Assert.Equal("A field name", m.HidingFieldName);
     }
 
     [Fact]

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/transcoding.proto
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/transcoding.proto
@@ -198,9 +198,9 @@ message HelloRequest {
   google.protobuf.ListValue list_value = 19;
   google.protobuf.NullValue null_value = 20;
   google.protobuf.FieldMask field_mask_value = 21;
-  string hidden_field_name = 22 [json_name="json_customized_name"];
-  string field_name = 23 [json_name="json_customized_name"];
-  google.protobuf.FloatValue float_value = 24;
+  string field_name = 22 [json_name="json_customized_name"];
+  google.protobuf.FloatValue float_value = 23;
+  string hiding_field_name = 24 [json_name="field_name"];
 }
 
 message HelloReply {

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/transcoding.proto
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/transcoding.proto
@@ -198,8 +198,9 @@ message HelloRequest {
   google.protobuf.ListValue list_value = 19;
   google.protobuf.NullValue null_value = 20;
   google.protobuf.FieldMask field_mask_value = 21;
-  string field_name = 22 [json_name="json_customized_name"];
-  google.protobuf.FloatValue float_value = 23;
+  string hidden_field_name = 22 [json_name="json_customized_name"];
+  string field_name = 23 [json_name="json_customized_name"];
+  google.protobuf.FloatValue float_value = 24;
 }
 
 message HelloReply {

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/UnaryServerCallHandlerTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/UnaryServerCallHandlerTests.cs
@@ -338,6 +338,58 @@ public class UnaryServerCallHandlerTests : LoggedTest
     }
 
     [Fact]
+    public async Task HandleCallAsync_MatchingQueryStringValues_JsonName_SetOnRequestMessage()
+    {
+        // Arrange
+        HelloRequest? request = null;
+        UnaryServerMethod<JsonTranscodingGreeterService, HelloRequest, HelloReply> invoker = (s, r, c) =>
+        {
+            request = r;
+            return Task.FromResult(new HelloReply());
+        };
+
+        var unaryServerCallHandler = CreateCallHandler(invoker);
+        var httpContext = TestHelpers.CreateHttpContext();
+        httpContext.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+        {
+            ["json_customized_name"] = "TestName!"
+        });
+
+        // Act
+        await unaryServerCallHandler.HandleCallAsync(httpContext);
+
+        // Assert
+        Assert.NotNull(request);
+        Assert.Equal("TestName!", request!.FieldName);
+    }
+
+    [Fact]
+    public async Task HandleCallAsync_MatchingQueryStringValues_JsonNameAndValueObject_SetOnRequestMessage()
+    {
+        // Arrange
+        HelloRequest? request = null;
+        UnaryServerMethod<JsonTranscodingGreeterService, HelloRequest, HelloReply> invoker = (s, r, c) =>
+        {
+            request = r;
+            return Task.FromResult(new HelloReply());
+        };
+
+        var unaryServerCallHandler = CreateCallHandler(invoker);
+        var httpContext = TestHelpers.CreateHttpContext();
+        httpContext.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+        {
+            ["float_value"] = "1.1"
+        });
+
+        // Act
+        await unaryServerCallHandler.HandleCallAsync(httpContext);
+
+        // Assert
+        Assert.NotNull(request);
+        Assert.Equal(1.1f, request!.FloatValue);
+    }
+
+    [Fact]
     public async Task HandleCallAsync_SuccessfulResponse_DefaultValuesInResponseJson()
     {
         // Arrange
@@ -414,7 +466,7 @@ public class UnaryServerCallHandlerTests : LoggedTest
             return Task.FromResult(new HelloReply());
         };
 
-        ServiceDescriptorHelpers.TryResolveDescriptors(HelloRequest.Descriptor, new[] { "repeated_strings" }, out var bodyFieldDescriptors);
+        ServiceDescriptorHelpers.TryResolveDescriptors(HelloRequest.Descriptor, new[] { "repeated_strings" }, allowJsonName: false, out var bodyFieldDescriptors);
 
         var descriptorInfo = TestHelpers.CreateDescriptorInfo(
             bodyDescriptor: HelloRequest.Types.SubMessage.Descriptor,

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/UnaryServerCallHandlerTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/UnaryServerCallHandlerTests.cs
@@ -361,6 +361,7 @@ public class UnaryServerCallHandlerTests : LoggedTest
         // Assert
         Assert.NotNull(request);
         Assert.Equal("TestName!", request!.FieldName);
+        Assert.Equal("", request!.HiddenFieldName);
     }
 
     [Fact]

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/UnaryServerCallHandlerTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/UnaryServerCallHandlerTests.cs
@@ -361,7 +361,6 @@ public class UnaryServerCallHandlerTests : LoggedTest
         // Assert
         Assert.NotNull(request);
         Assert.Equal("TestName!", request!.FieldName);
-        Assert.Equal("", request!.HiddenFieldName);
     }
 
     [Fact]
@@ -388,6 +387,33 @@ public class UnaryServerCallHandlerTests : LoggedTest
         // Assert
         Assert.NotNull(request);
         Assert.Equal(1.1f, request!.FloatValue);
+    }
+
+    [Fact]
+    public async Task HandleCallAsync_MatchingQueryStringValues_JsonNameHidesFieldName_SetOnRequestMessage()
+    {
+        // Arrange
+        HelloRequest? request = null;
+        UnaryServerMethod<JsonTranscodingGreeterService, HelloRequest, HelloReply> invoker = (s, r, c) =>
+        {
+            request = r;
+            return Task.FromResult(new HelloReply());
+        };
+
+        var unaryServerCallHandler = CreateCallHandler(invoker);
+        var httpContext = TestHelpers.CreateHttpContext();
+        httpContext.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+        {
+            ["field_name"] = "TestName!"
+        });
+
+        // Act
+        await unaryServerCallHandler.HandleCallAsync(httpContext);
+
+        // Assert
+        Assert.NotNull(request);
+        Assert.Equal("", request!.FieldName);
+        Assert.Equal("TestName!", request!.HidingFieldName);
     }
 
     [Fact]

--- a/src/Grpc/JsonTranscoding/test/testassets/Sandbox/greet.proto
+++ b/src/Grpc/JsonTranscoding/test/testassets/Sandbox/greet.proto
@@ -3,6 +3,7 @@
 
 syntax = "proto3";
 
+import "google/protobuf/field_mask.proto";
 import "google/api/annotations.proto";
 
 package greet;
@@ -23,11 +24,15 @@ service Greeter {
 
 message HelloRequest {
   string name = 1;
+  google.protobuf.FieldMask read_mask = 2;
+  string full_name = 3;
+  google.protobuf.FieldMask mask = 4;
 }
 
 message HelloRequestFrom {
   string name = 1;
   string from = 2;
+  string full_name = 3;
 }
 
 message HelloReply {

--- a/src/Grpc/JsonTranscoding/test/testassets/Sandbox/greet.proto
+++ b/src/Grpc/JsonTranscoding/test/testassets/Sandbox/greet.proto
@@ -3,7 +3,6 @@
 
 syntax = "proto3";
 
-import "google/protobuf/field_mask.proto";
 import "google/api/annotations.proto";
 
 package greet;
@@ -24,15 +23,11 @@ service Greeter {
 
 message HelloRequest {
   string name = 1;
-  google.protobuf.FieldMask read_mask = 2;
-  string full_name = 3;
-  google.protobuf.FieldMask mask = 4;
 }
 
 message HelloRequestFrom {
   string name = 1;
   string from = 2;
-  string full_name = 3;
 }
 
 message HelloReply {


### PR DESCRIPTION
Partially addresses https://github.com/dotnet/aspnetcore/issues/45753 (the issue reports two bugs)

Message fields have two names: the internal field name, which is conventionally `underscore_case`, and the JSON name, which is conventionally `camelCase`. The JSON name can be specified manually or automatically calculated from the field name, e.g. `full_name` -> `fullName`.

gRPC JSON transcoding supports binding query string values to message fields. The query string name can be either the field or JSON name. JSON names were not supported. This PR fixes that.