### PR TITLE
gRPC JSON transcoding: Fix known type messages in querystring values

### DIFF
--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/DurationConverter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/DurationConverter.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using Grpc.Shared;
 using Type = System.Type;
 
 namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/EnumConverter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/EnumConverter.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Google.Protobuf.Reflection;
+using Grpc.Shared;
 using Type = System.Type;
 
 namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/FieldMaskConverter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/FieldMaskConverter.cs
@@ -43,7 +43,7 @@ internal sealed class FieldMaskConverter<TMessage> : SettingsConverterBase<TMess
         var firstInvalid = paths.FirstOrDefault(p => !Legacy.IsPathValid(p));
         if (firstInvalid == null)
         {
-            writer.WriteStringValue(string.Join(",", paths.Select(Legacy.ToJsonName)));
+            writer.WriteStringValue(Legacy.GetFieldMaskText(paths));
         }
         else
         {

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/FieldMaskConverter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/FieldMaskConverter.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text.Json;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using Grpc.Shared;
 using Type = System.Type;
 
 namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/TimestampConverter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/TimestampConverter.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using Grpc.Shared;
 using Type = System.Type;
 
 namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Microsoft.AspNetCore.Grpc.JsonTranscoding.csproj
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Microsoft.AspNetCore.Grpc.JsonTranscoding.csproj
@@ -23,6 +23,7 @@
     <Compile Include="..\Shared\X509CertificateHelpers.cs" Link="Internal\Shared\X509CertificateHelpers.cs" />
     <Compile Include="..\Shared\HttpRoutePattern.cs" Link="Internal\Shared\HttpRoutePattern.cs" />
     <Compile Include="..\Shared\HttpRoutePatternParser.cs" Link="Internal\Shared\HttpRoutePatternParser.cs" />
+    <Compile Include="..\Shared\Legacy.cs" Link="Internal\Shared\Legacy.cs" />
     <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" LinkBase="Internal\Shared" />
 
     <Reference Include="Google.Api.CommonProtos" />

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.Swagger/Microsoft.AspNetCore.Grpc.Swagger.csproj
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.Swagger/Microsoft.AspNetCore.Grpc.Swagger.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Swagger for gRPC ASP.NET Core</Description>
     <PackageTags>gRPC RPC HTTP/2 REST Swagger OpenAPI</PackageTags>
@@ -12,6 +12,7 @@
     <Compile Include="..\Shared\ServiceDescriptorHelpers.cs" Link="Internal\Shared\ServiceDescriptorHelpers.cs" />
     <Compile Include="..\Shared\HttpRoutePattern.cs" Link="Internal\Shared\HttpRoutePattern.cs" />
     <Compile Include="..\Shared\HttpRoutePatternParser.cs" Link="Internal\Shared\HttpRoutePatternParser.cs" />
+    <Compile Include="..\Shared\Legacy.cs" Link="Internal\Shared\Legacy.cs" />
 
     <Reference Include="Microsoft.AspNetCore.Grpc.JsonTranscoding" />
     <Reference Include="Swashbuckle.AspNetCore" />

--- a/src/Grpc/JsonTranscoding/src/Shared/Legacy.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/Legacy.cs
@@ -237,6 +237,11 @@ internal static class Legacy
         }
     }
 
+    public static string GetFieldMaskText(IList<string> paths)
+    {
+        return string.Join(",", paths.Select(ToJsonName));
+    }
+
     /// <summary>
     /// Appends a number of nanoseconds to a StringBuilder. Either 0 digits are added (in which
     /// case no "." is appended), or 3 6 or 9 digits. This is internal for use in Timestamp as well

--- a/src/Grpc/JsonTranscoding/src/Shared/Legacy.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/Legacy.cs
@@ -42,7 +42,7 @@ using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
 using Type = System.Type;
 
-namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;
+namespace Grpc.Shared;
 
 // Source here is from https://github.com/protocolbuffers/protobuf
 // Most of this code will be replaced over time with optimized implementations.

--- a/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
@@ -25,7 +25,6 @@ using Google.Api;
 using Google.Protobuf;
 using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
-using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;
 using Microsoft.Extensions.Primitives;
 using Type = System.Type;
 

--- a/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
+++ b/src/Grpc/JsonTranscoding/src/Shared/ServiceDescriptorHelpers.cs
@@ -25,6 +25,7 @@ using Google.Api;
 using Google.Protobuf;
 using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
+using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;
 using Microsoft.Extensions.Primitives;
 using Type = System.Type;
 
@@ -180,14 +181,39 @@ internal static class ServiceDescriptorHelpers
                     throw new InvalidOperationException("String required to convert to enum.");
                 }
             case FieldType.Message:
-                if (IsWrapperType(descriptor.MessageType))
+                if (IsWellKnownType(descriptor.MessageType))
                 {
-                    if (value == null)
+                    if (IsWrapperType(descriptor.MessageType))
                     {
-                        return null;
-                    }
+                        if (value == null)
+                        {
+                            return null;
+                        }
 
-                    return ConvertValue(value, descriptor.MessageType.FindFieldByName("value"));
+                        return ConvertValue(value, descriptor.MessageType.FindFieldByName("value"));
+                    }
+                    else if (descriptor.MessageType.FullName == FieldMask.Descriptor.FullName)
+                    {
+                        return FieldMask.FromString((string)value!);
+                    }
+                    else if (descriptor.MessageType.FullName == Duration.Descriptor.FullName)
+                    {
+                        var (seconds, nanos) = Legacy.ParseDuration((string)value!);
+
+                        var duration = new Duration();
+                        duration.Seconds = seconds;
+                        duration.Nanos = nanos;
+                        return duration;
+                    }
+                    else if (descriptor.MessageType.FullName == Timestamp.Descriptor.FullName)
+                    {
+                        var (seconds, nanos) = Legacy.ParseTimestamp((string)value!);
+
+                        var timestamp = new Timestamp();
+                        timestamp.Seconds = seconds;
+                        timestamp.Nanos = nanos;
+                        return timestamp;
+                    }
                 }
                 break;
         }
@@ -279,7 +305,7 @@ internal static class ServiceDescriptorHelpers
         }
     }
 
-    public static bool TryGetHttpRule(MethodDescriptor methodDescriptor, [NotNullWhen(true)]out HttpRule? httpRule)
+    public static bool TryGetHttpRule(MethodDescriptor methodDescriptor, [NotNullWhen(true)] out HttpRule? httpRule)
     {
         var options = methodDescriptor.GetOptions();
         httpRule = options?.GetExtension(AnnotationsExtensions.Http);
@@ -287,7 +313,7 @@ internal static class ServiceDescriptorHelpers
         return httpRule != null;
     }
 
-    public static bool TryResolvePattern(HttpRule http, [NotNullWhen(true)]out string? pattern, [NotNullWhen(true)]out string? verb)
+    public static bool TryResolvePattern(HttpRule http, [NotNullWhen(true)] out string? pattern, [NotNullWhen(true)] out string? verb)
     {
         switch (http.PatternCase)
         {
@@ -456,14 +482,21 @@ internal static class ServiceDescriptorHelpers
                     case FieldType.SInt32:
                     case FieldType.SInt64:
                     case FieldType.Enum:
-                        var joinedPath = string.Join(".", path.Select(d => d.JsonName));
-                        queryParameters[joinedPath] = fieldDescriptor;
+                        {
+                            var joinedPath = string.Join(".", path.Select(d => d.JsonName));
+                            queryParameters[joinedPath] = fieldDescriptor;
+                        }
                         break;
                     case FieldType.Group:
                     case FieldType.Message:
                     default:
                         // Complex repeated fields aren't valid query parameters.
-                        if (!fieldDescriptor.IsRepeated)
+                        if (IsCustomType(fieldDescriptor.MessageType))
+                        {
+                            var joinedPath = string.Join(".", path.Select(d => d.JsonName));
+                            queryParameters[joinedPath] = fieldDescriptor;
+                        }
+                        else if (!fieldDescriptor.IsRepeated)
                         {
                             RecursiveVisitMessages(queryParameters, existingParameters, fieldDescriptor.MessageType, path);
                         }
@@ -474,6 +507,23 @@ internal static class ServiceDescriptorHelpers
                 path.RemoveAt(path.Count - 1);
             }
         }
+    }
+
+    private static bool IsCustomType(MessageDescriptor messageDescriptor)
+    {
+        // The messages flags here should be kept in sync with GrpcDataContractResolver.TryCustomizeMessage.
+        if (IsWrapperType(messageDescriptor) ||
+            messageDescriptor.FullName == Timestamp.Descriptor.FullName ||
+            messageDescriptor.FullName == Duration.Descriptor.FullName ||
+            messageDescriptor.FullName == FieldMask.Descriptor.FullName ||
+            messageDescriptor.FullName == Struct.Descriptor.FullName ||
+            messageDescriptor.FullName == ListValue.Descriptor.FullName ||
+            messageDescriptor.FullName == Value.Descriptor.FullName ||
+            messageDescriptor.FullName == Any.Descriptor.FullName)
+        {
+            return true;
+        }
+        return false;
     }
 
     public sealed record BodyDescriptorInfo(

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/UnaryServerCallHandlerTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/UnaryServerCallHandlerTests.cs
@@ -1309,6 +1309,70 @@ public class UnaryServerCallHandlerTests : LoggedTest
         Assert.Equal("A value!", anyMessage.GetProperty("value").GetString());
     }
 
+    [Fact]
+    public async Task HandleCallAsync_MatchingQueryStringValues_CustomDeserialization_SetOnRequestMessage()
+    {
+        // Arrange
+        HelloRequest? request = null;
+        UnaryServerMethod<JsonTranscodingGreeterService, HelloRequest, HelloReply> invoker = (s, r, c) =>
+        {
+            request = r;
+            return Task.FromResult(new HelloReply());
+        };
+
+        var timestamp = Timestamp.FromDateTimeOffset(new DateTimeOffset(2023, 2, 14, 17, 32, 0, TimeSpan.FromHours(8)));
+        var duration = Duration.FromTimeSpan(TimeSpan.FromHours(1));
+        var fieldmask = FieldMask.FromString("one,two,three.sub");
+
+        var unaryServerCallHandler = CreateCallHandler(invoker);
+        var httpContext = TestHelpers.CreateHttpContext();
+        httpContext.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+        {
+            ["timestamp_value"] = Legacy.GetTimestampText(timestamp.Nanos, timestamp.Seconds),
+            ["duration_value"] = Legacy.GetDurationText(duration.Nanos, duration.Seconds),
+            ["field_mask_value"] = Legacy.GetFieldMaskText(fieldmask.Paths),
+            ["float_value"] = "1.5"
+        });
+
+        // Act
+        await unaryServerCallHandler.HandleCallAsync(httpContext);
+
+        // Assert
+        Assert.NotNull(request);
+        Assert.Equal(timestamp, request!.TimestampValue);
+        Assert.Equal(duration, request!.DurationValue);
+        Assert.Equal(fieldmask, request!.FieldMaskValue);
+        Assert.Equal(1.5f, request!.FloatValue);
+    }
+
+    [Fact]
+    public async Task HandleCallAsync_MatchingQueryStringValues_KnownType_FieldSetter_SetOnRequestMessage()
+    {
+        // Arrange
+        HelloRequest? request = null;
+        UnaryServerMethod<JsonTranscodingGreeterService, HelloRequest, HelloReply> invoker = (s, r, c) =>
+        {
+            request = r;
+            return Task.FromResult(new HelloReply());
+        };
+
+        var fieldmask = FieldMask.FromString("one,two,three.sub");
+
+        var unaryServerCallHandler = CreateCallHandler(invoker);
+        var httpContext = TestHelpers.CreateHttpContext();
+        httpContext.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+        {
+            ["field_mask_value.paths"] = new StringValues(fieldmask.Paths.ToArray()),
+        });
+
+        // Act
+        await unaryServerCallHandler.HandleCallAsync(httpContext);
+
+        // Assert
+        Assert.NotNull(request);
+        Assert.Equal(fieldmask, request!.FieldMaskValue);
+    }
+
     private UnaryServerCallHandler<JsonTranscodingGreeterService, HelloRequest, HelloReply> CreateCallHandler(
         UnaryServerMethod<JsonTranscodingGreeterService, HelloRequest, HelloReply> invoker,
         CallHandlerDescriptorInfo? descriptorInfo = null,

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Parameters/ParametersTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Parameters/ParametersTests.cs
@@ -138,4 +138,26 @@ public class ParametersTests
         Assert.Equal(ParameterLocation.Query, operation.Parameters[4].In);
         Assert.Equal("parameterTwo", operation.Parameters[4].Name);
     }
+
+    [Fact]
+    public void KnownTypes_AllQueryFields()
+    {
+        // Arrange & Act
+        var swagger = OpenApiTestHelpers.GetOpenApiDocument<ParametersService>(_testOutputHelper);
+
+        // Assert
+        var path = swagger.Paths["/v1/parameters9"];
+        Assert.True(path.Operations.TryGetValue(OperationType.Get, out var operation));
+        Assert.Equal(3, operation.Parameters.Count);
+        Assert.Equal(ParameterLocation.Query, operation.Parameters[0].In);
+        Assert.Equal("fieldMaskValue", operation.Parameters[0].Name);
+        Assert.Equal("string", operation.Parameters[0].Schema.Type);
+        Assert.Equal(ParameterLocation.Query, operation.Parameters[1].In);
+        Assert.Equal("stringValue", operation.Parameters[1].Name);
+        Assert.Equal("string", operation.Parameters[1].Schema.Type);
+        Assert.Equal(ParameterLocation.Query, operation.Parameters[2].In);
+        Assert.Equal("int32Value", operation.Parameters[2].Name);
+        Assert.Equal("integer", operation.Parameters[2].Schema.Type);
+        Assert.Equal("int32", operation.Parameters[2].Schema.Format);
+    }
 }

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Proto/messages.proto
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Proto/messages.proto
@@ -4,6 +4,7 @@
 syntax = "proto3";
 
 import "google/protobuf/wrappers.proto";
+import "google/protobuf/field_mask.proto";
 
 package messages;
 
@@ -101,4 +102,8 @@ message OneOfMessage {
 
 message MapMessage {
   map<string, double> map_value = 1;
+}
+
+message FieldMaskMessage {
+  google.protobuf.FieldMask field_mask_value = 1;
 }

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Proto/parameters.proto
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Proto/parameters.proto
@@ -6,6 +6,8 @@ syntax = "proto3";
 package params;
 
 import "google/api/annotations.proto";
+import "google/protobuf/field_mask.proto";
+import "google/protobuf/wrappers.proto";
 
 // Add go_package to keep protoc happy when testing generating OpenAPI from commandline.
 option go_package = "github.com/dotnet/aspnetcore/swagger";
@@ -69,6 +71,12 @@ service Parameters {
       get: "/v1/parameters8/{parameter_one.nested_parameter_one=messages1/*}/{parameter_one.nested_parameter_two=shelves/*/books/*}"
     };
   }
+
+  rpc DemoParametersNine (RequestFive) returns (ParamResponse) {
+    option (google.api.http) = {
+      get: "/v1/parameters9"
+    };
+  }
 }
 
 message RequestOne {
@@ -101,6 +109,12 @@ message RequestFour {
     int64 nested_parameter_three = 3;
     repeated int64 nested_parameter_four = 4;
   }
+}
+
+message RequestFive {
+  google.protobuf.FieldMask field_mask_value = 1;
+  google.protobuf.StringValue string_value = 2;
+  google.protobuf.Int32Value int32_value = 3;
 }
 
 message RequestBody {

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/SchemaGeneratorIntegrationTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/SchemaGeneratorIntegrationTests.cs
@@ -168,4 +168,17 @@ public class SchemaGeneratorIntegrationTests
         Assert.Equal("number", schema.Properties["mapValue"].AdditionalProperties.Type);
         Assert.Equal("double", schema.Properties["mapValue"].AdditionalProperties.Format);
     }
+
+    [Fact]
+    public void GenerateSchema_FieldMask_ReturnSchema()
+    {
+        // Arrange & Act
+        var (schema, repository) = GenerateSchema(typeof(FieldMaskMessage));
+
+        // Assert
+        schema = repository.Schemas[schema.Reference.Id];
+        Assert.Equal("object", schema.Type);
+        Assert.Equal(1, schema.Properties.Count);
+        Assert.Equal("string", schema.Properties["fieldMaskValue"].Type);
+    }
 }


### PR DESCRIPTION
Partially addresses https://github.com/dotnet/aspnetcore/issues/45753 (the issue reports two bugs)

Some gRPC known types have custom serialization. For example, the `Duration` type has `seconds` and `nanos` fields but is serialized to and from an ISO date string in JSON. Previously, known types set via the query string only supported setting fields. Example query string: `&totalTime.seconds=9&totalTime.nanos=34234`. This doesn't match up with fields suggested by swagger integration, which adds query variables using the custom JSON pattern.

This PR fixes some known types not being settable in the query string using a custom JSON pattern and makes them usable from Swagger UI. Only popular types that are convertible to string are supported (field mask, timestamp, duration). Will evaluate supporting complex types in the future.

Test to verify values are set onto message:
![image](https://user-images.githubusercontent.com/303201/218715618-6cbcfa2d-f2e8-44ad-9486-c354b6a52cc6.png)