### PR TITLE
Fallback using the `CultureInfo.Parent` instead of using hyphen

### DIFF
--- a/src/Middleware/Localization/src/RequestLocalizationMiddleware.cs
+++ b/src/Middleware/Localization/src/RequestLocalizationMiddleware.cs
@@ -154,6 +154,11 @@ public class RequestLocalizationMiddleware
         bool fallbackToParentCultures,
         int currentDepth)
     {
+        if (cultureName == "")
+        {
+            return null;
+        }
+
         var culture = GetCultureInfo(cultureName, supportedCultures);
 
         if (culture == null && fallbackToParentCultures && currentDepth < MaxCultureFallbackDepth)

--- a/src/Middleware/Localization/src/RequestLocalizationMiddleware.cs
+++ b/src/Middleware/Localization/src/RequestLocalizationMiddleware.cs
@@ -154,7 +154,9 @@ public class RequestLocalizationMiddleware
         bool fallbackToParentCultures,
         int currentDepth)
     {
-        if (cultureName == "")
+        // If the cultureName is an empty string there
+        // is no chance we can resolve the culture info.
+        if (cultureName.Equals(string.Empty))
         {
             return null;
         }

--- a/src/Middleware/Localization/test/UnitTests/RequestLocalizationMiddlewareTest.cs
+++ b/src/Middleware/Localization/test/UnitTests/RequestLocalizationMiddlewareTest.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
+
+namespace Microsoft.Extensions.Localization;
+
+public class RequestLocalizationMiddlewareTest
+{
+    [Theory]
+    [InlineData("zh-Hans-CN")]
+    [InlineData("zh-Hans")]
+    [InlineData("zh-CN")]
+    [InlineData("zh-Hant-TW")]
+    [InlineData("zh-Hant")]
+    [InlineData("zh-TW")]
+    public async Task RequestLocalizationMiddleware_ShouldFallBackToParentCultures_RegradlessOfHyphenSeparatorCheck(string requestedCulture)
+    {
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                .UseTestServer()
+                .Configure(app =>
+                {
+                    var supportedCultures = new[] { "ar", "en", "zh" };
+
+                    app.UseRequestLocalization(options =>
+                    {
+                        options.AddSupportedCultures(supportedCultures)
+                            .AddSupportedUICultures(supportedCultures)
+                            .AddInitialRequestCultureProvider(new CookieRequestCultureProvider
+                            {
+                                CookieName = "Preferences"
+                            });
+                    });
+
+                    app.Run(async context =>
+                    {
+                        var requestCulture = context.Features.Get<IRequestCultureFeature>();
+
+                        Assert.Equal("zh", requestCulture.RequestCulture.Culture.Name);
+                        Assert.Equal("zh", requestCulture.RequestCulture.UICulture.Name);
+
+                        await Task.CompletedTask;
+                    });
+                });
+            }).Build();
+
+        await host.StartAsync();
+
+        using (var server = host.GetTestServer())
+        {
+            var client = server.CreateClient();
+
+            client.DefaultRequestHeaders.Add("Cookie", new CookieHeaderValue("Preferences", $"c={requestedCulture}|uic={requestedCulture}").ToString());
+
+            var response = await client.GetAsync(string.Empty);
+
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/src/Middleware/Localization/test/UnitTests/RequestLocalizationMiddlewareTest.cs
+++ b/src/Middleware/Localization/test/UnitTests/RequestLocalizationMiddlewareTest.cs
@@ -15,13 +15,17 @@ namespace Microsoft.Extensions.Localization;
 public class RequestLocalizationMiddlewareTest
 {
     [Theory]
-    [InlineData("zh-Hans-CN")]
-    [InlineData("zh-Hans")]
-    [InlineData("zh-CN")]
-    [InlineData("zh-Hant-TW")]
-    [InlineData("zh-Hant")]
-    [InlineData("zh-TW")]
-    public async Task RequestLocalizationMiddleware_ShouldFallBackToParentCultures_RegradlessOfHyphenSeparatorCheck(string requestedCulture)
+    [InlineData("zh-Hans-CN", "zh")]
+    [InlineData("zh-Hans", "zh")]
+    [InlineData("zh-CN", "zh")]
+    [InlineData("zh-Hant-TW", "zh")]
+    [InlineData("zh-Hant", "zh")]
+    [InlineData("zh-TW", "zh")]
+    [InlineData("zh-CN", "zh-Hans")]
+    [InlineData("zh-Hans-CN", "zh-Hans")]
+    [InlineData("zh-Hant-TW", "zh-Hant")]
+    [InlineData("zh-TW", "zh-Hant")]
+    public async Task RequestLocalizationMiddleware_ShouldFallBackToParentCultures_RegradlessOfHyphenSeparatorCheck(string requestedCulture, string parentCulture)
     {
         using var host = new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>
@@ -30,7 +34,7 @@ public class RequestLocalizationMiddlewareTest
                 .UseTestServer()
                 .Configure(app =>
                 {
-                    var supportedCultures = new[] { "ar", "en", "zh" };
+                    var supportedCultures = new[] { "ar", "en", parentCulture };
 
                     app.UseRequestLocalization(options =>
                     {
@@ -46,8 +50,8 @@ public class RequestLocalizationMiddlewareTest
                     {
                         var requestCulture = context.Features.Get<IRequestCultureFeature>();
 
-                        Assert.Equal("zh", requestCulture.RequestCulture.Culture.Name);
-                        Assert.Equal("zh", requestCulture.RequestCulture.UICulture.Name);
+                        Assert.Equal(parentCulture, requestCulture.RequestCulture.Culture.Name);
+                        Assert.Equal(parentCulture, requestCulture.RequestCulture.UICulture.Name);
 
                         await Task.CompletedTask;
                     });


### PR DESCRIPTION
Nowadays `RequestLocalizationMiddleware` is using hyphen for fallback to the parent culture(s) which is different behavior than other places where we are using `CultureInfo.Parent`

The issue is might occur with Chinsese cultures for instance `zh-Hans-CN`, this will fallback into `zh-Hans` which is totally wrong, the best approach to get the parent culture using `CultureInfo.Parent` this way we will get `zh-CHS`, `zh-Hans`, `zh` respectively