### PR TITLE
Add support for binding parameter with [FromBody]

### DIFF
--- a/src/Http/Http.Extensions/gen/RequestDelegateGenerator.cs
+++ b/src/Http/Http.Extensions/gen/RequestDelegateGenerator.cs
@@ -69,7 +69,7 @@ public sealed class RequestDelegateGenerator : IIncrementalGenerator
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = ({{endpoint.EmitHandlerDelegateType()}})del;
+                    var handler = ({{endpoint.EmitHandlerDelegateCast()}})del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)

--- a/src/Http/Http.Extensions/gen/RequestDelegateGeneratorSources.cs
+++ b/src/Http/Http.Extensions/gen/RequestDelegateGeneratorSources.cs
@@ -100,6 +100,1416 @@ namespace Microsoft.AspNetCore.Http.Generated
                 return httpContext.Response.WriteAsJsonAsync(obj);
             }
         }
+
+        private static async ValueTask<(bool, T?)> TryResolveBody<T>(HttpContext httpContext, bool allowEmpty)
+        {
+            var feature = httpContext.Features.Get<Microsoft.AspNetCore.Http.Features.IHttpRequestBodyDetectionFeature>();
+
+            if (feature?.CanHaveBody == true)
+            {
+                if (!httpContext.Request.HasJsonContentType())
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
+                    return (false, default);
+                }
+                try
+                {
+                    var bodyValue = await httpContext.Request.ReadFromJsonAsync<T>();
+                    if (!allowEmpty && bodyValue == null)
+                    {
+                        httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                        return (false, bodyValue);
+                    }
+                    return (true, bodyValue);
+                }
+                catch (IOException)
+                {
+                    return (false, default);
+                }
+                catch (System.Text.Json.JsonException)
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    return (false, default);
+                }
+            }
+            return (false, default);
+        }
+    }
+
+    {{GeneratedCodeAttribute}}
+    file class EndpointFilterInvocationContext<T0> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+
+        public int Count => 1;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    {{GeneratedCodeAttribute}}
+    file class EndpointFilterInvocationContext<T0, T1> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+
+        public int Count => 2;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    {{GeneratedCodeAttribute}}
+    file class EndpointFilterInvocationContext<T0, T1, T2> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+
+        public int Count => 3;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    {{GeneratedCodeAttribute}}
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+
+        public int Count => 4;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    {{GeneratedCodeAttribute}}
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+
+        public int Count => 5;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    {{GeneratedCodeAttribute}}
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+
+        public int Count => 6;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    {{GeneratedCodeAttribute}}
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+
+        public int Count => 7;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    {{GeneratedCodeAttribute}}
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+
+        public int Count => 8;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    {{GeneratedCodeAttribute}}
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7, T8> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+            Arg8 = arg8;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                8 => Arg8,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                   case 8:
+                        Arg8 = (T8)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+        public T8 Arg8 { get; set; }
+
+        public int Count => 9;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               8 => (T)(object)Arg8!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    {{GeneratedCodeAttribute}}
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+            Arg8 = arg8;
+            Arg9 = arg9;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                8 => Arg8,
+                9 => Arg9,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                   case 8:
+                        Arg8 = (T8)(object?)value!;
+                        break;
+                   case 9:
+                        Arg9 = (T9)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+        public T8 Arg8 { get; set; }
+        public T9 Arg9 { get; set; }
+
+        public int Count => 10;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               8 => (T)(object)Arg8!,
+               9 => (T)(object)Arg9!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
     }
 }
 """;

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointEmitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointEmitter.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Text;
 
 namespace Microsoft.AspNetCore.Http.Generators.StaticRouteHandlerModel.Emitters;
@@ -24,6 +23,9 @@ internal static class EndpointEmitter
                 {
                     Source: EndpointParameterSource.Query,
                 } => parameter.EmitQueryParameterPreparation(),
+                {
+                    Source: EndpointParameterSource.JsonBody
+                } => parameter.EmitJsonBodyParameterPreparationString(),
                 _ => throw new Exception("Unreachable!")
             };
 

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Endpoint.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Endpoint.cs
@@ -36,6 +36,7 @@ internal class Endpoint
         }
 
         Response = new EndpointResponse(method, wellKnownTypes);
+        IsAwaitable = Response.IsAwaitable;
 
         if (method.Parameters.Length == 0)
         {
@@ -58,9 +59,11 @@ internal class Endpoint
         }
 
         Parameters = parameters;
+        IsAwaitable |= parameters.Any(parameter => parameter.Source == EndpointParameterSource.JsonBody);
     }
 
     public string HttpMethod { get; }
+    public bool IsAwaitable { get; set; }
     public string? RoutePattern { get; }
     public EndpointResponse? Response { get; }
     public EndpointParameter[] Parameters { get; } = Array.Empty<EndpointParameter>();

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.App.Analyzers.Infrastructure;
 using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
 using Microsoft.CodeAnalysis;
 using WellKnownType = Microsoft.AspNetCore.App.Analyzers.Infrastructure.WellKnownTypeData.WellKnownType;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.AspNetCore.Http.Generators.StaticRouteHandlerModel;
 
@@ -21,16 +21,22 @@ internal class EndpointParameter
 
         var fromQueryMetadataInterfaceType = wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Http_Metadata_IFromQueryMetadata);
 
-        if (GetSpecialTypeAssigningCode(Type, wellKnownTypes) is string assigningCode)
+        if (TryGetSpecialTypeAssigningCode(Type, wellKnownTypes, out var specialTypeAssigningCode))
         {
             Source = EndpointParameterSource.SpecialType;
-            AssigningCode = assigningCode;
+            AssigningCode = specialTypeAssigningCode;
         }
         else if (parameter.HasAttributeImplementingInterface(fromQueryMetadataInterfaceType))
         {
             Source = EndpointParameterSource.Query;
             AssigningCode = $"httpContext.Request.Query[\"{parameter.Name}\"]";
             IsOptional = parameter.Type is INamedTypeSymbol parameterType && parameterType.NullableAnnotation == NullableAnnotation.Annotated;
+        }
+        else if (TryGetExplicitFromJsonBody(parameter, wellKnownTypes, out var jsonBodyAssigningCode, out var isOptional))
+        {
+            Source = EndpointParameterSource.JsonBody;
+            AssigningCode = jsonBodyAssigningCode;
+            IsOptional = isOptional;
         }
         else
         {
@@ -48,44 +54,82 @@ internal class EndpointParameter
     public string HandlerArgument { get; }
     public bool IsOptional { get; }
 
-    public string EmitArgument()
+    public string EmitArgument() => Source switch
     {
-        return HandlerArgument;
-    }
+        EndpointParameterSource.SpecialType or EndpointParameterSource.Query => HandlerArgument,
+        EndpointParameterSource.JsonBody => IsOptional ? HandlerArgument : $"{HandlerArgument}!",
+        _ => throw new Exception("Unreachable!")
+    };
 
     // TODO: Handle special form types like IFormFileCollection that need special body-reading logic.
-    private static string? GetSpecialTypeAssigningCode(ITypeSymbol type, WellKnownTypes wellKnownTypes)
+    private static bool TryGetSpecialTypeAssigningCode(ITypeSymbol type, WellKnownTypes wellKnownTypes, [NotNullWhen(true)] out string? callingCode)
     {
+        callingCode = null;
         if (SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Http_HttpContext)))
         {
-            return "httpContext";
+            callingCode = "httpContext";
+            return true;
         }
         if (SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Http_HttpRequest)))
         {
-            return "httpContext.Request";
+            callingCode = "httpContext.Request";
+            return true;
         }
         if (SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Http_HttpResponse)))
         {
-            return "httpContext.Response";
+            callingCode = "httpContext.Response";
+            return true;
         }
         if (SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.Get(WellKnownType.System_IO_Pipelines_PipeReader)))
         {
-            return "httpContext.Request.BodyReader";
+            callingCode = "httpContext.Request.BodyReader";
+            return true;
         }
         if (SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.Get(WellKnownType.System_IO_Stream)))
         {
-            return "httpContext.Request.Body";
+            callingCode = "httpContext.Request.Body";
+            return true;
         }
         if (SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.Get(WellKnownType.System_Security_Claims_ClaimsPrincipal)))
         {
-            return "httpContext.User";
+            callingCode = "httpContext.User";
+            return true;
         }
         if (SymbolEqualityComparer.Default.Equals(type, wellKnownTypes.Get(WellKnownType.System_Threading_CancellationToken)))
         {
-            return "httpContext.RequestAborted";
+            callingCode = "httpContext.RequestAborted";
+            return true;
         }
 
-        return null;
+        return false;
+    }
+
+    private static bool TryGetExplicitFromJsonBody(IParameterSymbol parameter,
+        WellKnownTypes wellKnownTypes,
+        [NotNullWhen(true)] out string? assigningCode,
+        out bool isOptional)
+    {
+        var attributes = parameter.GetAttributes();
+        assigningCode = null;
+        isOptional = false;
+        foreach (var attribute in attributes)
+        {
+            if (WellKnownTypes.Implements(attribute.AttributeClass, wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Http_Metadata_IFromBodyMetadata)))
+            {
+                foreach (var namedArgument in attribute.NamedArguments)
+                {
+                    if (namedArgument.Key == "AllowEmpty")
+                    {
+                        isOptional |= namedArgument.Value.Value is true;
+                    }
+                }
+                isOptional |= (parameter.NullableAnnotation == NullableAnnotation.Annotated || parameter.HasExplicitDefaultValue);
+                assigningCode = $"await GeneratedRouteBuilderExtensionsCore.TryResolveBody<{parameter.Type}>(httpContext, {(isOptional ? "true" : "false")});";
+                return true;
+
+            }
+        }
+        return false;
     }
 
     public override bool Equals(object obj) =>

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/StaticRouteHandlerModel.Emitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/StaticRouteHandlerModel.Emitter.cs
@@ -39,20 +39,20 @@ internal static class StaticRouteHandlerModelEmitter
     {
         if (endpoint.Parameters.Length == 0)
         {
-            return endpoint.Response.IsVoid ? "System.Action" : $"System.Func<{endpoint.Response.WrappedResponseType}>";
+            return endpoint.Response.IsVoid ? "Action" : $"Func<{endpoint.Response.WrappedResponseType}>";
         }
         else
         {
             var parameterTypeList = string.Join(", ", endpoint.Parameters.Select(
-                p => p.Type.ToDisplayString(p.IsOptional is true ? NullableFlowState.MaybeNull : NullableFlowState.NotNull)));
+                p => p.Type.ToDisplayString(p.IsOptional ? NullableFlowState.MaybeNull : NullableFlowState.NotNull)));
 
             if (endpoint.Response.IsVoid)
             {
-                return $"System.Action<{parameterTypeList}>";
+                return $"Action<{parameterTypeList}>";
             }
             else
             {
-                return $"System.Func<{parameterTypeList}, {endpoint.Response.WrappedResponseType}>";
+                return $"Func<{parameterTypeList}, {endpoint.Response.WrappedResponseType}>";
             }
         }
     }

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/StaticRouteHandlerModel.Emitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/StaticRouteHandlerModel.Emitter.cs
@@ -35,6 +35,28 @@ internal static class StaticRouteHandlerModelEmitter
         }
     }
 
+    public static string EmitHandlerDelegateCast(this Endpoint endpoint)
+    {
+        if (endpoint.Parameters.Length == 0)
+        {
+            return endpoint.Response.IsVoid ? "System.Action" : $"System.Func<{endpoint.Response.WrappedResponseType}>";
+        }
+        else
+        {
+            var parameterTypeList = string.Join(", ", endpoint.Parameters.Select(
+                p => p.Type.ToDisplayString(p.IsOptional is true ? NullableFlowState.MaybeNull : NullableFlowState.NotNull)));
+
+            if (endpoint.Response.IsVoid)
+            {
+                return $"System.Action<{parameterTypeList}>";
+            }
+            else
+            {
+                return $"System.Func<{parameterTypeList}, {endpoint.Response.WrappedResponseType}>";
+            }
+        }
+    }
+
     public static string EmitSourceKey(this Endpoint endpoint)
     {
         return $@"(@""{endpoint.Location.File}"", {endpoint.Location.LineNumber})";
@@ -61,7 +83,7 @@ internal static class StaticRouteHandlerModelEmitter
      */
     public static string EmitRequestHandler(this Endpoint endpoint)
     {
-        var handlerSignature = endpoint.Response.IsAwaitable ? "async Task RequestHandler(HttpContext httpContext)" : "Task RequestHandler(HttpContext httpContext)";
+        var handlerSignature = endpoint.IsAwaitable ? "async Task RequestHandler(HttpContext httpContext)" : "Task RequestHandler(HttpContext httpContext)";
         var resultAssignment = endpoint.Response.IsVoid ? string.Empty : "var result = ";
         var awaitHandler = endpoint.Response.IsAwaitable ? "await " : string.Empty;
         var setContentType = endpoint.Response.IsVoid ? string.Empty : $@"httpContext.Response.ContentType ??= ""{endpoint.Response.ContentType}"";";
@@ -69,7 +91,13 @@ internal static class StaticRouteHandlerModelEmitter
         var requestHandlerSource = $$"""
                     {{handlerSignature}}
                     {
+                        var wasParamCheckFailure = false;
 {{endpoint.EmitParameterPreparation()}}
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            {{(endpoint.IsAwaitable ? "return;" : "return Task.CompletedTask;")}}
+                        }
                         {{setContentType}}
                         {{resultAssignment}}{{awaitHandler}}handler({{endpoint.EmitArgumentList()}});
                         {{(endpoint.Response.IsVoid ? "return Task.CompletedTask;" : endpoint.EmitResponseWritingCall())}}
@@ -81,7 +109,7 @@ internal static class StaticRouteHandlerModelEmitter
 
     private static string EmitResponseWritingCall(this Endpoint endpoint)
     {
-        var returnOrAwait = endpoint.Response.IsAwaitable ? "await" : "return";
+        var returnOrAwait = endpoint.IsAwaitable ? "await" : "return";
 
         if (endpoint.Response.IsIResult)
         {
@@ -116,12 +144,22 @@ internal static class StaticRouteHandlerModelEmitter
      * can be used to reduce the boxing that happens at runtime when constructing
      * the context object.
      */
-    public static string EmitFilteredRequestHandler(this Endpoint _)
+    public static string EmitFilteredRequestHandler(this Endpoint endpoint)
     {
+        var argumentList = endpoint.Parameters.Length == 0 ? string.Empty : $", {endpoint.EmitArgumentList()}";
+        var invocationConstructor = endpoint.Parameters.Length == 0 ? "DefaultEndpointFilterInvocationContext" : "EndpointFilterInvocationContext";
+        var invocationGenericArgs = endpoint.Parameters.Length == 0 ? string.Empty : $"<{endpoint.EmitFilterInvocationContextTypeArgs()}>";
+
         return $$"""
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
-                        var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
+                        var wasParamCheckFailure = false;
+{{endpoint.EmitParameterPreparation()}}
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
+                        var result = await filteredInvocation(new {{invocationConstructor}}{{invocationGenericArgs}}(httpContext{{argumentList}}));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 """;
@@ -143,7 +181,7 @@ return ValueTask.FromResult<object?>(handler({endpoint.EmitFilteredArgumentList(
     {
         if (endpoint.Parameters.Length == 0)
         {
-            return "";
+            return string.Empty;
         }
 
         var sb = new StringBuilder();
@@ -151,6 +189,28 @@ return ValueTask.FromResult<object?>(handler({endpoint.EmitFilteredArgumentList(
         for (var i = 0; i < endpoint.Parameters.Length; i++)
         {
             sb.Append($"ic.GetArgument<{endpoint.Parameters[i].Type}>({i})");
+
+            if (i < endpoint.Parameters.Length - 1)
+            {
+                sb.Append(", ");
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    public static string EmitFilterInvocationContextTypeArgs(this Endpoint endpoint)
+    {
+        if (endpoint.Parameters.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+
+        for (var i = 0; i < endpoint.Parameters.Length; i++)
+        {
+            sb.Append(endpoint.Parameters[i].Type.ToDisplayString(endpoint.Parameters[i].IsOptional ? NullableFlowState.MaybeNull : NullableFlowState.NotNull));
 
             if (i < endpoint.Parameters.Length - 1)
             {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitBodyParam_ComplexReturn_Snapshot.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitBodyParam_ComplexReturn_Snapshot.generated.txt
@@ -37,10 +37,10 @@ namespace Microsoft.AspNetCore.Builder
         private static readonly string[] DeleteVerb = new[] { global::Microsoft.AspNetCore.Http.HttpMethods.Delete };
         private static readonly string[] PatchVerb = new[] { global::Microsoft.AspNetCore.Http.HttpMethods.Patch };
 
-        internal static global::Microsoft.AspNetCore.Builder.RouteHandlerBuilder MapGet(
+        internal static global::Microsoft.AspNetCore.Builder.RouteHandlerBuilder MapPost(
             this global::Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints,
             [global::System.Diagnostics.CodeAnalysis.StringSyntax("Route")] string pattern,
-            global::System.Func<Microsoft.AspNetCore.Http.HttpRequest, Microsoft.AspNetCore.Http.HttpResponse, string> handler,
+            global::System.Func<TestMapActions.Todo, Microsoft.AspNetCore.Http.HttpResults.Ok<TestMapActions.Todo>> handler,
             [global::System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
             [global::System.Runtime.CompilerServices.CallerLineNumber]int lineNumber = 0)
         {
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Builder
                     endpoints,
                     pattern,
                     handler,
-                    GetVerb,
+                    PostVerb,
                     filePath,
                     lineNumber);
         }
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (System.Func<Microsoft.AspNetCore.Http.HttpRequest, Microsoft.AspNetCore.Http.HttpResponse, string>)del;
+                    var handler = (System.Func<TestMapActions.Todo, Microsoft.AspNetCore.Http.HttpResults.Ok<TestMapActions.Todo>>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)
@@ -104,36 +104,113 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<Microsoft.AspNetCore.Http.HttpRequest>(0), ic.GetArgument<Microsoft.AspNetCore.Http.HttpResponse>(1)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<TestMapActions.Todo>(0)));
                         },
                         options.EndpointBuilder,
                         handler.Method);
                     }
 
-                    Task RequestHandler(HttpContext httpContext)
+                    async Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        var req_local = httpContext.Request;
-                        var res_local = httpContext.Response;
+                        // Endpoint Parameter: todo (Type = TestMapActions.Todo, IsOptional = False, Source = JsonBody)
+                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<TestMapActions.Todo>(httpContext, false);;
+                        if (!isSuccessful)
+                        {
+                            return;
+                        }
+
                         if (wasParamCheckFailure)
                         {
                             httpContext.Response.StatusCode = 400;
-                            return Task.CompletedTask;
+                            return;
                         }
-                        httpContext.Response.ContentType ??= "text/plain";
-                        var result = handler(req_local, res_local);
-                        return httpContext.Response.WriteAsync(result);
+                        httpContext.Response.ContentType ??= "";
+                        var result = handler(todo_local!);
+                        await result.ExecuteAsync(httpContext);
                     }
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        var req_local = httpContext.Request;
-                        var res_local = httpContext.Response;
+                        // Endpoint Parameter: todo (Type = TestMapActions.Todo, IsOptional = False, Source = JsonBody)
+                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<TestMapActions.Todo>(httpContext, false);;
+                        if (!isSuccessful)
+                        {
+                            return;
+                        }
+
                         if (wasParamCheckFailure)
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<Microsoft.AspNetCore.Http.HttpRequest, Microsoft.AspNetCore.Http.HttpResponse>(httpContext, req_local, res_local));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<TestMapActions.Todo>(httpContext, todo_local!));
+                        await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
+                    }
+
+                    RequestDelegate targetDelegate = filteredInvocation is null ? RequestHandler : RequestHandlerFiltered;
+                    var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
+                    return new RequestDelegateResult(targetDelegate, metadata);
+                }),
+            [(@"TestMapActions.cs", 18)] = (
+               (methodInfo, options) =>
+                {
+                    Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 18));
+                    return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
+                },
+                (del, options, inferredMetadataResult) =>
+                {
+                    var handler = (System.Func<TestMapActions.Todo?, Microsoft.AspNetCore.Http.HttpResults.Ok<TestMapActions.Todo>>)del;
+                    EndpointFilterDelegate? filteredInvocation = null;
+
+                    if (options?.EndpointBuilder?.FilterFactories.Count > 0)
+                    {
+                        filteredInvocation = GeneratedRouteBuilderExtensionsCore.BuildFilterDelegate(ic =>
+                        {
+                            if (ic.HttpContext.Response.StatusCode == 400)
+                            {
+                                return ValueTask.FromResult<object?>(Results.Empty);
+                            }
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<TestMapActions.Todo?>(0)));
+                        },
+                        options.EndpointBuilder,
+                        handler.Method);
+                    }
+
+                    async Task RequestHandler(HttpContext httpContext)
+                    {
+                        var wasParamCheckFailure = false;
+                        // Endpoint Parameter: todo (Type = TestMapActions.Todo?, IsOptional = True, Source = JsonBody)
+                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<TestMapActions.Todo?>(httpContext, true);;
+                        if (!isSuccessful)
+                        {
+                            return;
+                        }
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return;
+                        }
+                        httpContext.Response.ContentType ??= "";
+                        var result = handler(todo_local);
+                        await result.ExecuteAsync(httpContext);
+                    }
+                    async Task RequestHandlerFiltered(HttpContext httpContext)
+                    {
+                        var wasParamCheckFailure = false;
+                        // Endpoint Parameter: todo (Type = TestMapActions.Todo?, IsOptional = True, Source = JsonBody)
+                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<TestMapActions.Todo?>(httpContext, true);;
+                        if (!isSuccessful)
+                        {
+                            return;
+                        }
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<TestMapActions.Todo?>(httpContext, todo_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitBodyParam_ComplexReturn_Snapshot.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitBodyParam_ComplexReturn_Snapshot.generated.txt
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (System.Func<TestMapActions.Todo, Microsoft.AspNetCore.Http.HttpResults.Ok<TestMapActions.Todo>>)del;
+                    var handler = (Func<TestMapActions.Todo, Microsoft.AspNetCore.Http.HttpResults.Ok<TestMapActions.Todo>>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)
@@ -114,7 +114,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     {
                         var wasParamCheckFailure = false;
                         // Endpoint Parameter: todo (Type = TestMapActions.Todo, IsOptional = False, Source = JsonBody)
-                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<TestMapActions.Todo>(httpContext, false);;
+                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<TestMapActions.Todo>(httpContext, false);
                         if (!isSuccessful)
                         {
                             return;
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     {
                         var wasParamCheckFailure = false;
                         // Endpoint Parameter: todo (Type = TestMapActions.Todo, IsOptional = False, Source = JsonBody)
-                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<TestMapActions.Todo>(httpContext, false);;
+                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<TestMapActions.Todo>(httpContext, false);
                         if (!isSuccessful)
                         {
                             return;
@@ -160,7 +160,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (System.Func<TestMapActions.Todo?, Microsoft.AspNetCore.Http.HttpResults.Ok<TestMapActions.Todo>>)del;
+                    var handler = (Func<TestMapActions.Todo?, Microsoft.AspNetCore.Http.HttpResults.Ok<TestMapActions.Todo>>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)
@@ -181,7 +181,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     {
                         var wasParamCheckFailure = false;
                         // Endpoint Parameter: todo (Type = TestMapActions.Todo?, IsOptional = True, Source = JsonBody)
-                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<TestMapActions.Todo?>(httpContext, true);;
+                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<TestMapActions.Todo?>(httpContext, true);
                         if (!isSuccessful)
                         {
                             return;
@@ -200,7 +200,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     {
                         var wasParamCheckFailure = false;
                         // Endpoint Parameter: todo (Type = TestMapActions.Todo?, IsOptional = True, Source = JsonBody)
-                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<TestMapActions.Todo?>(httpContext, true);;
+                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<TestMapActions.Todo?>(httpContext, true);
                         if (!isSuccessful)
                         {
                             return;

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleSpecialTypeParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleSpecialTypeParam_StringReturn.generated.txt
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (System.Func<Microsoft.AspNetCore.Http.HttpRequest, Microsoft.AspNetCore.Http.HttpResponse, string>)del;
+                    var handler = (Func<Microsoft.AspNetCore.Http.HttpRequest, Microsoft.AspNetCore.Http.HttpResponse, string>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleStringParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleStringParam_StringReturn.generated.txt
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (System.Func<string, string, string>)del;
+                    var handler = (Func<string, string, string>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleStringParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleStringParam_StringReturn.generated.txt
@@ -84,11 +84,11 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         private static readonly Dictionary<(string, int), (MetadataPopulator, RequestDelegateFactoryFunc)> map = new()
         {
-            [(@"TestMapActions.cs", 15)] = (
+            [(@"TestMapActions.cs", 16)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 15));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 16));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -112,12 +112,12 @@ namespace Microsoft.AspNetCore.Http.Generated
 
                     Task RequestHandler(HttpContext httpContext)
                     {
+                        var wasParamCheckFailure = false;
                         // Endpoint Parameter: p1 (Type = string, IsOptional = False, Source = Query)
                         var p1_raw = httpContext.Request.Query["p1"];
                         if (StringValues.IsNullOrEmpty(p1_raw))
                         {
-                            httpContext.Response.StatusCode = 400;
-                            return Task.CompletedTask;
+                            wasParamCheckFailure = true;
                         }
                         var p1_local = p1_raw.ToString();
 
@@ -125,18 +125,43 @@ namespace Microsoft.AspNetCore.Http.Generated
                         var p2_raw = httpContext.Request.Query["p2"];
                         if (StringValues.IsNullOrEmpty(p2_raw))
                         {
-                            httpContext.Response.StatusCode = 400;
-                            return Task.CompletedTask;
+                            wasParamCheckFailure = true;
                         }
                         var p2_local = p2_raw.ToString();
 
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return Task.CompletedTask;
+                        }
                         httpContext.Response.ContentType ??= "text/plain";
                         var result = handler(p1_local, p2_local);
                         return httpContext.Response.WriteAsync(result);
                     }
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
-                        var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
+                        var wasParamCheckFailure = false;
+                        // Endpoint Parameter: p1 (Type = string, IsOptional = False, Source = Query)
+                        var p1_raw = httpContext.Request.Query["p1"];
+                        if (StringValues.IsNullOrEmpty(p1_raw))
+                        {
+                            wasParamCheckFailure = true;
+                        }
+                        var p1_local = p1_raw.ToString();
+
+                        // Endpoint Parameter: p2 (Type = string, IsOptional = False, Source = Query)
+                        var p2_raw = httpContext.Request.Query["p2"];
+                        if (StringValues.IsNullOrEmpty(p2_raw))
+                        {
+                            wasParamCheckFailure = true;
+                        }
+                        var p2_local = p2_raw.ToString();
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string, string>(httpContext, p1_local, p2_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -190,6 +215,1416 @@ namespace Microsoft.AspNetCore.Http.Generated
             {
                 return httpContext.Response.WriteAsJsonAsync(obj);
             }
+        }
+
+        private static async ValueTask<(bool, T?)> TryResolveBody<T>(HttpContext httpContext, bool allowEmpty)
+        {
+            var feature = httpContext.Features.Get<Microsoft.AspNetCore.Http.Features.IHttpRequestBodyDetectionFeature>();
+
+            if (feature?.CanHaveBody == true)
+            {
+                if (!httpContext.Request.HasJsonContentType())
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
+                    return (false, default);
+                }
+                try
+                {
+                    var bodyValue = await httpContext.Request.ReadFromJsonAsync<T>();
+                    if (!allowEmpty && bodyValue == null)
+                    {
+                        httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                        return (false, bodyValue);
+                    }
+                    return (true, bodyValue);
+                }
+                catch (IOException)
+                {
+                    return (false, default);
+                }
+                catch (System.Text.Json.JsonException)
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    return (false, default);
+                }
+            }
+            return (false, default);
+        }
+    }
+
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+
+        public int Count => 1;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+
+        public int Count => 2;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+
+        public int Count => 3;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+
+        public int Count => 4;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+
+        public int Count => 5;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+
+        public int Count => 6;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+
+        public int Count => 7;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+
+        public int Count => 8;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7, T8> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+            Arg8 = arg8;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                8 => Arg8,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                   case 8:
+                        Arg8 = (T8)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+        public T8 Arg8 { get; set; }
+
+        public int Count => 9;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               8 => (T)(object)Arg8!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+            Arg8 = arg8;
+            Arg9 = arg9;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                8 => Arg8,
+                9 => Arg9,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                   case 8:
+                        Arg8 = (T8)(object?)value!;
+                        break;
+                   case 9:
+                        Arg9 = (T9)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+        public T8 Arg8 { get; set; }
+        public T9 Arg9 { get; set; }
+
+        public int Count => 10;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               8 => (T)(object)Arg8!,
+               9 => (T)(object)Arg9!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
     }
 }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_NoParam_StringReturn_WithFilter.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_NoParam_StringReturn_WithFilter.generated.txt
@@ -84,11 +84,11 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         private static readonly Dictionary<(string, int), (MetadataPopulator, RequestDelegateFactoryFunc)> map = new()
         {
-            [(@"TestMapActions.cs", 15)] = (
+            [(@"TestMapActions.cs", 16)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 15));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 16));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -112,13 +112,25 @@ namespace Microsoft.AspNetCore.Http.Generated
 
                     Task RequestHandler(HttpContext httpContext)
                     {
+                        var wasParamCheckFailure = false;
 
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return Task.CompletedTask;
+                        }
                         httpContext.Response.ContentType ??= "text/plain";
                         var result = handler();
                         return httpContext.Response.WriteAsync(result);
                     }
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
+                        var wasParamCheckFailure = false;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
                         var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
@@ -173,6 +185,1416 @@ namespace Microsoft.AspNetCore.Http.Generated
             {
                 return httpContext.Response.WriteAsJsonAsync(obj);
             }
+        }
+
+        private static async ValueTask<(bool, T?)> TryResolveBody<T>(HttpContext httpContext, bool allowEmpty)
+        {
+            var feature = httpContext.Features.Get<Microsoft.AspNetCore.Http.Features.IHttpRequestBodyDetectionFeature>();
+
+            if (feature?.CanHaveBody == true)
+            {
+                if (!httpContext.Request.HasJsonContentType())
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
+                    return (false, default);
+                }
+                try
+                {
+                    var bodyValue = await httpContext.Request.ReadFromJsonAsync<T>();
+                    if (!allowEmpty && bodyValue == null)
+                    {
+                        httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                        return (false, bodyValue);
+                    }
+                    return (true, bodyValue);
+                }
+                catch (IOException)
+                {
+                    return (false, default);
+                }
+                catch (System.Text.Json.JsonException)
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    return (false, default);
+                }
+            }
+            return (false, default);
+        }
+    }
+
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+
+        public int Count => 1;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+
+        public int Count => 2;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+
+        public int Count => 3;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+
+        public int Count => 4;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+
+        public int Count => 5;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+
+        public int Count => 6;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+
+        public int Count => 7;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+
+        public int Count => 8;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7, T8> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+            Arg8 = arg8;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                8 => Arg8,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                   case 8:
+                        Arg8 = (T8)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+        public T8 Arg8 { get; set; }
+
+        public int Count => 9;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               8 => (T)(object)Arg8!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+            Arg8 = arg8;
+            Arg9 = arg9;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                8 => Arg8,
+                9 => Arg9,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                   case 8:
+                        Arg8 = (T8)(object?)value!;
+                        break;
+                   case 9:
+                        Arg9 = (T9)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+        public T8 Arg8 { get; set; }
+        public T9 Arg9 { get; set; }
+
+        public int Count => 10;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               8 => (T)(object)Arg8!,
+               9 => (T)(object)Arg9!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
     }
 }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_NoParam_StringReturn_WithFilter.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_NoParam_StringReturn_WithFilter.generated.txt
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (System.Func<string>)del;
+                    var handler = (Func<string>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithEmptyQueryStringValueProvided_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithEmptyQueryStringValueProvided_StringReturn.generated.txt
@@ -84,11 +84,11 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         private static readonly Dictionary<(string, int), (MetadataPopulator, RequestDelegateFactoryFunc)> map = new()
         {
-            [(@"TestMapActions.cs", 15)] = (
+            [(@"TestMapActions.cs", 16)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 15));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 16));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -112,17 +112,32 @@ namespace Microsoft.AspNetCore.Http.Generated
 
                     Task RequestHandler(HttpContext httpContext)
                     {
+                        var wasParamCheckFailure = false;
                         // Endpoint Parameter: p (Type = string?, IsOptional = True, Source = Query)
                         var p_raw = httpContext.Request.Query["p"];
                         var p_local = p_raw.Count > 0 ? p_raw.ToString() : null;
 
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return Task.CompletedTask;
+                        }
                         httpContext.Response.ContentType ??= "text/plain";
                         var result = handler(p_local);
                         return httpContext.Response.WriteAsync(result);
                     }
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
-                        var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
+                        var wasParamCheckFailure = false;
+                        // Endpoint Parameter: p (Type = string?, IsOptional = True, Source = Query)
+                        var p_raw = httpContext.Request.Query["p"];
+                        var p_local = p_raw.Count > 0 ? p_raw.ToString() : null;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string?>(httpContext, p_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -176,6 +191,1416 @@ namespace Microsoft.AspNetCore.Http.Generated
             {
                 return httpContext.Response.WriteAsJsonAsync(obj);
             }
+        }
+
+        private static async ValueTask<(bool, T?)> TryResolveBody<T>(HttpContext httpContext, bool allowEmpty)
+        {
+            var feature = httpContext.Features.Get<Microsoft.AspNetCore.Http.Features.IHttpRequestBodyDetectionFeature>();
+
+            if (feature?.CanHaveBody == true)
+            {
+                if (!httpContext.Request.HasJsonContentType())
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
+                    return (false, default);
+                }
+                try
+                {
+                    var bodyValue = await httpContext.Request.ReadFromJsonAsync<T>();
+                    if (!allowEmpty && bodyValue == null)
+                    {
+                        httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                        return (false, bodyValue);
+                    }
+                    return (true, bodyValue);
+                }
+                catch (IOException)
+                {
+                    return (false, default);
+                }
+                catch (System.Text.Json.JsonException)
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    return (false, default);
+                }
+            }
+            return (false, default);
+        }
+    }
+
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+
+        public int Count => 1;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+
+        public int Count => 2;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+
+        public int Count => 3;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+
+        public int Count => 4;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+
+        public int Count => 5;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+
+        public int Count => 6;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+
+        public int Count => 7;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+
+        public int Count => 8;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7, T8> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+            Arg8 = arg8;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                8 => Arg8,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                   case 8:
+                        Arg8 = (T8)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+        public T8 Arg8 { get; set; }
+
+        public int Count => 9;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               8 => (T)(object)Arg8!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+            Arg8 = arg8;
+            Arg9 = arg9;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                8 => Arg8,
+                9 => Arg9,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                   case 8:
+                        Arg8 = (T8)(object?)value!;
+                        break;
+                   case 9:
+                        Arg9 = (T9)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+        public T8 Arg8 { get; set; }
+        public T9 Arg9 { get; set; }
+
+        public int Count => 10;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               8 => (T)(object)Arg8!,
+               9 => (T)(object)Arg9!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
     }
 }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithEmptyQueryStringValueProvided_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithEmptyQueryStringValueProvided_StringReturn.generated.txt
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (System.Func<string?, string>)del;
+                    var handler = (Func<string?, string>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithQueryStringValueProvided_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithQueryStringValueProvided_StringReturn.generated.txt
@@ -84,11 +84,11 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         private static readonly Dictionary<(string, int), (MetadataPopulator, RequestDelegateFactoryFunc)> map = new()
         {
-            [(@"TestMapActions.cs", 15)] = (
+            [(@"TestMapActions.cs", 16)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 15));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 16));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -112,17 +112,32 @@ namespace Microsoft.AspNetCore.Http.Generated
 
                     Task RequestHandler(HttpContext httpContext)
                     {
+                        var wasParamCheckFailure = false;
                         // Endpoint Parameter: p (Type = string?, IsOptional = True, Source = Query)
                         var p_raw = httpContext.Request.Query["p"];
                         var p_local = p_raw.Count > 0 ? p_raw.ToString() : null;
 
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return Task.CompletedTask;
+                        }
                         httpContext.Response.ContentType ??= "text/plain";
                         var result = handler(p_local);
                         return httpContext.Response.WriteAsync(result);
                     }
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
-                        var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
+                        var wasParamCheckFailure = false;
+                        // Endpoint Parameter: p (Type = string?, IsOptional = True, Source = Query)
+                        var p_raw = httpContext.Request.Query["p"];
+                        var p_local = p_raw.Count > 0 ? p_raw.ToString() : null;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string?>(httpContext, p_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -176,6 +191,1416 @@ namespace Microsoft.AspNetCore.Http.Generated
             {
                 return httpContext.Response.WriteAsJsonAsync(obj);
             }
+        }
+
+        private static async ValueTask<(bool, T?)> TryResolveBody<T>(HttpContext httpContext, bool allowEmpty)
+        {
+            var feature = httpContext.Features.Get<Microsoft.AspNetCore.Http.Features.IHttpRequestBodyDetectionFeature>();
+
+            if (feature?.CanHaveBody == true)
+            {
+                if (!httpContext.Request.HasJsonContentType())
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
+                    return (false, default);
+                }
+                try
+                {
+                    var bodyValue = await httpContext.Request.ReadFromJsonAsync<T>();
+                    if (!allowEmpty && bodyValue == null)
+                    {
+                        httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                        return (false, bodyValue);
+                    }
+                    return (true, bodyValue);
+                }
+                catch (IOException)
+                {
+                    return (false, default);
+                }
+                catch (System.Text.Json.JsonException)
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    return (false, default);
+                }
+            }
+            return (false, default);
+        }
+    }
+
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+
+        public int Count => 1;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+
+        public int Count => 2;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+
+        public int Count => 3;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+
+        public int Count => 4;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+
+        public int Count => 5;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+
+        public int Count => 6;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+
+        public int Count => 7;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+
+        public int Count => 8;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7, T8> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+            Arg8 = arg8;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                8 => Arg8,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                   case 8:
+                        Arg8 = (T8)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+        public T8 Arg8 { get; set; }
+
+        public int Count => 9;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               8 => (T)(object)Arg8!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+            Arg8 = arg8;
+            Arg9 = arg9;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                8 => Arg8,
+                9 => Arg9,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                   case 8:
+                        Arg8 = (T8)(object?)value!;
+                        break;
+                   case 9:
+                        Arg9 = (T9)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+        public T8 Arg8 { get; set; }
+        public T9 Arg9 { get; set; }
+
+        public int Count => 10;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               8 => (T)(object)Arg8!,
+               9 => (T)(object)Arg9!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
     }
 }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithQueryStringValueProvided_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithQueryStringValueProvided_StringReturn.generated.txt
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (System.Func<string?, string>)del;
+                    var handler = (Func<string?, string>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithoutQueryStringValueProvided_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithoutQueryStringValueProvided_StringReturn.generated.txt
@@ -84,11 +84,11 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         private static readonly Dictionary<(string, int), (MetadataPopulator, RequestDelegateFactoryFunc)> map = new()
         {
-            [(@"TestMapActions.cs", 15)] = (
+            [(@"TestMapActions.cs", 16)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 15));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 16));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -112,17 +112,32 @@ namespace Microsoft.AspNetCore.Http.Generated
 
                     Task RequestHandler(HttpContext httpContext)
                     {
+                        var wasParamCheckFailure = false;
                         // Endpoint Parameter: p (Type = string?, IsOptional = True, Source = Query)
                         var p_raw = httpContext.Request.Query["p"];
                         var p_local = p_raw.Count > 0 ? p_raw.ToString() : null;
 
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return Task.CompletedTask;
+                        }
                         httpContext.Response.ContentType ??= "text/plain";
                         var result = handler(p_local);
                         return httpContext.Response.WriteAsync(result);
                     }
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
-                        var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
+                        var wasParamCheckFailure = false;
+                        // Endpoint Parameter: p (Type = string?, IsOptional = True, Source = Query)
+                        var p_raw = httpContext.Request.Query["p"];
+                        var p_local = p_raw.Count > 0 ? p_raw.ToString() : null;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string?>(httpContext, p_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -176,6 +191,1416 @@ namespace Microsoft.AspNetCore.Http.Generated
             {
                 return httpContext.Response.WriteAsJsonAsync(obj);
             }
+        }
+
+        private static async ValueTask<(bool, T?)> TryResolveBody<T>(HttpContext httpContext, bool allowEmpty)
+        {
+            var feature = httpContext.Features.Get<Microsoft.AspNetCore.Http.Features.IHttpRequestBodyDetectionFeature>();
+
+            if (feature?.CanHaveBody == true)
+            {
+                if (!httpContext.Request.HasJsonContentType())
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
+                    return (false, default);
+                }
+                try
+                {
+                    var bodyValue = await httpContext.Request.ReadFromJsonAsync<T>();
+                    if (!allowEmpty && bodyValue == null)
+                    {
+                        httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                        return (false, bodyValue);
+                    }
+                    return (true, bodyValue);
+                }
+                catch (IOException)
+                {
+                    return (false, default);
+                }
+                catch (System.Text.Json.JsonException)
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    return (false, default);
+                }
+            }
+            return (false, default);
+        }
+    }
+
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+
+        public int Count => 1;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+
+        public int Count => 2;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+
+        public int Count => 3;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+
+        public int Count => 4;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+
+        public int Count => 5;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+
+        public int Count => 6;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+
+        public int Count => 7;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+
+        public int Count => 8;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7, T8> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+            Arg8 = arg8;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                8 => Arg8,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                   case 8:
+                        Arg8 = (T8)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+        public T8 Arg8 { get; set; }
+
+        public int Count => 9;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               8 => (T)(object)Arg8!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+            Arg8 = arg8;
+            Arg9 = arg9;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                8 => Arg8,
+                9 => Arg9,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                   case 8:
+                        Arg8 = (T8)(object?)value!;
+                        break;
+                   case 9:
+                        Arg9 = (T9)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+        public T8 Arg8 { get; set; }
+        public T9 Arg9 { get; set; }
+
+        public int Count => 10;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               8 => (T)(object)Arg8!,
+               9 => (T)(object)Arg9!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
     }
 }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithoutQueryStringValueProvided_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithoutQueryStringValueProvided_StringReturn.generated.txt
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (System.Func<string?, string>)del;
+                    var handler = (Func<string?, string>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleStringParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleStringParam_StringReturn.generated.txt
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (System.Func<string, string>)del;
+                    var handler = (Func<string, string>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleStringParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleStringParam_StringReturn.generated.txt
@@ -84,11 +84,11 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         private static readonly Dictionary<(string, int), (MetadataPopulator, RequestDelegateFactoryFunc)> map = new()
         {
-            [(@"TestMapActions.cs", 15)] = (
+            [(@"TestMapActions.cs", 16)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 15));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 16));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -112,22 +112,40 @@ namespace Microsoft.AspNetCore.Http.Generated
 
                     Task RequestHandler(HttpContext httpContext)
                     {
+                        var wasParamCheckFailure = false;
                         // Endpoint Parameter: p (Type = string, IsOptional = False, Source = Query)
                         var p_raw = httpContext.Request.Query["p"];
                         if (StringValues.IsNullOrEmpty(p_raw))
                         {
-                            httpContext.Response.StatusCode = 400;
-                            return Task.CompletedTask;
+                            wasParamCheckFailure = true;
                         }
                         var p_local = p_raw.ToString();
 
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return Task.CompletedTask;
+                        }
                         httpContext.Response.ContentType ??= "text/plain";
                         var result = handler(p_local);
                         return httpContext.Response.WriteAsync(result);
                     }
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
-                        var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
+                        var wasParamCheckFailure = false;
+                        // Endpoint Parameter: p (Type = string, IsOptional = False, Source = Query)
+                        var p_raw = httpContext.Request.Query["p"];
+                        if (StringValues.IsNullOrEmpty(p_raw))
+                        {
+                            wasParamCheckFailure = true;
+                        }
+                        var p_local = p_raw.ToString();
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string>(httpContext, p_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -181,6 +199,1416 @@ namespace Microsoft.AspNetCore.Http.Generated
             {
                 return httpContext.Response.WriteAsJsonAsync(obj);
             }
+        }
+
+        private static async ValueTask<(bool, T?)> TryResolveBody<T>(HttpContext httpContext, bool allowEmpty)
+        {
+            var feature = httpContext.Features.Get<Microsoft.AspNetCore.Http.Features.IHttpRequestBodyDetectionFeature>();
+
+            if (feature?.CanHaveBody == true)
+            {
+                if (!httpContext.Request.HasJsonContentType())
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
+                    return (false, default);
+                }
+                try
+                {
+                    var bodyValue = await httpContext.Request.ReadFromJsonAsync<T>();
+                    if (!allowEmpty && bodyValue == null)
+                    {
+                        httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                        return (false, bodyValue);
+                    }
+                    return (true, bodyValue);
+                }
+                catch (IOException)
+                {
+                    return (false, default);
+                }
+                catch (System.Text.Json.JsonException)
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    return (false, default);
+                }
+            }
+            return (false, default);
+        }
+    }
+
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+
+        public int Count => 1;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+
+        public int Count => 2;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+
+        public int Count => 3;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+
+        public int Count => 4;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+
+        public int Count => 5;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+
+        public int Count => 6;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+
+        public int Count => 7;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+
+        public int Count => 8;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7, T8> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+            Arg8 = arg8;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                8 => Arg8,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                   case 8:
+                        Arg8 = (T8)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+        public T8 Arg8 { get; set; }
+
+        public int Count => 9;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               8 => (T)(object)Arg8!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+            Arg8 = arg8;
+            Arg9 = arg9;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                8 => Arg8,
+                9 => Arg9,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                   case 8:
+                        Arg8 = (T8)(object?)value!;
+                        break;
+                   case 9:
+                        Arg9 = (T9)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+        public T8 Arg8 { get; set; }
+        public T9 Arg9 { get; set; }
+
+        public int Count => 10;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               8 => (T)(object)Arg8!,
+               9 => (T)(object)Arg9!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
     }
 }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_NoParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_NoParam_StringReturn.generated.txt
@@ -114,49 +114,6 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         private static readonly Dictionary<(string, int), (MetadataPopulator, RequestDelegateFactoryFunc)> map = new()
         {
-            [(@"TestMapActions.cs", 15)] = (
-               (methodInfo, options) =>
-                {
-                    Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 15));
-                    return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
-                },
-                (del, options, inferredMetadataResult) =>
-                {
-                    var handler = (System.Func<string>)del;
-                    EndpointFilterDelegate? filteredInvocation = null;
-
-                    if (options?.EndpointBuilder?.FilterFactories.Count > 0)
-                    {
-                        filteredInvocation = GeneratedRouteBuilderExtensionsCore.BuildFilterDelegate(ic =>
-                        {
-                            if (ic.HttpContext.Response.StatusCode == 400)
-                            {
-                                return ValueTask.FromResult<object?>(Results.Empty);
-                            }
-                            return ValueTask.FromResult<object?>(handler());
-                        },
-                        options.EndpointBuilder,
-                        handler.Method);
-                    }
-
-                    Task RequestHandler(HttpContext httpContext)
-                    {
-
-                        httpContext.Response.ContentType ??= "text/plain";
-                        var result = handler();
-                        return httpContext.Response.WriteAsync(result);
-                    }
-                    async Task RequestHandlerFiltered(HttpContext httpContext)
-                    {
-                        var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
-                        await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
-                    }
-
-                    RequestDelegate targetDelegate = filteredInvocation is null ? RequestHandler : RequestHandlerFiltered;
-                    var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
-                    return new RequestDelegateResult(targetDelegate, metadata);
-                }),
             [(@"TestMapActions.cs", 16)] = (
                (methodInfo, options) =>
                 {
@@ -185,13 +142,25 @@ namespace Microsoft.AspNetCore.Http.Generated
 
                     Task RequestHandler(HttpContext httpContext)
                     {
+                        var wasParamCheckFailure = false;
 
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return Task.CompletedTask;
+                        }
                         httpContext.Response.ContentType ??= "text/plain";
                         var result = handler();
                         return httpContext.Response.WriteAsync(result);
                     }
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
+                        var wasParamCheckFailure = false;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
                         var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
@@ -205,6 +174,61 @@ namespace Microsoft.AspNetCore.Http.Generated
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
                     options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 17));
+                    return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
+                },
+                (del, options, inferredMetadataResult) =>
+                {
+                    var handler = (System.Func<string>)del;
+                    EndpointFilterDelegate? filteredInvocation = null;
+
+                    if (options?.EndpointBuilder?.FilterFactories.Count > 0)
+                    {
+                        filteredInvocation = GeneratedRouteBuilderExtensionsCore.BuildFilterDelegate(ic =>
+                        {
+                            if (ic.HttpContext.Response.StatusCode == 400)
+                            {
+                                return ValueTask.FromResult<object?>(Results.Empty);
+                            }
+                            return ValueTask.FromResult<object?>(handler());
+                        },
+                        options.EndpointBuilder,
+                        handler.Method);
+                    }
+
+                    Task RequestHandler(HttpContext httpContext)
+                    {
+                        var wasParamCheckFailure = false;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return Task.CompletedTask;
+                        }
+                        httpContext.Response.ContentType ??= "text/plain";
+                        var result = handler();
+                        return httpContext.Response.WriteAsync(result);
+                    }
+                    async Task RequestHandlerFiltered(HttpContext httpContext)
+                    {
+                        var wasParamCheckFailure = false;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
+                        var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
+                        await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
+                    }
+
+                    RequestDelegate targetDelegate = filteredInvocation is null ? RequestHandler : RequestHandlerFiltered;
+                    var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
+                    return new RequestDelegateResult(targetDelegate, metadata);
+                }),
+            [(@"TestMapActions.cs", 18)] = (
+               (methodInfo, options) =>
+                {
+                    Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 18));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -228,13 +252,25 @@ namespace Microsoft.AspNetCore.Http.Generated
 
                     async Task RequestHandler(HttpContext httpContext)
                     {
+                        var wasParamCheckFailure = false;
 
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return;
+                        }
                         httpContext.Response.ContentType ??= "application/json";
                         var result = await handler();
                         await httpContext.Response.WriteAsync(result);
                     }
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
+                        var wasParamCheckFailure = false;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
                         var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
@@ -243,11 +279,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
                     return new RequestDelegateResult(targetDelegate, metadata);
                 }),
-            [(@"TestMapActions.cs", 18)] = (
+            [(@"TestMapActions.cs", 19)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 18));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 19));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -271,13 +307,25 @@ namespace Microsoft.AspNetCore.Http.Generated
 
                     async Task RequestHandler(HttpContext httpContext)
                     {
+                        var wasParamCheckFailure = false;
 
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return;
+                        }
                         httpContext.Response.ContentType ??= "application/json";
                         var result = await handler();
                         await httpContext.Response.WriteAsync(result);
                     }
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
+                        var wasParamCheckFailure = false;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
                         var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
@@ -332,6 +380,1416 @@ namespace Microsoft.AspNetCore.Http.Generated
             {
                 return httpContext.Response.WriteAsJsonAsync(obj);
             }
+        }
+
+        private static async ValueTask<(bool, T?)> TryResolveBody<T>(HttpContext httpContext, bool allowEmpty)
+        {
+            var feature = httpContext.Features.Get<Microsoft.AspNetCore.Http.Features.IHttpRequestBodyDetectionFeature>();
+
+            if (feature?.CanHaveBody == true)
+            {
+                if (!httpContext.Request.HasJsonContentType())
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
+                    return (false, default);
+                }
+                try
+                {
+                    var bodyValue = await httpContext.Request.ReadFromJsonAsync<T>();
+                    if (!allowEmpty && bodyValue == null)
+                    {
+                        httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                        return (false, bodyValue);
+                    }
+                    return (true, bodyValue);
+                }
+                catch (IOException)
+                {
+                    return (false, default);
+                }
+                catch (System.Text.Json.JsonException)
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    return (false, default);
+                }
+            }
+            return (false, default);
+        }
+    }
+
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+
+        public int Count => 1;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+
+        public int Count => 2;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+
+        public int Count => 3;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+
+        public int Count => 4;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+
+        public int Count => 5;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+
+        public int Count => 6;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+
+        public int Count => 7;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+
+        public int Count => 8;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7, T8> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+            Arg8 = arg8;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                8 => Arg8,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                   case 8:
+                        Arg8 = (T8)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+        public T8 Arg8 { get; set; }
+
+        public int Count => 9;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               8 => (T)(object)Arg8!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+            Arg8 = arg8;
+            Arg9 = arg9;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                8 => Arg8,
+                9 => Arg9,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                   case 8:
+                        Arg8 = (T8)(object?)value!;
+                        break;
+                   case 9:
+                        Arg9 = (T9)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+        public T8 Arg8 { get; set; }
+        public T9 Arg9 { get; set; }
+
+        public int Count => 10;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               8 => (T)(object)Arg8!,
+               9 => (T)(object)Arg9!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
     }
 }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_NoParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_NoParam_StringReturn.generated.txt
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (System.Func<string>)del;
+                    var handler = (Func<string>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)
@@ -178,7 +178,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (System.Func<string>)del;
+                    var handler = (Func<string>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)
@@ -233,7 +233,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (System.Func<System.Threading.Tasks.Task<string>>)del;
+                    var handler = (Func<System.Threading.Tasks.Task<string>>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)
@@ -288,7 +288,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (System.Func<System.Threading.Tasks.ValueTask<string>>)del;
+                    var handler = (Func<System.Threading.Tasks.ValueTask<string>>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_WithParams_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_WithParams_StringReturn.generated.txt
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (System.Func<Microsoft.AspNetCore.Http.HttpRequest, string>)del;
+                    var handler = (Func<Microsoft.AspNetCore.Http.HttpRequest, string>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)
@@ -178,7 +178,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (System.Func<Microsoft.AspNetCore.Http.HttpResponse, string>)del;
+                    var handler = (Func<Microsoft.AspNetCore.Http.HttpResponse, string>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)
@@ -233,7 +233,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (System.Func<Microsoft.AspNetCore.Http.HttpRequest, Microsoft.AspNetCore.Http.HttpResponse, string>)del;
+                    var handler = (Func<Microsoft.AspNetCore.Http.HttpRequest, Microsoft.AspNetCore.Http.HttpResponse, string>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_WithParams_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_WithParams_StringReturn.generated.txt
@@ -114,11 +114,11 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         private static readonly Dictionary<(string, int), (MetadataPopulator, RequestDelegateFactoryFunc)> map = new()
         {
-            [(@"TestMapActions.cs", 15)] = (
+            [(@"TestMapActions.cs", 16)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 15));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 16));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -142,14 +142,26 @@ namespace Microsoft.AspNetCore.Http.Generated
 
                     Task RequestHandler(HttpContext httpContext)
                     {
+                        var wasParamCheckFailure = false;
                         var req_local = httpContext.Request;
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return Task.CompletedTask;
+                        }
                         httpContext.Response.ContentType ??= "text/plain";
                         var result = handler(req_local);
                         return httpContext.Response.WriteAsync(result);
                     }
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
-                        var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
+                        var wasParamCheckFailure = false;
+                        var req_local = httpContext.Request;
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<Microsoft.AspNetCore.Http.HttpRequest>(httpContext, req_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -157,11 +169,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
                     return new RequestDelegateResult(targetDelegate, metadata);
                 }),
-            [(@"TestMapActions.cs", 16)] = (
+            [(@"TestMapActions.cs", 17)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 16));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 17));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -185,14 +197,26 @@ namespace Microsoft.AspNetCore.Http.Generated
 
                     Task RequestHandler(HttpContext httpContext)
                     {
+                        var wasParamCheckFailure = false;
                         var res_local = httpContext.Response;
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return Task.CompletedTask;
+                        }
                         httpContext.Response.ContentType ??= "text/plain";
                         var result = handler(res_local);
                         return httpContext.Response.WriteAsync(result);
                     }
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
-                        var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
+                        var wasParamCheckFailure = false;
+                        var res_local = httpContext.Response;
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<Microsoft.AspNetCore.Http.HttpResponse>(httpContext, res_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -200,11 +224,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
                     return new RequestDelegateResult(targetDelegate, metadata);
                 }),
-            [(@"TestMapActions.cs", 17)] = (
+            [(@"TestMapActions.cs", 18)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 17));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 18));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -228,15 +252,28 @@ namespace Microsoft.AspNetCore.Http.Generated
 
                     Task RequestHandler(HttpContext httpContext)
                     {
+                        var wasParamCheckFailure = false;
                         var req_local = httpContext.Request;
                         var res_local = httpContext.Response;
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return Task.CompletedTask;
+                        }
                         httpContext.Response.ContentType ??= "text/plain";
                         var result = handler(req_local, res_local);
                         return httpContext.Response.WriteAsync(result);
                     }
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
-                        var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
+                        var wasParamCheckFailure = false;
+                        var req_local = httpContext.Request;
+                        var res_local = httpContext.Response;
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<Microsoft.AspNetCore.Http.HttpRequest, Microsoft.AspNetCore.Http.HttpResponse>(httpContext, req_local, res_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -290,6 +327,1416 @@ namespace Microsoft.AspNetCore.Http.Generated
             {
                 return httpContext.Response.WriteAsJsonAsync(obj);
             }
+        }
+
+        private static async ValueTask<(bool, T?)> TryResolveBody<T>(HttpContext httpContext, bool allowEmpty)
+        {
+            var feature = httpContext.Features.Get<Microsoft.AspNetCore.Http.Features.IHttpRequestBodyDetectionFeature>();
+
+            if (feature?.CanHaveBody == true)
+            {
+                if (!httpContext.Request.HasJsonContentType())
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
+                    return (false, default);
+                }
+                try
+                {
+                    var bodyValue = await httpContext.Request.ReadFromJsonAsync<T>();
+                    if (!allowEmpty && bodyValue == null)
+                    {
+                        httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                        return (false, bodyValue);
+                    }
+                    return (true, bodyValue);
+                }
+                catch (IOException)
+                {
+                    return (false, default);
+                }
+                catch (System.Text.Json.JsonException)
+                {
+                    httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    return (false, default);
+                }
+            }
+            return (false, default);
+        }
+    }
+
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+
+        public int Count => 1;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+
+        public int Count => 2;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+
+        public int Count => 3;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+
+        public int Count => 4;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+
+        public int Count => 5;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+
+        public int Count => 6;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+
+        public int Count => 7;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+
+        public int Count => 8;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7, T8> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+            Arg8 = arg8;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                8 => Arg8,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                   case 8:
+                        Arg8 = (T8)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+        public T8 Arg8 { get; set; }
+
+        public int Count => 9;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               8 => (T)(object)Arg8!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+    %GENERATEDCODEATTRIBUTE%
+    file class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> : EndpointFilterInvocationContext, IList<object?>
+    {
+        internal EndpointFilterInvocationContext(HttpContext httpContext, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        {
+            HttpContext = httpContext;
+            Arg0 = arg0;
+            Arg1 = arg1;
+            Arg2 = arg2;
+            Arg3 = arg3;
+            Arg4 = arg4;
+            Arg5 = arg5;
+            Arg6 = arg6;
+            Arg7 = arg7;
+            Arg8 = arg8;
+            Arg9 = arg9;
+        }
+
+        public object? this[int index]
+        {
+            get => index switch
+            {
+                0 => Arg0,
+                1 => Arg1,
+                2 => Arg2,
+                3 => Arg3,
+                4 => Arg4,
+                5 => Arg5,
+                6 => Arg6,
+                7 => Arg7,
+                8 => Arg8,
+                9 => Arg9,
+                _ => new IndexOutOfRangeException()
+            };
+            set
+            {
+                switch (index)
+                {
+                   case 0:
+                        Arg0 = (T0)(object?)value!;
+                        break;
+                   case 1:
+                        Arg1 = (T1)(object?)value!;
+                        break;
+                   case 2:
+                        Arg2 = (T2)(object?)value!;
+                        break;
+                   case 3:
+                        Arg3 = (T3)(object?)value!;
+                        break;
+                   case 4:
+                        Arg4 = (T4)(object?)value!;
+                        break;
+                   case 5:
+                        Arg5 = (T5)(object?)value!;
+                        break;
+                   case 6:
+                        Arg6 = (T6)(object?)value!;
+                        break;
+                   case 7:
+                        Arg7 = (T7)(object?)value!;
+                        break;
+                   case 8:
+                        Arg8 = (T8)(object?)value!;
+                        break;
+                   case 9:
+                        Arg9 = (T9)(object?)value!;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        public override HttpContext HttpContext { get; }
+
+        public override IList<object?> Arguments => this;
+
+        public T0 Arg0 { get; set; }
+        public T1 Arg1 { get; set; }
+        public T2 Arg2 { get; set; }
+        public T3 Arg3 { get; set; }
+        public T4 Arg4 { get; set; }
+        public T5 Arg5 { get; set; }
+        public T6 Arg6 { get; set; }
+        public T7 Arg7 { get; set; }
+        public T8 Arg8 { get; set; }
+        public T9 Arg9 { get; set; }
+
+        public int Count => 10;
+
+        public bool IsReadOnly => false;
+
+        public bool IsFixedSize => true;
+
+        public void Add(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Contains(object? item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        public void CopyTo(object?[] array, int arrayIndex)
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                array[arrayIndex++] = Arguments[i];
+            }
+        }
+
+        public IEnumerator<object?> GetEnumerator()
+        {
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                yield return Arguments[i];
+            }
+        }
+
+        public override T GetArgument<T>(int index)
+        {
+            return index switch
+            {
+               0 => (T)(object)Arg0!,
+               1 => (T)(object)Arg1!,
+               2 => (T)(object)Arg2!,
+               3 => (T)(object)Arg3!,
+               4 => (T)(object)Arg4!,
+               5 => (T)(object)Arg5!,
+               6 => (T)(object)Arg6!,
+               7 => (T)(object)Arg7!,
+               8 => (T)(object)Arg8!,
+               9 => (T)(object)Arg9!,
+               _ => throw new IndexOutOfRangeException()
+            };
+        }
+
+        public int IndexOf(object? item)
+        {
+            return Arguments.IndexOf(item);
+        }
+
+        public void Insert(int index, object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(object? item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotSupportedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
     }
 }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorIncrementalityTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorIncrementalityTests.cs
@@ -41,5 +41,17 @@ public class RequestDelegateGeneratorIncrementalityTests : RequestDelegateGenera
         Assert.All(outputSteps, (value) => Assert.Equal(IncrementalStepRunReason.New, value.Reason));
     }
 
+    [Fact]
+    public async Task MapAction_ChangeBodyParamNullability_TriggersUpdate()
+    {
+        var source = @"app.MapGet(""/"", ([FromBody] Todo todo) => TypedResults.Ok(todo));";
+        var updatedSource = @"app.MapGet(""/"", ([FromBody] Todo? todo) => TypedResults.Ok(todo));";
+
+        var (result, compilation) = await RunGeneratorAsync(source, updatedSource);
+        var outputSteps = GetRunStepOutputs(result);
+
+        Assert.All(outputSteps, (value) => Assert.Equal(IncrementalStepRunReason.New, value.Reason));
+    }
+
     private static IEnumerable<(object Value, IncrementalStepRunReason Reason)> GetRunStepOutputs(GeneratorRunResult result) => result.TrackedOutputSteps.SelectMany(step => step.Value).SelectMany(value => value.Outputs);
 }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorTests.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Generators.StaticRouteHandlerModel;
 
 namespace Microsoft.AspNetCore.Http.Generators.Tests;
@@ -489,6 +492,126 @@ app.MapGet(route, () => "Hello world!");
         var httpContext = CreateHttpContext();
         await endpoint.RequestDelegate(httpContext);
         await VerifyResponseBodyAsync(httpContext, expectedBody);
+    }
+
+    public static object[][] MapAction_ExplicitBodyParam_ComplexReturn_Data
+    {
+        get
+        {
+            var expectedBody = """{"id":0,"name":"Test Item","isComplete":false}""";
+            var todo = new Todo()
+            {
+                Id = 0,
+                Name = "Test Item",
+                IsComplete = false
+            };
+            var withFilter = """
+.AddEndpointFilter((c, n) => n(c));
+""";
+            var fromBodyRequiredSource = """app.MapPost("/", ([FromBody] Todo todo) => TypedResults.Ok(todo));""";
+            var fromBodyAllowEmptySource = """app.MapPost("/", ([FromBody(AllowEmpty = true)] Todo todo) => TypedResults.Ok(todo));""";
+            var fromBodyNullableSource = """app.MapPost("/", ([FromBody] Todo? todo) => TypedResults.Ok(todo));""";
+            var fromBodyDefaultValueSource = """
+#nullable disable
+IResult postTodoWithDefault([FromBody] Todo todo = null) => TypedResults.Ok(todo);
+app.MapPost("/", postTodoWithDefault);
+#nullable restore
+""";
+            var fromBodyRequiredWithFilterSource = $"""app.MapPost("/", ([FromBody] Todo todo) => TypedResults.Ok(todo)){withFilter}""";
+            var fromBodyAllowEmptyWithFilterSource = $"""app.MapPost("/", ([FromBody(AllowEmpty = true)] Todo todo) => TypedResults.Ok(todo)){withFilter}""";
+            var fromBodyNullableWithFilterSource = $"""app.MapPost("/", ([FromBody] Todo? todo) => TypedResults.Ok(todo)){withFilter}""";
+            var fromBodyDefaultValueWithFilterSource = $"""
+#nullable disable
+IResult postTodoWithDefault([FromBody] Todo todo = null) => TypedResults.Ok(todo);
+app.MapPost("/", postTodoWithDefault){withFilter}
+#nullable restore
+""";
+
+            return new[]
+            {
+                new object[] { fromBodyRequiredSource, todo, 200, expectedBody },
+                new object[] { fromBodyRequiredSource, null, 400, string.Empty },
+                new object[] { fromBodyAllowEmptySource, todo, 200, expectedBody },
+                new object[] { fromBodyAllowEmptySource, null, 200, string.Empty },
+                new object[] { fromBodyNullableSource, todo, 200, expectedBody },
+                new object[] { fromBodyNullableSource, null, 200, string.Empty },
+                new object[] { fromBodyDefaultValueSource, todo, 200, expectedBody },
+                new object[] { fromBodyDefaultValueSource, null, 200, string.Empty },
+                new object[] { fromBodyRequiredWithFilterSource, todo, 200, expectedBody },
+                new object[] { fromBodyRequiredWithFilterSource, null, 400, string.Empty },
+                new object[] { fromBodyAllowEmptyWithFilterSource, todo, 200, expectedBody },
+                new object[] { fromBodyAllowEmptyWithFilterSource, null, 200, string.Empty },
+                new object[] { fromBodyNullableWithFilterSource, todo, 200, expectedBody },
+                new object[] { fromBodyNullableWithFilterSource, null, 200, string.Empty },
+                new object[] { fromBodyDefaultValueWithFilterSource, todo, 200, expectedBody },
+                new object[] { fromBodyDefaultValueSource, null, 200, string.Empty },
+            };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(MapAction_ExplicitBodyParam_ComplexReturn_Data))]
+    public async Task MapAction_ExplicitBodyParam_ComplexReturn(string source, Todo requestData, int expectedStatusCode, string expectedBody)
+    {
+        var (_, compilation) = await RunGeneratorAsync(source);
+        var endpoint = GetEndpointFromCompilation(compilation);
+
+        var httpContext = CreateHttpContext();
+        httpContext.Features.Set<IHttpRequestBodyDetectionFeature>(new RequestBodyDetectionFeature(true));
+        httpContext.Request.Headers["Content-Type"] = "application/json";
+
+        var requestBodyBytes = JsonSerializer.SerializeToUtf8Bytes(requestData);
+        var stream = new MemoryStream(requestBodyBytes);
+        httpContext.Request.Body = stream;
+        httpContext.Request.Headers["Content-Length"] = stream.Length.ToString(CultureInfo.InvariantCulture);
+
+        await endpoint.RequestDelegate(httpContext);
+        await VerifyResponseBodyAsync(httpContext, expectedBody, expectedStatusCode);
+    }
+
+    [Fact]
+    public async Task MapAction_ExplicitBodyParam_ComplexReturn_Snapshot()
+    {
+        var expectedBody = """{"id":0,"name":"Test Item","isComplete":false}""";
+        var todo = new Todo()
+        {
+            Id = 0,
+            Name = "Test Item",
+            IsComplete = false
+        };
+        var source = """
+app.MapPost("/fromBodyRequired", ([FromBody] Todo todo) => TypedResults.Ok(todo));
+#pragma warning disable CS8622
+app.MapPost("/fromBodyOptional", ([FromBody] Todo? todo) => TypedResults.Ok(todo));
+#pragma warning restore CS8622
+""";
+        var (_, compilation) = await RunGeneratorAsync(source);
+
+        await VerifyAgainstBaselineUsingFile(compilation);
+
+        var endpoints = GetEndpointsFromCompilation(compilation);
+
+        Assert.Equal(2, endpoints.Length);
+
+        // formBodyRequired accepts a provided input
+        var httpContext = CreateHttpContextWithBody(todo);
+        await endpoints[0].RequestDelegate(httpContext);
+        await VerifyResponseBodyAsync(httpContext, expectedBody);
+
+        // formBodyRequired throws on null input
+        httpContext = CreateHttpContextWithBody(null);
+        await endpoints[0].RequestDelegate(httpContext);
+        Assert.Equal(400, httpContext.Response.StatusCode);
+
+        // formBodyOptional accepts a provided input
+        httpContext = CreateHttpContextWithBody(todo);
+        await endpoints[1].RequestDelegate(httpContext);
+        await VerifyResponseBodyAsync(httpContext, expectedBody);
+
+        // formBodyOptional accepts a null input
+        httpContext = CreateHttpContextWithBody(null);
+        await endpoints[1].RequestDelegate(httpContext);
+        await VerifyResponseBodyAsync(httpContext, string.Empty);
     }
 
     [Fact]


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/46337.

This PR includes the following:
- Add support for processing a JSON body from HttpContext if it has a `[FromBody]` parameter
- Supports requiredness checks based on nullability, `AllowEmpty`, and default values
- Adds support for generating `EndpointFilterInvocationContext` using the generic overloads

This PR doesn't address the following scenarios:

- https://github.com/dotnet/aspnetcore/issues/46622
- https://github.com/dotnet/aspnetcore/issues/46639
- https://github.com/dotnet/aspnetcore/issues/46640
