### PR TITLE
Add WebViewManager.Dispatch() method

### DIFF
--- a/src/Components/WebView/WebView/src/PageContext.cs
+++ b/src/Components/WebView/WebView/src/PageContext.cs
@@ -25,6 +25,7 @@ internal sealed class PageContext : IAsyncDisposable
     public WebViewNavigationManager NavigationManager { get; }
     public WebViewJSRuntime JSRuntime { get; }
     public WebViewRenderer Renderer { get; }
+    public IServiceProvider ServiceProvider => _serviceScope.ServiceProvider;
 
     public PageContext(
         Dispatcher dispatcher,
@@ -35,17 +36,16 @@ internal sealed class PageContext : IAsyncDisposable
         string startUrl)
     {
         _serviceScope = serviceScope;
-        var services = serviceScope.ServiceProvider;
 
-        NavigationManager = (WebViewNavigationManager)services.GetRequiredService<NavigationManager>();
+        NavigationManager = (WebViewNavigationManager)ServiceProvider.GetRequiredService<NavigationManager>();
         NavigationManager.AttachToWebView(ipcSender, baseUrl, startUrl);
 
-        JSRuntime = (WebViewJSRuntime)services.GetRequiredService<IJSRuntime>();
+        JSRuntime = (WebViewJSRuntime)ServiceProvider.GetRequiredService<IJSRuntime>();
         JSRuntime.AttachToWebView(ipcSender);
 
-        var loggerFactory = services.GetRequiredService<ILoggerFactory>();
+        var loggerFactory = ServiceProvider.GetRequiredService<ILoggerFactory>();
         var jsComponents = new JSComponentInterop(jsComponentsConfiguration);
-        Renderer = new WebViewRenderer(services, dispatcher, ipcSender, loggerFactory, JSRuntime, jsComponents);
+        Renderer = new WebViewRenderer(ServiceProvider, dispatcher, ipcSender, loggerFactory, JSRuntime, jsComponents);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Components/WebView/WebView/src/PublicAPI.Unshipped.txt
+++ b/src/Components/WebView/WebView/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.AspNetCore.Components.WebView.WebViewManager.Dispatch(System.Action<System.IServiceProvider!>! action) -> void

--- a/src/Components/WebView/WebView/src/PublicAPI.Unshipped.txt
+++ b/src/Components/WebView/WebView/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,2 @@
 #nullable enable
-Microsoft.AspNetCore.Components.WebView.WebViewManager.DispatchAsync(System.Action<System.IServiceProvider!>! workItem) -> System.Threading.Tasks.Task!
-Microsoft.AspNetCore.Components.WebView.WebViewManager.DispatchAsync<TResult>(System.Func<System.IServiceProvider!, TResult>! workItem) -> System.Threading.Tasks.Task<TResult>!
 Microsoft.AspNetCore.Components.WebView.WebViewManager.TryDispatchAsync(System.Action<System.IServiceProvider!>! workItem) -> System.Threading.Tasks.Task<bool>!

--- a/src/Components/WebView/WebView/src/PublicAPI.Unshipped.txt
+++ b/src/Components/WebView/WebView/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 #nullable enable
-Microsoft.AspNetCore.Components.WebView.WebViewManager.Dispatch(System.Action<System.IServiceProvider!>! action) -> void
+Microsoft.AspNetCore.Components.WebView.WebViewManager.DispatchAsync(System.Action<System.IServiceProvider!>! workItem) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.WebView.WebViewManager.DispatchAsync<TResult>(System.Func<System.IServiceProvider!, TResult>! workItem) -> System.Threading.Tasks.Task<TResult>!
+Microsoft.AspNetCore.Components.WebView.WebViewManager.TryDispatchAsync(System.Action<System.IServiceProvider!>! workItem) -> System.Threading.Tasks.Task<bool>!

--- a/src/Components/WebView/WebView/src/WebViewManager.cs
+++ b/src/Components/WebView/WebView/src/WebViewManager.cs
@@ -116,43 +116,6 @@ public abstract class WebViewManager : IAsyncDisposable
     /// Calls the specified <paramref name="workItem"/> asynchronously and passes in the scoped services available to Razor components.
     /// </summary>
     /// <param name="workItem">The action to call.</param>
-    /// <returns>A <see cref="Task"/> that will be completed when the action has finished executing.</returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="workItem"/> is <c>null</c>.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if this method is called before Blazor has started in the web view.</exception>
-    public async Task DispatchAsync(Action<IServiceProvider> workItem)
-    {
-        ArgumentNullException.ThrowIfNull(workItem);
-        if (_currentPageContext is null)
-        {
-            throw new InvalidOperationException($"{nameof(DispatchAsync)} can't be called until after Blazor has started in the web view.");
-        }
-
-        await _currentPageContext.Renderer.Dispatcher.InvokeAsync(() => workItem(_currentPageContext.ServiceProvider));
-    }
-
-    /// <summary>
-    /// Calls the specified <paramref name="workItem"/> asynchronously and passes in the scoped services available to Razor components.
-    /// </summary>
-    /// <typeparam name="TResult"></typeparam>
-    /// <param name="workItem">The action to call.</param>
-    /// <returns>A <see cref="Task"/> representing a value of type <typeparamref name="TResult"/> returned by the called <paramref name="workItem"/> that will be completed when the action has finished executing.</returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="workItem"/> is <c>null</c>.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if this method is called before Blazor has started in the web view.</exception>
-    public async Task<TResult> DispatchAsync<TResult>(Func<IServiceProvider, TResult> workItem)
-    {
-        ArgumentNullException.ThrowIfNull(workItem);
-        if (_currentPageContext is null)
-        {
-            throw new InvalidOperationException($"{nameof(DispatchAsync)} can't be called until after Blazor has started in the web view.");
-        }
-
-        return await _currentPageContext.Renderer.Dispatcher.InvokeAsync(() => workItem(_currentPageContext.ServiceProvider));
-    }
-
-    /// <summary>
-    /// Calls the specified <paramref name="workItem"/> asynchronously and passes in the scoped services available to Razor components.
-    /// </summary>
-    /// <param name="workItem">The action to call.</param>
     /// <returns>Returns a <see cref="Task"/> representing <c>true</c> if the <paramref name="workItem"/> was called, or <c>false</c> if it was not called because Blazor is not currently running.</returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="workItem"/> is <c>null</c>.</exception>
     public async Task<bool> TryDispatchAsync(Action<IServiceProvider> workItem)

--- a/src/Components/WebView/WebView/src/WebViewManager.cs
+++ b/src/Components/WebView/WebView/src/WebViewManager.cs
@@ -168,6 +168,7 @@ public abstract class WebViewManager : IAsyncDisposable
 
     /// <summary>
     /// Calls the specified <paramref name="workItem"/> asynchronously and passes in the scoped services available to Razor components.
+    /// This method will not throw any exceptions if it is unable to call the specified <paramref name="workItem"/>, but if it does call it, then exceptions may still be thrown by the <paramref name="workItem"/> itself.
     /// </summary>
     /// <param name="workItem">The action to call.</param>
     /// <returns>Returns a <see cref="Task"/> representing <c>true</c> if the <paramref name="workItem"/> was called, or <c>false</c> if it was not called because Blazor is not currently running.</returns>

--- a/src/Components/WebView/WebView/src/WebViewManager.cs
+++ b/src/Components/WebView/WebView/src/WebViewManager.cs
@@ -168,7 +168,8 @@ public abstract class WebViewManager : IAsyncDisposable
 
         return true;
     }
-    /// <summary>
+
+        /// <summary>
     /// Removes a previously-attached root component from the current page.
     /// </summary>
     /// <param name="selector">The CSS selector describing where in the page the component was placed. This must exactly match the selector provided on an earlier call to <see cref="AddRootComponentAsync(Type, string, ParameterView)"/>.</param>

--- a/src/Components/WebView/WebView/src/WebViewManager.cs
+++ b/src/Components/WebView/WebView/src/WebViewManager.cs
@@ -169,7 +169,7 @@ public abstract class WebViewManager : IAsyncDisposable
         return true;
     }
 
-        /// <summary>
+    /// <summary>
     /// Removes a previously-attached root component from the current page.
     /// </summary>
     /// <param name="selector">The CSS selector describing where in the page the component was placed. This must exactly match the selector provided on an earlier call to <see cref="AddRootComponentAsync(Type, string, ParameterView)"/>.</param>

--- a/src/Components/WebView/WebView/src/WebViewManager.cs
+++ b/src/Components/WebView/WebView/src/WebViewManager.cs
@@ -176,14 +176,14 @@ public abstract class WebViewManager : IAsyncDisposable
     {
         ArgumentNullException.ThrowIfNull(workItem);
 
-        if (_currentPageContext is null)
+        var capturedCurrentPageContext = _currentPageContext;
+
+        if (capturedCurrentPageContext is null)
         {
             return false;
         }
 
-        var capturedCurrentPageContext = _currentPageContext;
-
-        return await _currentPageContext.Renderer.Dispatcher.InvokeAsync(() =>
+        return await capturedCurrentPageContext.Renderer.Dispatcher.InvokeAsync(() =>
         {
             if (capturedCurrentPageContext != _currentPageContext)
             {

--- a/src/Components/WebView/WebView/src/WebViewManager.cs
+++ b/src/Components/WebView/WebView/src/WebViewManager.cs
@@ -113,6 +113,23 @@ public abstract class WebViewManager : IAsyncDisposable
     }
 
     /// <summary>
+    /// Calls the specified <paramref name="action"/> and passes in the scoped services available to Blazor components.
+    /// </summary>
+    /// <param name="action">The action to invoke.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="action"/> is <c>null</c>.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if this method is called before Blazor has started in the web view.</exception>
+    public void Dispatch(Action<IServiceProvider> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        if (_currentPageContext is null)
+        {
+            throw new InvalidOperationException($"{nameof(Dispatch)} can't be called until after Blazor has started in the web view.");
+        }
+
+        action(_currentPageContext.ServiceProvider);
+    }
+
+    /// <summary>
     /// Removes a previously-attached root component from the current page.
     /// </summary>
     /// <param name="selector">The CSS selector describing where in the page the component was placed. This must exactly match the selector provided on an earlier call to <see cref="AddRootComponentAsync(Type, string, ParameterView)"/>.</param>


### PR DESCRIPTION
This enables callers to invoke methods with access to the scoped services used in BlazorWebView controls.

In Blazor Hybrid apps there is often a mix of "native UI code" and "Blazor web UI code". The code that executes "within" the BlazorWebView has access to the scoped services of the BlazorWebView's context. This includes services such as NavigationManager, JSInterop, etc. However, code from the native UI (for example, a WinForms or .NET MAUI Button control) has no access to those services because that code does not run within the scoped context of the BlazorWebView.

This PR adds a new API `TryDispatchAsync (Action<IServiceProvider> action)` that enables running code that _does_ have access to the scoped services.

For example, in .NET MAUI you could have code like this:

```c#
private async void MyMauiButtonHandler(object sender, EventArgs e)
{
    var wasDispatchCalled = await _blazorWebView.TryDispatchAsync(sp =>
    {
        var navMan = sp.GetRequiredService<NavigationManager>();
        navMan.CallSomeNavigationApi(...);
    });

    if (!wasDispatchCalled)
    {
        // consider what to do if it wasn't called - that's up to your app to decide
    }
}
```

Without the new `TryDispatchAsync()` methods you would invariably get an error such as:
1. Some service is not initialized. This is because the service is being used outside of its scope.
2. A scope validation error because a singleton service is trying to consume a scoped service

Note: This is the ASP.NET Core side of the PR. The MAUI side is in progress. But, feel free to review this in the meantime.

Fixes #46808

MAUI issue: https://github.com/dotnet/maui/issues/5804
