### PR TITLE
Transport.Quic.Tests: don't fail on distros that don't have quic.

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
@@ -20,20 +20,25 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Tests;
 [Collection(nameof(NoParallelCollection))]
 public class WebHostTests : LoggedTest
 {
-    // This test isn't conditional on QuicListener.IsSupported. Instead, it verifies that HTTP/3 runs on expected platforms:
+    // This test isn't conditional on QuicListener.IsSupported. Instead, it verifies that HTTP/3 runs on expected CI platforms:
     // 1. Windows 11 or later.
     // 2. Linux with libmsquic package installed.
     [ConditionalFact]
+    [SkipNonHelix]
     [SkipOnAlpine("https://github.com/dotnet/aspnetcore/issues/46537")]
     [SkipOnMariner("https://github.com/dotnet/aspnetcore/issues/46537")]
     [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/46616", Queues = "Debian.12.Arm64.Open;")]
     [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "HTTP/3 isn't supported on MacOS.")]
     [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win11_21H2)]
+    public void HelixPlatform_QuickListenerIsSupported()
+    {
+        Assert.True(QuicListener.IsSupported, "QuicListener.IsSupported should be true.");
+    }
+
+    [ConditionalFact]
+    [MsQuicSupported]
     public async Task PlatformSmoketest_HelloWorld_ClientSuccess()
     {
-        // First check that System.Net.Quic reports that's supported.
-        Assert.True(QuicListener.IsSupported, "QuicListener.IsSupported should be true.");
-
         // Next, do a basic HTTP/3 end-to-end test that ensures Kestrel can server a HTTP/3 request from a client.
         //
         // Arrange

--- a/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
@@ -33,63 +33,7 @@ public class WebHostTests : LoggedTest
     public void HelixPlatform_QuickListenerIsSupported()
     {
         Assert.True(QuicListener.IsSupported, "QuicListener.IsSupported should be true.");
-    }
-
-    [ConditionalFact]
-    [MsQuicSupported]
-    public async Task PlatformSmoketest_HelloWorld_ClientSuccess()
-    {
-        // Next, do a basic HTTP/3 end-to-end test that ensures Kestrel can server a HTTP/3 request from a client.
-        //
-        // Arrange
-        using var httpEventSource = new HttpEventSourceListener(LoggerFactory);
-
-        var builder = new HostBuilder()
-            .ConfigureWebHost(webHostBuilder =>
-            {
-                webHostBuilder
-                    .UseKestrel(o =>
-                    {
-                        o.ConfigureEndpointDefaults(listenOptions =>
-                        {
-                            listenOptions.Protocols = Core.HttpProtocols.Http3;
-                        });
-                        o.ConfigureHttpsDefaults(httpsOptions =>
-                        {
-                            httpsOptions.ServerCertificate = TestResources.GetTestCertificate();
-                        });
-                    })
-                    .UseUrls("https://127.0.0.1:0")
-                    .Configure(app =>
-                    {
-                        app.Run(async context =>
-                        {
-                            await context.Response.WriteAsync("hello, world");
-                        });
-                    });
-            })
-            .ConfigureServices(AddTestLogging);
-
-        using (var host = builder.Build())
-        using (var client = CreateClient())
-        {
-            await host.StartAsync();
-
-            var request = new HttpRequestMessage(HttpMethod.Get, $"https://127.0.0.1:{host.GetPort()}/");
-            request.Version = HttpVersion.Version30;
-            request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
-
-            // Act
-            var response = await client.SendAsync(request);
-
-            // Assert
-            response.EnsureSuccessStatusCode();
-            Assert.Equal(HttpVersion.Version30, response.Version);
-            var responseText = await response.Content.ReadAsStringAsync();
-            Assert.Equal("hello, world", responseText);
-
-            await host.StopAsync();
-        }
+        Assert.True(new MsQuicSupportedAttribute().IsMet, "MsQuicSupported.IsMet should be true.");
     }
 
     [ConditionalFact]


### PR DESCRIPTION
The test suite has a test that unconditionally fails when quic is not supported. The test is meant to ensure quic tests are executed.

Instead of running the test everywhere, this changes it to run only on Microsoft CI, where CI configurations are expected to have quic installed.

This change is similar to https://github.com/dotnet/runtime/pull/82108.

@dougbu ptal.

cc @omajid 