### PR TITLE
Preserve DOM elements when inserting passive content

### DIFF
--- a/src/Components/Samples/BestForYouRecipes/Components/NavSidebar.razor.css
+++ b/src/Components/Samples/BestForYouRecipes/Components/NavSidebar.razor.css
@@ -10,6 +10,7 @@ nav {
     background-color: #435869;
     box-shadow: 0 2px 4px 0px rgb(0 0 0 / 30%);
     z-index: 1;
+    transition: width 0.1s ease-out;
 }
 
 nav:hover {

--- a/src/Components/Web.JS/src/Boot.United.ts
+++ b/src/Components/Web.JS/src/Boot.United.ts
@@ -12,10 +12,15 @@ import { enableFormEnhancement } from './FormEnhancement';
 import { enableNavigationEnhancement, performEnhancedPageLoad } from './NavigationEnhancement';
 import { RootComponentsFunctions } from './Rendering/JSRootComponents';
 import { WebAssemblyComponentAttacher } from './Platform/WebAssemblyComponentAttacher';
+import { synchronizeDOMContent } from './DomSync/DomSync';
 
 let booted = false;
 let hasStartedWebAssembly = false;
 let hasStartedServer = false;
+
+Blazor._internal.mergePassiveContentIntoDOM = function (html: string) {
+  synchronizeDOMContent({ parent: document }, html);
+}
 
 async function boot(options?: Partial<UnitedStartOptions>): Promise<void> {
   if (booted) {

--- a/src/Components/Web.JS/src/DomSync/AttributeSync.ts
+++ b/src/Components/Web.JS/src/DomSync/AttributeSync.ts
@@ -33,7 +33,7 @@ export function synchronizeAttributes(destination: Element, endState: Element) {
     const endStateAttribName = endStateAttrib.name;
     const endStateAttribValue = endStateAttrib.value;
     const destinationAttribValue = destinationAttributesByName.get(endStateAttribName);
-    if (destinationAttribValue) {
+    if (destinationAttribValue !== undefined) {
       if (destinationAttribValue !== endStateAttribValue) {
         //console.log(`Changing value of attribute '${endStateAttribName}' from '${destinationAttribValue}' to '${endStateAttribValue}'`);
         destination.setAttribute(endStateAttribName, endStateAttribValue);

--- a/src/Components/Web.JS/src/DomSync/AttributeSync.ts
+++ b/src/Components/Web.JS/src/DomSync/AttributeSync.ts
@@ -1,0 +1,53 @@
+export function synchronizeAttributes(destination: Element, endState: Element) {
+  // Optimize for the common case where all attributes are unchanged and are even still in the same order
+  // In this case, we don't even have to build the name/value map
+  const destinationAttributesLength = destination.attributes.length;
+  const endStateAttributesLength = endState.attributes.length;
+  let hasDifference = false;
+  if (destinationAttributesLength === endStateAttributesLength) {
+    for (let i = 0; i < destinationAttributesLength; i++) {
+      const destAttrib = destination.attributes[i];
+      const endStateAttrib = endState.attributes[i];
+      if (destAttrib.name !== endStateAttrib.name || destAttrib.value !== endStateAttrib.value) {
+        hasDifference = true;
+        break;
+      }
+    }
+
+    if (!hasDifference) {
+      return;
+    }
+  }
+
+  // Collect the destination attributes in a map so we can match them to the end-state attributes
+  const destinationAttributesByName = new Map<string, string>();
+  for (let i = 0; i < destinationAttributesLength; i++) {
+    const attrib = destination.attributes[i];
+    destinationAttributesByName.set(attrib.name, attrib.value);
+  }
+
+  // Loop through end state and insert/update. Track which ones we saw because any that are left
+  // over will then be deleted.
+  for (let i = 0; i < endStateAttributesLength; i++) {
+    const endStateAttrib = endState.attributes[i];
+    const endStateAttribName = endStateAttrib.name;
+    const endStateAttribValue = endStateAttrib.value;
+    const destinationAttribValue = destinationAttributesByName.get(endStateAttribName);
+    if (destinationAttribValue) {
+      if (destinationAttribValue !== endStateAttribValue) {
+        //console.log(`Changing value of attribute '${endStateAttribName}' from '${destinationAttribValue}' to '${endStateAttribValue}'`);
+        destination.setAttribute(endStateAttribName, endStateAttribValue);
+      }
+
+      destinationAttributesByName.delete(endStateAttribName);
+    } else {
+      //console.log(`Adding attribute '${endStateAttribName}' with value '${endStateAttribValue}'`);
+      destination.setAttribute(endStateAttribName, endStateAttribValue);
+    }
+  }
+
+  for (let name of destinationAttributesByName.keys()) {
+    //console.log(`Removing attribute '${name}' with value '${destinationAttributesByName.get(name)}'`);
+    destination.removeAttribute(name);
+  }
+}

--- a/src/Components/Web.JS/src/DomSync/DomSync.ts
+++ b/src/Components/Web.JS/src/DomSync/DomSync.ts
@@ -1,0 +1,150 @@
+import { synchronizeAttributes } from './AttributeSync';
+import { Operation, getEditScript, ComparisonResult } from './EditDistance';
+import { ItemList, SiblingSubsetNodeList } from './SiblingSubsetNodeList';
+
+interface NodeRange {
+  parent: Node;
+  
+  // If set, we assume that startMarker and endMarker are both immediate children of parentNode,
+  // and we are describing the range of siblings between the two
+  subset?: SiblingSubset;
+}
+
+interface SiblingSubset {
+  startMarker: Comment;
+  endMarker: Comment;
+}
+
+export function synchronizeDOMContent(destinationWithOldContent: NodeRange, newContent: string | ParentNode) {  
+  const treatAsWholeDocument = destinationWithOldContent.parent instanceof Document;
+  const newContentFragment = parseContent(newContent, treatAsWholeDocument);
+  synchronizeSubtree(destinationWithOldContent, newContentFragment);
+}
+
+function parseContent(content: string | Node, treatAsWholeDocument: boolean): Node {
+  if (content instanceof Node) {
+    return content;
+  }
+
+  // Annoyingly, neither HTML parsing approach handles all cases
+  if (treatAsWholeDocument) {
+    // This approach always returns a Document and will automatically surround your content with other elements
+    // like <html> and <body>
+    const parser = new DOMParser();
+    return parser.parseFromString(content, 'text/html');
+  } else {
+    // This approach always strips off certain top-level elements like <body>
+    const parserTemplate = document.createElement('template');
+    parserTemplate.innerHTML = content;
+    return parserTemplate.content;
+  }
+}
+
+function synchronizeSubtree(destination: NodeRange, desiredEndState: Node) {
+  const existingNodes = nodeRangeToItemList(destination);
+  const edits = getEditScript(existingNodes, desiredEndState.childNodes, compareNodes);
+  if (!edits) {
+    return;
+  }
+
+  let destinationIndex = 0;
+  let sourceIndex = 0;
+
+  for (let editIndex = 0; editIndex < edits.length; editIndex++) {
+    switch (edits[editIndex]) {
+      case Operation.RetainAsIdentical:
+        //console.log('Skip', existingNodes.item(destinationIndex));
+        destinationIndex++;
+        sourceIndex++;
+        break;
+      case Operation.RetainAsCompatible:
+        //console.log('RetainWithEdit', existingNodes.item(destinationIndex), desiredEndState.childNodes[sourceIndex]);
+        synchronizeNodeViaRetain(existingNodes.item(destinationIndex)!, desiredEndState.childNodes[sourceIndex]);
+        destinationIndex++;
+        sourceIndex++;
+        break;
+      case Operation.Insert:
+        const nodeToInsert = desiredEndState.childNodes[sourceIndex];
+        //console.log('Insert', nodeToInsert);
+        destination.parent.insertBefore(nodeToInsert, existingNodes.item(destinationIndex));
+        destinationIndex++;
+        break;
+      case Operation.Delete:
+        const nodeToDelete = existingNodes.item(destinationIndex)!;
+        //console.log('Delete', nodeToDelete);
+        destination.parent.removeChild(nodeToDelete);
+        break;
+    }
+  }
+}
+
+function synchronizeNodeViaRetain(destination: Node, endState: Node) {
+  if (destination.nodeType !== endState.nodeType) {
+    throw new Error('Can only retain nodes of the same type');
+  }
+
+  switch (destination.nodeType) {
+    case NodeType.ELEMENT:
+      synchronizeAttributes(destination as Element, endState as Element);
+      synchronizeSubtree({ parent: destination }, endState);
+      break;
+    case NodeType.TEXT:
+      //console.log(`Change text node content from '${(destination as Text).textContent}' to '${(endState as Text).textContent}'`);
+      (destination as Text).textContent = (endState as Text).textContent;
+      break;
+    case NodeType.COMMENT:
+      (destination as Text).textContent = (endState as Text).textContent;
+      break;
+    default:
+      throw new Error(`Unsupported node type for synchronizeNodeViaRetain: ${destination.nodeType}`);
+  }
+}
+
+function compareNodes(a: Node, b: Node): ComparisonResult {
+  if (a.nodeType !== b.nodeType) {
+    return ComparisonResult.Incompatible;
+  }
+
+  switch (a.nodeType) {
+    case NodeType.ELEMENT:
+      return compareElements(a as Element, b as Element);
+    case NodeType.TEXT:
+      return (a as Text).textContent === (b as Text).textContent ? ComparisonResult.Identical : ComparisonResult.Compatible;
+    case NodeType.COMMENT:
+      return (a as Text).textContent === (b as Text).textContent ? ComparisonResult.Identical : ComparisonResult.Compatible;
+    case NodeType.DOCTYPE:
+      // TODO: Would these ever have to be updated?
+      return ComparisonResult.Identical;
+    default:
+      throw new Error(`Unsupported node type for diffing: ${a.nodeType}`);
+  }
+}
+
+function compareElements(a: Element, b: Element): ComparisonResult {
+  if (a.tagName !== b.tagName) {
+    return ComparisonResult.Incompatible;
+  }
+
+  // If there are mismatching keys, prevent retention. Note that the converse isn't handled here and would have to be
+  // covered as a post-processing step (i.e., even if elements *do* having matching keys, they may initially show as
+  // being inserted and deleted, so we'd need to scan the list of inserts/deletes and find pairs we can match up to
+  // treat as 'move' operations).
+  const aKey = a.getAttribute('key');
+  const bKey = b.getAttribute('key');
+  return aKey === bKey ? ComparisonResult.Compatible : ComparisonResult.Incompatible;
+}
+
+function nodeRangeToItemList(range: NodeRange): ItemList<Node> {
+  if (range.subset) {
+    return new SiblingSubsetNodeList(range.subset.startMarker, range.subset.endMarker);
+  } else {
+    return range.parent.childNodes;
+  }
+}
+
+const enum NodeType {
+  ELEMENT = 1,
+  TEXT = 3,
+  COMMENT = 8,
+  DOCTYPE = 10,
+}

--- a/src/Components/Web.JS/src/DomSync/EditDistance.ts
+++ b/src/Components/Web.JS/src/DomSync/EditDistance.ts
@@ -1,0 +1,102 @@
+// This is just basic Levenshtein. Consider further optimizations such as processing increasingly wide
+// diagonal stripes until we find a valid edit sequence. But bear in mind that naively limiting the search
+// to a diagonal stripe can produce a different edit script (with the same total cost) as you would get from
+// an unbounded search, and it might not retain as many elements.
+
+import { ItemList } from './SiblingSubsetNodeList';
+
+export function getEditScript<T>(before: ItemList<T>, after: ItemList<T>, comparer: (a: T, b: T) => ComparisonResult): Operation[] | null {
+  // Initialize matrices
+  const matrix: number[][] = [];
+  const comparisonResults: ComparisonResult[][] = [];
+  const beforeLength = before.length;
+  const afterLength = after.length;
+  if (before.length === 0 && afterLength === 0) {
+    return null;
+  }
+
+  for (let beforeIndex = 0; beforeIndex <= beforeLength; beforeIndex++) {
+    (matrix[beforeIndex] = Array(afterLength + 1))[0] = beforeIndex;
+    comparisonResults[beforeIndex] = Array(afterLength + 1);
+  }
+  const rowZero = matrix[0];
+  for (let afterIndex = 1; afterIndex <= afterLength; afterIndex++) {
+    rowZero[afterIndex] = afterIndex;
+  }
+
+  // Calculate edit costs
+  for (let beforeIndex = 1; beforeIndex <= beforeLength; beforeIndex++) {
+    for (let afterIndex = 1; afterIndex <= afterLength; afterIndex++) {
+      const beforeItem = before.item(beforeIndex - 1)!;
+      const afterItem = after.item(afterIndex - 1)!;
+      const costAsInsert = matrix[beforeIndex][afterIndex - 1] + 1;
+      const costAsDelete = matrix[beforeIndex - 1][afterIndex] + 1;
+
+      const comparisonResult = comparisonResults[beforeIndex][afterIndex] = comparer(beforeItem, afterItem);
+      if (comparisonResult === ComparisonResult.Incompatible) {
+        matrix[beforeIndex][afterIndex] = Math.min(costAsInsert, costAsDelete);
+      } else {
+        // Treat all compatible items as zero cost to edit. The distinction between 'Identical' and 'Compatible'
+        // is just so we can select between 'Skip' and 'RetainAndEdit'
+        const costAsRetain = matrix[beforeIndex - 1][afterIndex - 1];
+        matrix[beforeIndex][afterIndex] = Math.min(costAsInsert, costAsDelete, costAsRetain);
+      }
+    }
+  }
+
+  // Walk through it to select an edit script
+  let beforeIndex = beforeLength;
+  let afterIndex = afterLength;
+  const result: Operation[] = [];
+  while (beforeIndex > 0 || afterIndex > 0) {
+    if (beforeIndex === 0) {
+      // No choice but to insert
+      result.unshift(Operation.Insert);
+      afterIndex--;
+    } else if (afterIndex === 0) {
+      // No choice but to delete
+      result.unshift(Operation.Delete);
+      beforeIndex--;
+    } else {
+      const comparisonResult = comparisonResults[beforeIndex][afterIndex];
+      const costAsInsert = matrix[beforeIndex][afterIndex - 1];
+      const costAsDelete = matrix[beforeIndex - 1][afterIndex];
+      const costAsRetain = comparisonResult === ComparisonResult.Incompatible
+        ? Number.MAX_VALUE
+        : matrix[beforeIndex - 1][afterIndex - 1];
+
+      if (costAsRetain <= costAsInsert && costAsRetain <= costAsDelete) {
+        const operation = comparisonResult === ComparisonResult.Identical
+          ? Operation.RetainAsIdentical
+          : Operation.RetainAsCompatible;
+        result.unshift(operation);
+        beforeIndex--;
+        afterIndex--;
+      } else if (costAsInsert < costAsDelete) {
+        result.unshift(Operation.Insert);
+        afterIndex--;
+      } else {
+        result.unshift(Operation.Delete);
+        beforeIndex--;
+      }
+    }
+  }
+
+  //console.log('Compared', before, after);
+  //console.log(matrix);
+  //console.log(result);
+  return result;
+}
+
+export const enum Operation {
+  RetainAsIdentical = 0,
+  RetainAsCompatible = 1,
+  Insert = 2,
+  Delete = 3,
+}
+
+export const enum ComparisonResult {
+  Identical = 0,
+  Compatible = 1,
+  Incompatible = 2,
+}

--- a/src/Components/Web.JS/src/DomSync/SiblingSubsetNodeList.ts
+++ b/src/Components/Web.JS/src/DomSync/SiblingSubsetNodeList.ts
@@ -1,0 +1,30 @@
+export class SiblingSubsetNodeList implements ItemList<Node> {
+  private readonly siblings: NodeList;
+  private readonly startIndex: number;
+  private readonly endIndexExcl: number;
+
+  readonly length: number;
+
+  item(index: number): Node | null {
+    return this.siblings.item(this.startIndex + index);
+  }
+
+  forEach(callbackfn: (value: Node, key: number, parent: ItemList<Node>) => void, thisArg?: any): void {
+    for (let i = 0; i < this.length; i++) {
+      callbackfn.call(thisArg, this.item(i)!, i, this);
+    }
+  }
+
+  constructor(startExcl: Comment, endExcl: Comment) {
+    this.siblings = startExcl.parentNode!.childNodes;
+    this.startIndex = Array.prototype.indexOf.call(this.siblings, startExcl) + 1;
+    this.endIndexExcl = Array.prototype.indexOf.call(this.siblings, endExcl);
+    this.length = this.endIndexExcl - this.startIndex;
+  }
+}
+
+export interface ItemList<T> { // Designed to be compatible with NodeList
+  readonly length: number;
+  item(index: number): T | null;
+  forEach(callbackfn: (value: T, key: number, parent: ItemList<T>) => void, thisArg?: any): void;
+}

--- a/src/Components/Web.JS/src/GlobalExports.ts
+++ b/src/Components/Web.JS/src/GlobalExports.ts
@@ -30,6 +30,7 @@ interface IBlazor {
   rootComponents: typeof RootComponentsFunctions;
 
   _internal: {
+    mergePassiveContentIntoDOM?: (html: string) => void,
     navigationManager: typeof navigationManagerInternalFunctions | any,
     domWrapper: typeof domFunctions,
     Virtualize: typeof Virtualize,

--- a/src/Mvc/Mvc.RazorPages/src/PassiveComponentRenderer.cs
+++ b/src/Mvc/Mvc.RazorPages/src/PassiveComponentRenderer.cs
@@ -179,11 +179,10 @@ internal class PassiveComponentRenderer
         using var streamReader = new StreamReader(memoryStream);
         var htmlString = streamReader.ReadToEnd();
         var htmlStringJson = JsonSerializer.Serialize(htmlString);
-
+        
         using var writer = _writerFactory.CreateWriter(httpContext.Response.BodyWriter.AsStream(), Encoding.UTF8);
-        await writer.WriteAsync("\n<script>(function() { const newHtml = ");
+        await writer.WriteAsync("\n<script>Blazor._internal.mergePassiveContentIntoDOM(");
         await writer.WriteAsync(htmlStringJson);
-        await writer.WriteAsync("; document.body.innerHTML = new DOMParser().parseFromString(newHtml, 'text/html').querySelector('body').innerHTML;");
-        await writer.WriteAsync("})()</script>");
+        await writer.WriteAsync(");</script>");
     }
 }


### PR DESCRIPTION
This introduces a new DOM diffing mechanism that lets us insert server-rendered content while preserving as much of the existing DOM as possible. It's based on a traditional edit-distance algorithm with the additional ability to distinguish between subtrees that can be skipped completely vs ones we have to recurse into. Further optimizations could be added it we want.