### PR TITLE
Streaming SSR partial doc updates

### DIFF
--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -13,6 +13,7 @@ Microsoft.AspNetCore.Components.NavigationOptions.HistoryEntryState.get -> strin
 Microsoft.AspNetCore.Components.NavigationOptions.HistoryEntryState.init -> void
 Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddAttribute(int sequence, string! name, Microsoft.AspNetCore.Components.ComponentRenderMode renderMode) -> void
 Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.AddContent(int sequence, Microsoft.AspNetCore.Components.MarkupString? markupContent) -> void
+Microsoft.AspNetCore.Components.RenderTree.Renderer.GetComponentDepth(int componentId) -> int
 Microsoft.AspNetCore.Components.RenderTree.Renderer.WaitForStreamingQuiescence() -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.ComponentRenderMode.get -> Microsoft.AspNetCore.Components.ComponentRenderMode
 Microsoft.AspNetCore.Components.RouteData.FormValues.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, Microsoft.Extensions.Primitives.StringValues>>?

--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -466,6 +466,24 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
             : EventArgsTypeCache.GetEventArgsType(methodInfo);
     }
 
+    /// <summary>
+    /// Returns the number of ancestors above the specified component.
+    /// </summary>
+    /// <param name="componentId">The component ID.</param>
+    /// <returns>The number of components in the ancestor chain, not including the specified component itself.</returns>
+    protected int GetComponentDepth(int componentId)
+    {
+        var state = GetRequiredComponentState(componentId).ParentComponentState;
+        var depth = 0;
+        while (state is not null)
+        {
+            depth++;
+            state = state.ParentComponentState;
+        }
+
+        return depth;
+    }
+
     internal void InstantiateChildComponentOnFrame(ref RenderTreeFrame frame, int parentComponentId)
     {
         if (frame.FrameTypeField != RenderTreeFrameType.Component)

--- a/src/Components/Web.JS/src/Boot.United.ts
+++ b/src/Components/Web.JS/src/Boot.United.ts
@@ -13,6 +13,7 @@ import { enableNavigationEnhancement, performEnhancedPageLoad } from './Navigati
 import { RootComponentsFunctions } from './Rendering/JSRootComponents';
 import { WebAssemblyComponentAttacher } from './Platform/WebAssemblyComponentAttacher';
 import { synchronizeDOMContent } from './DomSync/DomSync';
+import { synchronizeComponentContent } from './DomSync/ComponentSync';
 
 let booted = false;
 let hasStartedWebAssembly = false;
@@ -20,6 +21,10 @@ let hasStartedServer = false;
 
 Blazor._internal.mergePassiveContentIntoDOM = function (html: string) {
   synchronizeDOMContent({ parent: document }, html);
+}
+
+Blazor._internal.mergePassiveComponentIntoDOM = function (componentId: number, html: string) {
+  synchronizeComponentContent(componentId, html);
 }
 
 async function boot(options?: Partial<UnitedStartOptions>): Promise<void> {

--- a/src/Components/Web.JS/src/DomSync/ComponentSync.ts
+++ b/src/Components/Web.JS/src/DomSync/ComponentSync.ts
@@ -1,0 +1,42 @@
+import { synchronizeDOMContent } from './DomSync';
+
+export function synchronizeComponentContent(componentId: number, html: string) {
+  const startMarker = findPassiveComponentStartMarker(componentId);
+  const endMarker = findPassiveComponentEndMarker(startMarker);
+  synchronizeDOMContent({ parent: startMarker.parentNode!, subset: { startMarker, endMarker } }, html);
+}
+
+function findPassiveComponentStartMarker(componentId: number): Comment {
+  const expectedText = `c${componentId}`;
+  const iterator = document.createNodeIterator(document, NodeFilter.SHOW_COMMENT);
+  let node: Node | null;
+  while (node = iterator.nextNode()) {
+    if (node.textContent === expectedText) {
+      return node as Comment;
+    }
+  }
+
+  throw new Error(`Cannot find marker for passive component ${componentId} in the document`);
+}
+
+const passiveComponentStartMarkerPattern = /^c\d+$/;
+
+function findPassiveComponentEndMarker(startMarker: Comment): Comment {
+  let depth = 1;
+  let currentNode: Node | null = startMarker;
+  while (currentNode) {
+    currentNode = currentNode.nextSibling;
+    if (currentNode?.nodeType === 8) { // Comment
+      if (currentNode.textContent === '/c') {
+        depth--;
+        if (depth === 0) {
+          return currentNode as Comment;
+        }
+      } else if (passiveComponentStartMarkerPattern.test(currentNode.textContent!)) {
+        depth++;
+      }
+    }
+  }
+
+  throw new Error(`Cannot find closing marker corresponding to ${startMarker.textContent}`);
+}

--- a/src/Components/Web.JS/src/GlobalExports.ts
+++ b/src/Components/Web.JS/src/GlobalExports.ts
@@ -31,6 +31,7 @@ interface IBlazor {
 
   _internal: {
     mergePassiveContentIntoDOM?: (html: string) => void,
+    mergePassiveComponentIntoDOM?: (componentId: number, html: string) => void,
     navigationManager: typeof navigationManagerInternalFunctions | any,
     domWrapper: typeof domFunctions,
     Virtualize: typeof Virtualize,

--- a/src/Components/Web.JS/src/Rendering/LogicalElements.ts
+++ b/src/Components/Web.JS/src/Rendering/LogicalElements.ts
@@ -184,6 +184,10 @@ export function getLogicalChildrenArray(element: LogicalElement): LogicalElement
   return element[logicalChildrenPropname] as LogicalElement[];
 }
 
+export function isKnownLogicalElement(element: Node): boolean {
+  return !!element[logicalChildrenPropname];
+}
+
 export function permuteLogicalChildren(parent: LogicalElement, permutationList: PermutationListEntry[]): void {
   // The permutationList must represent a valid permutation, i.e., the list of 'from' indices
   // is distinct, and the list of 'to' indices is a permutation of it. The algorithm here

--- a/src/Mvc/Mvc.RazorPages/src/PassiveComponentRenderer.cs
+++ b/src/Mvc/Mvc.RazorPages/src/PassiveComponentRenderer.cs
@@ -75,7 +75,8 @@ internal class PassiveComponentRenderer
         viewBuffer.AppendHtml(result);
 
         using var writer = _writerFactory.CreateWriter(httpContext.Response.BodyWriter.AsStream(), Encoding.UTF8);
-        await viewBuffer.WriteToAsync(writer, _htmlEncoder);
+        await htmlRenderer.Dispatcher.InvokeAsync(
+            () => viewBuffer.WriteToAsync(writer, _htmlEncoder));
 
         try
         {

--- a/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/StreamingComponentUpdate.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/RazorComponents/StreamingComponentUpdate.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.RenderTree;
+
+namespace Microsoft.AspNetCore.Components.Rendering;
+
+internal readonly struct StreamingComponentUpdate
+{
+    public IReadOnlyList<int> UpdatedComponentIds { get; private init; }
+
+    public static StreamingComponentUpdate SnapshotFromRenderBatch(RenderBatch batch)
+    {
+        var updatedComponentIds = new List<int>();
+
+        var updatedComponentsArray = batch.UpdatedComponents.Array;
+        var updatedComponentsCount = batch.UpdatedComponents.Count;
+        for (var i = 0; i < updatedComponentsCount; i++)
+        {
+            updatedComponentIds.Add(updatedComponentsArray[i].ComponentId);
+        }
+
+        return new StreamingComponentUpdate { UpdatedComponentIds = updatedComponentIds };
+    }
+}


### PR DESCRIPTION
Makes streaming SSR updates now only include the minimal subtrees needed to cover all of the updated components (instead of sending the entire document), then patch just the subtrees into the document, still preserving DOM nodes where possible.

This reduces the workload on both server and client.