### PR TITLE
Revert "Remove unnecessary code from F# templates"

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/Program.fs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyWeb-FSharp/Program.fs
@@ -1,5 +1,6 @@
 open System
 open Microsoft.AspNetCore.Builder
+open Microsoft.Extensions.Hosting
 
 [<EntryPoint>]
 let main args =

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/Controllers/HomeController.fs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/Controllers/HomeController.fs
@@ -1,10 +1,17 @@
-namespace Company.WebApplication1.Controllers
+﻿namespace Company.WebApplication1.Controllers
 
+open System
+open System.Collections.Generic
+open System.Linq
+open System.Threading.Tasks
 open System.Diagnostics
+
 open Microsoft.AspNetCore.Mvc
+open Microsoft.Extensions.Logging
+
 open Company.WebApplication1.Models
 
-type HomeController () =
+type HomeController (logger : ILogger<HomeController>) =
     inherit Controller()
 
     member this.Index () =
@@ -15,7 +22,7 @@ type HomeController () =
 
     [<ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)>]
     member this.Error () =
-        let reqId =
+        let reqId = 
             if isNull Activity.Current then
                 this.HttpContext.TraceIdentifier
             else

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/Program.fs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/Program.fs
@@ -2,12 +2,21 @@ namespace Company.WebApplication1
 
 #nowarn "20"
 
+open System
+open System.Collections.Generic
+open System.IO
+open System.Linq
+open System.Threading.Tasks
+open Microsoft.AspNetCore
 open Microsoft.AspNetCore.Builder
+open Microsoft.AspNetCore.Hosting
 #if !NoHttps
 open Microsoft.AspNetCore.HttpsPolicy
 #endif
+open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Hosting
+open Microsoft.Extensions.Logging
 
 module Program =
     let exitCode = 0

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/Controllers/WeatherForecastController.fs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/Controllers/WeatherForecastController.fs
@@ -1,7 +1,11 @@
-namespace Company.WebApplication1.Controllers
+﻿namespace Company.WebApplication1.Controllers
 
 open System
+open System.Collections.Generic
+open System.Linq
+open System.Threading.Tasks
 open Microsoft.AspNetCore.Mvc
+open Microsoft.Extensions.Logging
 open Company.WebApplication1
 
 [<ApiController>]

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/Program.fs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/Program.fs
@@ -1,11 +1,20 @@
 namespace Company.WebApplication1
 #nowarn "20"
-
+open System
+open System.Collections.Generic
+open System.IO
+open System.Linq
+open System.Threading.Tasks
+open Microsoft.AspNetCore
 open Microsoft.AspNetCore.Builder
+open Microsoft.AspNetCore.Hosting
 #if !NoHttps
 open Microsoft.AspNetCore.HttpsPolicy
 #endif
+open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Hosting
+open Microsoft.Extensions.Logging
 
 module Program =
     let exitCode = 0

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-FSharp/Program.fs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-FSharp/Program.fs
@@ -1,5 +1,9 @@
 namespace Company.Application1
 
+open System
+open System.Collections.Generic
+open System.Linq
+open System.Threading.Tasks
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Hosting
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-FSharp/Worker.fs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-FSharp/Worker.fs
@@ -1,6 +1,8 @@
 namespace Company.Application1
 
 open System
+open System.Collections.Generic
+open System.Linq
 open System.Threading
 open System.Threading.Tasks
 open Microsoft.Extensions.Hosting


### PR DESCRIPTION
reverts dotnet/aspnetcore#46443

code flow is blocked due to this five repos down the chain: https://github.com/dotnet/installer/pull/15564.

(if ci can't test this code here, then it doesn't belong in this repo)