### PR TITLE
Expand FromX support and add route vs. query param inference

### DIFF
--- a/src/Http/Http.Extensions/gen/RequestDelegateGenerator.cs
+++ b/src/Http/Http.Extensions/gen/RequestDelegateGenerator.cs
@@ -120,7 +120,7 @@ public sealed class RequestDelegateGenerator : IIncrementalGenerator
                     lineNumber);
         }
 """);
-                }
+               }
 
                 return code.ToString();
             });

--- a/src/Http/Http.Extensions/gen/RequestDelegateGenerator.cs
+++ b/src/Http/Http.Extensions/gen/RequestDelegateGenerator.cs
@@ -120,7 +120,7 @@ public sealed class RequestDelegateGenerator : IIncrementalGenerator
                     lineNumber);
         }
 """);
-               }
+                }
 
                 return code.ToString();
             });

--- a/src/Http/Http.Extensions/gen/RequestDelegateGeneratorSources.cs
+++ b/src/Http/Http.Extensions/gen/RequestDelegateGeneratorSources.cs
@@ -134,6 +134,13 @@ namespace Microsoft.AspNetCore.Http.Generated
             }
             return (false, default);
         }
+
+        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
+        {
+            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
+                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
+                : httpContext.Request.Query[$"{parameterName}"];
+        }
     }
 
     {{GeneratedCodeAttribute}}

--- a/src/Http/Http.Extensions/gen/RequestDelegateGeneratorSources.cs
+++ b/src/Http/Http.Extensions/gen/RequestDelegateGeneratorSources.cs
@@ -134,13 +134,6 @@ namespace Microsoft.AspNetCore.Http.Generated
             }
             return (false, default);
         }
-
-        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
-        {
-            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
-                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
-                : httpContext.Request.Query[$"{parameterName}"];
-        }
     }
 
     {{GeneratedCodeAttribute}}

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointEmitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointEmitter.cs
@@ -21,8 +21,14 @@ internal static class EndpointEmitter
                     Source: EndpointParameterSource.SpecialType
                 } => parameter.EmitSpecialParameterPreparation(),
                 {
-                    Source: EndpointParameterSource.Query,
-                } => parameter.EmitQueryParameterPreparation(),
+                    Source: EndpointParameterSource.Query or EndpointParameterSource.Header,
+                } => parameter.EmitQueryOrHeaderParameterPreparation(),
+                {
+                  Source: EndpointParameterSource.Route,
+                } => parameter.EmitRouteParameterPreparation(),
+                {
+                    Source: EndpointParameterSource.RouteOrQuery
+                } => parameter.EmitRouteOrQueryParameterPreparation(),
                 {
                     Source: EndpointParameterSource.JsonBody
                 } => parameter.EmitJsonBodyParameterPreparationString(),

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointEmitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointEmitter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Linq;
 using System.Text;
 
 namespace Microsoft.AspNetCore.Http.Generators.StaticRouteHandlerModel.Emitters;
@@ -51,4 +52,6 @@ internal static class EndpointEmitter
 
         return parameterPreparationBuilder.ToString();
     }
+
+    public static string EmitArgumentList(this Endpoint endpoint) => string.Join(", ", endpoint.Parameters.Select(p => p.EmitArgument()));
 }

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
@@ -129,7 +129,7 @@ internal static class EndpointParameterEmitter
                         {endpointParameter.EmitParameterDiagnosticComment()}
 """);
 
-        var assigningCode = $"await GeneratedRouteBuilderExtensionsCore.TryResolveBody<{endpointParameter.Type}>(httpContext, {(endpointParameter.IsOptional ? "true" : "false")})";
+        var assigningCode = $"await GeneratedRouteBuilderExtensionsCore.TryResolveBody<{endpointParameter.Type.ToDisplayString(EmitterConstants.DisplayFormat)}>(httpContext, {(endpointParameter.IsOptional ? "true" : "false")})";
         builder.AppendLine($$"""
                         var (isSuccessful, {{endpointParameter.EmitHandlerArgument()}}) = {{assigningCode}};
 """);
@@ -172,7 +172,7 @@ internal static class EndpointParameterEmitter
     }
 
     private static string EmitParameterDiagnosticComment(this EndpointParameter endpointParameter) =>
-        $"// Endpoint Parameter: {endpointParameter.Name} (Type = {endpointParameter.Type}, IsOptional = {endpointParameter.IsOptional}, Source = {endpointParameter.Source})";
+        $"// Endpoint Parameter: {endpointParameter.Name} (Type = {endpointParameter.Type.ToDisplayString(EmitterConstants.DisplayFormat)}, IsOptional = {endpointParameter.IsOptional}, Source = {endpointParameter.Source})";
 
     private static string EmitHandlerArgument(this EndpointParameter endpointParameter) => $"{endpointParameter.Name}_local";
     private static string EmitAssigningCodeResult(this EndpointParameter endpointParameter) => $"{endpointParameter.Name}_raw";

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Endpoint.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Endpoint.cs
@@ -91,7 +91,7 @@ internal class Endpoint
 
         for (var i = 0; i < a.Parameters.Length; i++)
         {
-            if (!a.Parameters[i].Equals(b.Parameters[i]))
+            if (!a.Parameters[i].SignatureEquals(b.Parameters[i]))
             {
                 return false;
             }
@@ -108,7 +108,7 @@ internal class Endpoint
 
         foreach (var parameter in endpoint.Parameters)
         {
-            hashCode.Add(parameter);
+            hashCode.Add(parameter.Type, SymbolEqualityComparer.Default);
         }
 
         return hashCode.ToHashCode();

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Endpoint.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Endpoint.cs
@@ -13,8 +13,6 @@ namespace Microsoft.AspNetCore.Http.Generators.StaticRouteHandlerModel;
 
 internal class Endpoint
 {
-    private string? _argumentListCache;
-
     public Endpoint(IInvocationOperation operation, WellKnownTypes wellKnownTypes)
     {
         Operation = operation;
@@ -67,8 +65,6 @@ internal class Endpoint
     public string? RoutePattern { get; }
     public EndpointResponse? Response { get; }
     public EndpointParameter[] Parameters { get; } = Array.Empty<EndpointParameter>();
-    public string EmitArgumentList() => _argumentListCache ??= string.Join(", ", Parameters.Select(p => p.EmitArgument()));
-
     public List<DiagnosticDescriptor> Diagnostics { get; } = new List<DiagnosticDescriptor>();
 
     public (string File, int LineNumber) Location { get; }

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
@@ -135,7 +135,7 @@ internal class EndpointParameter
         {
             return false;
         }
-        isOptional |= fromBodyAttribute.TryGetNamedArgumentValue<bool>("AllowEmpty", out var allowEmptyValue) && allowEmptyValue;
+        isOptional |= fromBodyAttribute.TryGetNamedArgumentValue<int>("EmptyBodyBehavior", out var emptyBodyBehaviorValue) && emptyBodyBehaviorValue == 1;
         isOptional |= (parameter.NullableAnnotation == NullableAnnotation.Annotated || parameter.HasExplicitDefaultValue);
         return true;
     }

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/StaticRouteHandlerModel.Emitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/StaticRouteHandlerModel.Emitter.cs
@@ -185,7 +185,7 @@ return ValueTask.FromResult<object?>(handler({endpoint.EmitFilteredArgumentList(
 
         for (var i = 0; i < endpoint.Parameters.Length; i++)
         {
-            sb.Append($"ic.GetArgument<{endpoint.Parameters[i].Type}>({i})");
+            sb.Append($"ic.GetArgument<{endpoint.Parameters[i].Type.ToDisplayString(EmitterConstants.DisplayFormat)}>({i})");
 
             if (i < endpoint.Parameters.Length - 1)
             {

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/StaticRouteHandlerModel.Emitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/StaticRouteHandlerModel.Emitter.cs
@@ -207,7 +207,7 @@ return ValueTask.FromResult<object?>(handler({endpoint.EmitFilteredArgumentList(
 
         for (var i = 0; i < endpoint.Parameters.Length; i++)
         {
-            sb.Append(endpoint.Parameters[i].Type.ToDisplayString(endpoint.Parameters[i].IsOptional ? NullableFlowState.MaybeNull : NullableFlowState.NotNull));
+            sb.Append(endpoint.Parameters[i].Type.ToDisplayString(endpoint.Parameters[i].IsOptional ? NullableFlowState.MaybeNull : NullableFlowState.NotNull, EmitterConstants.DisplayFormat));
 
             if (i < endpoint.Parameters.Length - 1)
             {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitBodyParam_ComplexReturn_Snapshot.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitBodyParam_ComplexReturn_Snapshot.generated.txt
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<Microsoft.AspNetCore.Http.Generators.Tests.Todo>(0)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::Microsoft.AspNetCore.Http.Generators.Tests.Todo>(0)));
                         },
                         options.EndpointBuilder,
                         handler.Method);
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<Microsoft.AspNetCore.Http.Generators.Tests.Todo?>(0)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::Microsoft.AspNetCore.Http.Generators.Tests.Todo?>(0)));
                         },
                         options.EndpointBuilder,
                         handler.Method);
@@ -298,13 +298,6 @@ namespace Microsoft.AspNetCore.Http.Generated
                 }
             }
             return (false, default);
-        }
-
-        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
-        {
-            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
-                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
-                : httpContext.Request.Query[$"{parameterName}"];
         }
     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitBodyParam_ComplexReturn_Snapshot.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitBodyParam_ComplexReturn_Snapshot.generated.txt
@@ -84,11 +84,11 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         private static readonly Dictionary<(string, int), (MetadataPopulator, RequestDelegateFactoryFunc)> map = new()
         {
-            [(@"TestMapActions.cs", 16)] = (
+            [(@"TestMapActions.cs", 18)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 16));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 18));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -151,11 +151,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
                     return new RequestDelegateResult(targetDelegate, metadata);
                 }),
-            [(@"TestMapActions.cs", 18)] = (
+            [(@"TestMapActions.cs", 20)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 18));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 20));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitBodyParam_ComplexReturn_Snapshot.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitBodyParam_ComplexReturn_Snapshot.generated.txt
@@ -113,8 +113,8 @@ namespace Microsoft.AspNetCore.Http.Generated
                     async Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: todo (Type = Microsoft.AspNetCore.Http.Generators.Tests.Todo, IsOptional = False, Source = JsonBody)
-                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<Microsoft.AspNetCore.Http.Generators.Tests.Todo>(httpContext, false);
+                        // Endpoint Parameter: todo (Type = global::Microsoft.AspNetCore.Http.Generators.Tests.Todo, IsOptional = False, Source = JsonBody)
+                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<global::Microsoft.AspNetCore.Http.Generators.Tests.Todo>(httpContext, false);
                         if (!isSuccessful)
                         {
                             return;
@@ -132,8 +132,8 @@ namespace Microsoft.AspNetCore.Http.Generated
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: todo (Type = Microsoft.AspNetCore.Http.Generators.Tests.Todo, IsOptional = False, Source = JsonBody)
-                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<Microsoft.AspNetCore.Http.Generators.Tests.Todo>(httpContext, false);
+                        // Endpoint Parameter: todo (Type = global::Microsoft.AspNetCore.Http.Generators.Tests.Todo, IsOptional = False, Source = JsonBody)
+                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<global::Microsoft.AspNetCore.Http.Generators.Tests.Todo>(httpContext, false);
                         if (!isSuccessful)
                         {
                             return;
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<Microsoft.AspNetCore.Http.Generators.Tests.Todo>(httpContext, todo_local!));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<global::Microsoft.AspNetCore.Http.Generators.Tests.Todo>(httpContext, todo_local!));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -180,8 +180,8 @@ namespace Microsoft.AspNetCore.Http.Generated
                     async Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: todo (Type = Microsoft.AspNetCore.Http.Generators.Tests.Todo?, IsOptional = True, Source = JsonBody)
-                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<Microsoft.AspNetCore.Http.Generators.Tests.Todo?>(httpContext, true);
+                        // Endpoint Parameter: todo (Type = global::Microsoft.AspNetCore.Http.Generators.Tests.Todo?, IsOptional = True, Source = JsonBody)
+                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<global::Microsoft.AspNetCore.Http.Generators.Tests.Todo?>(httpContext, true);
                         if (!isSuccessful)
                         {
                             return;
@@ -199,8 +199,8 @@ namespace Microsoft.AspNetCore.Http.Generated
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: todo (Type = Microsoft.AspNetCore.Http.Generators.Tests.Todo?, IsOptional = True, Source = JsonBody)
-                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<Microsoft.AspNetCore.Http.Generators.Tests.Todo?>(httpContext, true);
+                        // Endpoint Parameter: todo (Type = global::Microsoft.AspNetCore.Http.Generators.Tests.Todo?, IsOptional = True, Source = JsonBody)
+                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<global::Microsoft.AspNetCore.Http.Generators.Tests.Todo?>(httpContext, true);
                         if (!isSuccessful)
                         {
                             return;
@@ -210,7 +210,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<Microsoft.AspNetCore.Http.Generators.Tests.Todo?>(httpContext, todo_local));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<global::Microsoft.AspNetCore.Http.Generators.Tests.Todo?>(httpContext, todo_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitServiceParam_SimpleReturn_Snapshot.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitServiceParam_SimpleReturn_Snapshot.generated.txt
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: svc (Type = Microsoft.AspNetCore.Http.Generators.Tests.TestService, IsOptional = False, Source = Service)
+                        // Endpoint Parameter: svc (Type = global::Microsoft.AspNetCore.Http.Generators.Tests.TestService, IsOptional = False, Source = Service)
                         var svc_local = httpContext.RequestServices.GetRequiredService<Microsoft.AspNetCore.Http.Generators.Tests.TestService>();
 
                         if (wasParamCheckFailure)
@@ -158,14 +158,14 @@ namespace Microsoft.AspNetCore.Http.Generated
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: svc (Type = Microsoft.AspNetCore.Http.Generators.Tests.TestService, IsOptional = False, Source = Service)
+                        // Endpoint Parameter: svc (Type = global::Microsoft.AspNetCore.Http.Generators.Tests.TestService, IsOptional = False, Source = Service)
                         var svc_local = httpContext.RequestServices.GetRequiredService<Microsoft.AspNetCore.Http.Generators.Tests.TestService>();
 
                         if (wasParamCheckFailure)
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<Microsoft.AspNetCore.Http.Generators.Tests.TestService>(httpContext, svc_local));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>(httpContext, svc_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -202,7 +202,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: svc (Type = System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>, IsOptional = False, Source = Service)
+                        // Endpoint Parameter: svc (Type = global::System.Collections.Generic.IEnumerable<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>, IsOptional = False, Source = Service)
                         var svc_local = httpContext.RequestServices.GetRequiredService<System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>>();
 
                         if (wasParamCheckFailure)
@@ -217,14 +217,14 @@ namespace Microsoft.AspNetCore.Http.Generated
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: svc (Type = System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>, IsOptional = False, Source = Service)
+                        // Endpoint Parameter: svc (Type = global::System.Collections.Generic.IEnumerable<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>, IsOptional = False, Source = Service)
                         var svc_local = httpContext.RequestServices.GetRequiredService<System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>>();
 
                         if (wasParamCheckFailure)
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>>(httpContext, svc_local));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<global::System.Collections.Generic.IEnumerable<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>>(httpContext, svc_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -261,10 +261,10 @@ namespace Microsoft.AspNetCore.Http.Generated
                     Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: svc (Type = Microsoft.AspNetCore.Http.Generators.Tests.TestService?, IsOptional = True, Source = Service)
+                        // Endpoint Parameter: svc (Type = global::Microsoft.AspNetCore.Http.Generators.Tests.TestService?, IsOptional = True, Source = Service)
                         var svc_local = httpContext.RequestServices.GetService<Microsoft.AspNetCore.Http.Generators.Tests.TestService?>();;
 
-                        // Endpoint Parameter: svcs (Type = System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>, IsOptional = False, Source = Service)
+                        // Endpoint Parameter: svcs (Type = global::System.Collections.Generic.IEnumerable<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>, IsOptional = False, Source = Service)
                         var svcs_local = httpContext.RequestServices.GetRequiredService<System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>>();
 
                         if (wasParamCheckFailure)
@@ -279,17 +279,17 @@ namespace Microsoft.AspNetCore.Http.Generated
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: svc (Type = Microsoft.AspNetCore.Http.Generators.Tests.TestService?, IsOptional = True, Source = Service)
+                        // Endpoint Parameter: svc (Type = global::Microsoft.AspNetCore.Http.Generators.Tests.TestService?, IsOptional = True, Source = Service)
                         var svc_local = httpContext.RequestServices.GetService<Microsoft.AspNetCore.Http.Generators.Tests.TestService?>();;
 
-                        // Endpoint Parameter: svcs (Type = System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>, IsOptional = False, Source = Service)
+                        // Endpoint Parameter: svcs (Type = global::System.Collections.Generic.IEnumerable<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>, IsOptional = False, Source = Service)
                         var svcs_local = httpContext.RequestServices.GetRequiredService<System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>>();
 
                         if (wasParamCheckFailure)
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<Microsoft.AspNetCore.Http.Generators.Tests.TestService?, System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>>(httpContext, svc_local, svcs_local));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService?, global::System.Collections.Generic.IEnumerable<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>>(httpContext, svc_local, svcs_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitServiceParam_SimpleReturn_Snapshot.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitServiceParam_SimpleReturn_Snapshot.generated.txt
@@ -134,7 +134,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<Microsoft.AspNetCore.Http.Generators.Tests.TestService>(0)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>(0)));
                         },
                         options.EndpointBuilder,
                         handler.Method);
@@ -193,7 +193,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>>(0)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::System.Collections.Generic.IEnumerable<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>>(0)));
                         },
                         options.EndpointBuilder,
                         handler.Method);
@@ -252,7 +252,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<Microsoft.AspNetCore.Http.Generators.Tests.TestService?>(0), ic.GetArgument<System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Http.Generators.Tests.TestService>>(1)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService?>(0), ic.GetArgument<global::System.Collections.Generic.IEnumerable<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>>(1)));
                         },
                         options.EndpointBuilder,
                         handler.Method);
@@ -377,13 +377,6 @@ namespace Microsoft.AspNetCore.Http.Generated
                 }
             }
             return (false, default);
-        }
-
-        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
-        {
-            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
-                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
-                : httpContext.Request.Query[$"{parameterName}"];
         }
     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitServiceParam_SimpleReturn_Snapshot.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitServiceParam_SimpleReturn_Snapshot.generated.txt
@@ -378,6 +378,13 @@ namespace Microsoft.AspNetCore.Http.Generated
             }
             return (false, default);
         }
+
+        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
+        {
+            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
+                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
+                : httpContext.Request.Query[$"{parameterName}"];
+        }
     }
 
     %GENERATEDCODEATTRIBUTE%

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitServiceParam_SimpleReturn_Snapshot.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitServiceParam_SimpleReturn_Snapshot.generated.txt
@@ -114,11 +114,11 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         private static readonly Dictionary<(string, int), (MetadataPopulator, RequestDelegateFactoryFunc)> map = new()
         {
-            [(@"TestMapActions.cs", 16)] = (
+            [(@"TestMapActions.cs", 18)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 16));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 18));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -173,11 +173,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
                     return new RequestDelegateResult(targetDelegate, metadata);
                 }),
-            [(@"TestMapActions.cs", 17)] = (
+            [(@"TestMapActions.cs", 19)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 17));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 19));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -232,11 +232,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
                     return new RequestDelegateResult(targetDelegate, metadata);
                 }),
-            [(@"TestMapActions.cs", 18)] = (
+            [(@"TestMapActions.cs", 20)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 18));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 20));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitSource_SimpleReturn_Snapshot.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitSource_SimpleReturn_Snapshot.generated.txt
@@ -84,11 +84,11 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         private static readonly Dictionary<(string, int), (MetadataPopulator, RequestDelegateFactoryFunc)> map = new()
         {
-            [(@"TestMapActions.cs", 16)] = (
+            [(@"TestMapActions.cs", 18)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 16));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 18));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -153,11 +153,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
                     return new RequestDelegateResult(targetDelegate, metadata);
                 }),
-            [(@"TestMapActions.cs", 17)] = (
+            [(@"TestMapActions.cs", 19)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 17));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 19));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -222,11 +222,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
                     return new RequestDelegateResult(targetDelegate, metadata);
                 }),
-            [(@"TestMapActions.cs", 18)] = (
+            [(@"TestMapActions.cs", 20)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 18));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 20));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -299,11 +299,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
                     return new RequestDelegateResult(targetDelegate, metadata);
                 }),
-            [(@"TestMapActions.cs", 19)] = (
+            [(@"TestMapActions.cs", 21)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 19));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 21));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -368,11 +368,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
                     return new RequestDelegateResult(targetDelegate, metadata);
                 }),
-            [(@"TestMapActions.cs", 20)] = (
+            [(@"TestMapActions.cs", 22)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 20));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 22));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitSource_SimpleReturn_Snapshot.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitSource_SimpleReturn_Snapshot.generated.txt
@@ -37,10 +37,10 @@ namespace Microsoft.AspNetCore.Builder
         private static readonly string[] DeleteVerb = new[] { global::Microsoft.AspNetCore.Http.HttpMethods.Delete };
         private static readonly string[] PatchVerb = new[] { global::Microsoft.AspNetCore.Http.HttpMethods.Patch };
 
-        internal static global::Microsoft.AspNetCore.Builder.RouteHandlerBuilder MapPost(
+        internal static global::Microsoft.AspNetCore.Builder.RouteHandlerBuilder MapGet(
             this global::Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints,
             [global::System.Diagnostics.CodeAnalysis.StringSyntax("Route")] string pattern,
-            global::System.Func<global::Microsoft.AspNetCore.Http.Generators.Tests.Todo, global::Microsoft.AspNetCore.Http.HttpResults.Ok<global::Microsoft.AspNetCore.Http.Generators.Tests.Todo>> handler,
+            global::System.Func<global::System.String?, global::System.String> handler,
             [global::System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
             [global::System.Runtime.CompilerServices.CallerLineNumber]int lineNumber = 0)
         {
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Builder
                     endpoints,
                     pattern,
                     handler,
-                    PostVerb,
+                    GetVerb,
                     filePath,
                     lineNumber);
         }
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (Func<global::Microsoft.AspNetCore.Http.Generators.Tests.Todo, global::Microsoft.AspNetCore.Http.HttpResults.Ok<global::Microsoft.AspNetCore.Http.Generators.Tests.Todo>>)del;
+                    var handler = (Func<global::System.String?, global::System.String>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)
@@ -104,46 +104,101 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<Microsoft.AspNetCore.Http.Generators.Tests.Todo>(0)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<string?>(0)));
                         },
                         options.EndpointBuilder,
                         handler.Method);
                     }
 
-                    async Task RequestHandler(HttpContext httpContext)
+                    Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: todo (Type = Microsoft.AspNetCore.Http.Generators.Tests.Todo, IsOptional = False, Source = JsonBody)
-                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<Microsoft.AspNetCore.Http.Generators.Tests.Todo>(httpContext, false);
-                        if (!isSuccessful)
-                        {
-                            return;
-                        }
+                        // Endpoint Parameter: queryValue (Type = string?, IsOptional = True, Source = Query)
+                        var queryValue_raw = httpContext.Request.Query["queryValue"];
+                        var queryValue_local = queryValue_raw.Count > 0 ? queryValue_raw.ToString() : null;
 
                         if (wasParamCheckFailure)
                         {
                             httpContext.Response.StatusCode = 400;
-                            return;
+                            return Task.CompletedTask;
                         }
-                        httpContext.Response.ContentType ??= "";
-                        var result = handler(todo_local!);
-                        await result.ExecuteAsync(httpContext);
+                        httpContext.Response.ContentType ??= "text/plain";
+                        var result = handler(queryValue_local);
+                        return httpContext.Response.WriteAsync(result);
                     }
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: todo (Type = Microsoft.AspNetCore.Http.Generators.Tests.Todo, IsOptional = False, Source = JsonBody)
-                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<Microsoft.AspNetCore.Http.Generators.Tests.Todo>(httpContext, false);
-                        if (!isSuccessful)
-                        {
-                            return;
-                        }
+                        // Endpoint Parameter: queryValue (Type = string?, IsOptional = True, Source = Query)
+                        var queryValue_raw = httpContext.Request.Query["queryValue"];
+                        var queryValue_local = queryValue_raw.Count > 0 ? queryValue_raw.ToString() : null;
 
                         if (wasParamCheckFailure)
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<Microsoft.AspNetCore.Http.Generators.Tests.Todo>(httpContext, todo_local!));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string?>(httpContext, queryValue_local));
+                        await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
+                    }
+
+                    RequestDelegate targetDelegate = filteredInvocation is null ? RequestHandler : RequestHandlerFiltered;
+                    var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
+                    return new RequestDelegateResult(targetDelegate, metadata);
+                }),
+            [(@"TestMapActions.cs", 17)] = (
+               (methodInfo, options) =>
+                {
+                    Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 17));
+                    return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
+                },
+                (del, options, inferredMetadataResult) =>
+                {
+                    var handler = (Func<global::System.String?, global::System.String>)del;
+                    EndpointFilterDelegate? filteredInvocation = null;
+
+                    if (options?.EndpointBuilder?.FilterFactories.Count > 0)
+                    {
+                        filteredInvocation = GeneratedRouteBuilderExtensionsCore.BuildFilterDelegate(ic =>
+                        {
+                            if (ic.HttpContext.Response.StatusCode == 400)
+                            {
+                                return ValueTask.FromResult<object?>(Results.Empty);
+                            }
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<string?>(0)));
+                        },
+                        options.EndpointBuilder,
+                        handler.Method);
+                    }
+
+                    Task RequestHandler(HttpContext httpContext)
+                    {
+                        var wasParamCheckFailure = false;
+                        // Endpoint Parameter: headerValue (Type = string?, IsOptional = True, Source = Header)
+                        var headerValue_raw = httpContext.Request.Headers["headerValue"];
+                        var headerValue_local = headerValue_raw.Count > 0 ? headerValue_raw.ToString() : null;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return Task.CompletedTask;
+                        }
+                        httpContext.Response.ContentType ??= "text/plain";
+                        var result = handler(headerValue_local);
+                        return httpContext.Response.WriteAsync(result);
+                    }
+                    async Task RequestHandlerFiltered(HttpContext httpContext)
+                    {
+                        var wasParamCheckFailure = false;
+                        // Endpoint Parameter: headerValue (Type = string?, IsOptional = True, Source = Header)
+                        var headerValue_raw = httpContext.Request.Headers["headerValue"];
+                        var headerValue_local = headerValue_raw.Count > 0 ? headerValue_raw.ToString() : null;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string?>(httpContext, headerValue_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -160,7 +215,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (Func<global::Microsoft.AspNetCore.Http.Generators.Tests.Todo?, global::Microsoft.AspNetCore.Http.HttpResults.Ok<global::Microsoft.AspNetCore.Http.Generators.Tests.Todo>>)del;
+                    var handler = (Func<global::System.String?, global::System.String>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)
@@ -171,46 +226,109 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<Microsoft.AspNetCore.Http.Generators.Tests.Todo?>(0)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<string?>(0)));
                         },
                         options.EndpointBuilder,
                         handler.Method);
                     }
 
-                    async Task RequestHandler(HttpContext httpContext)
+                    Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: todo (Type = Microsoft.AspNetCore.Http.Generators.Tests.Todo?, IsOptional = True, Source = JsonBody)
-                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<Microsoft.AspNetCore.Http.Generators.Tests.Todo?>(httpContext, true);
-                        if (!isSuccessful)
+                        // Endpoint Parameter: routeValue (Type = string?, IsOptional = True, Source = Route)
+                        if (options?.RouteParameterNames?.Contains("routeValue", StringComparer.OrdinalIgnoreCase) != true)
                         {
-                            return;
+                            throw new InvalidOperationException($"'routeValue' is not a route parameter.");
                         }
+                        var routeValue_raw = httpContext.Request.RouteValues["routeValue"]?.ToString();
+                        var routeValue_local = routeValue_raw;
 
                         if (wasParamCheckFailure)
                         {
                             httpContext.Response.StatusCode = 400;
-                            return;
+                            return Task.CompletedTask;
                         }
-                        httpContext.Response.ContentType ??= "";
-                        var result = handler(todo_local);
-                        await result.ExecuteAsync(httpContext);
+                        httpContext.Response.ContentType ??= "text/plain";
+                        var result = handler(routeValue_local);
+                        return httpContext.Response.WriteAsync(result);
                     }
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: todo (Type = Microsoft.AspNetCore.Http.Generators.Tests.Todo?, IsOptional = True, Source = JsonBody)
-                        var (isSuccessful, todo_local) = await GeneratedRouteBuilderExtensionsCore.TryResolveBody<Microsoft.AspNetCore.Http.Generators.Tests.Todo?>(httpContext, true);
-                        if (!isSuccessful)
+                        // Endpoint Parameter: routeValue (Type = string?, IsOptional = True, Source = Route)
+                        if (options?.RouteParameterNames?.Contains("routeValue", StringComparer.OrdinalIgnoreCase) != true)
                         {
-                            return;
+                            throw new InvalidOperationException($"'routeValue' is not a route parameter.");
                         }
+                        var routeValue_raw = httpContext.Request.RouteValues["routeValue"]?.ToString();
+                        var routeValue_local = routeValue_raw;
 
                         if (wasParamCheckFailure)
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<Microsoft.AspNetCore.Http.Generators.Tests.Todo?>(httpContext, todo_local));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string?>(httpContext, routeValue_local));
+                        await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
+                    }
+
+                    RequestDelegate targetDelegate = filteredInvocation is null ? RequestHandler : RequestHandlerFiltered;
+                    var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
+                    return new RequestDelegateResult(targetDelegate, metadata);
+                }),
+            [(@"TestMapActions.cs", 19)] = (
+               (methodInfo, options) =>
+                {
+                    Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 19));
+                    return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
+                },
+                (del, options, inferredMetadataResult) =>
+                {
+                    var handler = (Func<global::System.String?, global::System.String>)del;
+                    EndpointFilterDelegate? filteredInvocation = null;
+
+                    if (options?.EndpointBuilder?.FilterFactories.Count > 0)
+                    {
+                        filteredInvocation = GeneratedRouteBuilderExtensionsCore.BuildFilterDelegate(ic =>
+                        {
+                            if (ic.HttpContext.Response.StatusCode == 400)
+                            {
+                                return ValueTask.FromResult<object?>(Results.Empty);
+                            }
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<string?>(0)));
+                        },
+                        options.EndpointBuilder,
+                        handler.Method);
+                    }
+
+                    Task RequestHandler(HttpContext httpContext)
+                    {
+                        var wasParamCheckFailure = false;
+                        // Endpoint Parameter: value (Type = string?, IsOptional = True, Source = RouteOrQuery)
+                        var value_raw = GeneratedRouteBuilderExtensionsCore.ResolveFromRouteOrQuery(httpContext, "value", options?.RouteParameterNames);
+                        var value_local = value_raw;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return Task.CompletedTask;
+                        }
+                        httpContext.Response.ContentType ??= "text/plain";
+                        var result = handler(value_local);
+                        return httpContext.Response.WriteAsync(result);
+                    }
+                    async Task RequestHandlerFiltered(HttpContext httpContext)
+                    {
+                        var wasParamCheckFailure = false;
+                        // Endpoint Parameter: value (Type = string?, IsOptional = True, Source = RouteOrQuery)
+                        var value_raw = GeneratedRouteBuilderExtensionsCore.ResolveFromRouteOrQuery(httpContext, "value", options?.RouteParameterNames);
+                        var value_local = value_raw;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string?>(httpContext, value_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitSource_SimpleReturn_Snapshot.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitSource_SimpleReturn_Snapshot.generated.txt
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Builder
         internal static global::Microsoft.AspNetCore.Builder.RouteHandlerBuilder MapGet(
             this global::Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints,
             [global::System.Diagnostics.CodeAnalysis.StringSyntax("Route")] string pattern,
-            global::System.Func<global::System.String?, global::System.String> handler,
+            global::System.Func<global::System.String, global::System.String> handler,
             [global::System.Runtime.CompilerServices.CallerFilePath] string filePath = "",
             [global::System.Runtime.CompilerServices.CallerLineNumber]int lineNumber = 0)
         {
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (Func<global::System.String?, global::System.String>)del;
+                    var handler = (Func<global::System.String, global::System.String>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<string?>(0)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::System.String>(0)));
                         },
                         options.EndpointBuilder,
                         handler.Method);
@@ -113,9 +113,13 @@ namespace Microsoft.AspNetCore.Http.Generated
                     Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: queryValue (Type = string?, IsOptional = True, Source = Query)
+                        // Endpoint Parameter: queryValue (Type = string, IsOptional = False, Source = Query)
                         var queryValue_raw = httpContext.Request.Query["queryValue"];
-                        var queryValue_local = queryValue_raw.Count > 0 ? queryValue_raw.ToString() : null;
+                        if (StringValues.IsNullOrEmpty(queryValue_raw))
+                        {
+                            wasParamCheckFailure = true;
+                        }
+                        var queryValue_local = queryValue_raw.ToString();
 
                         if (wasParamCheckFailure)
                         {
@@ -129,15 +133,19 @@ namespace Microsoft.AspNetCore.Http.Generated
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: queryValue (Type = string?, IsOptional = True, Source = Query)
+                        // Endpoint Parameter: queryValue (Type = string, IsOptional = False, Source = Query)
                         var queryValue_raw = httpContext.Request.Query["queryValue"];
-                        var queryValue_local = queryValue_raw.Count > 0 ? queryValue_raw.ToString() : null;
+                        if (StringValues.IsNullOrEmpty(queryValue_raw))
+                        {
+                            wasParamCheckFailure = true;
+                        }
+                        var queryValue_local = queryValue_raw.ToString();
 
                         if (wasParamCheckFailure)
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string?>(httpContext, queryValue_local));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string>(httpContext, queryValue_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -154,7 +162,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (Func<global::System.String?, global::System.String>)del;
+                    var handler = (Func<global::System.String, global::System.String>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)
@@ -165,7 +173,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<string?>(0)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::System.String>(0)));
                         },
                         options.EndpointBuilder,
                         handler.Method);
@@ -174,9 +182,13 @@ namespace Microsoft.AspNetCore.Http.Generated
                     Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: headerValue (Type = string?, IsOptional = True, Source = Header)
+                        // Endpoint Parameter: headerValue (Type = string, IsOptional = False, Source = Header)
                         var headerValue_raw = httpContext.Request.Headers["headerValue"];
-                        var headerValue_local = headerValue_raw.Count > 0 ? headerValue_raw.ToString() : null;
+                        if (StringValues.IsNullOrEmpty(headerValue_raw))
+                        {
+                            wasParamCheckFailure = true;
+                        }
+                        var headerValue_local = headerValue_raw.ToString();
 
                         if (wasParamCheckFailure)
                         {
@@ -190,15 +202,19 @@ namespace Microsoft.AspNetCore.Http.Generated
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: headerValue (Type = string?, IsOptional = True, Source = Header)
+                        // Endpoint Parameter: headerValue (Type = string, IsOptional = False, Source = Header)
                         var headerValue_raw = httpContext.Request.Headers["headerValue"];
-                        var headerValue_local = headerValue_raw.Count > 0 ? headerValue_raw.ToString() : null;
+                        if (StringValues.IsNullOrEmpty(headerValue_raw))
+                        {
+                            wasParamCheckFailure = true;
+                        }
+                        var headerValue_local = headerValue_raw.ToString();
 
                         if (wasParamCheckFailure)
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string?>(httpContext, headerValue_local));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string>(httpContext, headerValue_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -215,7 +231,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (Func<global::System.String?, global::System.String>)del;
+                    var handler = (Func<global::System.String, global::System.String>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)
@@ -226,7 +242,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<string?>(0)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::System.String>(0)));
                         },
                         options.EndpointBuilder,
                         handler.Method);
@@ -235,12 +251,16 @@ namespace Microsoft.AspNetCore.Http.Generated
                     Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: routeValue (Type = string?, IsOptional = True, Source = Route)
+                        // Endpoint Parameter: routeValue (Type = string, IsOptional = False, Source = Route)
                         if (options?.RouteParameterNames?.Contains("routeValue", StringComparer.OrdinalIgnoreCase) != true)
                         {
                             throw new InvalidOperationException($"'routeValue' is not a route parameter.");
                         }
                         var routeValue_raw = httpContext.Request.RouteValues["routeValue"]?.ToString();
+                        if (routeValue_raw == null)
+                        {
+                            wasParamCheckFailure = true;
+                        }
                         var routeValue_local = routeValue_raw;
 
                         if (wasParamCheckFailure)
@@ -249,25 +269,29 @@ namespace Microsoft.AspNetCore.Http.Generated
                             return Task.CompletedTask;
                         }
                         httpContext.Response.ContentType ??= "text/plain";
-                        var result = handler(routeValue_local);
+                        var result = handler(routeValue_local!);
                         return httpContext.Response.WriteAsync(result);
                     }
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: routeValue (Type = string?, IsOptional = True, Source = Route)
+                        // Endpoint Parameter: routeValue (Type = string, IsOptional = False, Source = Route)
                         if (options?.RouteParameterNames?.Contains("routeValue", StringComparer.OrdinalIgnoreCase) != true)
                         {
                             throw new InvalidOperationException($"'routeValue' is not a route parameter.");
                         }
                         var routeValue_raw = httpContext.Request.RouteValues["routeValue"]?.ToString();
+                        if (routeValue_raw == null)
+                        {
+                            wasParamCheckFailure = true;
+                        }
                         var routeValue_local = routeValue_raw;
 
                         if (wasParamCheckFailure)
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string?>(httpContext, routeValue_local));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string>(httpContext, routeValue_local!));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -284,7 +308,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 },
                 (del, options, inferredMetadataResult) =>
                 {
-                    var handler = (Func<global::System.String?, global::System.String>)del;
+                    var handler = (Func<global::System.String, global::System.String>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)
@@ -295,7 +319,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<string?>(0)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::System.String>(0)));
                         },
                         options.EndpointBuilder,
                         handler.Method);
@@ -304,8 +328,12 @@ namespace Microsoft.AspNetCore.Http.Generated
                     Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: value (Type = string?, IsOptional = True, Source = RouteOrQuery)
-                        var value_raw = GeneratedRouteBuilderExtensionsCore.ResolveFromRouteOrQuery(httpContext, "value", options?.RouteParameterNames);
+                        // Endpoint Parameter: value (Type = string, IsOptional = False, Source = RouteOrQuery)
+                        var value_raw = options?.RouteParameterNames?.Contains("value", StringComparer.OrdinalIgnoreCase) == true? new StringValues(httpContext.Request.RouteValues[$"value"]?.ToString()): httpContext.Request.Query[$"value"];;
+                        if (value_raw is StringValues { Count: 0 })
+                        {
+                            wasParamCheckFailure = true;
+                        }
                         var value_local = value_raw;
 
                         if (wasParamCheckFailure)
@@ -314,21 +342,94 @@ namespace Microsoft.AspNetCore.Http.Generated
                             return Task.CompletedTask;
                         }
                         httpContext.Response.ContentType ??= "text/plain";
-                        var result = handler(value_local);
+                        var result = handler(value_local!);
                         return httpContext.Response.WriteAsync(result);
                     }
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: value (Type = string?, IsOptional = True, Source = RouteOrQuery)
-                        var value_raw = GeneratedRouteBuilderExtensionsCore.ResolveFromRouteOrQuery(httpContext, "value", options?.RouteParameterNames);
+                        // Endpoint Parameter: value (Type = string, IsOptional = False, Source = RouteOrQuery)
+                        var value_raw = options?.RouteParameterNames?.Contains("value", StringComparer.OrdinalIgnoreCase) == true? new StringValues(httpContext.Request.RouteValues[$"value"]?.ToString()): httpContext.Request.Query[$"value"];;
+                        if (value_raw is StringValues { Count: 0 })
+                        {
+                            wasParamCheckFailure = true;
+                        }
                         var value_local = value_raw;
 
                         if (wasParamCheckFailure)
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string?>(httpContext, value_local));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string>(httpContext, value_local!));
+                        await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
+                    }
+
+                    RequestDelegate targetDelegate = filteredInvocation is null ? RequestHandler : RequestHandlerFiltered;
+                    var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
+                    return new RequestDelegateResult(targetDelegate, metadata);
+                }),
+            [(@"TestMapActions.cs", 20)] = (
+               (methodInfo, options) =>
+                {
+                    Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 20));
+                    return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
+                },
+                (del, options, inferredMetadataResult) =>
+                {
+                    var handler = (Func<global::System.String, global::System.String>)del;
+                    EndpointFilterDelegate? filteredInvocation = null;
+
+                    if (options?.EndpointBuilder?.FilterFactories.Count > 0)
+                    {
+                        filteredInvocation = GeneratedRouteBuilderExtensionsCore.BuildFilterDelegate(ic =>
+                        {
+                            if (ic.HttpContext.Response.StatusCode == 400)
+                            {
+                                return ValueTask.FromResult<object?>(Results.Empty);
+                            }
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::System.String>(0)));
+                        },
+                        options.EndpointBuilder,
+                        handler.Method);
+                    }
+
+                    Task RequestHandler(HttpContext httpContext)
+                    {
+                        var wasParamCheckFailure = false;
+                        // Endpoint Parameter: value (Type = string, IsOptional = False, Source = RouteOrQuery)
+                        var value_raw = options?.RouteParameterNames?.Contains("value", StringComparer.OrdinalIgnoreCase) == true? new StringValues(httpContext.Request.RouteValues[$"value"]?.ToString()): httpContext.Request.Query[$"value"];;
+                        if (value_raw is StringValues { Count: 0 })
+                        {
+                            wasParamCheckFailure = true;
+                        }
+                        var value_local = value_raw;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return Task.CompletedTask;
+                        }
+                        httpContext.Response.ContentType ??= "text/plain";
+                        var result = handler(value_local!);
+                        return httpContext.Response.WriteAsync(result);
+                    }
+                    async Task RequestHandlerFiltered(HttpContext httpContext)
+                    {
+                        var wasParamCheckFailure = false;
+                        // Endpoint Parameter: value (Type = string, IsOptional = False, Source = RouteOrQuery)
+                        var value_raw = options?.RouteParameterNames?.Contains("value", StringComparer.OrdinalIgnoreCase) == true? new StringValues(httpContext.Request.RouteValues[$"value"]?.ToString()): httpContext.Request.Query[$"value"];;
+                        if (value_raw is StringValues { Count: 0 })
+                        {
+                            wasParamCheckFailure = true;
+                        }
+                        var value_local = value_raw;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string>(httpContext, value_local!));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -416,13 +517,6 @@ namespace Microsoft.AspNetCore.Http.Generated
                 }
             }
             return (false, default);
-        }
-
-        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
-        {
-            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
-                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
-                : httpContext.Request.Query[$"{parameterName}"];
         }
     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitSource_SimpleReturn_Snapshot.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_ExplicitSource_SimpleReturn_Snapshot.generated.txt
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: queryValue (Type = string, IsOptional = False, Source = Query)
+                        // Endpoint Parameter: queryValue (Type = global::System.String, IsOptional = False, Source = Query)
                         var queryValue_raw = httpContext.Request.Query["queryValue"];
                         if (StringValues.IsNullOrEmpty(queryValue_raw))
                         {
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: queryValue (Type = string, IsOptional = False, Source = Query)
+                        // Endpoint Parameter: queryValue (Type = global::System.String, IsOptional = False, Source = Query)
                         var queryValue_raw = httpContext.Request.Query["queryValue"];
                         if (StringValues.IsNullOrEmpty(queryValue_raw))
                         {
@@ -145,7 +145,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string>(httpContext, queryValue_local));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<global::System.String>(httpContext, queryValue_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -182,7 +182,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: headerValue (Type = string, IsOptional = False, Source = Header)
+                        // Endpoint Parameter: headerValue (Type = global::System.String, IsOptional = False, Source = Header)
                         var headerValue_raw = httpContext.Request.Headers["headerValue"];
                         if (StringValues.IsNullOrEmpty(headerValue_raw))
                         {
@@ -202,7 +202,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: headerValue (Type = string, IsOptional = False, Source = Header)
+                        // Endpoint Parameter: headerValue (Type = global::System.String, IsOptional = False, Source = Header)
                         var headerValue_raw = httpContext.Request.Headers["headerValue"];
                         if (StringValues.IsNullOrEmpty(headerValue_raw))
                         {
@@ -214,7 +214,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string>(httpContext, headerValue_local));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<global::System.String>(httpContext, headerValue_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -251,7 +251,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: routeValue (Type = string, IsOptional = False, Source = Route)
+                        // Endpoint Parameter: routeValue (Type = global::System.String, IsOptional = False, Source = Route)
                         if (options?.RouteParameterNames?.Contains("routeValue", StringComparer.OrdinalIgnoreCase) != true)
                         {
                             throw new InvalidOperationException($"'routeValue' is not a route parameter.");
@@ -275,7 +275,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: routeValue (Type = string, IsOptional = False, Source = Route)
+                        // Endpoint Parameter: routeValue (Type = global::System.String, IsOptional = False, Source = Route)
                         if (options?.RouteParameterNames?.Contains("routeValue", StringComparer.OrdinalIgnoreCase) != true)
                         {
                             throw new InvalidOperationException($"'routeValue' is not a route parameter.");
@@ -291,7 +291,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string>(httpContext, routeValue_local!));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<global::System.String>(httpContext, routeValue_local!));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -328,7 +328,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: value (Type = string, IsOptional = False, Source = RouteOrQuery)
+                        // Endpoint Parameter: value (Type = global::System.String, IsOptional = False, Source = RouteOrQuery)
                         var value_raw = options?.RouteParameterNames?.Contains("value", StringComparer.OrdinalIgnoreCase) == true? new StringValues(httpContext.Request.RouteValues[$"value"]?.ToString()): httpContext.Request.Query[$"value"];;
                         if (value_raw is StringValues { Count: 0 })
                         {
@@ -348,7 +348,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: value (Type = string, IsOptional = False, Source = RouteOrQuery)
+                        // Endpoint Parameter: value (Type = global::System.String, IsOptional = False, Source = RouteOrQuery)
                         var value_raw = options?.RouteParameterNames?.Contains("value", StringComparer.OrdinalIgnoreCase) == true? new StringValues(httpContext.Request.RouteValues[$"value"]?.ToString()): httpContext.Request.Query[$"value"];;
                         if (value_raw is StringValues { Count: 0 })
                         {
@@ -360,7 +360,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string>(httpContext, value_local!));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<global::System.String>(httpContext, value_local!));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -397,7 +397,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: value (Type = string, IsOptional = False, Source = RouteOrQuery)
+                        // Endpoint Parameter: value (Type = global::System.String, IsOptional = False, Source = RouteOrQuery)
                         var value_raw = options?.RouteParameterNames?.Contains("value", StringComparer.OrdinalIgnoreCase) == true? new StringValues(httpContext.Request.RouteValues[$"value"]?.ToString()): httpContext.Request.Query[$"value"];;
                         if (value_raw is StringValues { Count: 0 })
                         {
@@ -417,7 +417,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: value (Type = string, IsOptional = False, Source = RouteOrQuery)
+                        // Endpoint Parameter: value (Type = global::System.String, IsOptional = False, Source = RouteOrQuery)
                         var value_raw = options?.RouteParameterNames?.Contains("value", StringComparer.OrdinalIgnoreCase) == true? new StringValues(httpContext.Request.RouteValues[$"value"]?.ToString()): httpContext.Request.Query[$"value"];;
                         if (value_raw is StringValues { Count: 0 })
                         {
@@ -429,7 +429,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string>(httpContext, value_local!));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<global::System.String>(httpContext, value_local!));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleSpecialTypeParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleSpecialTypeParam_StringReturn.generated.txt
@@ -222,6 +222,13 @@ namespace Microsoft.AspNetCore.Http.Generated
             }
             return (false, default);
         }
+
+        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
+        {
+            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
+                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
+                : httpContext.Request.Query[$"{parameterName}"];
+        }
     }
 
     %GENERATEDCODEATTRIBUTE%

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleSpecialTypeParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleSpecialTypeParam_StringReturn.generated.txt
@@ -133,7 +133,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<Microsoft.AspNetCore.Http.HttpRequest, Microsoft.AspNetCore.Http.HttpResponse>(httpContext, req_local, res_local));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<global::Microsoft.AspNetCore.Http.HttpRequest, global::Microsoft.AspNetCore.Http.HttpResponse>(httpContext, req_local, res_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleSpecialTypeParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleSpecialTypeParam_StringReturn.generated.txt
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<Microsoft.AspNetCore.Http.HttpRequest>(0), ic.GetArgument<Microsoft.AspNetCore.Http.HttpResponse>(1)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::Microsoft.AspNetCore.Http.HttpRequest>(0), ic.GetArgument<global::Microsoft.AspNetCore.Http.HttpResponse>(1)));
                         },
                         options.EndpointBuilder,
                         handler.Method);
@@ -221,13 +221,6 @@ namespace Microsoft.AspNetCore.Http.Generated
                 }
             }
             return (false, default);
-        }
-
-        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
-        {
-            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
-                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
-                : httpContext.Request.Query[$"{parameterName}"];
         }
     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleSpecialTypeParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleSpecialTypeParam_StringReturn.generated.txt
@@ -84,11 +84,11 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         private static readonly Dictionary<(string, int), (MetadataPopulator, RequestDelegateFactoryFunc)> map = new()
         {
-            [(@"TestMapActions.cs", 16)] = (
+            [(@"TestMapActions.cs", 18)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 16));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 18));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleStringParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleStringParam_StringReturn.generated.txt
@@ -250,6 +250,13 @@ namespace Microsoft.AspNetCore.Http.Generated
             }
             return (false, default);
         }
+
+        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
+        {
+            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
+                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
+                : httpContext.Request.Query[$"{parameterName}"];
+        }
     }
 
     %GENERATEDCODEATTRIBUTE%

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleStringParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleStringParam_StringReturn.generated.txt
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: p1 (Type = string, IsOptional = False, Source = Query)
+                        // Endpoint Parameter: p1 (Type = global::System.String, IsOptional = False, Source = Query)
                         var p1_raw = httpContext.Request.Query["p1"];
                         if (StringValues.IsNullOrEmpty(p1_raw))
                         {
@@ -121,7 +121,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                         }
                         var p1_local = p1_raw.ToString();
 
-                        // Endpoint Parameter: p2 (Type = string, IsOptional = False, Source = Query)
+                        // Endpoint Parameter: p2 (Type = global::System.String, IsOptional = False, Source = Query)
                         var p2_raw = httpContext.Request.Query["p2"];
                         if (StringValues.IsNullOrEmpty(p2_raw))
                         {
@@ -141,7 +141,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: p1 (Type = string, IsOptional = False, Source = Query)
+                        // Endpoint Parameter: p1 (Type = global::System.String, IsOptional = False, Source = Query)
                         var p1_raw = httpContext.Request.Query["p1"];
                         if (StringValues.IsNullOrEmpty(p1_raw))
                         {
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                         }
                         var p1_local = p1_raw.ToString();
 
-                        // Endpoint Parameter: p2 (Type = string, IsOptional = False, Source = Query)
+                        // Endpoint Parameter: p2 (Type = global::System.String, IsOptional = False, Source = Query)
                         var p2_raw = httpContext.Request.Query["p2"];
                         if (StringValues.IsNullOrEmpty(p2_raw))
                         {
@@ -161,7 +161,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string, string>(httpContext, p1_local, p2_local));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<global::System.String, global::System.String>(httpContext, p1_local, p2_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleStringParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleStringParam_StringReturn.generated.txt
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<string>(0), ic.GetArgument<string>(1)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::System.String>(0), ic.GetArgument<global::System.String>(1)));
                         },
                         options.EndpointBuilder,
                         handler.Method);
@@ -249,13 +249,6 @@ namespace Microsoft.AspNetCore.Http.Generated
                 }
             }
             return (false, default);
-        }
-
-        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
-        {
-            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
-                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
-                : httpContext.Request.Query[$"{parameterName}"];
         }
     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleStringParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_MultipleStringParam_StringReturn.generated.txt
@@ -84,11 +84,11 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         private static readonly Dictionary<(string, int), (MetadataPopulator, RequestDelegateFactoryFunc)> map = new()
         {
-            [(@"TestMapActions.cs", 16)] = (
+            [(@"TestMapActions.cs", 18)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 16));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 18));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_NoParam_StringReturn_WithFilter.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_NoParam_StringReturn_WithFilter.generated.txt
@@ -220,6 +220,13 @@ namespace Microsoft.AspNetCore.Http.Generated
             }
             return (false, default);
         }
+
+        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
+        {
+            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
+                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
+                : httpContext.Request.Query[$"{parameterName}"];
+        }
     }
 
     %GENERATEDCODEATTRIBUTE%

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_NoParam_StringReturn_WithFilter.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_NoParam_StringReturn_WithFilter.generated.txt
@@ -220,13 +220,6 @@ namespace Microsoft.AspNetCore.Http.Generated
             }
             return (false, default);
         }
-
-        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
-        {
-            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
-                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
-                : httpContext.Request.Query[$"{parameterName}"];
-        }
     }
 
     %GENERATEDCODEATTRIBUTE%

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_NoParam_StringReturn_WithFilter.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_NoParam_StringReturn_WithFilter.generated.txt
@@ -84,11 +84,11 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         private static readonly Dictionary<(string, int), (MetadataPopulator, RequestDelegateFactoryFunc)> map = new()
         {
-            [(@"TestMapActions.cs", 16)] = (
+            [(@"TestMapActions.cs", 18)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 16));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 18));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithEmptyQueryStringValueProvided_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithEmptyQueryStringValueProvided_StringReturn.generated.txt
@@ -226,6 +226,13 @@ namespace Microsoft.AspNetCore.Http.Generated
             }
             return (false, default);
         }
+
+        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
+        {
+            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
+                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
+                : httpContext.Request.Query[$"{parameterName}"];
+        }
     }
 
     %GENERATEDCODEATTRIBUTE%

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithEmptyQueryStringValueProvided_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithEmptyQueryStringValueProvided_StringReturn.generated.txt
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: p (Type = string?, IsOptional = True, Source = Query)
+                        // Endpoint Parameter: p (Type = global::System.String?, IsOptional = True, Source = Query)
                         var p_raw = httpContext.Request.Query["p"];
                         var p_local = p_raw.Count > 0 ? p_raw.ToString() : null;
 
@@ -129,7 +129,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: p (Type = string?, IsOptional = True, Source = Query)
+                        // Endpoint Parameter: p (Type = global::System.String?, IsOptional = True, Source = Query)
                         var p_raw = httpContext.Request.Query["p"];
                         var p_local = p_raw.Count > 0 ? p_raw.ToString() : null;
 
@@ -137,7 +137,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<string?>(httpContext, p_local));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<global::System.String?>(httpContext, p_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithEmptyQueryStringValueProvided_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithEmptyQueryStringValueProvided_StringReturn.generated.txt
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<string?>(0)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::System.String?>(0)));
                         },
                         options.EndpointBuilder,
                         handler.Method);
@@ -225,13 +225,6 @@ namespace Microsoft.AspNetCore.Http.Generated
                 }
             }
             return (false, default);
-        }
-
-        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
-        {
-            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
-                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
-                : httpContext.Request.Query[$"{parameterName}"];
         }
     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithEmptyQueryStringValueProvided_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithEmptyQueryStringValueProvided_StringReturn.generated.txt
@@ -84,11 +84,11 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         private static readonly Dictionary<(string, int), (MetadataPopulator, RequestDelegateFactoryFunc)> map = new()
         {
-            [(@"TestMapActions.cs", 16)] = (
+            [(@"TestMapActions.cs", 18)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 16));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 18));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithQueryStringValueProvided_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithQueryStringValueProvided_StringReturn.generated.txt
@@ -226,6 +226,13 @@ namespace Microsoft.AspNetCore.Http.Generated
             }
             return (false, default);
         }
+
+        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
+        {
+            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
+                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
+                : httpContext.Request.Query[$"{parameterName}"];
+        }
     }
 
     %GENERATEDCODEATTRIBUTE%

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithoutQueryStringValueProvided_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleNullableStringParam_WithoutQueryStringValueProvided_StringReturn.generated.txt
@@ -226,6 +226,13 @@ namespace Microsoft.AspNetCore.Http.Generated
             }
             return (false, default);
         }
+
+        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
+        {
+            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
+                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
+                : httpContext.Request.Query[$"{parameterName}"];
+        }
     }
 
     %GENERATEDCODEATTRIBUTE%

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleStringParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_SingleStringParam_StringReturn.generated.txt
@@ -234,6 +234,13 @@ namespace Microsoft.AspNetCore.Http.Generated
             }
             return (false, default);
         }
+
+        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
+        {
+            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
+                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
+                : httpContext.Request.Query[$"{parameterName}"];
+        }
     }
 
     %GENERATEDCODEATTRIBUTE%

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_NoParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_NoParam_StringReturn.generated.txt
@@ -114,121 +114,121 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         private static readonly Dictionary<(string, int), (MetadataPopulator, RequestDelegateFactoryFunc)> map = new()
         {
-            [(@"TestMapActions.cs", 16)] = (
-               (methodInfo, options) =>
-                {
-                    Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 16));
-                    return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
-                },
-                (del, options, inferredMetadataResult) =>
-                {
-                    var handler = (Func<global::System.String>)del;
-                    EndpointFilterDelegate? filteredInvocation = null;
-
-                    if (options?.EndpointBuilder?.FilterFactories.Count > 0)
-                    {
-                        filteredInvocation = GeneratedRouteBuilderExtensionsCore.BuildFilterDelegate(ic =>
-                        {
-                            if (ic.HttpContext.Response.StatusCode == 400)
-                            {
-                                return ValueTask.FromResult<object?>(Results.Empty);
-                            }
-                            return ValueTask.FromResult<object?>(handler());
-                        },
-                        options.EndpointBuilder,
-                        handler.Method);
-                    }
-
-                    Task RequestHandler(HttpContext httpContext)
-                    {
-                        var wasParamCheckFailure = false;
-
-                        if (wasParamCheckFailure)
-                        {
-                            httpContext.Response.StatusCode = 400;
-                            return Task.CompletedTask;
-                        }
-                        httpContext.Response.ContentType ??= "text/plain";
-                        var result = handler();
-                        return httpContext.Response.WriteAsync(result);
-                    }
-                    async Task RequestHandlerFiltered(HttpContext httpContext)
-                    {
-                        var wasParamCheckFailure = false;
-
-                        if (wasParamCheckFailure)
-                        {
-                            httpContext.Response.StatusCode = 400;
-                        }
-                        var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
-                        await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
-                    }
-
-                    RequestDelegate targetDelegate = filteredInvocation is null ? RequestHandler : RequestHandlerFiltered;
-                    var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
-                    return new RequestDelegateResult(targetDelegate, metadata);
-                }),
-            [(@"TestMapActions.cs", 17)] = (
-               (methodInfo, options) =>
-                {
-                    Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 17));
-                    return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
-                },
-                (del, options, inferredMetadataResult) =>
-                {
-                    var handler = (Func<global::System.String>)del;
-                    EndpointFilterDelegate? filteredInvocation = null;
-
-                    if (options?.EndpointBuilder?.FilterFactories.Count > 0)
-                    {
-                        filteredInvocation = GeneratedRouteBuilderExtensionsCore.BuildFilterDelegate(ic =>
-                        {
-                            if (ic.HttpContext.Response.StatusCode == 400)
-                            {
-                                return ValueTask.FromResult<object?>(Results.Empty);
-                            }
-                            return ValueTask.FromResult<object?>(handler());
-                        },
-                        options.EndpointBuilder,
-                        handler.Method);
-                    }
-
-                    Task RequestHandler(HttpContext httpContext)
-                    {
-                        var wasParamCheckFailure = false;
-
-                        if (wasParamCheckFailure)
-                        {
-                            httpContext.Response.StatusCode = 400;
-                            return Task.CompletedTask;
-                        }
-                        httpContext.Response.ContentType ??= "text/plain";
-                        var result = handler();
-                        return httpContext.Response.WriteAsync(result);
-                    }
-                    async Task RequestHandlerFiltered(HttpContext httpContext)
-                    {
-                        var wasParamCheckFailure = false;
-
-                        if (wasParamCheckFailure)
-                        {
-                            httpContext.Response.StatusCode = 400;
-                        }
-                        var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
-                        await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
-                    }
-
-                    RequestDelegate targetDelegate = filteredInvocation is null ? RequestHandler : RequestHandlerFiltered;
-                    var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
-                    return new RequestDelegateResult(targetDelegate, metadata);
-                }),
             [(@"TestMapActions.cs", 18)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
                     options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 18));
+                    return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
+                },
+                (del, options, inferredMetadataResult) =>
+                {
+                    var handler = (Func<global::System.String>)del;
+                    EndpointFilterDelegate? filteredInvocation = null;
+
+                    if (options?.EndpointBuilder?.FilterFactories.Count > 0)
+                    {
+                        filteredInvocation = GeneratedRouteBuilderExtensionsCore.BuildFilterDelegate(ic =>
+                        {
+                            if (ic.HttpContext.Response.StatusCode == 400)
+                            {
+                                return ValueTask.FromResult<object?>(Results.Empty);
+                            }
+                            return ValueTask.FromResult<object?>(handler());
+                        },
+                        options.EndpointBuilder,
+                        handler.Method);
+                    }
+
+                    Task RequestHandler(HttpContext httpContext)
+                    {
+                        var wasParamCheckFailure = false;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return Task.CompletedTask;
+                        }
+                        httpContext.Response.ContentType ??= "text/plain";
+                        var result = handler();
+                        return httpContext.Response.WriteAsync(result);
+                    }
+                    async Task RequestHandlerFiltered(HttpContext httpContext)
+                    {
+                        var wasParamCheckFailure = false;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
+                        var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
+                        await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
+                    }
+
+                    RequestDelegate targetDelegate = filteredInvocation is null ? RequestHandler : RequestHandlerFiltered;
+                    var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
+                    return new RequestDelegateResult(targetDelegate, metadata);
+                }),
+            [(@"TestMapActions.cs", 19)] = (
+               (methodInfo, options) =>
+                {
+                    Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 19));
+                    return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
+                },
+                (del, options, inferredMetadataResult) =>
+                {
+                    var handler = (Func<global::System.String>)del;
+                    EndpointFilterDelegate? filteredInvocation = null;
+
+                    if (options?.EndpointBuilder?.FilterFactories.Count > 0)
+                    {
+                        filteredInvocation = GeneratedRouteBuilderExtensionsCore.BuildFilterDelegate(ic =>
+                        {
+                            if (ic.HttpContext.Response.StatusCode == 400)
+                            {
+                                return ValueTask.FromResult<object?>(Results.Empty);
+                            }
+                            return ValueTask.FromResult<object?>(handler());
+                        },
+                        options.EndpointBuilder,
+                        handler.Method);
+                    }
+
+                    Task RequestHandler(HttpContext httpContext)
+                    {
+                        var wasParamCheckFailure = false;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                            return Task.CompletedTask;
+                        }
+                        httpContext.Response.ContentType ??= "text/plain";
+                        var result = handler();
+                        return httpContext.Response.WriteAsync(result);
+                    }
+                    async Task RequestHandlerFiltered(HttpContext httpContext)
+                    {
+                        var wasParamCheckFailure = false;
+
+                        if (wasParamCheckFailure)
+                        {
+                            httpContext.Response.StatusCode = 400;
+                        }
+                        var result = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext));
+                        await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
+                    }
+
+                    RequestDelegate targetDelegate = filteredInvocation is null ? RequestHandler : RequestHandlerFiltered;
+                    var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
+                    return new RequestDelegateResult(targetDelegate, metadata);
+                }),
+            [(@"TestMapActions.cs", 20)] = (
+               (methodInfo, options) =>
+                {
+                    Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 20));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -279,11 +279,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
                     return new RequestDelegateResult(targetDelegate, metadata);
                 }),
-            [(@"TestMapActions.cs", 19)] = (
+            [(@"TestMapActions.cs", 21)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 19));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 21));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_NoParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_NoParam_StringReturn.generated.txt
@@ -415,13 +415,6 @@ namespace Microsoft.AspNetCore.Http.Generated
             }
             return (false, default);
         }
-
-        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
-        {
-            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
-                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
-                : httpContext.Request.Query[$"{parameterName}"];
-        }
     }
 
     %GENERATEDCODEATTRIBUTE%

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_NoParam_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_NoParam_StringReturn.generated.txt
@@ -415,6 +415,13 @@ namespace Microsoft.AspNetCore.Http.Generated
             }
             return (false, default);
         }
+
+        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
+        {
+            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
+                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
+                : httpContext.Request.Query[$"{parameterName}"];
+        }
     }
 
     %GENERATEDCODEATTRIBUTE%

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_WithParams_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_WithParams_StringReturn.generated.txt
@@ -161,7 +161,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<Microsoft.AspNetCore.Http.HttpRequest>(httpContext, req_local));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<global::Microsoft.AspNetCore.Http.HttpRequest>(httpContext, req_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -216,7 +216,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<Microsoft.AspNetCore.Http.HttpResponse>(httpContext, res_local));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<global::Microsoft.AspNetCore.Http.HttpResponse>(httpContext, res_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 
@@ -273,7 +273,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                         {
                             httpContext.Response.StatusCode = 400;
                         }
-                        var result = await filteredInvocation(new EndpointFilterInvocationContext<Microsoft.AspNetCore.Http.HttpRequest, Microsoft.AspNetCore.Http.HttpResponse>(httpContext, req_local, res_local));
+                        var result = await filteredInvocation(new EndpointFilterInvocationContext<global::Microsoft.AspNetCore.Http.HttpRequest, global::Microsoft.AspNetCore.Http.HttpResponse>(httpContext, req_local, res_local));
                         await GeneratedRouteBuilderExtensionsCore.ExecuteObjectResult(result, httpContext);
                     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_WithParams_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_WithParams_StringReturn.generated.txt
@@ -362,6 +362,13 @@ namespace Microsoft.AspNetCore.Http.Generated
             }
             return (false, default);
         }
+
+        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
+        {
+            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
+                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
+                : httpContext.Request.Query[$"{parameterName}"];
+        }
     }
 
     %GENERATEDCODEATTRIBUTE%

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_WithParams_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_WithParams_StringReturn.generated.txt
@@ -134,7 +134,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<Microsoft.AspNetCore.Http.HttpRequest>(0)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::Microsoft.AspNetCore.Http.HttpRequest>(0)));
                         },
                         options.EndpointBuilder,
                         handler.Method);
@@ -189,7 +189,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<Microsoft.AspNetCore.Http.HttpResponse>(0)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::Microsoft.AspNetCore.Http.HttpResponse>(0)));
                         },
                         options.EndpointBuilder,
                         handler.Method);
@@ -244,7 +244,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<Microsoft.AspNetCore.Http.HttpRequest>(0), ic.GetArgument<Microsoft.AspNetCore.Http.HttpResponse>(1)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::Microsoft.AspNetCore.Http.HttpRequest>(0), ic.GetArgument<global::Microsoft.AspNetCore.Http.HttpResponse>(1)));
                         },
                         options.EndpointBuilder,
                         handler.Method);
@@ -361,13 +361,6 @@ namespace Microsoft.AspNetCore.Http.Generated
                 }
             }
             return (false, default);
-        }
-
-        private static StringValues ResolveFromRouteOrQuery(HttpContext httpContext, string parameterName, IEnumerable<string>? routeParameterNames)
-        {
-            return routeParameterNames?.Contains(parameterName, StringComparer.OrdinalIgnoreCase) == true
-                ? new StringValues(httpContext.Request.RouteValues[$"{parameterName}"]?.ToString())
-                : httpContext.Request.Query[$"{parameterName}"];
         }
     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_WithParams_StringReturn.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/Multiple_MapAction_WithParams_StringReturn.generated.txt
@@ -114,11 +114,11 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         private static readonly Dictionary<(string, int), (MetadataPopulator, RequestDelegateFactoryFunc)> map = new()
         {
-            [(@"TestMapActions.cs", 16)] = (
+            [(@"TestMapActions.cs", 18)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 16));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 18));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -169,11 +169,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
                     return new RequestDelegateResult(targetDelegate, metadata);
                 }),
-            [(@"TestMapActions.cs", 17)] = (
+            [(@"TestMapActions.cs", 19)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 17));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 19));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -224,11 +224,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
                     return new RequestDelegateResult(targetDelegate, metadata);
                 }),
-            [(@"TestMapActions.cs", 18)] = (
+            [(@"TestMapActions.cs", 20)] = (
                (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 18));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 20));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorIncrementalityTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorIncrementalityTests.cs
@@ -1,5 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Http.Generators.Tests;

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorIncrementalityTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorIncrementalityTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.CodeAnalysis;
+
 namespace Microsoft.AspNetCore.Http.Generators.Tests;
 
 public class RequestDelegateGeneratorIncrementalityTests : RequestDelegateGeneratorTestBase
@@ -44,8 +45,12 @@ public class RequestDelegateGeneratorIncrementalityTests : RequestDelegateGenera
     [Fact]
     public async Task MapAction_ChangeBodyParamNullability_TriggersUpdate()
     {
-        var source = @"app.MapGet(""/"", ([FromBody] Todo todo) => TypedResults.Ok(todo));";
-        var updatedSource = @"app.MapGet(""/"", ([FromBody] Todo? todo) => TypedResults.Ok(todo));";
+        var source = $"""app.MapGet("/", ([{typeof(FromBodyAttribute)}] {typeof(Todo)} todo) => TypedResults.Ok(todo));""";
+        var updatedSource = $"""
+#pragma warning disable CS8622
+app.MapGet("/", ([{typeof(FromBodyAttribute)}] {typeof(Todo)}? todo) => TypedResults.Ok(todo));
+#pragma warning disable CS8622
+""";
 
         var (result, compilation) = await RunGeneratorAsync(source, updatedSource);
         var outputSteps = GetRunStepOutputs(result);

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorTestBase.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorTestBase.cs
@@ -195,7 +195,9 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Http.Generators.Tests;
 
 public static class TestMapActions
 {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorTestBase.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorTestBase.cs
@@ -204,25 +204,6 @@ public static class TestMapActions
         {{sources}}
         return app;
     }
-
-    public interface ITodo
-    {
-        public int Id { get; }
-        public string? Name { get; }
-        public bool IsComplete { get; }
-    }
-
-    public class Todo
-    {
-        public int Id { get; set; }
-        public string? Name { get; set; } = "Todo";
-        public bool IsComplete { get; set; }
-    }
-
-    public class FromBodyAttribute : Attribute, IFromBodyMetadata
-    {
-        public bool AllowEmpty { get; set; }
-    }
 }
 """;
     private static Task<Compilation> CreateCompilationAsync(string sources)
@@ -372,13 +353,6 @@ Actual Line:
         public ICollection<EndpointDataSource> DataSources { get; }
 
         public IServiceProvider ServiceProvider => ApplicationBuilder.ApplicationServices;
-    }
-
-    public class Todo
-    {
-        public int Id { get; set; }
-        public string Name { get; set; } = "Todo";
-        public bool IsComplete { get; set; }
     }
 
     internal sealed class RequestBodyDetectionFeature : IHttpRequestBodyDetectionFeature

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Generators.StaticRouteHandlerModel;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Http.Generators.Tests;
@@ -520,7 +521,7 @@ app.MapGet(route, () => "Hello world!");
 .AddEndpointFilter((c, n) => n(c));
 """;
             var fromBodyRequiredSource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}] {typeof(Todo)} todo) => TypedResults.Ok(todo));""";
-            var fromBodyAllowEmptySource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}(AllowEmpty = true)] {typeof(Todo)} todo) => TypedResults.Ok(todo));""";
+            var fromBodyAllowEmptySource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}(EmptyBodyBehavior = {typeof(EmptyBodyBehavior)}.Allow)] {typeof(Todo)} todo) => TypedResults.Ok(todo));""";
             var fromBodyNullableSource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}] {typeof(Todo)}? todo) => TypedResults.Ok(todo));""";
             var fromBodyDefaultValueSource = $"""
 #nullable disable
@@ -529,7 +530,7 @@ app.MapPost("/", postTodoWithDefault);
 #nullable restore
 """;
             var fromBodyRequiredWithFilterSource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}] {typeof(Todo)} todo) => TypedResults.Ok(todo)){withFilter}""";
-            var fromBodyAllowEmptyWithFilterSource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}(AllowEmpty = true)] {typeof(Todo)} todo) => TypedResults.Ok(todo)){withFilter}""";
+            var fromBodyAllowEmptyWithFilterSource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}(EmptyBodyBehavior = {typeof(EmptyBodyBehavior)}.Allow)] {typeof(Todo)} todo) => TypedResults.Ok(todo)){withFilter}""";
             var fromBodyNullableWithFilterSource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}] {typeof(Todo)}?  todo) => TypedResults.Ok(todo)){withFilter}""";
             var fromBodyDefaultValueWithFilterSource = $"""
 #nullable disable
@@ -940,10 +941,11 @@ app.MapGet("/multipleFromService", ([{{typeof(FromServicesAttribute)}}]{{typeof(
     public async Task MapAction_ExplicitSource_SimpleReturn_Snapshot()
     {
         var source = $$"""
-app.MapGet("/fromQuery", ([{{typeof(FromQueryAttribute)}}] string? queryValue) => queryValue ?? string.Empty);
-app.MapGet("/fromHeader", ([{{typeof(FromHeaderAttribute)}}] string? headerValue) => headerValue ?? string.Empty);
-app.MapGet("/fromHeader/{routeValue}", ([{{typeof(FromRouteAttribute)}}] string? routeValue) => routeValue ?? string.Empty);
-app.MapGet("/{value}", (string? value) => value ?? string.Empty);
+app.MapGet("/fromQuery", ([{{typeof(FromQueryAttribute)}}] string queryValue) => queryValue ?? string.Empty);
+app.MapGet("/fromHeader", ([{{typeof(FromHeaderAttribute)}}] string headerValue) => headerValue ?? string.Empty);
+app.MapGet("/fromRoute/{routeValue}", ([{{typeof(FromRouteAttribute)}}] string routeValue) => routeValue ?? string.Empty);
+app.MapGet("/fromRouteRequiredImplicit/{value}", (string value) => value);
+app.MapGet("/fromQueryRequiredImplicit", (string value) => value);
 """;
         var (_, compilation) = await RunGeneratorAsync(source);
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorTests.cs
@@ -43,12 +43,12 @@ public class RequestDelegateGeneratorTests : RequestDelegateGeneratorTestBase
         get
         {
             var expectedBody = "TestQueryValue";
-            var fromQueryRequiredSource = $"""app.MapGet("/", ([{typeof(FromQueryAttribute)}] string queryValue) => queryValue);""";
-            var fromQueryWithNameRequiredSource = $"""app.MapGet("/", ([{typeof(FromQueryAttribute)}(Name = "queryValue")] string parameterName) => parameterName);""";
-            var fromQueryNullableSource = $"""app.MapGet("/", ([{typeof(FromQueryAttribute)}] string? queryValue) => queryValue ?? string.Empty);""";
-            var fromQueryDefaultValueSource = $"""
+            var fromQueryRequiredSource = """app.MapGet("/", ([FromQuery] string queryValue) => queryValue);""";
+            var fromQueryWithNameRequiredSource = """app.MapGet("/", ([FromQuery(Name = "queryValue")] string parameterName) => parameterName);""";
+            var fromQueryNullableSource = """app.MapGet("/", ([FromQuery] string? queryValue) => queryValue ?? string.Empty);""";
+            var fromQueryDefaultValueSource = """
 #nullable disable
-string getQueryWithDefault([{typeof(FromQueryAttribute)}] string queryValue = null) => queryValue ?? string.Empty;
+string getQueryWithDefault([FromQuery] string queryValue = null) => queryValue ?? string.Empty;
 app.MapGet("/", getQueryWithDefault);
 #nullable restore
 """;
@@ -279,12 +279,12 @@ app.MapGet("/hello", () => "Hello world!")
 
     public static IEnumerable<object[]> MapAction_NoParam_ComplexReturn_Data => new List<object[]>()
     {
-        new object[] { $$"""app.MapGet("/", () => new {{typeof(Todo)}}() { Name = "Test Item"});""" },
-        new object[] { $$"""
-object GetTodo() => new {{typeof(Todo)}}() { Name = "Test Item"};
+        new object[] { """app.MapGet("/", () => new Todo() { Name = "Test Item"});""" },
+        new object[] { """
+object GetTodo() => new Todo() { Name = "Test Item"};
 app.MapGet("/", GetTodo);
 """},
-        new object[] { $$"""app.MapGet("/", () => TypedResults.Ok(new {{typeof(Todo)}}() { Name = "Test Item"}));""" }
+        new object[] { """app.MapGet("/", () => TypedResults.Ok(new Todo() { Name = "Test Item"}));""" }
     };
 
     [Theory]
@@ -310,7 +310,7 @@ app.MapGet("/", GetTodo);
         new object[] { @"app.MapGet(""/"", () => Console.WriteLine(""Returns void""));", null },
         new object[] { @"app.MapGet(""/"", () => TypedResults.Ok(""Alright!""));", null },
         new object[] { @"app.MapGet(""/"", () => Results.NotFound(""Oops!""));", null },
-        new object[] { $$"""app.MapGet("/", () => Task.FromResult(new {{typeof(Todo)}}() { Name = "Test Item"}));""", "application/json" },
+        new object[] { @"app.MapGet(""/"", () => Task.FromResult(new Todo() { Name = ""Test Item"" }));", "application/json" },
         new object[] { @"app.MapGet(""/"", () => ""Hello world!"");", "text/plain" }
     };
 
@@ -330,8 +330,8 @@ app.MapGet("/", GetTodo);
     public static IEnumerable<object[]>  MapAction_NoParam_TaskOfTReturn_Data => new List<object[]>()
     {
         new object[] { @"app.MapGet(""/"", () => Task.FromResult(""Hello world!""));", "Hello world!" },
-        new object[] { $$"""app.MapGet("/", () => Task.FromResult(new {{typeof(Todo)}}() { Name = "Test Item"}));""", """{"id":0,"name":"Test Item","isComplete":false}""" },
-        new object[] { $$"""app.MapGet("/", () => Task.FromResult(TypedResults.Ok(new {{typeof(Todo)}}() { Name = "Test Item"})));""", """{"id":0,"name":"Test Item","isComplete":false}""" }
+        new object[] { @"app.MapGet(""/"", () => Task.FromResult(new Todo() { Name = ""Test Item"" }));", """{"id":0,"name":"Test Item","isComplete":false}""" },
+        new object[] { @"app.MapGet(""/"", () => Task.FromResult(TypedResults.Ok(new Todo() { Name = ""Test Item"" })));", """{"id":0,"name":"Test Item","isComplete":false}""" }
     };
 
     [Theory]
@@ -355,8 +355,8 @@ app.MapGet("/", GetTodo);
     public static IEnumerable<object[]> MapAction_NoParam_ValueTaskOfTReturn_Data => new List<object[]>()
     {
         new object[] { @"app.MapGet(""/"", () => ValueTask.FromResult(""Hello world!""));", "Hello world!" },
-        new object[] { $$"""app.MapGet("/", () => ValueTask.FromResult(new {{typeof(Todo)}}() { Name = "Test Item"}));""", """{"id":0,"name":"Test Item","isComplete":false}""" },
-        new object[] { $$"""app.MapGet("/", () => ValueTask.FromResult(TypedResults.Ok(new {{typeof(Todo)}}() { Name = "Test Item"})));""", """{"id":0,"name":"Test Item","isComplete":false}""" }
+        new object[] { @"app.MapGet(""/"", () => ValueTask.FromResult(new Todo() { Name = ""Test Item""}));", """{"id":0,"name":"Test Item","isComplete":false}""" },
+        new object[] { @"app.MapGet(""/"", () => ValueTask.FromResult(TypedResults.Ok(new Todo() { Name = ""Test Item""})));", """{"id":0,"name":"Test Item","isComplete":false}""" }
     };
 
     [Theory]
@@ -381,10 +381,10 @@ app.MapGet("/", GetTodo);
     {
         new object[] { @"app.MapGet(""/"", () => new ValueTask<object>(""Hello world!""));", "Hello world!" },
         new object[] { @"app.MapGet(""/"", () => Task<object>.FromResult(""Hello world!""));", "Hello world!" },
-        new object[] { $$"""app.MapGet("/", () => new ValueTask<object>(new {{typeof(Todo)}}() { Name = "Test Item"}));""", """{"id":0,"name":"Test Item","isComplete":false}""" },
-        new object[] { $$"""app.MapGet("/", () => Task<object>.FromResult(new {{typeof(Todo)}}() { Name = "Test Item"}));""", """{"id":0,"name":"Test Item","isComplete":false}""" },
-        new object[] { $$"""app.MapGet("/", () => new ValueTask<object>(TypedResults.Ok(new {{typeof(Todo)}}() { Name = "Test Item"})));""", """{"id":0,"name":"Test Item","isComplete":false}""" },
-        new object[] { $$"""app.MapGet("/", () => Task<object>.FromResult(TypedResults.Ok(new {{typeof(Todo)}}() { Name = "Test Item"})));""", """{"id":0,"name":"Test Item","isComplete":false}""" }
+        new object[] { @"app.MapGet(""/"", () => new ValueTask<object>(new Todo() { Name = ""Test Item""}));", """{"id":0,"name":"Test Item","isComplete":false}""" },
+        new object[] { @"app.MapGet(""/"", () => Task<object>.FromResult(new Todo() { Name = ""Test Item""}));", """{"id":0,"name":"Test Item","isComplete":false}""" },
+        new object[] { @"app.MapGet(""/"", () => new ValueTask<object>(TypedResults.Ok(new Todo() { Name = ""Test Item""})));", """{"id":0,"name":"Test Item","isComplete":false}""" },
+        new object[] { @"app.MapGet(""/"", () => Task<object>.FromResult(TypedResults.Ok(new Todo() { Name = ""Test Item""})));", """{"id":0,"name":"Test Item","isComplete":false}""" }
     };
 
     [Theory]
@@ -520,21 +520,21 @@ app.MapGet(route, () => "Hello world!");
             var withFilter = """
 .AddEndpointFilter((c, n) => n(c));
 """;
-            var fromBodyRequiredSource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}] {typeof(Todo)} todo) => TypedResults.Ok(todo));""";
-            var fromBodyAllowEmptySource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}(EmptyBodyBehavior = {typeof(EmptyBodyBehavior)}.Allow)] {typeof(Todo)} todo) => TypedResults.Ok(todo));""";
-            var fromBodyNullableSource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}] {typeof(Todo)}? todo) => TypedResults.Ok(todo));""";
-            var fromBodyDefaultValueSource = $"""
+            var fromBodyRequiredSource = """app.MapPost("/", ([FromBody] Todo todo) => TypedResults.Ok(todo));""";
+            var fromBodyAllowEmptySource = """app.MapPost("/", ([FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] Todo todo) => TypedResults.Ok(todo));""";
+            var fromBodyNullableSource = """app.MapPost("/", ([FromBody] Todo? todo) => TypedResults.Ok(todo));""";
+            var fromBodyDefaultValueSource = """
 #nullable disable
-IResult postTodoWithDefault([{typeof(FromBodyAttribute)}] {typeof(Todo)} todo = null) => TypedResults.Ok(todo);
+IResult postTodoWithDefault([FromBody] Todo todo = null) => TypedResults.Ok(todo);
 app.MapPost("/", postTodoWithDefault);
 #nullable restore
 """;
-            var fromBodyRequiredWithFilterSource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}] {typeof(Todo)} todo) => TypedResults.Ok(todo)){withFilter}""";
-            var fromBodyAllowEmptyWithFilterSource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}(EmptyBodyBehavior = {typeof(EmptyBodyBehavior)}.Allow)] {typeof(Todo)} todo) => TypedResults.Ok(todo)){withFilter}""";
-            var fromBodyNullableWithFilterSource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}] {typeof(Todo)}?  todo) => TypedResults.Ok(todo)){withFilter}""";
+            var fromBodyRequiredWithFilterSource = $"""app.MapPost("/", ([FromBody] Todo todo) => TypedResults.Ok(todo)){withFilter}""";
+            var fromBodyAllowEmptyWithFilterSource = $"""app.MapPost("/", ([FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] Todo todo) => TypedResults.Ok(todo)){withFilter}""";
+            var fromBodyNullableWithFilterSource = $"""app.MapPost("/", ([FromBody] Todo?  todo) => TypedResults.Ok(todo)){withFilter}""";
             var fromBodyDefaultValueWithFilterSource = $"""
 #nullable disable
-IResult postTodoWithDefault([{typeof(FromBodyAttribute)}] {typeof(Todo)} todo = null) => TypedResults.Ok(todo);
+IResult postTodoWithDefault([FromBody] Todo todo = null) => TypedResults.Ok(todo);
 app.MapPost("/", postTodoWithDefault){withFilter}
 #nullable restore
 """;
@@ -592,9 +592,9 @@ app.MapPost("/", postTodoWithDefault){withFilter}
             IsComplete = false
         };
         var source = $"""
-app.MapPost("/fromBodyRequired", ([{typeof(FromBodyAttribute)}] {typeof(Todo)} todo) => TypedResults.Ok(todo));
+app.MapPost("/fromBodyRequired", ([FromBody] Todo todo) => TypedResults.Ok(todo));
 #pragma warning disable CS8622
-app.MapPost("/fromBodyOptional", ([{typeof(FromBodyAttribute)}] {typeof(Todo)}? todo) => TypedResults.Ok(todo));
+app.MapPost("/fromBodyOptional", ([FromBody] Todo? todo) => TypedResults.Ok(todo));
 #pragma warning restore CS8622
 """;
         var (_, compilation) = await RunGeneratorAsync(source);
@@ -631,12 +631,12 @@ app.MapPost("/fromBodyOptional", ([{typeof(FromBodyAttribute)}] {typeof(Todo)}? 
         get
         {
             var expectedBody = "Test header value";
-            var fromHeaderRequiredSource = $"""app.MapGet("/", ([{typeof(FromHeaderAttribute)}] string headerValue) => headerValue);""";
-            var fromHeaderWithNameRequiredSource = $"""app.MapGet("/", ([{typeof(FromHeaderAttribute)}(Name = "headerValue")] string parameterName) => parameterName);""";
-            var fromHeaderNullableSource = $"""app.MapGet("/", ([{typeof(FromHeaderAttribute)}] string? headerValue) => headerValue ?? string.Empty);""";
-            var fromHeaderDefaultValueSource = $"""
+            var fromHeaderRequiredSource = """app.MapGet("/", ([FromHeader] string headerValue) => headerValue);""";
+            var fromHeaderWithNameRequiredSource = """app.MapGet("/", ([FromHeader(Name = "headerValue")] string parameterName) => parameterName);""";
+            var fromHeaderNullableSource = """app.MapGet("/", ([FromHeader] string? headerValue) => headerValue ?? string.Empty);""";
+            var fromHeaderDefaultValueSource = """
 #nullable disable
-string getHeaderWithDefault([{typeof(FromHeaderAttribute)}] string headerValue = null) => headerValue ?? string.Empty;
+string getHeaderWithDefault([FromHeader] string headerValue = null) => headerValue ?? string.Empty;
 app.MapGet("/", getHeaderWithDefault);
 #nullable restore
 """;
@@ -677,12 +677,12 @@ app.MapGet("/", getHeaderWithDefault);
         get
         {
             var expectedBody = "Test route value";
-            var fromRouteRequiredSource = $$"""app.MapGet("/{routeValue}", ([{{typeof(FromRouteAttribute)}}] string routeValue) => routeValue);""";
-            var fromRouteWithNameRequiredSource = $$"""app.MapGet("/{routeValue}", ([{{typeof(FromRouteAttribute)}}(Name = "routeValue" )] string parameterName) => parameterName);""";
-            var fromRouteNullableSource = $$"""app.MapGet("/{routeValue}", ([{{typeof(FromRouteAttribute)}}] string? routeValue) => routeValue ?? string.Empty);""";
-            var fromRouteDefaultValueSource = $$"""
+            var fromRouteRequiredSource = """app.MapGet("/{routeValue}", ([FromRoute] string routeValue) => routeValue);""";
+            var fromRouteWithNameRequiredSource = """app.MapGet("/{routeValue}", ([FromRoute(Name = "routeValue" )] string parameterName) => parameterName);""";
+            var fromRouteNullableSource = """app.MapGet("/{routeValue}", ([FromRoute] string? routeValue) => routeValue ?? string.Empty);""";
+            var fromRouteDefaultValueSource = """
 #nullable disable
-string getRouteWithDefault([{{typeof(FromRouteAttribute)}}] string routeValue = null) => routeValue ?? string.Empty;
+string getRouteWithDefault([FromRoute] string routeValue = null) => routeValue ?? string.Empty;
 app.MapGet("/{routeValue}", getRouteWithDefault);
 #nullable restore
 """;
@@ -721,7 +721,7 @@ app.MapGet("/{routeValue}", getRouteWithDefault);
     [Fact]
     public async Task MapAction_ExplicitRouteParamWithInvalidName_SimpleReturn()
     {
-        var source = $$"""app.MapGet("/{routeValue}", ([{{typeof(FromRouteAttribute)}}(Name = "invalidName" )] string parameterName) => parameterName);""";
+        var source = $$"""app.MapGet("/{routeValue}", ([FromRoute(Name = "invalidName" )] string parameterName) => parameterName);""";
         var (_, compilation) = await RunGeneratorAsync(source);
         var endpoint = GetEndpointFromCompilation(compilation);
 
@@ -825,20 +825,20 @@ app.MapGet("/", (IServiceProvider provider) => "Hello world!");
     {
         get
         {
-            var fromServiceRequiredSource = $$"""app.MapPost("/", ([{{typeof(FromServicesAttribute)}}]{{typeof(TestService)}} svc) => svc.TestServiceMethod());""";
-            var fromServiceNullableSource = $$"""app.MapPost("/", ([{{typeof(FromServicesAttribute)}}]{{typeof(TestService)}}? svc) => svc?.TestServiceMethod() ?? string.Empty);""";
-            var fromServiceDefaultValueSource = $$"""
+            var fromServiceRequiredSource = """app.MapPost("/", ([FromServices]TestService svc) => svc.TestServiceMethod());""";
+            var fromServiceNullableSource = """app.MapPost("/", ([FromServices]TestService? svc) => svc?.TestServiceMethod() ?? string.Empty);""";
+            var fromServiceDefaultValueSource = """
 #nullable disable
-string postServiceWithDefault([{{typeof(FromServicesAttribute)}}]{{typeof(TestService)}} svc = null) => svc?.TestServiceMethod() ?? string.Empty;
+string postServiceWithDefault([FromServices]TestService svc = null) => svc?.TestServiceMethod() ?? string.Empty;
 app.MapPost("/", postServiceWithDefault);
 #nullable restore
 """;
 
-            var fromServiceEnumerableRequiredSource = $$"""app.MapPost("/", ([{{typeof(FromServicesAttribute)}}]IEnumerable<{{typeof(TestService)}}>  svc) => svc.FirstOrDefault()?.TestServiceMethod() ?? string.Empty);""";
-            var fromServiceEnumerableNullableSource = $$"""app.MapPost("/", ([{{typeof(FromServicesAttribute)}}]IEnumerable<{{typeof(TestService)}}>? svc) => svc?.FirstOrDefault()?.TestServiceMethod() ?? string.Empty);""";
-            var fromServiceEnumerableDefaultValueSource = $$"""
+            var fromServiceEnumerableRequiredSource = """app.MapPost("/", ([FromServices]IEnumerable<TestService>  svc) => svc.FirstOrDefault()?.TestServiceMethod() ?? string.Empty);""";
+            var fromServiceEnumerableNullableSource = """app.MapPost("/", ([FromServices]IEnumerable<TestService>? svc) => svc?.FirstOrDefault()?.TestServiceMethod() ?? string.Empty);""";
+            var fromServiceEnumerableDefaultValueSource = """
 #nullable disable
-string postServiceWithDefault([{{typeof(FromServicesAttribute)}}]IEnumerable<{{typeof(TestService)}}> svc = null) => svc?.FirstOrDefault()?.TestServiceMethod() ?? string.Empty;
+string postServiceWithDefault([FromServices]IEnumerable<TestService> svc = null) => svc?.FirstOrDefault()?.TestServiceMethod() ?? string.Empty;
 app.MapPost("/", postServiceWithDefault);
 #nullable restore
 """;
@@ -892,10 +892,10 @@ app.MapPost("/", postServiceWithDefault);
     [Fact]
     public async Task MapAction_ExplicitServiceParam_SimpleReturn_Snapshot()
     {
-        var source = $$"""
-app.MapGet("/fromServiceRequired", ([{{typeof(FromServicesAttribute)}}]{{typeof(TestService)}} svc) => svc.TestServiceMethod());
-app.MapGet("/enumerableFromService", ([{{typeof(FromServicesAttribute)}}]IEnumerable<{{typeof(TestService)}}> svc) => svc?.FirstOrDefault()?.TestServiceMethod() ?? string.Empty);
-app.MapGet("/multipleFromService", ([{{typeof(FromServicesAttribute)}}]{{typeof(TestService)}}? svc, [FromServices]IEnumerable<{{typeof(TestService)}}> svcs) =>
+        var source = """
+app.MapGet("/fromServiceRequired", ([FromServices]TestService svc) => svc.TestServiceMethod());
+app.MapGet("/enumerableFromService", ([FromServices]IEnumerable<TestService> svc) => svc?.FirstOrDefault()?.TestServiceMethod() ?? string.Empty);
+app.MapGet("/multipleFromService", ([FromServices]TestService? svc, [FromServices]IEnumerable<TestService> svcs) =>
     $"{(svcs?.FirstOrDefault()?.TestServiceMethod() ?? string.Empty)}, {svc?.TestServiceMethod()}");
 """;
         var httpContext = CreateHttpContext();
@@ -940,10 +940,10 @@ app.MapGet("/multipleFromService", ([{{typeof(FromServicesAttribute)}}]{{typeof(
     [Fact]
     public async Task MapAction_ExplicitSource_SimpleReturn_Snapshot()
     {
-        var source = $$"""
-app.MapGet("/fromQuery", ([{{typeof(FromQueryAttribute)}}] string queryValue) => queryValue ?? string.Empty);
-app.MapGet("/fromHeader", ([{{typeof(FromHeaderAttribute)}}] string headerValue) => headerValue ?? string.Empty);
-app.MapGet("/fromRoute/{routeValue}", ([{{typeof(FromRouteAttribute)}}] string routeValue) => routeValue ?? string.Empty);
+        var source = """
+app.MapGet("/fromQuery", ([FromQuery] string queryValue) => queryValue ?? string.Empty);
+app.MapGet("/fromHeader", ([FromHeader] string headerValue) => headerValue ?? string.Empty);
+app.MapGet("/fromRoute/{routeValue}", ([FromRoute] string routeValue) => routeValue ?? string.Empty);
 app.MapGet("/fromRouteRequiredImplicit/{value}", (string value) => value);
 app.MapGet("/fromQueryRequiredImplicit", (string value) => value);
 """;

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorTests.cs
@@ -45,6 +45,7 @@ public class RequestDelegateGeneratorTests : RequestDelegateGeneratorTestBase
             var expectedBody = "TestQueryValue";
             var fromQueryRequiredSource = """app.MapGet("/", ([FromQuery] string queryValue) => queryValue);""";
             var fromQueryWithNameRequiredSource = """app.MapGet("/", ([FromQuery(Name = "queryValue")] string parameterName) => parameterName);""";
+            var fromQueryWithNullNameRequiredSource = """app.MapGet("/", ([FromQuery(Name = null)] string queryValue) => queryValue);""";
             var fromQueryNullableSource = """app.MapGet("/", ([FromQuery] string? queryValue) => queryValue ?? string.Empty);""";
             var fromQueryDefaultValueSource = """
 #nullable disable
@@ -59,6 +60,8 @@ app.MapGet("/", getQueryWithDefault);
                 new object[] { fromQueryRequiredSource, null, 400, string.Empty },
                 new object[] { fromQueryWithNameRequiredSource, expectedBody, 200, expectedBody },
                 new object[] { fromQueryWithNameRequiredSource, null, 400, string.Empty },
+                new object[] { fromQueryWithNullNameRequiredSource, expectedBody, 200, expectedBody },
+                new object[] { fromQueryWithNullNameRequiredSource, null, 400, string.Empty },
                 new object[] { fromQueryNullableSource, expectedBody, 200, expectedBody },
                 new object[] { fromQueryNullableSource, null, 200, string.Empty },
                 new object[] { fromQueryDefaultValueSource, expectedBody, 200, expectedBody },
@@ -521,7 +524,8 @@ app.MapGet(route, () => "Hello world!");
 .AddEndpointFilter((c, n) => n(c));
 """;
             var fromBodyRequiredSource = """app.MapPost("/", ([FromBody] Todo todo) => TypedResults.Ok(todo));""";
-            var fromBodyAllowEmptySource = """app.MapPost("/", ([FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] Todo todo) => TypedResults.Ok(todo));""";
+            var fromBodyEmptyBodyBehaviorSource = """app.MapPost("/", ([FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] Todo todo) => TypedResults.Ok(todo));""";
+            var fromBodyAllowEmptySource = """app.MapPost("/", ([CustomFromBody(AllowEmpty = true)] Todo todo) => TypedResults.Ok(todo));""";
             var fromBodyNullableSource = """app.MapPost("/", ([FromBody] Todo? todo) => TypedResults.Ok(todo));""";
             var fromBodyDefaultValueSource = """
 #nullable disable
@@ -530,7 +534,8 @@ app.MapPost("/", postTodoWithDefault);
 #nullable restore
 """;
             var fromBodyRequiredWithFilterSource = $"""app.MapPost("/", ([FromBody] Todo todo) => TypedResults.Ok(todo)){withFilter}""";
-            var fromBodyAllowEmptyWithFilterSource = $"""app.MapPost("/", ([FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] Todo todo) => TypedResults.Ok(todo)){withFilter}""";
+            var fromBodyEmptyBehaviorWithFilterSource = $"""app.MapPost("/", ([FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] Todo todo) => TypedResults.Ok(todo)){withFilter}""";
+            var fromBodyAllowEmptyWithFilterSource = $"""app.MapPost("/", ([CustomFromBody(AllowEmpty = true)] Todo todo) => TypedResults.Ok(todo)){withFilter}""";
             var fromBodyNullableWithFilterSource = $"""app.MapPost("/", ([FromBody] Todo?  todo) => TypedResults.Ok(todo)){withFilter}""";
             var fromBodyDefaultValueWithFilterSource = $"""
 #nullable disable
@@ -543,6 +548,8 @@ app.MapPost("/", postTodoWithDefault){withFilter}
             {
                 new object[] { fromBodyRequiredSource, todo, 200, expectedBody },
                 new object[] { fromBodyRequiredSource, null, 400, string.Empty },
+                new object[] { fromBodyEmptyBodyBehaviorSource, todo, 200, expectedBody },
+                new object[] { fromBodyEmptyBodyBehaviorSource, null, 200, string.Empty },
                 new object[] { fromBodyAllowEmptySource, todo, 200, expectedBody },
                 new object[] { fromBodyAllowEmptySource, null, 200, string.Empty },
                 new object[] { fromBodyNullableSource, todo, 200, expectedBody },
@@ -551,6 +558,8 @@ app.MapPost("/", postTodoWithDefault){withFilter}
                 new object[] { fromBodyDefaultValueSource, null, 200, string.Empty },
                 new object[] { fromBodyRequiredWithFilterSource, todo, 200, expectedBody },
                 new object[] { fromBodyRequiredWithFilterSource, null, 400, string.Empty },
+                new object[] { fromBodyEmptyBehaviorWithFilterSource, todo, 200, expectedBody },
+                new object[] { fromBodyEmptyBehaviorWithFilterSource, null, 200, string.Empty },
                 new object[] { fromBodyAllowEmptyWithFilterSource, todo, 200, expectedBody },
                 new object[] { fromBodyAllowEmptyWithFilterSource, null, 200, string.Empty },
                 new object[] { fromBodyNullableWithFilterSource, todo, 200, expectedBody },
@@ -633,6 +642,7 @@ app.MapPost("/fromBodyOptional", ([FromBody] Todo? todo) => TypedResults.Ok(todo
             var expectedBody = "Test header value";
             var fromHeaderRequiredSource = """app.MapGet("/", ([FromHeader] string headerValue) => headerValue);""";
             var fromHeaderWithNameRequiredSource = """app.MapGet("/", ([FromHeader(Name = "headerValue")] string parameterName) => parameterName);""";
+            var fromHeaderWithNullNameRequiredSource = """app.MapGet("/", ([FromHeader(Name = null)] string headerValue) => headerValue);""";
             var fromHeaderNullableSource = """app.MapGet("/", ([FromHeader] string? headerValue) => headerValue ?? string.Empty);""";
             var fromHeaderDefaultValueSource = """
 #nullable disable
@@ -647,6 +657,8 @@ app.MapGet("/", getHeaderWithDefault);
                 new object[] { fromHeaderRequiredSource, null, 400, string.Empty },
                 new object[] { fromHeaderWithNameRequiredSource, expectedBody, 200, expectedBody },
                 new object[] { fromHeaderWithNameRequiredSource, null, 400, string.Empty },
+                new object[] { fromHeaderWithNullNameRequiredSource, expectedBody, 200, expectedBody },
+                new object[] { fromHeaderWithNullNameRequiredSource, null, 400, string.Empty },
                 new object[] { fromHeaderNullableSource, expectedBody, 200, expectedBody },
                 new object[] { fromHeaderNullableSource, null, 200, string.Empty },
                 new object[] { fromHeaderDefaultValueSource, expectedBody, 200, expectedBody },
@@ -679,6 +691,7 @@ app.MapGet("/", getHeaderWithDefault);
             var expectedBody = "Test route value";
             var fromRouteRequiredSource = """app.MapGet("/{routeValue}", ([FromRoute] string routeValue) => routeValue);""";
             var fromRouteWithNameRequiredSource = """app.MapGet("/{routeValue}", ([FromRoute(Name = "routeValue" )] string parameterName) => parameterName);""";
+            var fromRouteWithNullNameRequiredSource = """app.MapGet("/{routeValue}", ([FromRoute(Name = null )] string routeValue) => routeValue);""";
             var fromRouteNullableSource = """app.MapGet("/{routeValue}", ([FromRoute] string? routeValue) => routeValue ?? string.Empty);""";
             var fromRouteDefaultValueSource = """
 #nullable disable
@@ -693,6 +706,8 @@ app.MapGet("/{routeValue}", getRouteWithDefault);
                 new object[] { fromRouteRequiredSource, null, 400, string.Empty },
                 new object[] { fromRouteWithNameRequiredSource, expectedBody, 200, expectedBody },
                 new object[] { fromRouteWithNameRequiredSource, null, 400, string.Empty },
+                new object[] { fromRouteWithNullNameRequiredSource, expectedBody, 200, expectedBody },
+                new object[] { fromRouteWithNullNameRequiredSource, null, 400, string.Empty },
                 new object[] { fromRouteNullableSource, expectedBody, 200, expectedBody },
                 new object[] { fromRouteNullableSource, null, 200, string.Empty },
                 new object[] { fromRouteDefaultValueSource, expectedBody, 200, expectedBody },

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorTests.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using System.Globalization;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Generators.StaticRouteHandlerModel;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Http.Generators.Tests;
@@ -35,75 +37,58 @@ public class RequestDelegateGeneratorTests : RequestDelegateGeneratorTestBase
         await VerifyResponseBodyAsync(httpContext, expectedBody);
     }
 
-    [Fact]
-    public async Task MapAction_SingleStringParam_StringReturn()
+    public static object[][] MapAction_ExplicitQueryParam_StringReturn_Data
     {
-        var (results, compilation) = await RunGeneratorAsync("""
-app.MapGet("/hello", ([FromQuery]string p) => p);
-""");
+        get
+        {
+            var expectedBody = "TestQueryValue";
+            var fromQueryRequiredSource = $"""app.MapGet("/", ([{typeof(FromQueryAttribute)}] string queryValue) => queryValue);""";
+            var fromQueryWithNameRequiredSource = $"""app.MapGet("/", ([{typeof(FromQueryAttribute)}(Name = "queryValue")] string parameterName) => parameterName);""";
+            var fromQueryNullableSource = $"""app.MapGet("/", ([{typeof(FromQueryAttribute)}] string? queryValue) => queryValue ?? string.Empty);""";
+            var fromQueryDefaultValueSource = $"""
+#nullable disable
+string getQueryWithDefault([{typeof(FromQueryAttribute)}] string queryValue = null) => queryValue ?? string.Empty;
+app.MapGet("/", getQueryWithDefault);
+#nullable restore
+""";
 
-        var endpointModel = GetStaticEndpoint(results, GeneratorSteps.EndpointModelStep);
-        var endpoint = GetEndpointFromCompilation(compilation);
-
-        Assert.Equal("/hello", endpointModel.RoutePattern);
-        Assert.Equal("MapGet", endpointModel.HttpMethod);
-        var p = Assert.Single(endpointModel.Parameters);
-        Assert.Equal(EndpointParameterSource.Query, p.Source);
-        Assert.Equal("p", p.Name);
-
-        var httpContext = CreateHttpContext();
-        httpContext.Request.QueryString = new QueryString("?p=Hello%20world!");
-
-        await endpoint.RequestDelegate(httpContext);
-        await VerifyResponseBodyAsync(httpContext, "Hello world!");
-        await VerifyAgainstBaselineUsingFile(compilation);
+            return new[]
+            {
+                new object[] { fromQueryRequiredSource, expectedBody, 200, expectedBody },
+                new object[] { fromQueryRequiredSource, null, 400, string.Empty },
+                new object[] { fromQueryWithNameRequiredSource, expectedBody, 200, expectedBody },
+                new object[] { fromQueryWithNameRequiredSource, null, 400, string.Empty },
+                new object[] { fromQueryNullableSource, expectedBody, 200, expectedBody },
+                new object[] { fromQueryNullableSource, null, 200, string.Empty },
+                new object[] { fromQueryDefaultValueSource, expectedBody, 200, expectedBody },
+                new object[] { fromQueryDefaultValueSource, null, 200, string.Empty },
+            };
+        }
     }
 
-    [Fact]
-    public async Task MapAction_SingleNullableStringParam_WithQueryStringValueProvided_StringReturn()
+    [Theory]
+    [MemberData(nameof(MapAction_ExplicitQueryParam_StringReturn_Data))]
+    public async Task MapAction_ExplicitQueryParam_StringReturn(string source, string queryValue, int expectedStatusCode, string expectedBody)
     {
-        var (results, compilation) = await RunGeneratorAsync("""
-app.MapGet("/hello", ([FromQuery]string? p) => p ?? "Error!");
-""");
+        var (results, compilation) = await RunGeneratorAsync(source);
 
         var endpointModel = GetStaticEndpoint(results, GeneratorSteps.EndpointModelStep);
         var endpoint = GetEndpointFromCompilation(compilation);
 
-        Assert.Equal("/hello", endpointModel.RoutePattern);
+        Assert.Equal("/", endpointModel.RoutePattern);
         Assert.Equal("MapGet", endpointModel.HttpMethod);
         var p = Assert.Single(endpointModel.Parameters);
         Assert.Equal(EndpointParameterSource.Query, p.Source);
-        Assert.Equal("p", p.Name);
+        Assert.Equal("queryValue", p.Name);
 
         var httpContext = CreateHttpContext();
-        httpContext.Request.QueryString = new QueryString("?p=Hello%20world!");
+        if (queryValue is not null)
+        {
+            httpContext.Request.QueryString = new QueryString($"?queryValue={queryValue}");
+        }
 
         await endpoint.RequestDelegate(httpContext);
-        await VerifyResponseBodyAsync(httpContext, "Hello world!");
-        await VerifyAgainstBaselineUsingFile(compilation);
-    }
-
-    [Fact]
-    public async Task MapAction_SingleNullableStringParam_WithoutQueryStringValueProvided_StringReturn()
-    {
-        var (results, compilation) = await RunGeneratorAsync("""
-app.MapGet("/hello", ([FromQuery]string? p) => p ?? "Was null!");
-""");
-
-        var endpointModel = GetStaticEndpoint(results, GeneratorSteps.EndpointModelStep);
-        var endpoint = GetEndpointFromCompilation(compilation);
-
-        Assert.Equal("/hello", endpointModel.RoutePattern);
-        Assert.Equal("MapGet", endpointModel.HttpMethod);
-        var p = Assert.Single(endpointModel.Parameters);
-        Assert.Equal(EndpointParameterSource.Query, p.Source);
-        Assert.Equal("p", p.Name);
-
-        var httpContext = CreateHttpContext();
-
-        await endpoint.RequestDelegate(httpContext);
-        await VerifyResponseBodyAsync(httpContext, "Was null!");
-        await VerifyAgainstBaselineUsingFile(compilation);
+        await VerifyResponseBodyAsync(httpContext, expectedBody, expectedStatusCode);
     }
 
     [Fact]
@@ -291,13 +276,18 @@ app.MapGet("/hello", () => "Hello world!")
         await VerifyResponseBodyAsync(httpContext, expectedBody);
     }
 
-    [Theory]
-    [InlineData(@"app.MapGet(""/"", () => new Todo() { Name = ""Test Item""});")]
-    [InlineData("""
-object GetTodo() => new Todo() { Name = "Test Item"};
+    public static IEnumerable<object[]> MapAction_NoParam_ComplexReturn_Data => new List<object[]>()
+    {
+        new object[] { $$"""app.MapGet("/", () => new {{typeof(Todo)}}() { Name = "Test Item"});""" },
+        new object[] { $$"""
+object GetTodo() => new {{typeof(Todo)}}() { Name = "Test Item"};
 app.MapGet("/", GetTodo);
-""")]
-    [InlineData(@"app.MapGet(""/"", () => TypedResults.Ok(new Todo() { Name = ""Test Item""}));")]
+"""},
+        new object[] { $$"""app.MapGet("/", () => TypedResults.Ok(new {{typeof(Todo)}}() { Name = "Test Item"}));""" }
+    };
+
+    [Theory]
+    [MemberData(nameof(MapAction_NoParam_ComplexReturn_Data))]
     public async Task MapAction_NoParam_ComplexReturn(string source)
     {
         var expectedBody = """{"id":0,"name":"Test Item","isComplete":false}""";
@@ -314,12 +304,17 @@ app.MapGet("/", GetTodo);
         await VerifyResponseBodyAsync(httpContext, expectedBody);
     }
 
+    public static IEnumerable<object[]> MapAction_ProducesCorrectContentType_Data => new List<object[]>()
+    {
+        new object[] { @"app.MapGet(""/"", () => Console.WriteLine(""Returns void""));", null },
+        new object[] { @"app.MapGet(""/"", () => TypedResults.Ok(""Alright!""));", null },
+        new object[] { @"app.MapGet(""/"", () => Results.NotFound(""Oops!""));", null },
+        new object[] { $$"""app.MapGet("/", () => Task.FromResult(new {{typeof(Todo)}}() { Name = "Test Item"}));""", "application/json" },
+        new object[] { @"app.MapGet(""/"", () => ""Hello world!"");", "text/plain" }
+    };
+
     [Theory]
-    [InlineData(@"app.MapGet(""/"", () => Console.WriteLine(""Returns void""));", null)]
-    [InlineData(@"app.MapGet(""/"", () => TypedResults.Ok(""Alright!""));", null)]
-    [InlineData(@"app.MapGet(""/"", () => Results.NotFound(""Oops!""));", null)]
-    [InlineData(@"app.MapGet(""/"", () => Task.FromResult(new Todo() { Name = ""Test Item""}));", "application/json")]
-    [InlineData(@"app.MapGet(""/"", () => ""Hello world!"");", "text/plain")]
+    [MemberData(nameof(MapAction_ProducesCorrectContentType_Data))]
     public async Task MapAction_ProducesCorrectContentType(string source, string expectedContentType)
     {
         var (result, compilation) = await RunGeneratorAsync(source);
@@ -331,10 +326,15 @@ app.MapGet("/", GetTodo);
         Assert.Equal(expectedContentType, endpointModel.Response.ContentType);
     }
 
+    public static IEnumerable<object[]>  MapAction_NoParam_TaskOfTReturn_Data => new List<object[]>()
+    {
+        new object[] { @"app.MapGet(""/"", () => Task.FromResult(""Hello world!""));", "Hello world!" },
+        new object[] { $$"""app.MapGet("/", () => Task.FromResult(new {{typeof(Todo)}}() { Name = "Test Item"}));""", """{"id":0,"name":"Test Item","isComplete":false}""" },
+        new object[] { $$"""app.MapGet("/", () => Task.FromResult(TypedResults.Ok(new {{typeof(Todo)}}() { Name = "Test Item"})));""", """{"id":0,"name":"Test Item","isComplete":false}""" }
+    };
+
     [Theory]
-    [InlineData(@"app.MapGet(""/"", () => Task.FromResult(""Hello world!""));", "Hello world!")]
-    [InlineData(@"app.MapGet(""/"", () => Task.FromResult(new Todo() { Name = ""Test Item""}));", """{"id":0,"name":"Test Item","isComplete":false}""")]
-    [InlineData(@"app.MapGet(""/"", () => Task.FromResult(TypedResults.Ok(new Todo() { Name = ""Test Item""})));", """{"id":0,"name":"Test Item","isComplete":false}""")]
+    [MemberData(nameof(MapAction_NoParam_TaskOfTReturn_Data))]
     public async Task MapAction_NoParam_TaskOfTReturn(string source, string expectedBody)
     {
         var (result, compilation) = await RunGeneratorAsync(source);
@@ -351,10 +351,15 @@ app.MapGet("/", GetTodo);
         await VerifyResponseBodyAsync(httpContext, expectedBody);
     }
 
+    public static IEnumerable<object[]> MapAction_NoParam_ValueTaskOfTReturn_Data => new List<object[]>()
+    {
+        new object[] { @"app.MapGet(""/"", () => ValueTask.FromResult(""Hello world!""));", "Hello world!" },
+        new object[] { $$"""app.MapGet("/", () => ValueTask.FromResult(new {{typeof(Todo)}}() { Name = "Test Item"}));""", """{"id":0,"name":"Test Item","isComplete":false}""" },
+        new object[] { $$"""app.MapGet("/", () => ValueTask.FromResult(TypedResults.Ok(new {{typeof(Todo)}}() { Name = "Test Item"})));""", """{"id":0,"name":"Test Item","isComplete":false}""" }
+    };
+
     [Theory]
-    [InlineData(@"app.MapGet(""/"", () => ValueTask.FromResult(""Hello world!""));", "Hello world!")]
-    [InlineData(@"app.MapGet(""/"", () => ValueTask.FromResult(new Todo() { Name = ""Test Item""}));", """{"id":0,"name":"Test Item","isComplete":false}""")]
-    [InlineData(@"app.MapGet(""/"", () => ValueTask.FromResult(TypedResults.Ok(new Todo() { Name = ""Test Item""})));", """{"id":0,"name":"Test Item","isComplete":false}""")]
+    [MemberData(nameof(MapAction_NoParam_ValueTaskOfTReturn_Data))]
     public async Task MapAction_NoParam_ValueTaskOfTReturn(string source, string expectedBody)
     {
         var (result, compilation) = await RunGeneratorAsync(source);
@@ -371,13 +376,18 @@ app.MapGet("/", GetTodo);
         await VerifyResponseBodyAsync(httpContext, expectedBody);
     }
 
+    public static IEnumerable<object[]> MapAction_NoParam_TaskLikeOfObjectReturn_Data => new List<object[]>()
+    {
+        new object[] { @"app.MapGet(""/"", () => new ValueTask<object>(""Hello world!""));", "Hello world!" },
+        new object[] { @"app.MapGet(""/"", () => Task<object>.FromResult(""Hello world!""));", "Hello world!" },
+        new object[] { $$"""app.MapGet("/", () => new ValueTask<object>(new {{typeof(Todo)}}() { Name = "Test Item"}));""", """{"id":0,"name":"Test Item","isComplete":false}""" },
+        new object[] { $$"""app.MapGet("/", () => Task<object>.FromResult(new {{typeof(Todo)}}() { Name = "Test Item"}));""", """{"id":0,"name":"Test Item","isComplete":false}""" },
+        new object[] { $$"""app.MapGet("/", () => new ValueTask<object>(TypedResults.Ok(new {{typeof(Todo)}}() { Name = "Test Item"})));""", """{"id":0,"name":"Test Item","isComplete":false}""" },
+        new object[] { $$"""app.MapGet("/", () => Task<object>.FromResult(TypedResults.Ok(new {{typeof(Todo)}}() { Name = "Test Item"})));""", """{"id":0,"name":"Test Item","isComplete":false}""" }
+    };
+
     [Theory]
-    [InlineData(@"app.MapGet(""/"", () => new ValueTask<object>(""Hello world!""));", "Hello world!")]
-    [InlineData(@"app.MapGet(""/"", () => Task<object>.FromResult(""Hello world!""));", "Hello world!")]
-    [InlineData(@"app.MapGet(""/"", () => new ValueTask<object>(new Todo() { Name = ""Test Item""}));", """{"id":0,"name":"Test Item","isComplete":false}""")]
-    [InlineData(@"app.MapGet(""/"", () => Task<object>.FromResult(new Todo() { Name = ""Test Item""}));", """{"id":0,"name":"Test Item","isComplete":false}""")]
-    [InlineData(@"app.MapGet(""/"", () => new ValueTask<object>(TypedResults.Ok(new Todo() { Name = ""Test Item""})));", """{"id":0,"name":"Test Item","isComplete":false}""")]
-    [InlineData(@"app.MapGet(""/"", () => Task<object>.FromResult(TypedResults.Ok(new Todo() { Name = ""Test Item""})));", """{"id":0,"name":"Test Item","isComplete":false}""")]
+    [MemberData(nameof(MapAction_NoParam_TaskLikeOfObjectReturn_Data))]
     public async Task MapAction_NoParam_TaskLikeOfObjectReturn(string source, string expectedBody)
     {
         var (result, compilation) = await RunGeneratorAsync(source);
@@ -509,21 +519,21 @@ app.MapGet(route, () => "Hello world!");
             var withFilter = """
 .AddEndpointFilter((c, n) => n(c));
 """;
-            var fromBodyRequiredSource = """app.MapPost("/", ([FromBody] Todo todo) => TypedResults.Ok(todo));""";
-            var fromBodyAllowEmptySource = """app.MapPost("/", ([FromBody(AllowEmpty = true)] Todo todo) => TypedResults.Ok(todo));""";
-            var fromBodyNullableSource = """app.MapPost("/", ([FromBody] Todo? todo) => TypedResults.Ok(todo));""";
-            var fromBodyDefaultValueSource = """
+            var fromBodyRequiredSource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}] {typeof(Todo)} todo) => TypedResults.Ok(todo));""";
+            var fromBodyAllowEmptySource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}(AllowEmpty = true)] {typeof(Todo)} todo) => TypedResults.Ok(todo));""";
+            var fromBodyNullableSource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}] {typeof(Todo)}? todo) => TypedResults.Ok(todo));""";
+            var fromBodyDefaultValueSource = $"""
 #nullable disable
-IResult postTodoWithDefault([FromBody] Todo todo = null) => TypedResults.Ok(todo);
+IResult postTodoWithDefault([{typeof(FromBodyAttribute)}] {typeof(Todo)} todo = null) => TypedResults.Ok(todo);
 app.MapPost("/", postTodoWithDefault);
 #nullable restore
 """;
-            var fromBodyRequiredWithFilterSource = $"""app.MapPost("/", ([FromBody] Todo todo) => TypedResults.Ok(todo)){withFilter}""";
-            var fromBodyAllowEmptyWithFilterSource = $"""app.MapPost("/", ([FromBody(AllowEmpty = true)] Todo todo) => TypedResults.Ok(todo)){withFilter}""";
-            var fromBodyNullableWithFilterSource = $"""app.MapPost("/", ([FromBody] Todo? todo) => TypedResults.Ok(todo)){withFilter}""";
+            var fromBodyRequiredWithFilterSource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}] {typeof(Todo)} todo) => TypedResults.Ok(todo)){withFilter}""";
+            var fromBodyAllowEmptyWithFilterSource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}(AllowEmpty = true)] {typeof(Todo)} todo) => TypedResults.Ok(todo)){withFilter}""";
+            var fromBodyNullableWithFilterSource = $"""app.MapPost("/", ([{typeof(FromBodyAttribute)}] {typeof(Todo)}?  todo) => TypedResults.Ok(todo)){withFilter}""";
             var fromBodyDefaultValueWithFilterSource = $"""
 #nullable disable
-IResult postTodoWithDefault([FromBody] Todo todo = null) => TypedResults.Ok(todo);
+IResult postTodoWithDefault([{typeof(FromBodyAttribute)}] {typeof(Todo)} todo = null) => TypedResults.Ok(todo);
 app.MapPost("/", postTodoWithDefault){withFilter}
 #nullable restore
 """;
@@ -580,10 +590,10 @@ app.MapPost("/", postTodoWithDefault){withFilter}
             Name = "Test Item",
             IsComplete = false
         };
-        var source = """
-app.MapPost("/fromBodyRequired", ([FromBody] Todo todo) => TypedResults.Ok(todo));
+        var source = $"""
+app.MapPost("/fromBodyRequired", ([{typeof(FromBodyAttribute)}] {typeof(Todo)} todo) => TypedResults.Ok(todo));
 #pragma warning disable CS8622
-app.MapPost("/fromBodyOptional", ([FromBody] Todo? todo) => TypedResults.Ok(todo));
+app.MapPost("/fromBodyOptional", ([{typeof(FromBodyAttribute)}] {typeof(Todo)}? todo) => TypedResults.Ok(todo));
 #pragma warning restore CS8622
 """;
         var (_, compilation) = await RunGeneratorAsync(source);
@@ -615,6 +625,176 @@ app.MapPost("/fromBodyOptional", ([FromBody] Todo? todo) => TypedResults.Ok(todo
         await VerifyResponseBodyAsync(httpContext, string.Empty);
     }
 
+    public static object[][] MapAction_ExplicitHeaderParam_SimpleReturn_Data
+    {
+        get
+        {
+            var expectedBody = "Test header value";
+            var fromHeaderRequiredSource = $"""app.MapGet("/", ([{typeof(FromHeaderAttribute)}] string headerValue) => headerValue);""";
+            var fromHeaderWithNameRequiredSource = $"""app.MapGet("/", ([{typeof(FromHeaderAttribute)}(Name = "headerValue")] string parameterName) => parameterName);""";
+            var fromHeaderNullableSource = $"""app.MapGet("/", ([{typeof(FromHeaderAttribute)}] string? headerValue) => headerValue ?? string.Empty);""";
+            var fromHeaderDefaultValueSource = $"""
+#nullable disable
+string getHeaderWithDefault([{typeof(FromHeaderAttribute)}] string headerValue = null) => headerValue ?? string.Empty;
+app.MapGet("/", getHeaderWithDefault);
+#nullable restore
+""";
+
+            return new[]
+            {
+                new object[] { fromHeaderRequiredSource, expectedBody, 200, expectedBody },
+                new object[] { fromHeaderRequiredSource, null, 400, string.Empty },
+                new object[] { fromHeaderWithNameRequiredSource, expectedBody, 200, expectedBody },
+                new object[] { fromHeaderWithNameRequiredSource, null, 400, string.Empty },
+                new object[] { fromHeaderNullableSource, expectedBody, 200, expectedBody },
+                new object[] { fromHeaderNullableSource, null, 200, string.Empty },
+                new object[] { fromHeaderDefaultValueSource, expectedBody, 200, expectedBody },
+                new object[] { fromHeaderDefaultValueSource, null, 200, string.Empty },
+            };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(MapAction_ExplicitHeaderParam_SimpleReturn_Data))]
+    public async Task MapAction_ExplicitHeaderParam_SimpleReturn(string source, string requestData, int expectedStatusCode, string expectedBody)
+    {
+        var (_, compilation) = await RunGeneratorAsync(source);
+        var endpoint = GetEndpointFromCompilation(compilation);
+
+        var httpContext = CreateHttpContext();
+        if (requestData is not null)
+        {
+            httpContext.Request.Headers["headerValue"] = requestData;
+        }
+
+        await endpoint.RequestDelegate(httpContext);
+        await VerifyResponseBodyAsync(httpContext, expectedBody, expectedStatusCode);
+    }
+
+    public static object[][] MapAction_ExplicitRouteParam_SimpleReturn_Data
+    {
+        get
+        {
+            var expectedBody = "Test route value";
+            var fromRouteRequiredSource = $$"""app.MapGet("/{routeValue}", ([{{typeof(FromRouteAttribute)}}] string routeValue) => routeValue);""";
+            var fromRouteWithNameRequiredSource = $$"""app.MapGet("/{routeValue}", ([{{typeof(FromRouteAttribute)}}(Name = "routeValue" )] string parameterName) => parameterName);""";
+            var fromRouteNullableSource = $$"""app.MapGet("/{routeValue}", ([{{typeof(FromRouteAttribute)}}] string? routeValue) => routeValue ?? string.Empty);""";
+            var fromRouteDefaultValueSource = $$"""
+#nullable disable
+string getRouteWithDefault([{{typeof(FromRouteAttribute)}}] string routeValue = null) => routeValue ?? string.Empty;
+app.MapGet("/{routeValue}", getRouteWithDefault);
+#nullable restore
+""";
+
+            return new[]
+            {
+                new object[] { fromRouteRequiredSource, expectedBody, 200, expectedBody },
+                new object[] { fromRouteRequiredSource, null, 400, string.Empty },
+                new object[] { fromRouteWithNameRequiredSource, expectedBody, 200, expectedBody },
+                new object[] { fromRouteWithNameRequiredSource, null, 400, string.Empty },
+                new object[] { fromRouteNullableSource, expectedBody, 200, expectedBody },
+                new object[] { fromRouteNullableSource, null, 200, string.Empty },
+                new object[] { fromRouteDefaultValueSource, expectedBody, 200, expectedBody },
+                new object[] { fromRouteDefaultValueSource, null, 200, string.Empty },
+            };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(MapAction_ExplicitRouteParam_SimpleReturn_Data))]
+    public async Task MapAction_ExplicitRouteParam_SimpleReturn(string source, string requestData, int expectedStatusCode, string expectedBody)
+    {
+        var (_, compilation) = await RunGeneratorAsync(source);
+        var endpoint = GetEndpointFromCompilation(compilation);
+
+        var httpContext = CreateHttpContext();
+        if (requestData is not null)
+        {
+            httpContext.Request.RouteValues["routeValue"] = requestData;
+        }
+
+        await endpoint.RequestDelegate(httpContext);
+        await VerifyResponseBodyAsync(httpContext, expectedBody, expectedStatusCode);
+    }
+
+    [Fact]
+    public async Task MapAction_ExplicitRouteParamWithInvalidName_SimpleReturn()
+    {
+        var source = $$"""app.MapGet("/{routeValue}", ([{{typeof(FromRouteAttribute)}}(Name = "invalidName" )] string parameterName) => parameterName);""";
+        var (_, compilation) = await RunGeneratorAsync(source);
+        var endpoint = GetEndpointFromCompilation(compilation);
+
+        var httpContext = CreateHttpContext();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => endpoint.RequestDelegate(httpContext));
+        Assert.Equal("'invalidName' is not a route parameter.", exception.Message);
+    }
+
+    public static object[][] MapAction_RouteOrQueryParam_SimpleReturn_Data
+    {
+        get
+        {
+            var expectedBody = "ValueFromRouteOrQuery";
+            var implicitRouteRequiredSource = """app.MapGet("/{value}", (string value) => value);""";
+            var implicitQueryRequiredSource = """app.MapGet("", (string value) => value);""";
+            var implicitRouteNullableSource = """app.MapGet("/{value}", (string? value) => value ?? string.Empty);""";
+            var implicitQueryNullableSource = """app.MapGet("/", (string? value) => value ?? string.Empty);""";
+            var implicitRouteDefaultValueSource = """
+#nullable disable
+string getRouteWithDefault(string value = null) => value ?? string.Empty;
+app.MapGet("/{value}", getRouteWithDefault);
+#nullable restore
+""";
+
+            var implicitQueryDefaultValueSource = """
+#nullable disable
+string getQueryWithDefault(string value = null) => value ?? string.Empty;
+app.MapGet("/", getQueryWithDefault);
+#nullable restore
+""";
+
+            return new[]
+            {
+                new object[] { implicitRouteRequiredSource, true, false, 200, expectedBody },
+                new object[] { implicitRouteRequiredSource, false, false, 400, string.Empty },
+                new object[] { implicitQueryRequiredSource, false, true, 200, expectedBody },
+                new object[] { implicitQueryRequiredSource, false, false, 400, string.Empty },
+
+                new object[] { implicitRouteNullableSource, true, false, 200, expectedBody },
+                new object[] { implicitRouteNullableSource, false, false, 200, string.Empty },
+                new object[] { implicitQueryNullableSource, false, true, 200, expectedBody },
+                new object[] { implicitQueryNullableSource, false, false, 200, string.Empty },
+
+                new object[] { implicitRouteDefaultValueSource, true, false, 200, expectedBody },
+                new object[] { implicitRouteDefaultValueSource, false, false, 200, string.Empty },
+                new object[] { implicitQueryDefaultValueSource, false, true, 200, expectedBody },
+                new object[] { implicitQueryDefaultValueSource, false, false, 200, string.Empty },
+            };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(MapAction_RouteOrQueryParam_SimpleReturn_Data))]
+    public async Task MapAction_RouteOrQueryParam_SimpleReturn(string source, bool hasRoute, bool hasQuery, int expectedStatusCode, string expectedBody)
+    {
+        var (_, compilation) = await RunGeneratorAsync(source);
+        var endpoint = GetEndpointFromCompilation(compilation);
+
+        var httpContext = CreateHttpContext();
+        if (hasRoute)
+        {
+            httpContext.Request.RouteValues["value"] = expectedBody;
+        }
+
+        if (hasQuery)
+        {
+            httpContext.Request.QueryString = new QueryString($"?value={expectedBody}");
+        }
+
+        await endpoint.RequestDelegate(httpContext);
+        await VerifyResponseBodyAsync(httpContext, expectedBody, expectedStatusCode);
+    }
+
     [Fact]
     public async Task MapAction_UnknownParameter_EmitsDiagnostic_NoSource()
     {
@@ -644,20 +824,20 @@ app.MapGet("/", (IServiceProvider provider) => "Hello world!");
     {
         get
         {
-            var fromServiceRequiredSource = $$"""app.MapPost("/", ([FromServices]{{typeof(TestService)}} svc) => svc.TestServiceMethod());""";
-            var fromServiceNullableSource = $$"""app.MapPost("/", ([FromServices]{{typeof(TestService)}}? svc) => svc?.TestServiceMethod() ?? string.Empty);""";
+            var fromServiceRequiredSource = $$"""app.MapPost("/", ([{{typeof(FromServicesAttribute)}}]{{typeof(TestService)}} svc) => svc.TestServiceMethod());""";
+            var fromServiceNullableSource = $$"""app.MapPost("/", ([{{typeof(FromServicesAttribute)}}]{{typeof(TestService)}}? svc) => svc?.TestServiceMethod() ?? string.Empty);""";
             var fromServiceDefaultValueSource = $$"""
 #nullable disable
-string postServiceWithDefault([FromServices]{{typeof(TestService)}} svc = null) => svc?.TestServiceMethod() ?? string.Empty;
+string postServiceWithDefault([{{typeof(FromServicesAttribute)}}]{{typeof(TestService)}} svc = null) => svc?.TestServiceMethod() ?? string.Empty;
 app.MapPost("/", postServiceWithDefault);
 #nullable restore
 """;
 
-            var fromServiceEnumerableRequiredSource = $$"""app.MapPost("/", ([FromServices]IEnumerable<{{typeof(TestService)}}>  svc) => svc.FirstOrDefault()?.TestServiceMethod() ?? string.Empty);""";
-            var fromServiceEnumerableNullableSource = $$"""app.MapPost("/", ([FromServices]IEnumerable<{{typeof(TestService)}}>? svc) => svc?.FirstOrDefault()?.TestServiceMethod() ?? string.Empty);""";
+            var fromServiceEnumerableRequiredSource = $$"""app.MapPost("/", ([{{typeof(FromServicesAttribute)}}]IEnumerable<{{typeof(TestService)}}>  svc) => svc.FirstOrDefault()?.TestServiceMethod() ?? string.Empty);""";
+            var fromServiceEnumerableNullableSource = $$"""app.MapPost("/", ([{{typeof(FromServicesAttribute)}}]IEnumerable<{{typeof(TestService)}}>? svc) => svc?.FirstOrDefault()?.TestServiceMethod() ?? string.Empty);""";
             var fromServiceEnumerableDefaultValueSource = $$"""
 #nullable disable
-string postServiceWithDefault([FromServices]IEnumerable<{{typeof(TestService)}}> svc = null) => svc?.FirstOrDefault()?.TestServiceMethod() ?? string.Empty;
+string postServiceWithDefault([{{typeof(FromServicesAttribute)}}]IEnumerable<{{typeof(TestService)}}> svc = null) => svc?.FirstOrDefault()?.TestServiceMethod() ?? string.Empty;
 app.MapPost("/", postServiceWithDefault);
 #nullable restore
 """;
@@ -712,9 +892,9 @@ app.MapPost("/", postServiceWithDefault);
     public async Task MapAction_ExplicitServiceParam_SimpleReturn_Snapshot()
     {
         var source = $$"""
-app.MapGet("/fromServiceRequired", ([FromServices]{{typeof(TestService)}} svc) => svc.TestServiceMethod());
-app.MapGet("/enumerableFromService", ([FromServices]IEnumerable<{{typeof(TestService)}}> svc) => svc?.FirstOrDefault()?.TestServiceMethod() ?? string.Empty);
-app.MapGet("/multipleFromService", ([FromServices]{{typeof(TestService)}}? svc, [FromServices]IEnumerable<{{typeof(TestService)}}> svcs) =>
+app.MapGet("/fromServiceRequired", ([{{typeof(FromServicesAttribute)}}]{{typeof(TestService)}} svc) => svc.TestServiceMethod());
+app.MapGet("/enumerableFromService", ([{{typeof(FromServicesAttribute)}}]IEnumerable<{{typeof(TestService)}}> svc) => svc?.FirstOrDefault()?.TestServiceMethod() ?? string.Empty);
+app.MapGet("/multipleFromService", ([{{typeof(FromServicesAttribute)}}]{{typeof(TestService)}}? svc, [FromServices]IEnumerable<{{typeof(TestService)}}> svcs) =>
     $"{(svcs?.FirstOrDefault()?.TestServiceMethod() ?? string.Empty)}, {svc?.TestServiceMethod()}");
 """;
         var httpContext = CreateHttpContext();
@@ -754,6 +934,20 @@ app.MapGet("/multipleFromService", ([FromServices]{{typeof(TestService)}}? svc, 
         httpContext.RequestServices = services;
         await endpoints[2].RequestDelegate(httpContext);
         await VerifyResponseBodyAsync(httpContext, $"{expectedBody}, {expectedBody}");
+    }
+
+    [Fact]
+    public async Task MapAction_ExplicitSource_SimpleReturn_Snapshot()
+    {
+        var source = $$"""
+app.MapGet("/fromQuery", ([{{typeof(FromQueryAttribute)}}] string? queryValue) => queryValue ?? string.Empty);
+app.MapGet("/fromHeader", ([{{typeof(FromHeaderAttribute)}}] string? headerValue) => headerValue ?? string.Empty);
+app.MapGet("/fromHeader/{routeValue}", ([{{typeof(FromRouteAttribute)}}] string? routeValue) => routeValue ?? string.Empty);
+app.MapGet("/{value}", (string? value) => value ?? string.Empty);
+""";
+        var (_, compilation) = await RunGeneratorAsync(source);
+
+        await VerifyAgainstBaselineUsingFile(compilation);
     }
 
     [Fact]

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
@@ -1,8 +1,29 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using Microsoft.AspNetCore.Http.Metadata;
+
 namespace Microsoft.AspNetCore.Http.Generators.Tests;
 
 public class TestService
 {
     public string TestServiceMethod() => "Produced from service!";
+}
+
+public class Todo
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "Todo";
+    public bool IsComplete { get; set; }
+}
+
+public interface ITodo
+{
+    public int Id { get; }
+    public string Name { get; }
+    public bool IsComplete { get; }
+}
+
+public class FromBodyAttribute : Attribute, IFromBodyMetadata
+{
+    public bool AllowEmpty { get; set; }
 }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
@@ -15,15 +15,3 @@ public class Todo
     public string Name { get; set; } = "Todo";
     public bool IsComplete { get; set; }
 }
-
-public interface ITodo
-{
-    public int Id { get; }
-    public string Name { get; }
-    public bool IsComplete { get; }
-}
-
-public class FromBodyAttribute : Attribute, IFromBodyMetadata
-{
-    public bool AllowEmpty { get; set; }
-}

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
@@ -15,3 +15,8 @@ public class Todo
     public string Name { get; set; } = "Todo";
     public bool IsComplete { get; set; }
 }
+
+public class CustomFromBodyAttribute : Attribute, IFromBodyMetadata
+{
+    public bool AllowEmpty { get; set; }
+}

--- a/src/Shared/RoslynUtils/SymbolExtensions.cs
+++ b/src/Shared/RoslynUtils/SymbolExtensions.cs
@@ -82,4 +82,25 @@ internal static class SymbolExtensions
 
     public static ISymbol? GetAnySymbol(this SymbolInfo info)
         => info.Symbol ?? info.CandidateSymbols.FirstOrDefault();
+
+    public static bool IsOptional(this IParameterSymbol parameterSymbol) =>
+        parameterSymbol.Type is INamedTypeSymbol
+        {
+            NullableAnnotation: NullableAnnotation.Annotated
+        } || parameterSymbol.HasExplicitDefaultValue;
+
+    public static bool TryGetNamedArgumentValue<T>(this AttributeData attribute, string argumentName, [NotNullWhen(true)] out T? argumentValue)
+    {
+        argumentValue = default;
+        foreach (var namedArgument in attribute.NamedArguments)
+        {
+            if (namedArgument.Key == argumentName)
+            {
+                var routeParameterNameConstant = namedArgument.Value;
+                argumentValue = (T)routeParameterNameConstant.Value!;
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/Shared/RoslynUtils/SymbolExtensions.cs
+++ b/src/Shared/RoslynUtils/SymbolExtensions.cs
@@ -89,15 +89,15 @@ internal static class SymbolExtensions
             NullableAnnotation: NullableAnnotation.Annotated
         } || parameterSymbol.HasExplicitDefaultValue;
 
-    public static bool TryGetNamedArgumentValue<T>(this AttributeData attribute, string argumentName, [NotNullWhen(true)] out T? argumentValue)
+    public static bool TryGetNamedArgumentValue<T>(this AttributeData attribute, string argumentName, out T? argumentValue)
     {
         argumentValue = default;
         foreach (var namedArgument in attribute.NamedArguments)
         {
-            if (namedArgument.Key == argumentName)
+            if (string.Equals(namedArgument.Key, argumentName, StringComparison.Ordinal))
             {
                 var routeParameterNameConstant = namedArgument.Value;
-                argumentValue = (T)routeParameterNameConstant.Value!;
+                argumentValue = (T?)routeParameterNameConstant.Value;
                 return true;
             }
         }

--- a/src/Shared/RoslynUtils/WellKnownTypeData.cs
+++ b/src/Shared/RoslynUtils/WellKnownTypeData.cs
@@ -101,6 +101,7 @@ internal static class WellKnownTypeData
         Microsoft_AspNetCore_Mvc_ViewFeatures_SaveTempDataAttribute,
         Microsoft_AspNetCore_Mvc_SkipStatusCodePagesAttribute,
         Microsoft_AspNetCore_Mvc_ValidateAntiForgeryTokenAttribute,
+        Microsoft_AspNetCore_Mvc_ModelBinding_EmptyBodyBehavior,
         Microsoft_AspNetCore_Authorization_AllowAnonymousAttribute,
         Microsoft_AspNetCore_Authorization_AuthorizeAttribute
     }
@@ -201,6 +202,7 @@ internal static class WellKnownTypeData
         "Microsoft.AspNetCore.Mvc.ViewFeatures.SaveTempDataAttribute",
         "Microsoft.AspNetCore.Mvc.SkipStatusCodePagesAttribute",
         "Microsoft.AspNetCore.Mvc.ValidateAntiForgeryTokenAttribute",
+        "Microsoft.AspNetCore.Mvc.ModelBinding.EmptyBodyBehavior",
         "Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute",
         "Microsoft.AspNetCore.Authorization.AuthorizeAttribute"
     };


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/46275.

- Add support for parameters with `FromRoute` and `FromHeader` attribute
  - Includes support for `Name` argument on attributes
  - Includes support for requiredness checks via nullability and default value checks
- Add support  for `Name` argument in `FromQuery` attribute
- Add support for default value-based requiredness check on `FromQuery` attributes
- Update tests to use `SharedTypes` instead of types in test source
- Add support for inference for parameters between route and query values 