### PR TITLE
Fix AcceptedAtRoute link generation and add tests

### DIFF
--- a/src/Http/Http.Results/src/AcceptedAtRoute.cs
+++ b/src/Http/Http.Results/src/AcceptedAtRoute.cs
@@ -79,7 +79,7 @@ public sealed class AcceptedAtRoute : IResult, IEndpointMetadataProvider, IStatu
         ArgumentNullException.ThrowIfNull(httpContext);
 
         var linkGenerator = httpContext.RequestServices.GetRequiredService<LinkGenerator>();
-        var url = linkGenerator.GetUriByAddress(
+        var url = linkGenerator.GetUriByRouteValues(
             httpContext,
             RouteName,
             RouteValues,

--- a/src/Http/Http.Results/src/AcceptedAtRouteOfT.cs
+++ b/src/Http/Http.Results/src/AcceptedAtRouteOfT.cs
@@ -93,7 +93,7 @@ public sealed class AcceptedAtRoute<TValue> : IResult, IEndpointMetadataProvider
         ArgumentNullException.ThrowIfNull(httpContext);
 
         var linkGenerator = httpContext.RequestServices.GetRequiredService<LinkGenerator>();
-        var url = linkGenerator.GetUriByAddress(
+        var url = linkGenerator.GetUriByRouteValues(
             httpContext,
             RouteName,
             RouteValues,

--- a/src/Http/Http.Results/test/AcceptedAtRouteOfTResultTests.cs
+++ b/src/Http/Http.Results/test/AcceptedAtRouteOfTResultTests.cs
@@ -97,6 +97,7 @@ public class AcceptedAtRouteOfTResultTests
         // Assert
         Assert.Equal(StatusCodes.Status202Accepted, httpContext.Response.StatusCode);
         Assert.Equal(expectedUrl, httpContext.Response.Headers["Location"]);
+        Assert.Equal(new RouteValueDictionary(values), linkGenerator.RouteValuesAddress.ExplicitValues);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/AcceptedAtRouteResultTests.cs
+++ b/src/Http/Http.Results/test/AcceptedAtRouteResultTests.cs
@@ -51,6 +51,7 @@ public class AcceptedAtRouteResultTests
         // Assert
         Assert.Equal(StatusCodes.Status202Accepted, httpContext.Response.StatusCode);
         Assert.Equal(expectedUrl, httpContext.Response.Headers["Location"]);
+        Assert.Equal(new RouteValueDictionary(values), linkGenerator.RouteValuesAddress.ExplicitValues);
     }
 
     [Fact]

--- a/src/Http/Http.Results/test/CreatedAtRouteOfTResultTests.cs
+++ b/src/Http/Http.Results/test/CreatedAtRouteOfTResultTests.cs
@@ -57,7 +57,8 @@ public partial class CreatedAtRouteOfTResultTests
     {
         // Arrange
         var expectedUrl = "testAction";
-        var httpContext = GetHttpContext(expectedUrl);
+        var linkGenerator = new TestLinkGenerator { Url = expectedUrl };
+        var httpContext = GetHttpContext(linkGenerator);
 
         // Act
         var result = new CreatedAtRoute<object>(routeName: null, routeValues: values, value: null);
@@ -66,13 +67,15 @@ public partial class CreatedAtRouteOfTResultTests
         // Assert
         Assert.Equal(StatusCodes.Status201Created, httpContext.Response.StatusCode);
         Assert.Equal(expectedUrl, httpContext.Response.Headers["Location"]);
+        Assert.Equal(new RouteValueDictionary(values), linkGenerator.RouteValuesAddress.ExplicitValues);
     }
 
     [Fact]
     public async Task CreatedAtRouteResult_ThrowsOnNullUrl()
     {
         // Arrange
-        var httpContext = GetHttpContext(expectedUrl: null);
+        var linkGenerator = new TestLinkGenerator();
+        var httpContext = GetHttpContext(linkGenerator);
 
         var result = new CreatedAtRoute<object>(
             routeName: null,
@@ -173,23 +176,20 @@ public partial class CreatedAtRouteOfTResultTests
 
     private record Todo(int Id, string Title);
 
-    private static HttpContext GetHttpContext(string expectedUrl)
+    private static HttpContext GetHttpContext(LinkGenerator linkGenerator)
     {
         var httpContext = new DefaultHttpContext();
         httpContext.Request.PathBase = new PathString("");
         httpContext.Response.Body = new MemoryStream();
-        httpContext.RequestServices = CreateServices(expectedUrl);
+        httpContext.RequestServices = CreateServices(linkGenerator);
         return httpContext;
     }
 
-    private static IServiceProvider CreateServices(string expectedUrl)
+    private static IServiceProvider CreateServices(LinkGenerator linkGenerator)
     {
         var services = new ServiceCollection();
         services.AddSingleton<ILoggerFactory, NullLoggerFactory>();
-        services.AddSingleton<LinkGenerator>(new TestLinkGenerator
-        {
-            Url = expectedUrl
-        });
+        services.AddSingleton<LinkGenerator>(linkGenerator);
 
         return services.BuildServiceProvider();
     }

--- a/src/Http/Http.Results/test/CreatedAtRouteResultTests.cs
+++ b/src/Http/Http.Results/test/CreatedAtRouteResultTests.cs
@@ -40,7 +40,8 @@ public partial class CreatedAtRouteResultTests
     {
         // Arrange
         var expectedUrl = "testAction";
-        var httpContext = GetHttpContext(expectedUrl);
+        var linkGenerator = new TestLinkGenerator { Url = expectedUrl };
+        var httpContext = GetHttpContext(linkGenerator);
 
         // Act
         var result = new CreatedAtRoute(routeName: null, routeValues: values);
@@ -49,13 +50,15 @@ public partial class CreatedAtRouteResultTests
         // Assert
         Assert.Equal(StatusCodes.Status201Created, httpContext.Response.StatusCode);
         Assert.Equal(expectedUrl, httpContext.Response.Headers["Location"]);
+        Assert.Equal(new RouteValueDictionary(values), linkGenerator.RouteValuesAddress.ExplicitValues);
     }
 
     [Fact]
     public async Task CreatedAtRouteResult_ThrowsOnNullUrl()
     {
         // Arrange
-        var httpContext = GetHttpContext(expectedUrl: null);
+        var linkGenerator = new TestLinkGenerator();
+        var httpContext = GetHttpContext(linkGenerator);
 
         var result = new CreatedAtRoute(
             routeName: null,
@@ -119,23 +122,20 @@ public partial class CreatedAtRouteResultTests
     private static void PopulateMetadata<TResult>(MethodInfo method, EndpointBuilder builder)
         where TResult : IEndpointMetadataProvider => TResult.PopulateMetadata(method, builder);
 
-    private static HttpContext GetHttpContext(string expectedUrl)
+    private static HttpContext GetHttpContext(LinkGenerator linkGenerator)
     {
         var httpContext = new DefaultHttpContext();
         httpContext.Request.PathBase = new PathString("");
         httpContext.Response.Body = new MemoryStream();
-        httpContext.RequestServices = CreateServices(expectedUrl);
+        httpContext.RequestServices = CreateServices(linkGenerator);
         return httpContext;
     }
 
-    private static IServiceProvider CreateServices(string expectedUrl)
+    private static IServiceProvider CreateServices(LinkGenerator linkGenerator)
     {
         var services = new ServiceCollection();
         services.AddSingleton<ILoggerFactory, NullLoggerFactory>();
-        services.AddSingleton<LinkGenerator>(new TestLinkGenerator
-        {
-            Url = expectedUrl
-        });
+        services.AddSingleton<LinkGenerator>(linkGenerator);
 
         return services.BuildServiceProvider();
     }

--- a/src/Http/Http.Results/test/TestLinkGenerator.cs
+++ b/src/Http/Http.Results/test/TestLinkGenerator.cs
@@ -8,6 +8,7 @@ namespace Microsoft.AspNetCore.Http.HttpResults;
 internal sealed class TestLinkGenerator : LinkGenerator
 {
     public string Url { get; set; }
+    public RouteValuesAddress RouteValuesAddress { get; set; }
 
     public override string GetPathByAddress<TAddress>(HttpContext httpContext, TAddress address, RouteValueDictionary values, RouteValueDictionary ambientValues = null, PathString? pathBase = null, FragmentString fragment = default, LinkOptions options = null)
     {
@@ -20,8 +21,14 @@ internal sealed class TestLinkGenerator : LinkGenerator
     }
 
     public override string GetUriByAddress<TAddress>(HttpContext httpContext, TAddress address, RouteValueDictionary values, RouteValueDictionary ambientValues = null, string scheme = null, HostString? host = null, PathString? pathBase = null, FragmentString fragment = default, LinkOptions options = null)
-        => Url;
+        => AssertAddressAndReturnUrl(address);
 
     public override string GetUriByAddress<TAddress>(TAddress address, RouteValueDictionary values, string scheme, HostString host, PathString pathBase = default, FragmentString fragment = default, LinkOptions options = null)
-        => Url;
+        => AssertAddressAndReturnUrl(address);
+
+    private string AssertAddressAndReturnUrl<TAddress>(TAddress address)
+    {
+        RouteValuesAddress = Assert.IsAssignableFrom<RouteValuesAddress>(address);
+        return Url;
+    }
 }

--- a/src/Http/Http.Results/test/TestLinkGenerator.cs
+++ b/src/Http/Http.Results/test/TestLinkGenerator.cs
@@ -28,7 +28,7 @@ internal sealed class TestLinkGenerator : LinkGenerator
 
     private string AssertAddressAndReturnUrl<TAddress>(TAddress address)
     {
-        RouteValuesAddress = Assert.IsAssignableFrom<RouteValuesAddress>(address);
+        RouteValuesAddress = Assert.IsType<RouteValuesAddress>(address);
         return Url;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/46722

Previously `AcceptedAtRoute` was calling `GetUriByAddress`, and the address was the route name. This is basically the same as the `GetUriByName` extension method (see below) and searches for an endpoint by the endpoint name instead of the route name.

https://github.com/dotnet/aspnetcore/blob/bb3f0d626627d399695a9fa0741e4803c0c23eb8/src/Http/Routing/src/LinkGeneratorEndpointNameAddressExtensions.cs#L151-L208