### PR TITLE
Templates.Blazor.Tests: skip Playwright based tests when Playwright is not available.

### DIFF
--- a/src/Shared/BrowserTesting/src/BrowserManager.cs
+++ b/src/Shared/BrowserTesting/src/BrowserManager.cs
@@ -18,14 +18,12 @@ public class BrowserManager
     private readonly BrowserManagerConfiguration _browserManagerConfiguration;
     private readonly Dictionary<string, IBrowser> _launchBrowsers = new(StringComparer.Ordinal);
 
-#pragma warning disable CA1802 // Allow declaring this 'static readonly' (instead of 'const') to avoid compiler detecting unused branches.
-    private static readonly bool IsPlaywrightDisabled =
+    private static bool IsPlaywrightDisabled =>
 #if DISABLE_PLAYWRIGHT
-                                                        true;
+                                        true;
 #else
-                                                        false;
+                                        false;
 #endif
-#pragma warning restore CA1802
 
     private object _lock = new();
     private Task _initializeTask;

--- a/src/Shared/BrowserTesting/src/Microsoft.AspNetCore.BrowserTesting.csproj
+++ b/src/Shared/BrowserTesting/src/Microsoft.AspNetCore.BrowserTesting.csproj
@@ -6,6 +6,7 @@
     <IsShippingPackage>false</IsShippingPackage>
     <AddPublicApiAnalyzers>false</AddPublicApiAnalyzers>
     <IsTestAssetProject>true</IsTestAssetProject>
+    <DefineConstants Condition="'$(IsPlaywrightAvailable)' != 'true'">$(DefineConstants);DISABLE_PLAYWRIGHT</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Shared/BrowserTesting/src/Microsoft.AspNetCore.BrowserTesting.csproj
+++ b/src/Shared/BrowserTesting/src/Microsoft.AspNetCore.BrowserTesting.csproj
@@ -6,7 +6,7 @@
     <IsShippingPackage>false</IsShippingPackage>
     <AddPublicApiAnalyzers>false</AddPublicApiAnalyzers>
     <IsTestAssetProject>true</IsTestAssetProject>
-    <DefineConstants Condition="'$(IsPlaywrightAvailable)' != 'true'">$(DefineConstants);DISABLE_PLAYWRIGHT</DefineConstants>
+    <DefineConstants Condition="'$(IsPlaywrightAvailable)' == 'false'">$(DefineConstants);DISABLE_PLAYWRIGHT</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Playwright is not available on some distros, like RHEL, CentOS, and Fedora.
This causes the `Templates.Blazor.Tests` test suite to fail when ran on those distros.

Rather than failing, these tests should be skipped.

This uses the existing `IsPlaywrightAvailable` project property.
When it is `false`, the tests are skipped by making the `BrowserManager` return the browsers as as unavailable/disabled.

This enables running the test suite on a platform where Playwright is not available by appending `/p:IsPlaywrightAvailable=false` to the build command.

@dougbu ptal.

cc @omajid 