### PR TITLE
Fix hanging response when nonstreaming rendering

### DIFF
--- a/src/Http/WebUtilities/src/HttpResponseStreamWriter.cs
+++ b/src/Http/WebUtilities/src/HttpResponseStreamWriter.cs
@@ -15,6 +15,11 @@ namespace Microsoft.AspNetCore.WebUtilities;
 /// </summary>
 public class HttpResponseStreamWriter : TextWriter
 {
+    // It's important that MemoryPoolHttpResponseStreamWriterFactory's DefaultBufferSize is larger than this,
+    // because HttpResponseStreamWriter fills _charBuffer buffer with this many chars, then HTML-encodes them
+    // to fill the larger _byteBuffer. If MemoryPoolHttpResponseStreamWriterFactory produces a PipeWriter whose
+    // buffer is smaller than _byteBuffer, then when HttpResponseStreamWriter's FlushInternal tries to write
+    // synchronously to a stream wrapped around that PipeWriter, it will block forever.
     internal const int DefaultBufferSize = 16 * 1024;
 
     private readonly Stream _stream;

--- a/src/Mvc/Mvc.Core/src/Infrastructure/MemoryPoolHttpResponseStreamWriterFactory.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/MemoryPoolHttpResponseStreamWriterFactory.cs
@@ -25,7 +25,11 @@ internal sealed class MemoryPoolHttpResponseStreamWriterFactory : IHttpResponseS
     /// <see cref="MemoryPoolHttpResponseStreamWriterFactory"/> maintains <see cref="ArrayPool{T}"/>s
     /// for these arrays.
     /// </remarks>
-    public const int DefaultBufferSize = 16 * 1024;
+    ///
+    // stevesa: At 16KB this was too small and led to deadlocks. See the comment in HttpResponseStreamWriter.
+    //          I'm not 100% sure whether or not the same problem will occur in a real PassiveComponentRenderer
+    //          implementation.
+    public const int DefaultBufferSize = 32 * 1024;
 
     private readonly ArrayPool<byte> _bytePool;
     private readonly ArrayPool<char> _charPool;


### PR DESCRIPTION
After the most recent changes that enable partial doc updates with SSR, the non-streaming responses started hanging forever if they are above a certain size.

I tracked this down to a disagreement between `MemoryPoolHttpResponseStreamWriterFactory` and `HttpResponseStreamWriter` about how big their buffers should be (the latter doesn't leave enough space for the data provided by the former). Whether or not this is a real product defect is unclear:

 * Maybe this is a real defect in ASP.NET Core today but never gets hit in practice because nothing uses this new rendering pattern
 * Or maybe it's a fault in the hackery in this prototype. I really don't like all the indirection inside `ViewBuffer` and `ComponentHtmlContent` etc - they are mutually recursing into each other, making it very unclear what order things really happen in.

To repro the issue, just clone the repo as of the commit before this PR, and change BestForYou's `Index.razor` to remove the `[StreamRendering(true)]`. 

I propose that we wait and see if a similar issue arises when we implement streaming SSR for real before blaming the underlying framework code that's already in production.