### PR TITLE
Web.ProjectTemplates: exclude 'Program.cs' from all templates that replace it.

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
@@ -68,21 +68,23 @@
         },
         {
           "condition": "(!UseProgramMain && UseMinimalAPIs && (NoAuth || WindowsAuth))",
+          "exclude": [
+            "Program.cs",
+            "Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs"
+          ],
           "rename": {
             "Program.MinimalAPIs.WindowsOrNoAuth.cs": "Program.cs"
-          },
-          "exclude": [
-            "Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs"
-          ]
+          }
         },
         {
           "condition": "(!UseProgramMain && UseMinimalAPIs && (IndividualAuth || OrganizationalAuth))",
+          "exclude": [
+            "Program.cs",
+            "Program.MinimalAPIs.WindowsOrNoAuth.cs"
+          ],
           "rename": {
             "Program.MinimalAPIs.OrgOrIndividualB2CAuth.cs": "Program.cs"
-          },
-          "exclude": [
-            "Program.MinimalAPIs.WindowsOrNoAuth.cs"
-          ]
+          }
         },
         {
           "condition": "(UseControllers)",


### PR DESCRIPTION
Without these changes, 

- Templates.Mvc.Test.WebApiTemplateTest.WebApiTemplateMinimalApisNoHttpsCSharp
- Templates.Mvc.Test.WebApiTemplateTest.WebApiTemplateMinimalApisCSharp

tests fail for me, because `dotnet new` uses the wrong `Program.cs` file.

Such an exclude was already present for the `(UseProgramMain)` template.

I assume without the exclude, the template engine may do something like:
- Generate `Program.MinimalAPIs.WindowsOrNoAuth.cs` as `Program.cs`
- Generate `Program.cs` (replacing the previous)

@dougbu ptal.

cc @omajid 