### PR TITLE
CheckSlidingExpiration should use Events property

### DIFF
--- a/src/Security/Authentication/Cookies/src/CookieAuthenticationHandler.cs
+++ b/src/Security/Authentication/Cookies/src/CookieAuthenticationHandler.cs
@@ -93,7 +93,7 @@ public class CookieAuthenticationHandler : SignInAuthenticationHandler<CookieAut
             {
                 ShouldRenew = timeRemaining < timeElapsed,
             };
-            await Options.Events.CheckSlidingExpiration(eventContext);
+            await Events.CheckSlidingExpiration(eventContext);
 
             if (eventContext.ShouldRenew)
             {


### PR DESCRIPTION
# {PR title}

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description
When calling `CheckSlidingExpiration` the `Events ` property should be used.

{Detail}

Fixes #46776
