### PR TITLE
Update Selenium versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -283,9 +283,9 @@
     <MicrosoftPlaywrightVersion>1.28.0</MicrosoftPlaywrightVersion>
     <PollyExtensionsHttpVersion>3.0.0</PollyExtensionsHttpVersion>
     <PollyVersion>7.2.3</PollyVersion>
-    <SeleniumSupportVersion>4.8.0</SeleniumSupportVersion>
-    <SeleniumWebDriverChromeDriverVersion>109.0.5414.7400</SeleniumWebDriverChromeDriverVersion>
-    <SeleniumWebDriverVersion>4.8.0</SeleniumWebDriverVersion>
+    <SeleniumSupportVersion>4.8.1</SeleniumSupportVersion>
+    <SeleniumWebDriverChromeDriverVersion>110.0.5481.7700</SeleniumWebDriverChromeDriverVersion>
+    <SeleniumWebDriverVersion>4.8.1</SeleniumWebDriverVersion>
     <SerilogExtensionsLoggingVersion>1.4.0</SerilogExtensionsLoggingVersion>
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
     <StackExchangeRedisVersion>2.6.90</StackExchangeRedisVersion>


### PR DESCRIPTION
We're hoping this fixes the [aspnetcore-components-e2e](https://dev.azure.com/dnceng-public/public/_build?definitionId=87&_a=summary) test pipeline that has been timing out.