### PR TITLE
Refactor RoutePatternFactory to trim regex dependency where possible

### DIFF
--- a/src/Http/Routing/src/Patterns/RoutePatternFactory.cs
+++ b/src/Http/Routing/src/Patterns/RoutePatternFactory.cs
@@ -624,6 +624,10 @@ public static class RoutePatternFactory
         }
     }
 
+    /// <summary>
+    /// String policy references are infered to be regex constraints. Creating them is moved here to its own method so apps can
+    /// trim away the regex dependency when RoutePatternFactory.Parse(string) is used. This is the method typically used by the various Map methods.
+    /// </summary>
     private static Dictionary<string, List<RoutePatternParameterPolicyReference>>? CreateRoutePatternPolicyReferences(RouteValueDictionary? parameterPolicies)
     {
         Dictionary<string, List<RoutePatternParameterPolicyReference>>? updatedParameterPolicies = null;


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/46142

Creating regex constraint from a string is moved out of `RoutePatternFactory.Parse(string)` path, which all the `MapXXX` methods use.

I looked at this, and it was a pretty simple refactor. I'd like to see the improvement in preview 2, so I just went ahead and did it.