### PR TITLE
Use new Chromium headless mode to fix E2E test timeouts

### DIFF
--- a/src/Components/test/E2ETest/Tests/CircuitTests.cs
+++ b/src/Components/test/E2ETest/Tests/CircuitTests.cs
@@ -5,6 +5,7 @@ using BasicTestApp;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
+using Microsoft.AspNetCore.Testing;
 using OpenQA.Selenium;
 using TestServer;
 using Xunit.Abstractions;
@@ -34,6 +35,7 @@ public class CircuitTests : ServerTestBase<BasicTestAppServerSiteFixture<ServerS
     [InlineData("render-throw")]
     [InlineData("afterrender-sync-throw")]
     [InlineData("afterrender-async-throw")]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/46836")]
     public void ComponentLifecycleMethodThrowsExceptionTerminatesTheCircuit(string id)
     {
         Browser.MountTestComponent<ReliabilityComponent>();

--- a/src/Components/test/E2ETest/Tests/CircuitTests.cs
+++ b/src/Components/test/E2ETest/Tests/CircuitTests.cs
@@ -54,6 +54,7 @@ public class CircuitTests : ServerTestBase<BasicTestAppServerSiteFixture<ServerS
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/46836")]
     public void ComponentDisposeMethodThrowsExceptionTerminatesTheCircuit()
     {
         Browser.MountTestComponent<ReliabilityComponent>();

--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
@@ -427,6 +427,7 @@ public abstract class ComponentRenderingTestBase : ServerTestBase<ToggleExecutio
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/46835")]
     public void CanUseFocusExtensionToFocusElementPreventScroll()
     {
         Browser.Manage().Window.Size = new System.Drawing.Size(100, 300);

--- a/src/Shared/E2ETesting/BrowserFixture.cs
+++ b/src/Shared/E2ETesting/BrowserFixture.cs
@@ -148,7 +148,7 @@ public class BrowserFixture : IAsyncLifetime
             !Debugger.IsAttached &&
             !string.Equals(Environment.GetEnvironmentVariable("E2E_TEST_VISIBLE"), "true", StringComparison.OrdinalIgnoreCase))
         {
-            opts.AddArgument("--headless");
+            //opts.AddArgument("--headless");
         }
 
         opts.AddArgument("--no-sandbox");

--- a/src/Shared/E2ETesting/BrowserFixture.cs
+++ b/src/Shared/E2ETesting/BrowserFixture.cs
@@ -148,7 +148,7 @@ public class BrowserFixture : IAsyncLifetime
             !Debugger.IsAttached &&
             !string.Equals(Environment.GetEnvironmentVariable("E2E_TEST_VISIBLE"), "true", StringComparison.OrdinalIgnoreCase))
         {
-            //opts.AddArgument("--headless");
+            opts.AddArgument("--headless=new");
         }
 
         opts.AddArgument("--no-sandbox");

--- a/src/Shared/E2ETesting/selenium-config.json
+++ b/src/Shared/E2ETesting/selenium-config.json
@@ -1,7 +1,7 @@
 {
   "drivers": {
     "chrome": {
-      "version" : "109.0.5414.74"
+      "version" : "110.0.5481.77"
     }
   },
   "ignoreExtraDrivers": true


### PR DESCRIPTION
Our E2E tests were timing out as of the update to Chrome 110. I tracked this down to a newly-introduced issue whereby it no longer works if you use `--headless` and `--user-data-dir` at the same time. Which some (but not all) of our tests do.

The underlying reason seems to be that Chromium now has two "headless" modes:

 * The existing, traditional headless mode (`--headless`). This used to work with `--user-data-dir`, but as of Chrome 110, that combination stops the browser from even starting up. I doubt that's an intentional regression on the part of Chromium/chromedriver, but nonetheless that's now what happens (also on Chrome and chromedriver v111).
 * A new headless mode (`--headless=new`) which seemingly works in all cases including with `--user-data-dir`. So, this PR switches us over to that mode.

Even if Chrome later fixes `--headless`, it's still a good thing for us to switch to the newer mechanism, presuming it will remain in support for longer.

Also this PR updates the `selenium-config.json` value, though this only affects local dev, not CI.

## Quarantines

This fixes the timeouts, but a few E2E tests are now failing in new ways - see https://github.com/dotnet/aspnetcore/issues/46836 and https://github.com/dotnet/aspnetcore/issues/46835. I guess that either:

 * They became broken due to other code changes while the E2E tests were down, so we didn't realise they were getting broken
 * Or, they are somehow incompatible with `--headless=new` on CI

I did verify they pass locally, even with `--headless=new`, so they are going to have to be investigated separately.