### PR TITLE
Allow Regex engine to be trimmed

### DIFF
--- a/src/Http/Routing/src/Constraints/RegexRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/RegexRouteConstraint.cs
@@ -41,7 +41,8 @@ public class RegexRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatch
         ArgumentNullException.ThrowIfNull(regexPattern);
 
         // Create regex instance lazily to avoid compiling regexes at app startup. Delay creation until Constraint is first evaluated.
-        // This is not thread safe. No side effect but multiple instances of a regex instance could be created from a burst of requests.
+        // This is not thread-safe. No side effect, but multiple instances of a regex instance could be created from a burst of requests.
+        // The regex instance is created by a delegate here to allow the regex engine to be trimmed when this constructor is trimmed.
         _regexFactory = () => new Regex(
             regexPattern,
             RegexOptions.CultureInvariant | RegexOptions.Compiled | RegexOptions.IgnoreCase,

--- a/src/Http/Routing/src/Constraints/RegexRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/RegexRouteConstraint.cs
@@ -41,7 +41,6 @@ public class RegexRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatch
         ArgumentNullException.ThrowIfNull(regexPattern);
 
         // Create regex instance lazily to avoid compiling regexes at app startup. Delay creation until Constraint is first evaluated.
-        // This is not thread-safe. No side effect, but multiple instances of a regex instance could be created from a burst of requests.
         // The regex instance is created by a delegate here to allow the regex engine to be trimmed when this constructor is trimmed.
         _regexFactory = () => new Regex(
             regexPattern,
@@ -60,6 +59,7 @@ public class RegexRouteConstraint : IRouteConstraint, IParameterLiteralNodeMatch
             {
                 Debug.Assert(_regexFactory is not null);
 
+                // This is not thread-safe. No side effect, but multiple instances of a regex instance could be created from a burst of requests.
                 _constraint = _regexFactory();
             }
 


### PR DESCRIPTION
Move the lazy Regex creation code to a delegate that is only set with the RegexRouteConstraint constructor that takes a string regexPattern. This allows for the Regex engine to be trimmed when the regexPattern constructor is trimmed.

Fix #46142

Publishing `dotnet new api -aot` app on `win-x64`:

**main:** 12.1 MB (12,725,760 bytes)
**PR:** 11.3 MB (11,909,120 bytes)