### PR TITLE
Tidy up some irregularities in certificate reloading

### DIFF
--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -77,6 +77,7 @@ public class KestrelConfigurationLoader
     private IList<Action> EndpointsToAdd { get; } = new List<Action>();
 
     private CertificateConfig? DefaultCertificateConfig { get; set; }
+    internal X509Certificate2? DefaultCertificate { get; set; }
 
     /// <summary>
     /// Specifies a configuration Action to run when an endpoint with the given name is loaded from configuration.
@@ -273,6 +274,7 @@ public class KestrelConfigurationLoader
 
         Options.ConfigurationBackedListenOptions.Clear();
         DefaultCertificateConfig = null;
+        DefaultCertificate = null;
 
         ConfigurationReader = new ConfigurationReader(Configuration);
 
@@ -404,7 +406,7 @@ public class KestrelConfigurationLoader
             if (defaultCert != null)
             {
                 DefaultCertificateConfig = defaultCertConfig;
-                Options.DefaultCertificate = defaultCert;
+                DefaultCertificate = defaultCert;
             }
         }
         else
@@ -414,7 +416,7 @@ public class KestrelConfigurationLoader
             {
                 Logger.LocatedDevelopmentCertificate(certificate);
                 DefaultCertificateConfig = certificateConfig;
-                Options.DefaultCertificate = certificate;
+                DefaultCertificate = certificate;
             }
         }
     }

--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -338,7 +338,7 @@ public class KestrelConfigurationLoader
                 if (httpsOptions.ServerCertificate == null && httpsOptions.ServerCertificateSelector == null)
                 {
                     // Fallback
-                    Options.ApplyDefaultCert(httpsOptions);
+                    Options.ApplyDefaultCertificate(httpsOptions);
 
                     // Ensure endpoint is reloaded if it used the default certificate and the certificate changed.
                     endpoint.Certificate = DefaultCertificateConfig;

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -336,7 +336,6 @@ public class KestrelServerOptions
             if (!CertificateManager.Instance.IsTrusted(cert))
             {
                 logger.DeveloperCertificateNotTrusted();
-                return null;
             }
 
             return cert;

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -151,12 +151,12 @@ public class KestrelServerOptions
     private Action<HttpsConnectionAdapterOptions> HttpsDefaults { get; set; } = _ => { };
 
     /// <summary>
-    /// The default server certificate for https endpoints. This is applied lazily after HttpsDefaults and user options.
+    /// The development server certificate for https endpoints. This is applied lazily after HttpsDefaults and user options.
     /// </summary>
     /// <remarks>
     /// Getter exposed for testing.
     /// </remarks>
-    internal X509Certificate2? DefaultCertificate { get; private set; }
+    internal X509Certificate2? DevelopmentCertificate { get; private set; }
 
     /// <summary>
     /// Allow tests to explicitly set the default certificate.
@@ -166,7 +166,7 @@ public class KestrelServerOptions
     /// <summary>
     /// Has the default dev certificate load been attempted?
     /// </summary>
-    internal bool IsDevCertLoaded { get; set; }
+    internal bool IsDevelopmentCertificateLoaded { get; set; }
 
     /// <summary>
     /// Internal AppContext switch to toggle the WebTransport and HTTP/3 datagrams experiemental features.
@@ -235,7 +235,7 @@ public class KestrelServerOptions
         HttpsDefaults(httpsOptions);
     }
 
-    internal void ApplyDefaultCert(HttpsConnectionAdapterOptions httpsOptions)
+    internal void ApplyDefaultCertificate(HttpsConnectionAdapterOptions httpsOptions)
     {
         if (httpsOptions.ServerCertificate != null || httpsOptions.ServerCertificateSelector != null)
         {
@@ -254,15 +254,15 @@ public class KestrelServerOptions
             return;
         }
 
-        if (!IsDevCertLoaded)
+        if (!IsDevelopmentCertificateLoaded)
         {
-            IsDevCertLoaded = true;
-            Debug.Assert(DefaultCertificate is null);
+            IsDevelopmentCertificateLoaded = true;
+            Debug.Assert(DevelopmentCertificate is null);
             var logger = ApplicationServices!.GetRequiredService<ILogger<KestrelServer>>();
-            DefaultCertificate = GetDevelopmentCertificateFromStore(logger);
+            DevelopmentCertificate = GetDevelopmentCertificateFromStore(logger);
         }
 
-        httpsOptions.ServerCertificate = DefaultCertificate;
+        httpsOptions.ServerCertificate = DevelopmentCertificate;
     }
 
     internal void Serialize(Utf8JsonWriter writer)
@@ -279,8 +279,8 @@ public class KestrelServerOptions
         writer.WritePropertyName(nameof(AllowResponseHeaderCompression));
         writer.WriteBooleanValue(AllowResponseHeaderCompression);
 
-        writer.WritePropertyName(nameof(IsDevCertLoaded));
-        writer.WriteBooleanValue(IsDevCertLoaded);
+        writer.WritePropertyName(nameof(IsDevelopmentCertificateLoaded));
+        writer.WriteBooleanValue(IsDevelopmentCertificateLoaded);
 
         writer.WriteString(nameof(RequestHeaderEncodingSelector), RequestHeaderEncodingSelector == DefaultHeaderEncodingSelector ? "default" : "configured");
         writer.WriteString(nameof(ResponseHeaderEncodingSelector), ResponseHeaderEncodingSelector == DefaultHeaderEncodingSelector ? "default" : "configured");

--- a/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
@@ -166,7 +166,7 @@ public static class ListenOptionsHttpsExtensions
         var options = new HttpsConnectionAdapterOptions();
         listenOptions.KestrelServerOptions.ApplyHttpsDefaults(options);
         configureOptions(options);
-        listenOptions.KestrelServerOptions.ApplyDefaultCert(options);
+        listenOptions.KestrelServerOptions.ApplyDefaultCertificate(options);
 
         if (options.ServerCertificate == null && options.ServerCertificateSelector == null)
         {
@@ -181,7 +181,7 @@ public static class ListenOptionsHttpsExtensions
     {
         var options = new HttpsConnectionAdapterOptions();
         listenOptions.KestrelServerOptions.ApplyHttpsDefaults(options);
-        listenOptions.KestrelServerOptions.ApplyDefaultCert(options);
+        listenOptions.KestrelServerOptions.ApplyDefaultCertificate(options);
 
         if (options.ServerCertificate == null && options.ServerCertificateSelector == null)
         {

--- a/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
@@ -54,7 +54,7 @@ public class KestrelServerTests
     public void StartWithHttpsAddressConfiguresHttpsEndpoints()
     {
         var options = CreateServerOptions();
-        options.DefaultCertificate = TestResources.GetTestCertificate();
+        options.TestOverrideDefaultCertificate = TestResources.GetTestCertificate();
         using (var server = CreateServer(options))
         {
             server.Features.Get<IServerAddressesFeature>().Addresses.Add("https://127.0.0.1:0");

--- a/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
@@ -70,7 +70,7 @@ public class KestrelServerTests
     public void KestrelServerThrowsUsefulExceptionIfDefaultHttpsProviderNotAdded()
     {
         var options = CreateServerOptions();
-        options.IsDevCertLoaded = true; // Prevent the system default from being loaded
+        options.IsDevelopmentCertificateLoaded = true; // Prevent the system default from being loaded
         using (var server = CreateServer(options, throwOnCriticalErrors: false))
         {
             server.Features.Get<IServerAddressesFeature>().Addresses.Add("https://127.0.0.1:0");

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -241,7 +241,7 @@ public class KestrelConfigurationLoaderTests
                 }).Load();
 
             Assert.True(ran1);
-            Assert.Null(serverOptions.DefaultCertificate); // Not used since configuration cert is present
+            Assert.Null(serverOptions.DevelopmentCertificate); // Not used since configuration cert is present
         }
         finally
         {
@@ -308,8 +308,8 @@ public class KestrelConfigurationLoaderTests
 
             // With all of the configuration certs removed, the only place left to check is the CertificateManager.
             // We don't want to depend on machine state, so we cheat and say we already looked.
-            serverOptions.IsDevCertLoaded = true;
-            Assert.Null(serverOptions.DefaultCertificate);
+            serverOptions.IsDevelopmentCertificateLoaded = true;
+            Assert.Null(serverOptions.DevelopmentCertificate);
 
             // Since there are no configuration certs and we bypassed the CertificateManager, there will be an
             // exception about not finding any certs at all.
@@ -320,7 +320,7 @@ public class KestrelConfigurationLoaderTests
             void CheckCertificates(X509Certificate2 expectedCert)
             {
                 var httpsOptions = new HttpsConnectionAdapterOptions();
-                serverOptions.ApplyDefaultCert(httpsOptions);
+                serverOptions.ApplyDefaultCertificate(httpsOptions);
                 Assert.Equal(expectedCert.SerialNumber, httpsOptions.ServerCertificate.SerialNumber);
                 Assert.Equal(expectedCert.SerialNumber, serverOptions.ConfigurationLoader.DefaultCertificate.SerialNumber);
             }
@@ -517,7 +517,7 @@ public class KestrelConfigurationLoaderTests
             }).Load();
 
         Assert.True(ran1);
-        Assert.Null(serverOptions.DefaultCertificate); // Not used since configuration cert is present
+        Assert.Null(serverOptions.DevelopmentCertificate); // Not used since configuration cert is present
     }
 
     [Fact]
@@ -541,7 +541,7 @@ public class KestrelConfigurationLoaderTests
                 .Configure(config)
                 .Load();
 
-            Assert.Null(serverOptions.DefaultCertificate);
+            Assert.Null(serverOptions.DevelopmentCertificate);
         }
         finally
         {
@@ -572,7 +572,7 @@ public class KestrelConfigurationLoaderTests
                 .Configure(config)
                 .Load();
 
-            Assert.Null(serverOptions.DefaultCertificate);
+            Assert.Null(serverOptions.DevelopmentCertificate);
         }
         finally
         {

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -305,7 +305,18 @@ public class KestrelConfigurationLoaderTests
 
             // Remove Development certificate
             serverOptions.ConfigurationLoader.Configuration = new ConfigurationBuilder().AddInMemoryCollection(endpointConfig).Build();
-            _ = serverOptions.ConfigurationLoader.Reload();
+            try
+            {
+                _ = serverOptions.ConfigurationLoader.Reload();
+            }
+            catch (InvalidOperationException e)
+            {
+                // Since there are no longer any IConfiguration certificates, we'll fall back to the certificate store.
+                // Unfortunately, the state of the store varies by box (usually there is a cert on dev boxes, but not
+                // on CI boxes) and modifying the state of the real store at test-time seems inappropriate.  An alternative
+                // approach would be make it possible to replace CertificateManager.Instance in individual tests, but that
+                // seems like overkill since we only want to confirm that the configuration loader no longer has a cert.
+            }
 
             Assert.Null(serverOptions.ConfigurationLoader.DefaultCertificate);
 

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -241,7 +241,7 @@ public class KestrelConfigurationLoaderTests
                 }).Load();
 
             Assert.True(ran1);
-            Assert.NotNull(serverOptions.DefaultCertificate);
+            Assert.Null(serverOptions.DefaultCertificate); // Not used since configuration cert is present
         }
         finally
         {
@@ -390,7 +390,7 @@ public class KestrelConfigurationLoaderTests
             }).Load();
 
         Assert.True(ran1);
-        Assert.NotNull(serverOptions.DefaultCertificate);
+        Assert.Null(serverOptions.DefaultCertificate); // Not used since configuration cert is present
     }
 
     [Fact]

--- a/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
+++ b/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
@@ -506,7 +506,7 @@ public class AddressRegistrationTests : TestApplicationErrorLoggerLoggedTest
                     {
                         if (mockHttps)
                         {
-                            options.DefaultCertificate = TestResources.GetTestCertificate();
+                            options.TestOverrideDefaultCertificate = TestResources.GetTestCertificate();
                         }
                     })
                     .Configure(ConfigureEchoAddress);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -70,6 +70,7 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         var logger = serviceProvider.GetRequiredService<ILogger<KestrelServer>>();
         var httpsLogger = serviceProvider.GetRequiredService<ILogger<HttpsConnectionMiddleware>>();
         var loader = new KestrelConfigurationLoader(options, configuration, env.Object, reloadOnChange: false, logger, httpsLogger);
+        options.ConfigurationLoader = loader; // Since we're constructing it explicitly, we have to hook it up explicitly
         loader.Load();
 
         void ConfigureListenOptions(ListenOptions listenOptions)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
@@ -44,7 +44,7 @@ public class HttpsTests : LoggedTest
     public void UseHttpsDefaultsToDefaultCert()
     {
         var serverOptions = CreateServerOptions();
-        serverOptions.DefaultCertificate = _x509Certificate2;
+        serverOptions.TestOverrideDefaultCertificate = _x509Certificate2;
 
         serverOptions.ListenLocalhost(5000, options =>
         {
@@ -409,7 +409,7 @@ public class HttpsTests : LoggedTest
     public async Task Http3_UseHttpsNoArgsWithDefaultCertificate_UseDefaultCertificate()
     {
         var serverOptions = CreateServerOptions();
-        serverOptions.DefaultCertificate = _x509Certificate2;
+        serverOptions.TestOverrideDefaultCertificate = _x509Certificate2;
 
         IFeatureCollection bindFeatures = null;
         var multiplexedConnectionListenerFactory = new MockMultiplexedConnectionListenerFactory();
@@ -494,7 +494,7 @@ public class HttpsTests : LoggedTest
     public async Task Http1And2And3_NoUseHttps_MultiplexBindNotCalled()
     {
         var serverOptions = CreateServerOptions();
-        serverOptions.DefaultCertificate = _x509Certificate2;
+        serverOptions.TestOverrideDefaultCertificate = _x509Certificate2;
 
         var bindCalled = false;
         var multiplexedConnectionListenerFactory = new MockMultiplexedConnectionListenerFactory();
@@ -528,7 +528,7 @@ public class HttpsTests : LoggedTest
     public async Task Http3_NoUseHttps_Throws()
     {
         var serverOptions = CreateServerOptions();
-        serverOptions.DefaultCertificate = _x509Certificate2;
+        serverOptions.TestOverrideDefaultCertificate = _x509Certificate2;
 
         var bindCalled = false;
         var multiplexedConnectionListenerFactory = new MockMultiplexedConnectionListenerFactory();
@@ -564,7 +564,7 @@ public class HttpsTests : LoggedTest
     public async Task Http3_ServerOptionsSelectionCallback_Works()
     {
         var serverOptions = CreateServerOptions();
-        serverOptions.DefaultCertificate = _x509Certificate2;
+        serverOptions.TestOverrideDefaultCertificate = _x509Certificate2;
 
         IFeatureCollection bindFeatures = null;
         var multiplexedConnectionListenerFactory = new MockMultiplexedConnectionListenerFactory();
@@ -610,7 +610,7 @@ public class HttpsTests : LoggedTest
     public async Task Http3_TlsHandshakeCallbackOptions_Works()
     {
         var serverOptions = CreateServerOptions();
-        serverOptions.DefaultCertificate = _x509Certificate2;
+        serverOptions.TestOverrideDefaultCertificate = _x509Certificate2;
 
         IFeatureCollection bindFeatures = null;
         var multiplexedConnectionListenerFactory = new MockMultiplexedConnectionListenerFactory();

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
@@ -51,7 +51,7 @@ public class HttpsTests : LoggedTest
             options.UseHttps();
         });
 
-        Assert.False(serverOptions.IsDevCertLoaded);
+        Assert.False(serverOptions.IsDevelopmentCertificateLoaded);
 
         serverOptions.ListenLocalhost(5001, options =>
         {
@@ -61,7 +61,7 @@ public class HttpsTests : LoggedTest
                 Assert.Null(opt.ServerCertificate);
             });
         });
-        Assert.False(serverOptions.IsDevCertLoaded);
+        Assert.False(serverOptions.IsDevelopmentCertificateLoaded);
     }
 
     [Fact]
@@ -115,8 +115,8 @@ public class HttpsTests : LoggedTest
             });
         });
         // Never lazy loaded
-        Assert.False(serverOptions.IsDevCertLoaded);
-        Assert.Null(serverOptions.DefaultCertificate);
+        Assert.False(serverOptions.IsDevelopmentCertificateLoaded);
+        Assert.Null(serverOptions.DevelopmentCertificate);
     }
 
     [Fact]
@@ -143,8 +143,8 @@ public class HttpsTests : LoggedTest
             });
         });
         // Never lazy loaded
-        Assert.False(serverOptions.IsDevCertLoaded);
-        Assert.Null(serverOptions.DefaultCertificate);
+        Assert.False(serverOptions.IsDevelopmentCertificateLoaded);
+        Assert.Null(serverOptions.DevelopmentCertificate);
     }
 
     [ConditionalFact]


### PR DESCRIPTION
# Tidy up some irregularities in certificate loading

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Address some issues that arise when certificate configuration changes happen while the server is running.

## Description

While validating #46296, I noticed some irregularities in the way certificates are reloaded when (e.g.) appsettings.json is changed while the server is running.

1. If you start with the dev cert from the store and then light up, in sequence, the Development certificate, the Default certificate and an Endpoint certificate, each replaces its predecessor.  If you then remove them in the reverse order, the Development certificate doesn't go away when it is removed from the configuration.  This was because the `KestrelServerOptions.DefaultCertificate` wasn't being cleared.  To improve clarity and address this issue, I've split out the possible sources of the default certificate - this makes the precedence explicit and allows the state of each to be managed separately.
2. If you change the password of an endpoint certificate to an invalid value, reloading the configuration fails with an exception.  Unfortunately, the endpoint has already been removed from the list, so when the password is correct, there's no record of it and the creation of its "replacement" fails because the port is already in use.  I've deferred the updating of the endpoint list until after the dangerous parts of `Reload` have completed.  (It's still not atomic, but failures in the actual state change code are too unlikely to justify additional complexity.)
