### PR TITLE
Expose the SslStream and Cipher Suite on ITlsHandshakeFeature

### DIFF
--- a/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
@@ -23,7 +23,7 @@ public interface ITlsHandshakeFeature
     /// <summary>
     /// Gets the <see cref="TlsCipherSuite"/>.
     /// </summary>
-    TlsCipherSuite? NegotiatedCipherSuite { get => null; }
+    TlsCipherSuite? NegotiatedCipherSuite => null;
 #endif
 
     /// <summary>

--- a/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
@@ -3,7 +3,7 @@
 
 using System.Security.Authentication;
 
-#if NET7_0_OR_GREATER
+#if NETCOREAPP
 using System.Net.Security;
 #endif
 
@@ -19,7 +19,7 @@ public interface ITlsHandshakeFeature
     /// </summary>
     SslProtocols Protocol { get; }
 
-#if NET7_0_OR_GREATER
+#if NETCOREAPP
     /// <summary>
     /// Gets the <see cref="TlsCipherSuite"/>.
     /// </summary>

--- a/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
@@ -23,7 +23,7 @@ public interface ITlsHandshakeFeature
     /// <summary>
     /// Gets the <see cref="TlsCipherSuite"/>.
     /// </summary>
-    TlsCipherSuite? NegotiatedCipherSuite { get => default; }
+    TlsCipherSuite? NegotiatedCipherSuite { get => null; }
 #endif
 
     /// <summary>

--- a/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
@@ -24,11 +24,6 @@ public interface ITlsHandshakeFeature
     /// Gets the <see cref="TlsCipherSuite"/>.
     /// </summary>
     TlsCipherSuite? NegotiatedCipherSuite { get => default; }
-
-    /// <summary>
-    /// Gets the <see cref="SslStream"/>.
-    /// </summary>
-    SslStream? SslStream { get => default; }
 #endif
 
     /// <summary>

--- a/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
@@ -3,6 +3,10 @@
 
 using System.Security.Authentication;
 
+#if NET7_0_OR_GREATER
+using System.Net.Security;
+#endif
+
 namespace Microsoft.AspNetCore.Connections.Features;
 
 /// <summary>
@@ -14,6 +18,13 @@ public interface ITlsHandshakeFeature
     /// Gets the <see cref="SslProtocols"/>.
     /// </summary>
     SslProtocols Protocol { get; }
+
+#if NET7_0_OR_GREATER
+    /// <summary>
+    /// Gets the <see cref="TlsCipherSuite"/>.
+    /// </summary>
+    TlsCipherSuite? NegotiatedCipherSuite { get => default; }
+#endif
 
     /// <summary>
     /// Gets the <see cref="CipherAlgorithmType"/>.

--- a/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
@@ -24,6 +24,11 @@ public interface ITlsHandshakeFeature
     /// Gets the <see cref="TlsCipherSuite"/>.
     /// </summary>
     TlsCipherSuite? NegotiatedCipherSuite { get => default; }
+
+    /// <summary>
+    /// Gets the <see cref="SslStream"/>.
+    /// </summary>
+    SslStream? SslStream { get => default; }
 #endif
 
     /// <summary>

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Microsoft.AspNetCore.Connections.Features.IConnectionNamedPipeFeature
 Microsoft.AspNetCore.Connections.Features.IConnectionNamedPipeFeature.NamedPipe.get -> System.IO.Pipes.NamedPipeServerStream!
+Microsoft.AspNetCore.Connections.Features.ITlsHandshakeFeature.NegotiatedCipherSuite.get -> System.Net.Security.TlsCipherSuite?
 Microsoft.AspNetCore.Connections.IConnectionListenerFactorySelector
 Microsoft.AspNetCore.Connections.IConnectionListenerFactorySelector.CanBind(System.Net.EndPoint! endpoint) -> bool
 Microsoft.AspNetCore.Connections.NamedPipeEndPoint

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@
 Microsoft.AspNetCore.Connections.Features.IConnectionNamedPipeFeature
 Microsoft.AspNetCore.Connections.Features.IConnectionNamedPipeFeature.NamedPipe.get -> System.IO.Pipes.NamedPipeServerStream!
 Microsoft.AspNetCore.Connections.Features.ITlsHandshakeFeature.NegotiatedCipherSuite.get -> System.Net.Security.TlsCipherSuite?
+Microsoft.AspNetCore.Connections.Features.ITlsHandshakeFeature.SslStream.get -> System.Net.Security.SslStream?
 Microsoft.AspNetCore.Connections.IConnectionListenerFactorySelector
 Microsoft.AspNetCore.Connections.IConnectionListenerFactorySelector.CanBind(System.Net.EndPoint! endpoint) -> bool
 Microsoft.AspNetCore.Connections.NamedPipeEndPoint

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -2,7 +2,6 @@
 Microsoft.AspNetCore.Connections.Features.IConnectionNamedPipeFeature
 Microsoft.AspNetCore.Connections.Features.IConnectionNamedPipeFeature.NamedPipe.get -> System.IO.Pipes.NamedPipeServerStream!
 Microsoft.AspNetCore.Connections.Features.ITlsHandshakeFeature.NegotiatedCipherSuite.get -> System.Net.Security.TlsCipherSuite?
-Microsoft.AspNetCore.Connections.Features.ITlsHandshakeFeature.SslStream.get -> System.Net.Security.SslStream?
 Microsoft.AspNetCore.Connections.IConnectionListenerFactorySelector
 Microsoft.AspNetCore.Connections.IConnectionListenerFactorySelector.CanBind(System.Net.EndPoint! endpoint) -> bool
 Microsoft.AspNetCore.Connections.NamedPipeEndPoint

--- a/src/Servers/Connections.Abstractions/src/TlsConnectionCallbackContext.cs
+++ b/src/Servers/Connections.Abstractions/src/TlsConnectionCallbackContext.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NET7_0_OR_GREATER
+#if NETCOREAPP
 using System.Net.Security;
 using System.Threading;
 using Microsoft.AspNetCore.Connections;

--- a/src/Servers/Connections.Abstractions/src/TlsConnectionCallbackOptions.cs
+++ b/src/Servers/Connections.Abstractions/src/TlsConnectionCallbackOptions.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NET7_0_OR_GREATER
+#if NETCOREAPP
 using System;
 using System.Collections.Generic;
 using System.Net.Security;

--- a/src/Servers/Kestrel/Core/src/Features/ISslStreamFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Features/ISslStreamFeature.cs
@@ -7,11 +7,13 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 
 /// <summary>
 /// Feature to get access the connection's <see cref="SslStream" />.
+/// This feature will not be available for non-TLS connections or HTTP/3.
 /// </summary>
 public interface ISslStreamFeature
 {
     /// <summary>
     /// Gets the <see cref="SslStream"/>.
+    /// Note that <see cref="ISslStreamFeature"/> will not be available for non-TLS connections or HTTP/3.
     /// </summary>
     SslStream SslStream { get; }
 }

--- a/src/Servers/Kestrel/Core/src/Features/ISslStreamFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Features/ISslStreamFeature.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Security;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Features;
+
+/// <summary>
+/// Feature to set access the TLS application protocol
+/// </summary>
+public interface ISslStreamFeature
+{
+    /// <summary>
+    /// Gets the <see cref="SslStream"/>.
+    /// </summary>
+    SslStream SslStream { get; }
+}

--- a/src/Servers/Kestrel/Core/src/Features/ISslStreamFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Features/ISslStreamFeature.cs
@@ -6,7 +6,7 @@ using System.Net.Security;
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 
 /// <summary>
-/// Feature to set access the TLS application protocol
+/// Feature to get access the connection's <see cref="SslStream" />.
 /// </summary>
 public interface ISslStreamFeature
 {

--- a/src/Servers/Kestrel/Core/src/Features/ISslStreamFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Features/ISslStreamFeature.cs
@@ -6,7 +6,7 @@ using System.Net.Security;
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 
 /// <summary>
-/// Feature to get access the connection's <see cref="SslStream" />.
+/// Feature to get access to the connection's <see cref="SslStream" />.
 /// This feature will not be available for non-TLS connections or HTTP/3.
 /// </summary>
 public interface ISslStreamFeature

--- a/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
@@ -66,7 +66,13 @@ internal sealed class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicat
         set => _protocol = value;
     }
 
+    public SslStream? SslStream
+    {
+        get => _sslStream;
+    }
+
     // We don't store the values for these because they could be changed by a renegotiation.
+
     TlsCipherSuite? ITlsHandshakeFeature.NegotiatedCipherSuite { get => NegotiatedCipherSuite; }
     // Split the writable property from the interface implementation because it doesn't make sense to allow setting null
     internal TlsCipherSuite NegotiatedCipherSuite

--- a/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
@@ -16,15 +16,6 @@ internal sealed class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicat
     private readonly SslStream _sslStream;
     private readonly ConnectionContext _context;
     private X509Certificate2? _clientCert;
-    private ReadOnlyMemory<byte>? _applicationProtocol;
-    private SslProtocols? _protocol;
-    private TlsCipherSuite? _cipherSuite;
-    private CipherAlgorithmType? _cipherAlgorithm;
-    private int? _cipherStrength;
-    private HashAlgorithmType? _hashAlgorithm;
-    private int? _hashStrength;
-    private ExchangeAlgorithmType? _keyExchangeAlgorithm;
-    private int? _keyExchangeStrength;
     private Task<X509Certificate2?>? _clientCertTask;
 
     public TlsConnectionFeature(SslStream sslStream, ConnectionContext context)
@@ -54,68 +45,27 @@ internal sealed class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicat
     // Used for event source, not part of any of the feature interfaces.
     public string? HostName { get; set; }
 
-    public ReadOnlyMemory<byte> ApplicationProtocol
-    {
-        get => _applicationProtocol ?? _sslStream.NegotiatedApplicationProtocol.Protocol;
-        set => _applicationProtocol = value;
-    }
+    public ReadOnlyMemory<byte> ApplicationProtocol => _sslStream.NegotiatedApplicationProtocol.Protocol;
 
-    public SslProtocols Protocol
-    {
-        get => _protocol ?? _sslStream.SslProtocol;
-        set => _protocol = value;
-    }
+    public SslProtocols Protocol => _sslStream.SslProtocol;
 
-    public SslStream SslStream
-    {
-        get => _sslStream;
-    }
+    public SslStream SslStream => _sslStream;
 
     // We don't store the values for these because they could be changed by a renegotiation.
 
-    TlsCipherSuite? ITlsHandshakeFeature.NegotiatedCipherSuite { get => NegotiatedCipherSuite; }
-    // Split the writable property from the interface implementation because it doesn't make sense to allow setting null
-    internal TlsCipherSuite NegotiatedCipherSuite
-    {
-        get => _cipherSuite ?? _sslStream.NegotiatedCipherSuite;
-        set => _cipherSuite = value;
-    }
+    public TlsCipherSuite? NegotiatedCipherSuite => _sslStream.NegotiatedCipherSuite;
 
-    public CipherAlgorithmType CipherAlgorithm
-    {
-        get => _cipherAlgorithm ?? _sslStream.CipherAlgorithm;
-        set => _cipherAlgorithm = value;
-    }
+    public CipherAlgorithmType CipherAlgorithm => _sslStream.CipherAlgorithm;
 
-    public int CipherStrength
-    {
-        get => _cipherStrength ?? _sslStream.CipherStrength;
-        set => _cipherStrength = value;
-    }
+    public int CipherStrength => _sslStream.CipherStrength;
 
-    public HashAlgorithmType HashAlgorithm
-    {
-        get => _hashAlgorithm ?? _sslStream.HashAlgorithm;
-        set => _hashAlgorithm = value;
-    }
+    public HashAlgorithmType HashAlgorithm => _sslStream.HashAlgorithm;
 
-    public int HashStrength
-    {
-        get => _hashStrength ?? _sslStream.HashStrength;
-        set => _hashStrength = value;
-    }
+    public int HashStrength => _sslStream.HashStrength;
 
-    public ExchangeAlgorithmType KeyExchangeAlgorithm
-    {
-        get => _keyExchangeAlgorithm ?? _sslStream.KeyExchangeAlgorithm;
-        set => _keyExchangeAlgorithm = value;
-    }
+    public ExchangeAlgorithmType KeyExchangeAlgorithm => _sslStream.KeyExchangeAlgorithm;
 
-    public int KeyExchangeStrength
-    {
-        get => _keyExchangeStrength ?? _sslStream.KeyExchangeStrength;
-        set => _keyExchangeStrength = value;
-    }
+    public int KeyExchangeStrength => _sslStream.KeyExchangeStrength;
 
     public Task<X509Certificate2?> GetClientCertificateAsync(CancellationToken cancellationToken)
     {

--- a/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
@@ -11,7 +11,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 
-internal sealed class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicationProtocolFeature, ITlsHandshakeFeature
+internal sealed class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicationProtocolFeature, ITlsHandshakeFeature, ISslStreamFeature
 {
     private readonly SslStream _sslStream;
     private readonly ConnectionContext _context;
@@ -66,7 +66,7 @@ internal sealed class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicat
         set => _protocol = value;
     }
 
-    public SslStream? SslStream
+    public SslStream SslStream
     {
         get => _sslStream;
     }

--- a/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
@@ -18,6 +18,7 @@ internal sealed class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicat
     private X509Certificate2? _clientCert;
     private ReadOnlyMemory<byte>? _applicationProtocol;
     private SslProtocols? _protocol;
+    private TlsCipherSuite? _cipherSuite;
     private CipherAlgorithmType? _cipherAlgorithm;
     private int? _cipherStrength;
     private HashAlgorithmType? _hashAlgorithm;
@@ -66,6 +67,14 @@ internal sealed class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicat
     }
 
     // We don't store the values for these because they could be changed by a renegotiation.
+    TlsCipherSuite? ITlsHandshakeFeature.NegotiatedCipherSuite { get => NegotiatedCipherSuite; }
+    // Split the writable property from the interface implementation because it doesn't make sense to allow setting null
+    internal TlsCipherSuite NegotiatedCipherSuite
+    {
+        get => _cipherSuite ?? _sslStream.NegotiatedCipherSuite;
+        set => _cipherSuite = value;
+    }
+
     public CipherAlgorithmType CipherAlgorithm
     {
         get => _cipherAlgorithm ?? _sslStream.CipherAlgorithm;

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -145,6 +145,7 @@ internal sealed class HttpsConnectionMiddleware
         context.Features.Set<ITlsConnectionFeature>(feature);
         context.Features.Set<ITlsHandshakeFeature>(feature);
         context.Features.Set<ITlsApplicationProtocolFeature>(feature);
+        context.Features.Set<ISslStreamFeature>(feature);
 
         try
         {

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -146,6 +146,7 @@ internal sealed class HttpsConnectionMiddleware
         context.Features.Set<ITlsHandshakeFeature>(feature);
         context.Features.Set<ITlsApplicationProtocolFeature>(feature);
         context.Features.Set<ISslStreamFeature>(feature);
+        context.Features.Set<SslStream>(sslStream); // Anti-pattern, but retain for back compat
 
         try
         {
@@ -300,7 +301,6 @@ internal sealed class HttpsConnectionMiddleware
             selector = (sender, name) =>
             {
                 feature.HostName = name;
-                context.Features.Set(sslStream);
                 var cert = _serverCertificateSelector(context, name);
                 if (cert != null)
                 {

--- a/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.AspNetCore.Server.Kestrel.Core.Features.ISslStreamFeature
+Microsoft.AspNetCore.Server.Kestrel.Core.Features.ISslStreamFeature.SslStream.get -> System.Net.Security.SslStream!
 Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenNamedPipe(string! pipeName) -> void
 Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenNamedPipe(string! pipeName, System.Action<Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions!>! configure) -> void
 Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.PipeName.get -> string?


### PR DESCRIPTION
# Expose the SslStream and Cipher Suite on ITlsHandshakeFeature

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

As was sensibly requested in #46442, we should expose these properties - their omission was likely an oversight.

Fixes #46442
Fixes #46823
