### PR TITLE
Suppress downgrade error in hosting bundle

### DIFF
--- a/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/Bundle.wxs
@@ -6,6 +6,7 @@
         <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense">
             <bal:WixStandardBootstrapperApplication LicenseUrl="https://go.microsoft.com/fwlink/?LinkId=329770"
                                                     LogoFile="DotNetLogo.bmp"
+                                                    SuppressDowngradeFailure="yes"
                                                     SuppressOptionsUI="yes"
                                                     ThemeFile="thm.xml"
                                                     LocalizationFile="thm.wxl"/>


### PR DESCRIPTION
Completes the fix from https://github.com/dotnet/aspnetcore/pull/42857

Allows a windows hosting bundle to be installed on a machine that already has a newer asp.net hosting bundle installed.