### PR TITLE
Suggest team members to run CI checks for long-standing PRs

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -3532,7 +3532,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "Looks like this PR hasn't been active for some time and the codebase could have been changed in the meantime.\nTo make sure no breaking changes are introduced, please remove the `pending ci rerun` label to kick off a new CI run."
+              "comment": "Looks like this PR hasn't been active for some time and the codebase could have been changed in the meantime.\nTo make sure no breaking changes are introduced, please leave an `/azp run` comment here to rerun the CI pipeline again and confirm success before merging the change."
             }
           },
           {
@@ -3548,14 +3548,27 @@
     {
       "taskType": "trigger",
       "capabilityId": "IssueResponder",
-      "subCapability": "PullRequestResponder",
+      "subCapability": "PullRequestCommentResponder",
       "version": "1.0",
       "config": {
         "conditions": {
           "operator": "and",
           "operands": [
             {
-              "name": "labelRemoved",
+              "name": "activitySenderHasPermissions",
+              "parameters": {
+                "permissions": "write"
+              }
+            },
+            {
+              "name": "commentContains",
+              "parameters": {
+                "isRegex": true,
+                "commentPattern": "^(\\/azp run)$"
+              }
+            },
+            {
+              "name": "hasLabel",
               "parameters": {
                 "label": "pending-ci-rerun"
               }
@@ -3564,16 +3577,14 @@
         },
         "eventType": "pull_request",
         "eventNames": [
-          "pull_request",
-          "issues",
-          "project_card"
+          "issue_comment"
         ],
-        "taskName": "Unblock PRs which are no longer awaiting for a ci run",
+        "taskName": "Remove pending-ci-rerun label when CI rerun requested",
         "actions": [
           {
-            "name": "addReply",
+            "name": "removeLabel",
             "parameters": {
-              "comment": "/azp run"
+              "label": "pending-ci-rerun"
             }
           }
         ]

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -3532,7 +3532,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "Looks like this PR hasn't been active for some time and the codebase could have been changed in the meantime.\nTo make sure no breaking changes are introduced, please leave an `/azp run` comment here to rerun the CI pipeline again and confirm success before merging the change."
+              "comment": "Looks like this PR hasn't been active for some time and the codebase could have been changed in the meantime.\nTo make sure no breaking changes are introduced, please leave an `/azp run` comment here to rerun the CI pipeline and confirm success before merging the change."
             }
           },
           {


### PR DESCRIPTION
At the moment we have automation in place to automatically drop a `/azp run` comment on PRs, which have `pending-ci-rerun` label.

Turned out, that msftbot doesn't have permissions for running CI jobs, so that command couldn't run.
This change moves the responsibility of rerunning the CI checks on the team members instead. Also, it removes the `pending-ci-rerun` label, as soon as the rerun was requested.