### PR TITLE
Revert "Defer search for dev cert until build bind time (#46296)"

### DIFF
--- a/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
+++ b/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
@@ -73,6 +73,12 @@ public class HttpsConnectionAdapterOptions
     public SslProtocols SslProtocols { get; set; }
 
     /// <summary>
+    /// The protocols enabled on this endpoint.
+    /// </summary>
+    /// <remarks>Defaults to HTTP/1.x only.</remarks>
+    internal HttpProtocols HttpProtocols { get; set; }
+
+    /// <summary>
     /// Specifies whether the certificate revocation list is checked during authentication.
     /// </summary>
     public bool CheckCertificateRevocation { get; set; }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TransportManager.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TransportManager.cs
@@ -77,7 +77,7 @@ internal sealed class TransportManager
         // The QUIC transport will check if TlsConnectionCallbackOptions is missing.
         if (listenOptions.HttpsOptions != null)
         {
-            var sslServerAuthenticationOptions = HttpsConnectionMiddleware.CreateHttp3Options(listenOptions.HttpsOptions.Value);
+            var sslServerAuthenticationOptions = HttpsConnectionMiddleware.CreateHttp3Options(listenOptions.HttpsOptions);
             features.Set(new TlsConnectionCallbackOptions
             {
                 ApplicationProtocols = sslServerAuthenticationOptions.ApplicationProtocols ?? new List<SslApplicationProtocol> { SslApplicationProtocol.Http3 },

--- a/src/Servers/Kestrel/Core/src/ListenOptions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptions.cs
@@ -140,8 +140,7 @@ public class ListenOptions : IConnectionBuilder, IMultiplexedConnectionBuilder
     }
 
     internal bool IsTls { get; set; }
-    /// <remarks>Should not be inspected until the configuration has been loaded.</remarks>
-    internal Lazy<HttpsConnectionAdapterOptions>? HttpsOptions { get; set; }
+    internal HttpsConnectionAdapterOptions? HttpsOptions { get; set; }
     internal TlsHandshakeCallbackOptions? HttpsCallbackOptions { get; set; }
 
     /// <summary>

--- a/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
@@ -163,24 +163,33 @@ public static class ListenOptionsHttpsExtensions
     {
         ArgumentNullException.ThrowIfNull(configureOptions);
 
-        return listenOptions.UseHttps(new Lazy<HttpsConnectionAdapterOptions>(() =>
+        var options = new HttpsConnectionAdapterOptions();
+        listenOptions.KestrelServerOptions.ApplyHttpsDefaults(options);
+        configureOptions(options);
+        listenOptions.KestrelServerOptions.ApplyDefaultCert(options);
+
+        if (options.ServerCertificate == null && options.ServerCertificateSelector == null)
         {
-            // We defer configuration of the https options until build time so that the IConfiguration will be available.
-            // This is particularly important in docker containers, where the docker tools use IConfiguration to tell
-            // us where the development certificates have been mounted.
+            throw new InvalidOperationException(CoreStrings.NoCertSpecifiedNoDevelopmentCertificateFound);
+        }
 
-            var options = new HttpsConnectionAdapterOptions();
-            listenOptions.KestrelServerOptions.ApplyHttpsDefaults(options);
-            configureOptions(options);
-            listenOptions.KestrelServerOptions.ApplyDefaultCert(options);
+        return listenOptions.UseHttps(options);
+    }
 
-            if (options.ServerCertificate == null && options.ServerCertificateSelector == null)
-            {
-                throw new InvalidOperationException(CoreStrings.NoCertSpecifiedNoDevelopmentCertificateFound);
-            }
+    // Use Https if a default cert is available
+    internal static bool TryUseHttps(this ListenOptions listenOptions)
+    {
+        var options = new HttpsConnectionAdapterOptions();
+        listenOptions.KestrelServerOptions.ApplyHttpsDefaults(options);
+        listenOptions.KestrelServerOptions.ApplyDefaultCert(options);
 
-            return options;
-        }));
+        if (options.ServerCertificate == null && options.ServerCertificateSelector == null)
+        {
+            return false;
+        }
+
+        listenOptions.UseHttps(options);
+        return true;
     }
 
     /// <summary>
@@ -192,28 +201,16 @@ public static class ListenOptionsHttpsExtensions
     /// <returns>The <see cref="ListenOptions"/>.</returns>
     public static ListenOptions UseHttps(this ListenOptions listenOptions, HttpsConnectionAdapterOptions httpsOptions)
     {
-        return listenOptions.UseHttps(new Lazy<HttpsConnectionAdapterOptions>(httpsOptions));
-    }
+        var loggerFactory = listenOptions.KestrelServerOptions?.ApplicationServices.GetRequiredService<ILoggerFactory>() ?? NullLoggerFactory.Instance;
 
-    /// <summary>
-    /// Configure Kestrel to use HTTPS. This does not use default certificates or other defaults specified via config or
-    /// <see cref="KestrelServerOptions.ConfigureHttpsDefaults(Action{HttpsConnectionAdapterOptions})"/>.
-    /// </summary>
-    /// <param name="listenOptions">The <see cref="ListenOptions"/> to configure.</param>
-    /// <param name="lazyHttpsOptions">Options to configure HTTPS.</param>
-    /// <returns>The <see cref="ListenOptions"/>.</returns>
-    private static ListenOptions UseHttps(this ListenOptions listenOptions, Lazy<HttpsConnectionAdapterOptions> lazyHttpsOptions)
-    {
         listenOptions.IsTls = true;
-        listenOptions.HttpsOptions = lazyHttpsOptions;
+        listenOptions.HttpsOptions = httpsOptions;
 
-        // NB: This lambda will only be invoked if either HTTP/1.* or HTTP/2 is being used
         listenOptions.Use(next =>
         {
-            // Evaluate the HttpsConnectionAdapterOptions, now that the configuration, if any, has been loaded
-            var httpsOptions = listenOptions.HttpsOptions.Value;
-            var loggerFactory = listenOptions.KestrelServerOptions?.ApplicationServices.GetRequiredService<ILoggerFactory>() ?? NullLoggerFactory.Instance;
-            var middleware = new HttpsConnectionMiddleware(next, httpsOptions, listenOptions.Protocols, loggerFactory);
+            // Set the list of protocols from listen options
+            httpsOptions.HttpProtocols = listenOptions.Protocols;
+            var middleware = new HttpsConnectionMiddleware(next, httpsOptions, loggerFactory);
             return middleware.OnConnectionAsync;
         });
 
@@ -273,7 +270,6 @@ public static class ListenOptionsHttpsExtensions
         listenOptions.IsTls = true;
         listenOptions.HttpsCallbackOptions = callbackOptions;
 
-        // NB: This lambda will only be invoked if either HTTP/1.* or HTTP/2 is being used
         listenOptions.Use(next =>
         {
             // Set the list of protocols from listen options.

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -228,8 +228,7 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
     public void ThrowsWhenNoServerCertificateIsProvided()
     {
         Assert.Throws<ArgumentException>(() => new HttpsConnectionMiddleware(context => Task.CompletedTask,
-            new HttpsConnectionAdapterOptions(),
-            ListenOptions.DefaultHttpProtocols)
+            new HttpsConnectionAdapterOptions())
             );
     }
 
@@ -1269,8 +1268,7 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         new HttpsConnectionMiddleware(context => Task.CompletedTask, new HttpsConnectionAdapterOptions
         {
             ServerCertificate = cert,
-        },
-        ListenOptions.DefaultHttpProtocols);
+        });
     }
 
     [Theory]
@@ -1288,8 +1286,7 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         new HttpsConnectionMiddleware(context => Task.CompletedTask, new HttpsConnectionAdapterOptions
         {
             ServerCertificate = cert,
-        },
-        ListenOptions.DefaultHttpProtocols);
+        });
     }
 
     [Theory]
@@ -1308,7 +1305,7 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
             new HttpsConnectionMiddleware(context => Task.CompletedTask, new HttpsConnectionAdapterOptions
             {
                 ServerCertificate = cert,
-            }, ListenOptions.DefaultHttpProtocols));
+            }));
 
         Assert.Equal(CoreStrings.FormatInvalidServerCertificateEku(cert.Thumbprint), ex.Message);
     }
@@ -1355,10 +1352,11 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         var httpConnectionAdapterOptions = new HttpsConnectionAdapterOptions
         {
             ServerCertificate = _x509Certificate2,
+            HttpProtocols = HttpProtocols.Http1AndHttp2
         };
-        var middleware = new HttpsConnectionMiddleware(context => Task.CompletedTask, httpConnectionAdapterOptions, HttpProtocols.Http1AndHttp2);
+        new HttpsConnectionMiddleware(context => Task.CompletedTask, httpConnectionAdapterOptions);
 
-        Assert.Equal(HttpProtocols.Http1, middleware._httpProtocols);
+        Assert.Equal(HttpProtocols.Http1, httpConnectionAdapterOptions.HttpProtocols);
     }
 
     [ConditionalFact]
@@ -1369,10 +1367,11 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         var httpConnectionAdapterOptions = new HttpsConnectionAdapterOptions
         {
             ServerCertificate = _x509Certificate2,
+            HttpProtocols = HttpProtocols.Http1AndHttp2
         };
-        var middleware = new HttpsConnectionMiddleware(context => Task.CompletedTask, httpConnectionAdapterOptions, HttpProtocols.Http1AndHttp2);
+        new HttpsConnectionMiddleware(context => Task.CompletedTask, httpConnectionAdapterOptions);
 
-        Assert.Equal(HttpProtocols.Http1AndHttp2, middleware._httpProtocols);
+        Assert.Equal(HttpProtocols.Http1AndHttp2, httpConnectionAdapterOptions.HttpProtocols);
     }
 
     [ConditionalFact]
@@ -1383,9 +1382,10 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         var httpConnectionAdapterOptions = new HttpsConnectionAdapterOptions
         {
             ServerCertificate = _x509Certificate2,
+            HttpProtocols = HttpProtocols.Http2
         };
 
-        Assert.Throws<NotSupportedException>(() => new HttpsConnectionMiddleware(context => Task.CompletedTask, httpConnectionAdapterOptions, HttpProtocols.Http2));
+        Assert.Throws<NotSupportedException>(() => new HttpsConnectionMiddleware(context => Task.CompletedTask, httpConnectionAdapterOptions));
     }
 
     [ConditionalFact]
@@ -1396,10 +1396,11 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         var httpConnectionAdapterOptions = new HttpsConnectionAdapterOptions
         {
             ServerCertificate = _x509Certificate2,
+            HttpProtocols = HttpProtocols.Http2
         };
 
         // Does not throw
-        new HttpsConnectionMiddleware(context => Task.CompletedTask, httpConnectionAdapterOptions, HttpProtocols.Http2);
+        new HttpsConnectionMiddleware(context => Task.CompletedTask, httpConnectionAdapterOptions);
     }
 
     private static async Task App(HttpContext httpContext)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
@@ -53,18 +53,14 @@ public class HttpsTests : LoggedTest
 
         Assert.False(serverOptions.IsDevCertLoaded);
 
-        var ranUseHttpsAction = false;
         serverOptions.ListenLocalhost(5001, options =>
         {
             options.UseHttps(opt =>
             {
                 // The default cert is applied after UseHttps.
                 Assert.Null(opt.ServerCertificate);
-                ranUseHttpsAction = true;
             });
         });
-        _ = serverOptions.CodeBackedListenOptions[1].HttpsOptions.Value; // Force evaluation
-        Assert.True(ranUseHttpsAction);
         Assert.False(serverOptions.IsDevCertLoaded);
     }
 
@@ -110,20 +106,14 @@ public class HttpsTests : LoggedTest
             options.ServerCertificate = _x509Certificate2;
             options.ClientCertificateMode = ClientCertificateMode.RequireCertificate;
         });
-        var ranUseHttpsAction = false;
         serverOptions.ListenLocalhost(5000, options =>
         {
             options.UseHttps(opt =>
             {
                 Assert.Equal(_x509Certificate2, opt.ServerCertificate);
                 Assert.Equal(ClientCertificateMode.RequireCertificate, opt.ClientCertificateMode);
-                ranUseHttpsAction = true;
             });
         });
-
-        _ = serverOptions.CodeBackedListenOptions.Single().HttpsOptions.Value; // Force evaluation
-        Assert.True(ranUseHttpsAction);
-
         // Never lazy loaded
         Assert.False(serverOptions.IsDevCertLoaded);
         Assert.Null(serverOptions.DefaultCertificate);
@@ -143,7 +133,6 @@ public class HttpsTests : LoggedTest
             };
             options.ClientCertificateMode = ClientCertificateMode.RequireCertificate;
         });
-        var ranUseHttpsAction = false;
         serverOptions.ListenLocalhost(5000, options =>
         {
             options.UseHttps(opt =>
@@ -151,13 +140,8 @@ public class HttpsTests : LoggedTest
                 Assert.Null(opt.ServerCertificate);
                 Assert.NotNull(opt.ServerCertificateSelector);
                 Assert.Equal(ClientCertificateMode.RequireCertificate, opt.ClientCertificateMode);
-                ranUseHttpsAction = true;
             });
         });
-
-        _ = serverOptions.CodeBackedListenOptions.Single().HttpsOptions.Value; // Force evaluation
-        Assert.True(ranUseHttpsAction);
-
         // Never lazy loaded
         Assert.False(serverOptions.IsDevCertLoaded);
         Assert.Null(serverOptions.DefaultCertificate);

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
@@ -5,14 +5,11 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Quic;
 using System.Net.Security;
-using System.Reflection;
-using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.AspNetCore.Testing;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -26,7 +23,6 @@ public class Http3TlsTests : LoggedTest
     [MsQuicSupported]
     public async Task ServerCertificateSelector_Invoked()
     {
-        var serverCertificateSelectorActionCalled = false;
         var builder = CreateHostBuilder(async context =>
         {
             await context.Response.WriteAsync("Hello World");
@@ -39,7 +35,6 @@ public class Http3TlsTests : LoggedTest
                 {
                     httpsOptions.ServerCertificateSelector = (context, host) =>
                     {
-                        serverCertificateSelectorActionCalled = true;
                         Assert.Null(context); // The context isn't available durring the quic handshake.
                         Assert.Equal("testhost", host);
                         return TestResources.GetTestCertificate();
@@ -63,8 +58,6 @@ public class Http3TlsTests : LoggedTest
         var result = await response.Content.ReadAsStringAsync();
         Assert.Equal(HttpVersion.Version30, response.Version);
         Assert.Equal("Hello World", result);
-
-        Assert.True(serverCertificateSelectorActionCalled);
 
         await host.StopAsync().DefaultTimeout();
     }
@@ -334,93 +327,6 @@ public class Http3TlsTests : LoggedTest
         Assert.Equal(configuredState, callbackState);
 
         await host.StopAsync().DefaultTimeout();
-    }
-
-    [ConditionalFact]
-    [MsQuicSupported]
-    public async Task LoadDevelopmentCertificateViaConfiguration()
-    {
-        var expectedCertificate = new X509Certificate2(TestResources.GetCertPath("aspnetdevcert.pfx"), "testPassword", X509KeyStorageFlags.Exportable);
-        var bytes = expectedCertificate.Export(X509ContentType.Pkcs12, "1234");
-        var path = GetCertificatePath();
-        Directory.CreateDirectory(Path.GetDirectoryName(path));
-        File.WriteAllBytes(path, bytes);
-
-        var config = new ConfigurationBuilder().AddInMemoryCollection(new[]
-        {
-            new KeyValuePair<string, string>("Certificates:Development:Password", "1234"),
-        }).Build();
-
-        var ranConfigureKestrelAction = false;
-        var ranUseHttpsAction = false;
-        var hostBuilder = CreateHostBuilder(async context =>
-        {
-            await context.Response.WriteAsync("Hello World");
-        }, configureKestrel: kestrelOptions =>
-        {
-            ranConfigureKestrelAction = true;
-            kestrelOptions.Configure(config);
-
-            kestrelOptions.ListenAnyIP(0, listenOptions =>
-            {
-                listenOptions.Protocols = HttpProtocols.Http3;
-                listenOptions.UseHttps(_ =>
-                {
-                    ranUseHttpsAction = true;
-                });
-            });
-        });
-
-        Assert.False(ranConfigureKestrelAction);
-        Assert.False(ranUseHttpsAction);
-
-        using var host = hostBuilder.Build();
-        await host.StartAsync().DefaultTimeout();
-
-        Assert.True(ranConfigureKestrelAction);
-        Assert.True(ranUseHttpsAction);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"https://127.0.0.1:{host.GetPort()}/");
-        request.Version = HttpVersion.Version30;
-        request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
-        request.Headers.Host = "testhost";
-
-        var ranCertificateValidation = false;
-        var httpHandler = new SocketsHttpHandler();
-        httpHandler.SslOptions = new SslClientAuthenticationOptions
-        {
-            RemoteCertificateValidationCallback = (object _sender, X509Certificate actualCertificate, X509Chain _chain, SslPolicyErrors _sslPolicyErrors) =>
-            {
-                ranCertificateValidation = true;
-                Assert.Equal(expectedCertificate.GetSerialNumberString(), actualCertificate.GetSerialNumberString());
-                return true;
-            },
-            TargetHost = "targethost",
-        };
-        using var client = new HttpMessageInvoker(httpHandler);
-
-        var response = await client.SendAsync(request, CancellationToken.None).DefaultTimeout();
-        response.EnsureSuccessStatusCode();
-        var result = await response.Content.ReadAsStringAsync();
-        Assert.Equal(HttpVersion.Version30, response.Version);
-        Assert.Equal("Hello World", result);
-
-        Assert.True(ranCertificateValidation);
-
-        await host.StopAsync().DefaultTimeout();
-    }
-
-    ///<remarks>
-    /// This is something of a hack - we should actually be calling
-    /// <see cref="Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader.TryGetCertificatePath"/>.
-    /// </remarks>
-    private static string GetCertificatePath()
-    {
-        var appData = Environment.GetEnvironmentVariable("APPDATA");
-        var home = Environment.GetEnvironmentVariable("HOME");
-        var basePath = appData != null ? Path.Combine(appData, "ASP.NET", "https") : null;
-        basePath = basePath ?? (home != null ? Path.Combine(home, ".aspnet", "https") : null);
-        return Path.Combine(basePath, $"{typeof(Http3TlsTests).Assembly.GetName().Name}.pfx");
     }
 
     private IHostBuilder CreateHostBuilder(RequestDelegate requestDelegate, HttpProtocols? protocol = null, Action<KestrelServerOptions> configureKestrel = null)


### PR DESCRIPTION
This reverts commit 303115ab41017bc2346b450830af92d57855dec7 (#46296).

Changing the order in which various certificate loading operations are performed broke dotnet-monitor.

https://github.com/dotnet/dotnet-docker/pull/4448#issuecomment-1444535517

This un-fixes #45801