### PR TITLE
JsonSubKeyClaim arrays

### DIFF
--- a/src/Security/Authentication/OAuth/src/JsonKeyClaimAction.cs
+++ b/src/Security/Authentication/OAuth/src/JsonKeyClaimAction.cs
@@ -53,7 +53,7 @@ public class JsonKeyClaimAction : ClaimAction
         }
     }
 
-    private void AddClaim(string value, ClaimsIdentity identity, string issuer)
+    private protected void AddClaim(string value, ClaimsIdentity identity, string issuer)
     {
         if (!string.IsNullOrEmpty(value))
         {

--- a/src/Security/Authentication/test/ClaimActionTests.cs
+++ b/src/Security/Authentication/test/ClaimActionTests.cs
@@ -42,6 +42,38 @@ public class ClaimActionTests
     }
 
     [Fact]
+    public void CanMapSingleSubValueUserDataToClaim()
+    {
+        var userData = JsonDocument.Parse("{ \"name\": { \"subkey\": \"test\" } }");
+
+        var identity = new ClaimsIdentity();
+
+        var action = new JsonSubKeyClaimAction("name", "name", "name", "subkey");
+        action.Run(userData.RootElement, identity, "iss");
+
+        Assert.Equal("name", identity.FindFirst("name").Type);
+        Assert.Equal("test", identity.FindFirst("name").Value);
+    }
+
+    [Fact]
+    public void CanMapArraySubValueUserDataToClaims()
+    {
+        var userData = JsonDocument.Parse("{ \"role\": { \"subkey\": [ \"role1\", null, \"role2\" ] } }");
+
+        var identity = new ClaimsIdentity();
+
+        var action = new JsonSubKeyClaimAction("role", "role", "role", "subkey");
+        action.Run(userData.RootElement, identity, "iss");
+
+        var roleClaims = identity.FindAll("role").ToList();
+        Assert.Equal(2, roleClaims.Count);
+        Assert.Equal("role", roleClaims[0].Type);
+        Assert.Equal("role1", roleClaims[0].Value);
+        Assert.Equal("role", roleClaims[1].Type);
+        Assert.Equal("role2", roleClaims[1].Value);
+    }
+
+    [Fact]
     public void MapAllSucceeds()
     {
         var userData = JsonDocument.Parse("{ \"name0\": \"value0\", \"name1\": \"value1\" }");


### PR DESCRIPTION
# JsonSubKeyClaim arrays

Updates `JsonSubKeyClaim` to add each element of a JSON array as a separate claim rather than adding the array as a single claim of a JSON string.

## Description

`JsonKeyClaim` supports JSON arrays in the sense that when the value is an array, each of the array elements are added as claims.

This PR updates the `JsonSubKeyClaim` to add the same treatment of arrays to the subkey. I would like to point out that `JsonKeyClaim` and `JsonSubKeyClaim` currently differ in behavior for `JsonValueKind.Object` and `JsonValueKind.Undefined`, where the former skips those, while the latter serializes them into claims as JSON strings. The current PR preserves this difference. If the difference is not intentional, then `JsonSubKeyClaim` can be made cleaner by getting the subproperty element and calling base's implementation, see https://github.com/dotnet/aspnetcore/compare/main...miloush:aspnetcore:JsonSubKeyClaimUnified instead.

This PR no longer includes the serialized array as a claim and as such is potentially breaking existing code that workarounds the current behavior by parsing JSON manually.

Added tests covering `JsonSubKeyClaim` and the new behavior akin to the `JsonKeyClaim` tests.

Fixes #46864
