### PR TITLE
Correct a few nullable annotations

### DIFF
--- a/src/Http/Headers/src/ContentRangeHeaderValue.cs
+++ b/src/Http/Headers/src/ContentRangeHeaderValue.cs
@@ -212,10 +212,10 @@ public class ContentRangeHeaderValue
     /// <param name="input">The value to parse.</param>
     /// <param name="parsedValue">The parsed value.</param>
     /// <returns><see langword="true"/> if input is a valid <see cref="ContentRangeHeaderValue"/>, otherwise <see langword="false"/>.</returns>
-    public static bool TryParse(StringSegment input, [NotNullWhen(true)] out ContentRangeHeaderValue parsedValue)
+    public static bool TryParse(StringSegment input, [NotNullWhen(true)] out ContentRangeHeaderValue? parsedValue)
     {
         var index = 0;
-        return Parser.TryParseValue(input, ref index, out parsedValue!);
+        return Parser.TryParseValue(input, ref index, out parsedValue);
     }
 
     private static int GetContentRangeLength(StringSegment input, int startIndex, out ContentRangeHeaderValue? parsedValue)

--- a/src/Http/Headers/src/EntityTagHeaderValue.cs
+++ b/src/Http/Headers/src/EntityTagHeaderValue.cs
@@ -159,10 +159,10 @@ public class EntityTagHeaderValue
     /// <param name="input">The value to parse.</param>
     /// <param name="parsedValue">The parsed value.</param>
     /// <returns><see langword="true"/> if input is a valid <see cref="EntityTagHeaderValue"/>, otherwise <see langword="false"/>.</returns>
-    public static bool TryParse(StringSegment input, [NotNullWhen(true)] out EntityTagHeaderValue parsedValue)
+    public static bool TryParse(StringSegment input, [NotNullWhen(true)] out EntityTagHeaderValue? parsedValue)
     {
         var index = 0;
-        return SingleValueParser.TryParseValue(input, ref index, out parsedValue!);
+        return SingleValueParser.TryParseValue(input, ref index, out parsedValue);
     }
 
     /// <summary>

--- a/src/Http/Headers/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Headers/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+*REMOVED*static Microsoft.Net.Http.Headers.ContentRangeHeaderValue.TryParse(Microsoft.Extensions.Primitives.StringSegment input, out Microsoft.Net.Http.Headers.ContentRangeHeaderValue! parsedValue) -> bool
+*REMOVED*static Microsoft.Net.Http.Headers.EntityTagHeaderValue.TryParse(Microsoft.Extensions.Primitives.StringSegment input, out Microsoft.Net.Http.Headers.EntityTagHeaderValue! parsedValue) -> bool
+*REMOVED*static Microsoft.Net.Http.Headers.RangeHeaderValue.TryParse(Microsoft.Extensions.Primitives.StringSegment input, out Microsoft.Net.Http.Headers.RangeHeaderValue! parsedValue) -> bool
+*REMOVED*static Microsoft.Net.Http.Headers.StringWithQualityHeaderValue.TryParse(Microsoft.Extensions.Primitives.StringSegment input, out Microsoft.Net.Http.Headers.StringWithQualityHeaderValue! parsedValue) -> bool
+static Microsoft.Net.Http.Headers.ContentRangeHeaderValue.TryParse(Microsoft.Extensions.Primitives.StringSegment input, out Microsoft.Net.Http.Headers.ContentRangeHeaderValue? parsedValue) -> bool
+static Microsoft.Net.Http.Headers.EntityTagHeaderValue.TryParse(Microsoft.Extensions.Primitives.StringSegment input, out Microsoft.Net.Http.Headers.EntityTagHeaderValue? parsedValue) -> bool
+static Microsoft.Net.Http.Headers.RangeHeaderValue.TryParse(Microsoft.Extensions.Primitives.StringSegment input, out Microsoft.Net.Http.Headers.RangeHeaderValue? parsedValue) -> bool
+static Microsoft.Net.Http.Headers.StringWithQualityHeaderValue.TryParse(Microsoft.Extensions.Primitives.StringSegment input, out Microsoft.Net.Http.Headers.StringWithQualityHeaderValue? parsedValue) -> bool

--- a/src/Http/Headers/src/RangeHeaderValue.cs
+++ b/src/Http/Headers/src/RangeHeaderValue.cs
@@ -143,10 +143,10 @@ public class RangeHeaderValue
     /// <param name="input">The value to parse.</param>
     /// <param name="parsedValue">The parsed value.</param>
     /// <returns><see langword="true"/> if input is a valid <see cref="RangeHeaderValue"/>, otherwise <see langword="false"/>.</returns>
-    public static bool TryParse(StringSegment input, [NotNullWhen(true)] out RangeHeaderValue parsedValue)
+    public static bool TryParse(StringSegment input, [NotNullWhen(true)] out RangeHeaderValue? parsedValue)
     {
         var index = 0;
-        return Parser.TryParseValue(input, ref index, out parsedValue!);
+        return Parser.TryParseValue(input, ref index, out parsedValue);
     }
 
     private static int GetRangeLength(StringSegment input, int startIndex, out RangeHeaderValue? parsedValue)

--- a/src/Http/Headers/src/StringWithQualityHeaderValue.cs
+++ b/src/Http/Headers/src/StringWithQualityHeaderValue.cs
@@ -134,10 +134,10 @@ public class StringWithQualityHeaderValue
     /// <param name="input">The value to parse.</param>
     /// <param name="parsedValue">The parsed value.</param>
     /// <returns><see langword="true"/> if input is a valid <see cref="StringWithQualityHeaderValue"/>, otherwise <see langword="false"/>.</returns>
-    public static bool TryParse(StringSegment input, [NotNullWhen(true)] out StringWithQualityHeaderValue parsedValue)
+    public static bool TryParse(StringSegment input, [NotNullWhen(true)] out StringWithQualityHeaderValue? parsedValue)
     {
         var index = 0;
-        return SingleValueParser.TryParseValue(input, ref index, out parsedValue!);
+        return SingleValueParser.TryParseValue(input, ref index, out parsedValue);
     }
 
     /// <summary>

--- a/src/Http/Headers/test/RangeItemHeaderValueTest.cs
+++ b/src/Http/Headers/test/RangeItemHeaderValueTest.cs
@@ -121,13 +121,13 @@ public class RangeItemHeaderValueTest
     [InlineData("-9999999999999999999")] // 19-digit numbers outside the Int64 range.
     public void TryParse_DifferentInvalidScenarios_AllReturnFalse(string input)
     {
-        RangeHeaderValue result;
+        RangeHeaderValue? result;
         Assert.False(RangeHeaderValue.TryParse("byte=" + input, out result));
     }
 
     private static void CheckValidTryParse(string input, long? expectedFrom, long? expectedTo)
     {
-        RangeHeaderValue result;
+        RangeHeaderValue? result;
         Assert.True(RangeHeaderValue.TryParse("byte=" + input, out result), input);
 
         var ranges = result.Ranges.ToArray();
@@ -141,7 +141,7 @@ public class RangeItemHeaderValueTest
 
     private static void CheckValidTryParse(string input, params Tuple<long?, long?>[] expectedRanges)
     {
-        RangeHeaderValue result;
+        RangeHeaderValue? result;
         Assert.True(RangeHeaderValue.TryParse("byte=" + input, out result), input);
 
         var ranges = result.Ranges.ToArray();

--- a/src/Middleware/ResponseCaching/src/ResponseCachingMiddleware.cs
+++ b/src/Middleware/ResponseCaching/src/ResponseCachingMiddleware.cs
@@ -438,7 +438,7 @@ public class ResponseCachingMiddleware
                 return true;
             }
 
-            EntityTagHeaderValue eTag;
+            EntityTagHeaderValue?    eTag;
             if (!StringValues.IsNullOrEmpty(cachedResponseHeaders.ETag)
                 && EntityTagHeaderValue.TryParse(cachedResponseHeaders.ETag.ToString(), out eTag)
                 && EntityTagHeaderValue.TryParseList(ifNoneMatchHeader, out var ifNoneMatchEtags))

--- a/src/Middleware/ResponseCaching/src/ResponseCachingMiddleware.cs
+++ b/src/Middleware/ResponseCaching/src/ResponseCachingMiddleware.cs
@@ -438,7 +438,7 @@ public class ResponseCachingMiddleware
                 return true;
             }
 
-            EntityTagHeaderValue?    eTag;
+            EntityTagHeaderValue? eTag;
             if (!StringValues.IsNullOrEmpty(cachedResponseHeaders.ETag)
                 && EntityTagHeaderValue.TryParse(cachedResponseHeaders.ETag.ToString(), out eTag)
                 && EntityTagHeaderValue.TryParseList(ifNoneMatchHeader, out var ifNoneMatchEtags))


### PR DESCRIPTION
This matches the other TryParse signatures in the same assembly to reflect the reality of potentially returning null on error.
