### PR TITLE
Add explicit reference to `Microsoft.Bcl.AsyncInterfaces` in HealthChecks

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -274,6 +274,10 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>e7926d6bb96976d9fc7aa1ac0a4e7a40f965b688</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0-preview.3.23152.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>e7926d6bb96976d9fc7aa1ac0a4e7a40f965b688</Sha>
+    </Dependency>
     <!--
          Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
          All Runtime.$rid packages should have the same version.

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -125,6 +125,7 @@
     <SystemThreadingRateLimitingVersion>8.0.0-preview.3.23152.1</SystemThreadingRateLimitingVersion>
     <!-- Only listed explicitly to workaround https://github.com/dotnet/cli/issues/10528 -->
     <MicrosoftNETCorePlatformsVersion>8.0.0-preview.3.23152.1</MicrosoftNETCorePlatformsVersion>
+    <MicrosoftBclAsyncInterfacesVersion>8.0.0-preview.3.23152.1</MicrosoftBclAsyncInterfacesVersion>
     <!-- Packages from dotnet/efcore -->
     <dotnetefVersion>8.0.0-preview.3.23152.4</dotnetefVersion>
     <MicrosoftEntityFrameworkCoreInMemoryVersion>8.0.0-preview.3.23152.4</MicrosoftEntityFrameworkCoreInMemoryVersion>
@@ -186,7 +187,6 @@
     <MicrosoftAspNetCoreMvcRazorExtensionsVersion>6.0.0</MicrosoftAspNetCoreMvcRazorExtensionsVersion>
     <MicrosoftCodeAnalysisRazorVersion>6.0.0</MicrosoftCodeAnalysisRazorVersion>
     <!-- Partner teams -->
-    <MicrosoftBclAsyncInterfacesVersion>8.0.0-preview.2.23126.3</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftBCLHashCodeVersion>1.1.1</MicrosoftBCLHashCodeVersion>
     <MicrosoftBuildVersion>17.4.0</MicrosoftBuildVersion>
     <MicrosoftAzureSignalRVersion>1.2.0</MicrosoftAzureSignalRVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -186,7 +186,7 @@
     <MicrosoftAspNetCoreMvcRazorExtensionsVersion>6.0.0</MicrosoftAspNetCoreMvcRazorExtensionsVersion>
     <MicrosoftCodeAnalysisRazorVersion>6.0.0</MicrosoftCodeAnalysisRazorVersion>
     <!-- Partner teams -->
-    <MicrosoftBclAsyncInterfacesVersion>1.0.0</MicrosoftBclAsyncInterfacesVersion>
+    <MicrosoftBclAsyncInterfacesVersion>8.0.0-preview.2.23126.3</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftBCLHashCodeVersion>1.1.1</MicrosoftBCLHashCodeVersion>
     <MicrosoftBuildVersion>17.4.0</MicrosoftBuildVersion>
     <MicrosoftAzureSignalRVersion>1.2.0</MicrosoftAzureSignalRVersion>

--- a/src/HealthChecks/HealthChecks/src/Microsoft.Extensions.Diagnostics.HealthChecks.csproj
+++ b/src/HealthChecks/HealthChecks/src/Microsoft.Extensions.Diagnostics.HealthChecks.csproj
@@ -33,6 +33,9 @@ Microsoft.Extensions.Diagnostics.HealthChecks.IHealthChecksBuilder
     <Reference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <Reference Include="Microsoft.Extensions.Options" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
+
+    <!-- See: https://github.com/dotnet/aspnetcore/issues/46683 -->
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Add explicit reference to `Microsoft.Bcl.AsyncInterfaces` in HealthChecks

Addresses #46683 by adding an explicit reference to `Microsoft.Bcl.AsyncInterfaces` from `Microsoft.Extensions.Diagnostics.HealthChecks` when the target framework is `netstandard2.0`.

Opening initially as a draft PR to gather feedback.