### PR TITLE
Revert "Update SDK (#46919)"

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.3.23127.4"
+    "version": "8.0.100-preview.2.23124.1"
   },
   "tools": {
-    "dotnet": "8.0.100-preview.3.23127.4",
+    "dotnet": "8.0.100-preview.2.23124.1",
     "runtimes": {
       "dotnet/x86": [
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"


### PR DESCRIPTION
Reverting SDK version due to CI build failures:

```
Processing binlog D:\a\_work\1\s/artifacts/log/Release/Build.binlog into solution at directory D:\a\_work\1\a/sourceIndex/
Unhandled exception. System.NotSupportedException: Unsupported log file format. Latest supported version is 15, the log file has version 16.
   at Microsoft.Build.Logging.StructuredLogger.BinLogReader.Replay(Stream stream, Progress progress) in C:\MSBuildStructuredLog\src\StructuredLogger\BinaryLogger\BinLogReader.cs:line 74
   at Microsoft.Build.Logging.StructuredLogger.BinLogReader.Replay(String sourceFilePath, Progress progress) in C:\MSBuildStructuredLog\src\StructuredLogger\BinaryLogger\BinLogReader.cs:line 50
   at Microsoft.Build.Logging.StructuredLogger.BinLogReader.Replay(String sourceFilePath) in C:\MSBuildStructuredLog\src\StructuredLogger\BinaryLogger\BinLogReader.cs:line 39
   at Microsoft.SourceBrowser.BinLogParser.BinLogCompilerInvocationsReader.<>c__DisplayClass1_0.<ExtractInvocations>b__0() in D:\a\_work\1\s\src\SourceBrowser\src\BinLogParser\BinLogReader.cs:line 58
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
   at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.get_Value()
   at Microsoft.SourceBrowser.BinLogParser.BinLogCompilerInvocationsReader.ExtractInvocations(String binLogFilePath) in D:\a\_work\1\s\src\SourceBrowser\src\BinLogParser\BinLogReader.cs:line 63
   at BinLogToSln.Program.Main(String[] args) in D:\a\_work\1\s\src\SourceBrowser\src\BinLogToSln\Program.cs:line 77
```

Last time this happened we needed to do this:

https://github.com/dotnet/aspnetcore/pull/45982

However it can take a few days to get the package updated in the feed, hence the revert.