### PR TITLE
Enable linux-musl composite artifact and rename to match the Blob convention

### DIFF
--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -179,7 +179,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <InternalArchiveOutputPath>$(InstallersOutputPath)$(InternalArchiveOutputFileName)</InternalArchiveOutputPath>
     <RedistArchiveOutputFileName>$(RuntimeInstallerBaseName)-$(PackageVersion)-$(TargetRuntimeIdentifier)$(ArchiveExtension)</RedistArchiveOutputFileName>
     <RedistArchiveOutputPath>$(InstallersOutputPath)$(RedistArchiveOutputFileName)</RedistArchiveOutputPath>
-    <CompositeArchiveOutputFileName>$(RuntimeInstallerBaseName)-$(PackageVersion)-$(TargetRuntimeIdentifier)-composite$(ArchiveExtension)</CompositeArchiveOutputFileName>
+    <CompositeArchiveOutputFileName>$(RuntimeInstallerBaseName)-composite-$(PackageVersion)-$(TargetRuntimeIdentifier)$(ArchiveExtension)</CompositeArchiveOutputFileName>
     <CompositeArchiveOutputPath>$(InstallersOutputPath)$(CompositeArchiveOutputFileName)</CompositeArchiveOutputPath>
   </PropertyGroup>
 
@@ -478,7 +478,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   </Target>
 
   <Target Name="_GenerateComposites"
-          Condition="'$(TargetOsName)' == 'linux'"
+          Condition="'$(BuildOsName)' == 'linux'"
           DependsOnTargets="_ExpandRuntimePackageRoot">
 
     <PropertyGroup>


### PR DESCRIPTION
# Changes to Composite Artifacts

Enable linux-musl composite artifact and rename to match the Blob convention

## Description

This change enables the generation of the composite artifacts for linux-musl, in addition to x64 and ARM64 Linux. Also, it changes the name under which these composite artifacts are generated. For example:

- From: aspnetcore-runtime-8.0.0-preview.2.23128.10-linux-x64-composite.tar.gz
- To: aspnetcore-runtime-composite-8.0.0-preview.2.23128.10-linux-x64.tar.gz

The motivations for these changes is that the .NET Docker Images require the artifacts they use to follow that naming convention. As for the linux-musl change, there is a request from them to generate it as well.