### PR TITLE
Remove some Linq usages from Routing

### DIFF
--- a/src/Http/Routing/src/EndpointNameAddressScheme.cs
+++ b/src/Http/Routing/src/EndpointNameAddressScheme.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Linq;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 
@@ -52,11 +51,17 @@ internal sealed class EndpointNameAddressScheme : IEndpointAddressScheme<string>
                 entries[endpointName] = new[] { endpoint };
                 continue;
             }
+            else
+            {
+                // Ok this is a duplicate, because we have two endpoints with the same name. Collect all the data
+                // so we can throw an exception. The extra allocations here don't matter since this is an exceptional case.
+                hasDuplicates = true;
 
-            // Ok this is a duplicate, because we have two endpoints with the same name. Bail out, because we
-            // are just going to throw, we don't need to finish collecting data.
-            hasDuplicates = true;
-            break;
+                var newEntry = new Endpoint[existing.Length + 1];
+                Array.Copy(existing, newEntry, existing.Length);
+                newEntry[existing.Length] = endpoint;
+                entries[endpointName] = newEntry;
+            }
         }
 
         if (!hasDuplicates)
@@ -66,21 +71,20 @@ internal sealed class EndpointNameAddressScheme : IEndpointAddressScheme<string>
         }
 
         // OK we need to report some duplicates.
-        var duplicates = endpoints
-            .GroupBy(GetEndpointName)
-            .Where(g => g.Key != null && g.Count() > 1);
-
         var builder = new StringBuilder();
         builder.AppendLine(Resources.DuplicateEndpointNameHeader);
 
-        foreach (var group in duplicates)
+        foreach (var group in entries)
         {
-            builder.AppendLine();
-            builder.AppendLine(Resources.FormatDuplicateEndpointNameEntry(group.Key));
-
-            foreach (var endpoint in group)
+            if (group.Key is not null && group.Value.Length > 1)
             {
-                builder.AppendLine(endpoint.DisplayName);
+                builder.AppendLine();
+                builder.AppendLine(Resources.FormatDuplicateEndpointNameEntry(group.Key));
+
+                foreach (var endpoint in group.Value)
+                {
+                    builder.AppendLine(endpoint.DisplayName);
+                }
             }
         }
 

--- a/src/Http/Routing/src/Matching/AcceptsMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/AcceptsMatcherPolicy.cs
@@ -236,9 +236,13 @@ internal sealed class AcceptsMatcherPolicy : MatcherPolicy, IEndpointComparerPol
             edges.Add(string.Empty, anyEndpoints.ToList());
         }
 
-        return edges
-            .Select(kvp => new PolicyNodeEdge(kvp.Key, kvp.Value))
-            .ToArray();
+        var result = new PolicyNodeEdge[edges.Count];
+        var index = 0;
+        foreach (var kvp in edges)
+        {
+            result[index++] = new PolicyNodeEdge(kvp.Key, kvp.Value);
+        }
+        return result;
     }
 
     private static Endpoint CreateRejectionEndpoint()
@@ -258,10 +262,13 @@ internal sealed class AcceptsMatcherPolicy : MatcherPolicy, IEndpointComparerPol
 
         // Since our 'edges' can have wildcards, we do a sort based on how wildcard-ey they
         // are then then execute them in linear order.
-        var ordered = edges
-            .Select(e => (mediaType: CreateEdgeMediaType(ref e), destination: e.Destination))
-            .OrderBy(e => GetScore(e.mediaType))
-            .ToArray();
+        var ordered = new (ReadOnlyMediaTypeHeaderValue mediaType, int destination)[edges.Count];
+        for (int i = 0; i < edges.Count; i++)
+        {
+            PolicyJumpTableEdge e = edges[i];
+            ordered[i] = (mediaType: CreateEdgeMediaType(ref e), destination: e.Destination);
+        }
+        Array.Sort(ordered, (left, right) => GetScore(left.mediaType).CompareTo(GetScore(right.mediaType)));
 
         // If any edge matches all content types, then treat that as the 'exit'. This will
         // always happen because we insert a 415 endpoint.

--- a/src/Http/Routing/src/Matching/AcceptsMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/AcceptsMatcherPolicy.cs
@@ -264,9 +264,9 @@ internal sealed class AcceptsMatcherPolicy : MatcherPolicy, IEndpointComparerPol
         // Since our 'edges' can have wildcards, we do a sort based on how wildcard-ey they
         // are then then execute them in linear order.
         var ordered = new (ReadOnlyMediaTypeHeaderValue mediaType, int destination)[edges.Count];
-        for (int i = 0; i < edges.Count; i++)
+        for (var i = 0; i < edges.Count; i++)
         {
-            PolicyJumpTableEdge e = edges[i];
+            var e = edges[i];
             ordered[i] = (mediaType: CreateEdgeMediaType(ref e), destination: e.Destination);
         }
         Array.Sort(ordered, static (left, right) => GetScore(left.mediaType).CompareTo(GetScore(right.mediaType)));

--- a/src/Http/Routing/src/Matching/AcceptsMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/AcceptsMatcherPolicy.cs
@@ -240,7 +240,8 @@ internal sealed class AcceptsMatcherPolicy : MatcherPolicy, IEndpointComparerPol
         var index = 0;
         foreach (var kvp in edges)
         {
-            result[index++] = new PolicyNodeEdge(kvp.Key, kvp.Value);
+            result[index] = new PolicyNodeEdge(kvp.Key, kvp.Value);
+            index++;
         }
         return result;
     }
@@ -268,7 +269,7 @@ internal sealed class AcceptsMatcherPolicy : MatcherPolicy, IEndpointComparerPol
             PolicyJumpTableEdge e = edges[i];
             ordered[i] = (mediaType: CreateEdgeMediaType(ref e), destination: e.Destination);
         }
-        Array.Sort(ordered, (left, right) => GetScore(left.mediaType).CompareTo(GetScore(right.mediaType)));
+        Array.Sort(ordered, static (left, right) => GetScore(left.mediaType).CompareTo(GetScore(right.mediaType)));
 
         // If any edge matches all content types, then treat that as the 'exit'. This will
         // always happen because we insert a 415 endpoint.

--- a/src/Http/Routing/src/Matching/HostMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/HostMatcherPolicy.cs
@@ -291,7 +291,7 @@ public sealed class HostMatcherPolicy : MatcherPolicy, IEndpointComparerPolicy, 
         // Since our 'edges' can have wildcards, we do a sort based on how wildcard-ey they
         // are then then execute them in linear order.
         var ordered = new (EdgeKey host, int destination)[edges.Count];
-        for (int i = 0; i < edges.Count; i++)
+        for (var i = 0; i < edges.Count; i++)
         {
             PolicyJumpTableEdge e = edges[i];
             ordered[i] = (host: (EdgeKey)e.State, destination: e.Destination);

--- a/src/Http/Routing/src/Matching/HostMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/HostMatcherPolicy.cs
@@ -263,7 +263,8 @@ public sealed class HostMatcherPolicy : MatcherPolicy, IEndpointComparerPolicy, 
         var index = 0;
         foreach (var kvp in edges)
         {
-            result[index++] = new PolicyNodeEdge(kvp.Key, kvp.Value);
+            result[index] = new PolicyNodeEdge(kvp.Key, kvp.Value);
+            index++;
         }
         return result;
     }
@@ -295,7 +296,7 @@ public sealed class HostMatcherPolicy : MatcherPolicy, IEndpointComparerPolicy, 
             PolicyJumpTableEdge e = edges[i];
             ordered[i] = (host: (EdgeKey)e.State, destination: e.Destination);
         }
-        Array.Sort(ordered, (left, right) => GetScore(left.host).CompareTo(GetScore(right.host)));
+        Array.Sort(ordered, static (left, right) => GetScore(left.host).CompareTo(GetScore(right.host)));
 
         return new HostPolicyJumpTable(exitDestination, ordered);
     }

--- a/src/Http/Routing/src/ParameterPolicyActivator.cs
+++ b/src/Http/Routing/src/ParameterPolicyActivator.cs
@@ -163,7 +163,7 @@ internal static class ParameterPolicyActivator
 
         foreach (var constructor in constructors)
         {
-            int length = constructor.GetParameters().Length;
+            var length = constructor.GetParameters().Length;
             if (length > longestLength)
             {
                 multipleBestLengthFound = false;

--- a/src/Http/Routing/src/ParameterPolicyActivator.cs
+++ b/src/Http/Routing/src/ParameterPolicyActivator.cs
@@ -1,9 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -93,8 +93,8 @@ internal static class ParameterPolicyActivator
     [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070", Justification = "We ensure the constructor is preserved when the constraint map is added.")]
     private static IParameterPolicy CreateParameterPolicy(IServiceProvider? serviceProvider, Type parameterPolicyType, string? argumentString)
     {
-        ConstructorInfo? activationConstructor = null;
-        object?[]? parameters = null;
+        ConstructorInfo? activationConstructor;
+        object?[]? parameters;
         var constructors = parameterPolicyType.GetConstructors();
 
         // If there is only one constructor and it has a single parameter, pass the argument string directly
@@ -113,12 +113,9 @@ internal static class ParameterPolicyActivator
             // arguments that can be resolved from DI
             //
             // For example, ctor(string, IService) will beat ctor(string)
-            var matchingConstructors = constructors
-                .Where(ci => GetNonConvertableParameterTypeCount(serviceProvider, ci.GetParameters()) == arguments.Length)
-                .OrderByDescending(ci => ci.GetParameters().Length)
-                .ToArray();
+            var matchingConstructors = GetMatchingConstructors(constructors, serviceProvider, arguments.Length);
 
-            if (matchingConstructors.Length == 0)
+            if (matchingConstructors.Count == 0)
             {
                 throw new RouteCreationException(
                             Resources.FormatDefaultInlineConstraintResolver_CouldNotFindCtor(
@@ -126,17 +123,14 @@ internal static class ParameterPolicyActivator
             }
             else
             {
-                // When there are multiple matching constructors, choose the one with the most service arguments
-                if (matchingConstructors.Length == 1
-                    || matchingConstructors[0].GetParameters().Length > matchingConstructors[1].GetParameters().Length)
+                if (matchingConstructors.Count == 1)
                 {
                     activationConstructor = matchingConstructors[0];
                 }
                 else
                 {
-                    throw new RouteCreationException(
-                                Resources.FormatDefaultInlineConstraintResolver_AmbiguousCtors(
-                                                       parameterPolicyType.Name, matchingConstructors[0].GetParameters().Length));
+                    // When there are multiple matching constructors, choose the one with the most service arguments
+                    activationConstructor = GetLongestConstructor(matchingConstructors, parameterPolicyType);
                 }
 
                 parameters = ConvertArguments(serviceProvider, activationConstructor.GetParameters(), arguments);
@@ -144,6 +138,52 @@ internal static class ParameterPolicyActivator
         }
 
         return (IParameterPolicy)activationConstructor.Invoke(parameters);
+    }
+
+    private static List<ConstructorInfo> GetMatchingConstructors(ConstructorInfo[] constructors, IServiceProvider? serviceProvider, int argumentsLength)
+    {
+        var result = new List<ConstructorInfo>();
+        foreach (var constructor in constructors)
+        {
+            if (GetNonConvertableParameterTypeCount(serviceProvider, constructor.GetParameters()) == argumentsLength)
+            {
+                result.Add(constructor);
+            }
+        }
+        return result;
+    }
+
+    private static ConstructorInfo GetLongestConstructor(List<ConstructorInfo> constructors, Type parameterPolicyType)
+    {
+        Debug.Assert(constructors.Count > 0);
+
+        var longestLength = -1;
+        ConstructorInfo? longest = null;
+        var multipleBestLengthFound = false;
+
+        foreach (var constructor in constructors)
+        {
+            int length = constructor.GetParameters().Length;
+            if (length > longestLength)
+            {
+                multipleBestLengthFound = false;
+                longestLength = length;
+                longest = constructor;
+            }
+            else if (longestLength == length)
+            {
+                multipleBestLengthFound = true;
+            }
+        }
+
+        if (multipleBestLengthFound)
+        {
+            throw new RouteCreationException(
+                        Resources.FormatDefaultInlineConstraintResolver_AmbiguousCtors(
+                                               parameterPolicyType.Name, longestLength));
+        }
+
+        return longest!;
     }
 
     private static int GetNonConvertableParameterTypeCount(IServiceProvider? serviceProvider, ParameterInfo[] parameters)

--- a/src/Http/Routing/src/Template/RouteTemplate.cs
+++ b/src/Http/Routing/src/Template/RouteTemplate.cs
@@ -28,7 +28,14 @@ public class RouteTemplate
         // RequiredValues will be ignored. RouteTemplate doesn't support them.
 
         TemplateText = other.RawText;
-        Segments = new List<TemplateSegment>(other.PathSegments.Select(p => new TemplateSegment(p)));
+
+        var segments = new List<TemplateSegment>(other.PathSegments.Count);
+        foreach (var p in other.PathSegments)
+        {
+            segments.Add(new TemplateSegment(p));
+        }
+        Segments = segments;
+
         Parameters = new List<TemplatePart>();
         for (var i = 0; i < Segments.Count; i++)
         {

--- a/src/Http/Routing/src/Template/RouteTemplate.cs
+++ b/src/Http/Routing/src/Template/RouteTemplate.cs
@@ -29,12 +29,11 @@ public class RouteTemplate
 
         TemplateText = other.RawText;
 
-        var segments = new List<TemplateSegment>(other.PathSegments.Count);
+        Segments = new List<TemplateSegment>(other.PathSegments.Count);
         foreach (var p in other.PathSegments)
         {
-            segments.Add(new TemplateSegment(p));
+            Segments.Add(new TemplateSegment(p));
         }
-        Segments = segments;
 
         Parameters = new List<TemplatePart>();
         for (var i = 0; i < Segments.Count; i++)


### PR DESCRIPTION
These Linq usages account for roughly 150KB of the 770KB of NativeAOT app size attributed to Routing code. The largest usages are the ones where we are using ValueTypes (like ValueType and KeyValuePair) over internal types. The size savings helps even if the app is using Linq because the generic instantiation will never be brought back into the app.

On Windows x64, the [BasicMinimalApi](https://github.com/aspnet/Benchmarks/tree/main/src/BenchmarksApps/BasicMinimalApi) using `EnableRequestDelegateGenerator=true`, the app size goes from:

**main**: 9.70 MB (10,179,584 bytes)
**PR**: 9.56 MB (10,024,960 bytes)