### PR TITLE
Fix warnings about dependabot.yml errors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
     schedule:
       day: friday
       interval: "weekly"
-      time: 05:00
+      time: "05:00"
       timezone: "America/Los_Angeles"
     commit-message:
       prefix: "[main] "
@@ -35,7 +35,7 @@ updates:
     schedule:
       day: friday
       interval: "weekly"
-      time: 05:00
+      time: "05:00"
       timezone: "America/Los_Angeles"
     allow:
       - dependency-type: "all"


### PR DESCRIPTION
- avoid "The property '#/updates/1/schedule/time' of type integer did not match the following type: string"
  - started showing up in pull request checks