### PR TITLE
Set up TryParse blocks for explicit header parameters.

### DIFF
--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
@@ -48,6 +48,8 @@ internal class EndpointParameter
             Source = EndpointParameterSource.Header;
             Name = GetParameterName(fromHeaderAttribute, parameter.Name);
             IsOptional = parameter.IsOptional();
+            IsParsable = TryGetParsability(parameter, wellKnownTypes, out var parsingBlockEmitter);
+            ParsingBlockEmitter = parsingBlockEmitter;
         }
         else if (TryGetExplicitFromJsonBody(parameter, wellKnownTypes, out var isOptional))
         {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateGeneratorTests.cs
@@ -220,6 +220,25 @@ app.MapGet("/{routeValue}", (HttpContext context, [FromRoute]{{typeName}} routeV
 
     [Theory]
     [MemberData(nameof(TryParsableParameters))]
+    public async Task MapAction_TryParsableExplicitHeaderParameters(string typeName, string headerValue, object expectedParameterValue)
+    {
+        var (results, compilation) = await RunGeneratorAsync($$"""
+app.MapGet("/", (HttpContext context, [FromHeader]{{typeName}} headerValue) =>
+{
+    context.Items["tryParsable"] = headerValue;
+});
+""");
+        var endpoint = GetEndpointFromCompilation(compilation);
+        var httpContext = CreateHttpContext();
+        httpContext.Request.Headers["headerValue"] = headerValue;
+
+        await endpoint.RequestDelegate(httpContext);
+        Assert.Equal(200, httpContext.Response.StatusCode);
+        Assert.Equal(expectedParameterValue, httpContext.Items["tryParsable"]);
+    }
+
+    [Theory]
+    [MemberData(nameof(TryParsableParameters))]
     public async Task MapAction_SingleParsable_StringReturn(string typeName, string queryStringInput, object expectedParameterValue)
     {
         var (results, compilation) = await RunGeneratorAsync($$"""


### PR DESCRIPTION
Adds TryParse support for explicit header parameters. Part of #46696 