### PR TITLE
Update SDK to 8.0.100-preview.3.23156.3

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.3.23127.4"
+    "version": "8.0.100-preview.3.23156.3"
   },
   "tools": {
-    "dotnet": "8.0.100-preview.3.23127.4",
+    "dotnet": "8.0.100-preview.3.23156.3",
     "runtimes": {
       "dotnet/x86": [
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"


### PR DESCRIPTION
From https://github.com/dotnet/aspnetcore-internal/issues/4250

> If your rotation falls on a Monday, update the SDK version in both [aspnetcore](https://github.com/dotnet/aspnetcore/blob/main/global.json) and [efcore](https://github.com/dotnet/efcore/blob/main/global.json) to the [latest available nightly](https://github.com/dotnet/installer)