### PR TITLE
Set InvariantGlobalization in api template

### DIFF
--- a/src/ProjectTemplates/Shared/Project.cs
+++ b/src/ProjectTemplates/Shared/Project.cs
@@ -352,6 +352,16 @@ public class Project : IDisposable
         }
     }
 
+    public async Task VerifyHasProperty(string propertyName, string expectedValue)
+    {
+        var projectFile = Directory.EnumerateFiles(TemplateOutputDir, "*proj").FirstOrDefault();
+
+        Assert.NotNull(projectFile);
+
+        var projectFileContents = await File.ReadAllTextAsync(projectFile);
+        Assert.Contains($"<{propertyName}>{expectedValue}</{propertyName}>", projectFileContents);
+    }
+
     public string ReadFile(string path)
     {
         AssertFileExists(path, shouldExist: true);

--- a/src/ProjectTemplates/Web.ProjectTemplates/Api-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/Api-CSharp.csproj.in
@@ -7,6 +7,7 @@
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">true</NoDefaultLaunchSettingsFile>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
     <ServerGarbageCollection>false</ServerGarbageCollection>
+    <InvariantGlobalization>true</InvariantGlobalization>
     <!--#if (NativeAot) -->
     <PublishAot>true</PublishAot>
     <!--#endif -->

--- a/src/ProjectTemplates/Web.ProjectTemplates/GrpcService-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/GrpcService-CSharp.csproj.in
@@ -4,6 +4,7 @@
     <TargetFramework>${DefaultNetCoreTargetFramework}</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
     <!--#if (NativeAot) -->
     <PublishAot>true</PublishAot>
     <!--#endif -->

--- a/src/ProjectTemplates/Web.ProjectTemplates/WebApi-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/WebApi-CSharp.csproj.in
@@ -4,6 +4,7 @@
     <TargetFramework>${DefaultNetCoreTargetFramework}</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
     <UserSecretsId Condition="'$(IndividualAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'">aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>

--- a/src/ProjectTemplates/Web.ProjectTemplates/WebApi-FSharp.fsproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/WebApi-FSharp.fsproj.in
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>${DefaultNetCoreTargetFramework}</TargetFramework>
+    <InvariantGlobalization>true</InvariantGlobalization>
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
   </PropertyGroup>

--- a/src/ProjectTemplates/Web.ProjectTemplates/Worker-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/Worker-CSharp.csproj.in
@@ -4,6 +4,7 @@
     <TargetFramework>${DefaultNetCoreTargetFramework}</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
     <UserSecretsId>dotnet-Company.Application1-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.Application1</RootNamespace>

--- a/src/ProjectTemplates/Web.ProjectTemplates/Worker-FSharp.fsproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/Worker-FSharp.fsproj.in
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>${DefaultNetCoreTargetFramework}</TargetFramework>
     <UserSecretsId>dotnet-Company.Application1-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>
+    <InvariantGlobalization>true</InvariantGlobalization>
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.Application1</RootNamespace>
   </PropertyGroup>

--- a/src/ProjectTemplates/test/Templates.Tests/ApiTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/ApiTemplateTest.cs
@@ -65,6 +65,8 @@ public class ApiTemplateTest : LoggedTest
             : new[] { "http", "IIS Express" };
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
+        await project.VerifyHasProperty("InvariantGlobalization", "true");
+
         // Avoid the F# compiler. See https://github.com/dotnet/aspnetcore/issues/14022
         if (languageOverride != null)
         {

--- a/src/ProjectTemplates/test/Templates.Tests/GrpcTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/GrpcTemplateTest.cs
@@ -75,6 +75,8 @@ public class GrpcTemplateTest : LoggedTest
         var expectedLaunchProfileNames = new[] { "http", "https" };
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
+        await project.VerifyHasProperty("InvariantGlobalization", "true");
+
         await project.RunDotNetPublishAsync();
 
         await project.RunDotNetBuildAsync();

--- a/src/ProjectTemplates/test/Templates.Tests/WorkerTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/WorkerTemplateTest.cs
@@ -40,6 +40,8 @@ public class WorkerTemplateTest : LoggedTest
 
         await project.RunDotNetNewAsync("worker", language: language, args: args);
 
+        await project.VerifyHasProperty("InvariantGlobalization", "true");
+
         await project.RunDotNetPublishAsync();
 
         // Run dotnet build after publish. The reason is that one uses Config = Debug and the other uses Config = Release


### PR DESCRIPTION
API server applications do not typically need culture aware behavior. A better default is to use invariant globalization mode for API apps.

This allows for the globalization code to be trimmed away, making the final executable size smaller. It also reduces startup and memory consumption because ICU isn't loaded.

This also allows the apps to run with consistent behavior on container images that don't include ICU, making the container image smaller as well.

Fix #47029
