### PR TITLE
Add the standard set of TryParsable tests to implicity route/query.

### DIFF
--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
@@ -74,7 +74,6 @@ internal class EndpointParameter
         }
         else
         {
-            // TODO: Inferencing rules go here - but for now:
             Source = EndpointParameterSource.Unknown;
         }
     }


### PR DESCRIPTION
This PR just makes use of all the TryParsable test cases and runs them through an implicit route parameter and query parameter scenario. It relies on existing behavior but adds explcit coverage.