### PR TITLE
Skip HelixPlatform_QuickListenerIsSupported on win-arm64

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
@@ -30,7 +30,7 @@ public class WebHostTests : LoggedTest
     [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/46616;https://github.com/dotnet/aspnetcore/issues/47065", Queues = "Debian.12.Arm64.Open;Windows.Amd64.Server2022.Open")]
     [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "HTTP/3 isn't supported on MacOS.")]
     [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win11_21H2)]
-    public void HelixPlatform_QuickListenerIsSupported()
+    public void HelixPlatform_QuicListenerIsSupported()
     {
         Assert.True(QuicListener.IsSupported, "QuicListener.IsSupported should be true.");
         Assert.True(new MsQuicSupportedAttribute().IsMet, "MsQuicSupported.IsMet should be true.");

--- a/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
@@ -27,7 +27,7 @@ public class WebHostTests : LoggedTest
     [SkipNonHelix]
     [SkipOnAlpine("https://github.com/dotnet/aspnetcore/issues/46537")]
     [SkipOnMariner("https://github.com/dotnet/aspnetcore/issues/46537")]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/46616", Queues = "Debian.12.Arm64.Open;")]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/46616;https://github.com/dotnet/aspnetcore/issues/47065", Queues = "Debian.12.Arm64.Open;Windows.Amd64.Server2022.Open")]
     [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "HTTP/3 isn't supported on MacOS.")]
     [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win11_21H2)]
     public void HelixPlatform_QuickListenerIsSupported()


### PR DESCRIPTION
The current version of msquic doesn't have win-arm64 binaries. See https://github.com/dotnet/msquic/pull/131.

Issues tracking re-enabling the test is https://github.com/dotnet/aspnetcore/issues/47065