### PR TITLE
Add generic variants of MVC attributes

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
@@ -2456,7 +2456,7 @@ public class DefaultApiDescriptionProviderTest
     }
 
     // This will show up as source = unknown
-    private void AcceptsProduct_Custom([ModelBinder(BinderType = typeof(BodyModelBinder))] Product product)
+    private void AcceptsProduct_Custom([ModelBinder<BodyModelBinder>] Product product)
     {
     }
 
@@ -2556,7 +2556,7 @@ public class DefaultApiDescriptionProviderTest
     {
     }
 
-    private void FromCustom([ModelBinder(typeof(BodyModelBinder))] int id)
+    private void FromCustom([ModelBinder<BodyModelBinder>] int id)
     {
     }
 

--- a/src/Mvc/Mvc.Core/src/Filters/MiddlewareFilterOfTAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/Filters/MiddlewareFilterOfTAttribute.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Mvc;
+
+/// <inheritdoc />
+/// <typeparam name="T">A type which configures a middleware pipeline.</typeparam>
+public class MiddlewareFilterAttribute<T> : MiddlewareFilterAttribute
+{
+    /// <summary>
+    /// Instantiates a new instance of <see cref="MiddlewareFilterAttribute"/>.
+    /// </summary>
+    public MiddlewareFilterAttribute() : base(typeof(T)) { }
+}

--- a/src/Mvc/Mvc.Core/src/ModelBinderOfTAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinderOfTAttribute.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Microsoft.AspNetCore.Mvc;
+
+/// <inheritdoc />
+/// <typeparam name="TBinder">A <see cref="Type"/> which implements <see cref="IModelBinder"/>.</typeparam>
+/// <remarks>
+/// This is a derived generic variant of the <see cref="ModelBinderAttribute"/>.
+/// Ensure that only one instance of either attribute is provided on the target.
+/// </remarks>
+public class ModelBinderAttribute<TBinder> : ModelBinderAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="ModelBinderAttribute"/>.
+    /// </summary>
+    /// <remarks>
+    /// Subclass this attribute and set <see cref="BindingSource"/> if <see cref="BindingSource.Custom"/> is not
+    /// correct for the specified type parameter.
+    /// </remarks>
+    public ModelBinderAttribute() : base(typeof(TBinder)) { }
+}

--- a/src/Mvc/Mvc.Core/src/ModelBinderOfTAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinderOfTAttribute.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Mvc;
 /// This is a derived generic variant of the <see cref="ModelBinderAttribute"/>.
 /// Ensure that only one instance of either attribute is provided on the target.
 /// </remarks>
-public class ModelBinderAttribute<TBinder> : ModelBinderAttribute
+public class ModelBinderAttribute<TBinder> : ModelBinderAttribute where TBinder : IModelBinder
 {
     /// <summary>
     /// Initializes a new instance of <see cref="ModelBinderAttribute"/>.

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/ModelAttributes.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/ModelAttributes.cs
@@ -214,6 +214,17 @@ public class ModelAttributes
 
     private static Type? GetMetadataType(Type type)
     {
-        return type.GetCustomAttribute<ModelMetadataTypeAttribute>()?.MetadataType;
+        // GetCustomAttribute will examine the members inheritance chain
+        // for attributes of a particular type by default. Meaning that
+        // in the following scenario, the `ModelMetadataType` attribute on
+        // both the derived _and_ base class will be returned.
+        // [ModelMetadataType<BaseModel>]
+        // private class BaseViewModel { }
+        // [ModelMetadataType<DerivedModel>]
+        // private class DerivedViewModel : BaseViewModel { }
+        // To avoid this, we call `GetCustomAttributes` directly
+        // to avoid examining the inheritance hierarchy.
+        // See https://source.dot.net/#System.Private.CoreLib/src/System/Attribute.CoreCLR.cs,677
+        return type.GetCustomAttributes<ModelMetadataTypeAttribute>(inherit: false).SingleOrDefault()?.MetadataType;
     }
 }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/ModelAttributes.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/ModelAttributes.cs
@@ -225,6 +225,14 @@ public class ModelAttributes
         // To avoid this, we call `GetCustomAttributes` directly
         // to avoid examining the inheritance hierarchy.
         // See https://source.dot.net/#System.Private.CoreLib/src/System/Attribute.CoreCLR.cs,677
-        return type.GetCustomAttributes<ModelMetadataTypeAttribute>(inherit: false).SingleOrDefault()?.MetadataType;
+        var modelMetadataTypeAttributes = type.GetCustomAttributes<ModelMetadataTypeAttribute>(inherit: false);
+        try
+        {
+            return modelMetadataTypeAttributes?.SingleOrDefault()?.MetadataType;
+        }
+        catch (InvalidOperationException e)
+        {
+            throw new InvalidOperationException("Only one ModelMetadataType attribute is permitted per type.", e);
+        }
     }
 }

--- a/src/Mvc/Mvc.Core/src/ModelMetadataTypeOfTAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ModelMetadataTypeOfTAttribute.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Mvc;
+
+/// <inheritdoc />
+/// <typeparam name="T">The type of metadata class that is associated with a data model class.</typeparam>
+/// <remarks>
+/// This is a derived generic variant of the <see cref="ModelMetadataTypeAttribute"/>
+/// which does not allow multiple instances on a single target.
+/// Ensure that only one instance of either attribute is provided on the target.
+/// </remarks>
+public class ModelMetadataTypeAttribute<T> : ModelMetadataTypeAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ModelMetadataTypeAttribute" /> class.
+    /// </summary>
+    public ModelMetadataTypeAttribute() : base(typeof(T)) { }
+}

--- a/src/Mvc/Mvc.Core/src/ProducesOfTAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ProducesOfTAttribute.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Mvc;
+
+/// <inheritdoc />
+/// <typeparam name="T">The <see cref="Type"/> of object that is going to be written in the response.</typeparam>
+/// <remarks>
+/// This is a derived generic variant of the <see cref="ProducesAttribute"/>.
+/// Ensure that only one instance of either attribute is provided on the target.
+/// </remarks>
+public class ProducesAttribute<T> : ProducesAttribute
+{
+    /// <summary>
+    /// Initializes an instance of <see cref="ProducesAttribute"/>.
+    /// </summary>
+    public ProducesAttribute() : base(typeof(T)) { }
+}

--- a/src/Mvc/Mvc.Core/src/ProducesResponseTypeOfTAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ProducesResponseTypeOfTAttribute.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Mvc;
+
+/// <inheritdoc />
+/// <typeparam name="T">The <see cref="Type"/> of object that is going to be written in the response.</typeparam>
+public class ProducesResponseTypeAttribute<T> : ProducesResponseTypeAttribute
+{
+    /// <summary>
+    /// Initializes an instance of <see cref="ProducesResponseTypeAttribute"/>.
+    /// </summary>
+    /// <param name="statusCode">The HTTP response status code.</param>
+    public ProducesResponseTypeAttribute(int statusCode) : base(typeof(T), statusCode) { }
+
+    /// <summary>
+    /// Initializes an instance of <see cref="ProducesResponseTypeAttribute"/>.
+    /// </summary>
+    /// <param name="statusCode">The HTTP response status code.</param>
+    /// <param name="contentType">The content type associated with the response.</param>
+    /// <param name="additionalContentTypes">Additional content types supported by the response.</param>
+    public ProducesResponseTypeAttribute(int statusCode, string contentType, params string[] additionalContentTypes)
+            : base(typeof(T), statusCode, contentType, additionalContentTypes) { }
+}

--- a/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
@@ -1,5 +1,20 @@
 #nullable enable
 *REMOVED*static Microsoft.AspNetCore.Routing.ControllerLinkGeneratorExtensions.GetUriByAction(this Microsoft.AspNetCore.Routing.LinkGenerator! generator, string! action, string! controller, object? values, string? scheme, Microsoft.AspNetCore.Http.HostString host, Microsoft.AspNetCore.Http.PathString pathBase = default(Microsoft.AspNetCore.Http.PathString), Microsoft.AspNetCore.Http.FragmentString fragment = default(Microsoft.AspNetCore.Http.FragmentString), Microsoft.AspNetCore.Routing.LinkOptions? options = null) -> string?
+Microsoft.AspNetCore.Mvc.MiddlewareFilterAttribute<T>
+Microsoft.AspNetCore.Mvc.MiddlewareFilterAttribute<T>.MiddlewareFilterAttribute() -> void
+Microsoft.AspNetCore.Mvc.ModelBinderAttribute<TBinder>
+Microsoft.AspNetCore.Mvc.ModelBinderAttribute<TBinder>.ModelBinderAttribute() -> void
+Microsoft.AspNetCore.Mvc.ModelMetadataTypeAttribute<T>
+Microsoft.AspNetCore.Mvc.ModelMetadataTypeAttribute<T>.ModelMetadataTypeAttribute() -> void
+Microsoft.AspNetCore.Mvc.ProducesAttribute<T>
+Microsoft.AspNetCore.Mvc.ProducesAttribute<T>.ProducesAttribute() -> void
+Microsoft.AspNetCore.Mvc.ProducesResponseTypeAttribute<T>
+Microsoft.AspNetCore.Mvc.ProducesResponseTypeAttribute<T>.ProducesResponseTypeAttribute(int statusCode) -> void
+Microsoft.AspNetCore.Mvc.ProducesResponseTypeAttribute<T>.ProducesResponseTypeAttribute(int statusCode, string! contentType, params string![]! additionalContentTypes) -> void
+Microsoft.AspNetCore.Mvc.ServiceFilterAttribute<TFilter>
+Microsoft.AspNetCore.Mvc.ServiceFilterAttribute<TFilter>.ServiceFilterAttribute() -> void
+Microsoft.AspNetCore.Mvc.TypeFilterAttribute<TFilter>
+Microsoft.AspNetCore.Mvc.TypeFilterAttribute<TFilter>.TypeFilterAttribute() -> void
 Microsoft.AspNetCore.Mvc.ValidationProblemDetails.Errors.set -> void
 static Microsoft.AspNetCore.Routing.ControllerLinkGeneratorExtensions.GetUriByAction(this Microsoft.AspNetCore.Routing.LinkGenerator! generator, string! action, string! controller, object? values, string! scheme, Microsoft.AspNetCore.Http.HostString host, Microsoft.AspNetCore.Http.PathString pathBase = default(Microsoft.AspNetCore.Http.PathString), Microsoft.AspNetCore.Http.FragmentString fragment = default(Microsoft.AspNetCore.Http.FragmentString), Microsoft.AspNetCore.Routing.LinkOptions? options = null) -> string?
 Microsoft.AspNetCore.Mvc.CreatedResult.CreatedResult() -> void

--- a/src/Mvc/Mvc.Core/src/ServiceFilterOfTAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ServiceFilterOfTAttribute.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Microsoft.AspNetCore.Mvc;
+
+/// <inheritdoc />
+/// <typeparam name="TFilter">The <see cref="Type"/> of filter to find.</typeparam>
+[DebuggerDisplay("ServiceFilter: Type={ServiceType} Order={Order}")]
+public class ServiceFilterAttribute<TFilter> : ServiceFilterAttribute where TFilter : IFilterMetadata
+{
+    /// <summary>
+    /// Instantiates a new <see cref="ServiceFilterAttribute"/> instance.
+    /// </summary>
+    public ServiceFilterAttribute() : base(typeof(TFilter)) { }
+}

--- a/src/Mvc/Mvc.Core/src/TypeFilterOfTAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/TypeFilterOfTAttribute.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Microsoft.AspNetCore.Mvc;
+
+/// <inheritdoc />
+/// <typeparam name="TFilter">The <see cref="Type"/> of filter to create.</typeparam>
+public class TypeFilterAttribute<TFilter> : TypeFilterAttribute where TFilter : IFilterMetadata
+{
+    /// <summary>
+    /// Instantiates a new <see cref="TypeFilterAttribute"/> instance.
+    /// </summary>
+    public TypeFilterAttribute() : base(typeof(TFilter)) { }
+}

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Metadata/ModelAttributesTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Metadata/ModelAttributesTest.cs
@@ -287,6 +287,18 @@ public class ModelAttributesTest
             attribute => Assert.IsType<ClassValidator>(attribute));
     }
 
+    [Fact]
+    public void GetAttributeForProperty_WithModelType_HandlesMultipleAttributesOnType()
+    {
+        // Arrange
+        var modelType = typeof(InvalidBaseViewModel);
+        var property = modelType.GetRuntimeProperties().FirstOrDefault(p => p.Name == nameof(BaseModel.RouteValue));
+
+        // Assert
+        var exception = Assert.Throws<InvalidOperationException>(() => ModelAttributes.GetAttributesForProperty(modelType, property));
+        Assert.Equal("Only one ModelMetadataType attribute is permitted per type.", exception.Message);
+    }
+
     [ClassValidator]
     private class BaseModel
     {
@@ -334,6 +346,10 @@ public class ModelAttributesTest
         [Required]
         public string RouteValue { get; set; }
     }
+
+    [ModelMetadataType<BaseModel>]
+    [ModelMetadataType(typeof(BaseModel))]
+    private class InvalidBaseViewModel : BaseViewModel { }
 
     [ModelMetadataType<DerivedModel>]
     private class DerivedViewModel : BaseViewModel

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Metadata/ModelAttributesTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Metadata/ModelAttributesTest.cs
@@ -322,7 +322,7 @@ public class ModelAttributesTest
     {
     }
 
-    [ModelMetadataType(typeof(BaseModel))]
+    [ModelMetadataType<BaseModel>]
     private class BaseViewModel
     {
         [Range(0, 10)]
@@ -335,7 +335,7 @@ public class ModelAttributesTest
         public string RouteValue { get; set; }
     }
 
-    [ModelMetadataType(typeof(DerivedModel))]
+    [ModelMetadataType<DerivedModel>]
     private class DerivedViewModel : BaseViewModel
     {
         [StringLength(2)]
@@ -358,7 +358,7 @@ public class ModelAttributesTest
         }
     }
 
-    [ModelMetadataType(typeof(MergedAttributesMetadata))]
+    [ModelMetadataType<MergedAttributesMetadata>]
     private class MergedAttributes
     {
         [Required]

--- a/src/Mvc/test/Mvc.IntegrationTests/BinderTypeBasedModelBinderIntegrationTest.cs
+++ b/src/Mvc/test/Mvc.IntegrationTests/BinderTypeBasedModelBinderIntegrationTest.cs
@@ -124,7 +124,7 @@ public class BinderTypeBasedModelBinderIntegrationTest
         public Address Address { get; set; }
     }
 
-    [ModelBinder(BinderType = typeof(AddressModelBinder))]
+    [ModelBinder<AddressModelBinder>]
     private class Address
     {
         public string Street { get; set; }
@@ -188,7 +188,7 @@ public class BinderTypeBasedModelBinderIntegrationTest
 
     private class Person3
     {
-        [ModelBinder(BinderType = typeof(Address3ModelBinder))]
+        [ModelBinder<Address3ModelBinder>]
         public Address3 Address { get; set; }
     }
 

--- a/src/Mvc/test/WebSites/ApiExplorerWebSite/Controllers/ApiExplorerResponseTypeOverrideOnActionController.cs
+++ b/src/Mvc/test/WebSites/ApiExplorerWebSite/Controllers/ApiExplorerResponseTypeOverrideOnActionController.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace ApiExplorerWebSite;
 
 [Produces("application/json", Type = typeof(Product))]
-[ProducesResponseType(typeof(ErrorInfo), 500)]
+[ProducesResponseType<ErrorInfo>(500)]
 [Route("ApiExplorerResponseTypeOverrideOnAction")]
 public class ApiExplorerResponseTypeOverrideOnActionController : Controller
 {
@@ -16,7 +16,7 @@ public class ApiExplorerResponseTypeOverrideOnActionController : Controller
     }
 
     [HttpGet("Action")]
-    [Produces(typeof(Customer))]
+    [Produces<Customer>]
     [ProducesResponseType(typeof(ErrorInfoOverride), 500)] // overriding the type specified on the server
     public object GetAction()
     {
@@ -24,7 +24,7 @@ public class ApiExplorerResponseTypeOverrideOnActionController : Controller
     }
 
     [HttpGet("Action2")]
-    [ProducesResponseType(typeof(Customer), 200, "text/plain")]
+    [ProducesResponseType<Customer>(200, "text/plain")]
     public object GetActionWithContentTypeOverride()
     {
         return null;

--- a/src/Mvc/test/WebSites/BasicWebSite/Controllers/AntiforgeryController.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/Controllers/AntiforgeryController.cs
@@ -44,7 +44,7 @@ public class AntiforgeryController : Controller
     [HttpPost]
     [AllowAnonymous]
     [ValidateAntiForgeryToken]
-    [TypeFilter(typeof(RedirectAntiforgeryValidationFailedResultFilter))]
+    [TypeFilter<RedirectAntiforgeryValidationFailedResultFilter>]
     public string LoginWithRedirectResultFilter(LoginViewModel model)
     {
         return "Ok";

--- a/src/Mvc/test/WebSites/BasicWebSite/Controllers/ContentNegotiation/ContentNegotiationController.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/Controllers/ContentNegotiation/ContentNegotiationController.cs
@@ -18,13 +18,13 @@ public class ContentNegotiationController : Controller
         return CreateUser();
     }
 
-    [Produces(typeof(User))]
+    [Produces<User>]
     public IActionResult UserInfo_ProducesWithTypeOnly()
     {
         return new ObjectResult(CreateUser());
     }
 
-    [Produces("application/xml", Type = typeof(User))]
+    [Produces<User>]
     public IActionResult UserInfo_ProducesWithTypeAndContentType()
     {
         return new ObjectResult(CreateUser());

--- a/src/Mvc/test/WebSites/BasicWebSite/Controllers/FiltersController.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/Controllers/FiltersController.cs
@@ -15,14 +15,14 @@ public class FiltersController : Controller
     public IActionResult AlwaysRunResultFiltersCanRunWhenResourceFilterShortCircuit([FromBody] Product product) =>
         throw new Exception("Shouldn't be executed");
 
-    [ServiceFilter(typeof(ServiceActionFilter))]
+    [ServiceFilter<ServiceActionFilter>]
     public IActionResult ServiceFilterTest() => Content("Service filter content");
 
     [TraceResultOutputFilter]
     public IActionResult TraceResult() => new EmptyResult();
 
     [Route("{culture}/[controller]/[action]")]
-    [MiddlewareFilter(typeof(LocalizationPipeline))]
+    [MiddlewareFilter<LocalizationPipeline>]
     public IActionResult MiddlewareFilterTest()
     {
         return Content($"CurrentCulture:{CultureInfo.CurrentCulture.Name},CurrentUICulture:{CultureInfo.CurrentUICulture.Name}");

--- a/src/Mvc/test/WebSites/BasicWebSite/Controllers/RequestScopedServiceController.cs
+++ b/src/Mvc/test/WebSites/BasicWebSite/Controllers/RequestScopedServiceController.cs
@@ -17,7 +17,7 @@ public class RequestScopedServiceController : Controller
     }
 
     [HttpGet]
-    [TypeFilter(typeof(RequestScopedFilter))]
+    [TypeFilter<RequestScopedFilter>]
     public void FromFilter()
     {
     }


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/37767.

Since we have derived classes, the behavior of `GetCustomAttribute` is now different. I've updated the impacted codepaths that I could find.

I didn't replace all instances of `ServiceFilter` and `TypeFilter` in our tests because some of them don't reference types that actually implement the `IFilterMetadata` interface ([example](https://github.com/dotnet/aspnetcore/blob/2b04b019f81acfb6ed909f7634746170381c0150/src/Mvc/Mvc.RazorPages/test/ApplicationModels/DefaultPageApplicationModelProviderTest.cs#L533-L551)). These tests aren't currently failing because they don't actually instantiate the factories.