### PR TITLE
Fix HRESULT check for IIS file watcher

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.cpp
@@ -112,7 +112,7 @@ FILE_WATCHER::Create(
         FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,
         NULL);
 
-    RETURN_LAST_ERROR_IF_NULL(_hDirectory);
+    RETURN_LAST_ERROR_IF(_hDirectory == INVALID_HANDLE_VALUE);
 
     RETURN_LAST_ERROR_IF_NULL(CreateIoCompletionPort(
         _hDirectory,


### PR DESCRIPTION
Had an IIS app failing to load and it was giving me some "failing to monitor app offline" error, had to attach the debugger to see that [CreateFileW](https://learn.microsoft.com/windows/win32/api/fileapi/nf-fileapi-createfilew#return-value) was returning an invalid handle with error code access denied to root cause why my app wasn't loading.

Looks like this check was [broken during a refactor](https://github.com/aspnet/IISIntegration/pull/1107). Now it should give a more accurate error if someone hits this.