### PR TITLE
[release/6.0] Use new Chromium headless mode to fix E2E test timeouts (#46812)

### DIFF
--- a/src/Components/test/E2ETest/Tests/CircuitTests.cs
+++ b/src/Components/test/E2ETest/Tests/CircuitTests.cs
@@ -9,6 +9,7 @@ using BasicTestApp.Reconnection;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
+using Microsoft.AspNetCore.Testing;
 using OpenQA.Selenium;
 using TestServer;
 using Xunit;
@@ -40,6 +41,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         [InlineData("render-throw")]
         [InlineData("afterrender-sync-throw")]
         [InlineData("afterrender-async-throw")]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/46836")]
         public void ComponentLifecycleMethodThrowsExceptionTerminatesTheCircuit(string id)
         {
             Browser.MountTestComponent<ReliabilityComponent>();
@@ -58,6 +60,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/46836")]
         public void ComponentDisposeMethodThrowsExceptionTerminatesTheCircuit()
         {
             Browser.MountTestComponent<ReliabilityComponent>();

--- a/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
+++ b/src/Components/test/E2ETest/Tests/ComponentRenderingTestBase.cs
@@ -433,6 +433,7 @@ namespace Microsoft.AspNetCore.Components.E2ETest.Tests
         }
 
         [Fact]
+        [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/46835")]
         public void CanUseFocusExtensionToFocusElementPreventScroll()
         {
             Browser.Manage().Window.Size = new System.Drawing.Size(100, 300);

--- a/src/Shared/E2ETesting/BrowserFixture.cs
+++ b/src/Shared/E2ETesting/BrowserFixture.cs
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.E2ETesting
                 !Debugger.IsAttached &&
                 !string.Equals(Environment.GetEnvironmentVariable("E2E_TEST_VISIBLE"), "true", StringComparison.OrdinalIgnoreCase))
             {
-                opts.AddArgument("--headless");
+                opts.AddArgument("--headless=new");
             }
 
             opts.AddArgument("--no-sandbox");

--- a/src/Shared/E2ETesting/selenium-config.json
+++ b/src/Shared/E2ETesting/selenium-config.json
@@ -1,7 +1,7 @@
 {
   "drivers": {
     "chrome": {
-      "version" : "106.0.5249.21"
+      "version" : "110.0.5481.77"
     }
   },
   "ignoreExtraDrivers": true


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/46812.

Fixes https://github.com/dotnet/aspnetcore/issues/47080