### PR TITLE
[release/7.0] Fix canceling flush of CancelInvocation when canceling server-to-client stream

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -624,7 +624,8 @@ public partial class HubConnection : IAsyncDisposable
                     Log.SendingCancellation(_logger, irq.InvocationId);
 
                     // Fire and forget, if it fails that means we aren't connected anymore.
-                    _ = SendHubMessage(_state.CurrentConnectionStateUnsynchronized, new CancelInvocationMessage(irq.InvocationId), irq.CancellationToken);
+                    // Don't pass irq.CancellationToken, that would result in canceling the Flush and a delayed CancelInvocationMessage being sent.
+                    _ = SendHubMessage(_state.CurrentConnectionStateUnsynchronized, new CancelInvocationMessage(irq.InvocationId), cancellationToken: default);
                 }
                 else
                 {


### PR DESCRIPTION
# Fix canceling flush of CancelInvocation when canceling server-to-client stream

## Description

With server-to-client streaming, the client can cancel the stream and tell the server to stop sending more stream items. This cancellation isn't working properly in 7.0 anymore.

Fixes #46861

## Customer Impact

The server keeps doing work to produce stream items even though the client will ignore them. This creates unnecessary work (cpu and network) on both the server and client that can be avoided.

## Regression?

- [x] Yes
- [ ] No

Regressed by #41180 in 7.0

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Reverted the part of the 7.0 change that regressed this, and added a test for the missing coverage

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A