### PR TITLE
Trim away netframework targets in source-build

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <GitHubRepositoryName>aspnetcore</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+    <SourceBuildTrimNetFrameworkTargets>true</SourceBuildTrimNetFrameworkTargets>
   </PropertyGroup>
 
   <Target Name="PrepareGlobalJsonForSourceBuild"


### PR DESCRIPTION
# Trim away netframework targets in source-build

This is part of the source-build work to enable trimming of net4* targets. Parent repo (`installer`) has been updated, so the next step is to update dependencies, like `aspnetcore`.

## Description

Trim away netframework targets in source-build

Fixes: https://github.com/dotnet/aspnetcore/issues/43696