### PR TITLE
Fix Linux-Musl Composite Artifacts not being built

### DIFF
--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -103,7 +103,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
       Special case the crossgen2 package reference on Windows to avoid the x86 package when building in Visual Studio.
     -->
     <BuildOsName>$(TargetOsName)</BuildOsName>
-    <BuildOsName Condition="'$(TargetOsName)' == 'linux-musl' and '$(TargetArchitecture)'!='x64'">linux</BuildOsName>
+    <BuildOsName Condition="'$(TargetOsName)' == 'linux-musl' and '$(TargetArchitecture)' != 'x64'">linux</BuildOsName>
     <BuildOsName Condition=" '$(PortableBuild)' == 'false' ">$(TargetRuntimeIdentifier.Substring(0,$(TargetRuntimeIdentifier.IndexOf('-'))))</BuildOsName>
     <Crossgen2BuildArchitecture Condition=" '$(BuildOsName)' == 'win' ">x64</Crossgen2BuildArchitecture>
     <Crossgen2BuildArchitecture Condition=" '$(Crossgen2BuildArchitecture)' == '' ">$(BuildArchitecture)</Crossgen2BuildArchitecture>
@@ -478,7 +478,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
   </Target>
 
   <Target Name="_GenerateComposites"
-          Condition="'$(BuildOsName)' == 'linux'"
+          Condition="'$(TargetOsName)' == 'linux' or '$(TargetOsName)' == 'linux-musl'"
           DependsOnTargets="_ExpandRuntimePackageRoot">
 
     <PropertyGroup>


### PR DESCRIPTION
# Linux-Musl Composite Artifacts Builds

Changes composites generation condition to enable linux-musl on x64 builds.

## Description

This PR modifies the condition that defines whether or not to generate a composite artifact in the current build. Originally, we were using `BuildOsName`. However, due to how some CI container images are built and configured, _linux-musl_ had to be special-cased for the x64 architecture. Then, `BuildOsName` is not changed to `linux` in this case, and consequently the `_GenerateComposites` target task is skipped. In this PR, we adjust this target's condition to always check for both, _linux_ and _linux-musl_, using the `TargetOsName` property instead.
