### PR TITLE
DbContextHealthCheck handles exceptions thrown by CustomTestQuery

### DIFF
--- a/src/Middleware/HealthChecks.EntityFrameworkCore/src/DbContextHealthCheck.cs
+++ b/src/Middleware/HealthChecks.EntityFrameworkCore/src/DbContextHealthCheck.cs
@@ -32,11 +32,18 @@ internal sealed class DbContextHealthCheck<TContext> : IHealthCheck where TConte
         var options = _options.Get(context.Registration.Name);
         var testQuery = options.CustomTestQuery ?? DefaultTestQuery;
 
-        if (await testQuery(_dbContext, cancellationToken))
+        try
         {
-            return HealthCheckResult.Healthy();
-        }
+            if (await testQuery(_dbContext, cancellationToken))
+            {
+                return HealthCheckResult.Healthy();
+            }
 
-        return new HealthCheckResult(context.Registration.FailureStatus);
+            return new HealthCheckResult(context.Registration.FailureStatus);
+        }
+        catch (Exception exception)
+        {
+            return HealthCheckResult.Unhealthy(exception.Message, exception);
+        }
     }
 }


### PR DESCRIPTION
# DbContextHealthCheck handles exceptions in a saner way

## Description

Fixes #47074

As mentioned in the issue this handles the case where the CustomTestQuery that runs against the db throws an error. 
Inspiration on how to handle a thrown exception was found in `Microsoft.Extensions.Diagnostics.HealthChecks.DefaultHealthCheckService`
