### PR TITLE
Fix verb in route template with gRPC transcoding

### DIFF
--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonTranscodingRouteAdapter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonTranscodingRouteAdapter.cs
@@ -66,15 +66,15 @@ internal sealed class JsonTranscodingRouteAdapter
             {
                 var fullPath = string.Join(".", segmentVariable.FieldPath);
 
-                var segmentCount = segmentVariable.EndSegment - segmentVariable.StartSegment;
+                var remainingSegmentCount = segmentVariable.EndSegment - segmentVariable.StartSegment;
 
                 // Handle situation where the last segment is catch all but there is a verb.
-                if (segmentCount == 1 && segmentVariable.HasCatchAllPath && pattern.Verb != null)
+                if (remainingSegmentCount == 1 && segmentVariable.HasCatchAllPath && pattern.Verb != null)
                 {
-                    segmentCount++;
+                    remainingSegmentCount++;
                 }
 
-                if (segmentCount == 1)
+                if (remainingSegmentCount == 1)
                 {
                     // Single segment parameter. Include in route with its default name.
                     tempSegments[i] = segmentVariable.HasCatchAllPath
@@ -111,7 +111,7 @@ internal sealed class JsonTranscodingRouteAdapter
                                 {
                                     var parameterName = $"__Complex_{fullPath}_{i}";
                                     var suffix = BuildSuffix(tempSegments.Skip(i + 1), pattern.Verb);
-                                    catchAllSuffix = BuildSuffix(tempSegments.Skip(i + segmentCount - 1), pattern.Verb);
+                                    catchAllSuffix = BuildSuffix(tempSegments.Skip(i + remainingSegmentCount - 1), pattern.Verb);
 
                                     // It's possible to have multiple routes with catch-all parameters that have different suffixes.
                                     // For example:
@@ -195,6 +195,7 @@ internal sealed class JsonTranscodingRouteAdapter
         }
 
         string resolvedRoutePattern = "/" + string.Join("/", tempSegments);
+        // If the route has a catch all then the verb is included in the catch all regex constraint.
         if (pattern.Verb != null && !haveCatchAll)
         {
             resolvedRoutePattern += ":" + pattern.Verb;

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonTranscodingRouteAdapter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonTranscodingRouteAdapter.cs
@@ -71,6 +71,7 @@ internal sealed class JsonTranscodingRouteAdapter
                 // Handle situation where the last segment is catch all but there is a verb.
                 if (remainingSegmentCount == 1 && segmentVariable.HasCatchAllPath && pattern.Verb != null)
                 {
+                    // Move past the catch all so the regex added below just includes the verb.
                     remainingSegmentCount++;
                 }
 

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonTranscodingRouteAdapter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonTranscodingRouteAdapter.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Grpc.Shared;
 using Microsoft.AspNetCore.Http;
 
@@ -55,6 +56,8 @@ internal sealed class JsonTranscodingRouteAdapter
         var rewriteActions = new List<Action<HttpContext>>();
 
         var tempSegments = pattern.Segments.ToList();
+        var haveCatchAll = false;
+
         var i = 0;
         while (i < tempSegments.Count)
         {
@@ -64,6 +67,13 @@ internal sealed class JsonTranscodingRouteAdapter
                 var fullPath = string.Join(".", segmentVariable.FieldPath);
 
                 var segmentCount = segmentVariable.EndSegment - segmentVariable.StartSegment;
+
+                // Handle situation where the last segment is catch all but there is a verb.
+                if (segmentCount == 1 && segmentVariable.HasCatchAllPath && pattern.Verb != null)
+                {
+                    segmentCount++;
+                }
+
                 if (segmentCount == 1)
                 {
                     // Single segment parameter. Include in route with its default name.
@@ -77,7 +87,6 @@ internal sealed class JsonTranscodingRouteAdapter
                     var routeParameterParts = new List<string>();
                     var routeValueFormatTemplateParts = new List<string>();
                     var variableParts = new List<string>();
-                    var haveCatchAll = false;
                     var catchAllSuffix = string.Empty;
 
                     while (i < segmentVariable.EndSegment && !haveCatchAll)
@@ -101,15 +110,15 @@ internal sealed class JsonTranscodingRouteAdapter
                             case SegmentType.CatchAll:
                                 {
                                     var parameterName = $"__Complex_{fullPath}_{i}";
-                                    var suffix = string.Join("/", tempSegments.Skip(i + 1));
-                                    catchAllSuffix = string.Join("/", tempSegments.Skip(i + segmentCount - 1));
+                                    var suffix = BuildSuffix(tempSegments.Skip(i + 1), pattern.Verb);
+                                    catchAllSuffix = BuildSuffix(tempSegments.Skip(i + segmentCount - 1), pattern.Verb);
 
                                     // It's possible to have multiple routes with catch-all parameters that have different suffixes.
                                     // For example:
                                     // - /{name=v1/**/b}/one
                                     // - /{name=v1/**/b}/two
                                     // The suffix is added as a route constraint to avoid matching multiple routes to a request.
-                                    var constraint = suffix.Length > 0 ? $":regex({suffix}$)" : string.Empty;
+                                    var constraint = suffix.Length > 0 ? $":regex({Regex.Escape(suffix)}$)" : string.Empty;
                                     tempSegments[i] = $"{{**{parameterName}{constraint}}}";
 
                                     routeValueFormatTemplateParts.Add($"{{{variableParts.Count}}}");
@@ -145,7 +154,7 @@ internal sealed class JsonTranscodingRouteAdapter
                         // the entire remainder of the URL in the route value, we must trim the suffix from that route value.
                         if (!string.IsNullOrEmpty(catchAllSuffix))
                         {
-                            finalValue = finalValue.Substring(0, finalValue.Length - catchAllSuffix.Length - 1);
+                            finalValue = finalValue[..^catchAllSuffix.Length];
                         }
                         context.Request.RouteValues[fullPath] = finalValue;
                     });
@@ -169,7 +178,15 @@ internal sealed class JsonTranscodingRouteAdapter
                         break;
                     case SegmentType.CatchAll:
                         // Ignore remaining segment values.
-                        tempSegments[i] = $"{{**__Discard_{i}}}";
+                        if (pattern.Verb != null)
+                        {
+                            tempSegments[i] = $"{{**__Discard_{i}:regex({Regex.Escape($":{pattern.Verb}")}$)}}";
+                        }
+                        else
+                        {
+                            tempSegments[i] = $"{{**__Discard_{i}}}";
+                        }
+                        haveCatchAll = true;
                         break;
                 }
 
@@ -177,7 +194,26 @@ internal sealed class JsonTranscodingRouteAdapter
             }
         }
 
-        return new JsonTranscodingRouteAdapter(pattern, "/" + string.Join("/", tempSegments), rewriteActions);
+        string resolvedRoutePattern = "/" + string.Join("/", tempSegments);
+        if (pattern.Verb != null && !haveCatchAll)
+        {
+            resolvedRoutePattern += ":" + pattern.Verb;
+        }
+        return new JsonTranscodingRouteAdapter(pattern, resolvedRoutePattern, rewriteActions);
+
+        static string BuildSuffix(IEnumerable<string> segments, string? verb)
+        {
+            var pattern = string.Join("/", segments);
+            if (!string.IsNullOrEmpty(pattern))
+            {
+                pattern = "/" + pattern;
+            }
+            if (verb != null)
+            {
+                pattern += ":" + verb;
+            }
+            return pattern;
+        }
     }
 
     private static SegmentType GetSegmentType(string segment)

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/RouteTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/RouteTests.cs
@@ -105,7 +105,7 @@ public class RouteTests : IntegrationTestBase
     }
 
     [Fact]
-    public async Task SimpleCatchAllParameter_PrefixSufficSlashes_MatchUrl_SuccessResult()
+    public async Task SimpleCatchAllParameter_PrefixSuffixSlashes_MatchUrl_SuccessResult()
     {
         // Arrange
         Task<HelloReply> UnaryMethod(HelloRequest request, ServerCallContext context)

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/RouteTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/RouteTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -201,6 +202,12 @@ public class RouteTests : IntegrationTestBase
 
         // Assert 2
         Assert.Equal("Hello test/name two!", result2.RootElement.GetProperty("message").GetString());
+
+        // Act 3
+        var response3 = await client.GetAsync("/v1/greeter/test/name").DefaultTimeout();
+
+        // Assert 3
+        Assert.Equal(HttpStatusCode.NotFound, response3.StatusCode);
     }
 
     [Fact]

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/RouteTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/RouteTests.cs
@@ -150,7 +150,7 @@ public class RouteTests : IntegrationTestBase
         var client = new HttpClient(Fixture.Handler) { BaseAddress = new Uri("http://localhost") };
 
         // Act 1
-        var response1 = await client.GetAsync("/v1/greeter/test:one").DefaultTimeout();
+        var response1 = await client.GetAsync("/v1/greeter_custom/test:one").DefaultTimeout();
         var responseStream1 = await response1.Content.ReadAsStreamAsync();
         using var result1 = await JsonDocument.ParseAsync(responseStream1);
 
@@ -158,12 +158,18 @@ public class RouteTests : IntegrationTestBase
         Assert.Equal("Hello test one!", result1.RootElement.GetProperty("message").GetString());
 
         // Act 2
-        var response2 = await client.GetAsync("/v1/greeter/test:two").DefaultTimeout();
+        var response2 = await client.GetAsync("/v1/greeter_custom/test:two").DefaultTimeout();
         var responseStream2 = await response2.Content.ReadAsStreamAsync();
         using var result2 = await JsonDocument.ParseAsync(responseStream2);
 
         // Assert 2
         Assert.Equal("Hello test two!", result2.RootElement.GetProperty("message").GetString());
+
+        // Act 3
+        var response3 = await client.GetAsync("/v1/greeter_custom/test").DefaultTimeout();
+
+        // Assert 3
+        Assert.Equal(HttpStatusCode.NotFound, response3.StatusCode);
     }
 
     [Fact]
@@ -188,7 +194,7 @@ public class RouteTests : IntegrationTestBase
         var client = new HttpClient(Fixture.Handler) { BaseAddress = new Uri("http://localhost") };
 
         // Act 1
-        var response1 = await client.GetAsync("/v1/greeter/test/name:one").DefaultTimeout();
+        var response1 = await client.GetAsync("/v1/greeter_customcatchall/test/name:one").DefaultTimeout();
         var responseStream1 = await response1.Content.ReadAsStreamAsync();
         using var result1 = await JsonDocument.ParseAsync(responseStream1);
 
@@ -196,7 +202,7 @@ public class RouteTests : IntegrationTestBase
         Assert.Equal("Hello test/name one!", result1.RootElement.GetProperty("message").GetString());
 
         // Act 2
-        var response2 = await client.GetAsync("/v1/greeter/test/name:two").DefaultTimeout();
+        var response2 = await client.GetAsync("/v1/greeter_customcatchall/test/name:two").DefaultTimeout();
         var responseStream2 = await response2.Content.ReadAsStreamAsync();
         using var result2 = await JsonDocument.ParseAsync(responseStream2);
 
@@ -204,7 +210,7 @@ public class RouteTests : IntegrationTestBase
         Assert.Equal("Hello test/name two!", result2.RootElement.GetProperty("message").GetString());
 
         // Act 3
-        var response3 = await client.GetAsync("/v1/greeter/test/name").DefaultTimeout();
+        var response3 = await client.GetAsync("/v1/greeter_customcatchall/test/name").DefaultTimeout();
 
         // Assert 3
         Assert.Equal(HttpStatusCode.NotFound, response3.StatusCode);
@@ -236,7 +242,7 @@ public class RouteTests : IntegrationTestBase
         content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
 
         // Act 1
-        var response1 = await client.PostAsync("/v1/greeter:one", content).DefaultTimeout();
+        var response1 = await client.PostAsync("/v1/greeter_custompost:one", content).DefaultTimeout();
         var responseStream1 = await response1.Content.ReadAsStreamAsync();
         using var result1 = await JsonDocument.ParseAsync(responseStream1);
 
@@ -244,11 +250,17 @@ public class RouteTests : IntegrationTestBase
         Assert.Equal("Hello test one!", result1.RootElement.GetProperty("message").GetString());
 
         // Act 2
-        var response2 = await client.PostAsync("/v1/greeter:two", content).DefaultTimeout();
+        var response2 = await client.PostAsync("/v1/greeter_custompost:two", content).DefaultTimeout();
         var responseStream2 = await response2.Content.ReadAsStreamAsync();
         using var result2 = await JsonDocument.ParseAsync(responseStream2);
 
         // Assert 2
         Assert.Equal("Hello test two!", result2.RootElement.GetProperty("message").GetString());
+
+        // Act 3
+        var response3 = await client.PostAsync("/v1/greeter_custompost", content).DefaultTimeout();
+
+        // Assert 3
+        Assert.Equal(HttpStatusCode.NotFound, response3.StatusCode);
     }
 }

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/RouteTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests/RouteTests.cs
@@ -8,8 +8,6 @@ using System.Text.Json;
 using Grpc.Core;
 using IntegrationTestsWebsite;
 using Microsoft.AspNetCore.Grpc.JsonTranscoding.IntegrationTests.Infrastructure;
-using Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal;
-using Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.Infrastructure;
 using Microsoft.AspNetCore.Testing;
 using Xunit.Abstractions;
 
@@ -104,5 +102,146 @@ public class RouteTests : IntegrationTestBase
 
         // Assert
         Assert.Equal("Hello complex_greeter/test2/b last_name!", result.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task SimpleCatchAllParameter_PrefixSufficSlashes_MatchUrl_SuccessResult()
+    {
+        // Arrange
+        Task<HelloReply> UnaryMethod(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply { Message = $"Hello {request.Name}!" });
+        }
+        var method = Fixture.DynamicGrpc.AddUnaryMethod<HelloRequest, HelloReply>(
+            UnaryMethod,
+            Greeter.Descriptor.FindMethodByName("SayHelloComplexCatchAll4"));
+
+        var client = new HttpClient(Fixture.Handler) { BaseAddress = new Uri("http://localhost") };
+
+        // Act
+        var response = await client.GetAsync("/v1/greeter//name/one/two//").DefaultTimeout();
+        var responseStream = await response.Content.ReadAsStreamAsync();
+        using var result = await JsonDocument.ParseAsync(responseStream);
+
+        // Assert
+        Assert.Equal("Hello /name/one/two//!", result.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task ParameterVerb_MatchUrl_SuccessResult()
+    {
+        // Arrange
+        Task<HelloReply> UnaryMethod1(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply { Message = $"Hello {request.Name} one!" });
+        }
+        Task<HelloReply> UnaryMethod2(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply { Message = $"Hello {request.Name} two!" });
+        }
+        var method1 = Fixture.DynamicGrpc.AddUnaryMethod<HelloRequest, HelloReply>(
+            UnaryMethod1,
+            Greeter.Descriptor.FindMethodByName("SayHelloCustomVerbOne"));
+        var method2 = Fixture.DynamicGrpc.AddUnaryMethod<HelloRequest, HelloReply>(
+            UnaryMethod2,
+            Greeter.Descriptor.FindMethodByName("SayHelloCustomVerbTwo"));
+
+        var client = new HttpClient(Fixture.Handler) { BaseAddress = new Uri("http://localhost") };
+
+        // Act 1
+        var response1 = await client.GetAsync("/v1/greeter/test:one").DefaultTimeout();
+        var responseStream1 = await response1.Content.ReadAsStreamAsync();
+        using var result1 = await JsonDocument.ParseAsync(responseStream1);
+
+        // Assert 2
+        Assert.Equal("Hello test one!", result1.RootElement.GetProperty("message").GetString());
+
+        // Act 2
+        var response2 = await client.GetAsync("/v1/greeter/test:two").DefaultTimeout();
+        var responseStream2 = await response2.Content.ReadAsStreamAsync();
+        using var result2 = await JsonDocument.ParseAsync(responseStream2);
+
+        // Assert 2
+        Assert.Equal("Hello test two!", result2.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task CatchAllVerb_MatchUrl_SuccessResult()
+    {
+        // Arrange
+        Task<HelloReply> UnaryMethod1(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply { Message = $"Hello {request.Name} one!" });
+        }
+        Task<HelloReply> UnaryMethod2(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply { Message = $"Hello {request.Name} two!" });
+        }
+        var method1 = Fixture.DynamicGrpc.AddUnaryMethod<HelloRequest, HelloReply>(
+            UnaryMethod1,
+            Greeter.Descriptor.FindMethodByName("SayHelloCatchAllCustomVerbOne"));
+        var method2 = Fixture.DynamicGrpc.AddUnaryMethod<HelloRequest, HelloReply>(
+            UnaryMethod2,
+            Greeter.Descriptor.FindMethodByName("SayHelloCatchAllCustomVerbTwo"));
+
+        var client = new HttpClient(Fixture.Handler) { BaseAddress = new Uri("http://localhost") };
+
+        // Act 1
+        var response1 = await client.GetAsync("/v1/greeter/test/name:one").DefaultTimeout();
+        var responseStream1 = await response1.Content.ReadAsStreamAsync();
+        using var result1 = await JsonDocument.ParseAsync(responseStream1);
+
+        // Assert 2
+        Assert.Equal("Hello test/name one!", result1.RootElement.GetProperty("message").GetString());
+
+        // Act 2
+        var response2 = await client.GetAsync("/v1/greeter/test/name:two").DefaultTimeout();
+        var responseStream2 = await response2.Content.ReadAsStreamAsync();
+        using var result2 = await JsonDocument.ParseAsync(responseStream2);
+
+        // Assert 2
+        Assert.Equal("Hello test/name two!", result2.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task PostVerb_MatchUrl_SuccessResult()
+    {
+        // Arrange
+        Task<HelloReply> UnaryMethod1(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply { Message = $"Hello {request.Name} one!" });
+        }
+        Task<HelloReply> UnaryMethod2(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply { Message = $"Hello {request.Name} two!" });
+        }
+        var method1 = Fixture.DynamicGrpc.AddUnaryMethod<HelloRequest, HelloReply>(
+            UnaryMethod1,
+            Greeter.Descriptor.FindMethodByName("SayHelloPostCustomVerbOne"));
+        var method2 = Fixture.DynamicGrpc.AddUnaryMethod<HelloRequest, HelloReply>(
+            UnaryMethod2,
+            Greeter.Descriptor.FindMethodByName("SayHelloPostCustomVerbTwo"));
+
+        var client = new HttpClient(Fixture.Handler) { BaseAddress = new Uri("http://localhost") };
+
+        var requestMessage = new HelloRequest { Name = "test" };
+        var content = new ByteArrayContent(Encoding.UTF8.GetBytes(requestMessage.ToString()));
+        content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+
+        // Act 1
+        var response1 = await client.PostAsync("/v1/greeter:one", content).DefaultTimeout();
+        var responseStream1 = await response1.Content.ReadAsStreamAsync();
+        using var result1 = await JsonDocument.ParseAsync(responseStream1);
+
+        // Assert 2
+        Assert.Equal("Hello test one!", result1.RootElement.GetProperty("message").GetString());
+
+        // Act 2
+        var response2 = await client.PostAsync("/v1/greeter:two", content).DefaultTimeout();
+        var responseStream2 = await response2.Content.ReadAsStreamAsync();
+        using var result2 = await JsonDocument.ParseAsync(responseStream2);
+
+        // Assert 2
+        Assert.Equal("Hello test two!", result2.RootElement.GetProperty("message").GetString());
     }
 }

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/JsonTranscodingServiceMethodProviderTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/JsonTranscodingServiceMethodProviderTests.cs
@@ -69,6 +69,25 @@ public class JsonTranscodingServiceMethodProviderTests
     }
 
     [Fact]
+    public void AddMethod_PatternVerb_RouteEndsWithVerb()
+    {
+        // Arrange & Act
+        var endpoints = MapEndpoints<JsonTranscodingColonRouteService>();
+
+        var startFrameImport = Assert.Single(FindGrpcEndpoints(endpoints, nameof(JsonTranscodingColonRouteService.StartFrameImport)));
+        var getFrameImport = Assert.Single(FindGrpcEndpoints(endpoints, nameof(JsonTranscodingColonRouteService.GetFrameImport)));
+
+        // Assert
+        Assert.Equal("POST", startFrameImport.Metadata.GetMetadata<IHttpMethodMetadata>()?.HttpMethods.Single());
+        Assert.Equal("/v1/frames:startFrameImport", startFrameImport.Metadata.GetMetadata<GrpcJsonTranscodingMetadata>()?.HttpRule.Post);
+        Assert.Equal("/v1/frames:startFrameImport", startFrameImport.RoutePattern.RawText);
+
+        Assert.Equal("POST", getFrameImport.Metadata.GetMetadata<IHttpMethodMetadata>()?.HttpMethods.Single());
+        Assert.Equal("/v1/frames:getFrameImport", getFrameImport.Metadata.GetMetadata<GrpcJsonTranscodingMetadata>()?.HttpRule.Post);
+        Assert.Equal("/v1/frames:getFrameImport", getFrameImport.RoutePattern.RawText);
+    }
+
+    [Fact]
     public void AddMethod_NoHttpRuleInProto_ThrowNotFoundError()
     {
         // Arrange & Act

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/transcoding.proto
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/transcoding.proto
@@ -130,6 +130,21 @@ service JsonTranscodingStreaming {
   }
 }
 
+service JsonTranscodingColonRoute {
+  rpc StartFrameImport(HelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      post: "/v1/frames:startFrameImport",
+      body: "*",
+    };
+  }
+  rpc GetFrameImport(HelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      post: "/v1/frames:getFrameImport",
+      body: "*",
+    };
+  }
+}
+
 message HelloRequest {
   message SubMessage {
     string subfield = 1;

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/TestObjects/Services/JsonTranscodingColonRouteService.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/TestObjects/Services/JsonTranscodingColonRouteService.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Transcoding;
+
+namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.TestObjects;
+
+public class JsonTranscodingColonRouteService : JsonTranscodingColonRoute.JsonTranscodingColonRouteBase
+{
+}

--- a/src/Grpc/JsonTranscoding/test/testassets/IntegrationTestsWebsite/Protos/greet.proto
+++ b/src/Grpc/JsonTranscoding/test/testassets/IntegrationTestsWebsite/Protos/greet.proto
@@ -46,6 +46,43 @@ service Greeter {
       get: "/v1/{name.last_name}/{name.first_name=complex_greeter/**/b}/c/d/two"
     };
   }
+  rpc SayHelloComplexCatchAll4 (HelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      get: "/v1/greeter/{name=**}"
+    };
+  }
+  rpc SayHelloCustomVerbOne (HelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      get: "/v1/greeter/{name}:one"
+    };
+  }
+  rpc SayHelloCustomVerbTwo (HelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      get: "/v1/greeter/{name}:two"
+    };
+  }
+  rpc SayHelloCatchAllCustomVerbOne (HelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      get: "/v1/greeter/{name=**}:one"
+    };
+  }
+  rpc SayHelloCatchAllCustomVerbTwo (HelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      get: "/v1/greeter/{name=**}:two"
+    };
+  }
+  rpc SayHelloPostCustomVerbOne (HelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      post: "/v1/greeter:one",
+      body: "*"
+    };
+  }
+  rpc SayHelloPostCustomVerbTwo (HelloRequest) returns (HelloReply) {
+    option (google.api.http) = {
+      post: "/v1/greeter:two",
+      body: "*"
+    };
+  }
 }
 
 // The request message containing the user's name.

--- a/src/Grpc/JsonTranscoding/test/testassets/IntegrationTestsWebsite/Protos/greet.proto
+++ b/src/Grpc/JsonTranscoding/test/testassets/IntegrationTestsWebsite/Protos/greet.proto
@@ -53,33 +53,33 @@ service Greeter {
   }
   rpc SayHelloCustomVerbOne (HelloRequest) returns (HelloReply) {
     option (google.api.http) = {
-      get: "/v1/greeter/{name}:one"
+      get: "/v1/greeter_custom/{name}:one"
     };
   }
   rpc SayHelloCustomVerbTwo (HelloRequest) returns (HelloReply) {
     option (google.api.http) = {
-      get: "/v1/greeter/{name}:two"
+      get: "/v1/greeter_custom/{name}:two"
     };
   }
   rpc SayHelloCatchAllCustomVerbOne (HelloRequest) returns (HelloReply) {
     option (google.api.http) = {
-      get: "/v1/greeter/{name=**}:one"
+      get: "/v1/greeter_customcatchall/{name=**}:one"
     };
   }
   rpc SayHelloCatchAllCustomVerbTwo (HelloRequest) returns (HelloReply) {
     option (google.api.http) = {
-      get: "/v1/greeter/{name=**}:two"
+      get: "/v1/greeter_customcatchall/{name=**}:two"
     };
   }
   rpc SayHelloPostCustomVerbOne (HelloRequest) returns (HelloReply) {
     option (google.api.http) = {
-      post: "/v1/greeter:one",
+      post: "/v1/greeter_custompost:one",
       body: "*"
     };
   }
   rpc SayHelloPostCustomVerbTwo (HelloRequest) returns (HelloReply) {
     option (google.api.http) = {
-      post: "/v1/greeter:two",
+      post: "/v1/greeter_custompost:two",
       body: "*"
     };
   }


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2054

gRPC JSON transcoding routes can have a "verb" at the end of the route. For example: `/v1/greeter/{name}:calculate`. It's used for the [custom method](https://google.aip.dev/136) pattern.

Transcoding was incorrectly ignoring the verb, which caused routing errors. This PR adds support for verb.