### PR TITLE
Fix x86 folder contents in ARM64 Windows Server Hosting Bundle installer

### DIFF
--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
@@ -234,7 +234,7 @@
                             <Component Id="AspNetCoreModuleV2.arm64" Guid="1b8ecba0-c002-442a-92c0-0fa9c0f21df4" Win64="no">
                                 <File Id="AspNetCoreModuleV2Dll.arm64"
                                     Name="aspnetcorev2.dll"
-                                    Source="$(var.ArtifactsDir)\bin\AspNetCoreModuleShim\arm64\Release\aspnetcorev2.dll"
+                                    Source="$(var.ArtifactsDir)\bin\AspNetCoreModuleShim\Win32\Release\aspnetcorev2.dll"
                                     DiskId="1"
                                     Vital="yes">
                                 </File>
@@ -248,7 +248,7 @@
                                 <Component Id="AspNetCoreModuleHandler.arm64" Guid="d927e5d3-c8b2-400c-b85c-ae5c2772d6c3" Win64="no">
                                     <File Id="AspNetCoreModuleHandlerDll.arm64"
                                           Name="aspnetcorev2_outofprocess.dll"
-                                          Source="$(var.ArtifactsDir)\bin\OutOfProcessRequestHandler\arm64\Release\aspnetcorev2_outofprocess.dll"
+                                          Source="$(var.ArtifactsDir)\bin\OutOfProcessRequestHandler\Win32\Release\aspnetcorev2_outofprocess.dll"
                                           DiskId="1"
                                           Vital="yes">
                                     </File>


### PR DESCRIPTION
# Fix x86 folder contents in Windows 11 ARM64 Server Hosting Bundle installer

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Consume x86 binaries in ARM64 Windows Server Hosting Bundle installer to fix x86 application pool crash. Resolve one of the two problems reported in #47115.

## Description

Before this change, the ARM64 installer picks up the pure ARM64 binaries and installs into `Program Files (x86)`, so that x86 application pool cannot load them and simply crashes. After this change, the installer switches to install x86 binaries into `Program Files (x86)` folder, so that x86 application pools won't crash. 

Fixes part of #47115 (but x64 application pool crash is not resolved by this pull request).
