### PR TITLE
[Blazor] Endpoint discovery

### DIFF
--- a/src/Components/Endpoints/src/Builder/ComponentTypeMetadata.cs
+++ b/src/Components/Endpoints/src/Builder/ComponentTypeMetadata.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Builder;
+
+/// <summary>
+/// Metadata that represents the component associated with an endpoint.
+/// </summary>
+public class ComponentTypeMetadata
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="ComponentTypeMetadata"/>.
+    /// </summary>
+    /// <param name="componentType">The component type.</param>
+    public ComponentTypeMetadata(Type componentType)
+    {
+        Type = componentType;
+    }
+
+    /// <summary>
+    /// Gets the component type.
+    /// </summary>
+    public Type Type { get; }
+}

--- a/src/Components/Endpoints/src/Builder/RazorComponentEndpointConventionBuilder.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentEndpointConventionBuilder.cs
@@ -1,19 +1,36 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components;
 
 namespace Microsoft.AspNetCore.Builder;
 
-internal class RazorComponentEndpointConventionBuilder : IEndpointConventionBuilder
+/// <summary>
+/// Builds conventions that will be used for customization of <see cref="EndpointBuilder"/> instances.
+/// </summary>
+
+// TODO: This will have APIs to add and remove entire assemblies from the list of considered endpoints
+// as well as adding/removing individual pages as endpoints.
+public class RazorComponentEndpointConventionBuilder : IEndpointConventionBuilder
 {
     private readonly object _lock;
+    private readonly ComponentApplicationBuilder _builder;
     private readonly List<Action<EndpointBuilder>> _conventions;
+    private readonly List<Action<EndpointBuilder>> _finallyConventions;
 
-    internal RazorComponentEndpointConventionBuilder(object @lock, List<Action<EndpointBuilder>> conventions)
+    internal RazorComponentEndpointConventionBuilder(
+        object @lock,
+        ComponentApplicationBuilder builder,
+        List<Action<EndpointBuilder>> conventions,
+        List<Action<EndpointBuilder>> finallyConventions)
     {
         _lock = @lock;
+        _builder = builder;
         _conventions = conventions;
+        _finallyConventions = finallyConventions;
     }
 
+    /// <inheritdoc/>
     public void Add(Action<EndpointBuilder> convention)
     {
         ArgumentNullException.ThrowIfNull(convention);
@@ -23,6 +40,17 @@ internal class RazorComponentEndpointConventionBuilder : IEndpointConventionBuil
         lock (_lock)
         {
             _conventions.Add(convention);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Finally(Action<EndpointBuilder> finallyConvention)
+    {
+        // The lock is shared with the data source. We want to lock here
+        // to avoid mutating this list while its read in the data source.
+        lock (_lock)
+        {
+            _finallyConventions.Add(finallyConvention);
         }
     }
 }

--- a/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSourceFactory.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSourceFactory.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Endpoints;
+
+namespace Microsoft.AspNetCore.Components.Infrastructure;
+
+internal class RazorComponentEndpointDataSourceFactory
+{
+    private readonly RazorComponentEndpointFactory _factory;
+
+    public RazorComponentEndpointDataSourceFactory(RazorComponentEndpointFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public RazorComponentEndpointDataSource<TRootComponent> CreateDataSource<TRootComponent>()
+        where TRootComponent : IRazorComponentApplication<TRootComponent>
+    {
+        var builder = TRootComponent.GetBuilder();
+        return new RazorComponentEndpointDataSource<TRootComponent>(builder, _factory);
+    }
+}

--- a/src/Components/Endpoints/src/Builder/RazorComponentEndpointFactory.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentEndpointFactory.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+
+namespace Microsoft.AspNetCore.Components.Endpoints;
+
+internal class RazorComponentEndpointFactory
+{
+    private static readonly HttpMethodMetadata HttpGet = new(new[] { HttpMethods.Get });
+
+#pragma warning disable CA1822 // It's a singleton
+    internal void AddEndpoints(
+#pragma warning restore CA1822 // It's a singleton
+        List<Endpoint> endpoints,
+        PageDefinition pageDefinition,
+        IReadOnlyList<Action<EndpointBuilder>> conventions,
+        IReadOnlyList<Action<EndpointBuilder>> finallyConventions)
+    {
+        // We do not provide a way to establish the order or the name for the page routes.
+        // Order is not supported in our client router.
+        // Name is only relevant for Link generation, which we don't support either.
+        var builder = new RouteEndpointBuilder(
+            null,
+            RoutePatternFactory.Parse(pageDefinition.Route),
+            order: 0);
+
+        // All attributes defined for the type are included as metadata.
+        foreach (var attribute in pageDefinition.Metadata)
+        {
+            builder.Metadata.Add(attribute);
+        }
+
+        // We do not support link generation, so explicitly opt-out.
+        builder.Metadata.Add(new SuppressLinkGenerationMetadata());
+        builder.Metadata.Add(HttpGet);
+        builder.Metadata.Add(new ComponentTypeMetadata(pageDefinition.Type));
+
+        foreach (var convention in conventions)
+        {
+            convention(builder);
+        }
+
+        foreach (var finallyConvention in finallyConventions)
+        {
+            finallyConvention(builder);
+        }
+
+        // Always override the order, since our client router does not support it.
+        builder.Order = 0;
+
+        // The display name is for debug purposes by endpoint routing.
+        builder.DisplayName = $"{builder.RoutePattern.RawText} ({pageDefinition.DisplayName})";
+
+        builder.RequestDelegate = RazorComponentEndpoint.CreateRouteDelegate(pageDefinition.Type);
+
+        endpoints.Add(builder.Build());
+    }
+}

--- a/src/Components/Endpoints/src/Builder/RazorComponentsEndpointRouteBuilderExtensions.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentsEndpointRouteBuilderExtensions.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Endpoints;
+using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -18,24 +20,27 @@ public static class RazorComponentsEndpointRouteBuilderExtensions
     /// </summary>
     /// <param name="endpoints"></param>
     /// <returns></returns>
-    public static IEndpointConventionBuilder MapRazorComponents(this IEndpointRouteBuilder endpoints)
+    public static RazorComponentEndpointConventionBuilder MapRazorComponents<TRootComponent>(this IEndpointRouteBuilder endpoints)
+        where TRootComponent : IRazorComponentApplication<TRootComponent>
     {
         ArgumentNullException.ThrowIfNull(endpoints);
 
         EnsureRazorComponentServices(endpoints);
 
-        return GetOrCreateDataSource(endpoints).DefaultBuilder;
+        return GetOrCreateDataSource<TRootComponent>(endpoints).DefaultBuilder;
     }
 
-    private static RazorComponentEndpointDataSource GetOrCreateDataSource(IEndpointRouteBuilder endpoints)
+    private static RazorComponentEndpointDataSource<TRootComponent> GetOrCreateDataSource<TRootComponent>(IEndpointRouteBuilder endpoints)
+        where TRootComponent : IRazorComponentApplication<TRootComponent>
     {
-        var dataSource = endpoints.DataSources.OfType<RazorComponentEndpointDataSource>().FirstOrDefault();
+        var dataSource = endpoints.DataSources.OfType<RazorComponentEndpointDataSource<TRootComponent>>().FirstOrDefault();
         if (dataSource == null)
         {
             // Very likely this needs to become a factory and we might need to have multiple endpoint data
             // sources, once we figure out the exact scenarios for
             // https://github.com/dotnet/aspnetcore/issues/46992
-            dataSource = endpoints.ServiceProvider.GetRequiredService<RazorComponentEndpointDataSource>();
+            var factory = endpoints.ServiceProvider.GetRequiredService<RazorComponentEndpointDataSourceFactory>();
+            dataSource = factory.CreateDataSource<TRootComponent>();
             endpoints.DataSources.Add(dataSource);
         }
 

--- a/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
+++ b/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Endpoints;
 using Microsoft.AspNetCore.Components.Infrastructure;
@@ -30,10 +29,9 @@ public static class RazorComponentsServiceCollectionExtensions
         // Results
         services.TryAddSingleton<RazorComponentResultExecutor>();
 
-        // Routing
-        // This can't be a singleton
-        // https://github.com/dotnet/aspnetcore/issues/46980
-        services.TryAddSingleton<RazorComponentEndpointDataSource>();
+        // Endpoints
+        services.TryAddSingleton<RazorComponentEndpointDataSourceFactory>();
+        services.TryAddSingleton<RazorComponentEndpointFactory>();
 
         // Common services required for components server side rendering
         services.TryAddSingleton<ServerComponentSerializer>(services => new ServerComponentSerializer(services.GetRequiredService<IDataProtectionProvider>()));

--- a/src/Components/Endpoints/src/Discovery/ComponentApplicationBuilder.cs
+++ b/src/Components/Endpoints/src/Discovery/ComponentApplicationBuilder.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components;
+
+/// <summary>
+/// Builder used to configure a <see cref="RazorComponentApplication"/> instance.
+/// </summary>
+public class ComponentApplicationBuilder
+{
+    private readonly HashSet<string> _assemblies = new();
+    private PageCollection? _pages;
+
+    // TODO: When we support proper discovery this will be public
+    // (and probably have a different shape).
+    internal void AddAssembly(string name)
+    {
+        _assemblies.Add(name);
+    }
+
+    /// <summary>
+    /// Builds the component application definition.
+    /// </summary>
+    /// <returns>The <see cref="RazorComponentApplication"/>.</returns>
+    public RazorComponentApplication Build()
+    {
+        return new RazorComponentApplication(_pages ?? PageCollection.Empty);
+    }
+
+    internal void RegisterPages(PageCollection pages)
+    {
+        _pages = pages;
+    }
+}

--- a/src/Components/Endpoints/src/Discovery/IRazorComponentApplication.cs
+++ b/src/Components/Endpoints/src/Discovery/IRazorComponentApplication.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.AspNetCore.Components;
+
+/// <summary>
+/// The definition of a Razor Components Application.
+/// </summary>
+/// <remarks>
+/// Typically the top level component (like the App component or the MainLayout component)
+/// for the application implements this interface.
+/// </remarks>
+/// <typeparam name="TComponent">The component used to define the application.</typeparam>
+public interface IRazorComponentApplication<TComponent>
+    where TComponent : IRazorComponentApplication<TComponent>
+{
+    /// <summary>
+    /// Creates a builder that can be used to customize the definition of the application.
+    /// For example, to add or remove pages, change routes, etc.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="ComponentApplicationBuilder"/> associated with the application
+    /// definition.
+    /// </returns>
+    static virtual ComponentApplicationBuilder GetBuilder()
+    {
+        var builder = new ComponentApplicationBuilder();
+        // TODO: We'll have to figure out the exact API shape here
+        // once we support discovery, since this will be generated on the user
+        // app and will be public.
+        // Similarly, RegisterPages will have to be called by the user app code
+        // with the source generated code.
+        // The builder provides the ability to choose what assemblies will be
+        // considered and checked as a source for endpoints.
+        // We also want to have a bit more granularity and exclude/replace individual
+        // pages from within a given assembly.
+        // We don't know if we need a generic "Feature" abstraction that can be registered
+        // or if we can instead extend the builder with new methods whenever we need to add
+        // new functionality.
+        // The builder is going to be responsible for generating the code that replaces
+        // scanning and reflection wherever we do it, so it needs to be something that
+        // the user can configure.
+        // In general, I want to avoid the "everything is a feature" for things like Pages.
+        // The way to tweak any aspect that affect a page is through conventions in the
+        // endpoint metadata.
+        // We might expose something like the PageCollection or PageFeature in the future
+        // so that users can decide the list of things that get considered as endpoints.
+        builder.AddAssembly(typeof(TComponent).Assembly.FullName!);
+        builder.RegisterPages(new PageCollection(CreatePageRouteCollection()));
+
+        return builder;
+
+        static IEnumerable<PageDefinition> CreatePageRouteCollection()
+        {
+            var exported = typeof(TComponent).Assembly.GetExportedTypes();
+            for (var i = 0; i < exported.Length; i++)
+            {
+                var candidate = exported[i];
+                if (candidate.IsAssignableTo(typeof(IComponent)) &&
+                    // Note that this does not support multiple routes, which is
+                    // something someone could do with an explicit [Route] attribute
+                    // definition.
+                    candidate.GetCustomAttribute<RouteAttribute>() is { } route)
+                {
+                    yield return new PageDefinition(
+                        candidate.FullName!,
+                        candidate,
+                        route.Template,
+                        // We remove the route attribute since it is captured on the endpoint.
+                        // This is similar to how MVC behaves.
+                        candidate.GetCustomAttributes(inherit: true).Except(Enumerable.Repeat(route, 1)).ToArray());
+                };
+            }
+        }
+    }
+}

--- a/src/Components/Endpoints/src/Discovery/PageCollection.cs
+++ b/src/Components/Endpoints/src/Discovery/PageCollection.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Components;
+
+internal class PageCollection
+{
+    public PageCollection(IEnumerable<PageDefinition> pages)
+    {
+        Pages = pages.ToList();
+    }
+
+    internal static PageCollection Empty { get; } = new PageCollection(Enumerable.Empty<PageDefinition>());
+
+    internal List<PageDefinition> Pages { get; }
+}

--- a/src/Components/Endpoints/src/Discovery/PageDefinition.cs
+++ b/src/Components/Endpoints/src/Discovery/PageDefinition.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components;
+
+/// <summary>
+/// The definition for a page, including the type and the associated routes.
+/// </summary>
+public class PageDefinition
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="PageDefinition"/>.
+    /// </summary>
+    /// <param name="displayName">The name for the page. Used for logging and debug purposes across the system.</param>
+    /// <param name="type">The page <see cref="System.Type"/>.</param>
+    /// <param name="route">The see list of routes for the page.</param>
+    /// <param name="metadata">The page metadata.</param>
+    internal PageDefinition(
+        string displayName,
+        Type type,
+        string route,
+        IReadOnlyList<object> metadata)
+    {
+        DisplayName = displayName;
+        Type = type;
+        Route = route;
+        Metadata = metadata;
+    }
+
+    /// <summary>
+    /// Gets the page display name.
+    /// </summary>
+    public string DisplayName { get; }
+
+    /// <summary>
+    /// Gets the page type.
+    /// </summary>
+    public Type Type { get; }
+
+    /// <summary>
+    /// Gets the routes for the page.
+    /// </summary>
+    public string Route { get; }
+
+    /// <summary>
+    /// Gets the metadata for the page.
+    /// </summary>
+    public IReadOnlyList<object> Metadata { get; }
+}

--- a/src/Components/Endpoints/src/Discovery/RazorComponentApplication.cs
+++ b/src/Components/Endpoints/src/Discovery/RazorComponentApplication.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components;
+
+/// <summary>
+/// The definition of a component based application.
+/// </summary>
+public class RazorComponentApplication
+{
+    private readonly PageCollection _pageCollection;
+
+    // TODO: we define the concepts explicitly (like the collection of pages)
+    // In the future we need to decide if we want to do generalize this concept and use
+    // something "generic" like a list of "features".
+    internal RazorComponentApplication(PageCollection pagesCollection)
+    {
+        _pageCollection = pagesCollection;
+    }
+
+    /// <summary>
+    /// Gets the list of <see cref="PageDefinition"/> associated with the application.
+    /// </summary>
+    /// <returns>The list of pages.</returns>
+    public IEnumerable<PageDefinition> Pages => _pageCollection.Pages;
+}

--- a/src/Components/Endpoints/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Endpoints/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,13 @@
+Microsoft.AspNetCore.Builder.ComponentTypeMetadata
+Microsoft.AspNetCore.Builder.ComponentTypeMetadata.ComponentTypeMetadata(System.Type! componentType) -> void
+Microsoft.AspNetCore.Builder.ComponentTypeMetadata.Type.get -> System.Type!
+Microsoft.AspNetCore.Builder.RazorComponentEndpointConventionBuilder
+Microsoft.AspNetCore.Builder.RazorComponentEndpointConventionBuilder.Add(System.Action<Microsoft.AspNetCore.Builder.EndpointBuilder!>! convention) -> void
+Microsoft.AspNetCore.Builder.RazorComponentEndpointConventionBuilder.Finally(System.Action<Microsoft.AspNetCore.Builder.EndpointBuilder!>! finallyConvention) -> void
 Microsoft.AspNetCore.Builder.RazorComponentsEndpointRouteBuilderExtensions
+Microsoft.AspNetCore.Components.ComponentApplicationBuilder
+Microsoft.AspNetCore.Components.ComponentApplicationBuilder.Build() -> Microsoft.AspNetCore.Components.RazorComponentApplication!
+Microsoft.AspNetCore.Components.ComponentApplicationBuilder.ComponentApplicationBuilder() -> void
 Microsoft.AspNetCore.Components.Endpoints.IComponentPrerenderer
 Microsoft.AspNetCore.Components.Endpoints.IComponentPrerenderer.Dispatcher.get -> Microsoft.AspNetCore.Components.Dispatcher!
 Microsoft.AspNetCore.Components.Endpoints.IComponentPrerenderer.PrerenderComponentAsync(Microsoft.AspNetCore.Http.HttpContext! httpContext, System.Type! componentType, Microsoft.AspNetCore.Components.RenderMode renderMode, Microsoft.AspNetCore.Components.ParameterView parameters) -> System.Threading.Tasks.ValueTask<Microsoft.AspNetCore.Html.IHtmlAsyncContent!>
@@ -24,10 +33,19 @@ Microsoft.AspNetCore.Components.Endpoints.RazorComponentResult<TComponent>.Razor
 Microsoft.AspNetCore.Components.Endpoints.RazorComponentResult<TComponent>.RazorComponentResult(System.Collections.Generic.IReadOnlyDictionary<string!, object?>! parameters) -> void
 Microsoft.AspNetCore.Components.Endpoints.RazorComponentResultExecutor
 Microsoft.AspNetCore.Components.Endpoints.RazorComponentResultExecutor.RazorComponentResultExecutor() -> void
+Microsoft.AspNetCore.Components.IRazorComponentApplication<TComponent>
+Microsoft.AspNetCore.Components.IRazorComponentApplication<TComponent>.GetBuilder() -> Microsoft.AspNetCore.Components.ComponentApplicationBuilder!
+Microsoft.AspNetCore.Components.PageDefinition
+Microsoft.AspNetCore.Components.PageDefinition.DisplayName.get -> string!
+Microsoft.AspNetCore.Components.PageDefinition.Metadata.get -> System.Collections.Generic.IReadOnlyList<object!>!
+Microsoft.AspNetCore.Components.PageDefinition.Route.get -> string!
+Microsoft.AspNetCore.Components.PageDefinition.Type.get -> System.Type!
 Microsoft.AspNetCore.Components.PersistedStateSerializationMode
 Microsoft.AspNetCore.Components.PersistedStateSerializationMode.Infer = 1 -> Microsoft.AspNetCore.Components.PersistedStateSerializationMode
 Microsoft.AspNetCore.Components.PersistedStateSerializationMode.Server = 2 -> Microsoft.AspNetCore.Components.PersistedStateSerializationMode
 Microsoft.AspNetCore.Components.PersistedStateSerializationMode.WebAssembly = 3 -> Microsoft.AspNetCore.Components.PersistedStateSerializationMode
+Microsoft.AspNetCore.Components.RazorComponentApplication
+Microsoft.AspNetCore.Components.RazorComponentApplication.Pages.get -> System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Components.PageDefinition!>!
 Microsoft.AspNetCore.Components.RenderMode
 Microsoft.AspNetCore.Components.RenderMode.Server = 2 -> Microsoft.AspNetCore.Components.RenderMode
 Microsoft.AspNetCore.Components.RenderMode.ServerPrerendered = 3 -> Microsoft.AspNetCore.Components.RenderMode
@@ -35,7 +53,7 @@ Microsoft.AspNetCore.Components.RenderMode.Static = 1 -> Microsoft.AspNetCore.Co
 Microsoft.AspNetCore.Components.RenderMode.WebAssembly = 4 -> Microsoft.AspNetCore.Components.RenderMode
 Microsoft.AspNetCore.Components.RenderMode.WebAssemblyPrerendered = 5 -> Microsoft.AspNetCore.Components.RenderMode
 Microsoft.Extensions.DependencyInjection.RazorComponentsServiceCollectionExtensions
-static Microsoft.AspNetCore.Builder.RazorComponentsEndpointRouteBuilderExtensions.MapRazorComponents(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints) -> Microsoft.AspNetCore.Builder.IEndpointConventionBuilder!
+static Microsoft.AspNetCore.Builder.RazorComponentsEndpointRouteBuilderExtensions.MapRazorComponents<TRootComponent>(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints) -> Microsoft.AspNetCore.Builder.RazorComponentEndpointConventionBuilder!
 static Microsoft.Extensions.DependencyInjection.RazorComponentsServiceCollectionExtensions.AddRazorComponents(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.AspNetCore.Components.Endpoints.IRazorComponentsBuilder!
 static readonly Microsoft.AspNetCore.Components.Endpoints.RazorComponentResultExecutor.DefaultContentType -> string!
 virtual Microsoft.AspNetCore.Components.Endpoints.RazorComponentResultExecutor.ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext! httpContext, Microsoft.AspNetCore.Components.Endpoints.RazorComponentResult! result) -> System.Threading.Tasks.Task!

--- a/src/Components/Endpoints/test/RazorComponentEndpointDataSourceTest.cs
+++ b/src/Components/Endpoints/test/RazorComponentEndpointDataSourceTest.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Microsoft.AspNetCore.Components.Endpoints;
+
+public class RazorComponentEndpointDataSourceTest
+{
+    [Fact]
+    public void RegistersEndpoints()
+    {
+        var endpointDataSource = CreateDataSource<App>();
+
+        var endpoints = endpointDataSource.Endpoints;
+        Assert.Equal(2, endpoints.Count);
+    }
+
+    [Fact]
+    public void RegistersEndpoints_CallsCustomImplementation()
+    {
+        var endpointDataSource = CreateDataSource<CustomApp>();
+
+        Assert.Equal(0, endpointDataSource.Endpoints.Count);
+    }
+
+    private RazorComponentEndpointDataSource<TComponent> CreateDataSource<TComponent>()
+        where TComponent : IRazorComponentApplication<TComponent>
+    {
+        return new RazorComponentEndpointDataSource<TComponent>(TComponent.GetBuilder(), new RazorComponentEndpointFactory());
+    }
+}
+
+public class CustomApp : IComponent, IRazorComponentApplication<CustomApp>
+{
+    public void Attach(RenderHandle renderHandle)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task SetParametersAsync(ParameterView parameters)
+    {
+        throw new NotImplementedException();
+    }
+
+    static ComponentApplicationBuilder IRazorComponentApplication<CustomApp>.GetBuilder()
+    {
+        return new ComponentApplicationBuilder();
+    }
+}
+
+public class App : IComponent, IRazorComponentApplication<App>
+{
+    public void Attach(RenderHandle renderHandle)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task SetParametersAsync(ParameterView parameters)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+[Route("/")]
+public class Index : IComponent
+{
+    public void Attach(RenderHandle renderHandle)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task SetParametersAsync(ParameterView parameters)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+[Route("/counter")]
+public class Counter : IComponent
+{
+    public void Attach(RenderHandle renderHandle)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task SetParametersAsync(ParameterView parameters)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Components/Endpoints/test/RazorComponentEndpointFactoryTest.cs
+++ b/src/Components/Endpoints/test/RazorComponentEndpointFactoryTest.cs
@@ -1,0 +1,148 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Microsoft.AspNetCore.Components.Endpoints;
+
+public class RazorComponentEndpointFactoryTest
+{
+    [Fact]
+    public void AddEndpoints_CreatesEndpointWithExpectedMetadata()
+    {
+        var endpoints = new List<Endpoint>();
+        var factory = new RazorComponentEndpointFactory();
+        var conventions = new List<Action<EndpointBuilder>>();
+        var finallyConventions = new List<Action<EndpointBuilder>>();
+        factory.AddEndpoints(endpoints, new PageDefinition(
+            "App",
+            typeof(App),
+            "/",
+            new object[] { new AuthorizeAttribute() }),
+            conventions,
+            finallyConventions);
+
+        var endpoint = Assert.Single(endpoints);
+        Assert.Equal("/ (App)", endpoint.DisplayName);
+        var routeEndpoint = Assert.IsType<RouteEndpoint>(endpoint);
+        Assert.Equal(0, routeEndpoint.Order);
+        Assert.Equal("/", routeEndpoint.RoutePattern.RawText);
+        Assert.Contains(endpoint.Metadata, m => m is ComponentTypeMetadata);
+        Assert.Contains(endpoint.Metadata, m => m is SuppressLinkGenerationMetadata);
+        Assert.Contains(endpoint.Metadata, m => m is AuthorizeAttribute);
+        Assert.NotNull(endpoint.RequestDelegate);
+
+        var methods = Assert.Single(endpoint.Metadata.GetOrderedMetadata<HttpMethodMetadata>());
+        var method = Assert.Single(methods.HttpMethods);
+        Assert.Equal("GET", method);
+    }
+
+    [Fact]
+    public void AddEndpoints_RunsConventions()
+    {
+        var endpoints = new List<Endpoint>();
+        var factory = new RazorComponentEndpointFactory();
+        var conventions = new List<Action<EndpointBuilder>>() {
+            builder => builder.Metadata.Add(new AuthorizeAttribute())
+        };
+
+        var finallyConventions = new List<Action<EndpointBuilder>>();
+        factory.AddEndpoints(
+            endpoints,
+            new PageDefinition(
+                "App",
+                typeof(App),
+                "/",
+                Array.Empty<object>()),
+            conventions,
+            finallyConventions);
+
+        var endpoint = Assert.Single(endpoints);
+        Assert.Contains(endpoint.Metadata, m => m is AuthorizeAttribute);
+    }
+
+    [Fact]
+    public void AddEndpoints_RunsFinallyConventions()
+    {
+        var endpoints = new List<Endpoint>();
+        var factory = new RazorComponentEndpointFactory();
+        var conventions = new List<Action<EndpointBuilder>>();
+
+        var finallyConventions = new List<Action<EndpointBuilder>>()
+        {
+            builder => builder.Metadata.Add(new AuthorizeAttribute())
+        };
+
+        factory.AddEndpoints(
+            endpoints,
+            new PageDefinition(
+                "App",
+                typeof(App),
+                "/",
+                Array.Empty<object>()),
+            conventions,
+            finallyConventions);
+
+        var endpoint = Assert.Single(endpoints);
+        Assert.Contains(endpoint.Metadata, m => m is AuthorizeAttribute);
+    }
+
+    [Fact]
+    public void AddEndpoints_RouteOrderCanNotBeChanged()
+    {
+        var endpoints = new List<Endpoint>();
+        var factory = new RazorComponentEndpointFactory();
+        var conventions = new List<Action<EndpointBuilder>>();
+
+        var finallyConventions = new List<Action<EndpointBuilder>>()
+        {
+            builder => ((RouteEndpointBuilder)builder).Order = -1
+        };
+
+        factory.AddEndpoints(
+            endpoints,
+            new PageDefinition(
+                "App",
+                typeof(App),
+                "/",
+                Array.Empty<object>()),
+            conventions,
+            finallyConventions);
+
+        var endpoint = Assert.Single(endpoints);
+        var routeEndpoint = Assert.IsType<RouteEndpoint>(endpoint);
+        Assert.Equal(0, routeEndpoint.Order);
+    }
+
+    [Fact]
+    public void AddEndpoints_RunsFinallyConventionsAfterRegularConventions()
+    {
+        var endpoints = new List<Endpoint>();
+        var factory = new RazorComponentEndpointFactory();
+        var conventions = new List<Action<EndpointBuilder>>()
+        {
+            builder => builder.Metadata.Add(new AuthorizeAttribute())
+        };
+
+        var finallyConventions = new List<Action<EndpointBuilder>>()
+        {
+            builder => builder.Metadata.Remove(builder.Metadata.OfType<AuthorizeAttribute>().Single())
+        };
+
+        factory.AddEndpoints(
+            endpoints,
+            new PageDefinition(
+                "App",
+                typeof(App),
+                "/",
+                Array.Empty<object>()),
+            conventions,
+            finallyConventions);
+
+        var endpoint = Assert.Single(endpoints);
+        Assert.DoesNotContain(endpoint.Metadata, m => m is AuthorizeAttribute);
+    }
+}

--- a/src/Components/Samples/BlazorServerApp/App.razor
+++ b/src/Components/Samples/BlazorServerApp/App.razor
@@ -1,4 +1,5 @@
-﻿<Router AppAssembly="@typeof(Program).Assembly">
+﻿@implements IRazorComponentApplication<App>
+<Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
         <FocusOnNavigate RouteData="@routeData" Selector="h1" />

--- a/src/Components/Samples/BlazorServerApp/App.razor
+++ b/src/Components/Samples/BlazorServerApp/App.razor
@@ -1,4 +1,4 @@
-<Router AppAssembly="@typeof(Program).Assembly">
+﻿<Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
         <FocusOnNavigate RouteData="@routeData" Selector="h1" />

--- a/src/Components/Samples/BlazorServerApp/App.razor
+++ b/src/Components/Samples/BlazorServerApp/App.razor
@@ -1,4 +1,3 @@
-﻿@implements IRazorComponentApplication<App>
 <Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />

--- a/src/Components/Samples/BlazorUnitedApp/Program.cs
+++ b/src/Components/Samples/BlazorUnitedApp/Program.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using BlazorUnitedApp.Data;
+using BlazorUnitedApp.Shared;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -26,6 +27,6 @@ app.UseStaticFiles();
 
 app.UseRouting();
 
-app.MapRazorComponents();
+app.MapRazorComponents<MainLayout>();
 
 app.Run();

--- a/src/Components/Samples/BlazorUnitedApp/Shared/MainLayout.razor
+++ b/src/Components/Samples/BlazorUnitedApp/Shared/MainLayout.razor
@@ -1,4 +1,5 @@
 ﻿@inherits LayoutComponentBase
+@implements IRazorComponentApplication<MainLayout>
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/issues/46984
https://github.com/dotnet/aspnetcore/issues/46985

I've implemented the "scaffold" for discovery even though we don't do discovery. The goal of the implementation is to avoid reflection completely and support source generation and allowing the user to tweak the results via endpoint conventions.

We are not doing discovery beyond the current assembly, and only for pages. We are also not allowing the user to customize the list of assemblies or pages that we discover just yet.

The approach that we are trying to follow is simpler than what MVC does, but we might end up with a similar design when we implement discovery entirely.

We rely on having a component that acts as the root/entry point of the application to discover the rest of the pages that are part of the application. Our entry point implements an interface (which we will automatically source generate a definition and implementation for based on the calls to `MapRazorComponents`) that returns a `ComponentApplicationBuilder`.

This builder is used internally to provide the list of pages along with their routes and other metadata. The builder is passed down to the `RazorComponentConventionEndpointBuilder`, which will be the piece that exposes additional methods to add or remove entire assemblies from the mappings or individual sets of types.

We use the data in the builder when we build the list of endpoints to generate the initial endpoint definition, which the user can the further customize via conventions.

* We expect customization to happen via conventions.
  * We don't think we need an application model like MVC, as endpoints are already customizable.
* We expect any reflection to happen in the default implementations for the `ComponentApplicationBuilder`.
  * The goal here is to source generate the implementation and avoid reflection completely elsewhere in the system.