### PR TITLE
Include verb in gRPC JSON transcoding swagger path

### DIFF
--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/GrpcJsonTranscodingDescriptionProvider.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/GrpcJsonTranscodingDescriptionProvider.cs
@@ -182,6 +182,11 @@ internal sealed class GrpcJsonTranscodingDescriptionProvider : IApiDescriptionPr
                 sb.Append(httpRoutePattern.Segments[i]);
             }
         }
+        if (httpRoutePattern.Verb != null)
+        {
+            sb.Append(':');
+            sb.Append(httpRoutePattern.Verb);
+        }
         return sb.ToString();
     }
 

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Parameters/ParametersTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Parameters/ParametersTests.cs
@@ -160,4 +160,27 @@ public class ParametersTests
         Assert.Equal("integer", operation.Parameters[2].Schema.Type);
         Assert.Equal("int32", operation.Parameters[2].Schema.Format);
     }
+
+    [Fact]
+    public void Verb()
+    {
+        // Arrange & Act
+        var swagger = OpenApiTestHelpers.GetOpenApiDocument<ParametersService>(_testOutputHelper);
+
+        // Assert
+        var path1 = swagger.Paths["/v1/parameters10/{parameterInt}:one"];
+        AssertParams(path1);
+        var path2 = swagger.Paths["/v1/parameters10/{parameterInt}:two"];
+        AssertParams(path2);
+
+        static void AssertParams(OpenApiPathItem path)
+        {
+            Assert.True(path.Operations.TryGetValue(OperationType.Get, out var operation));
+            Assert.Equal(2, operation.Parameters.Count);
+            Assert.Equal(ParameterLocation.Path, operation.Parameters[0].In);
+            Assert.Equal("parameterInt", operation.Parameters[0].Name);
+            Assert.Equal(ParameterLocation.Query, operation.Parameters[1].In);
+            Assert.Equal("parameterString", operation.Parameters[1].Name);
+        }
+    }
 }

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Proto/parameters.proto
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.Swagger.Tests/Proto/parameters.proto
@@ -77,6 +77,18 @@ service Parameters {
       get: "/v1/parameters9"
     };
   }
+
+  rpc DemoParametersTenOne (RequestOne) returns (ParamResponse) {
+    option (google.api.http) = {
+      get: "/v1/parameters10/{parameter_int}:one"
+    };
+  }
+
+  rpc DemoParametersTenTwo (RequestOne) returns (ParamResponse) {
+    option (google.api.http) = {
+      get: "/v1/parameters10/{parameter_int}:two"
+    };
+  }
 }
 
 message RequestOne {


### PR DESCRIPTION
Follow up to https://github.com/dotnet/aspnetcore/pull/47123

During manual testing I found the verb also needs to be included in the swagger (OpenAPI) path.