### PR TITLE
Update service worker templates to prevent index.html being served when an offline resource is requested.

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/Client/wwwroot/service-worker.published.js
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/Client/wwwroot/service-worker.published.js
@@ -11,6 +11,11 @@ const cacheName = `${cacheNamePrefix}${self.assetsManifest.version}`;
 const offlineAssetsInclude = [ /\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /\.json$/, /\.css$/, /\.woff$/, /\.png$/, /\.jpe?g$/, /\.gif$/, /\.ico$/, /\.blat$/, /\.dat$/ ];
 const offlineAssetsExclude = [ /^service-worker\.js$/ ];
 
+// Replace with your base path if you are hosting on a subfolder. Ensure there is a trailing '/'.
+const base = "/";
+const baseUrl = new URL(base, self.origin);
+const manifestUrlList = self.assetsManifest.assets.map(asset => new URL(asset.url, baseUrl).href);
+
 async function onInstall(event) {
     console.info('Service worker: Install');
 
@@ -35,8 +40,10 @@ async function onActivate(event) {
 async function onFetch(event) {
     let cachedResponse = null;
     if (event.request.method === 'GET') {
-        // For all navigation requests, try to serve index.html from cache
-        const shouldServeIndexHtml = event.request.mode === 'navigate';
+        // For all navigation requests, try to serve index.html from cache,
+        // unless that request is for an offline resource.
+        const shouldServeIndexHtml = event.request.mode === 'navigate'
+            && !manifestUrlList.some(url => url === event.request.url);
 
         const request = shouldServeIndexHtml ? 'index.html' : event.request;
         const cache = await caches.open(cacheName);


### PR DESCRIPTION
# Update service worker templates

Prevent index.html being served when an offline resource is requested.

## Description

The service worker in the Blazor webassembly templates will serve index.html instead of the requested asset when an offline asset is requested with a navigate request. This PR resolves that issue.

Fixes #40678
