### PR TITLE
Add src/DefaultBuilder/ to area-hosting

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1504,8 +1504,7 @@
               "src/Azure/AzureAppServices.HostingStartup/",
               "src/Middleware/",
               "src/HttpClientFactory/",
-              "src/SiteExtensions/",
-              "src/DefaultBuilder/"
+              "src/SiteExtensions/"
             ]
           },
           {
@@ -1542,6 +1541,7 @@
           {
             "label": "area-hosting",
             "pathFilter": [
+              "src/DefaultBuilder/",
               "src/Hosting/"
             ]
           }


### PR DESCRIPTION
Follow up to #47181.

We might also want to look at [area-owners.md](https://github.com/dotnet/aspnetcore/blob/4d2071ee4b95d0b90d6538defb420c44b23b16e6/docs/area-owners.md#area-owners), but that already looks very out of date. Should we update it or delete it?