### PR TITLE
Use Environment.SystemDirectory to get system directory

### DIFF
--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -193,7 +193,7 @@ public sealed class WebApplicationBuilder
             // any trailing directory separator characters. I'm not even sure the casing can ever be different from these APIs, but I think it makes sense to
             // ignore case for Windows path comparisons given the file system is usually (always?) going to be case insensitive for the system path.
             string cwd = System.Environment.CurrentDirectory;
-            if (!OperatingSystem.IsWindows() || !string.Equals(cwd, System.Environment.Environment.SystemDirectory, StringComparison.OrdinalIgnoreCase))
+            if (!OperatingSystem.IsWindows() || !string.Equals(cwd, System.Environment.SystemDirectory, StringComparison.OrdinalIgnoreCase))
             {
                 configuration.AddInMemoryCollection(new[]
                 {

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -189,11 +189,11 @@ public sealed class WebApplicationBuilder
             // to really be the home for things like appsettings.json, we skip changing the ContentRoot in that case. The non-"default" initial
             // value for ContentRoot is AppContext.BaseDirectory (e.g. the executable path) which probably makes more sense than the system32.
 
-            // In my testing, both Environment.CurrentDirectory and Environment.GetFolderPath(Environment.SpecialFolder.System) return the path without
+            // In my testing, both Environment.CurrentDirectory and Environment.SystemDirectory return the path without
             // any trailing directory separator characters. I'm not even sure the casing can ever be different from these APIs, but I think it makes sense to
             // ignore case for Windows path comparisons given the file system is usually (always?) going to be case insensitive for the system path.
             string cwd = System.Environment.CurrentDirectory;
-            if (!OperatingSystem.IsWindows() || !string.Equals(cwd, System.Environment.GetFolderPath(System.Environment.SpecialFolder.System), StringComparison.OrdinalIgnoreCase))
+            if (!OperatingSystem.IsWindows() || !string.Equals(cwd, Environment.SystemDirectory, StringComparison.OrdinalIgnoreCase))
             {
                 configuration.AddInMemoryCollection(new[]
                 {

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -193,7 +193,7 @@ public sealed class WebApplicationBuilder
             // any trailing directory separator characters. I'm not even sure the casing can ever be different from these APIs, but I think it makes sense to
             // ignore case for Windows path comparisons given the file system is usually (always?) going to be case insensitive for the system path.
             string cwd = System.Environment.CurrentDirectory;
-            if (!OperatingSystem.IsWindows() || !string.Equals(cwd, Environment.SystemDirectory, StringComparison.OrdinalIgnoreCase))
+            if (!OperatingSystem.IsWindows() || !string.Equals(cwd, System.Environment.Environment.SystemDirectory, StringComparison.OrdinalIgnoreCase))
             {
                 configuration.AddInMemoryCollection(new[]
                 {

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -182,7 +182,7 @@ public sealed class WebApplicationBuilder
     {
         if (options.ContentRootPath is null && configuration[HostDefaults.ContentRootKey] is null)
         {
-            // Logic taken from https://github.com/dotnet/runtime/blob/78ed4438a42acab80541e9bde1910abaa8841db2/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs#L209-L227
+            // Logic taken from https://github.com/dotnet/runtime/blob/dc5a6c8be1644915c14c4a464447b0d54e223a46/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs#L209-L227
 
             // If we're running anywhere other than C:\Windows\system32, we default to using the CWD for the ContentRoot.
             // However, since many things like Windows services and MSIX installers have C:\Windows\system32 as there CWD which is not likely

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -595,7 +595,7 @@ public class WebApplicationTests
     public void ContentRootIsBaseDirectoryWhenCurrentIsSpecialFolderSystem()
     {
         var options = new RemoteInvokeOptions();
-        options.StartInfo.WorkingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.System);
+        options.StartInfo.WorkingDirectory = Environment.SystemDirectory;
 
         using var remoteHandle = RemoteExecutor.Invoke(static () =>
         {


### PR DESCRIPTION
`Environment.SystemDirectory` is a lot more efficient than `Environment.GetFolderPath(System.Environment.SpecialFolder.System)`.

Contributes to https://github.com/dotnet/aspnetcore/issues/47269