### PR TITLE
Add LookupName to EndpointParameter.

### DIFF
--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointEmitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointEmitter.cs
@@ -73,7 +73,7 @@ internal static class EndpointEmitter
                     codeWriter.WriteLine("var serviceProviderIsService = options?.ServiceProvider?.GetService<IServiceProviderIsService>();");
                     serviceProviderEmitted = true;
                 }
-                codeWriter.Write($@"var {parameter.Name}_JsonBodyOrServiceResolver = ");
+                codeWriter.Write($@"var {parameter.SymbolName}_JsonBodyOrServiceResolver = ");
                 codeWriter.WriteLine($"ResolveJsonBodyOrService<{parameter.Type.ToDisplayString(EmitterConstants.DisplayFormat)}>(serviceProviderIsService);");
             }
         }

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointEmitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointEmitter.cs
@@ -54,7 +54,7 @@ internal static class EndpointEmitter
         {
             if (parameter.Source == EndpointParameterSource.RouteOrQuery)
             {
-                var parameterName = parameter.ParameterName;
+                var parameterName = parameter.SymbolName;
                 codeWriter.Write($@"var {parameterName}_RouteOrQueryResolver = ");
                 codeWriter.WriteLine($@"GeneratedRouteBuilderExtensionsCore.ResolveFromRouteOrQuery(""{parameterName}"", options?.RouteParameterNames);");
             }

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointEmitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointEmitter.cs
@@ -54,7 +54,7 @@ internal static class EndpointEmitter
         {
             if (parameter.Source == EndpointParameterSource.RouteOrQuery)
             {
-                var parameterName = parameter.Name;
+                var parameterName = parameter.ParameterName;
                 codeWriter.Write($@"var {parameterName}_RouteOrQueryResolver = ");
                 codeWriter.WriteLine($@"GeneratedRouteBuilderExtensionsCore.ResolveFromRouteOrQuery(""{parameterName}"", options?.RouteParameterNames);");
             }

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
@@ -118,7 +118,7 @@ internal static class EndpointParameterEmitter
     {
         codeWriter.WriteLine(endpointParameter.EmitParameterDiagnosticComment());
 
-        var parameterName = endpointParameter.ParameterName;
+        var parameterName = endpointParameter.SymbolName;
         codeWriter.WriteLine($"var {endpointParameter.EmitAssigningCodeResult()} = {parameterName}_RouteOrQueryResolver(httpContext);");
 
         if (endpointParameter.IsArray)
@@ -149,7 +149,7 @@ internal static class EndpointParameterEmitter
         // Invoke TryResolveBody method to parse JSON and set
         // status codes on exceptions.
         var assigningCode = $"await GeneratedRouteBuilderExtensionsCore.TryResolveBodyAsync<{endpointParameter.Type.ToDisplayString(EmitterConstants.DisplayFormat)}>(httpContext, {(endpointParameter.IsOptional ? "true" : "false")})";
-        var resolveBodyResult = $"{endpointParameter.ParameterName}_resolveBodyResult";
+        var resolveBodyResult = $"{endpointParameter.SymbolName}_resolveBodyResult";
         codeWriter.WriteLine($"var {resolveBodyResult} = {assigningCode};");
         codeWriter.WriteLine($"var {endpointParameter.EmitHandlerArgument()} = {resolveBodyResult}.Item2;");
 
@@ -238,12 +238,12 @@ internal static class EndpointParameterEmitter
         codeWriter.WriteLine($"var {endpointParameter.EmitHandlerArgument()} = {assigningCode};");
     }
 
-    private static string EmitParameterDiagnosticComment(this EndpointParameter endpointParameter) => $"// Endpoint Parameter: {endpointParameter.ParameterName} (Type = {endpointParameter.Type}, IsOptional = {endpointParameter.IsOptional}, IsParsable = {endpointParameter.IsParsable}, IsArray = {endpointParameter.IsArray}, Source = {endpointParameter.Source})";
-    private static string EmitHandlerArgument(this EndpointParameter endpointParameter) => $"{endpointParameter.ParameterName}_local";
-    private static string EmitTempArgument(this EndpointParameter endpointParameter) => $"{endpointParameter.ParameterName}_temp";
+    private static string EmitParameterDiagnosticComment(this EndpointParameter endpointParameter) => $"// Endpoint Parameter: {endpointParameter.SymbolName} (Type = {endpointParameter.Type}, IsOptional = {endpointParameter.IsOptional}, IsParsable = {endpointParameter.IsParsable}, IsArray = {endpointParameter.IsArray}, Source = {endpointParameter.Source})";
+    private static string EmitHandlerArgument(this EndpointParameter endpointParameter) => $"{endpointParameter.SymbolName}_local";
+    private static string EmitTempArgument(this EndpointParameter endpointParameter) => $"{endpointParameter.SymbolName}_temp";
 
-    private static string EmitParsedTempArgument(this EndpointParameter endpointParameter) => $"{endpointParameter.ParameterName}_parsed_temp";
-    private static string EmitAssigningCodeResult(this EndpointParameter endpointParameter) => $"{endpointParameter.ParameterName}_raw";
+    private static string EmitParsedTempArgument(this EndpointParameter endpointParameter) => $"{endpointParameter.SymbolName}_parsed_temp";
+    private static string EmitAssigningCodeResult(this EndpointParameter endpointParameter) => $"{endpointParameter.SymbolName}_raw";
 
     public static string EmitArgument(this EndpointParameter endpointParameter) => endpointParameter.Source switch
     {

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
@@ -19,8 +19,8 @@ internal static class EndpointParameterEmitter
         codeWriter.WriteLine(endpointParameter.EmitParameterDiagnosticComment());
 
         var assigningCode = endpointParameter.Source is EndpointParameterSource.Header
-            ? $"httpContext.Request.Headers[\"{endpointParameter.Name}\"]"
-            : $"httpContext.Request.Query[\"{endpointParameter.Name}\"]";
+            ? $"httpContext.Request.Headers[\"{endpointParameter.LookupName}\"]"
+            : $"httpContext.Request.Query[\"{endpointParameter.LookupName}\"]";
         codeWriter.WriteLine($"var {endpointParameter.EmitAssigningCodeResult()} = {assigningCode};");
 
         // If we are not optional, then at this point we can just assign the string value to the handler argument,
@@ -94,12 +94,12 @@ internal static class EndpointParameterEmitter
 
         // Throw an exception of if the route parameter name that was specific in the `FromRoute`
         // attribute or in the parameter name does not appear in the actual route.
-        codeWriter.WriteLine($"""if (options?.RouteParameterNames?.Contains("{endpointParameter.Name}", StringComparer.OrdinalIgnoreCase) != true)""");
+        codeWriter.WriteLine($"""if (options?.RouteParameterNames?.Contains("{endpointParameter.LookupName}", StringComparer.OrdinalIgnoreCase) != true)""");
         codeWriter.StartBlock();
-        codeWriter.WriteLine($$"""throw new InvalidOperationException($"'{{endpointParameter.Name}}' is not a route parameter.");""");
+        codeWriter.WriteLine($$"""throw new InvalidOperationException($"'{{endpointParameter.LookupName}}' is not a route parameter.");""");
         codeWriter.EndBlock();
 
-        var assigningCode = $"(string?)httpContext.Request.RouteValues[\"{endpointParameter.Name}\"]";
+        var assigningCode = $"(string?)httpContext.Request.RouteValues[\"{endpointParameter.LookupName}\"]";
         codeWriter.WriteLine($"var {endpointParameter.EmitAssigningCodeResult()} = {assigningCode};");
 
         if (!endpointParameter.IsOptional)

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
@@ -118,7 +118,7 @@ internal static class EndpointParameterEmitter
     {
         codeWriter.WriteLine(endpointParameter.EmitParameterDiagnosticComment());
 
-        var parameterName = endpointParameter.Name;
+        var parameterName = endpointParameter.ParameterName;
         codeWriter.WriteLine($"var {endpointParameter.EmitAssigningCodeResult()} = {parameterName}_RouteOrQueryResolver(httpContext);");
 
         if (endpointParameter.IsArray)
@@ -149,7 +149,7 @@ internal static class EndpointParameterEmitter
         // Invoke TryResolveBody method to parse JSON and set
         // status codes on exceptions.
         var assigningCode = $"await GeneratedRouteBuilderExtensionsCore.TryResolveBodyAsync<{endpointParameter.Type.ToDisplayString(EmitterConstants.DisplayFormat)}>(httpContext, {(endpointParameter.IsOptional ? "true" : "false")})";
-        var resolveBodyResult = $"{endpointParameter.Name}_resolveBodyResult";
+        var resolveBodyResult = $"{endpointParameter.ParameterName}_resolveBodyResult";
         codeWriter.WriteLine($"var {resolveBodyResult} = {assigningCode};");
         codeWriter.WriteLine($"var {endpointParameter.EmitHandlerArgument()} = {resolveBodyResult}.Item2;");
 
@@ -170,8 +170,8 @@ internal static class EndpointParameterEmitter
         // Invoke ResolveJsonBodyOrService method to resolve the
         // type from DI if it exists. Otherwise, resolve the parameter
         // as a body parameter.
-        var assigningCode = $"await {endpointParameter.Name}_JsonBodyOrServiceResolver(httpContext, {(endpointParameter.IsOptional ? "true" : "false")})";
-        var resolveJsonBodyOrServiceResult = $"{endpointParameter.Name}_resolveJsonBodyOrServiceResult";
+        var assigningCode = $"await {endpointParameter.SymbolName}_JsonBodyOrServiceResolver(httpContext, {(endpointParameter.IsOptional ? "true" : "false")})";
+        var resolveJsonBodyOrServiceResult = $"{endpointParameter.SymbolName}_resolveJsonBodyOrServiceResult";
         codeWriter.WriteLine($"var {resolveJsonBodyOrServiceResult} = {assigningCode};");
         codeWriter.WriteLine($"var {endpointParameter.EmitHandlerArgument()} = {resolveJsonBodyOrServiceResult}.Item2;");
 
@@ -238,12 +238,12 @@ internal static class EndpointParameterEmitter
         codeWriter.WriteLine($"var {endpointParameter.EmitHandlerArgument()} = {assigningCode};");
     }
 
-    private static string EmitParameterDiagnosticComment(this EndpointParameter endpointParameter) => $"// Endpoint Parameter: {endpointParameter.Name} (Type = {endpointParameter.Type}, IsOptional = {endpointParameter.IsOptional}, IsParsable = {endpointParameter.IsParsable}, IsArray = {endpointParameter.IsArray}, Source = {endpointParameter.Source})";
-    private static string EmitHandlerArgument(this EndpointParameter endpointParameter) => $"{endpointParameter.Name}_local";
-    private static string EmitTempArgument(this EndpointParameter endpointParameter) => $"{endpointParameter.Name}_temp";
+    private static string EmitParameterDiagnosticComment(this EndpointParameter endpointParameter) => $"// Endpoint Parameter: {endpointParameter.ParameterName} (Type = {endpointParameter.Type}, IsOptional = {endpointParameter.IsOptional}, IsParsable = {endpointParameter.IsParsable}, IsArray = {endpointParameter.IsArray}, Source = {endpointParameter.Source})";
+    private static string EmitHandlerArgument(this EndpointParameter endpointParameter) => $"{endpointParameter.ParameterName}_local";
+    private static string EmitTempArgument(this EndpointParameter endpointParameter) => $"{endpointParameter.ParameterName}_temp";
 
-    private static string EmitParsedTempArgument(this EndpointParameter endpointParameter) => $"{endpointParameter.Name}_parsed_temp";
-    private static string EmitAssigningCodeResult(this EndpointParameter endpointParameter) => $"{endpointParameter.Name}_raw";
+    private static string EmitParsedTempArgument(this EndpointParameter endpointParameter) => $"{endpointParameter.ParameterName}_parsed_temp";
+    private static string EmitAssigningCodeResult(this EndpointParameter endpointParameter) => $"{endpointParameter.ParameterName}_raw";
 
     public static string EmitArgument(this EndpointParameter endpointParameter) => endpointParameter.Source switch
     {

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Endpoint.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Endpoint.cs
@@ -77,7 +77,7 @@ internal class Endpoint
                     Diagnostics.Add(Diagnostic.Create(
                         DiagnosticDescriptors.UnableToResolveParameterDescriptor,
                         Operation.Syntax.GetLocation(),
-                        parameter.ParameterName));
+                        parameter.SymbolName));
                     break;
             }
 

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Endpoint.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Endpoint.cs
@@ -77,7 +77,7 @@ internal class Endpoint
                     Diagnostics.Add(Diagnostic.Create(
                         DiagnosticDescriptors.UnableToResolveParameterDescriptor,
                         Operation.Syntax.GetLocation(),
-                        parameter.Name));
+                        parameter.ParameterName));
                     break;
             }
 

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
@@ -355,7 +355,7 @@ internal class EndpointParameter
     // https://github.com/dotnet/runtime/blob/dc5a6c8be1644915c14c4a464447b0d54e223a46/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs#L562
     private static string ConvertEndOfLineAndQuotationCharactersToEscapeForm(string s)
     {
-        int index = 0;
+        var index = 0;
         while (index < s.Length)
         {
             if (s[index] is '\n' or '\r' or '"' or '\\')

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
@@ -334,12 +334,6 @@ internal class EndpointParameter
     {
         if (attribute.TryGetNamedArgumentValue<string>("Name", out var fromSourceName) && fromSourceName is not null)
         {
-            // TODO: This is a quick hack to stop someone trying to inject code into
-            //       a lookup key as part of a dictionary. We should decide whether
-            //       we want to:
-            //
-            //       a) Accept any input but escape it.
-            //       b) Narrowly scope what we accept so it is constrained to what are acceptable in HTTP paths, querystrings, and headers.
             return ConvertEndOfLineAndQuotationCharactersToEscapeForm(fromSourceName);
         }
         else

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
@@ -17,7 +17,7 @@ internal class EndpointParameter
     public EndpointParameter(Endpoint endpoint, IParameterSymbol parameter, WellKnownTypes wellKnownTypes)
     {
         Type = parameter.Type;
-        Name = parameter.Name;
+        ParameterName = parameter.Name;
         LookupName = parameter.Name; // Default lookup name is same as parameter name (which is a valid C# identifier).
         Ordinal = parameter.Ordinal;
         Source = EndpointParameterSource.Unknown;
@@ -28,7 +28,6 @@ internal class EndpointParameter
         if (parameter.HasAttributeImplementingInterface(wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Http_Metadata_IFromRouteMetadata), out var fromRouteAttribute))
         {
             Source = EndpointParameterSource.Route;
-            Name = parameter.Name;
             LookupName = GetEscapedParameterName(fromRouteAttribute, parameter.Name);
             IsParsable = TryGetParsability(parameter, wellKnownTypes, out var parsingBlockEmitter);
             ParsingBlockEmitter = parsingBlockEmitter;
@@ -36,7 +35,6 @@ internal class EndpointParameter
         else if (parameter.HasAttributeImplementingInterface(wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Http_Metadata_IFromQueryMetadata), out var fromQueryAttribute))
         {
             Source = EndpointParameterSource.Query;
-            Name = parameter.Name;
             LookupName = GetEscapedParameterName(fromQueryAttribute, parameter.Name);
             IsParsable = TryGetParsability(parameter, wellKnownTypes, out var parsingBlockEmitter);
             ParsingBlockEmitter = parsingBlockEmitter;
@@ -44,7 +42,6 @@ internal class EndpointParameter
         else if (parameter.HasAttributeImplementingInterface(wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Http_Metadata_IFromHeaderMetadata), out var fromHeaderAttribute))
         {
             Source = EndpointParameterSource.Header;
-            Name = parameter.Name;
             LookupName = GetEscapedParameterName(fromHeaderAttribute, parameter.Name);
             IsParsable = TryGetParsability(parameter, wellKnownTypes, out var parsingBlockEmitter);
             ParsingBlockEmitter = parsingBlockEmitter;
@@ -135,7 +132,7 @@ internal class EndpointParameter
     public ITypeSymbol Type { get; }
     public ITypeSymbol ElementType { get; }
 
-    public string Name { get; }
+    public string ParameterName { get; }
     public string LookupName { get; }
     public int Ordinal { get; }
     public bool IsOptional { get; }
@@ -411,7 +408,7 @@ internal class EndpointParameter
     public override bool Equals(object obj) =>
         obj is EndpointParameter other &&
         other.Source == Source &&
-        other.Name == Name &&
+        other.ParameterName == ParameterName &&
         other.Ordinal == Ordinal &&
         other.IsOptional == IsOptional &&
         SymbolEqualityComparer.Default.Equals(other.Type, Type);
@@ -423,7 +420,7 @@ internal class EndpointParameter
     public override int GetHashCode()
     {
         var hashCode = new HashCode();
-        hashCode.Add(Name);
+        hashCode.Add(ParameterName);
         hashCode.Add(Type, SymbolEqualityComparer.Default);
         return hashCode.ToHashCode();
     }

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
@@ -17,7 +17,7 @@ internal class EndpointParameter
     public EndpointParameter(Endpoint endpoint, IParameterSymbol parameter, WellKnownTypes wellKnownTypes)
     {
         Type = parameter.Type;
-        ParameterName = parameter.Name;
+        SymbolName = parameter.Name;
         LookupName = parameter.Name; // Default lookup name is same as parameter name (which is a valid C# identifier).
         Ordinal = parameter.Ordinal;
         Source = EndpointParameterSource.Unknown;
@@ -132,7 +132,7 @@ internal class EndpointParameter
     public ITypeSymbol Type { get; }
     public ITypeSymbol ElementType { get; }
 
-    public string ParameterName { get; }
+    public string SymbolName { get; }
     public string LookupName { get; }
     public int Ordinal { get; }
     public bool IsOptional { get; }
@@ -408,7 +408,7 @@ internal class EndpointParameter
     public override bool Equals(object obj) =>
         obj is EndpointParameter other &&
         other.Source == Source &&
-        other.ParameterName == ParameterName &&
+        other.SymbolName == SymbolName &&
         other.Ordinal == Ordinal &&
         other.IsOptional == IsOptional &&
         SymbolEqualityComparer.Default.Equals(other.Type, Type);
@@ -420,7 +420,7 @@ internal class EndpointParameter
     public override int GetHashCode()
     {
         var hashCode = new HashCode();
-        hashCode.Add(ParameterName);
+        hashCode.Add(SymbolName);
         hashCode.Add(Type, SymbolEqualityComparer.Default);
         return hashCode.ToHashCode();
     }

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
@@ -370,7 +370,7 @@ internal class EndpointParameter
             return s;
         }
 
-        StringBuilder sb = new StringBuilder(s.Length);
+        var sb = new StringBuilder(s.Length);
         sb.Append(s, 0, index);
 
         while (index < s.Length)

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
@@ -342,7 +342,7 @@ internal class EndpointParameter
             //
             //       a) Accept any input but escape it.
             //       b) Narrowly scope what we accept so it is constrained to what are acceptable in HTTP paths, querystrings, and headers.
-            return fromSourceName.Replace("\\", "").Replace("\"", "");
+            return fromSourceName.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\r", "\\r");
         }
         else
         {

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
@@ -335,7 +335,7 @@ internal class EndpointParameter
 
     private static string GetEscapedParameterName(AttributeData attribute, string parameterName)
     {
-        if (attribute.TryGetNamedArgumentValue<string>("Name", out var fromSourceName))
+        if (attribute.TryGetNamedArgumentValue<string>("Name", out var fromSourceName) && fromSourceName is not null)
         {
             // TODO: This is a quick hack to stop someone trying to inject code into
             //       a lookup key as part of a dictionary. We should decide whether

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
@@ -384,8 +384,8 @@ internal class EndpointParameter
                     break;
 
                 case '\\':
-                    sb.Append("\\");
-                    sb.Append("\\");
+                    sb.Append('\\');
+                    sb.Append('\\');
                     break;
 
                 default:

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_JsonBodyOrService_HandlesBothJsonAndService.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_JsonBodyOrService_HandlesBothJsonAndService.generated.txt
@@ -90,11 +90,11 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         private static readonly Dictionary<(string, int), (MetadataPopulator, RequestDelegateFactoryFunc)> map = new()
         {
-            [(@"TestMapActions.cs", 24)] = (
+            [(@"TestMapActions.cs", 25)] = (
                 (methodInfo, options) =>
                 {
                     Debug.Assert(options?.EndpointBuilder != null, "EndpointBuilder not found.");
-                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 24));
+                    options.EndpointBuilder.Metadata.Add(new SourceKey(@"TestMapActions.cs", 25));
                     return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
                 },
                 (del, options, inferredMetadataResult) =>
@@ -113,7 +113,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                             {
                                 return ValueTask.FromResult<object?>(Results.Empty);
                             }
-                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::Microsoft.AspNetCore.Http.Generators.Tests.Todo>(0), ic.GetArgument<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>(1)));
+                            return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::Microsoft.AspNetCore.Http.Generators.Tests.Todo>(0)!, ic.GetArgument<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>(1)!));
                         },
                         options.EndpointBuilder,
                         handler.Method);
@@ -122,14 +122,14 @@ namespace Microsoft.AspNetCore.Http.Generated
                     async Task RequestHandler(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: todo (Type = Microsoft.AspNetCore.Http.Generators.Tests.Todo, IsOptional = False, IsParsable = False, Source = JsonBodyOrService)
+                        // Endpoint Parameter: todo (Type = Microsoft.AspNetCore.Http.Generators.Tests.Todo, IsOptional = False, IsParsable = False, IsArray = False, Source = JsonBodyOrService)
                         var todo_resolveJsonBodyOrServiceResult = await todo_JsonBodyOrServiceResolver(httpContext, false);
                         var todo_local = todo_resolveJsonBodyOrServiceResult.Item2;
                         if (!todo_resolveJsonBodyOrServiceResult.Item1)
                         {
                             return;
                         }
-                        // Endpoint Parameter: svc (Type = Microsoft.AspNetCore.Http.Generators.Tests.TestService, IsOptional = False, IsParsable = False, Source = JsonBodyOrService)
+                        // Endpoint Parameter: svc (Type = Microsoft.AspNetCore.Http.Generators.Tests.TestService, IsOptional = False, IsParsable = False, IsArray = False, Source = JsonBodyOrService)
                         var svc_resolveJsonBodyOrServiceResult = await svc_JsonBodyOrServiceResolver(httpContext, false);
                         var svc_local = svc_resolveJsonBodyOrServiceResult.Item2;
                         if (!svc_resolveJsonBodyOrServiceResult.Item1)
@@ -150,14 +150,14 @@ namespace Microsoft.AspNetCore.Http.Generated
                     async Task RequestHandlerFiltered(HttpContext httpContext)
                     {
                         var wasParamCheckFailure = false;
-                        // Endpoint Parameter: todo (Type = Microsoft.AspNetCore.Http.Generators.Tests.Todo, IsOptional = False, IsParsable = False, Source = JsonBodyOrService)
+                        // Endpoint Parameter: todo (Type = Microsoft.AspNetCore.Http.Generators.Tests.Todo, IsOptional = False, IsParsable = False, IsArray = False, Source = JsonBodyOrService)
                         var todo_resolveJsonBodyOrServiceResult = await todo_JsonBodyOrServiceResolver(httpContext, false);
                         var todo_local = todo_resolveJsonBodyOrServiceResult.Item2;
                         if (!todo_resolveJsonBodyOrServiceResult.Item1)
                         {
                             return;
                         }
-                        // Endpoint Parameter: svc (Type = Microsoft.AspNetCore.Http.Generators.Tests.TestService, IsOptional = False, IsParsable = False, Source = JsonBodyOrService)
+                        // Endpoint Parameter: svc (Type = Microsoft.AspNetCore.Http.Generators.Tests.TestService, IsOptional = False, IsParsable = False, IsArray = False, Source = JsonBodyOrService)
                         var svc_resolveJsonBodyOrServiceResult = await svc_JsonBodyOrServiceResolver(httpContext, false);
                         var svc_local = svc_resolveJsonBodyOrServiceResult.Item2;
                         if (!svc_resolveJsonBodyOrServiceResult.Item1)

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapPost_WithArrayQueryString_AndBody_ShouldUseBody.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapPost_WithArrayQueryString_AndBody_ShouldUseBody.generated.txt
@@ -102,6 +102,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var handler = (Func<global::System.String[], global::System.String>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
                     var serviceProviderIsService = options?.ServiceProvider?.GetService<IServiceProviderIsService>();
+                    var p_JsonBodyOrServiceResolver = ResolveJsonBodyOrService<global::System.String[]>(serviceProviderIsService);
 
                     if (options?.EndpointBuilder?.FilterFactories.Count > 0)
                     {
@@ -121,7 +122,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     {
                         var wasParamCheckFailure = false;
                         // Endpoint Parameter: p (Type = string[], IsOptional = False, IsParsable = False, IsArray = True, Source = JsonBodyOrService)
-                        var p_resolveJsonBodyOrServiceResult = await GeneratedRouteBuilderExtensionsCore.TryResolveJsonBodyOrServiceAsync<global::System.String[]>(httpContext, false, serviceProviderIsService);
+                        var p_resolveJsonBodyOrServiceResult = await p_JsonBodyOrServiceResolver(httpContext, false);
                         var p_local = p_resolveJsonBodyOrServiceResult.Item2;
                         if (!p_resolveJsonBodyOrServiceResult.Item1)
                         {
@@ -142,7 +143,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     {
                         var wasParamCheckFailure = false;
                         // Endpoint Parameter: p (Type = string[], IsOptional = False, IsParsable = False, IsArray = True, Source = JsonBodyOrService)
-                        var p_resolveJsonBodyOrServiceResult = await GeneratedRouteBuilderExtensionsCore.TryResolveJsonBodyOrServiceAsync<global::System.String[]>(httpContext, false, serviceProviderIsService);
+                        var p_resolveJsonBodyOrServiceResult = await p_JsonBodyOrServiceResolver(httpContext, false);
                         var p_local = p_resolveJsonBodyOrServiceResult.Item2;
                         if (!p_resolveJsonBodyOrServiceResult.Item1)
                         {
@@ -247,16 +248,16 @@ namespace Microsoft.AspNetCore.Http.Generated
 
             return (false, default);
         }
-        private static ValueTask<(bool, T?)> TryResolveJsonBodyOrServiceAsync<T>(HttpContext httpContext, bool isOptional, IServiceProviderIsService? serviceProviderIsService = null)
+        private static Func<HttpContext, bool, ValueTask<(bool, T?)>> ResolveJsonBodyOrService<T>(IServiceProviderIsService? serviceProviderIsService = null)
         {
             if (serviceProviderIsService is not null)
             {
                 if (serviceProviderIsService.IsService(typeof(T)))
                 {
-                    return new ValueTask<(bool, T?)>((true, httpContext.RequestServices.GetService<T>()));
+                    return static (httpContext, isOptional) => new ValueTask<(bool, T?)>((true, httpContext.RequestServices.GetService<T>()));
                 }
             }
-            return TryResolveBodyAsync<T>(httpContext, isOptional);
+            return static (httpContext, isOptional) => TryResolveBodyAsync<T>(httpContext, isOptional);
         }
 
     }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapPost_WithArrayQueryString_ShouldFail.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapPost_WithArrayQueryString_ShouldFail.generated.txt
@@ -102,6 +102,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var handler = (Func<global::System.String[], global::System.Int32>)del;
                     EndpointFilterDelegate? filteredInvocation = null;
                     var serviceProviderIsService = options?.ServiceProvider?.GetService<IServiceProviderIsService>();
+                    var p_JsonBodyOrServiceResolver = ResolveJsonBodyOrService<global::System.String[]>(serviceProviderIsService);
                     var serviceProvider = options?.ServiceProvider ?? options?.EndpointBuilder?.ApplicationServices;
                     var serializerOptions = serviceProvider?.GetService<IOptions<JsonOptions>>()?.Value.SerializerOptions ?? new JsonOptions().SerializerOptions;
                     var jsonTypeInfo =  (JsonTypeInfo<global::System.Int32>)serializerOptions.GetTypeInfo(typeof(global::System.Int32));
@@ -124,7 +125,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     {
                         var wasParamCheckFailure = false;
                         // Endpoint Parameter: p (Type = string[], IsOptional = False, IsParsable = False, IsArray = True, Source = JsonBodyOrService)
-                        var p_resolveJsonBodyOrServiceResult = await GeneratedRouteBuilderExtensionsCore.TryResolveJsonBodyOrServiceAsync<global::System.String[]>(httpContext, false, serviceProviderIsService);
+                        var p_resolveJsonBodyOrServiceResult = await p_JsonBodyOrServiceResolver(httpContext, false);
                         var p_local = p_resolveJsonBodyOrServiceResult.Item2;
                         if (!p_resolveJsonBodyOrServiceResult.Item1)
                         {
@@ -145,7 +146,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                     {
                         var wasParamCheckFailure = false;
                         // Endpoint Parameter: p (Type = string[], IsOptional = False, IsParsable = False, IsArray = True, Source = JsonBodyOrService)
-                        var p_resolveJsonBodyOrServiceResult = await GeneratedRouteBuilderExtensionsCore.TryResolveJsonBodyOrServiceAsync<global::System.String[]>(httpContext, false, serviceProviderIsService);
+                        var p_resolveJsonBodyOrServiceResult = await p_JsonBodyOrServiceResolver(httpContext, false);
                         var p_local = p_resolveJsonBodyOrServiceResult.Item2;
                         if (!p_resolveJsonBodyOrServiceResult.Item1)
                         {
@@ -250,16 +251,16 @@ namespace Microsoft.AspNetCore.Http.Generated
 
             return (false, default);
         }
-        private static ValueTask<(bool, T?)> TryResolveJsonBodyOrServiceAsync<T>(HttpContext httpContext, bool isOptional, IServiceProviderIsService? serviceProviderIsService = null)
+        private static Func<HttpContext, bool, ValueTask<(bool, T?)>> ResolveJsonBodyOrService<T>(IServiceProviderIsService? serviceProviderIsService = null)
         {
             if (serviceProviderIsService is not null)
             {
                 if (serviceProviderIsService.IsService(typeof(T)))
                 {
-                    return new ValueTask<(bool, T?)>((true, httpContext.RequestServices.GetService<T>()));
+                    return static (httpContext, isOptional) => new ValueTask<(bool, T?)>((true, httpContext.RequestServices.GetService<T>()));
                 }
             }
-            return TryResolveBodyAsync<T>(httpContext, isOptional);
+            return static (httpContext, isOptional) => TryResolveBodyAsync<T>(httpContext, isOptional);
         }
 
     }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.QueryParameters.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.QueryParameters.cs
@@ -50,7 +50,7 @@ app.MapGet("/", getQueryWithDefault);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             var p = Assert.Single(endpointModel.Parameters);
             Assert.Equal(EndpointParameterSource.Query, p.Source);
-            Assert.Equal("queryValue", p.Name);
+            Assert.Equal("queryValue", p.LookupName);
         });
 
         var httpContext = CreateHttpContext();

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.QueryParameters.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.QueryParameters.cs
@@ -77,7 +77,7 @@ app.MapGet("/hello", ([FromQuery]string? p) => p == string.Empty ? "No value, bu
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             var p = Assert.Single(endpointModel.Parameters);
             Assert.Equal(EndpointParameterSource.Query, p.Source);
-            Assert.Equal("p", p.Name);
+            Assert.Equal("p", p.ParameterName);
         });
 
         var httpContext = CreateHttpContext();

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.QueryParameters.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.QueryParameters.cs
@@ -77,7 +77,7 @@ app.MapGet("/hello", ([FromQuery]string? p) => p == string.Empty ? "No value, bu
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             var p = Assert.Single(endpointModel.Parameters);
             Assert.Equal(EndpointParameterSource.Query, p.Source);
-            Assert.Equal("p", p.ParameterName);
+            Assert.Equal("p", p.SymbolName);
         });
 
         var httpContext = CreateHttpContext();

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.RouteParameter.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.RouteParameter.cs
@@ -158,22 +158,22 @@ app.MapGet("/{value}", (string value, HttpContext httpContext) => value);
         {
             return new[]
             {
-                new object[] { "name", "name" },
-                new object[] { "_", "_" },
-                new object[] { "123", "123" },
-                new object[] { "💩", "💩" },
-                new object[] { "\r", "\\r" },
-                new object[] { "\x00E7" , "\x00E7" },
-                new object[] { "!!" , "!!" },
-                new object[] { "\\" , "\\\\" },
-                new object[] { "\'" , "\'" },
+                new object[] { "name" },
+                new object[] { "_" },
+                new object[] { "123" },
+                new object[] { "💩" },
+                new object[] { "\r" },
+                new object[] { "\x00E7"  },
+                new object[] { "!!" },
+                new object[] { "\\" },
+                new object[] { "\'" },
             };
         }
     }
 
     [Theory]
     [MemberData(nameof(MapAction_ExplicitRouteParam_RouteNames_Data))]
-    public async Task MapAction_ExplicitRouteParam_RouteNames(string routeParameterName, string lookupValue)
+    public async Task MapAction_ExplicitRouteParam_RouteNames(string routeParameterName)
     {
         var (_, compilation) = await RunGeneratorAsync($$"""app.MapGet(@"/{{{routeParameterName}}}", ([FromRoute(Name=@"{{routeParameterName}}")] string routeValue) => routeValue);""");
         var endpoint = GetEndpointFromCompilation(compilation);

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.RouteParameter.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.RouteParameter.cs
@@ -151,4 +151,37 @@ app.MapGet("/{value}", (string value, HttpContext httpContext) => value);
         await endpoint.RequestDelegate(httpContext);
         await VerifyResponseBodyAsync(httpContext, "fromRoute");
     }
+
+    public static object[][] MapAction_ExplicitRouteParam_RouteNames_Data
+    {
+        get
+        {
+            return new[]
+            {
+                new object[] { "name", "name" },
+                new object[] { "_", "_" },
+                new object[] { "123", "123" },
+                new object[] { "💩", "💩" },
+                new object[] { "\r", "\\r" },
+                new object[] { "\x00E7" , "\x00E7" },
+                new object[] { "!!" , "!!" },
+                new object[] { "\\" , "\\\\" },
+                new object[] { "\'" , "\'" },
+            };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(MapAction_ExplicitRouteParam_RouteNames_Data))]
+    public async Task MapAction_ExplicitRouteParam_RouteNames(string routeParameterName, string lookupValue)
+    {
+        var (_, compilation) = await RunGeneratorAsync($$"""app.MapGet(@"/{{{routeParameterName}}}", ([FromRoute(Name=@"{{routeParameterName}}")] string routeValue) => routeValue);""");
+        var endpoint = GetEndpointFromCompilation(compilation);
+
+        var httpContext = CreateHttpContext();
+        httpContext.Request.RouteValues[routeParameterName] = "test";
+
+        await endpoint.RequestDelegate(httpContext);
+        await VerifyResponseBodyAsync(httpContext, "test", 200);
+    }
 }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.TryParse.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.TryParse.cs
@@ -163,7 +163,7 @@ app.MapGet("/hello", ([FromQuery]{{parameterType}} p) => p.MagicValue);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             var p = Assert.Single(endpointModel.Parameters);
             Assert.Equal(EndpointParameterSource.Query, p.Source);
-            Assert.Equal("p", p.Name);
+            Assert.Equal("p", p.ParameterName);
         });
 
         var httpContext = CreateHttpContext();
@@ -187,7 +187,7 @@ app.MapGet("/hello", ([FromQuery]TryParseTodo p) => p.Name!);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             var p = Assert.Single(endpointModel.Parameters);
             Assert.Equal(EndpointParameterSource.Query, p.Source);
-            Assert.Equal("p", p.Name);
+            Assert.Equal("p", p.ParameterName);
         });
 
         var httpContext = CreateHttpContext();
@@ -212,7 +212,7 @@ app.MapGet("/hello", ([FromQuery]TodoStatus p) => p.ToString());
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             var p = Assert.Single(endpointModel.Parameters);
             Assert.Equal(EndpointParameterSource.Query, p.Source);
-            Assert.Equal("p", p.Name);
+            Assert.Equal("p", p.ParameterName);
         });
 
         var httpContext = CreateHttpContext();

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.TryParse.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.TryParse.cs
@@ -163,7 +163,7 @@ app.MapGet("/hello", ([FromQuery]{{parameterType}} p) => p.MagicValue);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             var p = Assert.Single(endpointModel.Parameters);
             Assert.Equal(EndpointParameterSource.Query, p.Source);
-            Assert.Equal("p", p.ParameterName);
+            Assert.Equal("p", p.SymbolName);
         });
 
         var httpContext = CreateHttpContext();
@@ -187,7 +187,7 @@ app.MapGet("/hello", ([FromQuery]TryParseTodo p) => p.Name!);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             var p = Assert.Single(endpointModel.Parameters);
             Assert.Equal(EndpointParameterSource.Query, p.Source);
-            Assert.Equal("p", p.ParameterName);
+            Assert.Equal("p", p.SymbolName);
         });
 
         var httpContext = CreateHttpContext();
@@ -212,7 +212,7 @@ app.MapGet("/hello", ([FromQuery]TodoStatus p) => p.ToString());
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             var p = Assert.Single(endpointModel.Parameters);
             Assert.Equal(EndpointParameterSource.Query, p.Source);
-            Assert.Equal("p", p.ParameterName);
+            Assert.Equal("p", p.SymbolName);
         });
 
         var httpContext = CreateHttpContext();

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.cs
@@ -42,7 +42,7 @@ app.MapGet("/hello", ({parameterType} p) => p == null ? "null!" : "Hello world!"
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             var p = Assert.Single(endpointModel.Parameters);
             Assert.Equal(EndpointParameterSource.SpecialType, p.Source);
-            Assert.Equal("p", p.ParameterName);
+            Assert.Equal("p", p.SymbolName);
         });
 
         var httpContext = CreateHttpContext();
@@ -67,12 +67,12 @@ app.MapGet("/hello", (HttpRequest req, HttpResponse res) => req is null || res i
                 reqParam =>
                 {
                     Assert.Equal(EndpointParameterSource.SpecialType, reqParam.Source);
-                    Assert.Equal("req", reqParam.ParameterName);
+                    Assert.Equal("req", reqParam.SymbolName);
                 },
                 reqParam =>
                 {
                     Assert.Equal(EndpointParameterSource.SpecialType, reqParam.Source);
-                    Assert.Equal("res", reqParam.ParameterName);
+                    Assert.Equal("res", reqParam.SymbolName);
                 });
         });
 
@@ -137,7 +137,7 @@ app.MapGet("/zh", (HttpRequest req, HttpResponse res) => "你好世界！");
                 Assert.Equal("MapGet", endpointModel.HttpMethod);
                 var reqParam = Assert.Single(endpointModel.Parameters);
                 Assert.Equal(EndpointParameterSource.SpecialType, reqParam.Source);
-                Assert.Equal("req", reqParam.ParameterName);
+                Assert.Equal("req", reqParam.SymbolName);
             },
             endpointModel =>
             {
@@ -145,7 +145,7 @@ app.MapGet("/zh", (HttpRequest req, HttpResponse res) => "你好世界！");
                 Assert.Equal("MapGet", endpointModel.HttpMethod);
                 var reqParam = Assert.Single(endpointModel.Parameters);
                 Assert.Equal(EndpointParameterSource.SpecialType, reqParam.Source);
-                Assert.Equal("res", reqParam.ParameterName);
+                Assert.Equal("res", reqParam.SymbolName);
             },
             endpointModel =>
             {
@@ -155,12 +155,12 @@ app.MapGet("/zh", (HttpRequest req, HttpResponse res) => "你好世界！");
                     reqParam =>
                     {
                         Assert.Equal(EndpointParameterSource.SpecialType, reqParam.Source);
-                        Assert.Equal("req", reqParam.ParameterName);
+                        Assert.Equal("req", reqParam.SymbolName);
                     },
                     reqParam =>
                     {
                         Assert.Equal(EndpointParameterSource.SpecialType, reqParam.Source);
-                        Assert.Equal("res", reqParam.ParameterName);
+                        Assert.Equal("res", reqParam.SymbolName);
                     });
             }));
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.cs
@@ -42,7 +42,7 @@ app.MapGet("/hello", ({parameterType} p) => p == null ? "null!" : "Hello world!"
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             var p = Assert.Single(endpointModel.Parameters);
             Assert.Equal(EndpointParameterSource.SpecialType, p.Source);
-            Assert.Equal("p", p.Name);
+            Assert.Equal("p", p.ParameterName);
         });
 
         var httpContext = CreateHttpContext();
@@ -67,12 +67,12 @@ app.MapGet("/hello", (HttpRequest req, HttpResponse res) => req is null || res i
                 reqParam =>
                 {
                     Assert.Equal(EndpointParameterSource.SpecialType, reqParam.Source);
-                    Assert.Equal("req", reqParam.Name);
+                    Assert.Equal("req", reqParam.ParameterName);
                 },
                 reqParam =>
                 {
                     Assert.Equal(EndpointParameterSource.SpecialType, reqParam.Source);
-                    Assert.Equal("res", reqParam.Name);
+                    Assert.Equal("res", reqParam.ParameterName);
                 });
         });
 
@@ -137,7 +137,7 @@ app.MapGet("/zh", (HttpRequest req, HttpResponse res) => "你好世界！");
                 Assert.Equal("MapGet", endpointModel.HttpMethod);
                 var reqParam = Assert.Single(endpointModel.Parameters);
                 Assert.Equal(EndpointParameterSource.SpecialType, reqParam.Source);
-                Assert.Equal("req", reqParam.Name);
+                Assert.Equal("req", reqParam.ParameterName);
             },
             endpointModel =>
             {
@@ -145,7 +145,7 @@ app.MapGet("/zh", (HttpRequest req, HttpResponse res) => "你好世界！");
                 Assert.Equal("MapGet", endpointModel.HttpMethod);
                 var reqParam = Assert.Single(endpointModel.Parameters);
                 Assert.Equal(EndpointParameterSource.SpecialType, reqParam.Source);
-                Assert.Equal("res", reqParam.Name);
+                Assert.Equal("res", reqParam.ParameterName);
             },
             endpointModel =>
             {
@@ -155,12 +155,12 @@ app.MapGet("/zh", (HttpRequest req, HttpResponse res) => "你好世界！");
                     reqParam =>
                     {
                         Assert.Equal(EndpointParameterSource.SpecialType, reqParam.Source);
-                        Assert.Equal("req", reqParam.Name);
+                        Assert.Equal("req", reqParam.ParameterName);
                     },
                     reqParam =>
                     {
                         Assert.Equal(EndpointParameterSource.SpecialType, reqParam.Source);
-                        Assert.Equal("res", reqParam.Name);
+                        Assert.Equal("res", reqParam.ParameterName);
                     });
             }));
 


### PR DESCRIPTION
This PR separates the variable name we use for code gen from the variable name we use for lookup up of dictionaries for input.