### PR TITLE
Enable SingleFileAnalyzer

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <EnableAOTAnalyzer Condition=" '$(EnableAOTAnalyzer)' == '' ">$([MSBuild]::ValueOrDefault($(IsTrimmable),'false'))</EnableAOTAnalyzer>
+    <!-- TODO: Remove when analyzer is enabled by default with AOT in SDK. See https://github.com/dotnet/sdk/issues/31284 -->
     <EnableSingleFileAnalyzer Condition=" '$(EnableSingleFileAnalyzer)' == '' ">$(EnableAOTAnalyzer)</EnableSingleFileAnalyzer>
   </PropertyGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,7 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <EnableAOTAnalyzer Condition=" '$(EnableAOTAnalyzer)' == '' ">$([MSBuild]::ValueOrDefault($(IsTrimmable),'false'))</EnableAOTAnalyzer>
+    <EnableSingleFileAnalyzer Condition=" '$(EnableSingleFileAnalyzer)' == '' ">$(EnableAOTAnalyzer)</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Hosting/Hosting/src/StaticWebAssets/StaticWebAssetsLoader.cs
+++ b/src/Hosting/Hosting/src/StaticWebAssets/StaticWebAssetsLoader.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.AspNetCore.StaticWebAssets;
 using Microsoft.Extensions.Configuration;
@@ -63,6 +64,8 @@ public class StaticWebAssetsLoader
         }
     }
 
+    [UnconditionalSuppressMessage("SingleFile", "IL3000:Assembly.Location",
+        Justification = "The code handles if the Assembly.Location is empty by calling AppContext.BaseDirectory. Workaround https://github.com/dotnet/runtime/issues/83607")]
     private static string? ResolveRelativeToAssembly(IWebHostEnvironment environment)
     {
         if (string.IsNullOrEmpty(environment.ApplicationName))


### PR DESCRIPTION
When publishing an app that uses WebApplication.CreateBuilder, we are getting unnecessary warnings.

We need the single file analyzer enabled in our code that is trimmable/AOT-able. When publishing for NativeAOT, the app is built into a single file, so we also need to ensure our code works correctly in single file mode.

Note, I logged https://github.com/dotnet/sdk/issues/31284 so this analyzer gets enabled by default when `EnableAotAnalyzer=true`.