### PR TITLE
Revised ASP.NET Core module installer for Windows ARM64

### DIFF
--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/AncmV2.wixproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/AncmV2.wixproj
@@ -82,7 +82,7 @@
                       '$(PackageLicenseExpression)' " />
   </Target>
   
-  <Target Name="BeforeBuild">
+  <Target Name="BeforeBuild" Condition="'$(Platform)' == 'arm64'">
     <MSBuild Projects="..\Forwarders\build.proj" />
   </Target>
 </Project>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/AncmV2.wixproj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/AncmV2.wixproj
@@ -81,4 +81,8 @@
                       '$(PackageIconFullPath)' ^
                       '$(PackageLicenseExpression)' " />
   </Target>
+  
+  <Target Name="BeforeBuild">
+    <MSBuild Projects="..\Forwarders\build.proj" />
+  </Target>
 </Project>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
@@ -144,6 +144,7 @@
                <Directory Id="IISModuleDirectory" Name="IIS">
                    <Directory Id="INSTALLLOCATION" ShortName="ANCM" Name="Asp.Net Core Module">
                        <Directory Id="VersionDir" Name="$(var.ProductVersionString)">
+                           <?if $(var.Platform) = "x86" OR $(var.Platform) = "x64" ?>
                            <Component Id="AspNetCoreModuleV2" Guid="3a692941-59be-43cf-98a8-6ed01b12a519" Win64="$(var.IsWin64)">
                                 <File Id="AspNetCoreModuleV2Dll"
                                     Name="aspnetcorev2.dll"
@@ -167,13 +168,80 @@
                                     </File>
                                </Component>
                            </Directory>
+                           <?else ?>
+                           <Component Id="AspNetCoreModuleV2.forwarder" Guid="4b6bb33a-01f0-48c7-bce9-5a5514ac0431" Win64="$(var.IsWin64)">
+                                <File Id="AspNetCoreModuleV2Dll.forwarder"
+                                    Name="aspnetcorev2.dll"
+                                    Source="$(var.ArtifactsDir)\bin\AspNetCoreModuleForwarders\aspnetcorev2.dll"
+                                    DiskId="1"
+                                    Vital="yes">
+                                </File>
+                               <RemoveFile Id="AspNetCoreModuleV2Dll_Remove.forwarder" Name="aspnetcorev2.dll" On="install" />
+                               <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\EventLog\Application\$(var.ProductShortName)">
+                                   <RegistryValue Name="EventMessageFile" Type="expandable" Value="[#AspNetCoreModuleV2Dll.forwarder]"/>
+                                   <RegistryValue Name="TypesSupported" Type="integer" Value="7"/>
+                               </RegistryKey>
+                           </Component>
+                           <Component Id="AspNetCoreModuleV2.x64" Guid="325cf239-162d-4de8-97e7-642e6c66181c" Win64="$(var.IsWin64)">
+                                <File Id="AspNetCoreModuleV2Dll.x64"
+                                    Name="aspnetcorev2_x64.dll"
+                                    Source="$(var.ArtifactsDir)\bin\AspNetCoreModuleShim\x64\$(var.Configuration)\aspnetcorev2.dll"
+                                    DiskId="1"
+                                    Vital="yes">
+                                </File>
+                               <RemoveFile Id="AspNetCoreModuleV2Dll_Remove.x64" Name="aspnetcorev2.dll" On="install" />
+                               <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\EventLog\Application\$(var.ProductShortName)">
+                                   <RegistryValue Name="EventMessageFile" Type="expandable" Value="[#AspNetCoreModuleV2Dll.x64]"/>
+                                   <RegistryValue Name="TypesSupported" Type="integer" Value="7"/>
+                               </RegistryKey>
+                           </Component>
+                           <Component Id="AspNetCoreModuleV2.arm64" Guid="923f1be7-5a83-46b3-8be7-cd3eeb2d1c48" Win64="$(var.IsWin64)">
+                                <File Id="AspNetCoreModuleV2Dll.arm64"
+                                    Name="aspnetcorev2_arm64.dll"
+                                    Source="$(var.AspNetCoreV2ProgramFilesTargetPath)"
+                                    DiskId="1"
+                                    Vital="yes">
+                                </File>
+                               <RemoveFile Id="AspNetCoreModuleV2Dll_Remove.arm64" Name="aspnetcorev2.dll" On="install" />
+                               <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\EventLog\Application\$(var.ProductShortName)">
+                                   <RegistryValue Name="EventMessageFile" Type="expandable" Value="[#AspNetCoreModuleV2Dll.arm64]"/>
+                                   <RegistryValue Name="TypesSupported" Type="integer" Value="7"/>
+                               </RegistryKey>
+                           </Component>
+                           <Directory Id="HandlerVersionDir" Name="$(var.ANCMFolderVersion)" >
+                               <Component Id="AspNetCoreModuleHandler.forwarder" Guid="4862728c-e943-49f0-901a-cd96e4bf03ef" Win64="$(var.IsWin64)">
+                                    <File Id="AspNetCoreModuleHandlerDll.forwarder"
+                                        Name="aspnetcorev2_outofprocess.dll"
+                                        Source="$(var.ArtifactsDir)\bin\AspNetCoreModuleForwarders\aspnetcorev2_outofprocess.dll"
+                                        DiskId="1"
+                                        Vital="yes">
+                                    </File>
+                               </Component>
+                               <Component Id="AspNetCoreModuleHandler.x64" Guid="d9b0b5c9-8bbe-46f2-97d5-ba23d1a1ffed" Win64="$(var.IsWin64)">
+                                    <File Id="AspNetCoreModuleHandlerDll.x64"
+                                        Name="aspnetcorev2_outofprocess_x64.dll"
+                                        Source="$(var.ArtifactsDir)\bin\OutOfProcessRequestHandler\x64\$(var.Configuration)\aspnetcorev2_outofprocess.dll"
+                                        DiskId="1"
+                                        Vital="yes">
+                                    </File>
+                               </Component>
+                               <Component Id="AspNetCoreModuleHandler.arm64" Guid="ab249ab5-9203-4fd5-87b6-8acc3e1a0702" Win64="$(var.IsWin64)">
+                                    <File Id="AspNetCoreModuleHandlerDll.arm64"
+                                        Name="aspnetcorev2_outofprocess_arm64.dll"
+                                        Source="$(var.AspNetCoreV2HandlerProgramFilesTargetPath)"
+                                        DiskId="1"
+                                        Vital="yes">
+                                    </File>
+                               </Component>
+                           </Directory>
+                           <?endif ?>
                        </Directory>
                    </Directory>
                </Directory>
            </Directory>
 
            <!-- WOW64 Support -->
-           <?if $(var.Platform) = "x64" ?>
+           <?if $(var.Platform) = "x64" OR $(var.Platform) = "arm64" ?>
            <Component Id="C_DiscoverabilityKeyWow" Guid="2eeb90e8-28d0-4543-9c2f-843b03bd6d05" Win64="no">
                <RegistryKey Root="HKLM" Key="$(var.DiscoverabilityKeyRoot)">
                     <RegistryKey Key="$(var.ProductShortName)">
@@ -216,64 +284,26 @@
             </Directory>
             <?endif ?>
             
-           <!-- ARM64 Support -->
-           <?if $(var.Platform) = "arm64" ?>
-           <Component Id="C_DiscoverabilityKeyARM64" Guid="2eeb90e8-28d0-4543-9c2f-843b03bd6d05" Win64="no">
-               <RegistryKey Root="HKLM" Key="$(var.DiscoverabilityKeyRoot)">
-                    <RegistryKey Key="$(var.ProductShortName)">
-                        <RegistryValue Type="integer" Name="Install" Value="1" />
-                        <RegistryValue Type="string" Name="Version" Value="$(var.ANCMMsiVersion)" />
-                    </RegistryKey>
-                </RegistryKey>
-            </Component>
-
-            <Directory Id="$(var.ProgramFilesFolder32)">
-                 <Directory Id="IISModuleDirectory32" Name="IIS">
-                    <Directory Id="INSTALLLOCATION32" ShortName="ANCM" Name="Asp.Net Core Module">
-                        <Directory Id="VersionDir32" Name="$(var.ProductVersionString)" SourceName="Arm64Only" >
-                            <Component Id="AspNetCoreModuleV2.arm64" Guid="1b8ecba0-c002-442a-92c0-0fa9c0f21df4" Win64="no">
-                                <File Id="AspNetCoreModuleV2Dll.arm64"
-                                    Name="aspnetcorev2.dll"
-                                    Source="$(var.ArtifactsDir)\bin\AspNetCoreModuleShim\arm64\Release\aspnetcorev2.dll"
-                                    DiskId="1"
-                                    Vital="yes">
-                                </File>
-                                <RemoveFile Id="AspNetCoreModuleV2Dll.arm64_Remove" Name="aspnetcorev2.dll" On="install" />
-                                <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\EventLog\Application\$(var.ProductShortName)">
-                                    <RegistryValue Name="EventMessageFile" Type="expandable" Value="[#AspNetCoreModuleV2Dll.arm64]"/>
-                                    <RegistryValue Name="TypesSupported" Type="integer" Value="7"/>
-                                </RegistryKey>
-                            </Component>
-                            <Directory Id="HandlerVersionDir32" Name="$(var.ANCMFolderVersion)" SourceName="Arm64Only">
-                                <Component Id="AspNetCoreModuleHandler.arm64" Guid="d927e5d3-c8b2-400c-b85c-ae5c2772d6c3" Win64="no">
-                                    <File Id="AspNetCoreModuleHandlerDll.arm64"
-                                          Name="aspnetcorev2_outofprocess.dll"
-                                          Source="$(var.ArtifactsDir)\bin\OutOfProcessRequestHandler\arm64\Release\aspnetcorev2_outofprocess.dll"
-                                          DiskId="1"
-                                          Vital="yes">
-                                    </File>
-                                </Component>
-                            </Directory>
-                        </Directory>
-                    </Directory>
-                </Directory>
-            </Directory>
-            <?endif ?>
         </Directory>
 
         <!-- Feature Definition -->
         <Feature Id="AspNetCoreModuleFeature" Title="!(loc.AspNetCoreModuleProductTitle)" Description="!(loc.AspNetCoreModuleProductDescription)" Level="1">
             <ComponentRef Id="C_DiscoverabilityKey"/>
+            <ComponentRef Id="AspNetCoreSchemaV2"/>
+            <?if $(var.Platform) = "x86" OR $(var.Platform) = "x64" ?>
             <ComponentRef Id="AspNetCoreModuleV2"/>
             <ComponentRef Id="AspNetCoreModuleHandler"/>
-            <ComponentRef Id="AspNetCoreSchemaV2"/>
-            <?if $(var.Platform) = "x64" ?>
+            <?endif ?>
+            <?if $(var.Platform) = "x64" OR $(var.Platform) = "arm64" ?>
             <ComponentRef Id="C_DiscoverabilityKeyWow"/>
             <ComponentRef Id="AspNetCoreModuleV2.wow"/>
             <ComponentRef Id="AspNetCoreModuleHandler.wow"/>
             <?endif ?>
             <?if $(var.Platform) = "arm64" ?>
-            <ComponentRef Id="C_DiscoverabilityKeyARM64"/>
+            <ComponentRef Id="AspNetCoreModuleV2.forwarder"/>
+            <ComponentRef Id="AspNetCoreModuleHandler.forwarder"/>
+            <ComponentRef Id="AspNetCoreModuleV2.x64"/>
+            <ComponentRef Id="AspNetCoreModuleHandler.x64"/>
             <ComponentRef Id="AspNetCoreModuleV2.arm64"/>
             <ComponentRef Id="AspNetCoreModuleHandler.arm64"/>
             <?endif ?>
@@ -297,7 +327,11 @@
         <CustomTable Id="IISGlobalModule">
             <Row>
                 <Data Column="Name">AspNetCoreModuleV2</Data>
+                <?if $(var.Platform) = "x86" OR $(var.Platform) = "x64" ?>
                 <Data Column="File_">AspNetCoreModuleV2Dll</Data>
+                <?else ?>
+                <Data Column="File_">AspNetCoreModuleV2Dll.forwarder</Data>
+                <?endif ?>
             </Row>
         </CustomTable>
 
@@ -309,6 +343,7 @@
             </Row>
         </CustomTable>
 
+        <!-- <?if $(var.Platform) = "x86" OR $(var.Platform) = "x64" ?> -->
         <CustomTable Id="IISTraceArea">
           <Row>
             <Data Column="ProviderName">WWW Server</Data>
@@ -319,6 +354,7 @@
             <Data Column="Component_">AspNetCoreModuleV2</Data>
           </Row>
         </CustomTable>
+        <!-- <?endif ?> -->
 
         <!--   All this magic just to set the handlers section OverrideModeDefault=allow -->
         <CustomAction Id="CA_UNLOCk_HANDLER_PROPERTY"

--- a/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/all.cmd
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/all.cmd
@@ -1,2 +1,2 @@
-call %1 -host_arch=x64 -arch=arm64
+call %1 -host_arch=x64 -arch=arm64 -no_logo
 call build.cmd %2 %3

--- a/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/all.cmd
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/all.cmd
@@ -1,0 +1,2 @@
+call %1 -host_arch=x64 -arch=arm64
+call build.cmd %2 %3

--- a/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/aspnetcorev2_arm64.def
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/aspnetcorev2_arm64.def
@@ -1,0 +1,2 @@
+EXPORTS
+    RegisterModule = aspnetcorev2_arm64.RegisterModule

--- a/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/aspnetcorev2_outofprocess_arm64.def
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/aspnetcorev2_outofprocess_arm64.def
@@ -1,0 +1,2 @@
+EXPORTS
+    CreateApplication = aspnetcorev2_outofprocess_arm64.CreateApplication

--- a/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/aspnetcorev2_outofprocess_x64.def
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/aspnetcorev2_outofprocess_x64.def
@@ -1,0 +1,2 @@
+EXPORTS
+    CreateApplication = aspnetcorev2_outofprocess_x64.CreateApplication

--- a/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/aspnetcorev2_x64.def
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/aspnetcorev2_x64.def
@@ -1,0 +1,2 @@
+EXPORTS
+    RegisterModule = aspnetcorev2_x64.RegisterModule

--- a/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/build.cmd
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/build.cmd
@@ -1,6 +1,9 @@
 SET objDir=%1
 SET binDir=%2
 
+mkdir %objDir%
+mkdir %binDir%
+
 cl /c /Fo%objDir%\aspnetcorev2_arm64.obj empty.cpp
 cl /c /arm64EC /Fo%objDir%\aspnetcorev2_x64.obj empty.cpp
 

--- a/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/build.cmd
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/build.cmd
@@ -1,21 +1,18 @@
 SET objDir=%1
 SET binDir=%2
 
-mkdir %objDir%
-mkdir %binDir%
+cl /nologo /c /Fo%objDir%\aspnetcorev2_arm64.obj empty.cpp
+cl /nologo /c /arm64EC /Fo%objDir%\aspnetcorev2_x64.obj empty.cpp
 
-cl /c /Fo%objDir%\aspnetcorev2_arm64.obj empty.cpp
-cl /c /arm64EC /Fo%objDir%\aspnetcorev2_x64.obj empty.cpp
+link /lib /nologo /machine:arm64 /def:aspnetcorev2_arm64.def /out:%objDir%\aspnetcorev2_arm64.lib
+link /lib /nologo /machine:x64 /def:aspnetcorev2_x64.def /out:%objDir%\aspnetcorev2_x64.lib
 
-link /lib /machine:arm64 /def:aspnetcorev2_arm64.def /out:%objDir%\aspnetcorev2_arm64.lib
-link /lib /machine:x64 /def:aspnetcorev2_x64.def /out:%objDir%\aspnetcorev2_x64.lib
+link /dll /nologo /noentry /machine:arm64x /defArm64Native:aspnetcorev2_arm64.def /def:aspnetcorev2_x64.def %objDir%\aspnetcorev2_arm64.obj %objDir%\aspnetcorev2_x64.obj /out:%binDir%\aspnetcorev2.dll %objDir%\aspnetcorev2_arm64.lib %objDir%\aspnetcorev2_x64.lib
 
-link /dll /noentry /machine:arm64x /defArm64Native:aspnetcorev2_arm64.def /def:aspnetcorev2_x64.def %objDir%\aspnetcorev2_arm64.obj %objDir%\aspnetcorev2_x64.obj /out:%binDir%\aspnetcorev2.dll %objDir%\aspnetcorev2_arm64.lib %objDir%\aspnetcorev2_x64.lib
+cl /nologo /nologo /c /Fo%objDir%\aspnetcorev2_outofprocess_arm64.obj empty.cpp
+cl /nologo /nologo /c /arm64EC /Fo%objDir%\aspnetcorev2_outofprocess_x64.obj empty.cpp
 
-cl /c /Fo%objDir%\aspnetcorev2_outofprocess_arm64.obj empty.cpp
-cl /c /arm64EC /Fo%objDir%\aspnetcorev2_outofprocess_x64.obj empty.cpp
-
-link /lib /machine:arm64 /def:aspnetcorev2_outofprocess_arm64.def /out:%objDir%\aspnetcorev2_outofprocess_arm64.lib
+link /lib /nologo /machine:arm64 /def:aspnetcorev2_outofprocess_arm64.def /out:%objDir%\aspnetcorev2_outofprocess_arm64.lib
 link /lib /machine:x64 /def:aspnetcorev2_outofprocess_x64.def /out:%objDir%\aspnetcorev2_outofprocess_x64.lib
 
-link /dll /noentry /machine:arm64x /defArm64Native:aspnetcorev2_outofprocess_arm64.def /def:aspnetcorev2_outofprocess_x64.def %objDir%\aspnetcorev2_outofprocess_arm64.obj %objDir%\aspnetcorev2_outofprocess_x64.obj /out:%binDir%\aspnetcorev2_outofprocess.dll %objDir%\aspnetcorev2_outofprocess_arm64.lib %objDir%\aspnetcorev2_outofprocess_x64.lib
+link /dll /nologo /noentry /machine:arm64x /defArm64Native:aspnetcorev2_outofprocess_arm64.def /def:aspnetcorev2_outofprocess_x64.def %objDir%\aspnetcorev2_outofprocess_arm64.obj %objDir%\aspnetcorev2_outofprocess_x64.obj /out:%binDir%\aspnetcorev2_outofprocess.dll %objDir%\aspnetcorev2_outofprocess_arm64.lib %objDir%\aspnetcorev2_outofprocess_x64.lib

--- a/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/build.cmd
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/build.cmd
@@ -1,0 +1,18 @@
+SET objDir=%1
+SET binDir=%2
+
+cl /c /Fo%objDir%\aspnetcorev2_arm64.obj empty.cpp
+cl /c /arm64EC /Fo%objDir%\aspnetcorev2_x64.obj empty.cpp
+
+link /lib /machine:arm64 /def:aspnetcorev2_arm64.def /out:%objDir%\aspnetcorev2_arm64.lib
+link /lib /machine:x64 /def:aspnetcorev2_x64.def /out:%objDir%\aspnetcorev2_x64.lib
+
+link /dll /noentry /machine:arm64x /defArm64Native:aspnetcorev2_arm64.def /def:aspnetcorev2_x64.def %objDir%\aspnetcorev2_arm64.obj %objDir%\aspnetcorev2_x64.obj /out:%binDir%\aspnetcorev2.dll %objDir%\aspnetcorev2_arm64.lib %objDir%\aspnetcorev2_x64.lib
+
+cl /c /Fo%objDir%\aspnetcorev2_outofprocess_arm64.obj empty.cpp
+cl /c /arm64EC /Fo%objDir%\aspnetcorev2_outofprocess_x64.obj empty.cpp
+
+link /lib /machine:arm64 /def:aspnetcorev2_outofprocess_arm64.def /out:%objDir%\aspnetcorev2_outofprocess_arm64.lib
+link /lib /machine:x64 /def:aspnetcorev2_outofprocess_x64.def /out:%objDir%\aspnetcorev2_outofprocess_x64.lib
+
+link /dll /noentry /machine:arm64x /defArm64Native:aspnetcorev2_outofprocess_arm64.def /def:aspnetcorev2_outofprocess_x64.def %objDir%\aspnetcorev2_outofprocess_arm64.obj %objDir%\aspnetcorev2_outofprocess_x64.obj /out:%binDir%\aspnetcorev2_outofprocess.dll %objDir%\aspnetcorev2_outofprocess_arm64.lib %objDir%\aspnetcorev2_outofprocess_x64.lib

--- a/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/build.proj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/build.proj
@@ -14,9 +14,11 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
-    <Prompt>&quot;$(DevEnvDir)\..\Tools\VsDevCmd&quot;</Prompt>
+    <Prompt>&quot;$(VSInstallDir)Common7\Tools\VsDevCmd&quot;</Prompt>
   </PropertyGroup>
-  <Target Name="Build">
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="Build" DependsOnTargets="SetBuildDefaultEnvironmentVariables">
+    <MakeDir Directories="$(ObjDir);$(BinDir)" />
     <Exec Command="all.cmd $(Prompt) $(ObjDir) $(BinDir)" />
   </Target>
 </Project>

--- a/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/build.proj
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/build.proj
@@ -1,0 +1,22 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0" DefaultTargets="Build">
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <RootNamespace>aspnetcorev2</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <IsTestProject>false</IsTestProject>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup>
+    <ObjDir>$(ArtifactsObjDir)\AspNetCoreModuleForwarders</ObjDir>
+    <BinDir>$(ArtifactsBinDir)\AspNetCoreModuleForwarders</BinDir>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <PropertyGroup>
+    <Prompt>&quot;$(DevEnvDir)\..\Tools\VsDevCmd&quot;</Prompt>
+  </PropertyGroup>
+  <Target Name="Build">
+    <Exec Command="all.cmd $(Prompt) $(ObjDir) $(BinDir)" />
+  </Target>
+</Project>

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
@@ -109,7 +109,7 @@ HandlerResolver::LoadRequestHandlerAssembly(const IHttpApplication &pApplication
 
         LOG_INFOF(L"Loading request handler:  '%ls'", handlerDllPath.c_str());
 
-        hRequestHandlerDll = LoadLibrary(handlerDllPath.c_str());
+        hRequestHandlerDll = LoadLibraryEx(handlerDllPath.c_str(), 0, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
         RETURN_LAST_ERROR_IF_NULL(hRequestHandlerDll);
 
         if (preventUnload)


### PR DESCRIPTION
# Revised ASP.NET Core module installer for Windows ARM64
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

* Switch to `LoadLibraryEx` with `LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR` flag set, so that the pure forwarder works as desired.
* Add ARM64X pure forwarders.
* Revise WiX installer to utilize ARM64X pure forwarders

Fixes #47115.

## Description

### About the change in `HandlerResolver.cpp`
To implement all proposed installer changes in #47115, then in the out-of-process folder three files present,

1. `aspnetcorev2_outofprocess.dll`, an ARM64X pure forwarder.
1. `aspnetcorev2_outofprocess_arm64.dll`, the pure ARM64 handler.
1. `aspnetcorev2_outofprocess_x64.dll`, the x64 handler.

Before this change, `LoadLibrary` only loads the pure forwarder, but then scans the default folders (the dll folder is not included) to load the actual handler which obviously fails.

After this change, `LoadLibraryEx` can pick up the correct handler as the dll folder is added in the search folder list.

### About files in `Forwarders` folder
Source code for the two ARM64X pure forwarders.

### About changes in `ANCMV2` folder
Before this change, only ARM64 web apps can run on IIS.

After this change, the new file structure enables ARM64/x64/x86 side by side execution on IIS.