### PR TITLE
Convert AspNetCoreAnalyzers strings to localizable strings

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/DiagnosticDescriptors.cs
@@ -10,8 +10,8 @@ internal static class DiagnosticDescriptors
 {
     internal static readonly DiagnosticDescriptor DoNotUseModelBindingAttributesOnRouteHandlerParameters = new(
         "ASP0003",
-        "Do not use model binding attributes with route handlers",
-        "{0} should not be specified for a {1} Delegate parameter",
+        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseModelBindingAttributesOnRouteHandlerParameters_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseModelBindingAttributesOnRouteHandlerParameters_Message), Resources.ResourceManager, typeof(Resources)),
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -19,8 +19,8 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor DoNotReturnActionResultsFromRouteHandlers = new(
         "ASP0004",
-        "Do not use action results with route handlers",
-        "IActionResult instances should not be returned from a {0} Delegate parameter. Consider returning an equivalent result from Microsoft.AspNetCore.Http.Results.",
+        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotReturnActionResultsFromRouteHandlers_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotReturnActionResultsFromRouteHandlers_Message), Resources.ResourceManager, typeof(Resources)),
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -28,8 +28,8 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor DetectMisplacedLambdaAttribute = new(
         "ASP0005",
-        "Do not place attribute on method called by route handler lambda",
-        "'{0}' should be placed directly on the route handler lambda to be effective",
+        new LocalizableResourceString(nameof(Resources.Analyzer_DetectMisplacedLambdaAttribute_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_DetectMisplacedLambdaAttribute_Message), Resources.ResourceManager, typeof(Resources)),
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -37,8 +37,8 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor DoNotUseNonLiteralSequenceNumbers = new(
         "ASP0006",
-        "Do not use non-literal sequence numbers",
-        "'{0}' should not be used as a sequence number. Instead, use an integer literal representing source code order.",
+        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseNonLiteralSequenceNumbers_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseNonLiteralSequenceNumbers_Message), Resources.ResourceManager, typeof(Resources)),
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -46,8 +46,8 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor DetectMismatchedParameterOptionality = new(
         "ASP0007",
-        "Route parameter and argument optionality is mismatched",
-        "'{0}' argument should be annotated as optional or nullable to match route parameter",
+        new LocalizableResourceString(nameof(Resources.Analyzer_DetectMismatchedParameterOptionality_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_DetectMismatchedParameterOptionality_Message), Resources.ResourceManager, typeof(Resources)),
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -55,8 +55,8 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor DoNotUseConfigureWebHostWithConfigureHostBuilder = new(
         "ASP0008",
-        "Do not use ConfigureWebHost with WebApplicationBuilder.Host",
-        "ConfigureWebHost cannot be used with WebApplicationBuilder.Host",
+        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseConfigureWebHostWithConfigureHostBuilder_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseConfigureWebHostWithConfigureHostBuilder_Message), Resources.ResourceManager, typeof(Resources)),
         "Usage",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
@@ -64,8 +64,8 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor DoNotUseConfigureWithConfigureWebHostBuilder = new(
         "ASP0009",
-        "Do not use Configure with WebApplicationBuilder.WebHost",
-        "Configure cannot be used with WebApplicationBuilder.WebHost",
+        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseConfigureWithConfigureWebHostBuilder_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseConfigureWithConfigureWebHostBuilder_Message), Resources.ResourceManager, typeof(Resources)),
         "Usage",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
@@ -73,8 +73,8 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor DoNotUseUseStartupWithConfigureWebHostBuilder = new(
         "ASP0010",
-        "Do not use UseStartup with WebApplicationBuilder.WebHost",
-        "UseStartup cannot be used with WebApplicationBuilder.WebHost",
+        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseUseStartupWithConfigureWebHostBuilder_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseUseStartupWithConfigureWebHostBuilder_Message), Resources.ResourceManager, typeof(Resources)),
         "Usage",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
@@ -82,8 +82,8 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor DoNotUseHostConfigureLogging = new(
         "ASP0011",
-        "Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging",
-        "Suggest using builder.Logging instead of {0}",
+        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseHostConfigureLogging_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseHostConfigureLogging_Message), Resources.ResourceManager, typeof(Resources)),
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -91,8 +91,8 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor DoNotUseHostConfigureServices = new(
         "ASP0012",
-        "Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices",
-        "Suggest using builder.Services instead of {0}",
+        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseHostConfigureServices_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_DoNotUseHostConfigureServices_Message), Resources.ResourceManager, typeof(Resources)),
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -100,8 +100,8 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor DisallowConfigureAppConfigureHostBuilder = new(
         "ASP0013",
-        "Suggest switching from using Configure methods to WebApplicationBuilder.Configuration",
-        "Suggest using WebApplicationBuilder.Configuration instead of {0}",
+        new LocalizableResourceString(nameof(Resources.Analyzer_DisallowConfigureAppConfigureHostBuilder_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_DisallowConfigureAppConfigureHostBuilder_Message), Resources.ResourceManager, typeof(Resources)),
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -109,8 +109,8 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor UseTopLevelRouteRegistrationsInsteadOfUseEndpoints = new(
         "ASP0014",
-        "Suggest using top level route registrations",
-        "Suggest using top level route registrations instead of {0}",
+        new LocalizableResourceString(nameof(Resources.Analyzer_UseTopLevelRouteRegistrationsInsteadOfUseEndpoints_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_UseTopLevelRouteRegistrationsInsteadOfUseEndpoints_Message), Resources.ResourceManager, typeof(Resources)),
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -163,8 +163,8 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor RouteParameterComplexTypeIsNotParsable = new(
         "ASP0020",
-        "Complex types referenced by route parameters must be parsable",
-        "Parameter '{0}' of type {1} should define a bool TryParse(string, IFormatProvider, out {1}) method, or implement IParsable<{1}>.",
+        new LocalizableResourceString(nameof(Resources.Analyzer_RouteParameterComplexTypeIsNotParsable_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_RouteParameterComplexTypeIsNotParsable_Message), Resources.ResourceManager, typeof(Resources)),
         "Usage",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
@@ -172,8 +172,8 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor BindAsyncSignatureMustReturnValueTaskOfT = new(
         "ASP0021",
-        "When implementing BindAsync(...) method, the return type must be ValueTask<T>.",
-        "Parameter '{0}' of type {1} has a BindAsync(...) method, but the return type is not ValueTask<{1}>. Consider implementing IBindFromHttpContext<{1}> to enforce implementation.",
+        new LocalizableResourceString(nameof(Resources.Analyzer_BindAsyncSignatureMustReturnValueTaskOfT_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_BindAsyncSignatureMustReturnValueTaskOfT_Message), Resources.ResourceManager, typeof(Resources)),
         "Usage",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
@@ -181,8 +181,8 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor AmbiguousRouteHandlerRoute = new(
         "ASP0022",
-        "Route conflict detected between route handlers",
-        "Route '{0}' conflicts with another handler route. An HTTP request that matches multiple routes results in an ambiguous match error. Fix the conflict by changing the route's pattern, HTTP method, or route constraints.",
+        new LocalizableResourceString(nameof(Resources.Analyzer_AmbiguousRouteHandlerRoute_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_AmbiguousRouteHandlerRoute_Message), Resources.ResourceManager, typeof(Resources)),
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -190,8 +190,8 @@ internal static class DiagnosticDescriptors
 
     internal static readonly DiagnosticDescriptor AmbiguousActionRoute = new(
         "ASP0023",
-        "Route conflict detected between controller actions",
-        "Route '{0}' conflicts with another action route. An HTTP request that matches multiple routes results in an ambiguous match error. Fix the conflict by changing the route's pattern, HTTP method, or route constraints.",
+        new LocalizableResourceString(nameof(Resources.Analyzer_AmbiguousActionRoute_Title), Resources.ResourceManager, typeof(Resources)),
+        new LocalizableResourceString(nameof(Resources.Analyzer_AmbiguousActionRoute_Message), Resources.ResourceManager, typeof(Resources)),
         "Usage",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Resources.resx
@@ -213,4 +213,100 @@
   <data name="Analyzer_MultipleFromBody_Title" xml:space="preserve">
     <value>Route handler has multiple parameters with the [FromBody] attribute.</value>
   </data>
+  <data name="Analyzer_DoNotUseModelBindingAttributesOnRouteHandlerParameters_Title" xml:space="preserve">
+    <value>Do not use model binding attributes with route handlers</value>
+  </data>
+  <data name="Analyzer_DoNotUseModelBindingAttributesOnRouteHandlerParameters_Message" xml:space="preserve">
+    <value>{0} should not be specified for a {1} Delegate parameter</value>
+  </data>
+  <data name="Analyzer_DoNotReturnActionResultsFromRouteHandlers_Title" xml:space="preserve">
+    <value>Do not use action results with route handlers</value>
+  </data>
+  <data name="Analyzer_DoNotReturnActionResultsFromRouteHandlers_Message" xml:space="preserve">
+    <value>IActionResult instances should not be returned from a {0} Delegate parameter. Consider returning an equivalent result from Microsoft.AspNetCore.Http.Results.</value>
+  </data>
+  <data name="Analyzer_DetectMisplacedLambdaAttribute_Title" xml:space="preserve">
+    <value>Do not place attribute on method called by route handler lambda</value>
+  </data>
+  <data name="Analyzer_DetectMisplacedLambdaAttribute_Message" xml:space="preserve">
+    <value>'{0}' should be placed directly on the route handler lambda to be effective</value>
+  </data>
+  <data name="Analyzer_DoNotUseNonLiteralSequenceNumbers_Title" xml:space="preserve">
+    <value>Do not use non-literal sequence numbers</value>
+  </data>
+  <data name="Analyzer_DoNotUseNonLiteralSequenceNumbers_Message" xml:space="preserve">
+    <value>'{0}' should not be used as a sequence number. Instead, use an integer literal representing source code order.</value>
+  </data>
+  <data name="Analyzer_DetectMismatchedParameterOptionality_Title" xml:space="preserve">
+    <value>Route parameter and argument optionality is mismatched</value>
+  </data>
+  <data name="Analyzer_DetectMismatchedParameterOptionality_Message" xml:space="preserve">
+    <value>'{0}' argument should be annotated as optional or nullable to match route parameter</value>
+  </data>
+  <data name="Analyzer_DoNotUseConfigureWebHostWithConfigureHostBuilder_Title" xml:space="preserve">
+    <value>Do not use ConfigureWebHost with WebApplicationBuilder.Host</value>
+  </data>
+  <data name="Analyzer_DoNotUseConfigureWebHostWithConfigureHostBuilder_Message" xml:space="preserve">
+    <value>ConfigureWebHost cannot be used with WebApplicationBuilder.Host</value>
+  </data>
+  <data name="Analyzer_DoNotUseConfigureWithConfigureWebHostBuilder_Title" xml:space="preserve">
+    <value>Do not use Configure with WebApplicationBuilder.WebHost</value>
+  </data>
+  <data name="Analyzer_DoNotUseConfigureWithConfigureWebHostBuilder_Message" xml:space="preserve">
+    <value>Configure cannot be used with WebApplicationBuilder.WebHost</value>
+  </data>
+  <data name="Analyzer_DoNotUseUseStartupWithConfigureWebHostBuilder_Title" xml:space="preserve">
+    <value>Do not use UseStartup with WebApplicationBuilder.WebHost</value>
+  </data>
+  <data name="Analyzer_DoNotUseUseStartupWithConfigureWebHostBuilder_Message" xml:space="preserve">
+    <value>UseStartup cannot be used with WebApplicationBuilder.WebHost</value>
+  </data>
+  <data name="Analyzer_DoNotUseHostConfigureLogging_Title" xml:space="preserve">
+    <value>Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging</value>
+  </data>
+  <data name="Analyzer_DoNotUseHostConfigureLogging_Message" xml:space="preserve">
+    <value>Suggest using builder.Logging instead of {0}</value>
+  </data>
+  <data name="Analyzer_DoNotUseHostConfigureServices_Title" xml:space="preserve">
+    <value>Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices</value>
+  </data>
+  <data name="Analyzer_DoNotUseHostConfigureServices_Message" xml:space="preserve">
+    <value>Suggest using builder.Services instead of {0}</value>
+  </data>
+  <data name="Analyzer_DisallowConfigureAppConfigureHostBuilder_Title" xml:space="preserve">
+    <value>Suggest switching from using Configure methods to WebApplicationBuilder.Configuration</value>
+  </data>
+  <data name="Analyzer_DisallowConfigureAppConfigureHostBuilder_Message" xml:space="preserve">
+    <value>Suggest using WebApplicationBuilder.Configuration instead of {0}</value>
+  </data>
+  <data name="Analyzer_UseTopLevelRouteRegistrationsInsteadOfUseEndpoints_Title" xml:space="preserve">
+    <value>Suggest using top level route registrations</value>
+  </data>
+  <data name="Analyzer_UseTopLevelRouteRegistrationsInsteadOfUseEndpoints_Message" xml:space="preserve">
+    <value>Suggest using top level route registrations instead of {0}</value>
+  </data>
+  <data name="Analyzer_RouteParameterComplexTypeIsNotParsable_Title" xml:space="preserve">
+    <value>Complex types referenced by route parameters must be parsable</value>
+  </data>
+  <data name="Analyzer_RouteParameterComplexTypeIsNotParsable_Message" xml:space="preserve">
+    <value>Parameter '{0}' of type {1} should define a bool TryParse(string, IFormatProvider, out {1}) method, or implement IParsable&lt;{1}&gt;.</value>
+  </data>
+  <data name="Analyzer_BindAsyncSignatureMustReturnValueTaskOfT_Title" xml:space="preserve">
+    <value>When implementing BindAsync(...) method, the return type must be ValueTask&lt;T&gt;.</value>
+  </data>
+  <data name="Analyzer_BindAsyncSignatureMustReturnValueTaskOfT_Message" xml:space="preserve">
+    <value>Parameter '{0}' of type {1} has a BindAsync(...) method, but the return type is not ValueTask&lt;{1}&gt;. Consider implementing IBindFromHttpContext&lt;{1}&gt; to enforce implementation.</value>
+  </data>
+  <data name="Analyzer_AmbiguousRouteHandlerRoute_Title" xml:space="preserve">
+    <value>Route conflict detected between route handlers</value>
+  </data>
+  <data name="Analyzer_AmbiguousRouteHandlerRoute_Message" xml:space="preserve">
+    <value>Route '{0}' conflicts with another handler route. An HTTP request that matches multiple routes results in an ambiguous match error. Fix the conflict by changing the route's pattern, HTTP method, or route constraints.</value>
+  </data>
+  <data name="Analyzer_AmbiguousActionRoute_Title" xml:space="preserve">
+    <value>Route conflict detected between controller actions</value>
+  </data>
+  <data name="Analyzer_AmbiguousActionRoute_Message" xml:space="preserve">
+    <value>Route '{0}' conflicts with another action route. An HTTP request that matches multiple routes results in an ambiguous match error. Fix the conflict by changing the route's pattern, HTTP method, or route constraints.</value>
+  </data>
 </root>


### PR DESCRIPTION
Converts the title and message strings for the AspNetCoreAnalyzers to localizable strings.

The changes to `Resources.resx` were generated using a series of regex find and replacements on `DiagnosticDescriptors.cs`.

Fixes #46498 