### PR TITLE
Adding RedirectUrl option for SpaProxy

### DIFF
--- a/src/Middleware/Spa/SpaProxy/src/SpaDevelopmentServerOptions.cs
+++ b/src/Middleware/Spa/SpaProxy/src/SpaDevelopmentServerOptions.cs
@@ -7,6 +7,18 @@ internal sealed class SpaDevelopmentServerOptions
 {
     public string ServerUrl { get; set; } = "";
 
+    public string? RedirectUrl { get; set; }
+
+    internal string GetRedirectUrl()
+    {
+        if (!String.IsNullOrEmpty(RedirectUrl))
+        {
+            return RedirectUrl;
+        }
+
+        return ServerUrl;
+    }
+
     public string LaunchCommand { get; set; } = "";
 
     public int MaxTimeoutInSeconds { get; set; }

--- a/src/Middleware/Spa/SpaProxy/src/SpaProxyMiddleware.cs
+++ b/src/Middleware/Spa/SpaProxy/src/SpaProxyMiddleware.cs
@@ -64,8 +64,8 @@ internal sealed class SpaProxyMiddleware
         }
         else
         {
-            _logger.LogInformation($"SPA proxy is ready. Redirecting to {_options.Value.ServerUrl}.");
-            context.Response.Redirect(_options.Value.ServerUrl);
+            _logger.LogInformation($"SPA proxy is ready. Redirecting to {_options.Value.GetRedirectUrl()}.");
+            context.Response.Redirect(_options.Value.GetRedirectUrl());
         }
 
         static string GenerateSpaLaunchPage(SpaDevelopmentServerOptions options)
@@ -82,7 +82,7 @@ internal sealed class SpaProxyMiddleware
 </head>
 <body>
   <h1>Launching the SPA proxy...</h1>
-  <p>This page will automatically redirect to <a href=""{HtmlEncoder.Default.Encode(options.ServerUrl)}"">{HtmlEncoder.Default.Encode(options.ServerUrl)}</a> when the SPA proxy is ready.</p>
+  <p>This page will automatically redirect to <a href=""{HtmlEncoder.Default.Encode(options.GetRedirectUrl())}"">{HtmlEncoder.Default.Encode(options.GetRedirectUrl())}</a> when the SPA proxy is ready.</p>
 </body>
 </html>";
         }

--- a/src/Middleware/Spa/SpaProxy/src/build/Microsoft.AspNetCore.SpaProxy.targets
+++ b/src/Middleware/Spa/SpaProxy/src/build/Microsoft.AspNetCore.SpaProxy.targets
@@ -11,6 +11,7 @@
       <_SpaProxyServerLaunchConfigLines Include="{" />
       <_SpaProxyServerLaunchConfigLines Include="  &quot;SpaProxyServer&quot;: {" />
       <_SpaProxyServerLaunchConfigLines Include="    &quot;ServerUrl&quot;: &quot;$(SpaProxyServerUrl)&quot;," />
+      <_SpaProxyServerLaunchConfigLines Include="    &quot;RedirectUrl&quot;: &quot;$(SpaProxyRedirectUrl)&quot;," />
       <_SpaProxyServerLaunchConfigLines Include="    &quot;LaunchCommand&quot;: &quot;$(SpaProxyLaunchCommand)&quot;," />
       <_SpaProxyServerLaunchConfigLines Include="    &quot;WorkingDirectory&quot;: &quot;$(_SpaRootFullPath)&quot;," />
       <_SpaProxyServerLaunchConfigLines Include="    &quot;MaxTimeoutInSeconds&quot;: &quot;$(SpaProxyTimeoutInSeconds)&quot;," />


### PR DESCRIPTION
# Adding RedirectUrl option for SpaProxy

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Adds new RedirectUrl option to SpaProxy that can be used to control where the SpaProxy middleware redirects requests to instead of using the ServerUrl. If this new option isn't set, it will use the ServerUrl like before.

Fixes #47299
