### PR TITLE
Show new API project template in VS

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/.template.config/ide.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/.template.config/ide.host.json
@@ -14,10 +14,5 @@
       "id": "NativeAot",
       "isVisible": true
     }
-  ],
-  "unsupportedHosts": [
-    {
-      "id": "vs"
-    }
   ]
 }


### PR DESCRIPTION
Enable the new API project template showing up in Visual Studio:

<img width="431" alt="image" src="https://user-images.githubusercontent.com/249088/226444467-1110ed2c-69a6-4508-97d9-c62281f508e4.png">

<img width="440" alt="image" src="https://user-images.githubusercontent.com/249088/226444549-11b0a029-3364-4cb3-a63b-dc6e8d5aaad5.png">
