### PR TITLE
Fix documentation for `user-jwts create --expires-on` option

### DIFF
--- a/src/Tools/dotnet-user-jwts/src/Resources.resx
+++ b/src/Tools/dotnet-user-jwts/src/Resources.resx
@@ -148,7 +148,7 @@
     <value>Issue a new JSON Web Token</value>
   </data>
   <data name="CreateCommand_ExpiresOnOption_Description" xml:space="preserve">
-    <value>The UTC date &amp; time the JWT should expire in the format 'yyyy-MM-dd [[[[HH:mm]]:ss]]'. Defaults to 6 months after the --not-before date. Do not use this option in conjunction with the --valid-for option.</value>
+    <value>The UTC date &amp; time the JWT should expire in the format 'yyyy-MM-dd [[[[HH:mm]]:ss]]'. Defaults to 3 months after the --not-before date. Do not use this option in conjunction with the --valid-for option.</value>
   </data>
   <data name="CreateCommand_InvalidClaims_Error" xml:space="preserve">
     <value>Malformed claims supplied. Ensure each claim is in the format "name=value".</value>


### PR DESCRIPTION
# Fix documentation for `dotnet user-jwts`

Fixes the documentation in the `user-jwts` tool when calling `dotnet user-jwts create`

## Description

Currently the documentation (when you run `dotnet user-jwts create --help` says:

```
Defaults to 6 months after the --not-before date
```

But the tool actually defaults to 3 months, as seen here:

https://github.com/dotnet/aspnetcore/blob/main/src/Tools/dotnet-user-jwts/src/Commands/CreateCommand.cs#L154
