### PR TITLE
WithOpenApi generates annotations for endpoints without MethodInfo

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -1344,6 +1344,29 @@ public class EndpointMetadataApiDescriptionProviderTest
         Assert.Equal(expectedName, parameter.ParameterDescriptor.Name);
     }
 
+    [Fact]
+    public void HandlesEndpointWithoutMethodInfo()
+    {
+        var builder = CreateBuilder();
+        builder.MapGet("/", (HttpContext context) => Task.CompletedTask);
+
+        var context = new ApiDescriptionProviderContext(Array.Empty<ActionDescriptor>());
+
+        var endpointDataSource = builder.DataSources.OfType<EndpointDataSource>().Single();
+        var hostEnvironment = new HostEnvironment
+        {
+            ApplicationName = nameof(EndpointMetadataApiDescriptionProviderTest)
+        };
+        var provider = CreateEndpointMetadataApiDescriptionProvider(endpointDataSource);
+
+        // Act
+        provider.OnProvidersExecuting(context);
+
+        // Assert
+        var apiDescription = Assert.Single(context.Results);
+        Assert.Equal("GET", apiDescription.HttpMethod);
+    }
+
     private static IEnumerable<string> GetSortedMediaTypes(ApiResponseType apiResponseType)
     {
         return apiResponseType.ApiResponseFormats

--- a/src/OpenApi/src/OpenApiEndpointConventionBuilderExtensions.cs
+++ b/src/OpenApi/src/OpenApiEndpointConventionBuilderExtensions.cs
@@ -80,11 +80,6 @@ public static class OpenApiEndpointConventionBuilderExtensions
         var metadata = new EndpointMetadataCollection(routeEndpointBuilder.Metadata);
         var methodInfo = metadata.OfType<MethodInfo>().SingleOrDefault();
 
-        if (methodInfo is null)
-        {
-            return;
-        }
-
         var applicationServices = routeEndpointBuilder.ApplicationServices;
         var hostEnvironment = applicationServices.GetService<IHostEnvironment>();
         var serviceProviderIsService = applicationServices.GetService<IServiceProviderIsService>();

--- a/src/OpenApi/src/OpenApiGenerator.cs
+++ b/src/OpenApi/src/OpenApiGenerator.cs
@@ -58,10 +58,11 @@ internal sealed class OpenApiGenerator
         EndpointMetadataCollection metadata,
         RoutePattern pattern)
     {
-        if (metadata.GetMetadata<IHttpMethodMetadata>() is { } httpMethodMetadata &&
-            httpMethodMetadata.HttpMethods.SingleOrDefault() is { } method &&
-            metadata.GetMetadata<IExcludeFromDescriptionMetadata>() is null or { ExcludeFromDescription: false })
+        if (metadata.GetMetadata<IExcludeFromDescriptionMetadata>() is null or { ExcludeFromDescription: false })
         {
+            var method = metadata.GetMetadata<IHttpMethodMetadata>() is { HttpMethods: { Count: 1 } httpMethods }
+                ? httpMethods.Single()
+                : HttpMethods.Get;
             return GetOperation(method, methodInfo, metadata, pattern);
         }
 

--- a/src/OpenApi/test/OpenApiGeneratorTests.cs
+++ b/src/OpenApi/test/OpenApiGeneratorTests.cs
@@ -914,6 +914,18 @@ public class OpenApiOperationGeneratorTests
     }
 
     [Fact]
+    public void HandlesEndpointWithNoMethodInfo()
+    {
+        var operationWithNoMethodInfo = GetOpenApiOperation((HttpContext context) => Task.CompletedTask, "/", httpMethods: new[] { "PUT" }, hasMethodInfo: false);
+
+        Assert.Empty(operationWithNoMethodInfo.Parameters);
+        Assert.Empty(operationWithNoMethodInfo.Responses);
+        Assert.Null(operationWithNoMethodInfo.RequestBody);
+        var tag = Assert.Single(operationWithNoMethodInfo.Tags);
+        Assert.Equal(nameof(OpenApiOperationGeneratorTests), tag.Name);
+    }
+
+    [Fact]
     public void HandlesParameterWithNameInAttribute()
     {
         static void ValidateParameter(OpenApiOperation operation, string expectedName)
@@ -973,7 +985,8 @@ public class OpenApiOperationGeneratorTests
         string pattern = null,
         IEnumerable<string> httpMethods = null,
         string displayName = null,
-        object[] additionalMetadata = null)
+        object[] additionalMetadata = null,
+        bool hasMethodInfo = true)
     {
         var methodInfo = action.Method;
         var attributes = methodInfo.GetCustomAttributes();
@@ -989,7 +1002,7 @@ public class OpenApiOperationGeneratorTests
             hostEnvironment,
             new ServiceProviderIsService());
 
-        return generator.GetOpenApiOperation(methodInfo, endpointMetadata, routePattern);
+        return generator.GetOpenApiOperation(hasMethodInfo ? methodInfo : null, endpointMetadata, routePattern);
     }
 
     private static void TestAction()

--- a/src/OpenApi/test/OpenApiGeneratorTests.cs
+++ b/src/OpenApi/test/OpenApiGeneratorTests.cs
@@ -22,11 +22,11 @@ namespace Microsoft.AspNetCore.OpenApi.Tests;
 public class OpenApiOperationGeneratorTests
 {
     [Fact]
-    public void OperationNotCreatedIfNoHttpMethods()
+    public void OperationDefaultsToGetIfNoHttpMethods()
     {
         var operation = GetOpenApiOperation(() => { }, "/", Array.Empty<string>());
 
-        Assert.Null(operation);
+        Assert.NotNull(operation);
     }
 
     [Fact]


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/44970.

Our current OpenAPI-implementation does _not_ generate OpenAPI specs from endpoints that are derived from a `RequestDelegate`.  For most scenarios, this is a reasonable approach as developers might not want endpoints used for health-checks to show up in their OpenAPI annotations. In some cases, it's helpful to display OpenAPI specs even if the endpoint is sourced from a RequestDelegate.

This PR makes it so that invoking `WithOpenApi` on an endpoint will generate OpenAPI info _even_ if it is source from a request delegate.

```csharp
app.MapGet("/authorize", (HttpContext context) => ...).WithOpenApi();
```

Will generate an OpenAPI operation that:
- contains no parameters
- emits no response
- respects tags, summary, and annotation attributes