### PR TITLE
Fix unobserved JSDisconnectedException in NavigationManager

### DIFF
--- a/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
+++ b/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
@@ -60,7 +60,7 @@ internal sealed partial class RemoteNavigationManager : NavigationManager, IHost
 
         if (_navigationLockStateBeforeJsRuntimeAttached.HasValue)
         {
-            SetHasLocationChangingListeners(_navigationLockStateBeforeJsRuntimeAttached.Value);
+            _ = SetHasLocationChangingListenersAsync(_navigationLockStateBeforeJsRuntimeAttached.Value);
             _navigationLockStateBeforeJsRuntimeAttached = null;
         }
     }
@@ -131,11 +131,20 @@ internal sealed partial class RemoteNavigationManager : NavigationManager, IHost
             return;
         }
 
-        SetHasLocationChangingListeners(value);
+        _ = SetHasLocationChangingListenersAsync(value);
     }
 
-    private void SetHasLocationChangingListeners(bool value)
-        => _jsRuntime.InvokeVoidAsync(Interop.SetHasLocationChangingListeners, value).Preserve();
+    private async Task SetHasLocationChangingListenersAsync(bool value)
+    {
+        try
+        {
+            await _jsRuntime.InvokeVoidAsync(Interop.SetHasLocationChangingListeners, value);
+        }
+        catch (JSDisconnectedException)
+        {
+            // If the browser is gone, we don't need it to clean up any browser-side state
+        }
+    }
 
     private static partial class Log
     {


### PR DESCRIPTION
# Fix unobserved JSDisconnectedException in NavigationManager

Fixes an issue where an unobserved `JSDisconnectedException` thrown in `NavigationManager` may invoke `TaskScheduler.UnobservedTaskException` when there is sufficient GC pressure on the server.

## Description

When all "location changing" listeners in a Blazor Server `NavigationManager` get disposed, a JS interop call notifies the browser that there is no need to invoke the .NET "location changing" event for future navigations. Assuming the application is implemented correctly, all location changing listeners will be disposed when the circuit shuts down. If the user of the app clicks the browser's refresh button, the circuit is closed and server-side Blazor state is disposed, ultimately causing the aforementioned JS interop call to run. This JS interop call will throw a `JSDisconnectedException` because the circuit has been disposed by that point.

The exception does not surface because it was thrown in a fired-and-forgotten task. However, when the `Task` object eventually gets GC'd, the `TaskScheduler.UnobservedTaskException` event gets invoked. This doesn't affect the behavior of the app, but it's annoying for customers to have to filter out meaningless unhandled exceptions thrown from the framework.

This PR fixes the problem by catching and ignoring the `JSDisconnectedException`, which is the recommended and common practice for that specific exception type.

Fixes #47109
