### PR TITLE
Move Returns400IfNoMatchingRouteValueForRequiredParam test case to shared RDG/RDF test infra.

### DIFF
--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -315,30 +315,6 @@ public partial class RequestDelegateFactoryTests : LoggedTest
         Assert.Equal("'id' is not a route parameter.", ex.Message);
     }
 
-    [Fact]
-    public async Task Returns400IfNoMatchingRouteValueForRequiredParam()
-    {
-        const string unmatchedName = "value";
-        const int unmatchedRouteParam = 42;
-
-        int? deserializedRouteParam = null;
-
-        void TestAction([FromRoute] int foo)
-        {
-            deserializedRouteParam = foo;
-        }
-
-        var httpContext = CreateHttpContext();
-        httpContext.Request.RouteValues[unmatchedName] = unmatchedRouteParam.ToString(NumberFormatInfo.InvariantInfo);
-
-        var factoryResult = RequestDelegateFactory.Create(TestAction);
-        var requestDelegate = factoryResult.RequestDelegate;
-
-        await requestDelegate(httpContext);
-
-        Assert.Equal(400, httpContext.Response.StatusCode);
-    }
-
     public static object?[][] TryParsableArrayParameters
     {
         get

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.RouteParameter.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.RouteParameter.cs
@@ -190,6 +190,25 @@ app.MapGet("/{value}", (string value, HttpContext httpContext) => value);
     }
 
     [Fact]
+    public async Task Returns400IfNoMatchingRouteValueForRequiredParam()
+    {
+        var (_, compilation) = await RunGeneratorAsync($$"""app.MapGet(@"/{foo}", (int foo) => foo);""");
+        var endpoint = GetEndpointFromCompilation(compilation);
+
+        const string unmatchedName = "value";
+        const int unmatchedRouteParam = 42;
+
+        var httpContext = CreateHttpContext();
+        httpContext.Request.RouteValues[unmatchedName] = unmatchedRouteParam.ToString(NumberFormatInfo.InvariantInfo);
+
+        var requestDelegate = endpoint.RequestDelegate;
+
+        await requestDelegate(httpContext);
+
+        Assert.Equal(400, httpContext.Response.StatusCode);
+    }
+
+    [Fact]
     public async Task RequestDelegatePopulatesFromRouteParameterBasedOnParameterName()
     {
         const string paramName = "value";


### PR DESCRIPTION
Moving more tests from RDFTests to shared RDF/RDG test infrastructure.