### PR TITLE
Resolve parent cultures via parent property instead of string process…

### DIFF
--- a/src/Middleware/Localization/src/RequestLocalizationMiddleware.cs
+++ b/src/Middleware/Localization/src/RequestLocalizationMiddleware.cs
@@ -169,22 +169,29 @@ public class RequestLocalizationMiddleware
 
     private static CultureInfo? GetCultureInfo(
         StringSegment cultureName,
-        IList<CultureInfo> supportedCultures,
+        IList<CultureInfo>? supportedCultures,
         bool fallbackToParentCultures,
         int currentDepth)
     {
+        // If the cultureName is an empty string there
+        // is not chance we can resolve the culture info.
+        if (cultureName == "")
+        {
+            return null;
+        }
+
         var culture = GetCultureInfo(cultureName, supportedCultures);
 
         if (culture == null && fallbackToParentCultures && currentDepth < MaxCultureFallbackDepth)
         {
-            var lastIndexOfHyphen = cultureName.LastIndexOf('-');
-
-            if (lastIndexOfHyphen > 0)
+            try
             {
-                // Trim the trailing section from the culture name, e.g. "fr-FR" becomes "fr"
-                var parentCultureName = cultureName.Subsegment(0, lastIndexOfHyphen);
+                culture = CultureInfo.GetCultureInfo(cultureName.ToString());
 
-                culture = GetCultureInfo(parentCultureName, supportedCultures, fallbackToParentCultures, currentDepth + 1);
+                culture = GetCultureInfo(culture.Parent.Name, supportedCultures, fallbackToParentCultures, currentDepth + 1);
+            }
+            catch (CultureNotFoundException)
+            {
             }
         }
 

--- a/src/Middleware/Localization/src/RequestLocalizationMiddleware.cs
+++ b/src/Middleware/Localization/src/RequestLocalizationMiddleware.cs
@@ -175,7 +175,7 @@ public class RequestLocalizationMiddleware
     {
         // If the cultureName is an empty string there
         // is not chance we can resolve the culture info.
-        if (cultureName == "")
+        if (cultureName.Equals(string.Empty))
         {
             return null;
         }

--- a/src/Middleware/Localization/src/RequestLocalizationMiddleware.cs
+++ b/src/Middleware/Localization/src/RequestLocalizationMiddleware.cs
@@ -174,7 +174,7 @@ public class RequestLocalizationMiddleware
         int currentDepth)
     {
         // If the cultureName is an empty string there
-        // is not chance we can resolve the culture info.
+        // is no chance we can resolve the culture info.
         if (cultureName.Equals(string.Empty))
         {
             return null;

--- a/src/Middleware/Localization/test/UnitTests/RequestLocalizationMiddlewareTest.cs
+++ b/src/Middleware/Localization/test/UnitTests/RequestLocalizationMiddlewareTest.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.AspNetCore.Localization;
+
+public class RequestLocalizationMiddlewareTest
+{
+    [Fact]
+    public async Task GetCultureInfoTraversesParentPropertyToResolveCulture()
+    {
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                .UseTestServer()
+                .Configure(app =>
+                {
+                    var options = new RequestLocalizationOptions
+                    {
+                        DefaultRequestCulture = new RequestCulture("en-US"),
+                        SupportedCultures = new List<CultureInfo>
+                        {
+                                new CultureInfo("zh-Hant")
+                        },
+                        SupportedUICultures = new List<CultureInfo>
+                        {
+                                new CultureInfo("zh-Hant")
+                        }
+                    };
+                    app.UseRequestLocalization(options);
+                    app.Run(context =>
+                    {
+                        // NOTE: This test exploits the fact that zh-TW's parent culture (zh-Hant) is not
+                        //       present in the string representation of the culture, thus proving that
+                        //       the GetCultureInfo(...) method in RequestLocalizationMiddleware is
+                        //       correctly traversing the Parent properties of CultureInfo instances
+                        //       rather than trying to process the string.
+                        //
+                        //       The more modern equivalent of zh-TW is zh-Hant-TW but zh-TW exists for
+                        //       legacy reasons.
+                        //
+                        //       Citation:
+                        //       https://social.msdn.microsoft.com/Forums/en-US/8b93c07b-93bd-465f-b48f-0fff544c06d8/quotzhhansquot-vs-quotzhchsquot-and-quotzhhantquot-vs-quotzhchtquot?forum=microsofttranslator
+                        var requestCultureFeature = context.Features.Get<IRequestCultureFeature>();
+                        var requestCulture = requestCultureFeature.RequestCulture;
+                        Assert.Equal("zh-Hant", requestCulture.Culture.ToString());
+                        Assert.Equal("zh-Hant", requestCulture.UICulture.ToString());
+                        return Task.FromResult(0);
+                    });
+                });
+            }).Build();
+
+        await host.StartAsync();
+
+        using (var server = host.GetTestServer())
+        {
+            var client = server.CreateClient();
+            var response = await client.GetAsync("/page?culture=zh-TW");
+        }
+    }
+
+    [Fact]
+    public async Task NotProvidingCultureReturnsDefault()
+    {
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                .UseTestServer()
+                .Configure(app =>
+                {
+                    var options = new RequestLocalizationOptions
+                    {
+                        DefaultRequestCulture = new RequestCulture("en-US")
+                    };
+                    app.UseRequestLocalization(options);
+                    app.Run(context =>
+                    {
+                        var requestCultureFeature = context.Features.Get<IRequestCultureFeature>();
+                        var requestCulture = requestCultureFeature.RequestCulture;
+                        Assert.Equal("en-US", requestCulture.Culture.ToString());
+                        Assert.Equal("en-US", requestCulture.UICulture.ToString());
+                        return Task.FromResult(0);
+                    });
+                });
+            }).Build();
+
+        await host.StartAsync();
+
+        using (var server = host.GetTestServer())
+        {
+            var client = server.CreateClient();
+            var response = await client.GetAsync("/page");
+        }
+    }
+
+}

--- a/src/Middleware/Localization/test/UnitTests/RequestLocalizationMiddlewareTest.cs
+++ b/src/Middleware/Localization/test/UnitTests/RequestLocalizationMiddlewareTest.cs
@@ -97,8 +97,7 @@ public class RequestLocalizationMiddlewareTest
         using (var server = host.GetTestServer())
         {
             var client = server.CreateClient();
-            var response = await client.GetAsync("/page");
+            var response = await client.GetAsync("/page?culture=");
         }
     }
-
 }


### PR DESCRIPTION
This PR replaces #46637.

Currently in the the `RequestLocalizationMiddleware` we resolve parent cultures by processing the string representation of a culture (e.g. `zh-Hant-TW`). For example we would check see if the following cultures are supported in this order:

1. `zh-Hant-TW`
2. `zh-Hant`
3. `zh`

However, this is not always strictly correct. For example the culture string `zh-TW` is a synonym for `zh-Hant-TW` and `zh-CN` is a synonym for `zh-Hans-CN` (both for legacy reasons). The localization APIs in .NET encode this information but it isn't possible to correctly infer the hierarchy from the string representation.

This change swaps over to using the `Parent` property on `CultureInfo` instances to walk back through the parent cultures. We basically go from this:

> `zh-TW` produces the following hierarchy: `zh-TW` > `zh`

To this:

> `zh-TW` produces the following hierarchy: `zh-TW` > `zh-Hant` > `zh`

Whilst generally speaking folks should prefer `zh-Hant-TW` over `zh-TW` the fact that this historical arrangement exists helps with unit testing this behavior ;)