### PR TITLE
Run Mvc.Razor.HelperResult callbacks inline

### DIFF
--- a/src/Mvc/test/Mvc.FunctionalTests/ViewEngineTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ViewEngineTests.cs
@@ -472,7 +472,7 @@ Partial";
     {
         // Arrange
         var expected = """
-<div class="">
+    <div class="">
         <h1>Some HTML</h1>
     </div>
     <div class="">
@@ -490,6 +490,6 @@ Partial";
         await response.AssertStatusCodeAsync(HttpStatusCode.OK);
         var body = await response.Content.ReadAsStringAsync();
 
-        Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
+        Assert.Equal(expected, body.Trim('\r', '\n'), ignoreLineEndingDifferences: true);
     }
 }

--- a/src/Mvc/test/Mvc.FunctionalTests/ViewEngineTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/ViewEngineTests.cs
@@ -466,4 +466,30 @@ Partial";
         // Assert
         Assert.Equal(expected, responseContent.Trim());
     }
+
+    [Fact]
+    public async Task RazorView_RunsAttributeCodeInline()
+    {
+        // Arrange
+        var expected = """
+<div class="">
+        <h1>Some HTML</h1>
+    </div>
+    <div class="">
+        <h1>Some HTML</h1>
+    </div>
+    <div class="hidden">
+        <h1>Some HTML</h1>
+    </div>
+""";
+
+        // Act
+        var response = await Client.GetAsync("http://localhost/ViewEngine/ViewWithForLoopCapture");
+
+        // Assert
+        await response.AssertStatusCodeAsync(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+
+        Assert.Equal(expected, body.Trim(), ignoreLineEndingDifferences: true);
+    }
 }

--- a/src/Mvc/test/WebSites/RazorWebSite/Controllers/ViewEngineController.cs
+++ b/src/Mvc/test/WebSites/RazorWebSite/Controllers/ViewEngineController.cs
@@ -78,4 +78,6 @@ public class ViewEngineController : Controller
     }
 
     public IActionResult SearchInPages() => View();
+
+    public IActionResult ViewWithForLoopCapture() => View();
 }

--- a/src/Mvc/test/WebSites/RazorWebSite/Views/ViewEngine/ViewWithForLoopCapture.cshtml
+++ b/src/Mvc/test/WebSites/RazorWebSite/Views/ViewEngine/ViewWithForLoopCapture.cshtml
@@ -1,0 +1,10 @@
+﻿@{
+    List<int> numbers = new List<int>() { 1, 2, 3 };
+}
+
+@for (int counter = 0; counter < numbers.Count; counter++)
+{
+    <div class="@if(numbers[counter] > 2){<text>hidden</text>}">
+        <h1>Some HTML</h1>
+    </div>
+}


### PR DESCRIPTION
I'm not sure we'd be willing to take the perf hit, but this fixes https://github.com/dotnet/razor/issues/8487. I'm guessing the compiler could do this more efficiently.