### PR TITLE
Support populating cache without serving from it.

### DIFF
--- a/src/Middleware/OutputCaching/src/OutputCacheMiddleware.cs
+++ b/src/Middleware/OutputCaching/src/OutputCacheMiddleware.cs
@@ -119,6 +119,8 @@ internal sealed class OutputCacheMiddleware
                 // Should we store the response to this request?
                 if (context.AllowCacheStorage)
                 {
+                    CreateCacheKey(context);
+
                     // It is also a pre-condition to response locking
 
                     var executed = false;

--- a/src/Middleware/OutputCaching/test/OutputCacheMiddlewareTests.cs
+++ b/src/Middleware/OutputCaching/test/OutputCacheMiddlewareTests.cs
@@ -983,8 +983,6 @@ public class OutputCacheMiddlewareTests
         }
     }
 
-
-
     [Fact]
     public async Task Can_Implement_Policy_That_Enables_Storage_Without_Serving()
     {

--- a/src/Middleware/OutputCaching/test/OutputCacheMiddlewareTests.cs
+++ b/src/Middleware/OutputCaching/test/OutputCacheMiddlewareTests.cs
@@ -1000,7 +1000,7 @@ public class OutputCacheMiddlewareTests
             await c.Response.WriteAsync(Guid.NewGuid().ToString());
         });
 
-        // Act - what I'm doing here is making four requests. The third request
+        // Act - Four requests are executed. The third request
         //       should trigger a cache refresh so that the first two requests
         //       have matching output, and the last two have matching output.
         var initialResponse = await SendRequestAsync(includeRefreshHeader: false);


### PR DESCRIPTION
This PR addresses: https://github.com/dotnet/aspnetcore/issues/46671

It allows folks to populate the cache without necessarily serving content from it. It allows for a scenario like described in the original issue where someone wants the client to be able to supply a header which triggers cache invalidation.