### PR TITLE
Added a reminder for the breaking-change process

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -3628,6 +3628,46 @@
           }
         ]
       }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "labelAdded",
+              "parameters": {
+                "label": "breaking-change"
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Breaking change actions reminder",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "needs-breaking-change-announcement"
+            }
+          },
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Thanks for identifying a breaking change.\n\n${assignees}, when you commit this breaking change please take the following actions, as part of the breaking changes announcement process:\n\\n- [ ] Create an announcement issue by using the [ASP.NET Core breaking change](https://github.com/aspnet/Announcements/issues/new?assignees=&labels=Breaking+change&template=breaking-change.yaml&title=%5BBreaking+change%5D%3A+) issue template.\n\\n- [ ] Link the breaking change announcement issue from this PR.\n\\n- [ ] Remove the `needs-breaking-change-announcement` label."
+            }
+          }
+        ]
+      }
     }
   ],
   "userGroups": []

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -3663,7 +3663,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "Thanks for identifying a breaking change.\n\n${assignees}, when you commit this breaking change please take the following actions, as part of the breaking changes announcement process:\n\\n- [ ] Create an announcement issue by using the [ASP.NET Core breaking change](https://github.com/aspnet/Announcements/issues/new?assignees=&labels=Breaking+change&template=breaking-change.yaml&title=%5BBreaking+change%5D%3A+) issue template.\n\\n- [ ] Link the breaking change announcement issue from this PR.\n\\n- [ ] Remove the `needs-breaking-change-announcement` label."
+              "comment": "Thanks for identifying a breaking change.\n\n${assignees}, after you commit this PR please take the following actions, as part of the breaking changes announcement process:\n\\n- [ ] Create an announcement issue by using the [ASP.NET Core breaking change](https://github.com/aspnet/Announcements/issues/new?assignees=&labels=Breaking+change&template=breaking-change.yaml&title=%5BBreaking+change%5D%3A+) issue template.\n\\n- [ ] Link the breaking change announcement issue from this PR.\n\\n- [ ] Remove the `needs-breaking-change-announcement` label."
             }
           }
         ]


### PR DESCRIPTION
This change is inspired by the breaking change automation process used in the dotnet/runtime repository. However, these are differences between the two. Basically, this process is only to remind engineers to announce breaking changes by filing appropriate announcement issues in the aspnet/announcements repository.

Here what the automation does:
When a PR is labeled with the `breaking-change` label, the bot will add a `needs-breaking-change-announcement` label to the issue and drop a comment with instructions about what needs to be done for the announcements. Below is an example as if I've added the `breaking-change` label:

> Thanks for identifying a breaking change.
>
> @mkArtakMSFT, after you commit this PR please take the following actions, as part of the breaking changes announcement process:
> - [ ] Create an announcement issue by using the [ASP.NET Core breaking change](https://github.com/aspnet/Announcements/issues/new?assignees=&labels=Breaking+change&template=breaking-change.yaml&title=%5BBreaking+change%5D%3A+) issue template.
> - [ ] Link the breaking change announcement issue from this PR.
> - [ ] Remove the `needs-breaking-change-announcement` label.
