### PR TITLE
Enable custom ICU loading.

### DIFF
--- a/src/Components/Web.JS/src/Platform/BootConfig.ts
+++ b/src/Components/Web.JS/src/Platform/BootConfig.ts
@@ -83,5 +83,6 @@ export type ExtendedResourceList = {
 export enum ICUDataMode {
   Sharded,
   All,
-  Invariant
+  Invariant,
+  Custom
 }

--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -493,29 +493,43 @@ function attachInteropInvoker(): void {
 }
 
 function getICUResourceName(bootConfig: BootJsonData, culture: string | undefined): string {
+  if (bootConfig.icuDataMode === ICUDataMode.Custom) {
+    const icuFiles = Object
+      .keys(bootConfig.resources.runtime)
+      .filter(n => n.startsWith('icudt') && n.endsWith('.dat'));
+    if (icuFiles.length === 1) {
+      const customIcuFile = icuFiles[0];
+      return customIcuFile;
+    }
+  }
+
   const combinedICUResourceName = 'icudt.dat';
   if (!culture || bootConfig.icuDataMode === ICUDataMode.All) {
     return combinedICUResourceName;
   }
 
   const prefix = culture.split('-')[0];
-  if ([
-    'en',
-    'fr',
-    'it',
-    'de',
-    'es',
-  ].includes(prefix)) {
+  if (prefix === 'en' ||
+    [
+      'fr',
+      'fr-FR',
+      'it',
+      'it-IT',
+      'de',
+      'de-DE',
+      'es',
+      'es-ES',
+    ].includes(culture)) {
     return 'icudt_EFIGS.dat';
-  } else if ([
+  }
+  if ([
     'zh',
     'ko',
     'ja',
   ].includes(prefix)) {
     return 'icudt_CJK.dat';
-  } else {
-    return 'icudt_no_CJK.dat';
   }
+  return 'icudt_no_CJK.dat';
 }
 
 function changeExtension(filename: string, newExtensionWithLeadingDot: string) {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/83585.

Needs to be merged together with a change in sdk repo https://github.com/dotnet/sdk/pull/31446 and a change in documentation in runtime repo https://github.com/dotnet/runtime/pull/83925.

It is an extension of the custom ICU feature implemented already in WASM apps, to Blazor apps. WASM change was introduced here: https://github.com/dotnet/runtime/pull/80421.

Changes from user perspective:
- they can decrease the size of runtime by loading a custom ICU file instead of pre-prepared icu files from the runtime pack. They need to prepare the file beforehand and provide info about its location to get loaded. Then, they add this information as MSBuild property  `<BlazorIcuDataFileName>icudt_path.dat</BlazorIcuDataFileName>`.

Changes:
- new icu mode: custom,
- in the custom mode we have only one ICU file in the `blazor.boot.json`, so it is fine to take the first result after filtering out the resources,
- edited `getICUResourceName` function to work the same way as https://github.com/ilonatommy/runtime/blob/0b3f4dc18a6dc5e01a03298974a943aef7431908/src/mono/wasm/runtime/icu.ts#L50, including correction of EFIGS cultures: EFIGS does not contain such cultures as e.g. "es-MX" and by loading EFIGS for these kind of cultures only because they start with "es" is a bug. Out of all shards, they are only in `no-CJK.dat` (see: https://github.com/ilonatommy/icu/tree/dotnet/main/icu-filters).