### PR TITLE
Flow FullAssemblySigningSupported for source-build to repo tasks

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -40,6 +40,11 @@
       <_AdditionalRepoTaskBuildArgs Condition="'$(DotNetRuntimeSourceFeedKey)' != ''" >$(_AdditionalRepoTaskBuildArgs) --runtimesourcefeedkey $(DotNetRuntimeSourceFeedKey)</_AdditionalRepoTaskBuildArgs>
     </PropertyGroup>
 
+    <ItemGroup>
+      <!-- We need to flow FullAssemblySigningSupported even when building repo tasks because they use full signing -->
+      <InnerBuildEnv Condition="'$(FullAssemblySigningSupported)' != ''" Include="FullAssemblySigningSupported=$(FullAssemblySigningSupported)" />
+    </ItemGroup>
+
     <!-- Call the build.sh script to build the repo tasks. Set IgnoreStandardErrorWarningFormat
          to true. This avoids fatal errors, because in internal builds there are usually a few failed installation
          attempts as the install script walks through potential locations for a runtime.


### PR DESCRIPTION
This property is being added to arcade via https://github.com/dotnet/arcade/pull/12749 and https://github.com/dotnet/arcade/pull/12940

Once this property is added to arcade, it flows correctly to the main aspnetcore build, but not to the build for repo tasks. The repo tasks still need this, otherwise they end up using full signing.
    
Fix that by manually passing the property along (using env var) when building the repo tasks.

(Integration tests for this change live in dotnet/installer. Once https://github.com/dotnet/installer/blob/d109cba3ff8ff46fe70be93a40c45002e5770267/eng/pipelines/templates/jobs/vmr-build.yml#L50-L54 is removed, this feature will get exercised end-to-end).