### PR TITLE
Use Json TypeInfoResolverChain

### DIFF
--- a/src/Http/Http.Extensions/src/JsonOptions.cs
+++ b/src/Http/Http.Extensions/src/JsonOptions.cs
@@ -6,8 +6,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Internal;
 
-#nullable enable
-
 namespace Microsoft.AspNetCore.Http.Json;
 
 /// <summary>
@@ -18,15 +16,15 @@ public class JsonOptions
 {
     internal static readonly JsonSerializerOptions DefaultSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
     {
-        // Web defaults don't use the relex JSON escaping encoder.
+        // Web defaults don't use the relaxed JSON escaping encoder.
         //
         // Because these options are for producing content that is written directly to the request
         // (and not embedded in an HTML page for example), we can use UnsafeRelaxedJsonEscaping.
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
 
         // The JsonSerializerOptions.GetTypeInfo method is called directly and needs a defined resolver
-        // setting the default resolver (reflection-based) but the user can overwrite it directly or calling
-        // .AddContext<TContext>()
+        // setting the default resolver (reflection-based) but the user can overwrite it directly or by modifying
+        // the TypeInfoResolverChain
         TypeInfoResolver = TrimmingAppContextSwitches.EnsureJsonTrimmability ? null : CreateDefaultTypeResolver()
     };
 

--- a/src/Http/Http.Extensions/src/JsonOptions.cs
+++ b/src/Http/Http.Extensions/src/JsonOptions.cs
@@ -32,7 +32,7 @@ public class JsonOptions
     /// <summary>
     /// Gets the <see cref="JsonSerializerOptions"/>.
     /// </summary>
-    public JsonSerializerOptions SerializerOptions { get; internal set; } = new JsonSerializerOptions(DefaultSerializerOptions);
+    public JsonSerializerOptions SerializerOptions { get; } = new JsonSerializerOptions(DefaultSerializerOptions);
 
 #pragma warning disable IL2026 // Suppressed in Microsoft.AspNetCore.Http.Extensions.WarningSuppressions.xml
 #pragma warning disable IL3050 // Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.

--- a/src/Http/Http.Extensions/src/ProblemDetailsJsonOptionsSetup.cs
+++ b/src/Http/Http.Extensions/src/ProblemDetailsJsonOptionsSetup.cs
@@ -1,37 +1,26 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Http;
 
-internal sealed class ProblemDetailsJsonOptionsSetup : IPostConfigureOptions<JsonOptions>
+/// <summary>
+/// Adds the ProblemDetailsJsonContext to the current JsonSerializerOptions.
+///
+/// This allows for consistent serialization behavior for ProblemDetails regardless if
+/// the default reflection-based serializer is used or not. And makes it trim/NativeAOT compatible.
+/// </summary>
+internal sealed class ProblemDetailsJsonOptionsSetup : IConfigureOptions<JsonOptions>
 {
-    public void PostConfigure(string? name, JsonOptions options)
+    public void Configure(JsonOptions options)
     {
-        var typeInfoResolverChain = options.SerializerOptions.TypeInfoResolverChain;
-        if (typeInfoResolverChain.Count == 0)
-        {
-            // Not adding our source gen context when the TypeInfoResolverChain is empty,
-            // since adding it will skip the reflection-based resolver and potentially
-            // cause unexpected serialization problems
-            return;
-        }
-
-        var lastResolver = typeInfoResolverChain[typeInfoResolverChain.Count - 1];
-        if (lastResolver is DefaultJsonTypeInfoResolver)
-        {
-            // In this case, the current configuration has a reflection-based resolver at the end
-            // and we are inserting our internal ProblemDetails context to be evaluated
-            // just before the reflection-based resolver.
-            typeInfoResolverChain.Insert(typeInfoResolverChain.Count - 1, ProblemDetailsJsonContext.Default);
-        }
-        else
-        {
-            // Combine the current resolver with our internal problem details context (adding last)
-            typeInfoResolverChain.Add(ProblemDetailsJsonContext.Default);
-        }
+        // Always insert the ProblemDetailsJsonContext to the beginning of the chain at the time
+        // this Configure is invoked. This JsonTypeInfoResolver will be before the default reflection-based resolver,
+        // and before any other resolvers currently added.
+        // If apps need to customize ProblemDetails serialization, they can prepend a custom ProblemDetails resolver
+        // to the chain in an IConfigureOptions<JsonOptions> registered after the call to AddProblemDetails().
+        options.SerializerOptions.TypeInfoResolverChain.Insert(0, new ProblemDetailsJsonContext());
     }
 }

--- a/src/Http/Http.Extensions/src/ProblemDetailsServiceCollectionExtensions.cs
+++ b/src/Http/Http.Extensions/src/ProblemDetailsServiceCollectionExtensions.cs
@@ -40,7 +40,8 @@ public static class ProblemDetailsServiceCollectionExtensions
         // Adding default services;
         services.TryAddSingleton<IProblemDetailsService, ProblemDetailsService>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IProblemDetailsWriter, DefaultProblemDetailsWriter>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<JsonOptions>, ProblemDetailsJsonOptionsSetup>());
+        // Use IConfigureOptions (instead of post-configure) so the registration gets added/invoked relative to when AddProblemDetails() is called.
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<JsonOptions>, ProblemDetailsJsonOptionsSetup>());
 
         if (configure != null)
         {

--- a/src/Http/Http.Extensions/test/ProblemDetailsServiceCollectionExtensionsTest.cs
+++ b/src/Http/Http.Extensions/test/ProblemDetailsServiceCollectionExtensionsTest.cs
@@ -27,7 +27,7 @@ public partial class ProblemDetailsServiceCollectionExtensionsTest
         // Assert
         Assert.Single(collection, (sd) => sd.ServiceType == typeof(IProblemDetailsService) && sd.ImplementationType == typeof(ProblemDetailsService));
         Assert.Single(collection, (sd) => sd.ServiceType == typeof(IProblemDetailsWriter) && sd.ImplementationType == typeof(DefaultProblemDetailsWriter));
-        Assert.Single(collection, (sd) => sd.ServiceType == typeof(IPostConfigureOptions<JsonOptions>) && sd.ImplementationType == typeof(ProblemDetailsJsonOptionsSetup));
+        Assert.Single(collection, (sd) => sd.ServiceType == typeof(IConfigureOptions<JsonOptions>) && sd.ImplementationType == typeof(ProblemDetailsJsonOptionsSetup));
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public partial class ProblemDetailsServiceCollectionExtensionsTest
         // Assert
         Assert.Single(collection, (sd) => sd.ServiceType == typeof(IProblemDetailsService) && sd.ImplementationType == typeof(ProblemDetailsService));
         Assert.Single(collection, (sd) => sd.ServiceType == typeof(IProblemDetailsWriter) && sd.ImplementationType == typeof(DefaultProblemDetailsWriter));
-        Assert.Single(collection, (sd) => sd.ServiceType == typeof(IPostConfigureOptions<JsonOptions>) && sd.ImplementationType == typeof(ProblemDetailsJsonOptionsSetup));
+        Assert.Single(collection, (sd) => sd.ServiceType == typeof(IConfigureOptions<JsonOptions>) && sd.ImplementationType == typeof(ProblemDetailsJsonOptionsSetup));
     }
 
     [Fact]
@@ -125,22 +125,34 @@ public partial class ProblemDetailsServiceCollectionExtensionsTest
         Assert.Throws<InvalidOperationException>(() => jsonOptions.Value);
     }
 
+    public enum CustomContextBehavior
+    {
+        Prepend,
+        Append,
+        Replace,
+    }
+
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void AddProblemDetails_CombinesProblemDetailsContext_WhenAddingCustomContext(bool prepend)
+    [InlineData(CustomContextBehavior.Prepend)]
+    [InlineData(CustomContextBehavior.Append)]
+    [InlineData(CustomContextBehavior.Replace)]
+    public void AddProblemDetails_CombinesProblemDetailsContext_WhenAddingCustomContext(CustomContextBehavior behavior)
     {
         // Arrange
         var collection = new ServiceCollection();
         collection.AddOptions<JsonOptions>();
 
-        if (prepend)
+        if (behavior == CustomContextBehavior.Prepend)
         {
             collection.ConfigureAll<JsonOptions>(options => options.SerializerOptions.TypeInfoResolverChain.Insert(0, TestExtensionsJsonContext.Default));
         }
-        else
+        else if (behavior == CustomContextBehavior.Append)
         {
             collection.ConfigureAll<JsonOptions>(options => options.SerializerOptions.TypeInfoResolverChain.Add(TestExtensionsJsonContext.Default));
+        }
+        else
+        {
+            collection.ConfigureAll<JsonOptions>(options => options.SerializerOptions.TypeInfoResolver = TestExtensionsJsonContext.Default);
         }
 
         // Act
@@ -157,7 +169,7 @@ public partial class ProblemDetailsServiceCollectionExtensionsTest
     }
 
     [Fact]
-    public void AddProblemDetails_DoesNotCombineProblemDetailsContext_WhenNullTypeInfoResolver()
+    public void AddProblemDetails_CombinesProblemDetailsContext_EvenWhenNullTypeInfoResolver()
     {
         // Arrange
         var collection = new ServiceCollection();
@@ -172,7 +184,8 @@ public partial class ProblemDetailsServiceCollectionExtensionsTest
         var jsonOptions = services.GetService<IOptions<JsonOptions>>();
 
         Assert.NotNull(jsonOptions.Value);
-        Assert.Null(jsonOptions.Value.SerializerOptions.TypeInfoResolver);
+        Assert.NotNull(jsonOptions.Value.SerializerOptions.TypeInfoResolver);
+        Assert.NotNull(jsonOptions.Value.SerializerOptions.TypeInfoResolver.GetTypeInfo(typeof(ProblemDetails), jsonOptions.Value.SerializerOptions));
     }
 
     [Fact]
@@ -203,11 +216,13 @@ public partial class ProblemDetailsServiceCollectionExtensionsTest
         // Arrange
         var collection = new ServiceCollection();
         collection.AddOptions<JsonOptions>();
-        var customProblemDetailsResolver = new CustomProblemDetailsTypeInfoResolver();
-        collection.ConfigureAll<JsonOptions>(options => options.SerializerOptions.TypeInfoResolverChain.Insert(0, customProblemDetailsResolver));
-        
+
         // Act
         collection.AddProblemDetails();
+
+        // add any custom ProblemDetails TypeInfoResolvers after calling AddProblemDetails()
+        var customProblemDetailsResolver = new CustomProblemDetailsTypeInfoResolver();
+        collection.ConfigureAll<JsonOptions>(options => options.SerializerOptions.TypeInfoResolverChain.Insert(0, customProblemDetailsResolver));
 
         // Assert
         var services = collection.BuildServiceProvider();

--- a/src/Http/Http.Results/test/HttpResultsHelperTests.cs
+++ b/src/Http/Http.Results/test/HttpResultsHelperTests.cs
@@ -30,7 +30,7 @@ public partial class HttpResultsHelperTests
 
         if (useJsonContext)
         {
-            serializerOptions.AddContext<TestJsonContext>();
+            serializerOptions.TypeInfoResolver = TestJsonContext.Default;
         }
 
         // Act
@@ -61,7 +61,7 @@ public partial class HttpResultsHelperTests
 
         if (useJsonContext)
         {
-            serializerOptions.AddContext<TestJsonContext>();
+            serializerOptions.TypeInfoResolver = TestJsonContext.Default;
         }
 
         // Act
@@ -94,7 +94,7 @@ public partial class HttpResultsHelperTests
 
         if (useJsonContext)
         {
-            serializerOptions.AddContext<TestJsonContext>();
+            serializerOptions.TypeInfoResolver = TestJsonContext.Default;
         }
 
         // Act
@@ -128,7 +128,7 @@ public partial class HttpResultsHelperTests
 
         if (useJsonContext)
         {
-            serializerOptions.AddContext<TestJsonContext>();
+            serializerOptions.TypeInfoResolver = TestJsonContext.Default;
         }
 
         // Act
@@ -162,7 +162,7 @@ public partial class HttpResultsHelperTests
 
         if (useJsonContext)
         {
-            serializerOptions.AddContext<TestJsonContext>();
+            serializerOptions.TypeInfoResolver = TestJsonContext.Default;
         }
 
         // Act

--- a/src/Mvc/Mvc.Core/src/JsonOptions.cs
+++ b/src/Mvc/Mvc.Core/src/JsonOptions.cs
@@ -41,8 +41,8 @@ public class JsonOptions
         MaxDepth = MvcOptions.DefaultMaxModelBindingRecursionDepth,
 
         // The JsonSerializerOptions.GetTypeInfo method is called directly and needs a defined resolver
-        // setting the default resolver (reflection-based) but the user can overwrite it directly or calling
-        // .AddContext<TContext>()
+        // setting the default resolver (reflection-based) but the user can overwrite it directly or by modifying
+        // the TypeInfoResolverChain
         TypeInfoResolver = TrimmingAppContextSwitches.EnsureJsonTrimmability ? null : CreateDefaultTypeResolver()
     };
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/Program.Main.cs
@@ -1,7 +1,6 @@
-using System.Text.Json.Serialization;
 #if NativeAot
-using Microsoft.AspNetCore.Http.Json;
-using Microsoft.Extensions.Options;
+using System.Text.Json.Serialization;
+
 #endif
 namespace Company.ApiApplication1;
 
@@ -15,7 +14,7 @@ public class Program
         #if (NativeAot)
         builder.Services.ConfigureHttpJsonOptions(options =>
         {
-            options.SerializerOptions.AddContext<AppJsonSerializerContext>();
+            options.SerializerOptions.TypeInfoResolverChain.Insert(0, AppJsonSerializerContext.Default);
         });
 
         #endif

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/Program.cs
@@ -9,7 +9,7 @@ builder.Logging.AddConsole();
 #if (NativeAot)
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
-    options.SerializerOptions.AddContext<AppJsonSerializerContext>();
+    options.SerializerOptions.TypeInfoResolverChain.Insert(0, AppJsonSerializerContext.Default);
 });
 
 #endif


### PR DESCRIPTION
- Removes all usages of JsonSerializerOptions.AddContext, which will be obsoleted by https://github.com/dotnet/runtime/issues/83280
- Update ProblemDetailsJsonContext to be added in a `Configure<JsonOptions>()` call back and to always be added to the beginning of the resolver chain at that time
    - This gives us the simplest, most understandable pattern for all libraries to follow.
- Small clean up in the API template's usings