### PR TITLE
Bump gson to 2.8.9.

### DIFF
--- a/src/SignalR/clients/java/signalr/core/build.gradle
+++ b/src/SignalR/clients/java/signalr/core/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group 'com.microsoft.signalr'
 
 dependencies {
-    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
     api 'io.reactivex.rxjava3:rxjava:3.0.11'
     implementation 'org.slf4j:slf4j-api:1.7.25'


### PR DESCRIPTION
Related to https://github.com/dotnet/aspnetcore/issues/46926

Whilst looking at the reported `okhttp` issue I noticed that our `gson` package was out of date.