### PR TITLE
Null check nullable Scope before disposing in SignalR HttpConnection.cs

### DIFF
--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -503,7 +503,7 @@ namespace Microsoft.AspNetCore.Certificates.Generation
 
             var removeLocation = storeName == StoreName.My ? RemoveLocations.Local : RemoveLocations.Trusted;
 
-            foreach (var certificate in certificates)
+            foreach (var certificate in certificatesWithName)
             {
                 RemoveCertificate(certificate, removeLocation);
             }

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -274,7 +274,7 @@ namespace Microsoft.AspNetCore.Http.Connections.Client
                 // We want to do these things even if the WaitForWriterToComplete/WaitForReaderToComplete fails
                 if (!_disposed)
                 {
-                    _scopeDisposable.Dispose();
+                    _scopeDisposable?.Dispose();
                     _disposed = true;
                 }
 


### PR DESCRIPTION
# Null check nullable Scope before disposing in SignalR HttpConnection.cs

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)
Null check nullable Scope before disposing in SignalR HttpConnection.cs. Addresses this issue: https://github.com/dotnet/aspnetcore/issues/47470

## Description

We're testing aspnet core 2.1 targeting `Microsoft.Extensions.Logging` 3.1 (instead of 2.2) as we're required to move over to Open Telemetry stack, and OTel .NET packages have a minimum dependency on `Microsoft.Extensions.Logging` 3.1. 

`Microsoft.Extensions.Logging.ILogger.BeginScope()` may return nullable scopes in 3.0+ as [per docs](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.loggerextensions.beginscope?view=dotnet-plat-ext-3.0), but `SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.Dispose()` is disposing it without checking to see if it's null or not. For whatever reason, the scope isn't null in `Microsoft.Extensions.Logging` 2.2 even though the docs say this version [could still return null](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.loggerextensions.beginscope?view=dotnet-plat-ext-2.2#returns). We can see this when running `Microsoft.AspNetCore.SignalR.Client.Tests.HttpConnectionTests+Negotiate.NegotiateReturnedConenctionIdIsSetOnConnection` test - as it's using [LogSinkLogger](https://github.com/dotnet/aspnetcore/blob/release/2.1/src/SignalR/common/testassets/Tests.Utils/ServerFixture.cs#L214), which returns null in its BeginScope<TState>() override. 

Upgrading `Microsoft.Extensions.Logging` references and its dependencies to 3.1 is correctly calling the override and returning null, but that dispose method above throws a null ref exception at runtime. Activity scopes are already null-checked before being disposed in other places - e.g. [aspnetcore/HostingApplicationDiagnostics.cs at release/2.1 · dotnet/aspnetcore · GitHub](https://github.com/dotnet/aspnetcore/blob/release/2.1/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs#L156).

This PR additionally fixes a set of flaky tests in the `Microsoft.AspNetCore.DeveloperCertificates.XPlat.Tests` group caused by existence of multiple test certs in the store, which the cleanup method isn't correctly deleting at startup. That change is in `CertificateManager.cs`.

Fixes (https://github.com/dotnet/aspnetcore/issues/47470)