### PR TITLE
Fix title in `Extensions.ApiDescription.Server` README.md

### DIFF
--- a/src/Tools/Extensions.ApiDescription.Server/README.md
+++ b/src/Tools/Extensions.ApiDescription.Server/README.md
@@ -1,4 +1,4 @@
-# Microsoft.Extensions.ApiDescription.Client
+# Microsoft.Extensions.ApiDescription.Server
 
 MSBuild glue for OpenAPI document generation.
 


### PR DESCRIPTION
It references `Extensions.ApiDescription.Client` instead of `Extensions.ApiDescription.Server`.

# Fix title in Extensions.ApiDescription.Server README.md

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

This is a simple fix for a typo (or copy-paste error) I found while searching for `Extensions.ApiDescription.Server` in the repo.