### PR TITLE
Treat 'Content-Range's with last-byte-pos equal to length as invalid

### DIFF
--- a/src/Http/Headers/src/ContentRangeHeaderValue.cs
+++ b/src/Http/Headers/src/ContentRangeHeaderValue.cs
@@ -35,10 +35,16 @@ public class ContentRangeHeaderValue
         // Scenario: "Content-Range: bytes 12-34/5678"
 
         ArgumentOutOfRangeException.ThrowIfNegative(length);
-        if ((to < 0) || (to > length))
+
+        // "To" is inclusive. Per RFC 7233:
+        // A Content-Range field value is invalid if it contains a byte-range-resp that has a
+        // last-byte-pos value less than its first-byte-pos value, or a complete-length value
+        // less than or equal to its last-byte-pos value.
+        if ((to < 0) || (length <= to))
         {
             throw new ArgumentOutOfRangeException(nameof(to));
         }
+
         if ((from < 0) || (from > to))
         {
             throw new ArgumentOutOfRangeException(nameof(from));

--- a/src/Http/Headers/test/ContentRangeHeaderValueTest.cs
+++ b/src/Http/Headers/test/ContentRangeHeaderValueTest.cs
@@ -166,6 +166,7 @@ public class ContentRangeHeaderValueTest
 
     [Theory]
     [MemberData(nameof(InvalidContentRangeValueStrings))]
+    [InlineData(null)]
     public void Parse_SetOfInvalidValueStrings_Throws(string? input)
     {
         Assert.Throws<FormatException>(() => ContentRangeHeaderValue.Parse(input));
@@ -196,6 +197,7 @@ public class ContentRangeHeaderValueTest
 
     [Theory]
     [MemberData(nameof(InvalidContentRangeValueStrings))]
+    [InlineData(null)]
     public void TryParse_SetOfInvalidValueStrings_ReturnsFalse(string? input)
     {
         Assert.False(ContentRangeHeaderValue.TryParse(input, out var result));
@@ -220,7 +222,6 @@ public class ContentRangeHeaderValueTest
             {"bytes 1-2/3,"}, // no character after 'length' allowed
             {"x bytes 1-2/3"},
             {"bytes 1-2/3.4"},
-            {null},
             {""},
             {"bytes 3-2/5"},
             {"bytes 6-6/5"},

--- a/src/Http/Headers/test/ContentRangeHeaderValueTest.cs
+++ b/src/Http/Headers/test/ContentRangeHeaderValueTest.cs
@@ -53,6 +53,7 @@ public class ContentRangeHeaderValueTest
         Assert.Throws<ArgumentOutOfRangeException>(() => new ContentRangeHeaderValue(0, 1, -1));
         Assert.Throws<ArgumentOutOfRangeException>(() => new ContentRangeHeaderValue(2, 1, 3));
         Assert.Throws<ArgumentOutOfRangeException>(() => new ContentRangeHeaderValue(1, 2, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ContentRangeHeaderValue(1, 2, 2));
     }
 
     [Fact]
@@ -164,32 +165,7 @@ public class ContentRangeHeaderValueTest
     }
 
     [Theory]
-    [InlineData("bytes 1-2/3,")] // no character after 'length' allowed
-    [InlineData("x bytes 1-2/3")]
-    [InlineData("bytes 1-2/3.4")]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("bytes 3-2/5")]
-    [InlineData("bytes 6-6/5")]
-    [InlineData("bytes 1-6/5")]
-    [InlineData("bytes 1-2/")]
-    [InlineData("bytes 1-2")]
-    [InlineData("bytes 1-/")]
-    [InlineData("bytes 1-")]
-    [InlineData("bytes 1")]
-    [InlineData("bytes ")]
-    [InlineData("bytes a-2/3")]
-    [InlineData("bytes 1-b/3")]
-    [InlineData("bytes 1-2/c")]
-    [InlineData("bytes1-2/3")]
-    // More than 19 digits >>Int64.MaxValue
-    [InlineData("bytes 1-12345678901234567890/3")]
-    [InlineData("bytes 12345678901234567890-3/3")]
-    [InlineData("bytes 1-2/12345678901234567890")]
-    // Exceed Int64.MaxValue, but use 19 digits
-    [InlineData("bytes 1-9999999999999999999/3")]
-    [InlineData("bytes 9999999999999999999-3/3")]
-    [InlineData("bytes 1-2/9999999999999999999")]
+    [MemberData(nameof(InvalidContentRangeValueStrings))]
     public void Parse_SetOfInvalidValueStrings_Throws(string? input)
     {
         Assert.Throws<FormatException>(() => ContentRangeHeaderValue.Parse(input));
@@ -219,47 +195,54 @@ public class ContentRangeHeaderValueTest
     }
 
     [Theory]
-    [InlineData("bytes 1-2/3,")] // no character after 'length' allowed
-    [InlineData("x bytes 1-2/3")]
-    [InlineData("bytes 1-2/3.4")]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("bytes 3-2/5")]
-    [InlineData("bytes 6-6/5")]
-    [InlineData("bytes 1-6/5")]
-    [InlineData("bytes 1-2/")]
-    [InlineData("bytes 1-2")]
-    [InlineData("bytes 1-/")]
-    [InlineData("bytes 1-")]
-    [InlineData("bytes 1")]
-    [InlineData("bytes ")]
-    [InlineData("bytes a-2/3")]
-    [InlineData("bytes 1-b/3")]
-    [InlineData("bytes 1-2/c")]
-    [InlineData("bytes1-2/3")]
-    // More than 19 digits >>Int64.MaxValue
-    [InlineData("bytes 1-12345678901234567890/3")]
-    [InlineData("bytes 12345678901234567890-3/3")]
-    [InlineData("bytes 1-2/12345678901234567890")]
-    // Exceed Int64.MaxValue, but use 19 digits
-    [InlineData("bytes 1-9999999999999999999/3")]
-    [InlineData("bytes 9999999999999999999-3/3")]
-    [InlineData("bytes 1-2/9999999999999999999")]
+    [MemberData(nameof(InvalidContentRangeValueStrings))]
     public void TryParse_SetOfInvalidValueStrings_ReturnsFalse(string? input)
     {
         Assert.False(ContentRangeHeaderValue.TryParse(input, out var result));
         Assert.Null(result);
     }
 
-    private void CheckValidParse(string? input, ContentRangeHeaderValue expectedResult)
+    private static void CheckValidParse(string? input, ContentRangeHeaderValue expectedResult)
     {
         var result = ContentRangeHeaderValue.Parse(input);
         Assert.Equal(expectedResult, result);
     }
 
-    private void CheckValidTryParse(string? input, ContentRangeHeaderValue expectedResult)
+    private static void CheckValidTryParse(string? input, ContentRangeHeaderValue expectedResult)
     {
         Assert.True(ContentRangeHeaderValue.TryParse(input, out var result));
         Assert.Equal(expectedResult, result);
     }
+
+    public static TheoryData<string> InvalidContentRangeValueStrings =>
+        new TheoryData<string>
+        {
+            {"bytes 1-2/3,"}, // no character after 'length' allowed
+            {"x bytes 1-2/3"},
+            {"bytes 1-2/3.4"},
+            {null},
+            {""},
+            {"bytes 3-2/5"},
+            {"bytes 6-6/5"},
+            {"bytes 1-6/5"},
+            {"bytes 1-2/"},
+            {"bytes 1-2"},
+            {"bytes 1-/"},
+            {"bytes 1-"},
+            {"bytes 1"},
+            {"bytes "},
+            {"bytes a-2/3"},
+            {"bytes 1-b/3"},
+            {"bytes 1-2/c"},
+            {"bytes1-2/3"},
+            {"bytes 0-0/0"},
+            // More than 19 digits >>Int64.MaxValue
+            {"bytes 1-12345678901234567890/3"},
+            {"bytes 12345678901234567890-3/3"},
+            {"bytes 1-2/12345678901234567890"},
+            // Exceed Int64.MaxValue, but use 19 digits
+            {"bytes 1-9999999999999999999/3"},
+            {"bytes 9999999999999999999-3/3"},
+            {"bytes 1-2/9999999999999999999"}
+        };
 }


### PR DESCRIPTION
Fix https://github.com/dotnet/aspnetcore/issues/44166

Per [RFC 7233](https://httpwg.org/specs/rfc7233.html#header.content-range):

> A Content-Range field value is invalid if it contains a [byte-range-resp](https://httpwg.org/specs/rfc7233.html#header.content-range) that has a [last-byte-pos](https://httpwg.org/specs/rfc7233.html#rule.ranges-specifier) value less than its [first-byte-pos](https://httpwg.org/specs/rfc7233.html#rule.ranges-specifier) value, or a [complete-length](https://httpwg.org/specs/rfc7233.html#header.content-range) value less than or equal to its [last-byte-pos](https://httpwg.org/specs/rfc7233.html#rule.ranges-specifier) value.

Also removed duplication of the invalid string data while I was touching the tests.