### PR TITLE
[cache] fix #38796 - fix inconsistent handling of empty byte[]

### DIFF
--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -400,7 +400,7 @@ public partial class RedisCache : IDistributedCache, IDisposable
             Refresh(cache, key, absExpr, sldExpr);
         }
 
-        if (results.Length >= 3 && results[2].HasValue)
+        if (results.Length >= 3 && !results[2].IsNull)
         {
             return results[2];
         }
@@ -436,7 +436,7 @@ public partial class RedisCache : IDistributedCache, IDisposable
             await RefreshAsync(cache, key, absExpr, sldExpr, token).ConfigureAwait(false);
         }
 
-        if (results.Length >= 3 && results[2].HasValue)
+        if (results.Length >= 3 && !results[2].IsNull)
         {
             return results[2];
         }

--- a/src/Caching/StackExchangeRedis/test/RedisCacheSetAndRemoveTests.cs
+++ b/src/Caching/StackExchangeRedis/test/RedisCacheSetAndRemoveTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
 using Xunit;
 
@@ -95,4 +97,34 @@ public class RedisCacheSetAndRemoveTests
 
         Assert.Throws<ArgumentNullException>(() => cache.Set(key, value));
     }
+
+    [Fact(Skip = SkipReason)]
+    public void GetSetEmptyNonNullBuffer()
+    {
+        var cache = RedisTestConfig.CreateCacheInstance(GetType().Name);
+        var key = Me();
+        cache.Remove(key); // known state
+        Assert.Null(cache.Get(key)); // expect null
+
+        cache.Set(key, Array.Empty<byte>());
+        var arr = cache.Get(key);
+        Assert.NotNull(arr);
+        Assert.Empty(arr);
+    }
+
+    [Fact(Skip = SkipReason)]
+    public async Task GetSetEmptyNonNullBufferAsync()
+    {
+        var cache = RedisTestConfig.CreateCacheInstance(GetType().Name);
+        var key = Me();
+        await cache.RemoveAsync(key); // known state
+        Assert.Null(await cache.GetAsync(key)); // expect null
+
+        cache.Set(key, Array.Empty<byte>());
+        var arr = await cache.GetAsync(key);
+        Assert.NotNull(arr);
+        Assert.Empty(arr);
+    }
+
+    private static string Me([CallerMemberName] string caller = "") => caller;
 }


### PR DESCRIPTION
# fix inconsistent handling of empty byte[]

As per #38796, handling of empty byte[] is inconsistent in redis cache, with `Get` returning `null`; this PR fixes this

## Description

`RedisValue.HasValue` is effectively "not null or empty"; we just want to test "not null"; so: use that

Fixes #38796

(tests executed successfully locally)