### PR TITLE
gRPC JSON transcoding: Fix body binding to repeated message or map

### DIFF
--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonRequestHelpers.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonRequestHelpers.cs
@@ -197,14 +197,15 @@ internal static class JsonRequestHelpers
                             // TODO: JsonSerializer currently doesn't support deserializing values onto an existing object or collection.
                             // Either update this to use new functionality in JsonSerializer or improve work-around perf.
                             type = JsonConverterHelper.GetFieldType(serverCallContext.DescriptorInfo.BodyFieldDescriptor);
+
+                            var args = type.GetGenericArguments();
                             if (serverCallContext.DescriptorInfo.BodyFieldDescriptor.IsMap)
                             {
-                                var args = type.GetGenericArguments();
                                 type = typeof(Dictionary<,>).MakeGenericType(args[0], args[1]);
                             }
                             else
                             {
-                                type = typeof(List<>).MakeGenericType(type.GetGenericArguments()[0]);
+                                type = typeof(List<>).MakeGenericType(args[0]);
                             }
 
                             GrpcServerLog.DeserializingMessage(serverCallContext.Logger, type);

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonRequestHelpers.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonRequestHelpers.cs
@@ -197,8 +197,15 @@ internal static class JsonRequestHelpers
                             // TODO: JsonSerializer currently doesn't support deserializing values onto an existing object or collection.
                             // Either update this to use new functionality in JsonSerializer or improve work-around perf.
                             type = JsonConverterHelper.GetFieldType(serverCallContext.DescriptorInfo.BodyFieldDescriptor);
-                            type = type.GetGenericArguments()[0];
-                            type = typeof(List<>).MakeGenericType(type);
+                            if (serverCallContext.DescriptorInfo.BodyFieldDescriptor.IsMap)
+                            {
+                                var args = type.GetGenericArguments();
+                                type = typeof(Dictionary<,>).MakeGenericType(args[0], args[1]);
+                            }
+                            else
+                            {
+                                type = typeof(List<>).MakeGenericType(type.GetGenericArguments()[0]);
+                            }
 
                             GrpcServerLog.DeserializingMessage(serverCallContext.Logger, type);
 

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Infrastructure/RepeatedFieldBinderService.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Infrastructure/RepeatedFieldBinderService.cs
@@ -1,0 +1,8 @@
+//// Licensed to the .NET Foundation under one or more agreements.
+//// The .NET Foundation licenses this file to you under the MIT license.
+
+//namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.Infrastructure;
+
+//public class RepeatedFieldBinderService : Example.Repeated.BindRepeatedFieldService.BindRepeatedFieldServiceBase
+//{
+//}

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Infrastructure/RepeatedFieldBinderService.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Infrastructure/RepeatedFieldBinderService.cs
@@ -1,8 +1,0 @@
-//// Licensed to the .NET Foundation under one or more agreements.
-//// The .NET Foundation licenses this file to you under the MIT license.
-
-//namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.Infrastructure;
-
-//public class RepeatedFieldBinderService : Example.Repeated.BindRepeatedFieldService.BindRepeatedFieldServiceBase
-//{
-//}

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.csproj
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/transcoding.proto
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/transcoding.proto
@@ -216,6 +216,8 @@ message HelloRequest {
   string field_name = 22 [json_name="json_customized_name"];
   google.protobuf.FloatValue float_value = 23;
   string hiding_field_name = 24 [json_name="field_name"];
+  repeated SubMessage repeated_messages = 25;
+  map<int32, int32> map_keyint_valueint = 26;
 }
 
 message HelloReply {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/47510

Repeated body binding worked with primitive fields but not messages. Also, it didn't work with maps. Fixed together.