### PR TITLE
Extend ControllerBase.Problem that can add extensions to ProblemDetails

### DIFF
--- a/src/Mvc/Mvc.Core/src/ControllerBase.cs
+++ b/src/Mvc/Mvc.Core/src/ControllerBase.cs
@@ -1852,6 +1852,7 @@ public abstract class ControllerBase
     /// <param name="instance">The value for <see cref="ProblemDetails.Instance" />.</param>
     /// <param name="title">The value for <see cref="ProblemDetails.Title" />.</param>
     /// <param name="type">The value for <see cref="ProblemDetails.Type" />.</param>
+    /// <param name="extensions">The value for <see cref="ProblemDetails.Extensions" />.</param>
     /// <returns>The created <see cref="ObjectResult"/> for the response.</returns>
     [NonAction]
     public virtual ObjectResult Problem(

--- a/src/Mvc/Mvc.Core/src/ControllerBase.cs
+++ b/src/Mvc/Mvc.Core/src/ControllerBase.cs
@@ -1859,7 +1859,8 @@ public abstract class ControllerBase
         string? instance = null,
         int? statusCode = null,
         string? title = null,
-        string? type = null)
+        string? type = null,
+        IDictionary<string, object?>? extensions = null)
     {
         ProblemDetails problemDetails;
         if (ProblemDetailsFactory == null)
@@ -1883,6 +1884,15 @@ public abstract class ControllerBase
                 type: type,
                 detail: detail,
                 instance: instance);
+        }
+
+        // add to extensions if extensions is not null
+        if (extensions != null)
+        {
+            foreach (var (key, value) in extensions)
+            {
+                problemDetails.Extensions.Add(key, value);
+            }
         }
 
         return new ObjectResult(problemDetails)

--- a/src/Mvc/Mvc.Core/src/PublicAPI.Shipped.txt
+++ b/src/Mvc/Mvc.Core/src/PublicAPI.Shipped.txt
@@ -2338,7 +2338,7 @@ virtual Microsoft.AspNetCore.Mvc.ControllerBase.PhysicalFile(string! physicalPat
 virtual Microsoft.AspNetCore.Mvc.ControllerBase.PhysicalFile(string! physicalPath, string! contentType, string? fileDownloadName, System.DateTimeOffset? lastModified, Microsoft.Net.Http.Headers.EntityTagHeaderValue! entityTag, bool enableRangeProcessing) -> Microsoft.AspNetCore.Mvc.PhysicalFileResult!
 virtual Microsoft.AspNetCore.Mvc.ControllerBase.PhysicalFile(string! physicalPath, string! contentType, System.DateTimeOffset? lastModified, Microsoft.Net.Http.Headers.EntityTagHeaderValue! entityTag) -> Microsoft.AspNetCore.Mvc.PhysicalFileResult!
 virtual Microsoft.AspNetCore.Mvc.ControllerBase.PhysicalFile(string! physicalPath, string! contentType, System.DateTimeOffset? lastModified, Microsoft.Net.Http.Headers.EntityTagHeaderValue! entityTag, bool enableRangeProcessing) -> Microsoft.AspNetCore.Mvc.PhysicalFileResult!
-virtual Microsoft.AspNetCore.Mvc.ControllerBase.Problem(string? detail = null, string? instance = null, int? statusCode = null, string? title = null, string? type = null) -> Microsoft.AspNetCore.Mvc.ObjectResult!
+virtual Microsoft.AspNetCore.Mvc.ControllerBase.Problem(string? detail = null, string? instance = null, int? statusCode = null, string? title = null, string? type = null, IDictionary<string, object?>? extensions = null) -> Microsoft.AspNetCore.Mvc.ObjectResult!
 virtual Microsoft.AspNetCore.Mvc.ControllerBase.Redirect(string! url) -> Microsoft.AspNetCore.Mvc.RedirectResult!
 virtual Microsoft.AspNetCore.Mvc.ControllerBase.RedirectPermanent(string! url) -> Microsoft.AspNetCore.Mvc.RedirectResult!
 virtual Microsoft.AspNetCore.Mvc.ControllerBase.RedirectPermanentPreserveMethod(string! url) -> Microsoft.AspNetCore.Mvc.RedirectResult!

--- a/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
+++ b/src/Mvc/Mvc.Core/test/ControllerBaseTest.cs
@@ -2494,6 +2494,31 @@ public class ControllerBaseTest
         Assert.Equal("https://tools.ietf.org/html/rfc4918#section-11.2", problemDetails.Type);
     }
 
+    [Fact]
+    public void ProblemDetails_UsesPassedInExtensions()
+    {
+        // Arrange
+        var options = GetApiBehaviorOptions();
+        var balance = 30;
+
+        var controller = new TestableController
+        {
+            ProblemDetailsFactory = new DefaultProblemDetailsFactory(Options.Create(options)),
+        };
+
+        // Act
+        var actionResult = controller.Problem(extensions: new Dictionary<string, object?>() { { "balance", 30 } });
+
+        // Assert
+        var badRequestResult = Assert.IsType<ObjectResult>(actionResult);
+        var problemDetails = Assert.IsType<ProblemDetails>(badRequestResult.Value);
+        Assert.Equal(422, actionResult.StatusCode);
+        Assert.Equal(422, problemDetails.Status);
+        Assert.Equal("Unprocessable entity.", problemDetails.Title);
+        Assert.Equal("https://tools.ietf.org/html/rfc4918#section-11.2", problemDetails.Type);
+        Assert.Equal(balance, problemDetails.Extensions["balance"]);
+    }
+
     private static ApiBehaviorOptions GetApiBehaviorOptions()
     {
         return new ApiBehaviorOptions


### PR DESCRIPTION
# Extend ControllerBase.Problem that can add extensions to ProblemDetails

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Add additional `extensions` parameter to the `ControllerBase.Problem` method to include add extensions into `ProblemDetails`.

## Description

With this PR, developers can add extension fields to ProblemDetails to provide more information to consumers directly.

``` csharp
public async Task<IActionResult> CheckBalance(decimal amount)
{
    var balance = // get balance from database asynchronously
    if (balance < amount)
    {
        return this.Problem(statusCode: StatusCodes.Status400BadRequest, detail: "Insufficient balance.", extensions: new Dictionary<string, object?>() { { "balance", balance } });
    }
    // balance is enough, do something else
}
```
