### PR TITLE
Pass /norestart to Hosting Bundle nested bundles

### DIFF
--- a/src/Installers/Windows/WindowsHostingBundle/DotNetCore.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/DotNetCore.wxs
@@ -30,7 +30,7 @@
                         Vital="yes"
                         InstallCondition="(NativeMachine=&quot;$(var.NativeMachine_arm64)&quot;) AND (NOT OPT_NO_RUNTIME OR OPT_NO_RUNTIME=&quot;0&quot;)"
                         InstallCommand="/quiet /norestart"
-                        RepairCommand="/quiet /repair"
+                        RepairCommand="/quiet /norestart /repair"
                         Permanent="yes"
                         DetectCondition="DotNetRedistLtsProductVersion_arm64 = v$(var.DotNetRedistLtsInstallerProductVersionarm64)">
             </ExePackage>            
@@ -42,8 +42,8 @@
                         Vital="yes"
                         InstallCondition="VersionNT64 AND NOT (NativeMachine=&quot;$(var.NativeMachine_arm64)&quot;) AND (NOT OPT_NO_RUNTIME OR OPT_NO_RUNTIME=&quot;0&quot;)"
                         InstallCommand="/quiet /norestart"
-                        RepairCommand="/quiet /repair"
-                        UninstallCommand="/quiet /uninstall"
+                        RepairCommand="/quiet /norestart /repair"
+                        UninstallCommand="/quiet /norestart /uninstall"
                         DetectCondition="DotNetRedistLtsProductVersion_x64 = v$(var.DotNetRedistLtsInstallerProductVersionx64)">
             </ExePackage>
 
@@ -54,8 +54,8 @@
                         Vital="yes"
                         InstallCondition="(NOT OPT_NO_RUNTIME OR OPT_NO_RUNTIME=&quot;0&quot;) AND (NOT OPT_NO_X86 OR OPT_NO_X86=&quot;0&quot;)"
                         InstallCommand="/quiet /norestart"
-                        RepairCommand="/quiet /repair"
-                        UninstallCommand="/quiet /uninstall"
+                        RepairCommand="/quiet /norestart /repair"
+                        UninstallCommand="/quiet /norestart /uninstall"
                         DetectCondition="DotNetRedistLtsProductVersion_x86 = v$(var.DotNetRedistLtsInstallerProductVersionx86)">
             </ExePackage>
         </PackageGroup>

--- a/src/Installers/Windows/WindowsHostingBundle/SharedFramework.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/SharedFramework.wxs
@@ -30,7 +30,7 @@
                         Vital="yes"
                         InstallCondition="(NativeMachine=&quot;$(var.NativeMachine_arm64)&quot;) AND (NOT OPT_NO_SHAREDFX OR OPT_NO_SHAREDFX=&quot;0&quot;)"
                         InstallCommand="/quiet /norestart"
-                        RepairCommand="/quiet /repair"
+                        RepairCommand="/quiet /norestart /repair"
                         Permanent="yes"
                         DetectCondition="SharedFxRedistProductVersion_arm64 = v$(var.SharedFxInstallerProductVersionarm64)">
             </ExePackage>
@@ -42,8 +42,8 @@
                         Vital="yes"
                         InstallCondition="VersionNT64 AND NOT (NativeMachine=&quot;$(var.NativeMachine_arm64)&quot;) AND (NOT OPT_NO_SHAREDFX OR OPT_NO_SHAREDFX=&quot;0&quot;)"
                         InstallCommand="/quiet /norestart"
-                        RepairCommand="/quiet /repair"
-                        UninstallCommand="/quiet /uninstall"
+                        RepairCommand="/quiet /norestart /repair"
+                        UninstallCommand="/quiet /norestart /uninstall"
                         DetectCondition="SharedFxRedistProductVersion_x64 = v$(var.SharedFxInstallerProductVersionx64)">
             </ExePackage>
 
@@ -54,8 +54,8 @@
                         Vital="yes"
                         InstallCondition="(NOT OPT_NO_SHAREDFX OR OPT_NO_SHAREDFX=&quot;0&quot;) AND (NOT OPT_NO_X86 OR OPT_NO_X86=&quot;0&quot;)"
                         InstallCommand="/quiet /norestart"
-                        RepairCommand="/quiet /repair"
-                        UninstallCommand="/quiet /uninstall"
+                        RepairCommand="/quiet /norestart /repair"
+                        UninstallCommand="/quiet /norestart /uninstall"
                         DetectCondition="SharedFxRedistProductVersion_x86 = v$(var.SharedFxInstallerProductVersionx86)">
             </ExePackage>
             


### PR DESCRIPTION
Based on a request from the Office team - they pass `/norestart` to the repair command of the hosting bundle, but still have to restart because args don't get passed through to inner bundles. We don't want to blindly pass through args, but I think it's reasonable to always pass `/norestart` to the inner bundles (If the user doesn't pass `/norestart` to the hosting bundle, we'll restart, and if they do pass it, we won't).

To be backported to 6 & 7

Part of https://github.com/dotnet/aspnetcore/issues/47544