### PR TITLE
[release/6.0] Pass /norestart to Hosting Bundle nested bundles

### DIFF
--- a/src/Installers/Windows/WindowsHostingBundle/DotNetCore.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/DotNetCore.wxs
@@ -23,8 +23,8 @@
                         Vital="yes"
                         InstallCondition="VersionNT64 AND (NOT OPT_NO_RUNTIME OR OPT_NO_RUNTIME=&quot;0&quot;)"
                         InstallCommand="/quiet /norestart"
-                        RepairCommand="/quiet /repair"
-                        UninstallCommand="/quiet /uninstall"
+                        RepairCommand="/quiet /norestart /repair"
+                        UninstallCommand="/quiet /norestart /uninstall"
                         DetectCondition="DotNetRedistLtsProductVersion_x64 = v$(var.DotNetRedistLtsInstallerProductVersionx64)">
             </ExePackage>
 
@@ -35,8 +35,8 @@
                         Vital="yes"
                         InstallCondition="(NOT OPT_NO_RUNTIME OR OPT_NO_RUNTIME=&quot;0&quot;) AND (NOT OPT_NO_X86 OR OPT_NO_X86=&quot;0&quot;)"
                         InstallCommand="/quiet /norestart"
-                        RepairCommand="/quiet /repair"
-                        UninstallCommand="/quiet /uninstall"
+                        RepairCommand="/quiet /norestart /repair"
+                        UninstallCommand="/quiet /norestart /uninstall"
                         DetectCondition="DotNetRedistLtsProductVersion_x86 = v$(var.DotNetRedistLtsInstallerProductVersionx86)">
             </ExePackage>
         </PackageGroup>

--- a/src/Installers/Windows/WindowsHostingBundle/SharedFramework.wxs
+++ b/src/Installers/Windows/WindowsHostingBundle/SharedFramework.wxs
@@ -23,8 +23,8 @@
                         Vital="yes"
                         InstallCondition="VersionNT64 AND (NOT OPT_NO_SHAREDFX OR OPT_NO_SHAREDFX=&quot;0&quot;)"
                         InstallCommand="/quiet /norestart"
-                        RepairCommand="/quiet /repair"
-                        UninstallCommand="/quiet /uninstall"
+                        RepairCommand="/quiet /norestart /repair"
+                        UninstallCommand="/quiet /norestart /uninstall"
                         DetectCondition="SharedFxRedistProductVersion_x64 = v$(var.SharedFxInstallerProductVersionx64)">
             </ExePackage>
 
@@ -35,8 +35,8 @@
                         Vital="yes"
                         InstallCondition="(NOT OPT_NO_SHAREDFX OR OPT_NO_SHAREDFX=&quot;0&quot;) AND (NOT OPT_NO_X86 OR OPT_NO_X86=&quot;0&quot;)"
                         InstallCommand="/quiet /norestart"
-                        RepairCommand="/quiet /repair"
-                        UninstallCommand="/quiet /uninstall"
+                        RepairCommand="/quiet /norestart /repair"
+                        UninstallCommand="/quiet /norestart /uninstall"
                         DetectCondition="SharedFxRedistProductVersion_x86 = v$(var.SharedFxInstallerProductVersionx86)">
             </ExePackage>
         </PackageGroup>


### PR DESCRIPTION
Backport of #47542 to release/6.0

/cc @wtgodbe

# Pass /norestart to Hosting Bundle nested bundles

Ensure that when `/norestart` is passed on the command line to the hosting bundle, the user sees the expected behavior (no restart)

## Description

WiX doesn't pass command line args to nested bundles/packages, since the nested package could be any arbitrary .exe. This means when that today, when the user passes /norestart to the hosting bundle in a `repair` or `uninstall` command, they'll still be prompted to restart. Always passing `/norestart` to these commands will give us the behavior that users would expect (`/norestart` = no restart, no `/norestart` = restart, prompted from the hosting bundle itself).

Fixes #47544

## Customer Impact

Fulfills request from the Office team

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

These `/norestart` args will only have any effect when the user passes `/norestart` to the hosting bundle. The risk is if there's a scenario I haven't thought of.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props
