### PR TITLE
Sanitize 0x7F in Content-Disposition filename

### DIFF
--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -509,7 +509,7 @@ public class ContentDispositionHeaderValue
             for (int i = 0; i < result.Length; i++)
             {
                 var c = result[i];
-                if ((int)c > 0x7f || (int)c < 0x20)
+                if ((int)c >= 0x7f || (int)c < 0x20)
                 {
                     c = '_'; // Replace out-of-range characters
                 }
@@ -530,12 +530,12 @@ public class ContentDispositionHeaderValue
             && value.EndsWith("\"", StringComparison.Ordinal);
     }
 
-    // tspecials are required to be in a quoted string.  Only non-ascii needs to be encoded.
+    // tspecials are required to be in a quoted string.  Only non-ascii and control characters need to be encoded.
     private static bool RequiresEncoding(StringSegment input)
     {
         Contract.Assert(input != null);
 
-        return input.AsSpan().IndexOfAnyExceptInRange((char)0x20, (char)0x7f) >= 0;
+        return input.AsSpan().IndexOfAnyExceptInRange((char)0x20, (char)0x7e) >= 0;
     }
 
     // Encode using MIME encoding

--- a/src/Http/Headers/test/ContentDispositionHeaderValueTest.cs
+++ b/src/Http/Headers/test/ContentDispositionHeaderValueTest.cs
@@ -238,11 +238,16 @@ public class ContentDispositionHeaderValueTest
     [InlineData("FileName.bat", "FileName.bat")]
     [InlineData("FileÃName.bat", "File_Name.bat")]
     [InlineData("File\nName.bat", "File_Name.bat")]
+    [InlineData("File\x19Name.bat", "File_Name.bat")]
+    [InlineData("File\x20Name.bat", "File\x20Name.bat")] // First unsanitized
+    [InlineData("File\x7eName.bat", "File\x7eName.bat")] // Last unsanitized
+    [InlineData("File\x7fName.bat", "File_Name.bat")]
     public void SetHttpFileName_ShouldSanitizeFileNameWhereNeeded(string httpFileName, string expectedFileName)
     {
         var contentDisposition = new ContentDispositionHeaderValue("inline");
         contentDisposition.SetHttpFileName(httpFileName);
         Assert.Equal(expectedFileName, contentDisposition.FileName);
+        Assert.Equal(httpFileName, contentDisposition.FileNameStar); // Should roundtrip through FileNameStar encoding
     }
 
     [Fact]

--- a/src/Mvc/Mvc.Core/test/FileResultHelperTest.cs
+++ b/src/Mvc/Mvc.Core/test/FileResultHelperTest.cs
@@ -198,7 +198,7 @@ public class FileResultTest
                 data.Add(char.ConvertFromUtf32(i), $"attachment; filename=_; filename*=UTF-8''%{i:X2}");
             }
 
-            data.Add(char.ConvertFromUtf32(127), $"attachment; filename=\"{char.ConvertFromUtf32(127)}\"; filename*=UTF-8''%7F");
+            data.Add(char.ConvertFromUtf32(127), $"attachment; filename=_; filename*=UTF-8''%7F");
 
             return data;
         }


### PR DESCRIPTION
We were using the ASCII boundaries, but it looks like we should have been using the ISO-8859 boundaries.

Fixes #47027