### PR TITLE
Signify bodylessness for HTTP/2 extended CONNECTs

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/BodyControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/BodyControl.cs
@@ -73,7 +73,8 @@ internal sealed class BodyControl
         else if (body.ExtendedConnect)
         {
             // CONNECT requests do not have a request or response body until after accepted,
-            // unless it's a 300+ response.
+            // unless it's a 300+ response. We set CanHaveBody to false here since it's only
+            // for requests (see IHttpRequestBodyDetectionFeature).
             CanHaveBody = false;
             _connectResponse.SetRequest(body.Context);
             _connectPipeWriter.SetRequest(body.Context);

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/BodyControl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/BodyControl.cs
@@ -9,8 +9,7 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 
 internal sealed class BodyControl
 {
-    private static readonly ThrowingWasUpgradedWriteOnlyStream _throwingResponseStream
-        = new ThrowingWasUpgradedWriteOnlyStream();
+    private static readonly ThrowingWasUpgradedWriteOnlyStream _throwingResponseStream = new();
     private static readonly ThrowingPipeWriter _throwingUpgradedPipeWriter = new(CoreStrings.ResponseStreamWasUpgraded);
     private readonly HttpResponseStream _response;
     private readonly HttpResponsePipeWriter _responseWriter;
@@ -75,6 +74,7 @@ internal sealed class BodyControl
         {
             // CONNECT requests do not have a request or response body until after accepted,
             // unless it's a 300+ response.
+            CanHaveBody = false;
             _connectResponse.SetRequest(body.Context);
             _connectPipeWriter.SetRequest(body.Context);
             return (_emptyRequest, _connectResponse, _emptyRequestReader, _connectPipeWriter);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2WebSocketTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2WebSocketTests.cs
@@ -78,6 +78,9 @@ public class Http2WebSocketTests : Http2TestBase
     {
         await InitializeConnectionAsync(async context =>
         {
+            var requestBodyDetectionFeature = context.Features.Get<IHttpRequestBodyDetectionFeature>();
+            Assert.False(requestBodyDetectionFeature.CanHaveBody);
+
             var connectFeature = context.Features.Get<IHttpExtendedConnectFeature>();
             Assert.True(connectFeature.IsExtendedConnect);
             Assert.Equal(HttpMethods.Connect, context.Request.Method);


### PR DESCRIPTION
Fix https://github.com/dotnet/aspnetcore/issues/46002

This change makes it so that for HTTP/2 extended CONNECTs (used in HTTP/2 WebSocket scenarios, see [RFC 8441](https://www.rfc-editor.org/rfc/rfc8441#page-4)), `CanHaveBody` is false.

There's more info in the linked issue.

@MihaZupan @Tratcher PTAL