### PR TITLE
Set exception handler feature in developer exception page

### DIFF
--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddlewareImpl.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddlewareImpl.cs
@@ -92,7 +92,7 @@ internal class DeveloperExceptionPageMiddlewareImpl
     {
         var httpContext = errorContext.HttpContext;
 
-        ExceptionHandlerFeature exceptionHandlerFeature = new()
+        var exceptionHandlerFeature = new ExceptionHandlerFeature()
         {
             Error = errorContext.Exception,
             Path = httpContext.Request.Path.ToString(),

--- a/src/Middleware/Diagnostics/test/UnitTests/DeveloperExceptionPageMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/DeveloperExceptionPageMiddlewareTest.cs
@@ -25,12 +25,16 @@ public class DeveloperExceptionPageMiddlewareTest
         using var host = new HostBuilder()
             .ConfigureServices(services =>
             {
+                services.AddRouting();
                 services.AddProblemDetails(configure =>
                 {
                     configure.CustomizeProblemDetails = (context) =>
                     {
                         var feature = context.HttpContext.Features.Get<IExceptionHandlerFeature>();
-                        context.ProblemDetails.Extensions.Add("originalExceptionMessage", feature?.Error.Message);
+                        context.ProblemDetails.Extensions.Add("OriginalExceptionMessage", feature?.Error.Message);
+                        context.ProblemDetails.Extensions.Add("EndpointDisplayName", feature?.Endpoint?.DisplayName);
+                        context.ProblemDetails.Extensions.Add("RouteValue", feature?.RouteValues?["id"]);
+                        context.ProblemDetails.Extensions.Add("Path", feature?.Path);
                     };
 
                 });
@@ -42,9 +46,13 @@ public class DeveloperExceptionPageMiddlewareTest
                 .Configure(app =>
                 {
                     app.UseDeveloperExceptionPage();
-                    app.Run(context =>
+                    app.UseRouting();
+                    app.UseEndpoints(endpoint =>
                     {
-                        throw new Exception("Test exception");
+                        endpoint.MapGet("/test/{id}", (int id) =>
+                        {
+                            throw new Exception("Test exception");
+                        });
                     });
                 });
             }).Build();
@@ -52,17 +60,22 @@ public class DeveloperExceptionPageMiddlewareTest
         await host.StartAsync();
 
         var server = host.GetTestServer();
-        var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/");
+        var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/test/1");
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
         // Act
-        await server.CreateClient().GetAsync("/path");
         var response = await server.CreateClient().SendAsync(request);
 
         // Assert
         var body = await response.Content.ReadFromJsonAsync<ProblemDetails>();
-        var originalExceptionMessage = ((JsonElement)body.Extensions["originalExceptionMessage"]).GetString();
+        var originalExceptionMessage = ((JsonElement)body.Extensions["OriginalExceptionMessage"]).GetString();
+        var endpointDisplayName = ((JsonElement)body.Extensions["EndpointDisplayName"]).GetString();
+        var routeValue = ((JsonElement)body.Extensions["RouteValue"]).GetString();
+        var path = ((JsonElement)body.Extensions["Path"]).GetString();
         Assert.Equal("Test exception", originalExceptionMessage);
+        Assert.Contains("/test/{id}", endpointDisplayName);
+        Assert.Equal("1", routeValue);
+        Assert.Equal("/test/1", path);
     }
 
     [Fact]

--- a/src/Middleware/Diagnostics/test/UnitTests/DeveloperExceptionPageMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/DeveloperExceptionPageMiddlewareTest.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -58,10 +59,9 @@ public class DeveloperExceptionPageMiddlewareTest
         await server.CreateClient().GetAsync("/path");
         var response = await server.CreateClient().SendAsync(request);
 
-
         // Assert
         var body = await response.Content.ReadFromJsonAsync<ProblemDetails>();
-        var originalExceptionMessage = (string)body.Extensions["originalExceptionMessage"];
+        var originalExceptionMessage = ((JsonElement)body.Extensions["originalExceptionMessage"]).GetString();
         Assert.Equal("Test exception", originalExceptionMessage);
     }
 

--- a/src/Middleware/Diagnostics/test/UnitTests/DeveloperExceptionPageMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/DeveloperExceptionPageMiddlewareTest.cs
@@ -36,7 +36,6 @@ public class DeveloperExceptionPageMiddlewareTest
                         context.ProblemDetails.Extensions.Add("RouteValue", feature?.RouteValues?["id"]);
                         context.ProblemDetails.Extensions.Add("Path", feature?.Path);
                     };
-
                 });
             })
             .ConfigureWebHost(webHostBuilder =>
@@ -96,7 +95,6 @@ public class DeveloperExceptionPageMiddlewareTest
                         context.ProblemDetails.Extensions.Add("RouteValue", feature?.RouteValues?["id"]);
                         context.ProblemDetails.Extensions.Add("Path", feature?.Path);
                     };
-
                 });
             })
             .ConfigureWebHost(webHostBuilder =>


### PR DESCRIPTION
When using the developer exception page, the exception handler
feature is now set before invoking the problem details service.
This makes it possible to get the original exception when using
the problem details service if wanted.

Fixes# https://github.com/dotnet/aspnetcore/issues/47060
