### PR TITLE
 Fix Heartbeat logging after disposal

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/Heartbeat.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/Heartbeat.cs
@@ -62,17 +62,20 @@ internal sealed class Heartbeat : IDisposable
         }
         catch (Exception ex)
         {
-            _trace.LogError(0, ex, $"{nameof(Heartbeat)}.{nameof(OnHeartbeat)}");
+            if (!_stopped)
+            {
+                _trace.LogError(0, ex, $"{nameof(Heartbeat)}.{nameof(OnHeartbeat)}");
+            }
         }
     }
 
     private void TimerLoop()
     {
+        Thread.Sleep(_interval);
         while (!_stopped)
         {
-            Thread.Sleep(_interval);
-
             OnHeartbeat();
+            Thread.Sleep(_interval);
         }
     }
 


### PR DESCRIPTION
#  Fix Heartbeat logging after disposal
Prevent Heartbeat from logging exceptions after disposal.
Fix timer loop so disposal check is immediately before heartbeat execution.

## Description
During CoreWCF (based on aspnetcore) unit tests we have an ILogger built on `ITestOutputHelper` which will abort the test run if something is logged after the test has completed execution. The Heartbeat class can log after `Dispose()` has been called, which means our test run is getting aborted.

This change fixes 2 issues. First, the existing implementation called `Thread.Sleep` between the disposal check and calling the heart beat handlers which means the handlers can easily get called after the host has been stopped. Then in the handler code, if there's an exception it would always log even if it was disposed.

Fixes #47577
