### PR TITLE
Enable StripSymbols under API template when -aot is passed in.

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/Api-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/Api-CSharp.csproj.in
@@ -10,6 +10,7 @@
     <InvariantGlobalization>true</InvariantGlobalization>
     <!--#if (NativeAot) -->
     <PublishAot>true</PublishAot>
+    <StripSymbols>true</StripSymbols>
     <!--#endif -->
   </PropertyGroup>
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/GrpcService-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/GrpcService-CSharp.csproj.in
@@ -7,6 +7,7 @@
     <InvariantGlobalization>true</InvariantGlobalization>
     <!--#if (NativeAot) -->
     <PublishAot>true</PublishAot>
+    <StripSymbols>true</StripSymbols>
     <!--#endif -->
   </PropertyGroup>
 


### PR DESCRIPTION
On Linux, when we publish the API template (with AOT) the outputted binary is around 50MB. Without symbols is is about 12MB. This PR turns on `<StripSymbols>true</StripSymbols>` by default.