### PR TITLE
Make HttpLogging middleware endpoint aware

### DIFF
--- a/src/Middleware/HttpLogging/src/HttpLoggingAttribute.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingAttribute.cs
@@ -13,13 +13,18 @@ public sealed class HttpLoggingAttribute : Attribute
     /// Initializes an instance of the <see cref="HttpLoggingAttribute"/> class.
     /// </summary>
     /// <param name="loggingFields">Specifies what fields to log for the endpoint.</param>
-    /// <param name="requestBodyLogLimit">Specifies the maximum number of bytes to be logged for the request body. A negative value means use the default setting in <see cref="HttpLoggingOptions.RequestBodyLogLimit"/>.</param>
-    /// <param name="responseBodyLogLimit">Specifies the maximum number of bytes to be logged for the response body. A negative value means use the default setting in <see cref="HttpLoggingOptions.ResponseBodyLogLimit"/>.</param>
+    /// <param name="requestBodyLogLimit">Specifies the maximum number of bytes to be logged for the request body. A value of <c>-1</c> means use the default setting in <see cref="HttpLoggingOptions.RequestBodyLogLimit"/>.</param>
+    /// <param name="responseBodyLogLimit">Specifies the maximum number of bytes to be logged for the response body. A value of <c>-1</c> means use the default setting in <see cref="HttpLoggingOptions.ResponseBodyLogLimit"/>.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="requestBodyLogLimit"/> or <paramref name="responseBodyLogLimit"/> is less than <c>-1</c>.</exception>
     public HttpLoggingAttribute(HttpLoggingFields loggingFields, int requestBodyLogLimit = -1, int responseBodyLogLimit = -1)
     {
         LoggingFields = loggingFields;
-        RequestBodyLogLimit = requestBodyLogLimit < 0 ? null : requestBodyLogLimit;
-        ResponseBodyLogLimit = responseBodyLogLimit < 0 ? null : responseBodyLogLimit;
+
+        ArgumentOutOfRangeException.ThrowIfLessThan(requestBodyLogLimit, -1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(responseBodyLogLimit, -1);
+
+        RequestBodyLogLimit = requestBodyLogLimit;
+        ResponseBodyLogLimit = responseBodyLogLimit;
     }
 
     /// <summary>
@@ -30,10 +35,10 @@ public sealed class HttpLoggingAttribute : Attribute
     /// <summary>
     /// Specifies the maximum number of bytes to be logged for the request body.
     /// </summary>
-    public int? RequestBodyLogLimit { get; }
+    public int RequestBodyLogLimit { get; }
 
     /// <summary>
     /// Specifies the maximum number of bytes to be logged for the response body.
     /// </summary>
-    public int? ResponseBodyLogLimit { get; }
+    public int ResponseBodyLogLimit { get; }
 }

--- a/src/Middleware/HttpLogging/src/HttpLoggingAttribute.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingAttribute.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.HttpLogging;
+
+/// <summary>
+/// Metadata that provides endpoint-specific settings for the HttpLogging middleware.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+public sealed class HttpLoggingAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes an instance of the <see cref="HttpLoggingAttribute"/> class.
+    /// </summary>
+    /// <param name="loggingFields">Specifies what fields to log for the endpoint.</param>
+    /// <param name="requestBodyLogLimit">Specifies the maximum number of bytes to be logged for the request body. A negative value means use the default setting in <see cref="HttpLoggingOptions.RequestBodyLogLimit"/>.</param>
+    /// <param name="responseBodyLogLimit">Specifies the maximum number of bytes to be logged for the response body. A negative value means use the default setting in <see cref="HttpLoggingOptions.ResponseBodyLogLimit"/>.</param>
+    public HttpLoggingAttribute(HttpLoggingFields loggingFields, int requestBodyLogLimit = -1, int responseBodyLogLimit = -1)
+    {
+        LoggingFields = loggingFields;
+        RequestBodyLogLimit = requestBodyLogLimit < 0 ? null : requestBodyLogLimit;
+        ResponseBodyLogLimit = responseBodyLogLimit < 0 ? null : responseBodyLogLimit;
+    }
+
+    /// <summary>
+    /// Specifies what fields to log.
+    /// </summary>
+    public HttpLoggingFields LoggingFields { get; }
+
+    /// <summary>
+    /// Specifies the maximum number of bytes to be logged for the request body.
+    /// </summary>
+    public int? RequestBodyLogLimit { get; }
+
+    /// <summary>
+    /// Specifies the maximum number of bytes to be logged for the response body.
+    /// </summary>
+    public int? ResponseBodyLogLimit { get; }
+}

--- a/src/Middleware/HttpLogging/src/HttpLoggingEndpointConventionBuilderExtensions.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingEndpointConventionBuilderExtensions.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.HttpLogging;
+
+namespace Microsoft.AspNetCore.Builder;
+
+/// <summary>
+/// HttpLogging middleware extension methods for <see cref="IEndpointConventionBuilder"/>.
+/// </summary>
+public static class HttpLoggingEndpointConventionBuilderExtensions
+{
+    /// <summary>
+    /// Adds endpoint specific settings for the HttpLogging middleware.
+    /// </summary>
+    /// <typeparam name="TBuilder">The type of endpoint convention builder.</typeparam>
+    /// <param name="builder">The endpoint convention builder.</param>
+    /// <param name="loggingFields">The <see cref="HttpLoggingFields"/> to apply to this endpoint.</param>
+    /// <param name="requestBodyLogLimit">Sets the <see cref="HttpLoggingOptions.RequestBodyLogLimit"/> for this endpoint.</param>
+    /// <param name="responseBodyLogLimit">Sets the <see cref="HttpLoggingOptions.ResponseBodyLogLimit"/> for this endpoint.</param>
+    /// <returns>The original convention builder parameter.</returns>
+    public static TBuilder WithHttpLogging<TBuilder>(this TBuilder builder, HttpLoggingFields loggingFields, int? requestBodyLogLimit = null, int? responseBodyLogLimit = null) where TBuilder : IEndpointConventionBuilder
+    {
+        builder.Add(endpointBuilder =>
+        {
+            endpointBuilder.Metadata.Add(new HttpLoggingAttribute(loggingFields, requestBodyLogLimit ?? -1, responseBodyLogLimit ?? -1));
+        });
+        return builder;
+    }
+}

--- a/src/Middleware/HttpLogging/src/HttpLoggingEndpointConventionBuilderExtensions.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingEndpointConventionBuilderExtensions.cs
@@ -16,14 +16,18 @@ public static class HttpLoggingEndpointConventionBuilderExtensions
     /// <typeparam name="TBuilder">The type of endpoint convention builder.</typeparam>
     /// <param name="builder">The endpoint convention builder.</param>
     /// <param name="loggingFields">The <see cref="HttpLoggingFields"/> to apply to this endpoint.</param>
-    /// <param name="requestBodyLogLimit">Sets the <see cref="HttpLoggingOptions.RequestBodyLogLimit"/> for this endpoint.</param>
-    /// <param name="responseBodyLogLimit">Sets the <see cref="HttpLoggingOptions.ResponseBodyLogLimit"/> for this endpoint.</param>
+    /// <param name="requestBodyLogLimit">Sets the <see cref="HttpLoggingOptions.RequestBodyLogLimit"/> for this endpoint. A value of <c>-1</c> means use the default setting in <see cref="HttpLoggingOptions.RequestBodyLogLimit"/>.</param>
+    /// <param name="responseBodyLogLimit">Sets the <see cref="HttpLoggingOptions.ResponseBodyLogLimit"/> for this endpoint. A value of <c>-1</c> means use the default setting in <see cref="HttpLoggingOptions.ResponseBodyLogLimit"/>.</param>
     /// <returns>The original convention builder parameter.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="requestBodyLogLimit"/> or <paramref name="responseBodyLogLimit"/> is less than <c>-1</c>.</exception>
     public static TBuilder WithHttpLogging<TBuilder>(this TBuilder builder, HttpLoggingFields loggingFields, int requestBodyLogLimit = -1, int responseBodyLogLimit = -1) where TBuilder : IEndpointConventionBuilder
     {
+        // Construct outside build.Add lambda to allow exceptions to be thrown immediately
+        var metadata = new HttpLoggingAttribute(loggingFields, requestBodyLogLimit, responseBodyLogLimit);
+
         builder.Add(endpointBuilder =>
         {
-            endpointBuilder.Metadata.Add(new HttpLoggingAttribute(loggingFields, requestBodyLogLimit, responseBodyLogLimit));
+            endpointBuilder.Metadata.Add(metadata);
         });
         return builder;
     }

--- a/src/Middleware/HttpLogging/src/HttpLoggingEndpointConventionBuilderExtensions.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingEndpointConventionBuilderExtensions.cs
@@ -19,11 +19,11 @@ public static class HttpLoggingEndpointConventionBuilderExtensions
     /// <param name="requestBodyLogLimit">Sets the <see cref="HttpLoggingOptions.RequestBodyLogLimit"/> for this endpoint.</param>
     /// <param name="responseBodyLogLimit">Sets the <see cref="HttpLoggingOptions.ResponseBodyLogLimit"/> for this endpoint.</param>
     /// <returns>The original convention builder parameter.</returns>
-    public static TBuilder WithHttpLogging<TBuilder>(this TBuilder builder, HttpLoggingFields loggingFields, int? requestBodyLogLimit = null, int? responseBodyLogLimit = null) where TBuilder : IEndpointConventionBuilder
+    public static TBuilder WithHttpLogging<TBuilder>(this TBuilder builder, HttpLoggingFields loggingFields, int requestBodyLogLimit = -1, int responseBodyLogLimit = -1) where TBuilder : IEndpointConventionBuilder
     {
         builder.Add(endpointBuilder =>
         {
-            endpointBuilder.Metadata.Add(new HttpLoggingAttribute(loggingFields, requestBodyLogLimit ?? -1, responseBodyLogLimit ?? -1));
+            endpointBuilder.Metadata.Add(new HttpLoggingAttribute(loggingFields, requestBodyLogLimit, responseBodyLogLimit));
         });
         return builder;
     }

--- a/src/Middleware/HttpLogging/src/HttpLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingMiddleware.cs
@@ -59,44 +59,47 @@ internal sealed class HttpLoggingMiddleware
         RequestBufferingStream? requestBufferingStream = null;
         Stream? originalBody = null;
 
-        if ((HttpLoggingFields.Request & options.LoggingFields) != HttpLoggingFields.None)
+        var loggingAttribute = context.GetEndpoint()?.Metadata.GetMetadata<HttpLoggingAttribute>();
+        var loggingFields = loggingAttribute?.LoggingFields ?? options.LoggingFields;
+
+        if ((HttpLoggingFields.Request & loggingFields) != HttpLoggingFields.None)
         {
             var request = context.Request;
             var list = new List<KeyValuePair<string, object?>>(
                 request.Headers.Count + DefaultRequestFieldsMinusHeaders);
 
-            if (options.LoggingFields.HasFlag(HttpLoggingFields.RequestProtocol))
+            if (loggingFields.HasFlag(HttpLoggingFields.RequestProtocol))
             {
                 AddToList(list, nameof(request.Protocol), request.Protocol);
             }
 
-            if (options.LoggingFields.HasFlag(HttpLoggingFields.RequestMethod))
+            if (loggingFields.HasFlag(HttpLoggingFields.RequestMethod))
             {
                 AddToList(list, nameof(request.Method), request.Method);
             }
 
-            if (options.LoggingFields.HasFlag(HttpLoggingFields.RequestScheme))
+            if (loggingFields.HasFlag(HttpLoggingFields.RequestScheme))
             {
                 AddToList(list, nameof(request.Scheme), request.Scheme);
             }
 
-            if (options.LoggingFields.HasFlag(HttpLoggingFields.RequestPath))
+            if (loggingFields.HasFlag(HttpLoggingFields.RequestPath))
             {
                 AddToList(list, nameof(request.PathBase), request.PathBase);
                 AddToList(list, nameof(request.Path), request.Path);
             }
 
-            if (options.LoggingFields.HasFlag(HttpLoggingFields.RequestQuery))
+            if (loggingFields.HasFlag(HttpLoggingFields.RequestQuery))
             {
                 AddToList(list, nameof(request.QueryString), request.QueryString.Value);
             }
 
-            if (options.LoggingFields.HasFlag(HttpLoggingFields.RequestHeaders))
+            if (loggingFields.HasFlag(HttpLoggingFields.RequestHeaders))
             {
                 FilterHeaders(list, request.Headers, options._internalRequestHeaders);
             }
 
-            if (options.LoggingFields.HasFlag(HttpLoggingFields.RequestBody))
+            if (loggingFields.HasFlag(HttpLoggingFields.RequestBody))
             {
                 if (request.ContentType is null)
                 {
@@ -109,7 +112,7 @@ internal sealed class HttpLoggingMiddleware
                     originalBody = request.Body;
                     requestBufferingStream = new RequestBufferingStream(
                         request.Body,
-                        options.RequestBodyLogLimit,
+                        loggingAttribute?.RequestBodyLogLimit ?? options.RequestBodyLogLimit,
                         _logger,
                         encoding);
                     request.Body = requestBufferingStream;
@@ -135,29 +138,30 @@ internal sealed class HttpLoggingMiddleware
         {
             var response = context.Response;
 
-            if (options.LoggingFields.HasFlag(HttpLoggingFields.ResponseStatusCode) || options.LoggingFields.HasFlag(HttpLoggingFields.ResponseHeaders))
+            if (loggingFields.HasFlag(HttpLoggingFields.ResponseStatusCode) || loggingFields.HasFlag(HttpLoggingFields.ResponseHeaders))
             {
                 originalUpgradeFeature = context.Features.Get<IHttpUpgradeFeature>();
 
                 if (originalUpgradeFeature != null && originalUpgradeFeature.IsUpgradableRequest)
                 {
-                    loggableUpgradeFeature = new UpgradeFeatureLoggingDecorator(originalUpgradeFeature, response, options, _logger);
+                    loggableUpgradeFeature = new UpgradeFeatureLoggingDecorator(originalUpgradeFeature, response, options._internalResponseHeaders, loggingFields, _logger);
 
                     context.Features.Set<IHttpUpgradeFeature>(loggableUpgradeFeature);
                 }
             }
 
-            if (options.LoggingFields.HasFlag(HttpLoggingFields.ResponseBody))
+            if (loggingFields.HasFlag(HttpLoggingFields.ResponseBody))
             {
                 originalBodyFeature = context.Features.Get<IHttpResponseBodyFeature>()!;
 
                 // TODO pool these.
                 responseBufferingStream = new ResponseBufferingStream(originalBodyFeature,
-                    options.ResponseBodyLogLimit,
+                    loggingAttribute?.ResponseBodyLogLimit ?? options.ResponseBodyLogLimit,
                     _logger,
                     context,
                     options.MediaTypeOptions.MediaTypeStates,
-                    options);
+                    options._internalResponseHeaders,
+                    loggingFields);
                 response.Body = responseBufferingStream;
                 context.Features.Set<IHttpResponseBodyFeature>(responseBufferingStream);
             }
@@ -174,7 +178,7 @@ internal sealed class HttpLoggingMiddleware
             if (ResponseHeadersNotYetWritten(responseBufferingStream, loggableUpgradeFeature))
             {
                 // No body, not an upgradable request or request not upgraded, write headers here.
-                LogResponseHeaders(response, options, _logger);
+                LogResponseHeaders(response, loggingFields, options._internalResponseHeaders, _logger);
             }
 
             if (responseBufferingStream != null)
@@ -229,19 +233,19 @@ internal sealed class HttpLoggingMiddleware
         list.Add(new KeyValuePair<string, object?>(key, value));
     }
 
-    public static void LogResponseHeaders(HttpResponse response, HttpLoggingOptions options, ILogger logger)
+    public static void LogResponseHeaders(HttpResponse response, HttpLoggingFields loggingFields, HashSet<string> allowedResponseHeaders, ILogger logger)
     {
         var list = new List<KeyValuePair<string, object?>>(
             response.Headers.Count + DefaultResponseFieldsMinusHeaders);
 
-        if (options.LoggingFields.HasFlag(HttpLoggingFields.ResponseStatusCode))
+        if (loggingFields.HasFlag(HttpLoggingFields.ResponseStatusCode))
         {
             list.Add(new KeyValuePair<string, object?>(nameof(response.StatusCode), response.StatusCode));
         }
 
-        if (options.LoggingFields.HasFlag(HttpLoggingFields.ResponseHeaders))
+        if (loggingFields.HasFlag(HttpLoggingFields.ResponseHeaders))
         {
-            FilterHeaders(list, response.Headers, options._internalResponseHeaders);
+            FilterHeaders(list, response.Headers, allowedResponseHeaders);
         }
 
         if (list.Count > 0)

--- a/src/Middleware/HttpLogging/src/HttpLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingMiddleware.cs
@@ -109,10 +109,16 @@ internal sealed class HttpLoggingMiddleware
                     options.MediaTypeOptions.MediaTypeStates,
                     out var encoding))
                 {
+                    var requestBodyLogLimit = options.RequestBodyLogLimit;
+                    if (loggingAttribute?.RequestBodyLogLimit is int)
+                    {
+                        requestBodyLogLimit = loggingAttribute.RequestBodyLogLimit;
+                    }
+
                     originalBody = request.Body;
                     requestBufferingStream = new RequestBufferingStream(
                         request.Body,
-                        loggingAttribute?.RequestBodyLogLimit ?? options.RequestBodyLogLimit,
+                        requestBodyLogLimit,
                         _logger,
                         encoding);
                     request.Body = requestBufferingStream;
@@ -154,9 +160,15 @@ internal sealed class HttpLoggingMiddleware
             {
                 originalBodyFeature = context.Features.Get<IHttpResponseBodyFeature>()!;
 
+                var responseBodyLogLimit = options.ResponseBodyLogLimit;
+                if (loggingAttribute?.ResponseBodyLogLimit is int)
+                {
+                    responseBodyLogLimit = loggingAttribute.ResponseBodyLogLimit;
+                }
+
                 // TODO pool these.
                 responseBufferingStream = new ResponseBufferingStream(originalBodyFeature,
-                    loggingAttribute?.ResponseBodyLogLimit ?? options.ResponseBodyLogLimit,
+                    responseBodyLogLimit,
                     _logger,
                     context,
                     options.MediaTypeOptions.MediaTypeStates,

--- a/src/Middleware/HttpLogging/src/HttpLoggingMiddleware.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingMiddleware.cs
@@ -220,7 +220,7 @@ internal sealed class HttpLoggingMiddleware
 
     private static bool BodyNotYetWritten(ResponseBufferingStream? responseBufferingStream)
     {
-        return responseBufferingStream == null || responseBufferingStream.FirstWrite == false;
+        return responseBufferingStream == null || responseBufferingStream.HeadersWritten == false;
     }
 
     private static bool NotUpgradeableRequestOrRequestNotUpgraded(UpgradeFeatureLoggingDecorator? upgradeFeatureLogging)

--- a/src/Middleware/HttpLogging/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/HttpLogging/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,8 @@
 #nullable enable
+Microsoft.AspNetCore.Builder.HttpLoggingEndpointConventionBuilderExtensions
+Microsoft.AspNetCore.HttpLogging.HttpLoggingAttribute
+Microsoft.AspNetCore.HttpLogging.HttpLoggingAttribute.HttpLoggingAttribute(Microsoft.AspNetCore.HttpLogging.HttpLoggingFields loggingFields, int requestBodyLogLimit = -1, int responseBodyLogLimit = -1) -> void
+Microsoft.AspNetCore.HttpLogging.HttpLoggingAttribute.LoggingFields.get -> Microsoft.AspNetCore.HttpLogging.HttpLoggingFields
+Microsoft.AspNetCore.HttpLogging.HttpLoggingAttribute.RequestBodyLogLimit.get -> int?
+Microsoft.AspNetCore.HttpLogging.HttpLoggingAttribute.ResponseBodyLogLimit.get -> int?
+static Microsoft.AspNetCore.Builder.HttpLoggingEndpointConventionBuilderExtensions.WithHttpLogging<TBuilder>(this TBuilder builder, Microsoft.AspNetCore.HttpLogging.HttpLoggingFields loggingFields, int? requestBodyLogLimit = null, int? responseBodyLogLimit = null) -> TBuilder

--- a/src/Middleware/HttpLogging/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/HttpLogging/src/PublicAPI.Unshipped.txt
@@ -3,6 +3,6 @@ Microsoft.AspNetCore.Builder.HttpLoggingEndpointConventionBuilderExtensions
 Microsoft.AspNetCore.HttpLogging.HttpLoggingAttribute
 Microsoft.AspNetCore.HttpLogging.HttpLoggingAttribute.HttpLoggingAttribute(Microsoft.AspNetCore.HttpLogging.HttpLoggingFields loggingFields, int requestBodyLogLimit = -1, int responseBodyLogLimit = -1) -> void
 Microsoft.AspNetCore.HttpLogging.HttpLoggingAttribute.LoggingFields.get -> Microsoft.AspNetCore.HttpLogging.HttpLoggingFields
-Microsoft.AspNetCore.HttpLogging.HttpLoggingAttribute.RequestBodyLogLimit.get -> int?
-Microsoft.AspNetCore.HttpLogging.HttpLoggingAttribute.ResponseBodyLogLimit.get -> int?
+Microsoft.AspNetCore.HttpLogging.HttpLoggingAttribute.RequestBodyLogLimit.get -> int
+Microsoft.AspNetCore.HttpLogging.HttpLoggingAttribute.ResponseBodyLogLimit.get -> int
 static Microsoft.AspNetCore.Builder.HttpLoggingEndpointConventionBuilderExtensions.WithHttpLogging<TBuilder>(this TBuilder builder, Microsoft.AspNetCore.HttpLogging.HttpLoggingFields loggingFields, int? requestBodyLogLimit = null, int? responseBodyLogLimit = null) -> TBuilder

--- a/src/Middleware/HttpLogging/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/HttpLogging/src/PublicAPI.Unshipped.txt
@@ -5,4 +5,4 @@ Microsoft.AspNetCore.HttpLogging.HttpLoggingAttribute.HttpLoggingAttribute(Micro
 Microsoft.AspNetCore.HttpLogging.HttpLoggingAttribute.LoggingFields.get -> Microsoft.AspNetCore.HttpLogging.HttpLoggingFields
 Microsoft.AspNetCore.HttpLogging.HttpLoggingAttribute.RequestBodyLogLimit.get -> int
 Microsoft.AspNetCore.HttpLogging.HttpLoggingAttribute.ResponseBodyLogLimit.get -> int
-static Microsoft.AspNetCore.Builder.HttpLoggingEndpointConventionBuilderExtensions.WithHttpLogging<TBuilder>(this TBuilder builder, Microsoft.AspNetCore.HttpLogging.HttpLoggingFields loggingFields, int? requestBodyLogLimit = null, int? responseBodyLogLimit = null) -> TBuilder
+static Microsoft.AspNetCore.Builder.HttpLoggingEndpointConventionBuilderExtensions.WithHttpLogging<TBuilder>(this TBuilder builder, Microsoft.AspNetCore.HttpLogging.HttpLoggingFields loggingFields, int requestBodyLogLimit = -1, int responseBodyLogLimit = -1) -> TBuilder

--- a/src/Middleware/HttpLogging/src/UpgradeFeatureLoggingDecorator.cs
+++ b/src/Middleware/HttpLogging/src/UpgradeFeatureLoggingDecorator.cs
@@ -11,17 +11,19 @@ internal sealed class UpgradeFeatureLoggingDecorator : IHttpUpgradeFeature
 {
     private readonly IHttpUpgradeFeature _innerUpgradeFeature;
     private readonly HttpResponse _response;
-    private readonly HttpLoggingOptions _options;
+    private readonly HashSet<string> _allowedResponseHeaders;
     private readonly ILogger _logger;
+    private readonly HttpLoggingFields _loggingFields;
 
     private bool _isUpgraded;
 
-    public UpgradeFeatureLoggingDecorator(IHttpUpgradeFeature innerUpgradeFeature, HttpResponse response, HttpLoggingOptions options, ILogger logger)
+    public UpgradeFeatureLoggingDecorator(IHttpUpgradeFeature innerUpgradeFeature, HttpResponse response, HashSet<string> allowedResponseHeaders, HttpLoggingFields loggingFields, ILogger logger)
     {
         _innerUpgradeFeature = innerUpgradeFeature ?? throw new ArgumentNullException(nameof(innerUpgradeFeature));
         _response = response ?? throw new ArgumentNullException(nameof(response));
-        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _allowedResponseHeaders = allowedResponseHeaders ?? throw new ArgumentNullException(nameof(allowedResponseHeaders));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _loggingFields = loggingFields;
     }
 
     public bool IsUpgradableRequest => _innerUpgradeFeature.IsUpgradableRequest;
@@ -34,7 +36,7 @@ internal sealed class UpgradeFeatureLoggingDecorator : IHttpUpgradeFeature
 
         _isUpgraded = true;
 
-        HttpLoggingMiddleware.LogResponseHeaders(_response, _options, _logger);
+        HttpLoggingMiddleware.LogResponseHeaders(_response, _loggingFields, _allowedResponseHeaders, _logger);
 
         return upgradeStream;
     }

--- a/src/Middleware/HttpLogging/test/HttpLoggingEndpointConventionBuilderTests.cs
+++ b/src/Middleware/HttpLogging/test/HttpLoggingEndpointConventionBuilderTests.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.HttpLogging.Tests;
+
+public class HttpLoggingEndpointConventionBuilderTests
+{
+    [Fact]
+    public void WithHttpLogging_SetsMetadata()
+    {
+        // Arrange
+        var testConventionBuilder = new TestEndpointConventionBuilder();
+        var loggingFields = HttpLoggingFields.RequestScheme | HttpLoggingFields.RequestPath;
+        var requestBodyLogLimit = 22;
+        var responseBodyLogLimit = 94;
+
+        // Act
+        testConventionBuilder.WithHttpLogging(loggingFields, requestBodyLogLimit, responseBodyLogLimit);
+
+        // Assert
+        var httpLogingAttribute = Assert.Single(testConventionBuilder.Conventions);
+
+        var endpointModel = new TestEndpointBuilder();
+        httpLogingAttribute(endpointModel);
+        var endpoint = endpointModel.Build();
+
+        var metadata = endpoint.Metadata.GetMetadata<HttpLoggingAttribute>();
+        Assert.NotNull(metadata);
+        Assert.Equal(requestBodyLogLimit, metadata.RequestBodyLogLimit);
+        Assert.Equal(responseBodyLogLimit, metadata.ResponseBodyLogLimit);
+        Assert.Equal(loggingFields, metadata.LoggingFields);
+    }
+
+    [Fact]
+    public void WithHttpLogging_ThrowsForInvalidLimits()
+    {
+        // Arrange
+        var testConventionBuilder = new TestEndpointConventionBuilder();
+
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            testConventionBuilder.WithHttpLogging(HttpLoggingFields.None, requestBodyLogLimit: -2));
+        Assert.Equal("requestBodyLogLimit", ex.ParamName);
+
+        ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            testConventionBuilder.WithHttpLogging(HttpLoggingFields.None, responseBodyLogLimit: -2));
+        Assert.Equal("responseBodyLogLimit", ex.ParamName);
+    }
+}
+
+internal class TestEndpointBuilder : EndpointBuilder
+{
+    public override Endpoint Build()
+    {
+        return new Endpoint(RequestDelegate, new EndpointMetadataCollection(Metadata), DisplayName);
+    }
+}
+
+internal class TestEndpointConventionBuilder : IEndpointConventionBuilder
+{
+    public IList<Action<EndpointBuilder>> Conventions { get; } = new List<Action<EndpointBuilder>>();
+
+    public void Add(Action<EndpointBuilder> convention)
+    {
+        Conventions.Add(convention);
+    }
+
+    public TestEndpointConventionBuilder ApplyToEndpoint(EndpointBuilder endpoint)
+    {
+        foreach (var convention in Conventions)
+        {
+            convention(endpoint);
+        }
+
+        return this;
+    }
+}

--- a/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
+++ b/src/Middleware/HttpLogging/test/HttpLoggingMiddlewareTests.cs
@@ -1,10 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net.Http;
 using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
@@ -1115,10 +1121,209 @@ public class HttpLoggingMiddlewareTests : LoggedTest
         Assert.False(httpContext.Features.Get<IHttpUpgradeFeature>() is UpgradeFeatureLoggingDecorator);
     }
 
+    [Fact]
+    public async Task HttpLoggingAttributeWithLessOptionsAppliesToEndpoint()
+    {
+        var app = CreateApp();
+        await app.StartAsync();
+
+        using var server = app.GetTestServer();
+        var client = server.CreateClient();
+        var initialResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/attr_responseonly"));
+
+        var filteredLogs = TestSink.Writes.Where(w => w.LoggerName.Contains("HttpLogging"));
+        Assert.DoesNotContain(filteredLogs, w => w.Message.Contains("Request"));
+        Assert.Contains(filteredLogs, w => w.Message.Contains("StatusCode: 200"));
+    }
+
+    [Fact]
+    public async Task HttpLoggingAttributeWithMoreOptionsAppliesToEndpoint()
+    {
+        var app = CreateApp(defaultFields: HttpLoggingFields.None);
+        await app.StartAsync();
+
+        using var server = app.GetTestServer();
+        var client = server.CreateClient();
+        var initialResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/attr_responseandrequest"));
+
+        var filteredLogs = TestSink.Writes.Where(w => w.LoggerName.Contains("HttpLogging"));
+        Assert.Contains(filteredLogs, w => w.Message.Contains("Request"));
+        Assert.Contains(filteredLogs, w => w.Message.Contains("StatusCode: 200"));
+    }
+
+    [Fact]
+    public async Task HttpLoggingAttributeCanRestrictHeaderOutputOnEndpoint()
+    {
+        var app = CreateApp();
+        await app.StartAsync();
+
+        using var server = app.GetTestServer();
+        var client = server.CreateClient();
+        var initialResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/attr_restrictedheaders"));
+
+        var filteredLogs = TestSink.Writes.Where(w => w.LoggerName.Contains("HttpLogging"));
+        Assert.DoesNotContain(filteredLogs, w => w.Message.Contains("Scheme"));
+        Assert.DoesNotContain(filteredLogs, w => w.Message.Contains("StatusCode: 200"));
+    }
+
+    [Fact]
+    public async Task HttpLoggingAttributeCanModifyRequestAndResponseSizeOnEndpoint()
+    {
+        var app = CreateApp();
+        await app.StartAsync();
+
+        using var server = app.GetTestServer();
+        var client = server.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, "/attr_restrictedsize") { Content = new ReadOnlyMemoryContent("from request"u8.ToArray()) };
+        request.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("text/plain");
+        var initialResponse = await client.SendAsync(request);
+
+        var filteredLogs = TestSink.Writes.Where(w => w.LoggerName.Contains("HttpLogging"));
+        Assert.Contains(filteredLogs, w => w.Message.Equals("RequestBody: fro"));
+        Assert.Contains(filteredLogs, w => w.Message.Equals("ResponseBody: testin"));
+    }
+
+    [Fact]
+    public async Task HttpLoggingExtensionWithLessOptionsAppliesToEndpoint()
+    {
+        var app = CreateApp();
+        await app.StartAsync();
+
+        using var server = app.GetTestServer();
+        var client = server.CreateClient();
+        var initialResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/ext_responseonly"));
+
+        var filteredLogs = TestSink.Writes.Where(w => w.LoggerName.Contains("HttpLogging"));
+        Assert.DoesNotContain(filteredLogs, w => w.Message.Contains("Request"));
+        Assert.Contains(filteredLogs, w => w.Message.Contains("StatusCode: 200"));
+    }
+
+    [Fact]
+    public async Task HttpLoggingExtensionWithMoreOptionsAppliesToEndpoint()
+    {
+        var app = CreateApp(defaultFields: HttpLoggingFields.None);
+        await app.StartAsync();
+
+        using var server = app.GetTestServer();
+        var client = server.CreateClient();
+        var initialResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/ext_responseandrequest"));
+
+        var filteredLogs = TestSink.Writes.Where(w => w.LoggerName.Contains("HttpLogging"));
+        Assert.Contains(filteredLogs, w => w.Message.Contains("Request"));
+        Assert.Contains(filteredLogs, w => w.Message.Contains("StatusCode: 200"));
+    }
+
+    [Fact]
+    public async Task HttpLoggingExtensionCanRestrictHeaderOutputOnEndpoint()
+    {
+        var app = CreateApp();
+        await app.StartAsync();
+
+        using var server = app.GetTestServer();
+        var client = server.CreateClient();
+        var initialResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/ext_restrictedheaders"));
+
+        var filteredLogs = TestSink.Writes.Where(w => w.LoggerName.Contains("HttpLogging"));
+        Assert.DoesNotContain(filteredLogs, w => w.Message.Contains("Scheme"));
+        Assert.DoesNotContain(filteredLogs, w => w.Message.Contains("StatusCode: 200"));
+    }
+
+    [Fact]
+    public async Task HttpLoggingExtensionCanModifyRequestAndResponseSizeOnEndpoint()
+    {
+        var app = CreateApp();
+        await app.StartAsync();
+
+        using var server = app.GetTestServer();
+        var client = server.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, "/ext_restrictedsize") { Content = new ReadOnlyMemoryContent("from request"u8.ToArray()) };
+        request.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("text/plain");
+        var initialResponse = await client.SendAsync(request);
+
+        var filteredLogs = TestSink.Writes.Where(w => w.LoggerName.Contains("HttpLogging"));
+        Assert.Contains(filteredLogs, w => w.Message.Equals("RequestBody: fro"));
+        Assert.Contains(filteredLogs, w => w.Message.Equals("ResponseBody: testin"));
+    }
+
     private IOptionsMonitor<HttpLoggingOptions> CreateOptionsAccessor()
     {
         var options = new HttpLoggingOptions();
         var optionsAccessor = Mock.Of<IOptionsMonitor<HttpLoggingOptions>>(o => o.CurrentValue == options);
         return optionsAccessor;
+    }
+
+    private IHost CreateApp(HttpLoggingFields defaultFields = HttpLoggingFields.All)
+    {
+        var builder = new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                    .UseTestServer()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddRouting();
+                        services.AddHttpLogging(o =>
+                        {
+                            o.LoggingFields = defaultFields;
+                        });
+                        services.AddSingleton(LoggerFactory);
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseHttpLogging();
+                        app.UseEndpoints(endpoint =>
+                        {
+                            endpoint.MapGet("/attr_responseonly", [HttpLogging(HttpLoggingFields.Response)] async (HttpContext c) =>
+                            {
+                                await c.Request.Body.ReadAsync(new byte[100]);
+                                return "testing";
+                            });
+
+                            endpoint.MapGet("/ext_responseonly", async (HttpContext c) =>
+                            {
+                                await c.Request.Body.ReadAsync(new byte[100]);
+                                return "testing";
+                            }).WithHttpLogging(HttpLoggingFields.Response);
+
+                            endpoint.MapGet("/attr_responseandrequest", [HttpLogging(HttpLoggingFields.Request | HttpLoggingFields.Response)] async (HttpContext c) =>
+                            {
+                                await c.Request.Body.ReadAsync(new byte[100]);
+                                return "testing";
+                            });
+
+                            endpoint.MapGet("/ext_responseandrequest", async(HttpContext c) =>
+                            {
+                                await c.Request.Body.ReadAsync(new byte[100]);
+                                return "testing";
+                            }).WithHttpLogging(HttpLoggingFields.Request | HttpLoggingFields.Response);
+
+                            endpoint.MapGet("/attr_restrictedheaders", [HttpLogging((HttpLoggingFields.Request & ~HttpLoggingFields.RequestScheme) | (HttpLoggingFields.Response & ~HttpLoggingFields.ResponseStatusCode))] async (HttpContext c) =>
+                            {
+                                await c.Request.Body.ReadAsync(new byte[100]);
+                                return "testing";
+                            });
+
+                            endpoint.MapGet("/ext_restrictedheaders", async (HttpContext c) =>
+                            {
+                                await c.Request.Body.ReadAsync(new byte[100]);
+                                return "testing";
+                            }).WithHttpLogging((HttpLoggingFields.Request & ~HttpLoggingFields.RequestScheme) | (HttpLoggingFields.Response & ~HttpLoggingFields.ResponseStatusCode));
+
+                            endpoint.MapGet("/attr_restrictedsize", [HttpLogging(HttpLoggingFields.Request | HttpLoggingFields.Response, requestBodyLogLimit: 3, responseBodyLogLimit: 6)] async (HttpContext c) =>
+                            {
+                                await c.Request.Body.ReadAsync(new byte[100]);
+                                return "testing";
+                            });
+
+                            endpoint.MapGet("/ext_restrictedsize", async (HttpContext c) =>
+                            {
+                                await c.Request.Body.ReadAsync(new byte[100]);
+                                return "testing";
+                            }).WithHttpLogging(HttpLoggingFields.Request | HttpLoggingFields.Response, requestBodyLogLimit: 3, responseBodyLogLimit: 6);
+                        });
+                    });
+                });
+        return builder.Build();
     }
 }

--- a/src/Middleware/HttpLogging/test/Microsoft.AspNetCore.HttpLogging.Tests.csproj
+++ b/src/Middleware/HttpLogging/test/Microsoft.AspNetCore.HttpLogging.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.HttpLogging" />
     <Reference Include="Microsoft.AspNetCore.TestHost" />
+    <Reference Include="Microsoft.AspNetCore.Routing" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/43222

And fixes https://github.com/dotnet/aspnetcore/issues/46703 as it was preventing testing the response byte limit.