### PR TITLE
Fix interpretation of 'deflate' content-coding.

### DIFF
--- a/src/Middleware/RequestDecompression/src/DeflateDecompressionProvider.cs
+++ b/src/Middleware/RequestDecompression/src/DeflateDecompressionProvider.cs
@@ -8,11 +8,15 @@ namespace Microsoft.AspNetCore.RequestDecompression;
 /// <summary>
 /// DEFLATE decompression provider.
 /// </summary>
+/// <remarks>
+/// As described in RFC 2616, the deflate content-coding token represents the "zlib" format
+/// (RFC 1950) in combination with the "deflate" compression algorithm (RFC 1951).
+/// </remarks>
 internal sealed class DeflateDecompressionProvider : IDecompressionProvider
 {
     /// <inheritdoc />
     public Stream GetDecompressionStream(Stream stream)
     {
-        return new DeflateStream(stream, CompressionMode.Decompress, leaveOpen: true);
+        return new ZLibStream(stream, CompressionMode.Decompress, leaveOpen: true);
     }
 }

--- a/src/Middleware/RequestDecompression/test/DefaultRequestDecompressionProviderTests.cs
+++ b/src/Middleware/RequestDecompression/test/DefaultRequestDecompressionProviderTests.cs
@@ -16,8 +16,8 @@ public class DefaultRequestDecompressionProviderTests
     [Theory]
     [InlineData("br", typeof(BrotliStream))]
     [InlineData("BR", typeof(BrotliStream))]
-    [InlineData("deflate", typeof(DeflateStream))]
-    [InlineData("DEFLATE", typeof(DeflateStream))]
+    [InlineData("deflate", typeof(ZLibStream))]
+    [InlineData("DEFLATE", typeof(ZLibStream))]
     [InlineData("gzip", typeof(GZipStream))]
     [InlineData("GZIP", typeof(GZipStream))]
     public void GetDecompressionProvider_SupportedContentEncoding_ReturnsProvider(


### PR DESCRIPTION
This PR replaces #47522 (see my comment in https://github.com/dotnet/aspnetcore/pull/47522#issuecomment-1496792015).

As described in RFC 2616, the deflate content-coding token represents the "zlib" format (RFC 1950) in combination with the "deflate" compression algorithm (RFC 1951).

.NET 7 introduced automatic request decompression middleware which treated the "deflate" content-coding as meaning raw, unwrapped deflate compression, which doesn't match the spec. Since we are not aware of clients doing this in practice, this PR just fixes this to correctly treat "deflate" as zlib+deflate.

This PR should make it into .NET 8 Preview 4. If we hear feedback that this breaks anything in practice, we can consider reintroducing the complexity in #47522 which will enable support for both the correct and incorrect use of "deflate".