### PR TITLE
Reset ConnectProtocol during reset

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -366,6 +366,7 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
         IsExtendedConnectRequest = false;
         IsExtendedConnectAccepted = false;
         IsWebTransportRequest = false;
+        ConnectProtocol = null;
 
         var remoteEndPoint = RemoteEndPoint;
         RemoteIpAddress = remoteEndPoint?.Address;


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/47647

cc @Tratcher @MihaZupan 

We don't seem to have any tests for this type of thing, and from looking at the H2 WS tests I wasn't sure if there's even a good way to add one given how those tests work. Any thoughts @Tratcher?