### PR TITLE
[blazor] Configure mono runtime with startupMemoryCache and runtimeOptions

### DIFF
--- a/src/Components/Web.JS/src/Platform/BootConfig.ts
+++ b/src/Components/Web.JS/src/Platform/BootConfig.ts
@@ -53,6 +53,8 @@ export interface BootJsonData {
   readonly cacheBootResources: boolean;
   readonly config: string[];
   readonly icuDataMode: ICUDataMode;
+  readonly startupMemoryCache: boolean | null;
+  readonly runtimeOptions: string[] | null;
 
   // These properties are tacked on, and not found in the boot.json file
   modifiableAssemblies: string | null;

--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -356,7 +356,17 @@ function prepareRuntimeConfig(resourceLoader: WebAssemblyResourceLoader): Dotnet
 async function createRuntimeInstance(resourceLoader: WebAssemblyResourceLoader): Promise<void> {
   const { dotnet } = await importDotnetJs(resourceLoader);
   const moduleConfig = prepareRuntimeConfig(resourceLoader);
-  (dotnet as any).withModuleConfig(moduleConfig);
+  const anyDotnet = (dotnet as any);
+
+  anyDotnet.withModuleConfig(moduleConfig);
+
+  if (resourceLoader.bootConfig.startupMemoryCache !== undefined) {
+    anyDotnet.withStartupMemoryCache(resourceLoader.bootConfig.startupMemoryCache);
+  }
+
+  if (resourceLoader.bootConfig.runtimeOptions) {
+    anyDotnet.withRuntimeOptions(resourceLoader.bootConfig.runtimeOptions);
+  }
 
   const runtime = await dotnet.create();
   const { MONO: mono, BINDING: binding, Module: module, setModuleImports, INTERNAL: mono_internal } = runtime;


### PR DESCRIPTION
_It is a duplicate of https://github.com/dotnet/aspnetcore/pull/47277, but this time based on a correct branch (main). Appologies for any extra work._

---

Configure mono runtime with `startupMemoryCache` and `runtimeOptions` from boot config.

## Description

- These options were added to the blazor.boot.json in https://github.com/dotnet/sdk/pull/31174.
- The `startupMemoryCache` controls whether a memory snapshot from the previous run is used, more details in the https://github.com/dotnet/runtime/blob/main/src/mono/wasm/memory-snapshot.md.
- The `runtimeOptions` enables to pass mono runtime options configured from msbuild, one of the use-cases is controlling jiterpreter.
