### PR TITLE
Add a .http file to API project template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/Company.ApiApplication1.http
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/Company.ApiApplication1.http
@@ -1,11 +1,11 @@
 @Company.ApiApplication1_HostAddress = http://localhost:5000
 
-Get {{Company.ApiApplication1_HostAddress}}/todos/
+GET {{Company.ApiApplication1_HostAddress}}/todos/
 Accept: application/json
 
 ###
 
-Get {{Company.ApiApplication1_HostAddress}}/todos/1
+GET {{Company.ApiApplication1_HostAddress}}/todos/1
 Accept: application/json
 
 ###

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/Company.ApiApplication1.http
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/Company.ApiApplication1.http
@@ -1,0 +1,11 @@
+@Company.ApiApplication1_HostAddress = http://localhost:5000
+
+Get {{Company.ApiApplication1_HostAddress}}/todos/
+Accept: application/json
+
+###
+
+Get {{Company.ApiApplication1_HostAddress}}/todos/1
+Accept: application/json
+
+###

--- a/src/ProjectTemplates/test/Templates.Tests/BaselineTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/BaselineTest.cs
@@ -75,6 +75,8 @@ public class BaselineTest : LoggedTest
         Project = await ProjectFactory.CreateProject(Output);
         await Project.RunDotNetNewRawAsync(arguments);
 
+        expectedFiles = expectedFiles.Select(f => f.Replace("{ProjectName}", Project.ProjectName)).ToArray();
+
         foreach (var file in expectedFiles)
         {
             AssertFileExists(Project.TemplateOutputDir, file, shouldExist: true);

--- a/src/ProjectTemplates/test/Templates.Tests/template-baselines.json
+++ b/src/ProjectTemplates/test/Templates.Tests/template-baselines.json
@@ -534,6 +534,7 @@
       "Files": [
         "Todo.cs",
         "Program.cs",
+        "{ProjectName}.http",
         "Properties/launchSettings.json"
       ],
       "AuthOption": "None"
@@ -554,6 +555,7 @@
       "Files": [
         "Todo.cs",
         "Program.cs",
+        "{ProjectName}.http",
         "Properties/launchSettings.json"
       ],
       "AuthOption": "None"

--- a/src/ProjectTemplates/test/Templates.Tests/template-baselines.json
+++ b/src/ProjectTemplates/test/Templates.Tests/template-baselines.json
@@ -545,6 +545,7 @@
       "Files": [
         "Todo.cs",
         "Program.cs",
+        "{ProjectName}.http",
         "Properties/launchSettings.json"
       ],
       "AuthOption": "None"
@@ -566,6 +567,7 @@
       "Files": [
         "Todo.cs",
         "Program.cs",
+        "{ProjectName}.http",
         "Properties/launchSettings.json"
       ],
       "AuthOption": "None"


### PR DESCRIPTION
Fixes #47675

Template baseline test updated to support referring to created project's name via `{ProjectName}` so that the .http file named after the profile name can be verified.

Example of the file generated being used in VS Code:

<img width="710" alt="image" src="https://user-images.githubusercontent.com/249088/231612673-ec60bffc-b858-4fc1-899e-275eb7f6a63a.png">
