### PR TITLE
Log if a server certificate lacks the subjectAlternativeName extensions

### DIFF
--- a/src/Servers/Kestrel/Core/src/CertificateLoader.cs
+++ b/src/Servers/Kestrel/Core/src/CertificateLoader.cs
@@ -106,6 +106,9 @@ public static class CertificateLoader
     internal static bool DoesCertificateHaveAnAccessiblePrivateKey(X509Certificate2 certificate)
         => certificate.HasPrivateKey;
 
+    internal static bool DoesCertificateHaveASubjectAlternativeName(X509Certificate2 certificate)
+        => certificate.Extensions.OfType<X509SubjectAlternativeNameExtension>().Any();
+
     private static void DisposeCertificates(X509Certificate2Collection? certificates, X509Certificate2? except)
     {
         if (certificates != null)

--- a/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
@@ -20,6 +20,7 @@ internal sealed class SniOptionsSelector
     private const string WildcardPrefix = "*.";
 
     private readonly string _endpointName;
+    private readonly ILogger<HttpsConnectionMiddleware> _logger;
 
     private readonly Func<ConnectionContext, string?, X509Certificate2?>? _fallbackServerCertificateSelector;
     private readonly Action<ConnectionContext, SslServerAuthenticationOptions>? _onAuthenticateCallback;
@@ -37,6 +38,7 @@ internal sealed class SniOptionsSelector
         ILogger<HttpsConnectionMiddleware> logger)
     {
         _endpointName = endpointName;
+        _logger = logger;
 
         _fallbackServerCertificateSelector = fallbackHttpsOptions.ServerCertificateSelector;
         _onAuthenticateCallback = fallbackHttpsOptions.OnAuthenticate;
@@ -75,7 +77,7 @@ internal sealed class SniOptionsSelector
 
             if (!certifcateConfigLoader.IsTestMock && sslOptions.ServerCertificate is X509Certificate2 cert2)
             {
-                HttpsConnectionMiddleware.EnsureCertificateIsAllowedForServerAuth(cert2);
+                HttpsConnectionMiddleware.EnsureCertificateIsAllowedForServerAuth(cert2, _logger);
             }
 
             var clientCertificateMode = sniConfig.ClientCertificateMode ?? fallbackHttpsOptions.ClientCertificateMode;
@@ -158,7 +160,7 @@ internal sealed class SniOptionsSelector
 
             if (fallbackCertificate != null)
             {
-                HttpsConnectionMiddleware.EnsureCertificateIsAllowedForServerAuth(fallbackCertificate);
+                HttpsConnectionMiddleware.EnsureCertificateIsAllowedForServerAuth(fallbackCertificate, _logger);
             }
 
             sslOptions.ServerCertificate = fallbackCertificate;

--- a/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
@@ -77,7 +77,7 @@ internal sealed class SniOptionsSelector
 
             if (!certifcateConfigLoader.IsTestMock && sslOptions.ServerCertificate is X509Certificate2 cert2)
             {
-                HttpsConnectionMiddleware.EnsureCertificateIsAllowedForServerAuth(cert2, _logger);
+                HttpsConnectionMiddleware.EnsureCertificateIsAllowedForServerAuth(cert2, logger);
             }
 
             var clientCertificateMode = sniConfig.ClientCertificateMode ?? fallbackHttpsOptions.ClientCertificateMode;

--- a/src/Servers/Kestrel/Core/src/KestrelServer.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServer.cs
@@ -35,7 +35,7 @@ public class KestrelServer : IServer
             options,
             new[] { transportFactory ?? throw new ArgumentNullException(nameof(transportFactory)) },
             Array.Empty<IMultiplexedConnectionListenerFactory>(),
-            new SimpleHttpsConfigurationService(),
+            new SimpleHttpsConfigurationService(loggerFactory.CreateLogger<HttpsConnectionMiddleware>()),
             loggerFactory,
             new KestrelMetrics(new DummyMeterFactory()));
     }
@@ -78,6 +78,13 @@ public class KestrelServer : IServer
 
     private sealed class SimpleHttpsConfigurationService : IHttpsConfigurationService
     {
+        private readonly ILogger<HttpsConnectionMiddleware> _httpsLogger;
+
+        public SimpleHttpsConfigurationService(ILogger<HttpsConnectionMiddleware> httpsLogger)
+        {
+            _httpsLogger = httpsLogger;
+        }
+
         public bool IsInitialized => true;
 
         public void Initialize(IHostEnvironment hostEnvironment, ILogger<KestrelServer> serverLogger, ILogger<HttpsConnectionMiddleware> httpsLogger)
@@ -87,7 +94,7 @@ public class KestrelServer : IServer
 
         public void PopulateMultiplexedTransportFeatures(FeatureCollection features, ListenOptions listenOptions)
         {
-            HttpsConfigurationService.PopulateMultiplexedTransportFeaturesWorker(features, listenOptions);
+            HttpsConfigurationService.PopulateMultiplexedTransportFeaturesWorker(features, listenOptions, _httpsLogger);
         }
 
         public ListenOptions UseHttpsWithDefaults(ListenOptions listenOptions)

--- a/src/Servers/Kestrel/Core/src/KestrelServer.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServer.cs
@@ -35,7 +35,7 @@ public class KestrelServer : IServer
             options,
             new[] { transportFactory ?? throw new ArgumentNullException(nameof(transportFactory)) },
             Array.Empty<IMultiplexedConnectionListenerFactory>(),
-            new SimpleHttpsConfigurationService(loggerFactory.CreateLogger<HttpsConnectionMiddleware>()),
+            new SimpleHttpsConfigurationService(loggerFactory),
             loggerFactory,
             new KestrelMetrics(new DummyMeterFactory()));
     }
@@ -80,9 +80,9 @@ public class KestrelServer : IServer
     {
         private readonly ILogger<HttpsConnectionMiddleware> _httpsLogger;
 
-        public SimpleHttpsConfigurationService(ILogger<HttpsConnectionMiddleware> httpsLogger)
+        public SimpleHttpsConfigurationService(ILoggerFactory loggerFactory)
         {
-            _httpsLogger = httpsLogger;
+            _httpsLogger = loggerFactory.CreateLogger<HttpsConnectionMiddleware>();
         }
 
         public bool IsInitialized => true;

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -90,7 +90,7 @@ internal sealed class HttpsConnectionMiddleware
         {
             Debug.Assert(_serverCertificate != null);
 
-            EnsureCertificateIsAllowedForServerAuth(_serverCertificate);
+            EnsureCertificateIsAllowedForServerAuth(_serverCertificate, _logger);
 
             var certificate = _serverCertificate;
             if (!certificate.HasPrivateKey)
@@ -314,7 +314,7 @@ internal sealed class HttpsConnectionMiddleware
                 var cert = _serverCertificateSelector(context, name);
                 if (cert != null)
                 {
-                    EnsureCertificateIsAllowedForServerAuth(cert);
+                    EnsureCertificateIsAllowedForServerAuth(cert, _logger);
                 }
                 return cert!;
             };
@@ -452,11 +452,15 @@ internal sealed class HttpsConnectionMiddleware
         return sslOptions;
     }
 
-    internal static void EnsureCertificateIsAllowedForServerAuth(X509Certificate2 certificate)
+    internal static void EnsureCertificateIsAllowedForServerAuth(X509Certificate2 certificate, ILogger<HttpsConnectionMiddleware> logger)
     {
         if (!CertificateLoader.IsCertificateAllowedForServerAuth(certificate))
         {
             throw new InvalidOperationException(CoreStrings.FormatInvalidServerCertificateEku(certificate.Thumbprint));
+        }
+        else if (!CertificateLoader.DoesCertificateHaveASubjectAlternativeName(certificate))
+        {
+            logger.NoSubjectAlternativeName(certificate.Thumbprint);
         }
     }
 
@@ -514,7 +518,7 @@ internal sealed class HttpsConnectionMiddleware
         return false;
     }
 
-    internal static SslServerAuthenticationOptions CreateHttp3Options(HttpsConnectionAdapterOptions httpsOptions)
+    internal static SslServerAuthenticationOptions CreateHttp3Options(HttpsConnectionAdapterOptions httpsOptions, ILogger<HttpsConnectionMiddleware> logger)
     {
         if (httpsOptions.OnAuthenticate != null)
         {
@@ -539,7 +543,7 @@ internal sealed class HttpsConnectionMiddleware
                 var cert = httpsOptions.ServerCertificateSelector(null, host);
                 if (cert != null)
                 {
-                    EnsureCertificateIsAllowedForServerAuth(cert);
+                    EnsureCertificateIsAllowedForServerAuth(cert, logger);
                 }
                 return cert!;
             };
@@ -595,6 +599,9 @@ internal static partial class HttpsConnectionMiddlewareLoggerExtensions
 
     [LoggerMessage(8, LogLevel.Debug, "Failed to open certificate store {StoreName}.", EventName = "FailToOpenStore")]
     public static partial void FailedToOpenStore(this ILogger<HttpsConnectionMiddleware> logger, string? storeName, Exception exception);
+
+    [LoggerMessage(9, LogLevel.Information, "Certificate with thumbprint {Thumbprint} lacks the subjectAlternativeName (SAN) extension and may not be accepted by browsers.", EventName = "NoSubjectAlternativeName")]
+    public static partial void NoSubjectAlternativeName(this ILogger logger, string thumbprint);
 
     public static void FailedToOpenStore(this ILogger<HttpsConnectionMiddleware> logger, StoreLocation storeLocation, Exception exception)
     {

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -601,7 +601,7 @@ internal static partial class HttpsConnectionMiddlewareLoggerExtensions
     public static partial void FailedToOpenStore(this ILogger<HttpsConnectionMiddleware> logger, string? storeName, Exception exception);
 
     [LoggerMessage(9, LogLevel.Information, "Certificate with thumbprint {Thumbprint} lacks the subjectAlternativeName (SAN) extension and may not be accepted by browsers.", EventName = "NoSubjectAlternativeName")]
-    public static partial void NoSubjectAlternativeName(this ILogger logger, string thumbprint);
+    public static partial void NoSubjectAlternativeName(this ILogger<HttpsConnectionMiddleware> logger, string thumbprint);
 
     public static void FailedToOpenStore(this ILogger<HttpsConnectionMiddleware> logger, StoreLocation storeLocation, Exception exception)
     {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/CertificateLoaderTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/CertificateLoaderTests.cs
@@ -53,4 +53,15 @@ public class CertificateLoaderTests : LoggedTest
 
         Assert.False(CertificateLoader.IsCertificateAllowedForServerAuth(cert));
     }
+
+    [Theory]
+    [InlineData("aspnetdevcert.pfx", true)]
+    [InlineData("no_extensions.pfx", false)]
+    public void DoesCertificateHaveASubjectAlternativeName(string testCertName, bool hasSan)
+    {
+        var certPath = TestResources.GetCertPath(testCertName);
+        TestOutputHelper.WriteLine("Loading " + certPath);
+        var cert = new X509Certificate2(certPath, "testPassword");
+        Assert.Equal(hasSan, CertificateLoader.DoesCertificateHaveASubjectAlternativeName(cert));
+    }
 }


### PR DESCRIPTION
# Log if a server certificate lacks the subjectAlternativeName extensions

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

CommonName was [deprecated](https://developer.chrome.com/blog/chrome-58-deprecations/#remove-support-for-commonname-matching-in-certificates) in favor of subjectAlternativeName so there's a good chance of getting a browser security warning if it's missing.
