### PR TITLE
Remove dependencies that exist in base image

### DIFF
--- a/eng/docker/rhel.Dockerfile
+++ b/eng/docker/rhel.Dockerfile
@@ -1,16 +1,6 @@
 # Dockerfile that creates a container suitable to build dotnet-cli
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
 
-RUN tdnf update -y && \
-    tdnf install -y \
-        tar \
-        ca-certificates \
-        icu \
-        awk \
-        # Provides useradd, needed below
-        shadow-utils \
-        rpm-build
-
 # Setup User to match Host User, and give superuser permissions
 ARG USER
 ARG USER_ID


### PR DESCRIPTION
Cleans up the dependencies added in https://github.com/dotnet/aspnetcore/pull/47693 that now exist in the base image (since https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/844).