### PR TITLE
Update the Worker template to use  `Host.CreateApplicationBuilder`

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.Main.cs
@@ -4,13 +4,10 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        IHost host = Host.CreateDefaultBuilder(args)
-            .ConfigureServices(services =>
-            {
-                services.AddHostedService<Worker>();
-            })
-            .Build();
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+        builder.Services.AddHostedService<Worker>();
 
+        IHost host = builder.Build();
         host.Run();
     }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.Main.cs
@@ -4,10 +4,10 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+        var builder = Host.CreateApplicationBuilder(args);
         builder.Services.AddHostedService<Worker>();
 
-        IHost host = builder.Build();
+        var host = builder.Build();
         host.Run();
     }
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.cs
@@ -1,10 +1,7 @@
 using Company.Application1;
 
-IHost host = Host.CreateDefaultBuilder(args)
-    .ConfigureServices(services =>
-    {
-        services.AddHostedService<Worker>();
-    })
-    .Build();
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+builder.Services.AddHostedService<Worker>();
 
+IHost host = builder.Build();
 host.Run();

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/Program.cs
@@ -1,7 +1,7 @@
 using Company.Application1;
 
-HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+var builder = Host.CreateApplicationBuilder(args);
 builder.Services.AddHostedService<Worker>();
 
-IHost host = builder.Build();
+var host = builder.Build();
 host.Run();

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-FSharp/Program.fs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-FSharp/Program.fs
@@ -8,13 +8,12 @@ open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Hosting
 
 module Program =
-    let createHostBuilder args =
-        Host.CreateDefaultBuilder(args)
-            .ConfigureServices(fun hostContext services ->
-                services.AddHostedService<Worker>() |> ignore)
 
     [<EntryPoint>]
     let main args =
-        createHostBuilder(args).Build().Run()
+        let builder = Host.CreateApplicationBuilder(args)
+        builder.Services.AddHostedService<Worker>() |> ignore
+
+        builder.Build().Run()
 
         0 // exit code


### PR DESCRIPTION
The callback approach that `Host.CreateDefaultBuilder` uses is no longer recommended going forward, and the programming model is no longer used in ASP.NET apps - it uses the `WebApplication.CreateBuilder()` API which is imperative, top-to-bottom programming. The Worker template should follow the same pattern.

Fix #43113
