### PR TITLE
Update ReadMe.SharedCode.md to mention runtime-sync.yml

### DIFF
--- a/src/Shared/runtime/ReadMe.SharedCode.md
+++ b/src/Shared/runtime/ReadMe.SharedCode.md
@@ -34,3 +34,7 @@ dotnet/aspnetcore code paths:
 ### Running dotnet/aspnetcore tests:
 - `(aspnetcore) PS D:\github\aspnetcore\src\Shared\test\Shared.Tests> dotnet test`
 - `(aspnetcore) PS D:\github\aspnetcore\src\servers\Kestrel\core\test> dotnet test`
+
+## Automation
+
+In dotnet/aspnetcore, the [runtime-sync](https://github.com/dotnet/aspnetcore/actions/workflows/runtime-sync.yml) GitHub action automatically creates PRs to pull in changes from dotnet/runtime.


### PR DESCRIPTION
So that someone doesn't accidentally follow the manual process described in the readme when #18943 gets reactivated.