### PR TITLE
Change incorrect usage of ArgumentNullException

### DIFF
--- a/src/DataProtection/Extensions/src/DataProtectionProvider.cs
+++ b/src/DataProtection/Extensions/src/DataProtectionProvider.cs
@@ -24,10 +24,7 @@ public static class DataProtectionProvider
     /// applications on the machine.</param>
     public static IDataProtectionProvider Create(string applicationName)
     {
-        if (string.IsNullOrEmpty(applicationName))
-        {
-            throw new ArgumentNullException(nameof(applicationName));
-        }
+        ArgumentThrowHelper.ThrowIfNullOrEmpty(applicationName);
 
         return CreateProvider(
             keyDirectory: null,
@@ -74,10 +71,7 @@ public static class DataProtectionProvider
     /// <param name="certificate">The <see cref="X509Certificate2"/> to be used for encryption.</param>
     public static IDataProtectionProvider Create(string applicationName, X509Certificate2 certificate)
     {
-        if (string.IsNullOrEmpty(applicationName))
-        {
-            throw new ArgumentNullException(nameof(applicationName));
-        }
+        ArgumentThrowHelper.ThrowIfNullOrEmpty(applicationName);
         ArgumentNullThrowHelper.ThrowIfNull(certificate);
 
         return CreateProvider(

--- a/src/DataProtection/Extensions/src/Microsoft.AspNetCore.DataProtection.Extensions.csproj
+++ b/src/DataProtection/Extensions/src/Microsoft.AspNetCore.DataProtection.Extensions.csproj
@@ -14,6 +14,7 @@
     <Compile Include="..\..\shared\src\*.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)TrimmingAttributes.cs" LinkBase="Shared"
       Condition="'$(TargetFramework)' != '$(DefaultNetCoreTargetFramework)'" />
+    <Compile Include="$(SharedSourceRoot)ThrowHelpers\ArgumentThrowHelper.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)ThrowHelpers\ArgumentNullThrowHelper.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)CallerArgument\CallerArgumentExpressionAttribute.cs" LinkBase="Shared" />
   </ItemGroup>

--- a/src/Http/Authentication.Abstractions/src/TokenExtensions.cs
+++ b/src/Http/Authentication.Abstractions/src/TokenExtensions.cs
@@ -36,7 +36,7 @@ public static class AuthenticationTokenExtensions
         {
             if (token.Name is null)
             {
-                throw new ArgumentNullException(nameof(tokens), "Token name cannot be null.");
+                throw new ArgumentException("Token name cannot be null for any token.", nameof(tokens));
             }
 
             // REVIEW: should probably check that there are no ; in the token name and throw or encode

--- a/src/Http/Http.Abstractions/src/Internal/ParsingHelpers.cs
+++ b/src/Http/Http.Abstractions/src/Internal/ParsingHelpers.cs
@@ -46,11 +46,8 @@ internal static class ParsingHelpers
     public static void SetHeaderJoined(IHeaderDictionary headers, string key, StringValues value)
     {
         ArgumentNullException.ThrowIfNull(headers);
+        ArgumentException.ThrowIfNullOrEmpty(key);
 
-        if (string.IsNullOrEmpty(key))
-        {
-            throw new ArgumentNullException(nameof(key));
-        }
         if (StringValues.IsNullOrEmpty(value))
         {
             headers.Remove(key);
@@ -87,11 +84,8 @@ internal static class ParsingHelpers
     public static void SetHeaderUnmodified(IHeaderDictionary headers, string key, StringValues? values)
     {
         ArgumentNullException.ThrowIfNull(headers);
+        ArgumentException.ThrowIfNullOrEmpty(key);
 
-        if (string.IsNullOrEmpty(key))
-        {
-            throw new ArgumentNullException(nameof(key));
-        }
         if (!values.HasValue || StringValues.IsNullOrEmpty(values.GetValueOrDefault()))
         {
             headers.Remove(key);

--- a/src/Http/Routing/src/Patterns/RoutePatternFactory.cs
+++ b/src/Http/Routing/src/Patterns/RoutePatternFactory.cs
@@ -823,7 +823,7 @@ public static class RoutePatternFactory
 
         if (@default != null && parameterKind == RoutePatternParameterKind.Optional)
         {
-            throw new ArgumentNullException(nameof(parameterKind), Resources.TemplateRoute_OptionalCannotHaveDefaultValue);
+            throw new ArgumentException(Resources.TemplateRoute_OptionalCannotHaveDefaultValue);
         }
 
         return ParameterPartCore(
@@ -860,7 +860,7 @@ public static class RoutePatternFactory
 
         if (@default != null && parameterKind == RoutePatternParameterKind.Optional)
         {
-            throw new ArgumentNullException(nameof(parameterKind), Resources.TemplateRoute_OptionalCannotHaveDefaultValue);
+            throw new ArgumentException(Resources.TemplateRoute_OptionalCannotHaveDefaultValue);
         }
 
         ArgumentNullException.ThrowIfNull(parameterPolicies);
@@ -899,7 +899,7 @@ public static class RoutePatternFactory
 
         if (@default != null && parameterKind == RoutePatternParameterKind.Optional)
         {
-            throw new ArgumentNullException(nameof(parameterKind), Resources.TemplateRoute_OptionalCannotHaveDefaultValue);
+            throw new ArgumentException(Resources.TemplateRoute_OptionalCannotHaveDefaultValue);
         }
 
         ArgumentNullException.ThrowIfNull(parameterPolicies);

--- a/src/Identity/EntityFrameworkCore/src/UserStore.cs
+++ b/src/Identity/EntityFrameworkCore/src/UserStore.cs
@@ -611,10 +611,7 @@ public class UserStore<TUser, TRole, TContext, [DynamicallyAccessedMembers(Dynam
     {
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
-        if (string.IsNullOrEmpty(normalizedRoleName))
-        {
-            throw new ArgumentNullException(nameof(normalizedRoleName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(normalizedRoleName);
 
         var role = await FindRoleAsync(normalizedRoleName, cancellationToken);
 

--- a/src/Identity/Extensions.Core/src/UserClaimsPrincipalFactory.cs
+++ b/src/Identity/Extensions.Core/src/UserClaimsPrincipalFactory.cs
@@ -28,7 +28,8 @@ public class UserClaimsPrincipalFactory<TUser> : IUserClaimsPrincipalFactory<TUs
         ArgumentNullThrowHelper.ThrowIfNull(userManager);
         if (optionsAccessor == null || optionsAccessor.Value == null)
         {
-            throw new ArgumentException($"{nameof(optionsAccessor)} cannot be null or wrap a null value.", nameof(optionsAccessor));
+            ArgumentNullThrowHelper.ThrowIfNull(optionsAccessor);
+            throw new ArgumentException($"{nameof(optionsAccessor)} cannot wrap a null value.", nameof(optionsAccessor));
         }
         UserManager = userManager;
         Options = optionsAccessor.Value;

--- a/src/Identity/Extensions.Core/src/UserClaimsPrincipalFactory.cs
+++ b/src/Identity/Extensions.Core/src/UserClaimsPrincipalFactory.cs
@@ -28,7 +28,7 @@ public class UserClaimsPrincipalFactory<TUser> : IUserClaimsPrincipalFactory<TUs
         ArgumentNullThrowHelper.ThrowIfNull(userManager);
         if (optionsAccessor == null || optionsAccessor.Value == null)
         {
-            throw new ArgumentNullException(nameof(optionsAccessor));
+            throw new ArgumentException($"{nameof(optionsAccessor)} cannot be null or wrap a null value.", nameof(optionsAccessor));
         }
         UserManager = userManager;
         Options = optionsAccessor.Value;

--- a/src/Identity/test/Identity.Test/UserClaimsPrincipalFactoryTest.cs
+++ b/src/Identity/test/Identity.Test/UserClaimsPrincipalFactoryTest.cs
@@ -15,7 +15,7 @@ public class UserClaimsPrincipalFactoryTest
         var userManager = MockHelpers.MockUserManager<PocoUser>().Object;
         var roleManager = MockHelpers.MockRoleManager<PocoRole>().Object;
         var options = new Mock<IOptions<IdentityOptions>>();
-        Assert.Throws<ArgumentNullException>("optionsAccessor",
+        Assert.Throws<ArgumentException>("optionsAccessor",
             () => new UserClaimsPrincipalFactory<PocoUser, PocoRole>(userManager, roleManager, options.Object));
         var identityOptions = new IdentityOptions();
         options.Setup(a => a.Value).Returns(identityOptions);

--- a/src/Identity/test/InMemory.Test/InMemoryStore.cs
+++ b/src/Identity/test/InMemory.Test/InMemoryStore.cs
@@ -57,10 +57,7 @@ public class InMemoryStore<TUser, TRole> :
     // RoleId == rolename for inmemory store tests
     public Task<IList<TUser>> GetUsersInRoleAsync(string roleName, CancellationToken cancellationToken = default(CancellationToken))
     {
-        if (String.IsNullOrEmpty(roleName))
-        {
-            throw new ArgumentNullException(nameof(roleName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(roleName);
 
         var role = _roles.Values.Where(x => x.NormalizedName.Equals(roleName)).SingleOrDefault();
         if (role == null)

--- a/src/Localization/Localization/src/Microsoft.Extensions.Localization.csproj
+++ b/src/Localization/Localization/src/Microsoft.Extensions.Localization.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedSourceRoot)ThrowHelpers\ArgumentThrowHelper.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)ThrowHelpers\ArgumentNullThrowHelper.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)CallerArgument\CallerArgumentExpressionAttribute.cs" LinkBase="Shared" />
   </ItemGroup>

--- a/src/Localization/Localization/src/ResourceLocationAttribute.cs
+++ b/src/Localization/Localization/src/ResourceLocationAttribute.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.Extensions.Localization;
 
@@ -17,10 +18,7 @@ public class ResourceLocationAttribute : Attribute
     /// <param name="resourceLocation">The location of resources for this Assembly.</param>
     public ResourceLocationAttribute(string resourceLocation)
     {
-        if (string.IsNullOrEmpty(resourceLocation))
-        {
-            throw new ArgumentNullException(nameof(resourceLocation));
-        }
+        ArgumentThrowHelper.ThrowIfNullOrEmpty(resourceLocation);
 
         ResourceLocation = resourceLocation;
     }

--- a/src/Localization/Localization/src/ResourceManagerStringLocalizerFactory.cs
+++ b/src/Localization/Localization/src/ResourceManagerStringLocalizerFactory.cs
@@ -76,11 +76,7 @@ public class ResourceManagerStringLocalizerFactory : IStringLocalizerFactory
     protected virtual string GetResourcePrefix(TypeInfo typeInfo, string? baseNamespace, string? resourcesRelativePath)
     {
         ArgumentNullThrowHelper.ThrowIfNull(typeInfo);
-
-        if (string.IsNullOrEmpty(baseNamespace))
-        {
-            throw new ArgumentNullException(nameof(baseNamespace));
-        }
+        ArgumentThrowHelper.ThrowIfNullOrEmpty(baseNamespace);
 
         if (string.IsNullOrEmpty(typeInfo.FullName))
         {
@@ -107,15 +103,8 @@ public class ResourceManagerStringLocalizerFactory : IStringLocalizerFactory
     /// <returns>The prefix for resource lookup.</returns>
     protected virtual string GetResourcePrefix(string baseResourceName, string baseNamespace)
     {
-        if (string.IsNullOrEmpty(baseResourceName))
-        {
-            throw new ArgumentNullException(nameof(baseResourceName));
-        }
-
-        if (string.IsNullOrEmpty(baseNamespace))
-        {
-            throw new ArgumentNullException(nameof(baseNamespace));
-        }
+        ArgumentThrowHelper.ThrowIfNullOrEmpty(baseResourceName);
+        ArgumentThrowHelper.ThrowIfNullOrEmpty(baseNamespace);
 
         var assemblyName = new AssemblyName(baseNamespace);
         var assembly = Assembly.Load(assemblyName);

--- a/src/Localization/Localization/src/RootNamespaceAttribute.cs
+++ b/src/Localization/Localization/src/RootNamespaceAttribute.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.Extensions.Localization;
 
@@ -18,10 +19,7 @@ public class RootNamespaceAttribute : Attribute
     /// <param name="rootNamespace">The RootNamespace for this Assembly.</param>
     public RootNamespaceAttribute(string rootNamespace)
     {
-        if (string.IsNullOrEmpty(rootNamespace))
-        {
-            throw new ArgumentNullException(nameof(rootNamespace));
-        }
+        ArgumentThrowHelper.ThrowIfNullOrEmpty(rootNamespace);
 
         RootNamespace = rootNamespace;
     }

--- a/src/Logging.AzureAppServices/src/AzureFileLoggerOptions.cs
+++ b/src/Logging.AzureAppServices/src/AzureFileLoggerOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.Extensions.Logging.AzureAppServices;
 
@@ -59,17 +60,8 @@ public class AzureFileLoggerOptions : BatchingLoggerOptions
         get { return _fileName; }
         set
         {
-            if (string.IsNullOrEmpty(value))
-            {
-                if (value is null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
-                else
-                {
-                    throw new ArgumentException("The value cannot be an empty string.", nameof(value));
-                }
-            }
+            ArgumentThrowHelper.ThrowIfNullOrEmpty(value);
+
             _fileName = value;
         }
     }

--- a/src/Logging.AzureAppServices/src/AzureFileLoggerOptions.cs
+++ b/src/Logging.AzureAppServices/src/AzureFileLoggerOptions.cs
@@ -61,7 +61,14 @@ public class AzureFileLoggerOptions : BatchingLoggerOptions
         {
             if (string.IsNullOrEmpty(value))
             {
-                throw new ArgumentNullException(nameof(value));
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+                else
+                {
+                    throw new ArgumentException("The value cannot be an empty string.", nameof(value));
+                }
             }
             _fileName = value;
         }

--- a/src/Logging.AzureAppServices/src/Microsoft.Extensions.Logging.AzureAppServices.csproj
+++ b/src/Logging.AzureAppServices/src/Microsoft.Extensions.Logging.AzureAppServices.csproj
@@ -28,4 +28,10 @@
   <ItemGroup>
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(SharedSourceRoot)ThrowHelpers\ArgumentThrowHelper.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)CallerArgument\CallerArgumentExpressionAttribute.cs" LinkBase="Shared" />
+  </ItemGroup>
+
 </Project>

--- a/src/Middleware/HttpLogging/src/W3CLoggerOptions.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggerOptions.cs
@@ -64,10 +64,7 @@ public sealed class W3CLoggerOptions
         get { return _fileName; }
         set
         {
-            if (string.IsNullOrEmpty(value))
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(value);
             _fileName = value;
         }
     }
@@ -83,10 +80,7 @@ public sealed class W3CLoggerOptions
         get { return _logDirectory; }
         set
         {
-            if (string.IsNullOrEmpty(value))
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(value);
             _logDirectory = value;
         }
     }

--- a/src/Middleware/HttpLogging/test/W3CLoggerOptionsTests.cs
+++ b/src/Middleware/HttpLogging/test/W3CLoggerOptionsTests.cs
@@ -26,14 +26,14 @@ public class W3CLoggerOptionsTests
     public void ThrowsOnEmptyFileName()
     {
         var options = new W3CLoggerOptions();
-        Assert.Throws<ArgumentNullException>(() => options.FileName = "");
+        Assert.Throws<ArgumentException>(() => options.FileName = "");
     }
 
     [Fact]
     public void ThrowsOnEmptyLogDirectory()
     {
         var options = new W3CLoggerOptions();
-        Assert.Throws<ArgumentNullException>(() => options.LogDirectory = "");
+        Assert.Throws<ArgumentException>(() => options.LogDirectory = "");
     }
 
     [Fact]

--- a/src/Middleware/Rewrite/src/ApacheModRewrite/CookieActionFactory.cs
+++ b/src/Middleware/Rewrite/src/ApacheModRewrite/CookieActionFactory.cs
@@ -16,10 +16,7 @@ internal sealed class CookieActionFactory
     /// <returns>The action</returns>
     public static ChangeCookieAction Create(string flagValue)
     {
-        if (string.IsNullOrEmpty(flagValue))
-        {
-            throw new ArgumentNullException(nameof(flagValue));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(flagValue);
 
         var i = 0;
         var separator = ':';

--- a/src/Middleware/Rewrite/src/IISUrlRewrite/IISRewriteMap.cs
+++ b/src/Middleware/Rewrite/src/IISUrlRewrite/IISRewriteMap.cs
@@ -9,10 +9,7 @@ internal sealed class IISRewriteMap
 
     public IISRewriteMap(string name)
     {
-        if (string.IsNullOrEmpty(name))
-        {
-            throw new ArgumentNullException(nameof(name));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(name);
         Name = name;
     }
 
@@ -26,14 +23,8 @@ internal sealed class IISRewriteMap
         }
         set
         {
-            if (string.IsNullOrEmpty(key))
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-            if (string.IsNullOrEmpty(value))
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(key);
+            ArgumentException.ThrowIfNullOrEmpty(value);
             _map[key] = value;
         }
     }

--- a/src/Middleware/Rewrite/src/RedirectRule.cs
+++ b/src/Middleware/Rewrite/src/RedirectRule.cs
@@ -16,15 +16,8 @@ internal sealed class RedirectRule : IRule
     public int StatusCode { get; }
     public RedirectRule(string regex, string replacement, int statusCode)
     {
-        if (string.IsNullOrEmpty(regex))
-        {
-            throw new ArgumentNullException(nameof(regex));
-        }
-
-        if (string.IsNullOrEmpty(replacement))
-        {
-            throw new ArgumentNullException(nameof(replacement));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(regex);
+        ArgumentException.ThrowIfNullOrEmpty(replacement);
 
         InitialMatch = new Regex(regex, RegexOptions.Compiled | RegexOptions.CultureInvariant, _regexTimeout);
         Replacement = replacement;

--- a/src/Middleware/Rewrite/src/RewriteRule.cs
+++ b/src/Middleware/Rewrite/src/RewriteRule.cs
@@ -16,15 +16,8 @@ internal sealed class RewriteRule : IRule
     public bool StopProcessing { get; }
     public RewriteRule(string regex, string replacement, bool stopProcessing)
     {
-        if (string.IsNullOrEmpty(regex))
-        {
-            throw new ArgumentNullException(nameof(regex));
-        }
-
-        if (string.IsNullOrEmpty(replacement))
-        {
-            throw new ArgumentNullException(nameof(replacement));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(regex);
+        ArgumentException.ThrowIfNullOrEmpty(replacement);
 
         InitialMatch = new Regex(regex, RegexOptions.Compiled | RegexOptions.CultureInvariant, _regexTimeout);
         Replacement = replacement;

--- a/src/Middleware/Rewrite/src/UrlActions/ChangeCookieAction.cs
+++ b/src/Middleware/Rewrite/src/UrlActions/ChangeCookieAction.cs
@@ -18,13 +18,9 @@ internal sealed class ChangeCookieAction : UrlAction
     // for testing
     internal ChangeCookieAction(string name, Func<DateTimeOffset> timeSource)
     {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
         _timeSource = timeSource;
-
-        if (string.IsNullOrEmpty(name))
-        {
-            throw new ArgumentNullException(nameof(name));
-        }
-
         Name = name;
     }
 

--- a/src/Middleware/StaticFiles/src/StaticFileContext.cs
+++ b/src/Middleware/StaticFiles/src/StaticFileContext.cs
@@ -45,7 +45,7 @@ internal struct StaticFileContext
     {
         if (subPath.Value == null)
         {
-            throw new ArgumentNullException(nameof(subPath));
+            throw new ArgumentException($"{nameof(subPath)} cannot wrap a null value.", nameof(subPath));
         }
 
         _context = context;

--- a/src/Mvc/Mvc.TagHelpers/test/GlobbingUrlBuilderTest.cs
+++ b/src/Mvc/Mvc.TagHelpers/test/GlobbingUrlBuilderTest.cs
@@ -457,7 +457,7 @@ public class GlobbingUrlBuilderTest
     {
         if (rootNode.Children == null || !rootNode.Children.Any())
         {
-            throw new ArgumentNullException(nameof(rootNode));
+            throw new ArgumentException($"{nameof(rootNode)} must have children.", nameof(rootNode));
         }
 
         var fileProvider = new Mock<IFileProvider>(MockBehavior.Strict);

--- a/src/Security/Authentication/Negotiate/src/NegotiateOptions.cs
+++ b/src/Security/Authentication/Negotiate/src/NegotiateOptions.cs
@@ -45,10 +45,7 @@ public class NegotiateOptions : AuthenticationSchemeOptions
     /// </summary>
     public void EnableLdap(string domain)
     {
-        if (string.IsNullOrEmpty(domain))
-        {
-            throw new ArgumentNullException(nameof(domain));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(domain);
 
         LdapSettings.EnableLdapClaimResolution = true;
         LdapSettings.Domain = domain;

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -1001,10 +1001,7 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
     /// The value of the cookie is: "N".</remarks>
     private void WriteNonceCookie(string nonce)
     {
-        if (string.IsNullOrEmpty(nonce))
-        {
-            throw new ArgumentNullException(nameof(nonce));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(nonce);
 
         var cookieOptions = Options.NonceCookie.Build(Context, Clock.UtcNow);
 

--- a/src/Servers/HttpSys/src/RequestProcessing/ResponseBody.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/ResponseBody.cs
@@ -581,10 +581,7 @@ internal sealed partial class ResponseBody : Stream
         // It's too expensive to validate the file attributes before opening the file. Open the file and then check the lengths.
         // This all happens inside of ResponseStreamAsyncResult.
         // TODO: Verbose log parameters
-        if (string.IsNullOrWhiteSpace(fileName))
-        {
-            throw new ArgumentNullException(nameof(fileName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(fileName);
         CheckDisposed();
 
         CheckWriteCount(count);

--- a/src/Servers/HttpSys/src/UrlPrefix.cs
+++ b/src/Servers/HttpSys/src/UrlPrefix.cs
@@ -67,10 +67,7 @@ public class UrlPrefix
             throw new ArgumentOutOfRangeException(nameof(scheme), scheme, Resources.Exception_UnsupportedScheme);
         }
 
-        if (string.IsNullOrWhiteSpace(host))
-        {
-            throw new ArgumentNullException(nameof(host));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(host);
 
         string port;
         if (!portValue.HasValue)

--- a/src/Servers/HttpSys/test/Tests/UrlPrefixTests.cs
+++ b/src/Servers/HttpSys/test/Tests/UrlPrefixTests.cs
@@ -36,7 +36,7 @@ public class UrlPrefixTests
     [InlineData("http:////:5000")]
     public void CreateThrowsForUrlsWithoutHost(string url)
     {
-        Assert.Throws<ArgumentNullException>(() => UrlPrefix.Create(url));
+        Assert.Throws<ArgumentException>(() => UrlPrefix.Create(url));
     }
 
     [Theory]

--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -84,10 +84,7 @@ public class KestrelConfigurationLoader
     /// </summary>
     public KestrelConfigurationLoader Endpoint(string name, Action<EndpointConfiguration> configureOptions)
     {
-        if (string.IsNullOrEmpty(name))
-        {
-            throw new ArgumentNullException(nameof(name));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(name);
 
         EndpointConfigurations[name] = configureOptions ?? throw new ArgumentNullException(nameof(configureOptions));
         return this;

--- a/src/Shared/TaskToApm.cs
+++ b/src/Shared/TaskToApm.cs
@@ -54,7 +54,7 @@ internal static class TaskToApm
             return task.GetAwaiter().GetResult();
         }
 
-        throw new ArgumentNullException(nameof(asyncResult));
+        throw new ArgumentException($"{nameof(asyncResult)} must be a TaskAsyncResult wrapping a {typeof(TResult).Name}.", nameof(asyncResult));
     }
 
     /// <summary>Provides a simple IAsyncResult that wraps a Task.</summary>

--- a/src/Shared/ThrowHelpers/ArgumentThrowHelper.cs
+++ b/src/Shared/ThrowHelpers/ArgumentThrowHelper.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Shared;
+
+#nullable enable
+
+internal static partial class ArgumentThrowHelper
+{
+#if !NET7_0_OR_GREATER
+    private const string EmptyString = "";
+#endif
+
+    /// <summary>Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is null or an <see cref="ArgumentException"/> if it is empty.</summary>
+    /// <param name="argument">The reference type argument to validate as neither null nor empty.</param>
+    /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
+    public static void ThrowIfNullOrEmpty([NotNull] string? argument, [CallerArgumentExpression("argument")] string? paramName = null)
+    {
+#if !NET7_0_OR_GREATER
+        if (argument is null or EmptyString)
+        {
+            ArgumentNullThrowHelper.ThrowIfNull(argument);
+            Throw(paramName);
+        }
+#else
+        ArgumentException.ThrowIfNullOrEmpty(argument, paramName);
+#endif
+    }
+
+#if !NET7_0_OR_GREATER
+    [DoesNotReturn]
+    internal static void Throw(string? paramName) =>
+        throw new ArgumentException("The value cannot be an empty string.", paramName);
+#endif
+}

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/DefaultTransportFactory.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/DefaultTransportFactory.cs
@@ -21,7 +21,7 @@ internal sealed partial class DefaultTransportFactory : ITransportFactory
     {
         if (httpClient == null && requestedTransportType != HttpTransportType.WebSockets)
         {
-            throw new ArgumentNullException(nameof(httpClient));
+            throw new ArgumentException($"{nameof(httpClient)} cannot be null when {nameof(requestedTransportType)} is not {nameof(HttpTransportType.WebSockets)}.", nameof(httpClient));
         }
 
         _requestedTransportType = requestedTransportType;

--- a/src/SignalR/common/SignalR.Common/src/Microsoft.AspNetCore.SignalR.Common.csproj
+++ b/src/SignalR/common/SignalR.Common/src/Microsoft.AspNetCore.SignalR.Common.csproj
@@ -18,6 +18,8 @@
     <Compile Include="$(SignalRSharedSourceRoot)Utf8BufferTextReader.cs" Link="Internal\Utf8BufferTextReader.cs" />
     <Compile Include="$(SignalRSharedSourceRoot)Utf8BufferTextWriter.cs" Link="Internal\Utf8BufferTextWriter.cs" />
     <Compile Include="$(SignalRSharedSourceRoot)ReusableUtf8JsonWriter.cs" Link="Internal\ReusableUtf8JsonWriter.cs" />
+    <Compile Include="$(SharedSourceRoot)ThrowHelpers\ArgumentThrowHelper.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)CallerArgument\CallerArgumentExpressionAttribute.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SignalR/common/SignalR.Common/src/Protocol/HubMethodInvocationMessage.cs
+++ b/src/SignalR/common/SignalR.Common/src/Protocol/HubMethodInvocationMessage.cs
@@ -50,7 +50,14 @@ public abstract class HubMethodInvocationMessage : HubInvocationMessage
     {
         if (string.IsNullOrEmpty(target))
         {
-            throw new ArgumentNullException(nameof(target));
+            if (target is null)
+            {
+                throw new ArgumentNullException(nameof(target));
+            }
+            else
+            {
+                throw new ArgumentException("The value cannot be an empty string.", nameof(target));
+            }
         }
 
         Target = target;

--- a/src/SignalR/common/SignalR.Common/src/Protocol/HubMethodInvocationMessage.cs
+++ b/src/SignalR/common/SignalR.Common/src/Protocol/HubMethodInvocationMessage.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.AspNetCore.SignalR.Protocol;
 
@@ -48,17 +49,7 @@ public abstract class HubMethodInvocationMessage : HubInvocationMessage
     protected HubMethodInvocationMessage(string? invocationId, string target, object?[] arguments)
         : base(invocationId)
     {
-        if (string.IsNullOrEmpty(target))
-        {
-            if (target is null)
-            {
-                throw new ArgumentNullException(nameof(target));
-            }
-            else
-            {
-                throw new ArgumentException("The value cannot be an empty string.", nameof(target));
-            }
-        }
+        ArgumentThrowHelper.ThrowIfNullOrEmpty(target);
 
         Target = target;
         Arguments = arguments;

--- a/src/SignalR/server/SignalR/test/DefaultTransportFactoryTests.cs
+++ b/src/SignalR/server/SignalR/test/DefaultTransportFactoryTests.cs
@@ -32,7 +32,7 @@ public class DefaultTransportFactoryTests
     [InlineData(HttpTransportType.ServerSentEvents | HttpTransportType.WebSockets)]
     public void DefaultTransportFactoryCannotBeCreatedWithoutHttpClient(HttpTransportType transportType)
     {
-        var exception = Assert.Throws<ArgumentNullException>(
+        var exception = Assert.Throws<ArgumentException>(
             () => new DefaultTransportFactory(transportType, new LoggerFactory(), httpClient: null, httpConnectionOptions: null, accessTokenProvider: null));
 
         Assert.Equal("httpClient", exception.ParamName);

--- a/src/SiteExtensions/Microsoft.Web.Xdt.Extensions/src/InsertOrAppendAttribute.cs
+++ b/src/SiteExtensions/Microsoft.Web.Xdt.Extensions/src/InsertOrAppendAttribute.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Xml;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.Web.XmlTransform;
 
 namespace Microsoft.Web.Xdt.Extensions;
@@ -44,17 +45,7 @@ public class InsertOrAppendAttribute : Transform
     /// <returns></returns>
     protected string GetArgumentValue(string name)
     {
-        if (string.IsNullOrEmpty(name))
-        {
-            if (name is null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-            else
-            {
-                throw new ArgumentException("The value cannot be an empty string.", nameof(name));
-            }
-        }
+        ArgumentThrowHelper.ThrowIfNullOrEmpty(name);
 
         string result = null;
         if (Arguments != null && Arguments.Count > 0)

--- a/src/SiteExtensions/Microsoft.Web.Xdt.Extensions/src/InsertOrAppendAttribute.cs
+++ b/src/SiteExtensions/Microsoft.Web.Xdt.Extensions/src/InsertOrAppendAttribute.cs
@@ -46,7 +46,14 @@ public class InsertOrAppendAttribute : Transform
     {
         if (string.IsNullOrEmpty(name))
         {
-            throw new ArgumentNullException(nameof(name));
+            if (name is null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+            else
+            {
+                throw new ArgumentException("The value cannot be an empty string.", nameof(name));
+            }
         }
 
         string result = null;

--- a/src/SiteExtensions/Microsoft.Web.Xdt.Extensions/src/Microsoft.Web.Xdt.Extensions.csproj
+++ b/src/SiteExtensions/Microsoft.Web.Xdt.Extensions/src/Microsoft.Web.Xdt.Extensions.csproj
@@ -15,4 +15,8 @@
     <PackageReference Include="Microsoft.Web.Xdt" Version="1.4.0" AllowExplicitReference="true" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="$(SharedSourceRoot)ThrowHelpers\ArgumentThrowHelper.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)CallerArgument\CallerArgumentExpressionAttribute.cs" LinkBase="Shared" />
+  </ItemGroup>
 </Project>

--- a/src/Testing/src/Microsoft.AspNetCore.Testing.csproj
+++ b/src/Testing/src/Microsoft.AspNetCore.Testing.csproj
@@ -61,6 +61,7 @@
       <PackagePath>contentFiles\cs\netstandard2.0\</PackagePath>
     </Content>
     <Compile Include="$(SharedSourceRoot)TaskExtensions.cs" LinkBase="Shared\TaskExtensions.cs" />
+    <Compile Include="$(SharedSourceRoot)ThrowHelpers\ArgumentThrowHelper.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)ThrowHelpers\ArgumentNullThrowHelper.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)CallerArgument\CallerArgumentExpressionAttribute.cs" LinkBase="Shared" />
   </ItemGroup>

--- a/src/Testing/src/xunit/SkipOnHelixAttribute.cs
+++ b/src/Testing/src/xunit/SkipOnHelixAttribute.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.AspNetCore.Testing;
 
@@ -14,10 +15,7 @@ public class SkipOnHelixAttribute : Attribute, ITestCondition
 {
     public SkipOnHelixAttribute(string issueUrl)
     {
-        if (string.IsNullOrEmpty(issueUrl))
-        {
-            throw new ArgumentNullException(nameof(issueUrl));
-        }
+        ArgumentThrowHelper.ThrowIfNullOrEmpty(issueUrl);
         IssueUrl = issueUrl;
     }
 


### PR DESCRIPTION
# Change incorrect usage of ArgumentNullException

## Description

Change some thrown exceptions from ArgumentNullException to ArgumentException.
Specifically also when it was thrown, if the argument was the empty string.

Fixes #23671
