### PR TITLE
Workaround for ASP.NET composite image per #84860

### DIFF
--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -503,13 +503,20 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     </ReadLinesFromFile>
 
     <ItemGroup>
+      <!-- Temporary workaround tracked by https://github.com/dotnet/runtime/issues/84860 -->
+      <ExcludeAssemblies Include="$(TargetDir)\Microsoft.Extensions.Logging.Abstractions.dll" />
+
       <BaseAssemblies Include="$(ManagedAssetsFullPath)\*.dll" />
       <BaseAssemblies Include="$(TargetDir)\*.dll" />
+
       <PartialCompositeAssemblyPaths Include="$(ManagedAssetsFullPath)\%(PartialCompositeAssemblyNames.Identity).dll" />
       <PartialCompositeAssemblyPaths Include="$(TargetDir)\%(PartialCompositeAssemblyNames.Identity).dll" />
       <PartialCompositeAssemblyPaths Remove="%(PartialCompositeAssemblyPaths.Identity)" Condition="!Exists('%(Identity)')" />
+      <PartialCompositeAssemblyPaths Remove="@(ExcludeAssemblies)" />
+
       <UnrootedAssemblyPaths Include="@(BaseAssemblies)" />
       <UnrootedAssemblyPaths Remove="@(PartialCompositeAssemblyPaths)" />
+      <UnrootedAssemblyPaths Remove="@(ExcludeAssemblies)" />
     </ItemGroup>
 
     <WriteLinesToFile File="$(CompositeResponseFile)" Lines="--composite" Overwrite="true" />
@@ -517,6 +524,7 @@ This package is an internal implementation of the .NET Core SDK and is not meant
     <WriteLinesToFile File="$(CompositeResponseFile)" Lines="--targetos:$(Crossgen2TargetOs)" Overwrite="false" />
     <WriteLinesToFile File="$(CompositeResponseFile)" Lines="-u:&quot;%(UnrootedAssemblyPaths.Identity)&quot;" Overwrite="false" />
     <WriteLinesToFile File="$(CompositeResponseFile)" Lines="&quot;%(PartialCompositeAssemblyPaths.Identity)&quot;" Overwrite="false" />
+    <WriteLinesToFile File="$(CompositeResponseFile)" Lines="-r:&quot;%(ExcludeAssemblies.Identity)&quot;" Overwrite="false" Condition="'@(ExcludeAssemblies)' != ''" />
     <WriteLinesToFile File="$(CompositeResponseFile)" Lines="--out:&quot;$(CompositeTargetDir)$(CompositeFileName).dll&quot;" Overwrite="false" />
     <WriteLinesToFile File="$(CompositeResponseFile)" Lines="--instruction-set:$(InstructionSetSupport)" Overwrite="false" Condition="'$(InstructionSetSupport)' != ''" />
     <WriteLinesToFile File="$(CompositeResponseFile)" Lines="-m:&quot;$(CrossgenOptimizationData)&quot;" Overwrite="false" Condition="'$(CrossgenOptimizationData)' != ''" />

--- a/src/Framework/App.Runtime/src/PartialCompositeAssemblyList.txt
+++ b/src/Framework/App.Runtime/src/PartialCompositeAssemblyList.txt
@@ -30,7 +30,6 @@ Microsoft.AspNetCore.Server.Kestrel
 Microsoft.AspNetCore.Server.Kestrel.Transport.Quic
 System.Net.Quic
 System.Diagnostics.Tracing
-Microsoft.Extensions.Logging.Abstractions
 Microsoft.Extensions.Features
 Microsoft.AspNetCore.Http.Abstractions
 Microsoft.AspNetCore.Http


### PR DESCRIPTION
In our work on enabling composite Docker containers on Linux we hit a problem caused by the fact that the SDK uses and publishes its own version of the managed assembly

Microsoft.Extensions.Logging.Abstractions

clashing with the version of the assembly in the composite image. As we're doing our best for publishing the Docker container in Preview 4, I propose merging in this simple workaround as a stopgap change; I have created a tracking issue for fixing this cleanly by fixing SDK to start using the version of the assembly from the aspnetcore repo instead of using its own copy.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 