### PR TITLE
 Replace lock with CAS

### DIFF
--- a/src/Caching/SqlServer/src/SqlServerCache.cs
+++ b/src/Caching/SqlServer/src/SqlServerCache.cs
@@ -185,7 +185,7 @@ public class SqlServerCache : IDistributedCache
     private void ScanForExpiredItemsIfRequired()
     {
         long ticks = _systemClock.UtcNow.UtcTicks;
-        long lastExpirationScanTicks = _lastExpirationScanTicks;
+        long lastExpirationScanTicks = Volatile.Read(ref _lastExpirationScanTicks);
         if ((ticks - lastExpirationScanTicks) > _expiredItemsDeletionIntervalTicks)
         {
             if (Interlocked.CompareExchange(ref _lastExpirationScanTicks, ticks, lastExpirationScanTicks) == lastExpirationScanTicks)


### PR DESCRIPTION
I'm just wondering if it would be more efficient and appropriate to use CAS instead of lock. `DefaultExpiredItemsDeletionInterval` is equal to 20 minutes. During this time, every method call (`Get`, `Set`, `Refresh`) will try to acquire a lock to check if it's time to scan for expired items.