### PR TITLE
Add exception to problem details context

### DIFF
--- a/src/Http/Http.Abstractions/src/ProblemDetails/ProblemDetailsContext.cs
+++ b/src/Http/Http.Abstractions/src/ProblemDetails/ProblemDetailsContext.cs
@@ -31,4 +31,9 @@ public sealed class ProblemDetailsContext
         get => _problemDetails ??= new ProblemDetails();
         init => _problemDetails = value;
     }
+
+    /// <summary>
+    /// The exception causing the problem or <c>null</c> if no exception information is available.
+    /// </summary>
+    public Exception? Exception { get; init; }
 }

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -8,6 +8,8 @@ Microsoft.AspNetCore.Http.HttpValidationProblemDetails.Errors.set -> void
 Microsoft.AspNetCore.Http.IProblemDetailsService.TryWriteAsync(Microsoft.AspNetCore.Http.ProblemDetailsContext! context) -> System.Threading.Tasks.ValueTask<bool>
 Microsoft.AspNetCore.Http.Metadata.IRouteDiagnosticsMetadata
 Microsoft.AspNetCore.Http.Metadata.IRouteDiagnosticsMetadata.Route.get -> string!
+Microsoft.AspNetCore.Http.ProblemDetailsContext.Exception.get -> System.Exception?
+Microsoft.AspNetCore.Http.ProblemDetailsContext.Exception.init -> void
 Microsoft.AspNetCore.Mvc.ProblemDetails.Extensions.set -> void
 static Microsoft.AspNetCore.Http.EndpointFilterInvocationContext.Create(Microsoft.AspNetCore.Http.HttpContext! httpContext) -> Microsoft.AspNetCore.Http.EndpointFilterInvocationContext!
 static Microsoft.AspNetCore.Http.EndpointFilterInvocationContext.Create<T1, T2, T3, T4, T5, T6, T7, T8>(Microsoft.AspNetCore.Http.HttpContext! httpContext, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) -> Microsoft.AspNetCore.Http.EndpointFilterInvocationContext!

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddlewareImpl.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddlewareImpl.cs
@@ -206,7 +206,11 @@ internal class DeveloperExceptionPageMiddlewareImpl
         }
 
         if (_problemDetailsService == null || !await _problemDetailsService.TryWriteAsync(new()
-            { HttpContext = httpContext, ProblemDetails = CreateProblemDetails(errorContext, httpContext), Exception = errorContext.Exception }))
+            {
+                HttpContext = httpContext,
+                ProblemDetails = CreateProblemDetails(errorContext, httpContext), 
+                Exception = errorContext.Exception 
+            }))
         {
             httpContext.Response.ContentType = "text/plain; charset=utf-8";
 

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddlewareImpl.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddlewareImpl.cs
@@ -205,8 +205,8 @@ internal class DeveloperExceptionPageMiddlewareImpl
             SetExceptionHandlerFeatures(errorContext);
         }
 
-        if (_problemDetailsService == null ||
-            !await _problemDetailsService.TryWriteAsync(new() { HttpContext = httpContext, ProblemDetails = CreateProblemDetails(errorContext, httpContext) }))
+        if (_problemDetailsService == null || !await _problemDetailsService.TryWriteAsync(new()
+            { HttpContext = httpContext, ProblemDetails = CreateProblemDetails(errorContext, httpContext), Exception = errorContext.Exception }))
         {
             httpContext.Response.ContentType = "text/plain; charset=utf-8";
 

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddlewareImpl.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddlewareImpl.cs
@@ -166,7 +166,8 @@ internal class ExceptionHandlerMiddlewareImpl
                 {
                     HttpContext = context,
                     AdditionalMetadata = exceptionHandlerFeature.Endpoint?.Metadata,
-                    ProblemDetails = { Status = DefaultStatusCode }
+                    ProblemDetails = { Status = DefaultStatusCode },
+                    Exception = edi.SourceException,
                 });
             }
 


### PR DESCRIPTION
# Add exception to problem details context

Adds an exception property to the problem details context. The exception is set in the developer exception page and exception handler middlewares.

Fixes #47651
