### PR TITLE
Fix null property name handling logic in SystemTextJsonValidationMetadataProvider

### DIFF
--- a/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/SystemTextJsonValidationMetadataProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/SystemTextJsonValidationMetadataProvider.cs
@@ -57,7 +57,7 @@ public sealed class SystemTextJsonValidationMetadataProvider : IDisplayMetadataP
 
         if (!string.IsNullOrEmpty(propertyName))
         {
-            propertyName = _jsonNamingPolicy.ConvertName(context.Key.Name);
+            propertyName = _jsonNamingPolicy.ConvertName(context.Key.Name!);
         }
 
         context.ValidationMetadata.ValidationModelName = propertyName;

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/SystemTextJsonValidationMetadataProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/SystemTextJsonValidationMetadataProvider.cs
@@ -55,9 +55,9 @@ public sealed class SystemTextJsonValidationMetadataProvider : IDisplayMetadataP
 
         var propertyName = ReadPropertyNameFrom(context.Attributes);
 
-        if (string.IsNullOrEmpty(propertyName))
+        if (!string.IsNullOrEmpty(propertyName))
         {
-            propertyName = _jsonNamingPolicy.ConvertName(context.Key.Name!);
+            propertyName = _jsonNamingPolicy.ConvertName(context.Key.Name);
         }
 
         context.ValidationMetadata.ValidationModelName = propertyName;

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/SystemTextJsonValidationMetadataProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/SystemTextJsonValidationMetadataProvider.cs
@@ -55,9 +55,9 @@ public sealed class SystemTextJsonValidationMetadataProvider : IDisplayMetadataP
 
         var propertyName = ReadPropertyNameFrom(context.Attributes);
 
-        if (!string.IsNullOrEmpty(propertyName))
+        if (string.IsNullOrEmpty(propertyName) && context.Key.Name is { } contextKeyName)
         {
-            propertyName = _jsonNamingPolicy.ConvertName(context.Key.Name!);
+            propertyName = _jsonNamingPolicy.ConvertName(contextKeyName);
         }
 
         context.ValidationMetadata.ValidationModelName = propertyName;

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/SystemTextJsonValidationMetadataProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/SystemTextJsonValidationMetadataProvider.cs
@@ -57,7 +57,7 @@ public sealed class SystemTextJsonValidationMetadataProvider : IDisplayMetadataP
 
         if (string.IsNullOrEmpty(propertyName))
         {
-            propertyName = context.Key.Name is { } contextKeyName
+            propertyName = context.Key.Name is string contextKeyName
                 ? _jsonNamingPolicy.ConvertName(contextKeyName)
                 : null;
         }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/SystemTextJsonValidationMetadataProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Metadata/SystemTextJsonValidationMetadataProvider.cs
@@ -55,9 +55,11 @@ public sealed class SystemTextJsonValidationMetadataProvider : IDisplayMetadataP
 
         var propertyName = ReadPropertyNameFrom(context.Attributes);
 
-        if (string.IsNullOrEmpty(propertyName) && context.Key.Name is { } contextKeyName)
+        if (string.IsNullOrEmpty(propertyName))
         {
-            propertyName = _jsonNamingPolicy.ConvertName(contextKeyName);
+            propertyName = context.Key.Name is { } contextKeyName
+                ? _jsonNamingPolicy.ConvertName(contextKeyName)
+                : null;
         }
 
         context.ValidationMetadata.ValidationModelName = propertyName;

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Metadata/SystemTextJsonValidationMetadataProviderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Metadata/SystemTextJsonValidationMetadataProviderTest.cs
@@ -44,6 +44,22 @@ public class SystemTextJsonValidationMetadataProviderTest
         Assert.Equal(JsonNamingPolicy.CamelCase.ConvertName(propertyName), context.ValidationMetadata.ValidationModelName);
     }
 
+    [Fact]
+    // Test for https://github.com/dotnet/aspnetcore/issues/47835
+    public void CreateValidationMetadata_SetValidationPropertyName_WithNullKeyName()
+    {
+        var metadataProvider = new SystemTextJsonValidationMetadataProvider(JsonNamingPolicy.SnakeCaseLower);
+        var key = ModelMetadataIdentity.ForType(typeof(SampleTestClass));
+        var modelAttributes = new ModelAttributes(Array.Empty<object>(), Array.Empty<object>(), Array.Empty<object>());
+        var context = new ValidationMetadataProviderContext(key, modelAttributes);
+
+        // Act
+        metadataProvider.CreateValidationMetadata(context);
+
+        // Assert
+        Assert.Null(context.ValidationMetadata.ValidationModelName);
+    }
+
     [Theory]
     [MemberData(nameof(NamingPolicies))]
     public void CreateValidationMetadata_SetValidationPropertyName_WithJsonNamingPolicy(JsonNamingPolicy namingPolicy)


### PR DESCRIPTION
Fixing what appears to be a negation bug causing null names to be passed to the underlying `JsonNamingPolicy`.

cf. https://github.com/dotnet/runtime/pull/85002#discussion_r1171340713

Fix https://github.com/dotnet/aspnetcore/issues/47835
