### PR TITLE
http.sys; add opt-in support for kernel-mode response buffering

### DIFF
--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -121,7 +121,7 @@ public class HttpSysOptions
     /// Applications that use asynchronous I/O and that may have more than one send outstanding at a time should not use this flag.
     /// Enabling this can results in higher CPU and memory usage by Http.Sys.
     /// </summary>
-    public bool EnableKernelResponseBuffering { get; set; } // internal via app-context for non-public release
+    public bool EnableKernelResponseBuffering { get; set; }
 
     /// <summary>
     /// Gets or sets the maximum number of concurrent connections to accept. Set `-1` for infinite.

--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -34,6 +34,10 @@ public class HttpSysOptions
     /// </summary>
     public HttpSysOptions()
     {
+        // this feature is being back-ported to net6/net7 via an app-context switch; respect that even on net8+ to avoid
+        // surprises when upgrading TFMs
+        const string EnableKernelResponseBufferingSwitch = "Microsoft.AspNetCore.Server.HttpSys.EnableKernelResponseBuffering";
+        EnableKernelResponseBuffering = AppContext.TryGetSwitch(EnableKernelResponseBufferingSwitch, out var enabled) && enabled;
     }
 
     /// <summary>
@@ -109,6 +113,15 @@ public class HttpSysOptions
     /// The default is `false` (complete normally).
     /// </summary>
     public bool ThrowWriteExceptions { get; set; }
+
+    /// <summary>
+    /// Enable buffering of response data in the Kernel.
+    /// It should be used by an application doing synchronous I/O or by an application doing asynchronous I/O with
+    /// no more than one outstanding write at a time, and can significantly improve throughput over high-latency connections.
+    /// Applications that use asynchronous I/O and that may have more than one send outstanding at a time should not use this flag.
+    /// Enabling this can results in higher CPU and memory usage by Http.Sys.
+    /// </summary>
+    public bool EnableKernelResponseBuffering { get; set; } // internal via app-context for non-public release
 
     /// <summary>
     /// Gets or sets the maximum number of concurrent connections to accept. Set `-1` for infinite.

--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -34,10 +34,6 @@ public class HttpSysOptions
     /// </summary>
     public HttpSysOptions()
     {
-        // this feature is being back-ported to net6/net7 via an app-context switch; respect that even on net8+ to avoid
-        // surprises when upgrading TFMs
-        const string EnableKernelResponseBufferingSwitch = "Microsoft.AspNetCore.Server.HttpSys.EnableKernelResponseBuffering";
-        EnableKernelResponseBuffering = AppContext.TryGetSwitch(EnableKernelResponseBufferingSwitch, out var enabled) && enabled;
     }
 
     /// <summary>
@@ -115,7 +111,7 @@ public class HttpSysOptions
     public bool ThrowWriteExceptions { get; set; }
 
     /// <summary>
-    /// Enable buffering of response data in the Kernel.
+    /// Enable buffering of response data in the Kernel. The default value is <code>false</code>.
     /// It should be used by an application doing synchronous I/O or by an application doing asynchronous I/O with
     /// no more than one outstanding write at a time, and can significantly improve throughput over high-latency connections.
     /// Applications that use asynchronous I/O and that may have more than one send outstanding at a time should not use this flag.

--- a/src/Servers/HttpSys/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/HttpSys/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.AspNetCore.Server.HttpSys.HttpSysOptions.EnableKernelResponseBuffering.get -> bool
+Microsoft.AspNetCore.Server.HttpSys.HttpSysOptions.EnableKernelResponseBuffering.set -> void
 Microsoft.AspNetCore.Server.HttpSys.HttpSysRequestTimingType
 Microsoft.AspNetCore.Server.HttpSys.HttpSysRequestTimingType.ConnectionStart = 0 -> Microsoft.AspNetCore.Server.HttpSys.HttpSysRequestTimingType
 Microsoft.AspNetCore.Server.HttpSys.HttpSysRequestTimingType.DataStart = 1 -> Microsoft.AspNetCore.Server.HttpSys.HttpSysRequestTimingType

--- a/src/Servers/HttpSys/src/RequestProcessing/Response.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Response.cs
@@ -275,8 +275,6 @@ internal sealed class Response
     // This will give us more control of the bytes that hit the wire, including encodings, HTTP 1.0, etc..
     // It may also be faster to do this work in managed code and then pass down only one buffer.
     // What would we loose by bypassing HttpSendHttpResponse?
-    //
-    // TODO: Consider using the HTTP_SEND_RESPONSE_FLAG_BUFFER_DATA flag for most/all responses rather than just Opaque.
     internal unsafe uint SendHeaders(ref UnmanagedBufferAllocator allocator,
         Span<HttpApiTypes.HTTP_DATA_CHUNK> dataChunks,
         ResponseStreamAsyncResult? asyncResult,


### PR DESCRIPTION
# http.sys; add opt-in support for kernel-mode response buffering

Adds support in for buffered responses when using http.sys, to avoid performance problems in small-write/high-latency scenarios.

## Description

As per linked issue, when using http.sys, in some scenarios, high volumes of small writes with high latency may cause significant performance impact, due to lack of a `Pipe` buffer in the http.sys implementation; as a simple workaround, here we optionally enable the http.sys support for response buffering as a global flag.

This is exposed by a new `HttpSysOptions.EnableKernelResponseBuffering` option.

This work is based on the very old (and not mergeable) work in [#418](https://github.com/aspnet/HttpSysServer/pull/418), with some additional input - credit to @davidni 

It is also planned to back-port this feature to net6/net7 (with the property `internal` - no change to public API), via an app-context switch `"Microsoft.AspNetCore.Server.HttpSys.EnableKernelResponseBuffering"`; <strike>this switch detection is retained in the default value to avoid issues for consumers when upgrading.</strike>

We have briefly discussed some new feature to allow per-request enable/disable, but have not implemented that at the current time. We can revisit that in the future.

Also considered: implementing a full `Pipe` implementation in the http.sys code with the pipe consumer writing to http.sys; attempting to minimise code impact until we have a definite demand for that.

Fixes #14455

Fixes [#5852](https://github.com/dotnet/aspnetcore/issues/5852)

Impact is hard to benchmark in a local network - latency is key; however, the change has been successfully validated internally via a private build. Ask me for details if you're curious. As a summary of the validation scenario - a large payload streaming operation that reads (proxies) an external request and mirrors that to response writes:

- without this change: takes over 3 minutes and eventually fails (not having transferred all the information)
- with this change: completes successfully in 8-10 seconds