### PR TITLE
Fix nullref when getting struct from feature collection and it isn't present

### DIFF
--- a/src/Extensions/Features/src/FeatureCollection.cs
+++ b/src/Extensions/Features/src/FeatureCollection.cs
@@ -117,6 +117,15 @@ public class FeatureCollection : IFeatureCollection
     /// <inheritdoc />
     public TFeature? Get<TFeature>()
     {
+        if (typeof(TFeature).IsValueType)
+        {
+            var feature = this[typeof(TFeature)];
+            if (feature is null && Nullable.GetUnderlyingType(typeof(TFeature)) == null)
+            {
+                throw new InvalidOperationException();
+            }
+            return (TFeature?)feature;
+        }
         return (TFeature?)this[typeof(TFeature)];
     }
 

--- a/src/Extensions/Features/src/FeatureCollection.cs
+++ b/src/Extensions/Features/src/FeatureCollection.cs
@@ -122,8 +122,9 @@ public class FeatureCollection : IFeatureCollection
             var feature = this[typeof(TFeature)];
             if (feature is null && Nullable.GetUnderlyingType(typeof(TFeature)) is null)
             {
-                throw new InvalidOperationException($"{typeof(TFeature).FullName} does not exist in the feature collection " +
-                $"and because it is a struct we can't return null. Use 'featureCollection[typeof({typeof(TFeature).FullName})] is not null' to check if it exists.");
+                throw new InvalidOperationException(
+                    $"{typeof(TFeature).FullName} does not exist in the feature collection " +
+                    $"and because it is a struct the method can't return null. Use 'featureCollection[typeof({typeof(TFeature).FullName})] is not null' to check if the feature exists.");
             }
             return (TFeature?)feature;
         }

--- a/src/Extensions/Features/src/FeatureCollection.cs
+++ b/src/Extensions/Features/src/FeatureCollection.cs
@@ -120,9 +120,10 @@ public class FeatureCollection : IFeatureCollection
         if (typeof(TFeature).IsValueType)
         {
             var feature = this[typeof(TFeature)];
-            if (feature is null && Nullable.GetUnderlyingType(typeof(TFeature)) == null)
+            if (feature is null && Nullable.GetUnderlyingType(typeof(TFeature)) is null)
             {
-                throw new InvalidOperationException();
+                throw new InvalidOperationException($"{typeof(TFeature).FullName} does not exist in the feature collection " +
+                $"and because it is a struct we can't return null. Use 'featureCollection[typeof({typeof(TFeature).FullName})] is not null' to check if it exists.");
             }
             return (TFeature?)feature;
         }

--- a/src/Extensions/Features/test/FeatureCollectionTests.cs
+++ b/src/Extensions/Features/test/FeatureCollectionTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Http.Features;
@@ -43,5 +44,62 @@ public class FeatureCollectionTests
 
         var thing2 = interfaces[typeof(IThing)];
         Assert.Null(thing2);
+    }
+
+    [Fact]
+    public void GetMissingStructFeatureThrows()
+    {
+        var interfaces = new FeatureCollection();
+
+        // Regression test: Used to throw NullReferenceException because it tried to unbox a null object to a struct
+        Assert.Throws<InvalidOperationException>(() => interfaces.Get<int>());
+    }
+
+    [Fact]
+    public void GetMissingFeatureReturnsNull()
+    {
+        var interfaces = new FeatureCollection();
+
+        Assert.Null(interfaces.Get<Thing>());
+    }
+
+    [Fact]
+    public void GetStructFeature()
+    {
+        var interfaces = new FeatureCollection();
+        var value = 20;
+        interfaces.Set(value);
+
+        Assert.Equal(value, interfaces.Get<int>());
+    }
+
+    [Fact]
+    public void GetNullableStructFeatureWhenSetWithNonNullableStruct()
+    {
+        var interfaces = new FeatureCollection();
+        var value = 20;
+        interfaces.Set(value);
+
+        Assert.Null(interfaces.Get<int?>());
+    }
+
+    [Fact]
+    public void GetNullableStructFeatureWhenSetWithNullableStruct()
+    {
+        var interfaces = new FeatureCollection();
+        var value = 20;
+        interfaces.Set<int?>(value);
+
+        Assert.Equal(value, interfaces.Get<int?>());
+    }
+
+    [Fact]
+    public void GetFeature()
+    {
+        var interfaces = new FeatureCollection();
+        var thing = new Thing();
+        interfaces.Set(thing);
+
+        Assert.Equal(thing, interfaces.Get<Thing>());
     }
 }

--- a/src/Extensions/Features/test/FeatureCollectionTests.cs
+++ b/src/Extensions/Features/test/FeatureCollectionTests.cs
@@ -52,7 +52,8 @@ public class FeatureCollectionTests
         var interfaces = new FeatureCollection();
 
         // Regression test: Used to throw NullReferenceException because it tried to unbox a null object to a struct
-        Assert.Throws<InvalidOperationException>(() => interfaces.Get<int>());
+        var ex = Assert.Throws<InvalidOperationException>(() => interfaces.Get<int>());
+        Assert.Equal("System.Int32 does not exist in the feature collection and because it is a struct we can't return null. Use 'featureCollection[typeof(System.Int32)] is not null' to check if it exists.", ex.Message);
     }
 
     [Fact]

--- a/src/Extensions/Features/test/FeatureCollectionTests.cs
+++ b/src/Extensions/Features/test/FeatureCollectionTests.cs
@@ -53,7 +53,7 @@ public class FeatureCollectionTests
 
         // Regression test: Used to throw NullReferenceException because it tried to unbox a null object to a struct
         var ex = Assert.Throws<InvalidOperationException>(() => interfaces.Get<int>());
-        Assert.Equal("System.Int32 does not exist in the feature collection and because it is a struct we can't return null. Use 'featureCollection[typeof(System.Int32)] is not null' to check if it exists.", ex.Message);
+        Assert.Equal("System.Int32 does not exist in the feature collection and because it is a struct the method can't return null. Use 'featureCollection[typeof(System.Int32)] is not null' to check if the feature exists.", ex.Message);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/46939

I believe `if (typeof(TFeature).IsValueType)` is intrinsic which should mean the JIT will optimize this like crazy and be a noop in the common class case. Did a quick microbenchmark to check and it showed no difference.