### PR TITLE
Add default configuration and logging to CreateSlimBuilder

### DIFF
--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Reflection;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
@@ -111,7 +112,8 @@ public sealed class WebApplicationBuilder
         });
 
         // Ensure the same behavior of the non-slim WebApplicationBuilder by adding the default "app" Configuration sources
-        ApplyDefaultAppConfiguration(options, configuration);
+        ApplyDefaultAppConfigurationSlim(_hostApplicationBuilder.Environment, configuration, options.Args);
+        AddDefaultServicesSlim(configuration, _hostApplicationBuilder.Services);
 
         // configure the ServiceProviderOptions here since CreateEmptyApplicationBuilder won't.
         var serviceProviderFactory = GetServiceProviderFactory(_hostApplicationBuilder);
@@ -204,14 +206,66 @@ public sealed class WebApplicationBuilder
         }
     }
 
-    private static void ApplyDefaultAppConfiguration(WebApplicationOptions options, ConfigurationManager configuration)
+    private static void ApplyDefaultAppConfigurationSlim(IHostEnvironment env, ConfigurationManager configuration, string[]? args)
     {
+        // Logic taken from https://github.com/dotnet/runtime/blob/6149ca07d2202c2d0d518e10568c0d0dd3473576/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs#L229-L256
+
+        var reloadOnChange = GetReloadConfigOnChangeValue(configuration);
+
+        configuration.AddJsonFile("appsettings.json", optional: true, reloadOnChange: reloadOnChange)
+            .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: reloadOnChange);
+
+        if (env.IsDevelopment() && env.ApplicationName is { Length: > 0 })
+        {
+            try
+            {
+                var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
+                configuration.AddUserSecrets(appAssembly, optional: true, reloadOnChange: reloadOnChange);
+            }
+            catch (FileNotFoundException)
+            {
+                // The assembly cannot be found, so just skip it.
+            }
+        }
+
         configuration.AddEnvironmentVariables();
 
-        if (options.Args is { Length: > 0 } args)
+        if (args is { Length: > 0 })
         {
             configuration.AddCommandLine(args);
         }
+
+        static bool GetReloadConfigOnChangeValue(ConfigurationManager configuration)
+        {
+            const string reloadConfigOnChangeKey = "hostBuilder:reloadConfigOnChange";
+            var result = true;
+            if (configuration[reloadConfigOnChangeKey] is string reloadConfigOnChange)
+            {
+                if (!bool.TryParse(reloadConfigOnChange, out result))
+                {
+                    throw new InvalidOperationException($"Failed to convert configuration value at '{configuration.GetSection(reloadConfigOnChangeKey).Path}' to type '{typeof(bool)}'.");
+                }
+            }
+            return result;
+        }
+    }
+
+    private static void AddDefaultServicesSlim(ConfigurationManager configuration, IServiceCollection services)
+    {
+        // Add the necessary services for the slim WebApplicationBuilder, taken from https://github.com/dotnet/runtime/blob/6149ca07d2202c2d0d518e10568c0d0dd3473576/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs#L266
+        services.AddLogging(logging =>
+        {
+            logging.AddConfiguration(configuration.GetSection("Logging"));
+            logging.AddSimpleConsole();
+
+            logging.Configure(options =>
+            {
+                options.ActivityTrackingOptions =
+                    ActivityTrackingOptions.SpanId |
+                    ActivityTrackingOptions.TraceId |
+                    ActivityTrackingOptions.ParentId;
+            });
+        });
     }
 
     /// <summary>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/Program.Main.cs
@@ -9,7 +9,6 @@ public class Program
     public static void Main(string[] args)
     {
         var builder = WebApplication.CreateSlimBuilder(args);
-        builder.Logging.AddConsole();
 
         #if (NativeAot)
         builder.Services.ConfigureHttpJsonOptions(options =>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/Program.cs
@@ -4,7 +4,6 @@ using System.Text.Json.Serialization;
 using Company.ApiApplication1;
 
 var builder = WebApplication.CreateSlimBuilder(args);
-builder.Logging.AddConsole();
 
 #if (NativeAot)
 builder.Services.ConfigureHttpJsonOptions(options =>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/appsettings.Development.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/appsettings.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/ProjectTemplates/test/Templates.Tests/template-baselines.json
+++ b/src/ProjectTemplates/test/Templates.Tests/template-baselines.json
@@ -532,6 +532,8 @@
       "Template": "api",
       "Arguments": "new api",
       "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
         "Todo.cs",
         "Program.cs",
         "{ProjectName}.http",
@@ -543,6 +545,8 @@
       "Template": "api",
       "Arguments": "new api -aot",
       "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
         "Todo.cs",
         "Program.cs",
         "{ProjectName}.http",
@@ -554,6 +558,8 @@
       "Template": "api",
       "Arguments": "new api --use-program-main",
       "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
         "Todo.cs",
         "Program.cs",
         "{ProjectName}.http",
@@ -565,6 +571,8 @@
       "Template": "api",
       "Arguments": "new api -aot --use-program-main",
       "Files": [
+        "appsettings.Development.json",
+        "appsettings.json",
         "Todo.cs",
         "Program.cs",
         "{ProjectName}.http",


### PR DESCRIPTION
# Add default configuration and logging to CreateSlimBuilder

Update slim builder to include:
- JSON file configuration for appsettings.json and appsettings.{EnvironmentName}.json
- UserSecrets configuration
- Console logging
- Logging configuration

This adds back some app size to the api template app. But it is worth the tradeoff given users expect these things to work out of the box.

Update api template with appsettings files and remove AddConsole

Fix #47598
