### PR TITLE
Write log message for matched fallback routes

### DIFF
--- a/src/Http/Routing/src/Builder/FallbackEndpointRouteBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/FallbackEndpointRouteBuilderExtensions.cs
@@ -77,6 +77,7 @@ public static class FallbackEndpointRouteBuilderExtensions
         var conventionBuilder = endpoints.Map(pattern, requestDelegate);
         conventionBuilder.WithDisplayName("Fallback " + pattern);
         conventionBuilder.Add(b => ((RouteEndpointBuilder)b).Order = int.MaxValue);
+        conventionBuilder.WithMetadata(FallbackMetadata.Instance);
         return conventionBuilder;
     }
 }

--- a/src/Http/Routing/src/EndpointRoutingMiddleware.cs
+++ b/src/Http/Routing/src/EndpointRoutingMiddleware.cs
@@ -109,6 +109,14 @@ internal sealed partial class EndpointRoutingMiddleware
 
             Log.MatchSuccess(_logger, endpoint);
 
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                if (endpoint.Metadata.GetMetadata<FallbackMetadata>() is not null)
+                {
+                    Log.FallbackMatch(_logger, endpoint);
+                }
+            }
+
             var shortCircuitMetadata = endpoint.Metadata.GetMetadata<ShortCircuitMetadata>();
             if (shortCircuitMetadata is not null)
             {
@@ -283,5 +291,8 @@ internal sealed partial class EndpointRoutingMiddleware
 
         [LoggerMessage(6, LogLevel.Information, "The endpoint '{EndpointName}' is being short circuited without running additional middleware or producing a response.", EventName = "ShortCircuitedEndpoint")]
         public static partial void ShortCircuitedEndpoint(ILogger logger, Endpoint endpointName);
+
+        [LoggerMessage(7, LogLevel.Information, "Matched endpoint '{EndpointName}' is a fallback endpoint.", EventName = "FallbackMatch", SkipEnabledCheck = true)]
+        public static partial void FallbackMatch(ILogger logger, Endpoint endpointName);
     }
 }

--- a/src/Http/Routing/src/EndpointRoutingMiddleware.cs
+++ b/src/Http/Routing/src/EndpointRoutingMiddleware.cs
@@ -109,12 +109,10 @@ internal sealed partial class EndpointRoutingMiddleware
 
             Log.MatchSuccess(_logger, endpoint);
 
-            if (_logger.IsEnabled(LogLevel.Information))
+            if (_logger.IsEnabled(LogLevel.Debug)
+                && endpoint.Metadata.GetMetadata<FallbackMetadata>() is not null)
             {
-                if (endpoint.Metadata.GetMetadata<FallbackMetadata>() is not null)
-                {
-                    Log.FallbackMatch(_logger, endpoint);
-                }
+                Log.FallbackMatch(_logger, endpoint);
             }
 
             var shortCircuitMetadata = endpoint.Metadata.GetMetadata<ShortCircuitMetadata>();
@@ -292,7 +290,7 @@ internal sealed partial class EndpointRoutingMiddleware
         [LoggerMessage(6, LogLevel.Information, "The endpoint '{EndpointName}' is being short circuited without running additional middleware or producing a response.", EventName = "ShortCircuitedEndpoint")]
         public static partial void ShortCircuitedEndpoint(ILogger logger, Endpoint endpointName);
 
-        [LoggerMessage(7, LogLevel.Information, "Matched endpoint '{EndpointName}' is a fallback endpoint.", EventName = "FallbackMatch", SkipEnabledCheck = true)]
+        [LoggerMessage(7, LogLevel.Debug, "Matched endpoint '{EndpointName}' is a fallback endpoint.", EventName = "FallbackMatch", SkipEnabledCheck = true)]
         public static partial void FallbackMatch(ILogger logger, Endpoint endpointName);
     }
 }

--- a/src/Http/Routing/src/FallbackMetadata.cs
+++ b/src/Http/Routing/src/FallbackMetadata.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Routing;
+
+internal sealed class FallbackMetadata
+{
+    public static readonly FallbackMetadata Instance = new FallbackMetadata();
+
+    private FallbackMetadata()
+    {
+    }
+}

--- a/src/Http/Routing/src/RouteEndpointDataSource.cs
+++ b/src/Http/Routing/src/RouteEndpointDataSource.cs
@@ -127,7 +127,7 @@ internal sealed class RouteEndpointDataSource : EndpointDataSource
         // The Map methods don't support customizing the order apart from using int.MaxValue to give MapFallback the lowest priority.
         // Otherwise, we always use the default of 0 unless a convention changes it later.
         var order = isFallback ? int.MaxValue : 0;
-        var displayName = pattern.RawText ?? pattern.DebuggerToString();
+        var displayName = pattern.DebuggerToString();
 
         // Don't include the method name for non-route-handlers because the name is just "Invoke" when built from
         // ApplicationBuilder.Build(). This was observed in MapSignalRTests and is not very useful. Maybe if we come up
@@ -172,6 +172,11 @@ internal sealed class RouteEndpointDataSource : EndpointDataSource
             DisplayName = displayName,
             ApplicationServices = _applicationServices,
         };
+
+        if (isFallback)
+        {
+            builder.Metadata.Add(FallbackMetadata.Instance);
+        }
 
         if (isRouteHandler)
         {

--- a/src/Http/Routing/test/UnitTests/Builder/FallbackEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/FallbackEndpointRouteBuilderExtensionsTest.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Microsoft.AspNetCore.Builder;
+
+public class FallbackEndpointRouteBuilderExtensionsTest
+{
+    private EndpointDataSource GetBuilderEndpointDataSource(IEndpointRouteBuilder endpointRouteBuilder) =>
+        Assert.Single(endpointRouteBuilder.DataSources);
+
+    [Fact]
+    public void MapFallback_AddFallbackMetadata()
+    {
+        var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(EmptyServiceProvider.Instance));
+
+        RequestDelegate initialRequestDelegate = static (context) => Task.CompletedTask;
+
+        builder.MapFallback(initialRequestDelegate);
+
+        var dataSource = GetBuilderEndpointDataSource(builder);
+        var endpoint = Assert.Single(dataSource.Endpoints);
+
+        Assert.Contains(FallbackMetadata.Instance, endpoint.Metadata);
+        Assert.Equal(int.MaxValue, ((RouteEndpoint)endpoint).Order);
+    }
+
+    [Fact]
+    public void MapFallback_Pattern_AddFallbackMetadata()
+    {
+        var builder = new DefaultEndpointRouteBuilder(new ApplicationBuilder(EmptyServiceProvider.Instance));
+
+        RequestDelegate initialRequestDelegate = static (context) => Task.CompletedTask;
+
+        builder.MapFallback("/", initialRequestDelegate);
+
+        var dataSource = GetBuilderEndpointDataSource(builder);
+        var endpoint = Assert.Single(dataSource.Endpoints);
+
+        Assert.Contains(FallbackMetadata.Instance, endpoint.Metadata);
+        Assert.Equal(int.MaxValue, ((RouteEndpoint)endpoint).Order);
+    }
+
+    private sealed class EmptyServiceProvider : IServiceProvider
+    {
+        public static EmptyServiceProvider Instance { get; } = new EmptyServiceProvider();
+        public object? GetService(Type serviceType) => null;
+    }
+}

--- a/src/Http/Routing/test/UnitTests/Builder/RouteHandlerEndpointRouteBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/RouteHandlerEndpointRouteBuilderExtensionsTest.cs
@@ -765,6 +765,7 @@ public class RouteHandlerEndpointRouteBuilderExtensionsTest : LoggedTest
         Assert.Single(routeEndpointBuilder.RoutePattern.Parameters);
         Assert.True(routeEndpointBuilder.RoutePattern.Parameters[0].IsCatchAll);
         Assert.Equal(int.MaxValue, routeEndpointBuilder.Order);
+        Assert.Contains(FallbackMetadata.Instance, routeEndpointBuilder.Metadata);
     }
 
     [Fact]

--- a/src/Http/Routing/test/UnitTests/TestObjects/TestMatcher.cs
+++ b/src/Http/Routing/test/UnitTests/TestObjects/TestMatcher.cs
@@ -9,18 +9,25 @@ namespace Microsoft.AspNetCore.Routing.TestObjects;
 internal class TestMatcher : Matcher
 {
     private readonly bool _isHandled;
+    private readonly Action<HttpContext> _setEndpointCallback;
 
-    public TestMatcher(bool isHandled)
+    public TestMatcher(bool isHandled, Action<HttpContext> setEndpointCallback = null)
     {
         _isHandled = isHandled;
+
+        setEndpointCallback ??= static c =>
+            {
+                c.Request.RouteValues = new RouteValueDictionary(new { controller = "Home", action = "Index" });
+                c.SetEndpoint(new Endpoint(TestConstants.EmptyRequestDelegate, EndpointMetadataCollection.Empty, "Test endpoint"));
+            };
+        _setEndpointCallback = setEndpointCallback;
     }
 
     public override Task MatchAsync(HttpContext httpContext)
     {
         if (_isHandled)
         {
-            httpContext.Request.RouteValues = new RouteValueDictionary(new { controller = "Home", action = "Index" });
-            httpContext.SetEndpoint(new Endpoint(TestConstants.EmptyRequestDelegate, EndpointMetadataCollection.Empty, "Test endpoint"));
+            _setEndpointCallback(httpContext);
         }
 
         return Task.CompletedTask;

--- a/src/Http/Routing/test/UnitTests/TestObjects/TestMatcherFactory.cs
+++ b/src/Http/Routing/test/UnitTests/TestObjects/TestMatcherFactory.cs
@@ -12,15 +12,17 @@ namespace Microsoft.AspNetCore.Routing.TestObjects;
 internal class TestMatcherFactory : MatcherFactory
 {
     private readonly bool _isHandled;
+    private readonly Action<HttpContext> _setEndpointCallback;
 
-    public TestMatcherFactory(bool isHandled)
+    public TestMatcherFactory(bool isHandled, Action<HttpContext> setEndpointCallback = null)
     {
         _isHandled = isHandled;
+        _setEndpointCallback = setEndpointCallback;
     }
 
     public override Matcher CreateMatcher(EndpointDataSource dataSource)
     {
-        return new TestMatcher(_isHandled);
+        return new TestMatcher(_isHandled, _setEndpointCallback);
     }
 }
 

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -596,9 +596,6 @@ internal static partial class HttpsConnectionMiddlewareLoggerExtensions
     [LoggerMessage(8, LogLevel.Debug, "Failed to open certificate store {StoreName}.", EventName = "FailToOpenStore")]
     public static partial void FailedToOpenStore(this ILogger<HttpsConnectionMiddleware> logger, string? storeName, Exception exception);
 
-    [LoggerMessage(9, LogLevel.Information, "Certificate with thumbprint {Thumbprint} lacks the subjectAlternativeName (SAN) extension and may not be accepted by browsers.", EventName = "NoSubjectAlternativeName")]
-    public static partial void NoSubjectAlternativeName(this ILogger<HttpsConnectionMiddleware> logger, string thumbprint);
-
     public static void FailedToOpenStore(this ILogger<HttpsConnectionMiddleware> logger, StoreLocation storeLocation, Exception exception)
     {
         var storeLocationString = storeLocation == StoreLocation.LocalMachine ? nameof(StoreLocation.LocalMachine) : nameof(StoreLocation.CurrentUser);

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -596,6 +596,9 @@ internal static partial class HttpsConnectionMiddlewareLoggerExtensions
     [LoggerMessage(8, LogLevel.Debug, "Failed to open certificate store {StoreName}.", EventName = "FailToOpenStore")]
     public static partial void FailedToOpenStore(this ILogger<HttpsConnectionMiddleware> logger, string? storeName, Exception exception);
 
+    [LoggerMessage(9, LogLevel.Information, "Certificate with thumbprint {Thumbprint} lacks the subjectAlternativeName (SAN) extension and may not be accepted by browsers.", EventName = "NoSubjectAlternativeName")]
+    public static partial void NoSubjectAlternativeName(this ILogger<HttpsConnectionMiddleware> logger, string thumbprint);
+
     public static void FailedToOpenStore(this ILogger<HttpsConnectionMiddleware> logger, StoreLocation storeLocation, Exception exception)
     {
         var storeLocationString = storeLocation == StoreLocation.LocalMachine ? nameof(StoreLocation.LocalMachine) : nameof(StoreLocation.CurrentUser);


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/46404

Fallback endpoints now have fallback metadata to identify them. Routing uses the metadata to decide whether to write a log message that a fallback route was used.

Fallback metadata could be made public in the future if there is a reason, but for now, it can be internal.