### PR TITLE
[release/7.0] Don't generate RequestBody for parameters when disabledInferredBody is true

### DIFF
--- a/src/OpenApi/src/OpenApiGenerator.cs
+++ b/src/OpenApi/src/OpenApiGenerator.cs
@@ -78,7 +78,7 @@ internal sealed class OpenApiGenerator
             Description = metadata.GetMetadata<IEndpointDescriptionMetadata>()?.Description,
             Tags = GetOperationTags(methodInfo, metadata),
             Parameters = GetOpenApiParameters(methodInfo, pattern, disableInferredBody),
-            RequestBody = GetOpenApiRequestBody(methodInfo, metadata, pattern),
+            RequestBody = GetOpenApiRequestBody(methodInfo, metadata, pattern, disableInferredBody),
             Responses = GetOpenApiResponses(methodInfo, metadata)
         };
 
@@ -251,7 +251,7 @@ internal sealed class OpenApiGenerator
         }
     }
 
-    private OpenApiRequestBody? GetOpenApiRequestBody(MethodInfo methodInfo, EndpointMetadataCollection metadata, RoutePattern pattern)
+    private OpenApiRequestBody? GetOpenApiRequestBody(MethodInfo methodInfo, EndpointMetadataCollection metadata, RoutePattern pattern, bool disableInferredBody)
     {
         var hasFormOrBodyParameter = false;
         ParameterInfo? requestBodyParameter = null;
@@ -259,7 +259,7 @@ internal sealed class OpenApiGenerator
         var parameters = PropertyAsParameterInfo.Flatten(methodInfo.GetParameters(), ParameterBindingMethodCache);
         foreach (var parameter in parameters)
         {
-            var (bodyOrFormParameter, _, _) = GetOpenApiParameterLocation(parameter, pattern, false);
+            var (bodyOrFormParameter, _, _) = GetOpenApiParameterLocation(parameter, pattern, disableInferredBody);
             hasFormOrBodyParameter |= bodyOrFormParameter;
             if (hasFormOrBodyParameter)
             {

--- a/src/OpenApi/test/OpenApiGeneratorTests.cs
+++ b/src/OpenApi/test/OpenApiGeneratorTests.cs
@@ -928,6 +928,18 @@ public class OpenApiOperationGeneratorTests
         ValidateParameter(GetOpenApiOperation(([FromHeader(Name = "headerName")] string param) => ""), "headerName");
     }
 
+    [Fact]
+    public void DoesNotGenerateRequestBodyWhenInferredBodyDisabled()
+    {
+        var operation = GetOpenApiOperation((string[] names) => { }, httpMethods: new[] { "GET" });
+
+        var parameter = Assert.Single(operation.Parameters);
+
+        Assert.Equal("names", parameter.Name);
+        Assert.Equal(ParameterLocation.Query, parameter.In);
+        Assert.Null(operation.RequestBody);
+    }
+
     private static OpenApiOperation GetOpenApiOperation(
         Delegate action,
         string pattern = null,


### PR DESCRIPTION
## Description

The `disableInferredBody` configuration was not respected when generating the specification for the `RequestBody` in the OpenAPI generator.

Fixes https://github.com/dotnet/aspnetcore/issues/47644

## Customer Impact

Without this bug fix, incorrect OpenAPI documents are produced for scenarios where customers are using certain parameter types in non-POST requests.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The impact area of the bug is localized (`WithOpenApi` + minimal APIs) so the risk is low.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A