### PR TITLE
Exclude more problematic assemblies from the ASP.NET composite

### DIFF
--- a/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
+++ b/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.csproj
@@ -504,7 +504,18 @@ This package is an internal implementation of the .NET Core SDK and is not meant
 
     <ItemGroup>
       <!-- Temporary workaround tracked by https://github.com/dotnet/runtime/issues/84860 -->
+      <ExcludeAssemblies Include="$(TargetDir)\Microsoft.Extensions.Configuration.dll" />
+      <ExcludeAssemblies Include="$(TargetDir)\Microsoft.Extensions.Configuration.Abstractions.dll" />
+      <ExcludeAssemblies Include="$(TargetDir)\Microsoft.Extensions.Configuration.Binder.dll" />
+      <ExcludeAssemblies Include="$(TargetDir)\Microsoft.Extensions.DependencyInjection.dll" />
+      <ExcludeAssemblies Include="$(TargetDir)\Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
+      <ExcludeAssemblies Include="$(TargetDir)\Microsoft.Extensions.Logging.dll" />
       <ExcludeAssemblies Include="$(TargetDir)\Microsoft.Extensions.Logging.Abstractions.dll" />
+      <ExcludeAssemblies Include="$(TargetDir)\Microsoft.Extensions.Logging.Console.dll" />
+      <ExcludeAssemblies Include="$(TargetDir)\Microsoft.Extensions.Logging.Configuration.dll" />
+      <ExcludeAssemblies Include="$(TargetDir)\Microsoft.Extensions.Options.dll" />
+      <ExcludeAssemblies Include="$(TargetDir)\Microsoft.Extensions.Options.ConfigurationExtensions.dll" />
+      <ExcludeAssemblies Include="$(TargetDir)\Microsoft.Extensions.Primitives.dll" />
 
       <BaseAssemblies Include="$(ManagedAssetsFullPath)\*.dll" />
       <BaseAssemblies Include="$(TargetDir)\*.dll" />

--- a/src/Framework/App.Runtime/src/PartialCompositeAssemblyList.txt
+++ b/src/Framework/App.Runtime/src/PartialCompositeAssemblyList.txt
@@ -2,14 +2,9 @@ System.Private.CoreLib
 System.Runtime
 Microsoft.AspNetCore.Hosting
 Microsoft.AspNetCore.Hosting.Abstractions
-Microsoft.Extensions.Configuration.Abstractions
-Microsoft.Extensions.DependencyInjection.Abstractions
-Microsoft.Extensions.Configuration
 Microsoft.EntityFrameworkCore
 System.ComponentModel
 Microsoft.AspNetCore.Server.Kestrel.Core
-Microsoft.Extensions.Logging
-Microsoft.Extensions.DependencyInjection
 Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets
 System.Console
 System.Threading
@@ -20,7 +15,6 @@ Microsoft.Extensions.Configuration.Json
 Microsoft.Extensions.Configuration.FileExtensions
 Microsoft.Extensions.FileProviders.Abstractions
 Microsoft.Extensions.FileProviders.Physical
-Microsoft.Extensions.Primitives
 Microsoft.Extensions.Configuration.EnvironmentVariables
 Microsoft.Extensions.Configuration.CommandLine
 System.Linq
@@ -36,7 +30,6 @@ Microsoft.AspNetCore.Http
 System.Diagnostics.DiagnosticSource
 Microsoft.AspNetCore.Mvc.Core
 Microsoft.AspNetCore.Razor.Runtime
-Microsoft.Extensions.Options
 Microsoft.AspNetCore.Connections.Abstractions
 System.Net.Primitives
 Microsoft.AspNetCore.Hosting.Server.Abstractions


### PR DESCRIPTION
Ivan has managed to identify the list of assemblies that cause problems in the dotnet app. I have rerun the perf measurements and, while there does seem to be impact (about 4 msecs increasing the plaintext benchmark startup time from 88 msecs to 92 msecs), we still seem slightly faster than the default R2R publishing (95 msecs) so I believe that excluding these assemblies from the ASP.NET composite image for now is the most expedient way to unblock the build of .NET composite Docker containers.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 