### PR TITLE
Fix incorrect paragraph elements in XML docs

### DIFF
--- a/src/Middleware/HttpLogging/src/HttpLoggingFields.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingFields.cs
@@ -21,11 +21,11 @@ public enum HttpLoggingFields : long
     /// <summary>
     /// Flag for logging the HTTP Request Path, which includes both the <see cref="HttpRequest.Path"/>
     /// and <see cref="HttpRequest.PathBase"/>.
-    /// <p>
+    /// <para>
     /// For example:
     /// Path: /index
     /// PathBase: /app
-    /// </p>
+    /// </para>
     /// </summary>
     RequestPath = 0x1,
 

--- a/src/Middleware/HttpLogging/src/HttpLoggingFields.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingFields.cs
@@ -31,10 +31,10 @@ public enum HttpLoggingFields : long
 
     /// <summary>
     /// Flag for logging the HTTP Request <see cref="HttpRequest.QueryString"/>.
-    /// <p>
+    /// <para>
     /// For example:
     /// Query: ?index=1
-    /// </p>
+    /// </para>
     /// RequestQuery contents can contain private information
     /// which may have regulatory concerns under GDPR
     /// and other laws. RequestQuery should not be logged
@@ -45,37 +45,37 @@ public enum HttpLoggingFields : long
 
     /// <summary>
     /// Flag for logging the HTTP Request <see cref="HttpRequest.Protocol"/>.
-    /// <p>
+    /// <para>
     /// For example:
     /// Protocol: HTTP/1.1
-    /// </p>
+    /// </para>
     /// </summary>
     RequestProtocol = 0x4,
 
     /// <summary>
     /// Flag for logging the HTTP Request <see cref="HttpRequest.Method"/>.
-    /// <p>
+    /// <para>
     /// For example:
     /// Method: GET
-    /// </p>
+    /// </para>
     /// </summary>
     RequestMethod = 0x8,
 
     /// <summary>
     /// Flag for logging the HTTP Request <see cref="HttpRequest.Scheme"/>.
-    /// <p>
+    /// <para>
     /// For example:
     /// Scheme: https
-    /// </p>
+    /// </para>
     /// </summary>
     RequestScheme = 0x10,
 
     /// <summary>
     /// Flag for logging the HTTP Response <see cref="HttpResponse.StatusCode"/>.
-    /// <p>
+    /// <para>
     /// For example:
     /// StatusCode: 200
-    /// </p>
+    /// </para>
     /// </summary>
     ResponseStatusCode = 0x20,
 
@@ -84,11 +84,11 @@ public enum HttpLoggingFields : long
     /// Request Headers are logged as soon as the middleware is invoked.
     /// Headers are redacted by default with the character '[Redacted]' unless specified in
     /// the <see cref="HttpLoggingOptions.RequestHeaders"/>.
-    /// <p>
+    /// <para>
     /// For example:
     /// Connection: keep-alive
     /// My-Custom-Request-Header: [Redacted]
-    /// </p>
+    /// </para>
     /// </summary>
     RequestHeaders = 0x40,
 
@@ -97,13 +97,15 @@ public enum HttpLoggingFields : long
     /// Response Headers are logged when the <see cref="HttpResponse.Body"/> is written to
     /// or when <see cref="IHttpResponseBodyFeature.StartAsync(System.Threading.CancellationToken)"/>
     /// is called.
+    /// <para>
     /// Headers are redacted by default with the character '[Redacted]' unless specified in
     /// the <see cref="HttpLoggingOptions.ResponseHeaders"/>.
-    /// <p>
+    /// </para>
+    /// <para>
     /// For example:
     /// Content-Length: 16
     /// My-Custom-Response-Header: [Redacted]
-    /// </p>
+    /// </para>
     /// </summary>
     ResponseHeaders = 0x80,
 

--- a/src/Middleware/HttpLogging/src/HttpLoggingOptions.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingOptions.cs
@@ -17,7 +17,7 @@ public sealed class HttpLoggingOptions
 
     /// <summary>
     /// Request header values that are allowed to be logged.
-    /// <p>
+    /// <para>
     /// If a request header is not present in the <see cref="RequestHeaders"/>,
     /// the header name will be logged with a redacted value.
     /// Request headers can contain authentication tokens,
@@ -25,7 +25,7 @@ public sealed class HttpLoggingOptions
     /// under GDPR and other laws. Arbitrary request headers
     /// should not be logged unless logs are secure and
     /// access controlled and the privacy impact assessed.
-    /// </p>
+    /// </para>
     /// </summary>
     public ISet<string> RequestHeaders => _internalRequestHeaders;
 
@@ -61,10 +61,10 @@ public sealed class HttpLoggingOptions
 
     /// <summary>
     /// Response header values that are allowed to be logged.
-    /// <p>
+    /// <para>
     /// If a response header is not present in the <see cref="ResponseHeaders"/>,
     /// the header name will be logged with a redacted value.
-    /// </p>
+    /// </para>
     /// </summary>
     public ISet<string> ResponseHeaders => _internalResponseHeaders;
 
@@ -93,10 +93,10 @@ public sealed class HttpLoggingOptions
 
     /// <summary>
     /// Options for configuring encodings for a specific media type.
-    /// <p>
+    /// <para>
     /// If the request or response do not match the supported media type,
     /// the response body will not be logged.
-    /// </p>
+    /// </para>
     /// </summary>
     public MediaTypeOptions MediaTypeOptions { get; } = MediaTypeOptions.BuildDefaultMediaTypeOptions();
 

--- a/src/Middleware/HttpLogging/src/W3CLoggerOptions.cs
+++ b/src/Middleware/HttpLogging/src/W3CLoggerOptions.cs
@@ -73,7 +73,7 @@ public sealed class W3CLoggerOptions
     }
 
     /// <summary>
-    /// Gets or sets a string representing the directory where the log file will be written to
+    /// Gets or sets a string representing the directory where the log file will be written to.
     /// Defaults to <c>./logs/</c> relative to the app directory (ContentRoot).
     /// If a full path is given, that full path will be used. If a relative path is given,
     /// the full path will be that path relative to ContentRoot.
@@ -110,13 +110,13 @@ public sealed class W3CLoggerOptions
 
     /// <summary>
     /// List of additional request header values to log.
-    /// <p>
+    /// <para>
     /// Request headers can contain authentication tokens,
     /// or private information which may have regulatory concerns
     /// under GDPR and other laws. Arbitrary request headers
     /// should not be logged unless logs are secure and
     /// access controlled and the privacy impact assessed.
-    /// </p>
+    /// </para>
     /// </summary>
     public ISet<string> AdditionalRequestHeaders { get; } = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
 


### PR DESCRIPTION
`<p>` isn't a valid XML doc tag. It should be `<para>` - https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags#para

Before:

![image](https://user-images.githubusercontent.com/303201/233560953-dd416fe3-f162-4bd6-910d-8584878e0e48.png)

After:

![image](https://user-images.githubusercontent.com/303201/233561083-8252ab63-c7a5-4316-aeb9-50c58b4c3545.png)
