### PR TITLE
Check for 'null' arguments in HttpContextServerVariableExtensions.GetServerVariable

### DIFF
--- a/src/Http/Http.Extensions/src/HttpContextServerVariableExtensions.cs
+++ b/src/Http/Http.Extensions/src/HttpContextServerVariableExtensions.cs
@@ -21,6 +21,9 @@ public static class HttpContextServerVariableExtensions
     /// </returns>
     public static string? GetServerVariable(this HttpContext context, string variableName)
     {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(variableName);
+        
         var feature = context.Features.Get<IServerVariablesFeature>();
 
         if (feature == null)


### PR DESCRIPTION
# Check for `null` arguments in `HttpContextServerVariableExtensions.GetServerVariable`

We received a bug report where a customer got a NRE with this method being the source. This PR makes a nicer exception get thrown instead.