### PR TITLE
Fix platform detection for FreeBSD

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -36,6 +36,8 @@ runtime_source_feed_key=''
 
 if [ "$(uname)" = "Darwin" ]; then
     target_os_name='osx'
+elif [ "$(uname)" = "FreeBSD" ]; then
+    target_os_name='freebsd'
 else
     target_os_name='linux'
 fi


### PR DESCRIPTION
# Fix platform detection for FreeBSD

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Accept FreeBSD as a valid OS without need for `--os-name`

## Description

The current version of `eng/build.sh` only checks for "Darwin" in `uname`'s return and assumes "linux" otherwise. Under normal circumstances this is fine as building under FreeBSD we use `--os-name FreeBSD` to override this behavior. Unfortunately this is not possible when source building. 

Fixes #47838
