### PR TITLE
Avoid closure in IConnectionBuilder.Use

### DIFF
--- a/src/Servers/Connections.Abstractions/src/ConnectionBuilderExtensions.cs
+++ b/src/Servers/Connections.Abstractions/src/ConnectionBuilderExtensions.cs
@@ -47,11 +47,11 @@ public static class ConnectionBuilderExtensions
 
     /// <summary>
     /// Add the given <paramref name="middleware"/> to the connection.
-    /// If you aren't calling the next function, use <see cref="Run(IConnectionBuilder, Func&lt;ConnectionContext, Task&gt;)"/> instead.
+    /// If you aren't calling the next function, use <see cref="Run(IConnectionBuilder, Func{ConnectionContext, Task})"/> instead.
     /// <para>
     /// Prefer using <see cref="Use(IConnectionBuilder, Func{ConnectionContext, ConnectionDelegate, Task})"/> for better performance as shown below:
     /// <code>
-    /// app.Use((context, next) =>
+    /// builder.Use((context, next) =>
     /// {
     ///     return next(context);
     /// });

--- a/src/Servers/Connections.Abstractions/src/ConnectionBuilderExtensions.cs
+++ b/src/Servers/Connections.Abstractions/src/ConnectionBuilderExtensions.cs
@@ -47,6 +47,27 @@ public static class ConnectionBuilderExtensions
 
     /// <summary>
     /// Add the given <paramref name="middleware"/> to the connection.
+    /// If you aren't calling the next function, use <see cref="Run(IConnectionBuilder, Func&lt;ConnectionContext, Task&gt;)"/> instead.
+    /// <para>
+    /// Prefer using <see cref="Use(IConnectionBuilder, Func{ConnectionContext, ConnectionDelegate, Task})"/> for better performance as shown below:
+    /// <code>
+    /// app.Use((context, next) =>
+    /// {
+    ///     return next(context);
+    /// });
+    /// </code>
+    /// </para>
+    /// </summary>
+    /// <param name="connectionBuilder">The <see cref="IConnectionBuilder"/>.</param>
+    /// <param name="middleware">The middleware to add to the <see cref="IConnectionBuilder"/>.</param>
+    /// <returns>The <see cref="IConnectionBuilder"/>.</returns>
+    public static IConnectionBuilder Use(this IConnectionBuilder connectionBuilder, Func<ConnectionContext, ConnectionDelegate, Task> middleware)
+    {
+        return connectionBuilder.Use(next => context => middleware(context, next));
+    }
+
+    /// <summary>
+    /// Add the given <paramref name="middleware"/> to the connection.
     /// </summary>
     /// <param name="connectionBuilder">The <see cref="IConnectionBuilder"/>.</param>
     /// <param name="middleware">The middleware to add to the <see cref="IConnectionBuilder"/>.</param>

--- a/src/Servers/Connections.Abstractions/src/ConnectionBuilderExtensions.cs
+++ b/src/Servers/Connections.Abstractions/src/ConnectionBuilderExtensions.cs
@@ -29,6 +29,16 @@ public static class ConnectionBuilderExtensions
 
     /// <summary>
     /// Add the given <paramref name="middleware"/> to the connection.
+    /// If you aren't calling the next function, use <see cref="Run(IConnectionBuilder, Func{ConnectionContext, Task})"/> instead.
+    /// <para>
+    /// Prefer using <see cref="Use(IConnectionBuilder, Func{ConnectionContext, ConnectionDelegate, Task})"/> for better performance as shown below:
+    /// <code>
+    /// builder.Use((context, next) =>
+    /// {
+    ///     return next(context);
+    /// });
+    /// </code>
+    /// </para>
     /// </summary>
     /// <param name="connectionBuilder">The <see cref="IConnectionBuilder"/>.</param>
     /// <param name="middleware">The middleware to add to the <see cref="IConnectionBuilder"/>.</param>
@@ -46,17 +56,8 @@ public static class ConnectionBuilderExtensions
     }
 
     /// <summary>
-    /// Add the given <paramref name="middleware"/> to the connection.
     /// If you aren't calling the next function, use <see cref="Run(IConnectionBuilder, Func{ConnectionContext, Task})"/> instead.
-    /// <para>
-    /// Prefer using <see cref="Use(IConnectionBuilder, Func{ConnectionContext, ConnectionDelegate, Task})"/> for better performance as shown below:
-    /// <code>
-    /// builder.Use((context, next) =>
-    /// {
-    ///     return next(context);
-    /// });
-    /// </code>
-    /// </para>
+    /// Add the given <paramref name="middleware"/> to the connection.
     /// </summary>
     /// <param name="connectionBuilder">The <see cref="IConnectionBuilder"/>.</param>
     /// <param name="middleware">The middleware to add to the <see cref="IConnectionBuilder"/>.</param>

--- a/src/Servers/Connections.Abstractions/src/ConnectionBuilderExtensions.cs
+++ b/src/Servers/Connections.Abstractions/src/ConnectionBuilderExtensions.cs
@@ -56,8 +56,8 @@ public static class ConnectionBuilderExtensions
     }
 
     /// <summary>
-    /// If you aren't calling the next function, use <see cref="Run(IConnectionBuilder, Func{ConnectionContext, Task})"/> instead.
     /// Add the given <paramref name="middleware"/> to the connection.
+    /// If you aren't calling the next function, use <see cref="Run(IConnectionBuilder, Func{ConnectionContext, Task})"/> instead.
     /// </summary>
     /// <param name="connectionBuilder">The <see cref="IConnectionBuilder"/>.</param>
     /// <param name="middleware">The middleware to add to the <see cref="IConnectionBuilder"/>.</param>

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -13,3 +13,4 @@ Microsoft.AspNetCore.Connections.NamedPipeEndPoint.ServerName.get -> string!
 override Microsoft.AspNetCore.Connections.NamedPipeEndPoint.Equals(object? obj) -> bool
 override Microsoft.AspNetCore.Connections.NamedPipeEndPoint.GetHashCode() -> int
 override Microsoft.AspNetCore.Connections.NamedPipeEndPoint.ToString() -> string!
+static Microsoft.AspNetCore.Connections.ConnectionBuilderExtensions.Use(this Microsoft.AspNetCore.Connections.IConnectionBuilder! connectionBuilder, System.Func<Microsoft.AspNetCore.Connections.ConnectionContext!, Microsoft.AspNetCore.Connections.ConnectionDelegate!, System.Threading.Tasks.Task!>! middleware) -> Microsoft.AspNetCore.Connections.IConnectionBuilder!

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -14,3 +14,4 @@ Microsoft.AspNetCore.Connections.NamedPipeEndPoint.ServerName.get -> string!
 override Microsoft.AspNetCore.Connections.NamedPipeEndPoint.Equals(object? obj) -> bool
 override Microsoft.AspNetCore.Connections.NamedPipeEndPoint.GetHashCode() -> int
 override Microsoft.AspNetCore.Connections.NamedPipeEndPoint.ToString() -> string!
+static Microsoft.AspNetCore.Connections.ConnectionBuilderExtensions.Use(this Microsoft.AspNetCore.Connections.IConnectionBuilder! connectionBuilder, System.Func<Microsoft.AspNetCore.Connections.ConnectionContext!, Microsoft.AspNetCore.Connections.ConnectionDelegate!, System.Threading.Tasks.Task!>! middleware) -> Microsoft.AspNetCore.Connections.IConnectionBuilder!

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -13,3 +13,4 @@ Microsoft.AspNetCore.Connections.NamedPipeEndPoint.ServerName.get -> string!
 override Microsoft.AspNetCore.Connections.NamedPipeEndPoint.Equals(object? obj) -> bool
 override Microsoft.AspNetCore.Connections.NamedPipeEndPoint.GetHashCode() -> int
 override Microsoft.AspNetCore.Connections.NamedPipeEndPoint.ToString() -> string!
+static Microsoft.AspNetCore.Connections.ConnectionBuilderExtensions.Use(this Microsoft.AspNetCore.Connections.IConnectionBuilder! connectionBuilder, System.Func<Microsoft.AspNetCore.Connections.ConnectionContext!, Microsoft.AspNetCore.Connections.ConnectionDelegate!, System.Threading.Tasks.Task!>! middleware) -> Microsoft.AspNetCore.Connections.IConnectionBuilder!

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -13,3 +13,4 @@ Microsoft.AspNetCore.Connections.NamedPipeEndPoint.ServerName.get -> string!
 override Microsoft.AspNetCore.Connections.NamedPipeEndPoint.Equals(object? obj) -> bool
 override Microsoft.AspNetCore.Connections.NamedPipeEndPoint.GetHashCode() -> int
 override Microsoft.AspNetCore.Connections.NamedPipeEndPoint.ToString() -> string!
+static Microsoft.AspNetCore.Connections.ConnectionBuilderExtensions.Use(this Microsoft.AspNetCore.Connections.IConnectionBuilder! connectionBuilder, System.Func<Microsoft.AspNetCore.Connections.ConnectionContext!, Microsoft.AspNetCore.Connections.ConnectionDelegate!, System.Threading.Tasks.Task!>! middleware) -> Microsoft.AspNetCore.Connections.IConnectionBuilder!

--- a/src/Servers/Kestrel/samples/Http2SampleApp/Program.cs
+++ b/src/Servers/Kestrel/samples/Http2SampleApp/Program.cs
@@ -50,7 +50,7 @@ public class Program
                                     throw new NotSupportedException("Prohibited cipher: " + tlsFeature.CipherAlgorithm);
                                 }
 
-                                return next();
+                                return next(context);
                             });
                         });
 


### PR DESCRIPTION
# Avoid closure in IConnectionBuilder.Use

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Add new Use connectionbuilder extension method

## Description

Add a new IConnectionBuilder.Use overload that requires users to pass the ConnectionContext to the next function which will save allocations over the previous extension method.

Fixes #46533
