### PR TITLE
Update AOT friendly templates in reaction to SDK default changes & discussions

### DIFF
--- a/src/ProjectTemplates/Shared/ArgConstants.cs
+++ b/src/ProjectTemplates/Shared/ArgConstants.cs
@@ -25,5 +25,5 @@ internal static class ArgConstants
     public const string AadB2cInstance = "--aad-b2c-instance";
     public const string UseLocalDb = "-uld";
     public const string NoHttps = "--no-https";
-    public const string PublishNativeAot = "--publish-native-aot";
+    public const string PublishNativeAot = "--aot";
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/Api-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/Api-CSharp.csproj.in
@@ -10,7 +10,6 @@
     <InvariantGlobalization>true</InvariantGlobalization>
     <!--#if (NativeAot) -->
     <PublishAot>true</PublishAot>
-    <StripSymbols>true</StripSymbols>
     <!--#endif -->
   </PropertyGroup>
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/GrpcService-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/GrpcService-CSharp.csproj.in
@@ -7,7 +7,6 @@
     <InvariantGlobalization>true</InvariantGlobalization>
     <!--#if (NativeAot) -->
     <PublishAot>true</PublishAot>
-    <StripSymbols>true</StripSymbols>
     <!--#endif -->
   </PropertyGroup>
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/Worker-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/Worker-CSharp.csproj.in
@@ -7,7 +7,6 @@
     <InvariantGlobalization>true</InvariantGlobalization>
     <!--#if (NativeAot) -->
     <PublishAot>true</PublishAot>
-    <StripSymbols>true</StripSymbols>
     <!--#endif -->
     <UserSecretsId>dotnet-Company.Application1-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/.template.config/dotnetcli.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Api-CSharp/.template.config/dotnetcli.host.json
@@ -23,8 +23,8 @@
       "shortName": ""
     },
     "NativeAot": {
-      "longName": "publish-native-aot",
-      "shortName": "aot"
+      "longName": "aot",
+      "shortName": ""
     }
   },
   "usageExamples": [

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/dotnetcli.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/GrpcService-CSharp/.template.config/dotnetcli.host.json
@@ -23,8 +23,8 @@
       "shortName": ""
     },
     "NativeAot": {
-      "longName": "publish-native-aot",
-      "shortName": "aot"
+      "longName": "aot",
+      "shortName": ""
     }
   },
   "usageExamples": [

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/.template.config/dotnetcli.host.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Worker-CSharp/.template.config/dotnetcli.host.json
@@ -17,8 +17,8 @@
       "shortName": ""
     },
     "NativeAot": {
-      "longName": "publish-native-aot",
-      "shortName": "aot"
+      "longName": "aot",
+      "shortName": ""
     }
   },
   "usageExamples": [

--- a/src/ProjectTemplates/test/Templates.Tests/template-baselines.json
+++ b/src/ProjectTemplates/test/Templates.Tests/template-baselines.json
@@ -541,7 +541,7 @@
     },
     "NativeAot": {
       "Template": "api",
-      "Arguments": "new api -aot",
+      "Arguments": "new api --aot",
       "Files": [
         "Todo.cs",
         "Program.cs",
@@ -563,7 +563,7 @@
     },
     "ProgramMainNativeAot": {
       "Template": "api",
-      "Arguments": "new api -aot --use-program-main",
+      "Arguments": "new api --aot --use-program-main",
       "Files": [
         "Todo.cs",
         "Program.cs",


### PR DESCRIPTION
Based on discussions ([matching PR in SDK repo](https://github.com/dotnet/sdk/pull/31980)).

* StripSymbols is going to be SDK default.
* `--aot` instead of `-aot` to match Unix conventions.

Cc @MichalStrehovsky @eerhardt 