### PR TITLE
Stop Calling JSON GetTypeInfo with the runtime type

### DIFF
--- a/src/Http/Http.Extensions/gen/RequestDelegateGeneratorSources.cs
+++ b/src/Http/Http.Extensions/gen/RequestDelegateGeneratorSources.cs
@@ -152,7 +152,7 @@ internal static class RequestDelegateGeneratorSources
         [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
             Justification = "The 'JsonSerializer.IsReflectionEnabledByDefault' feature switch, which is set to false by default for trimmed ASP.NET apps, ensures the JsonSerializer doesn't use Reflection.")]
         [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "See above.")]
-        private static Task WriteToResponseAsync<T>(T? value, HttpContext httpContext, JsonTypeInfo<T> jsonTypeInfo, JsonSerializerOptions options)
+        private static Task WriteToResponseAsync<T>(T? value, HttpContext httpContext, JsonTypeInfo<T> jsonTypeInfo)
         {
             var runtimeType = value?.GetType();
             if (runtimeType is null || jsonTypeInfo.Type == runtimeType || jsonTypeInfo.PolymorphismOptions is not null)
@@ -160,7 +160,7 @@ internal static class RequestDelegateGeneratorSources
                 return httpContext.Response.WriteAsJsonAsync(value!, jsonTypeInfo);
             }
 
-            return httpContext.Response.WriteAsJsonAsync<object?>(value, options);
+            return httpContext.Response.WriteAsJsonAsync<object?>(value, jsonTypeInfo.Options);
         }
 """;
 

--- a/src/Http/Http.Extensions/gen/RequestDelegateGeneratorSources.cs
+++ b/src/Http/Http.Extensions/gen/RequestDelegateGeneratorSources.cs
@@ -149,6 +149,9 @@ internal static class RequestDelegateGeneratorSources
 """;
 
     public static string WriteToResponseAsyncMethod => """
+        [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+            Justification = "<Pending>")]
+        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "See above.")]
         private static Task WriteToResponseAsync<T>(T? value, HttpContext httpContext, JsonTypeInfo<T> jsonTypeInfo, JsonSerializerOptions options)
         {
             var runtimeType = value?.GetType();
@@ -157,7 +160,7 @@ internal static class RequestDelegateGeneratorSources
                 return httpContext.Response.WriteAsJsonAsync(value!, jsonTypeInfo);
             }
 
-            return httpContext.Response.WriteAsJsonAsync(value!, options.GetTypeInfo(runtimeType));
+            return httpContext.Response.WriteAsJsonAsync<object?>(value, options);
         }
 """;
 

--- a/src/Http/Http.Extensions/gen/RequestDelegateGeneratorSources.cs
+++ b/src/Http/Http.Extensions/gen/RequestDelegateGeneratorSources.cs
@@ -150,7 +150,7 @@ internal static class RequestDelegateGeneratorSources
 
     public static string WriteToResponseAsyncMethod => """
         [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
-            Justification = "<Pending>")]
+            Justification = "The 'JsonSerializer.IsReflectionEnabledByDefault' feature switch, which is set to false by default for trimmed ASP.NET apps, ensures the JsonSerializer doesn't use Reflection.")]
         [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "See above.")]
         private static Task WriteToResponseAsync<T>(T? value, HttpContext httpContext, JsonTypeInfo<T> jsonTypeInfo, JsonSerializerOptions options)
         {

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointJsonResponseEmitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointJsonResponseEmitter.cs
@@ -23,6 +23,6 @@ internal static class EndpointJsonResponseEmitter
         {
             return $"httpContext.Response.WriteAsJsonAsync(result, jsonTypeInfo);";
         }
-        return $"GeneratedRouteBuilderExtensionsCore.WriteToResponseAsync(result, httpContext, jsonTypeInfo, serializerOptions);";
+        return $"GeneratedRouteBuilderExtensionsCore.WriteToResponseAsync(result, httpContext, jsonTypeInfo);";
     }
 }

--- a/src/Http/Http.Extensions/src/HttpResponseJsonExtensions.cs
+++ b/src/Http/Http.Extensions/src/HttpResponseJsonExtensions.cs
@@ -30,6 +30,8 @@ public static partial class HttpResponseJsonExtensions
     /// <param name="value">The value to write as JSON.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the operation.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
+    [RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
+    [RequiresDynamicCode(RequiresDynamicCodeMessage)]
     public static Task WriteAsJsonAsync<TValue>(
         this HttpResponse response,
         TValue value,
@@ -37,8 +39,7 @@ public static partial class HttpResponseJsonExtensions
     {
         ArgumentNullException.ThrowIfNull(response);
 
-        var options = ResolveSerializerOptions(response.HttpContext);
-        return response.WriteAsJsonAsync(value, jsonTypeInfo: (JsonTypeInfo<TValue>)options.GetTypeInfo(typeof(TValue)), contentType: null, cancellationToken);
+        return response.WriteAsJsonAsync(value, options: null, contentType: null, cancellationToken);
     }
 
     /// <summary>
@@ -108,9 +109,7 @@ public static partial class HttpResponseJsonExtensions
     /// <param name="contentType">The content-type to set on the response.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the operation.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
     public static Task WriteAsJsonAsync<TValue>(
-#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
         this HttpResponse response,
         TValue value,
         JsonTypeInfo<TValue> jsonTypeInfo,
@@ -204,6 +203,8 @@ public static partial class HttpResponseJsonExtensions
     /// <param name="type">The type of object to write.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the operation.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
+    [RequiresUnreferencedCode(RequiresUnreferencedCodeMessage)]
+    [RequiresDynamicCode(RequiresDynamicCodeMessage)]
     public static Task WriteAsJsonAsync(
         this HttpResponse response,
         object? value,
@@ -212,8 +213,7 @@ public static partial class HttpResponseJsonExtensions
     {
         ArgumentNullException.ThrowIfNull(response);
 
-        var options = ResolveSerializerOptions(response.HttpContext);
-        return response.WriteAsJsonAsync(value, jsonTypeInfo: options.GetTypeInfo(type), contentType: null, cancellationToken);
+        return response.WriteAsJsonAsync(value, type, options: null,  contentType: null, cancellationToken);
     }
 
     /// <summary>
@@ -302,9 +302,7 @@ public static partial class HttpResponseJsonExtensions
     /// <param name="contentType">The content-type to set on the response.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the operation.</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
     public static Task WriteAsJsonAsync(
-#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
         this HttpResponse response,
         object? value,
         Type type,

--- a/src/Http/Http.Extensions/src/RequestDelegateFactoryContext.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactoryContext.cs
@@ -59,5 +59,4 @@ internal sealed class RequestDelegateFactoryContext
 
     // Grab these options upfront to avoid the per request DI scope that would be made otherwise to get the options when writing Json
     public required JsonSerializerOptions JsonSerializerOptions { get; set; }
-    public required Expression JsonSerializerOptionsExpression { get; set; }
 }

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -2033,46 +2033,10 @@ public partial class RequestDelegateFactoryTests : LoggedTest
         Assert.Equal(nameof(JsonTodoChild), deserializedResponseBody["$type"]!.GetValue<string>());
     }
 
-    public static IEnumerable<object[]> JsonContextActions
-    {
-        get
-        {
-            return ComplexResult.Concat(ChildResult);
-        }
-    }
-
     [JsonSerializable(typeof(Todo))]
     [JsonSerializable(typeof(TodoChild))]
     private partial class TestJsonContext : JsonSerializerContext
     { }
-
-    [Theory]
-    [MemberData(nameof(JsonContextActions))]
-    public async Task RequestDelegateWritesAsJsonResponseBody_WithJsonSerializerContext(Delegate @delegate)
-    {
-        var httpContext = CreateHttpContext();
-        httpContext.RequestServices = new ServiceCollection()
-            .AddSingleton(LoggerFactory)
-            .ConfigureHttpJsonOptions(o => o.SerializerOptions.TypeInfoResolver = TestJsonContext.Default)
-            .BuildServiceProvider();
-
-        var responseBodyStream = new MemoryStream();
-        httpContext.Response.Body = responseBodyStream;
-
-        var rdfOptions = new RequestDelegateFactoryOptions() { ServiceProvider = httpContext.RequestServices };
-        var factoryResult = RequestDelegateFactory.Create(@delegate, rdfOptions);
-        var requestDelegate = factoryResult.RequestDelegate;
-
-        await requestDelegate(httpContext);
-
-        var deserializedResponseBody = JsonSerializer.Deserialize<Todo>(responseBodyStream.ToArray(), new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true
-        });
-
-        Assert.NotNull(deserializedResponseBody);
-        Assert.Equal("Write even more tests!", deserializedResponseBody!.Name);
-    }
 
     [Fact]
     public void CreateDelegateThrows_WhenGetJsonTypeInfoFail()

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -2043,6 +2043,7 @@ public partial class RequestDelegateFactoryTests : LoggedTest
 
     [JsonSerializable(typeof(Todo))]
     [JsonSerializable(typeof(TodoChild))]
+    [JsonSerializable(typeof(IAsyncEnumerable<JsonTodo>))]
     private partial class TestJsonContext : JsonSerializerContext
     { }
 
@@ -2059,7 +2060,8 @@ public partial class RequestDelegateFactoryTests : LoggedTest
         var responseBodyStream = new MemoryStream();
         httpContext.Response.Body = responseBodyStream;
 
-        var factoryResult = RequestDelegateFactory.Create(@delegate);
+        var rdfOptions = new RequestDelegateFactoryOptions() { ServiceProvider = httpContext.RequestServices };
+        var factoryResult = RequestDelegateFactory.Create(@delegate, rdfOptions);
         var requestDelegate = factoryResult.RequestDelegate;
 
         await requestDelegate(httpContext);
@@ -2071,6 +2073,64 @@ public partial class RequestDelegateFactoryTests : LoggedTest
 
         Assert.NotNull(deserializedResponseBody);
         Assert.Equal("Write even more tests!", deserializedResponseBody!.Name);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task RequestDelegateWritesAsJsonResponseBody_UnspeakableType(bool useJsonContext)
+    {
+        var httpContext = CreateHttpContext();
+        httpContext.RequestServices = new ServiceCollection()
+            .AddSingleton(LoggerFactory)
+            .ConfigureHttpJsonOptions(o => o.SerializerOptions.TypeInfoResolver = useJsonContext ? TestJsonContext.Default : o.SerializerOptions.TypeInfoResolver)
+            .BuildServiceProvider();
+
+        var responseBodyStream = new MemoryStream();
+        httpContext.Response.Body = responseBodyStream;
+
+        Delegate @delegate = IAsyncEnumerable<JsonTodo> () => GetTodosAsync();
+
+        var rdfOptions = new RequestDelegateFactoryOptions() { ServiceProvider = httpContext.RequestServices };
+        var factoryResult = RequestDelegateFactory.Create(@delegate, rdfOptions);
+        var requestDelegate = factoryResult.RequestDelegate;
+
+        await requestDelegate(httpContext);
+
+        var body = JsonSerializer.Deserialize<JsonTodo[]>(responseBodyStream.ToArray(), new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(body);
+        Assert.Equal(3, body.Length);
+
+        var one = Assert.IsType<JsonTodo>(body[0]);
+        Assert.Equal(1, one.Id);
+        Assert.True(one.IsComplete);
+        Assert.Equal("One", one.Name);
+
+        var two = Assert.IsType<JsonTodo>(body[1]);
+        Assert.Equal(2, two.Id);
+        Assert.False(two.IsComplete);
+        Assert.Equal("Two", two.Name);
+
+        var three = Assert.IsType<JsonTodoChild>(body[2]);
+        Assert.Equal(3, three.Id);
+        Assert.True(three.IsComplete);
+        Assert.Equal("Three", three.Name);
+        Assert.Equal("ThreeChild", three.Child);
+    }
+
+    private static async IAsyncEnumerable<JsonTodo> GetTodosAsync()
+    {
+        yield return new JsonTodo() { Id = 1, IsComplete = true, Name = "One" };
+
+        // ensure this is async
+        await Task.Yield();
+
+        yield return new JsonTodo() { Id = 2, IsComplete = false, Name = "Two" };
+        yield return new JsonTodoChild() { Id = 3, IsComplete = true, Name = "Three", Child = "ThreeChild" };
     }
 
     [Fact]

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTestBase.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTestBase.cs
@@ -192,8 +192,6 @@ public abstract class RequestDelegateCreationTestBase : LoggedTest
     {
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddSingleton(LoggerFactory);
-        var jsonOptions = new JsonOptions();
-        serviceCollection.AddSingleton(Options.Create(jsonOptions));
         if (configureServices is not null)
         {
             configureServices(serviceCollection);

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.Responses.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.Responses.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.AspNetCore.Routing.Internal;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.Primitives;
 using System.Text;
@@ -247,5 +248,41 @@ app.MapGet("/value-task", () => ValueTask.CompletedTask);
         httpContext = CreateHttpContext();
         await endpoints[1].RequestDelegate(httpContext);
         await VerifyResponseBodyAsync(httpContext, string.Empty);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task RequestDelegateWritesAsJsonResponseBody_UnspeakableType(bool useJsonContext)
+    {
+        var source = """
+app.MapGet("/todos", () => GetTodosAsync());
+
+static async IAsyncEnumerable<JsonTodo> GetTodosAsync()
+{
+    yield return new JsonTodo() { Id = 1, IsComplete = true, Name = "One" };
+
+    // ensure this is async
+    await Task.Yield();
+
+    yield return new JsonTodoChild() { Id = 2, IsComplete = false, Name = "Two", Child = "TwoChild" };
+}
+""";
+        var (_, compilation) = await RunGeneratorAsync(source);
+        var serviceProvider = CreateServiceProvider(serviceCollection =>
+        {
+            if (useJsonContext)
+            {
+                serviceCollection.ConfigureHttpJsonOptions(o => o.SerializerOptions.TypeInfoResolver = SharedTestJsonContext.Default);
+            }
+        });
+        var endpoint = GetEndpointFromCompilation(compilation, serviceProvider: serviceProvider);
+
+        var httpContext = CreateHttpContext(serviceProvider);
+
+        await endpoint.RequestDelegate(httpContext);
+
+        var expectedBody = """[{"id":1,"name":"One","isComplete":true},{"$type":"JsonTodoChild","child":"TwoChild","id":2,"name":"Two","isComplete":false}]""";
+        await VerifyResponseBodyAsync(httpContext, expectedBody);
     }
 }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.Responses.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.Responses.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.Primitives;
 using System.Text;
+using System.Text.Json;
 
 namespace Microsoft.AspNetCore.Http.Generators.Tests;
 
@@ -248,6 +249,70 @@ app.MapGet("/value-task", () => ValueTask.CompletedTask);
         httpContext = CreateHttpContext();
         await endpoints[1].RequestDelegate(httpContext);
         await VerifyResponseBodyAsync(httpContext, string.Empty);
+    }
+
+    public static IEnumerable<object[]> JsonContextActions
+    {
+        get
+        {
+            yield return new[] { "TestAction", """Todo TestAction() => new Todo { Name = "Write even more tests!" };""" };
+            yield return new[] { "TaskTestAction", """Task<Todo> TaskTestAction() => Task.FromResult(new Todo { Name = "Write even more tests!" });""" };
+            yield return new[] { "ValueTaskTestAction", """ValueTask<Todo> ValueTaskTestAction() => ValueTask.FromResult(new Todo { Name = "Write even more tests!" });""" };
+
+            yield return new[] { "StaticTestAction", """static Todo StaticTestAction() => new Todo { Name = "Write even more tests!" };""" };
+            yield return new[] { "StaticTaskTestAction", """static Task<Todo> StaticTaskTestAction() => Task.FromResult(new Todo { Name = "Write even more tests!" });""" };
+            yield return new[] { "StaticValueTaskTestAction", """static ValueTask<Todo> StaticValueTaskTestAction() => ValueTask.FromResult(new Todo { Name = "Write even more tests!" });""" };
+
+            yield return new[] { "TestAction", """Todo TestAction() => new JsonTodoChild { Name = "Write even more tests!", Child = "With type hierarchies!" };""" };
+
+            yield return new[] { "TaskTestAction", """Task<Todo> TaskTestAction() => Task.FromResult<Todo>(new JsonTodoChild { Name = "Write even more tests!", Child = "With type hierarchies!" });""" };
+            yield return new[] { "TaskTestActionAwaited", """
+                    async Task<Todo> TaskTestActionAwaited()
+                    {
+                        await Task.Yield();
+                        return new JsonTodoChild { Name = "Write even more tests!", Child = "With type hierarchies!" };
+                    }
+                    """ };
+
+            yield return new[] { "ValueTaskTestAction", """ValueTask<Todo> ValueTaskTestAction() => ValueTask.FromResult<Todo>(new JsonTodoChild { Name = "Write even more tests!", Child = "With type hierarchies!" });""" };
+            yield return new[] { "ValueTaskTestActionAwaited", """
+                    async ValueTask<Todo> ValueTaskTestActionAwaited()
+                    {
+                        await Task.Yield();
+                        return new JsonTodoChild { Name = "Write even more tests!", Child = "With type hierarchies!" };
+                    }
+                    """ };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(JsonContextActions))]
+    public async Task RequestDelegateWritesAsJsonResponseBody_WithJsonSerializerContext(string delegateName, string delegateSource)
+    {
+        var source = $"""
+app.MapGet("/test", {delegateName});
+
+{delegateSource}
+""";
+
+        var (_, compilation) = await RunGeneratorAsync(source);
+        var serviceProvider = CreateServiceProvider(serviceCollection =>
+        {
+            serviceCollection.ConfigureHttpJsonOptions(o => o.SerializerOptions.TypeInfoResolver = SharedTestJsonContext.Default);
+        });
+        var endpoint = GetEndpointFromCompilation(compilation, serviceProvider: serviceProvider);
+
+        var httpContext = CreateHttpContext(serviceProvider);
+
+        await endpoint.RequestDelegate(httpContext);
+
+        var deserializedResponseBody = JsonSerializer.Deserialize<Todo>(((MemoryStream)httpContext.Response.Body).ToArray(), new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(deserializedResponseBody);
+        Assert.Equal("Write even more tests!", deserializedResponseBody!.Name);
     }
 
     [Theory]

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
@@ -64,6 +64,10 @@ public class JsonTodoChild : JsonTodo
     public string? Child { get; set; }
 }
 
+[JsonSerializable(typeof(IAsyncEnumerable<JsonTodo>))]
+public partial class SharedTestJsonContext : JsonSerializerContext
+{ }
+
 public class CustomFromBodyAttribute : Attribute, IFromBodyMetadata
 {
     public bool AllowEmpty { get; set; }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
@@ -64,6 +64,7 @@ public class JsonTodoChild : JsonTodo
     public string? Child { get; set; }
 }
 
+[JsonSerializable(typeof(Todo))]
 [JsonSerializable(typeof(IAsyncEnumerable<JsonTodo>))]
 public partial class SharedTestJsonContext : JsonSerializerContext
 { }

--- a/src/Http/Http.Results/src/HttpResultsHelper.cs
+++ b/src/Http/Http.Results/src/HttpResultsHelper.cs
@@ -39,7 +39,7 @@ internal static partial class HttpResultsHelper
         var jsonTypeInfo = (JsonTypeInfo<TValue>)jsonSerializerOptions.GetTypeInfo(typeof(TValue));
 
         Type? runtimeType = value.GetType();
-        if (jsonTypeInfo.IsValid(runtimeType))
+        if (jsonTypeInfo.ShouldUseWith(runtimeType))
         {
             Log.WritingResultAsJson(logger, jsonTypeInfo.Type.Name);
             return httpContext.Response.WriteAsJsonAsync(

--- a/src/Http/Http.Results/src/HttpResultsHelper.cs
+++ b/src/Http/Http.Results/src/HttpResultsHelper.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
@@ -19,6 +20,9 @@ internal static partial class HttpResultsHelper
     internal const string DefaultContentType = "text/plain; charset=utf-8";
     private static readonly Encoding DefaultEncoding = Encoding.UTF8;
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "<Pending>")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "See above.")]
     public static Task WriteResultAsJsonAsync<TValue>(
         HttpContext httpContext,
         ILogger logger,
@@ -34,8 +38,8 @@ internal static partial class HttpResultsHelper
         jsonSerializerOptions ??= ResolveJsonOptions(httpContext).SerializerOptions;
         var jsonTypeInfo = (JsonTypeInfo<TValue>)jsonSerializerOptions.GetTypeInfo(typeof(TValue));
 
-        Type? runtimeType;
-        if (jsonTypeInfo.IsValid(runtimeType = value.GetType()))
+        Type? runtimeType = value.GetType();
+        if (jsonTypeInfo.IsValid(runtimeType))
         {
             Log.WritingResultAsJson(logger, jsonTypeInfo.Type.Name);
             return httpContext.Response.WriteAsJsonAsync(
@@ -46,14 +50,14 @@ internal static partial class HttpResultsHelper
 
         Log.WritingResultAsJson(logger, runtimeType.Name);
         // Since we don't know the type's polymorphic characteristics
-        // our best option is use the runtime type, so,
-        // call WriteAsJsonAsync() with the runtime type to serialize the runtime type rather than the declared type
+        // our best option is to serialize the value as 'object'.
+        // call WriteAsJsonAsync<object>() rather than the declared type
         // and avoid source generators issues.
         // https://github.com/dotnet/aspnetcore/issues/43894
         // https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-polymorphism
-        return httpContext.Response.WriteAsJsonAsync(
+        return httpContext.Response.WriteAsJsonAsync<object>(
            value,
-           jsonSerializerOptions.GetTypeInfo(runtimeType),
+           jsonSerializerOptions,
            contentType: contentType);
     }
 

--- a/src/Http/Http.Results/src/HttpResultsHelper.cs
+++ b/src/Http/Http.Results/src/HttpResultsHelper.cs
@@ -21,7 +21,7 @@ internal static partial class HttpResultsHelper
     private static readonly Encoding DefaultEncoding = Encoding.UTF8;
 
     [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
-        Justification = "<Pending>")]
+        Justification = "The 'JsonSerializer.IsReflectionEnabledByDefault' feature switch, which is set to false by default for trimmed ASP.NET apps, ensures the JsonSerializer doesn't use Reflection.")]
     [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "See above.")]
     public static Task WriteResultAsJsonAsync<TValue>(
         HttpContext httpContext,

--- a/src/Http/Http.Results/test/HttpResultsHelperTests.cs
+++ b/src/Http/Http.Results/test/HttpResultsHelperTests.cs
@@ -177,6 +177,58 @@ public partial class HttpResultsHelperTests
         Assert.Equal("With type hierarchies!", body!.Child);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task WriteResultAsJsonAsync_Works_UsingUnspeakableType(bool useJsonContext)
+    {
+        // Arrange
+        var value = GetTodosAsync();
+        var responseBodyStream = new MemoryStream();
+        var httpContext = CreateHttpContext(responseBodyStream);
+        var serializerOptions = new JsonOptions().SerializerOptions;
+
+        if (useJsonContext)
+        {
+            serializerOptions.TypeInfoResolver = TestJsonContext.Default;
+        }
+
+        // Act
+        await HttpResultsHelper.WriteResultAsJsonAsync(httpContext, NullLogger.Instance, value, jsonSerializerOptions: serializerOptions);
+
+        // Assert
+        var body = JsonSerializer.Deserialize<JsonTodo[]>(responseBodyStream.ToArray(), serializerOptions);
+
+        Assert.Equal(3, body.Length);
+
+        var one = Assert.IsType<JsonTodo>(body[0]);
+        Assert.Equal(1, one.Id);
+        Assert.True(one.IsComplete);
+        Assert.Equal("One", one.Name);
+
+        var two = Assert.IsType<JsonTodo>(body[1]);
+        Assert.Equal(2, two.Id);
+        Assert.False(two.IsComplete);
+        Assert.Equal("Two", two.Name);
+
+        var three = Assert.IsType<TodoJsonChild>(body[2]);
+        Assert.Equal(3, three.Id);
+        Assert.True(three.IsComplete);
+        Assert.Equal("Three", three.Name);
+        Assert.Equal("ThreeChild", three.Child);
+    }
+
+    private static async IAsyncEnumerable<JsonTodo> GetTodosAsync()
+    {
+        yield return new JsonTodo() { Id = 1, IsComplete = true, Name = "One" };
+
+        // ensure this is async
+        await Task.Yield();
+
+        yield return new JsonTodo() { Id = 2, IsComplete = false, Name = "Two" };
+        yield return new TodoJsonChild() { Id = 3, IsComplete = true, Name = "Three", Child = "ThreeChild" };
+    }
+
     private static DefaultHttpContext CreateHttpContext(Stream stream)
         => new()
         {
@@ -198,6 +250,8 @@ public partial class HttpResultsHelperTests
     [JsonSerializable(typeof(TodoChild))]
     [JsonSerializable(typeof(JsonTodo))]
     [JsonSerializable(typeof(TodoStruct))]
+    [JsonSerializable(typeof(IAsyncEnumerable<JsonTodo>))]
+    [JsonSerializable(typeof(JsonTodo[]))]
     private partial class TestJsonContext : JsonSerializerContext
     { }
 
@@ -224,7 +278,7 @@ public partial class HttpResultsHelperTests
         public string Child { get; set; }
     }
 
-    [JsonDerivedType(typeof(TodoJsonChild))]
+    [JsonDerivedType(typeof(TodoJsonChild), nameof(TodoJsonChild))]
     private class JsonTodo : Todo
     {
     }

--- a/src/Http/Routing/src/RequestDelegateFilterPipelineBuilder.cs
+++ b/src/Http/Routing/src/RequestDelegateFilterPipelineBuilder.cs
@@ -56,7 +56,7 @@ internal static class RequestDelegateFilterPipelineBuilder
             var obj = await filteredInvocation(new DefaultEndpointFilterInvocationContext(httpContext, new object[] { httpContext }));
             if (obj is not null)
             {
-                await ExecuteHandlerHelper.ExecuteReturnAsync(obj, httpContext, jsonSerializerOptions, jsonTypeInfo);
+                await ExecuteHandlerHelper.ExecuteReturnAsync(obj, httpContext, jsonTypeInfo);
             }
         };
     }

--- a/src/Mvc/Mvc.Core/src/Formatters/SystemTextJsonOutputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/SystemTextJsonOutputFormatter.cs
@@ -65,27 +65,38 @@ public class SystemTextJsonOutputFormatter : TextOutputFormatter
 
         var httpContext = context.HttpContext;
 
-        var runtimeType = context.Object?.GetType();
+        // context.ObjectType reflects the declared model type when specified.
+        // For polymorphic scenarios where the user declares a return type, but returns a derived type,
+        // we want to serialize all the properties on the derived type. This keeps parity with
+        // the behavior you get when the user does not declare the return type.
+        // To enable this our best option is to check if the JsonTypeInfo for the declared type is valid,
+        // if it is use it. If it isn't, serialize the value as 'object' and let JsonSerializer serialize it as necessary.
         JsonTypeInfo? jsonTypeInfo = null;
-
         if (context.ObjectType is not null)
         {
             var declaredTypeJsonInfo = SerializerOptions.GetTypeInfo(context.ObjectType);
 
+            var runtimeType = context.Object?.GetType();
             if (declaredTypeJsonInfo.IsValid(runtimeType))
             {
                 jsonTypeInfo = declaredTypeJsonInfo;
             }
         }
 
-        jsonTypeInfo ??= SerializerOptions.GetTypeInfo(runtimeType ?? typeof(object));
-
         var responseStream = httpContext.Response.Body;
         if (selectedEncoding.CodePage == Encoding.UTF8.CodePage)
         {
             try
             {
-                await JsonSerializer.SerializeAsync(responseStream, context.Object, jsonTypeInfo, httpContext.RequestAborted);
+                if (jsonTypeInfo is not null)
+                {
+                    await JsonSerializer.SerializeAsync(responseStream, context.Object, jsonTypeInfo, httpContext.RequestAborted);
+                }
+                else
+                {
+                    await JsonSerializer.SerializeAsync(responseStream, context.Object, SerializerOptions, httpContext.RequestAborted);
+                }
+
                 await responseStream.FlushAsync(httpContext.RequestAborted);
             }
             catch (OperationCanceledException) when (context.HttpContext.RequestAborted.IsCancellationRequested) { }
@@ -99,7 +110,15 @@ public class SystemTextJsonOutputFormatter : TextOutputFormatter
             ExceptionDispatchInfo? exceptionDispatchInfo = null;
             try
             {
-                await JsonSerializer.SerializeAsync(transcodingStream, context.Object, jsonTypeInfo);
+                if (jsonTypeInfo is not null)
+                {
+                    await JsonSerializer.SerializeAsync(transcodingStream, context.Object, jsonTypeInfo);
+                }
+                else
+                {
+                    await JsonSerializer.SerializeAsync(transcodingStream, context.Object, SerializerOptions);
+                }
+
                 await transcodingStream.FlushAsync();
             }
             catch (Exception ex)

--- a/src/Mvc/Mvc.Core/src/Formatters/SystemTextJsonOutputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/SystemTextJsonOutputFormatter.cs
@@ -77,7 +77,7 @@ public class SystemTextJsonOutputFormatter : TextOutputFormatter
             var declaredTypeJsonInfo = SerializerOptions.GetTypeInfo(context.ObjectType);
 
             var runtimeType = context.Object?.GetType();
-            if (declaredTypeJsonInfo.IsValid(runtimeType))
+            if (declaredTypeJsonInfo.ShouldUseWith(runtimeType))
             {
                 jsonTypeInfo = declaredTypeJsonInfo;
             }

--- a/src/Mvc/test/WebSites/FormatterWebSite/Controllers/JsonOutputFormatterController.cs
+++ b/src/Mvc/test/WebSites/FormatterWebSite/Controllers/JsonOutputFormatterController.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Mvc;
@@ -52,7 +52,7 @@ public class JsonOutputFormatterController : ControllerBase
         };
 
     [HttpGet]
-    public ActionResult<SimpleModel> PolymorphicResult() => new DeriviedModel
+    public ActionResult<SimpleModel> PolymorphicResult() => new DerivedModel
     {
         Id = 10,
         Name = "test",
@@ -71,7 +71,7 @@ public class JsonOutputFormatterController : ControllerBase
         public string StreetName { get; set; }
     }
 
-    public class DeriviedModel : SimpleModel
+    public class DerivedModel : SimpleModel
     {
         public string Address { get; set; }
     }

--- a/src/Shared/Json/JsonSerializerExtensions.cs
+++ b/src/Shared/Json/JsonSerializerExtensions.cs
@@ -13,7 +13,7 @@ internal static class JsonSerializerExtensions
     public static bool HasKnownPolymorphism(this JsonTypeInfo jsonTypeInfo)
      => jsonTypeInfo.Type.IsSealed || jsonTypeInfo.Type.IsValueType || jsonTypeInfo.PolymorphismOptions is not null;
 
-    public static bool IsValid(this JsonTypeInfo jsonTypeInfo, [NotNullWhen(false)] Type? runtimeType)
+    public static bool ShouldUseWith(this JsonTypeInfo jsonTypeInfo, [NotNullWhen(false)] Type? runtimeType)
      => runtimeType is null || jsonTypeInfo.Type == runtimeType || jsonTypeInfo.HasKnownPolymorphism();
 
     public static JsonTypeInfo GetReadOnlyTypeInfo(this JsonSerializerOptions options, Type type)

--- a/src/Shared/RouteHandlers/ExecuteHandlerHelper.cs
+++ b/src/Shared/RouteHandlers/ExecuteHandlerHelper.cs
@@ -40,7 +40,7 @@ internal static class ExecuteHandlerHelper
     {
         var runtimeType = value?.GetType();
 
-        if (jsonTypeInfo.IsValid(runtimeType))
+        if (jsonTypeInfo.ShouldUseWith(runtimeType))
         {
             // In this case the polymorphism is not
             // relevant for us and will be handled by STJ, if needed.

--- a/src/Shared/RouteHandlers/ExecuteHandlerHelper.cs
+++ b/src/Shared/RouteHandlers/ExecuteHandlerHelper.cs
@@ -35,7 +35,7 @@ internal static class ExecuteHandlerHelper
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
-        Justification = "<Pending>")]
+        Justification = "The 'JsonSerializer.IsReflectionEnabledByDefault' feature switch, which is set to false by default for trimmed ASP.NET apps, ensures the JsonSerializer doesn't use Reflection.")]
     [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "See above.")]
     public static Task WriteJsonResponseAsync<T>(HttpResponse response, T? value, JsonSerializerOptions options, JsonTypeInfo<T> jsonTypeInfo)
     {

--- a/src/Shared/RouteHandlers/ExecuteHandlerHelper.cs
+++ b/src/Shared/RouteHandlers/ExecuteHandlerHelper.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Http;
 
@@ -10,7 +9,7 @@ namespace Microsoft.AspNetCore.Internal;
 
 internal static class ExecuteHandlerHelper
 {
-    public static Task ExecuteReturnAsync(object obj, HttpContext httpContext, JsonSerializerOptions options, JsonTypeInfo<object> jsonTypeInfo)
+    public static Task ExecuteReturnAsync(object obj, HttpContext httpContext, JsonTypeInfo<object> jsonTypeInfo)
     {
         // Terminal built ins
         if (obj is IResult result)
@@ -25,7 +24,7 @@ internal static class ExecuteHandlerHelper
         else
         {
             // Otherwise, we JSON serialize when we reach the terminal state
-            return WriteJsonResponseAsync(httpContext.Response, obj, options, jsonTypeInfo);
+            return WriteJsonResponseAsync(httpContext.Response, obj, jsonTypeInfo);
         }
     }
 
@@ -37,7 +36,7 @@ internal static class ExecuteHandlerHelper
     [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
         Justification = "The 'JsonSerializer.IsReflectionEnabledByDefault' feature switch, which is set to false by default for trimmed ASP.NET apps, ensures the JsonSerializer doesn't use Reflection.")]
     [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "See above.")]
-    public static Task WriteJsonResponseAsync<T>(HttpResponse response, T? value, JsonSerializerOptions options, JsonTypeInfo<T> jsonTypeInfo)
+    public static Task WriteJsonResponseAsync<T>(HttpResponse response, T? value, JsonTypeInfo<T> jsonTypeInfo)
     {
         var runtimeType = value?.GetType();
 
@@ -54,6 +53,6 @@ internal static class ExecuteHandlerHelper
         // and avoid source generators issues.
         // https://github.com/dotnet/aspnetcore/issues/43894
         // https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-polymorphism
-        return response.WriteAsJsonAsync<object?>(value, options);
+        return response.WriteAsJsonAsync<object?>(value, jsonTypeInfo.Options);
     }
 }


### PR DESCRIPTION
Calling GetTypeInfo with the object's runtime type doesn't work when using unspeakable types and using JSON source generation. There is no way to mark the unspeakable type (like a C# compiler implemented IAsyncEnumerable iterator) as JsonSerializable.

Instead, when the "declared type"'s JsonTypeInfo isn't compatible with the runtime type w.r.t. polymorphism, serialize the value "as object", letting System.Text.Json's serialization take over to serialize the value.

Fix #47548