### PR TITLE
[release/6.0] Update Swashbuckle.AspNetCore (6.2.3 -> 6.5.0)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -258,7 +258,7 @@
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
     <StackExchangeRedisVersion>2.2.4</StackExchangeRedisVersion>
     <SystemReactiveLinqVersion>5.0.0</SystemReactiveLinqVersion>
-    <SwashbuckleAspNetCoreVersion>6.2.3</SwashbuckleAspNetCoreVersion>
+    <SwashbuckleAspNetCoreVersion>6.5.0</SwashbuckleAspNetCoreVersion>
     <XunitAbstractionsVersion>2.0.3</XunitAbstractionsVersion>
     <XunitAnalyzersVersion>0.10.0</XunitAnalyzersVersion>
     <XunitVersion>2.4.1</XunitVersion>


### PR DESCRIPTION
## Description

This PR updates the version of Swashbuckle.AspNetCore referenced in the templates to the latest version to pick up bug-fixes and new features.

## Customer Impact

This package upgrade adds support for applications using top-level statements in the OpenAPI CLI tool. While users can upgrade the version of Swashbuckle referenced in the their project themselves, this reduces the effort/cost of users having to figure out the issue and update themselves.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Change only impacts templates with Swashbuckle.AspNetCore references. Swashbuckle.AspNetCore has been released for a few months and has several million NuGet downloads with no major reported issues.

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A

