### PR TITLE
[release/7.0] Update Swashbuckle.AspNetCore (6.4.0 -> 6.5.0)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -281,7 +281,7 @@
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
     <StackExchangeRedisVersion>2.2.4</StackExchangeRedisVersion>
     <SystemReactiveLinqVersion>5.0.0</SystemReactiveLinqVersion>
-    <SwashbuckleAspNetCoreVersion>6.4.0</SwashbuckleAspNetCoreVersion>
+    <SwashbuckleAspNetCoreVersion>6.5.0</SwashbuckleAspNetCoreVersion>
     <XunitAbstractionsVersion>2.0.3</XunitAbstractionsVersion>
     <XunitAnalyzersVersion>1.0.0</XunitAnalyzersVersion>
     <XunitVersion>2.4.2</XunitVersion>


### PR DESCRIPTION
## Description

This PR updates the version of Swashbuckle.AspNetCore referenced in the templates to the latest version to pick up bug-fixes and new features.

## Customer Impact

This package upgrade includes a bug fix for applications using the new `WithOpenApi` extension method and support for inferring JWT bearer security schemes.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Change only impacts templates with Swashbuckle.AspNetCore references. Swashbuckle.AspNetCore has been released for a few months and has several million NuGet downloads with no major reported issues.

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A

