### PR TITLE
Fixed bug in Sections

### DIFF
--- a/src/Components/Components/src/Sections/SectionContent.cs
+++ b/src/Components/Components/src/Sections/SectionContent.cs
@@ -75,7 +75,7 @@ public sealed class SectionContent : ISectionContentProvider, IComponent, IDispo
             }
 
             _registry.AddProvider(identifier, this, IsDefaultContent);
-            _registeredIdentifier = SectionId;
+            _registeredIdentifier = identifier;
             _registeredIsDefaultContent = IsDefaultContent;
         }
 

--- a/src/Components/Components/src/Sections/SectionOutlet.cs
+++ b/src/Components/Components/src/Sections/SectionOutlet.cs
@@ -65,7 +65,7 @@ public sealed class SectionOutlet : ISectionContentSubscriber, IComponent, IDisp
             }
 
             _registry.Subscribe(identifier, this);
-            _subscribedIdentifier = SectionId;
+            _subscribedIdentifier = identifier;
         }
 
         RenderContent();

--- a/src/Components/test/E2ETest/Tests/SectionsTest.cs
+++ b/src/Components/test/E2ETest/Tests/SectionsTest.cs
@@ -144,6 +144,33 @@ public class SectionsTest : ServerTestBase<ToggleExecutionModeServerFixture<Prog
     }
 
     [Fact]
+    public void SectionContentWithSectionNameGetsDisposed_OldSectionOutletNoLongerRendersContent()
+    {
+        _appElement.FindElement(By.Id("section-content-with-name")).Click();
+
+        Browser.Exists(By.Id("test6"));
+
+        _appElement.FindElement(By.Id("section-content-with-name-dispose")).Click();
+
+        Browser.DoesNotExist(By.Id("test6"));
+    }
+
+    [Fact]
+    public void SectionOutletWithSectionNameGetsDisposed_ContentDissapears()
+    {
+        // Render Counter and change its id so the content is rendered in second SectionOutlet
+        _appElement.FindElement(By.Id("counter-render-section-content")).Click();
+
+        _appElement.FindElement(By.Id("counter-change-section-content-id")).Click();
+
+        Browser.Exists(By.Id("counter"));
+
+        _appElement.FindElement(By.Id("second-section-outlet-dispose")).Click();
+
+        Browser.DoesNotExist(By.Id("counter"));
+    }
+
+    [Fact]
     public void RenderTwoSectionContentsWithSameSectionId_LastRenderedOverridesSectionOutletContent()
     {
         _appElement.FindElement(By.Id("counter-render-section-content")).Click();

--- a/src/Components/test/testassets/BasicTestApp/SectionsTest/ParentComponentWithTwoChildren.razor
+++ b/src/Components/test/testassets/BasicTestApp/SectionsTest/ParentComponentWithTwoChildren.razor
@@ -9,16 +9,25 @@
 
 <p>Text between two section outlets</p>
 
-<SectionOutlet SectionName="@SecondSectionName" />
+@if (SecondSectionOutletExists)
+{
+    <SectionOutlet SectionName="@SecondSectionName" />
+}
 
 <p>Text between two section outlets</p>
 
 <SectionOutlet SectionId="ThirdSectionName" />
 
-
 <button id="section-outlet-dispose"
         @onclick="@(() => FirstSectionOutletExists = false)">
     Dispose first SectionOutlet
+</button>
+
+<br/>
+
+<button id="second-section-outlet-dispose"
+        @onclick="@(() => SecondSectionOutletExists = false)">
+    Dispose second SectionOutlet
 </button>
 
 @if (SectionOutletWithSameSectionIdExists)
@@ -114,6 +123,11 @@
     Change SectionContent SectionName
 </button><br />
 
+<button id="section-content-with-name-dispose"
+        @onclick="@(() => SectionContentWithSectionNameExists = false)">
+    Dispose SectionContent SectionName
+</button><br />
+
 <Counter
     SectionContentExists="CounterSectionContentExists"
     SectionId="CounterSectionContentId">
@@ -164,6 +178,7 @@
 
 @code {
     private bool FirstSectionOutletExists = true;
+    private bool SecondSectionOutletExists = true;
     private bool SectionOutletWithSameSectionIdExists = false;
     private bool SectionOutletWithSameSectionNameExists = false;
     private bool SectionOutletWithEqualSectionNameToSectionIdExist = false;


### PR DESCRIPTION
# Fixed bug in Sections

When implementing the final design for Sections (adding SectionName ) I forgot to change the line where we assign `_registeredIdentifier` in `SectionContent` to the `identifier` variable and left it as `_registeredIdentifier = SectionId`.  This caused to not being able to remove provider for the `SectionOutlet` and when `SectionContent` with `SectionName` was disposed `SectionOutlet` was still rendering the content. 
Same mistake in `SectionOutlet` `_subscribedIdentifier = SectionId`. This caused weird bug in hot reload when removing `SectionOutlet` with `SectionName` from the page resulting in error "Unhandled exception rendering component: There is already a subscriber to the content with the given section ID". Now fixed.

Added new e2e test cases when `SectionContent` with name gets disposed and when `SectionOutlet` with name gets disposed.

Fixes #47552
