### PR TITLE
[blazor] Apply disableDotnet6Compatibility to fix hotreload

### DIFF
--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -305,6 +305,7 @@ function prepareRuntimeConfig(options: Partial<WebAssemblyStartOptions>, platfor
     onConfigLoaded,
     onDownloadResourceProgress: setProgress,
     config,
+    disableDotnet6Compatibility: false,
     print,
     printErr,
   };


### PR DESCRIPTION
Fix regression from https://github.com/dotnet/aspnetcore/pull/47752

- Mono `disableDotnet6Compatibility: false` assignes provided API to a global namespace
- Hotreload function `receiveHotReload` expects global object `BINDING`