### PR TITLE
[GenerateEmbeddedResourcesManifest] handle Items with empty LogicalName #29306

### DIFF
--- a/src/FileProviders/Manifest.MSBuildTask/src/GenerateEmbeddedResourcesManifest.cs
+++ b/src/FileProviders/Manifest.MSBuildTask/src/GenerateEmbeddedResourcesManifest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -90,11 +90,11 @@ public class GenerateEmbeddedResourcesManifest : Microsoft.Build.Utilities.Task
         return manifest;
     }
 
-    private static string GetManifestPath(ITaskItem taskItem) => string.Equals(taskItem.GetMetadata(LogicalName), taskItem.GetMetadata(ManifestResourceName)) ?
+    private static string GetManifestPath(ITaskItem taskItem) => string.IsNullOrEmpty(taskItem.GetMetadata(LogicalName)) || string.Equals(taskItem.GetMetadata(LogicalName), taskItem.GetMetadata(ManifestResourceName)) ?
         taskItem.GetMetadata(TargetPath) :
         NormalizePath(taskItem.GetMetadata(LogicalName));
 
-    private static string GetAssemblyResourceName(ITaskItem taskItem) => string.Equals(taskItem.GetMetadata(LogicalName), taskItem.GetMetadata(ManifestResourceName)) ?
+    private static string GetAssemblyResourceName(ITaskItem taskItem) => string.IsNullOrEmpty(taskItem.GetMetadata(LogicalName)) || string.Equals(taskItem.GetMetadata(LogicalName), taskItem.GetMetadata(ManifestResourceName)) ?
         taskItem.GetMetadata(ManifestResourceName) :
         taskItem.GetMetadata(LogicalName);
 

--- a/src/FileProviders/Manifest.MSBuildTask/test/GenerateEmbeddedResourcesManifestTest.cs
+++ b/src/FileProviders/Manifest.MSBuildTask/test/GenerateEmbeddedResourcesManifestTest.cs
@@ -60,6 +60,28 @@ public class GenerateEmbeddedResourcesManifestTest
     }
 
     [Fact]
+    public void CreateEmbeddedItems_MapsMetadataFromEmbeddedResources_WithEmptyLogicalName()
+    {
+        // Arrange
+        var task = new TestGenerateEmbeddedResourcesManifest();
+        var embeddedFiles = CreateEmbeddedResource(
+            CreateMetadata("site.css"),
+            CreateMetadata(@"lib\js\jquery.validate.js", logicalName: string.Empty));
+
+        var expectedItems = new[]
+        {
+            CreateEmbeddedItem("site.css","site.css"),
+            CreateEmbeddedItem(@"lib\js\jquery.validate.js","lib.js.jquery.validate.js")
+        };
+
+        // Act
+        var embeddedItems = task.CreateEmbeddedItems(embeddedFiles);
+
+        // Assert
+        Assert.Equal(expectedItems, embeddedItems);
+    }
+
+    [Fact]
     public void BuildManifest_CanCreatesManifest_ForTopLevelFiles()
     {
         // Arrange


### PR DESCRIPTION
# [GenerateEmbeddedResourcesManifest] handle Items with empty LogicalName #29306

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Ensure that the `GenerateEmbeddedResourcesManifest` task handles the possibility of `Item`s with no `LogicalName`

## Description

A `LogicalName` isn't assigned to Resx resources. See https://github.com/dotnet/msbuild/blob/6300d22b25cc1bcb634663bd7087e31d8312bb15/src/Tasks/CreateManifestResourceName.cs#L231-L238

As a result, `GenerateEmbeddedResourcesManifest` needs to handle this possibility...otherwise it'll generate an invalid `Microsoft.Extensions.FileProviders.Embedded.Manifest.xml` with empty name attributes for `File` elements and empty `ResourcePath` elements.

Fixes #29306
