### PR TITLE
[blazor] Drop explicit change of extension of assembly to lazy load

### DIFF
--- a/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoPlatform.ts
@@ -393,7 +393,7 @@ async function loadLazyAssembly(resourceLoader: WebAssemblyResourceLoader, assem
   if (!assemblyMarkedAsLazy) {
     throw new Error(`${assemblyNameToLoad} must be marked with 'BlazorWebAssemblyLazyLoad' item group in your project file to allow lazy-loading.`);
   }
-  const dllNameToLoad = changeExtension(assemblyNameToLoad, '.dll');
+  const dllNameToLoad = assemblyNameToLoad;
   const pdbNameToLoad = changeExtension(assemblyNameToLoad, '.pdb');
   const shouldLoadPdb = hasDebuggingEnabled() && resources.pdb && lazyAssemblies.hasOwnProperty(pdbNameToLoad);
 


### PR DESCRIPTION
- In https://github.com/dotnet/aspnetcore/pull/46437 made an explicit change of extension of assembly to lazy load to `.dll`
- This change now conflicts with support for `.webcil`
- The assembly (file) name comes from the user and it's validated before that it points to an existing file, so the explicit change of extension is void even for `.dll` scenario (the user must have provided name with `.dll`)
- It would be better if users would be providing only assembly name, without extension at all, incuding `BlazorWebAssemblyLazyLoad` MSBuild item, but that is probably a breaking change

I would like to backport this change to preview4 if possible, so that webcil support is complete