### PR TITLE
Remove unused variable

### DIFF
--- a/src/Tools/dotnet-user-jwts/src/Commands/ListCommand.cs
+++ b/src/Tools/dotnet-user-jwts/src/Commands/ListCommand.cs
@@ -52,7 +52,7 @@ internal sealed class ListCommand
 
     private static void PrintJwtsJson(IReporter reporter, JwtStore jwtStore)
     {
-        if (jwtStore.Jwts is { Count: > 0 } jwts)
+        if (jwtStore.Jwts is { Count: > 0 })
         {
             reporter.Output(JsonSerializer.Serialize(jwtStore.Jwts, new JsonSerializerOptions { WriteIndented = true }));
         }


### PR DESCRIPTION
When using the latest build of .NET 8 Preview 4 SDK to build the aspnetcore repo, it results in the following analyzer error:

```
/repos/dotnet/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-user-jwts/src/Commands/ListCommand.cs(55,45): error IDE0059: Unnecessary assignment of a value to 'jwts' (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0059) [/repos/dotnet/src/aspnetcore/artifacts/source-build/self/src/src/Tools/dotnet-user-jwts/src/dotnet-user-jwts.csproj]
```

This was caught by the Source-build bootstrapping build workflow which uses a source-built version of the latest SDK to build the product's repos.

Fixed by removing the unused variable.