### PR TITLE
Run quarantined-pr job on all release branches

### DIFF
--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -9,9 +9,7 @@ trigger:
   branches:
     include:
     - main
-    - release/6.0
-    - release/7.0
-    - release/8.0
+    - release/*
 
 # Run PR validation on branches that include Helix tests
 pr:
@@ -19,9 +17,7 @@ pr:
   branches:
     include:
     - main
-    - release/6.0
-    - release/7.0
-    - release/8.0
+    - release/*
   paths:
     exclude:
     - .github/*


### PR DESCRIPTION
Probably better to future-proof the branch list than to be super careful about naming the exact set of branches