### PR TITLE
[release/7.0] Fix HTTP/3 and HTTP/2 header decoder buffer allocation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -133,10 +133,12 @@ dotnet_diagnostic.CA1829.severity = warning
 dotnet_diagnostic.CA1830.severity = warning
 
 # CA1831: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-# CA1832: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-# CA1833: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 dotnet_diagnostic.CA1831.severity = warning
+
+# CA1832: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 dotnet_diagnostic.CA1832.severity = warning
+
+# CA1833: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 dotnet_diagnostic.CA1833.severity = warning
 
 # CA1834: Consider using 'StringBuilder.Append(char)' when applicable
@@ -290,6 +292,12 @@ dotnet_diagnostic.CA1826.severity = suggestion
 dotnet_diagnostic.CA1827.severity = suggestion
 # CA1829: Use Length/Count property instead of Count() when available
 dotnet_diagnostic.CA1829.severity = suggestion
+# CA1831: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1831.severity = suggestion
+# CA1832: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1832.severity = suggestion
+# CA1833: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1833.severity = suggestion
 # CA1834: Consider using 'StringBuilder.Append(char)' when applicable
 dotnet_diagnostic.CA1834.severity = suggestion
 # CA1835: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'

--- a/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
+++ b/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
@@ -187,12 +187,11 @@ namespace System.Net.Http.HPack
             // will no longer be valid.
             if (_headerNameRange != null)
             {
-                EnsureStringCapacity(ref _headerNameOctets);
+                EnsureStringCapacity(ref _headerNameOctets, _headerNameLength);
                 _headerName = _headerNameOctets;
 
                 ReadOnlySpan<byte> headerBytes = data.Slice(_headerNameRange.GetValueOrDefault().start, _headerNameRange.GetValueOrDefault().length);
                 headerBytes.CopyTo(_headerName);
-                _headerNameLength = headerBytes.Length;
                 _headerNameRange = null;
             }
         }
@@ -427,6 +426,7 @@ namespace System.Net.Http.HPack
             {
                 // Fast path. Store the range rather than copying.
                 _headerNameRange = (start: currentIndex, count);
+                _headerNameLength = _stringLength;
                 currentIndex += count;
 
                 _state = State.HeaderValueLength;
@@ -621,11 +621,12 @@ namespace System.Net.Http.HPack
             _state = nextState;
         }
 
-        private void EnsureStringCapacity(ref byte[] dst)
+        private void EnsureStringCapacity(ref byte[] dst, int stringLength = -1)
         {
-            if (dst.Length < _stringLength)
+            stringLength = stringLength >= 0 ? stringLength : _stringLength;
+            if (dst.Length < stringLength)
             {
-                dst = new byte[Math.Max(_stringLength, Math.Min(dst.Length * 2, _maxHeadersLength))];
+                dst = new byte[Math.Max(stringLength, Math.Min(dst.Length * 2, _maxHeadersLength))];
             }
         }
 

--- a/src/Shared/runtime/Http3/QPack/QPackDecoder.cs
+++ b/src/Shared/runtime/Http3/QPack/QPackDecoder.cs
@@ -243,12 +243,11 @@ namespace System.Net.Http.QPack
             // will no longer be valid.
             if (_headerNameRange != null)
             {
-                EnsureStringCapacity(ref _headerNameOctets, _stringLength, existingLength: 0);
+                EnsureStringCapacity(ref _headerNameOctets, _headerNameLength, existingLength: 0);
                 _headerName = _headerNameOctets;
 
                 ReadOnlySpan<byte> headerBytes = data.Slice(_headerNameRange.GetValueOrDefault().start, _headerNameRange.GetValueOrDefault().length);
                 headerBytes.CopyTo(_headerName);
-                _headerNameLength = headerBytes.Length;
                 _headerNameRange = null;
             }
         }
@@ -294,6 +293,7 @@ namespace System.Net.Http.QPack
             {
                 // Fast path. Store the range rather than copying.
                 _headerNameRange = (start: currentIndex, count);
+                _headerNameLength = _stringLength;
                 currentIndex += count;
 
                 _state = State.HeaderValueLength;

--- a/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
@@ -46,7 +46,12 @@ namespace System.Net.Http.Unit.Tests.HPack
 
         private const string _headerNameString = "new-header";
 
+        // On purpose longer than 4096 (DefaultStringOctetsSize from HPackDecoder) to trigger https://github.com/dotnet/runtime/issues/78516
+        private static readonly string _literalHeaderNameString = string.Concat(Enumerable.Range(0, 4100).Select(c => (char)('a' + (c % 26))));
+
         private static readonly byte[] _headerNameBytes = Encoding.ASCII.GetBytes(_headerNameString);
+
+        private static readonly byte[] _literalHeaderNameBytes = Encoding.ASCII.GetBytes(_literalHeaderNameString);
 
         // n     e     w       -      h     e     a     d     e     r      *
         // 10101000 10111110 00010110 10011100 10100011 10010000 10110110 01111111
@@ -62,6 +67,12 @@ namespace System.Net.Http.Unit.Tests.HPack
 
         private static readonly byte[] _headerName = new byte[] { (byte)_headerNameBytes.Length }
             .Concat(_headerNameBytes)
+            .ToArray();
+
+        // size = 4096 ==> 0x7f, 0x81, 0x1f (7+) prefixed integer
+        // size = 4100 ==> 0x7f, 0x85, 0x1f (7+) prefixed integer
+        private static readonly byte[] _literalHeaderName = new byte[] { 0x7f, 0x85, 0x1f } // 4100
+            .Concat(_literalHeaderNameBytes)
             .ToArray();
 
         private static readonly byte[] _headerNameHuffman = new byte[] { (byte)(0x80 | _headerNameHuffmanBytes.Length) }
@@ -393,6 +404,101 @@ namespace System.Net.Http.Unit.Tests.HPack
         }
 
         [Fact]
+        public void DecodesLiteralHeaderFieldNeverIndexed_NewName_SingleBuffer()
+        {
+            byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
+                .Concat(_literalHeaderName)
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded, endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
+        }
+
+        [Fact]
+        public void DecodesLiteralHeaderFieldNeverIndexed_NewName_NameLengthBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
+                .Concat(_literalHeaderName)
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded[..1], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[1..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
+        }
+
+        [Fact]
+        public void DecodesLiteralHeaderFieldNeverIndexed_NewName_NameBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
+                .Concat(_literalHeaderName)
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded[..(_literalHeaderNameString.Length / 2)], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[(_literalHeaderNameString.Length / 2)..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
+        }
+
+        [Fact]
+        public void DecodesLiteralHeaderFieldNeverIndexed_NewName_NameAndValueBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
+                .Concat(_literalHeaderName)
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded[..^_headerValue.Length], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[^_headerValue.Length..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
+        }
+
+        [Fact]
+        public void DecodesLiteralHeaderFieldNeverIndexed_NewName_ValueLengthBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
+                .Concat(_literalHeaderName)
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded[..^(_headerValue.Length - 1)], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[^(_headerValue.Length - 1)..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
+        }
+
+        [Fact]
+        public void DecodesLiteralHeaderFieldNeverIndexed_NewName_ValueBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
+                .Concat(_literalHeaderName)
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded[..^(_headerValueString.Length / 2)], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[^(_headerValueString.Length / 2)..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
+        }
+
+        [Fact]
         public void DecodesDynamicTableSizeUpdate()
         {
             // 001   (Dynamic Table Size Update)
@@ -500,10 +606,8 @@ namespace System.Net.Http.Unit.Tests.HPack
             string string8191 = new string('a', MaxHeaderFieldSize - 1);
             string string8193 = new string('a', MaxHeaderFieldSize + 1);
             string string8194 = new string('a', MaxHeaderFieldSize + 2);
-
             var bytes = new byte[3];
             var success = IntegerEncoder.Encode(8194, 7, bytes, out var written);
-
             byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
                 .Concat(new byte[] { 0x7f, 0x80, 0x3f }) // 8191 encoded with 7-bit prefix, no Huffman encoding
                 .Concat(Encoding.ASCII.GetBytes(string8191))
@@ -520,14 +624,12 @@ namespace System.Net.Http.Unit.Tests.HPack
                 .Concat(new byte[] { 0x7f, 0x83, 0x3f }) // 8194 encoded with 7-bit prefix, no Huffman encoding
                 .Concat(Encoding.ASCII.GetBytes(string8194))
                 .ToArray();
-
             var ex = Assert.Throws<HPackDecodingException>(() => decoder.Decode(encoded, endHeaders: true, handler: _handler));
             Assert.Equal(SR.Format(SR.net_http_headers_exceeded_length, MaxHeaderFieldSize + 1), ex.Message);
             Assert.Equal(string8191, _handler.DecodedHeaders[string8191]);
             Assert.Equal(string8193, _handler.DecodedHeaders[string8193]);
             Assert.False(_handler.DecodedHeaders.ContainsKey(string8194));
         }
-
         [Fact]
         public void DecodesStringLength_IndividualBytes()
         {

--- a/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
@@ -413,7 +413,7 @@ namespace System.Net.Http.Unit.Tests.HPack
 
             _decoder.Decode(encoded, endHeaders: true, handler: _handler);
 
-            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.Single(_handler.DecodedHeaders);
             Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
         }
@@ -429,7 +429,7 @@ namespace System.Net.Http.Unit.Tests.HPack
             _decoder.Decode(encoded[..1], endHeaders: false, handler: _handler);
             _decoder.Decode(encoded[1..], endHeaders: true, handler: _handler);
 
-            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.Single(_handler.DecodedHeaders);
             Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
         }
@@ -445,7 +445,7 @@ namespace System.Net.Http.Unit.Tests.HPack
             _decoder.Decode(encoded[..(_literalHeaderNameString.Length / 2)], endHeaders: false, handler: _handler);
             _decoder.Decode(encoded[(_literalHeaderNameString.Length / 2)..], endHeaders: true, handler: _handler);
 
-            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.Single(_handler.DecodedHeaders);
             Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
         }
@@ -461,7 +461,7 @@ namespace System.Net.Http.Unit.Tests.HPack
             _decoder.Decode(encoded[..^_headerValue.Length], endHeaders: false, handler: _handler);
             _decoder.Decode(encoded[^_headerValue.Length..], endHeaders: true, handler: _handler);
 
-            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.Single(_handler.DecodedHeaders);
             Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
         }
@@ -477,7 +477,7 @@ namespace System.Net.Http.Unit.Tests.HPack
             _decoder.Decode(encoded[..^(_headerValue.Length - 1)], endHeaders: false, handler: _handler);
             _decoder.Decode(encoded[^(_headerValue.Length - 1)..], endHeaders: true, handler: _handler);
 
-            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.Single(_handler.DecodedHeaders);
             Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
         }

--- a/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
@@ -493,7 +493,7 @@ namespace System.Net.Http.Unit.Tests.HPack
             _decoder.Decode(encoded[..^(_headerValueString.Length / 2)], endHeaders: false, handler: _handler);
             _decoder.Decode(encoded[^(_headerValueString.Length / 2)..], endHeaders: true, handler: _handler);
 
-            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.Single(_handler.DecodedHeaders);
             Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
         }
@@ -843,7 +843,7 @@ namespace System.Net.Http.Unit.Tests.HPack
 
             if (expectDynamicTableEntry)
             {
-                Assert.Equal(1, dynamicTable.Count);
+                Assert.Single(dynamicTable);
                 Assert.Equal(expectedHeaderName, Encoding.ASCII.GetString(dynamicTable[0].Name));
                 Assert.Equal(expectedHeaderValue, Encoding.ASCII.GetString(dynamicTable[0].Value));
                 Assert.Equal(expectedHeaderName.Length + expectedHeaderValue.Length + 32, dynamicTable.Size);

--- a/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
@@ -843,7 +843,7 @@ namespace System.Net.Http.Unit.Tests.HPack
 
             if (expectDynamicTableEntry)
             {
-                Assert.Single(dynamicTable);
+                Assert.Equal(1, dynamicTable.Count);
                 Assert.Equal(expectedHeaderName, Encoding.ASCII.GetString(dynamicTable[0].Name));
                 Assert.Equal(expectedHeaderValue, Encoding.ASCII.GetString(dynamicTable[0].Value));
                 Assert.Equal(expectedHeaderName.Length + expectedHeaderValue.Length + 32, dynamicTable.Size);

--- a/src/Shared/test/Shared.Tests/runtime/Http3/QPackDecoderTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http3/QPackDecoderTest.cs
@@ -25,11 +25,11 @@ namespace System.Net.Http.Unit.Tests.QPack
         // 4.5.4 - Literal Header Field With Name Reference - Static Table - Index 44 (content-type)
         private static readonly byte[] _literalHeaderFieldWithNameReferenceStatic = new byte[] { 0x5f, 0x1d };
 
-        // 4.5.6 - Literal Field Line With Literal Name - (translate)
-        private static readonly byte[] _literalFieldLineWithLiteralName = new byte[] { 0x37, 0x02, 0x74, 0x72, 0x61, 0x6e, 0x73, 0x6c, 0x61, 0x74, 0x65 };
+        // 4.5.6 - Literal Field Line With Literal Name - (literal-header-field)
+        private static readonly byte[] _literalFieldLineWithLiteralName = new byte[] { 0x37, 0x0d, 0x6c, 0x69, 0x74, 0x65, 0x72, 0x61, 0x6c, 0x2d, 0x68, 0x65, 0x61, 0x64, 0x65, 0x72, 0x2d, 0x66, 0x69, 0x65, 0x6c, 0x64 };
 
         private const string _contentTypeString = "content-type";
-        private const string _translateString = "translate";
+        private const string _literalHeaderFieldString = "literal-header-field";
 
         // n     e     w       -      h     e     a     d     e     r      *
         // 10101000 10111110 00010110 10011100 10100011 10010000 10110110 01111111
@@ -97,7 +97,7 @@ namespace System.Net.Http.Unit.Tests.QPack
                 .Concat(_headerValue)
                 .ToArray();
 
-            TestDecodeWithoutIndexing(encoded, _translateString, _headerValueString);
+            TestDecodeWithoutIndexing(encoded, _literalHeaderFieldString, _headerValueString);
         }
 
         [Fact]
@@ -140,7 +140,7 @@ namespace System.Net.Http.Unit.Tests.QPack
                 .Concat(_headerValueHuffman)
                 .ToArray();
 
-            TestDecodeWithoutIndexing(encoded, _translateString, _headerValueString);
+            TestDecodeWithoutIndexing(encoded, _literalHeaderFieldString, _headerValueString);
         }
 
         [Fact]
@@ -171,6 +171,101 @@ namespace System.Net.Http.Unit.Tests.QPack
                 new KeyValuePair<string, string>(":path", new string('A', 8192 / 2)),
                 new KeyValuePair<string, string>(":scheme", "http")
             });
+        }
+
+        [Fact]
+        public void LiteralFieldWithoutNameReference_SingleBuffer()
+        {
+            byte[] encoded = _literalFieldLineWithLiteralName
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(new byte[] { 0x00, 0x00 }, endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded, endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderFieldString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
+        }
+
+        [Fact]
+        public void LiteralFieldWithoutNameReference_NameLengthBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalFieldLineWithLiteralName
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(new byte[] { 0x00, 0x00 }, endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[..1], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[1..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderFieldString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
+        }
+
+        [Fact]
+        public void LiteralFieldWithoutNameReference_NameBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalFieldLineWithLiteralName
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(new byte[] { 0x00, 0x00 }, endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[..(_literalHeaderFieldString.Length / 2)], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[(_literalHeaderFieldString.Length / 2)..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderFieldString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
+        }
+
+        [Fact]
+        public void LiteralFieldWithoutNameReference_NameAndValueBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalFieldLineWithLiteralName
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(new byte[] { 0x00, 0x00 }, endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[..^_headerValue.Length], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[^_headerValue.Length..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderFieldString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
+        }
+
+        [Fact]
+        public void LiteralFieldWithoutNameReference_ValueLengthBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalFieldLineWithLiteralName
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(new byte[] { 0x00, 0x00 }, endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[..^(_headerValue.Length - 1)], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[^(_headerValue.Length - 1)..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderFieldString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
+        }
+
+        [Fact]
+        public void LiteralFieldWithoutNameReference_ValueBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalFieldLineWithLiteralName
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(new byte[] { 0x00, 0x00 }, endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[..^(_headerValueString.Length / 2)], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[^(_headerValueString.Length / 2)..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderFieldString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
         }
 
         public static readonly TheoryData<byte[]> _incompleteHeaderBlockData = new TheoryData<byte[]>

--- a/src/Shared/test/Shared.Tests/runtime/Http3/QPackDecoderTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http3/QPackDecoderTest.cs
@@ -183,7 +183,7 @@ namespace System.Net.Http.Unit.Tests.QPack
             _decoder.Decode(new byte[] { 0x00, 0x00 }, endHeaders: false, handler: _handler);
             _decoder.Decode(encoded, endHeaders: true, handler: _handler);
 
-            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.Single(_handler.DecodedHeaders);
             Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderFieldString));
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
         }
@@ -199,7 +199,7 @@ namespace System.Net.Http.Unit.Tests.QPack
             _decoder.Decode(encoded[..1], endHeaders: false, handler: _handler);
             _decoder.Decode(encoded[1..], endHeaders: true, handler: _handler);
 
-            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.Single(_handler.DecodedHeaders);
             Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderFieldString));
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
         }
@@ -215,7 +215,7 @@ namespace System.Net.Http.Unit.Tests.QPack
             _decoder.Decode(encoded[..(_literalHeaderFieldString.Length / 2)], endHeaders: false, handler: _handler);
             _decoder.Decode(encoded[(_literalHeaderFieldString.Length / 2)..], endHeaders: true, handler: _handler);
 
-            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.Single(_handler.DecodedHeaders);
             Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderFieldString));
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
         }
@@ -231,7 +231,7 @@ namespace System.Net.Http.Unit.Tests.QPack
             _decoder.Decode(encoded[..^_headerValue.Length], endHeaders: false, handler: _handler);
             _decoder.Decode(encoded[^_headerValue.Length..], endHeaders: true, handler: _handler);
 
-            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.Single(_handler.DecodedHeaders);
             Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderFieldString));
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
         }
@@ -247,7 +247,7 @@ namespace System.Net.Http.Unit.Tests.QPack
             _decoder.Decode(encoded[..^(_headerValue.Length - 1)], endHeaders: false, handler: _handler);
             _decoder.Decode(encoded[^(_headerValue.Length - 1)..], endHeaders: true, handler: _handler);
 
-            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.Single(_handler.DecodedHeaders);
             Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderFieldString));
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
         }
@@ -263,7 +263,7 @@ namespace System.Net.Http.Unit.Tests.QPack
             _decoder.Decode(encoded[..^(_headerValueString.Length / 2)], endHeaders: false, handler: _handler);
             _decoder.Decode(encoded[^(_headerValueString.Length / 2)..], endHeaders: true, handler: _handler);
 
-            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.Single(_handler.DecodedHeaders);
             Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderFieldString));
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderFieldString]);
         }


### PR DESCRIPTION
Manual backport of #47793
Backport of runtime PR in main https://github.com/dotnet/runtime/pull/78862
Port of runtime 7.0 PR https://github.com/dotnet/runtime/pull/85337

Fixes https://github.com/dotnet/runtime/issues/78516

/cc @Tratcher @JamesNK 

# Fix HTTP/3 and HTTTP/2 header decoder buffer allocation

## Description

We resize an internal buffer by an incorrect amount, and subsequent copies to that buffer will throw. The problem occurs in HPack since 5.0 and in QPack since 7.0.

## Customer Impact

Reliability problem in HTTP/2 and HTTP/3, where some requests/responses with large headers that should be accepted might end up throwing exception.
- In HPack cases (HTTP/2 scenarios), the issue is much less likely to be hit as it requires 4KB of headers.
- In QPack (HTTP/3), the header size required to hit this is much smaller and that's where this was caught by the original issue reporter.

This is a shared code with runtime so this affects both client and server - existing PR in runtime: https://github.com/dotnet/runtime/pull/85337.

## Regression?

- [x] Yes
- [ ] No

Regressed in 7.0 for QPack.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Low, as this affects only QPack (H/3 is still not as wide-spread as other HTTP versions) and HPack in (rare) case of 4KB+ sized headers data buffers.

## Verification

- [ ] Manual (required)
- [x] Automated

Added tests for the root cause and similar scenarios, increasing test coverage. All of those are ran in CI.

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A