### PR TITLE
[release/6.0] Fix HTTP/2 header decoder buffer allocation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -122,10 +122,12 @@ dotnet_diagnostic.CA1829.severity = warning
 dotnet_diagnostic.CA1830.severity = warning
 
 # CA1831: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-# CA1832: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-# CA1833: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 dotnet_diagnostic.CA1831.severity = warning
+
+# CA1832: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 dotnet_diagnostic.CA1832.severity = warning
+
+# CA1833: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 dotnet_diagnostic.CA1833.severity = warning
 
 # CA1834: Consider using 'StringBuilder.Append(char)' when applicable
@@ -225,6 +227,12 @@ dotnet_diagnostic.CA1826.severity = suggestion
 dotnet_diagnostic.CA1827.severity = suggestion
 # CA1829: Use Length/Count property instead of Count() when available
 dotnet_diagnostic.CA1829.severity = suggestion
+# CA1831: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1831.severity = suggestion
+# CA1832: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1832.severity = suggestion
+# CA1833: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1833.severity = suggestion
 # CA1834: Consider using 'StringBuilder.Append(char)' when applicable
 dotnet_diagnostic.CA1834.severity = suggestion
 # CA1835: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'

--- a/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
+++ b/src/Shared/runtime/Http2/Hpack/HPackDecoder.cs
@@ -187,12 +187,11 @@ namespace System.Net.Http.HPack
             // will no longer be valid.
             if (_headerNameRange != null)
             {
-                EnsureStringCapacity(ref _headerNameOctets);
+                EnsureStringCapacity(ref _headerNameOctets, _headerNameLength);
                 _headerName = _headerNameOctets;
 
                 ReadOnlySpan<byte> headerBytes = data.Slice(_headerNameRange.GetValueOrDefault().start, _headerNameRange.GetValueOrDefault().length);
                 headerBytes.CopyTo(_headerName);
-                _headerNameLength = headerBytes.Length;
                 _headerNameRange = null;
             }
         }
@@ -427,6 +426,7 @@ namespace System.Net.Http.HPack
             {
                 // Fast path. Store the range rather than copying.
                 _headerNameRange = (start: currentIndex, count);
+                _headerNameLength = _stringLength;
                 currentIndex += count;
 
                 _state = State.HeaderValueLength;
@@ -616,11 +616,12 @@ namespace System.Net.Http.HPack
             _state = nextState;
         }
 
-        private void EnsureStringCapacity(ref byte[] dst)
+        private void EnsureStringCapacity(ref byte[] dst, int stringLength = -1)
         {
-            if (dst.Length < _stringLength)
+            stringLength = stringLength >= 0 ? stringLength : _stringLength;
+            if (dst.Length < stringLength)
             {
-                dst = new byte[Math.Max(_stringLength, Math.Min(dst.Length * 2, _maxHeadersLength))];
+                dst = new byte[Math.Max(stringLength, Math.Min(dst.Length * 2, _maxHeadersLength))];
             }
         }
 

--- a/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
@@ -413,7 +413,7 @@ namespace System.Net.Http.Unit.Tests.HPack
 
             _decoder.Decode(encoded, endHeaders: true, handler: _handler);
 
-            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.Single(_handler.DecodedHeaders);
             Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
         }
@@ -429,7 +429,7 @@ namespace System.Net.Http.Unit.Tests.HPack
             _decoder.Decode(encoded[..1], endHeaders: false, handler: _handler);
             _decoder.Decode(encoded[1..], endHeaders: true, handler: _handler);
 
-            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.Single(_handler.DecodedHeaders);
             Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
         }
@@ -445,7 +445,7 @@ namespace System.Net.Http.Unit.Tests.HPack
             _decoder.Decode(encoded[..(_literalHeaderNameString.Length / 2)], endHeaders: false, handler: _handler);
             _decoder.Decode(encoded[(_literalHeaderNameString.Length / 2)..], endHeaders: true, handler: _handler);
 
-            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.Single(_handler.DecodedHeaders);
             Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
         }
@@ -461,7 +461,7 @@ namespace System.Net.Http.Unit.Tests.HPack
             _decoder.Decode(encoded[..^_headerValue.Length], endHeaders: false, handler: _handler);
             _decoder.Decode(encoded[^_headerValue.Length..], endHeaders: true, handler: _handler);
 
-            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.Single(_handler.DecodedHeaders);
             Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
         }
@@ -477,7 +477,7 @@ namespace System.Net.Http.Unit.Tests.HPack
             _decoder.Decode(encoded[..^(_headerValue.Length - 1)], endHeaders: false, handler: _handler);
             _decoder.Decode(encoded[^(_headerValue.Length - 1)..], endHeaders: true, handler: _handler);
 
-            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.Single(_handler.DecodedHeaders);
             Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
         }
@@ -493,7 +493,7 @@ namespace System.Net.Http.Unit.Tests.HPack
             _decoder.Decode(encoded[..^(_headerValueString.Length / 2)], endHeaders: false, handler: _handler);
             _decoder.Decode(encoded[^(_headerValueString.Length / 2)..], endHeaders: true, handler: _handler);
 
-            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.Single(_handler.DecodedHeaders);
             Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
             Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
         }

--- a/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http2/HPackDecoderTest.cs
@@ -46,7 +46,12 @@ namespace System.Net.Http.Unit.Tests.HPack
 
         private const string _headerNameString = "new-header";
 
+        // On purpose longer than 4096 (DefaultStringOctetsSize from HPackDecoder) to trigger https://github.com/dotnet/runtime/issues/78516
+        private static readonly string _literalHeaderNameString = string.Concat(Enumerable.Range(0, 4100).Select(c => (char)('a' + (c % 26))));
+
         private static readonly byte[] _headerNameBytes = Encoding.ASCII.GetBytes(_headerNameString);
+
+        private static readonly byte[] _literalHeaderNameBytes = Encoding.ASCII.GetBytes(_literalHeaderNameString);
 
         // n     e     w       -      h     e     a     d     e     r      *
         // 10101000 10111110 00010110 10011100 10100011 10010000 10110110 01111111
@@ -62,6 +67,12 @@ namespace System.Net.Http.Unit.Tests.HPack
 
         private static readonly byte[] _headerName = new byte[] { (byte)_headerNameBytes.Length }
             .Concat(_headerNameBytes)
+            .ToArray();
+
+        // size = 4096 ==> 0x7f, 0x81, 0x1f (7+) prefixed integer
+        // size = 4100 ==> 0x7f, 0x85, 0x1f (7+) prefixed integer
+        private static readonly byte[] _literalHeaderName = new byte[] { 0x7f, 0x85, 0x1f } // 4100
+            .Concat(_literalHeaderNameBytes)
             .ToArray();
 
         private static readonly byte[] _headerNameHuffman = new byte[] { (byte)(0x80 | _headerNameHuffmanBytes.Length) }
@@ -393,6 +404,101 @@ namespace System.Net.Http.Unit.Tests.HPack
         }
 
         [Fact]
+        public void DecodesLiteralHeaderFieldNeverIndexed_NewName_SingleBuffer()
+        {
+            byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
+                .Concat(_literalHeaderName)
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded, endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
+        }
+
+        [Fact]
+        public void DecodesLiteralHeaderFieldNeverIndexed_NewName_NameLengthBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
+                .Concat(_literalHeaderName)
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded[..1], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[1..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
+        }
+
+        [Fact]
+        public void DecodesLiteralHeaderFieldNeverIndexed_NewName_NameBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
+                .Concat(_literalHeaderName)
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded[..(_literalHeaderNameString.Length / 2)], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[(_literalHeaderNameString.Length / 2)..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
+        }
+
+        [Fact]
+        public void DecodesLiteralHeaderFieldNeverIndexed_NewName_NameAndValueBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
+                .Concat(_literalHeaderName)
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded[..^_headerValue.Length], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[^_headerValue.Length..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
+        }
+
+        [Fact]
+        public void DecodesLiteralHeaderFieldNeverIndexed_NewName_ValueLengthBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
+                .Concat(_literalHeaderName)
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded[..^(_headerValue.Length - 1)], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[^(_headerValue.Length - 1)..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
+        }
+
+        [Fact]
+        public void DecodesLiteralHeaderFieldNeverIndexed_NewName_ValueBrokenIntoSeparateBuffers()
+        {
+            byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
+                .Concat(_literalHeaderName)
+                .Concat(_headerValue)
+                .ToArray();
+
+            _decoder.Decode(encoded[..^(_headerValueString.Length / 2)], endHeaders: false, handler: _handler);
+            _decoder.Decode(encoded[^(_headerValueString.Length / 2)..], endHeaders: true, handler: _handler);
+
+            Assert.Equal(1, _handler.DecodedHeaders.Count);
+            Assert.True(_handler.DecodedHeaders.ContainsKey(_literalHeaderNameString));
+            Assert.Equal(_headerValueString, _handler.DecodedHeaders[_literalHeaderNameString]);
+        }
+
+        [Fact]
         public void DecodesDynamicTableSizeUpdate()
         {
             // 001   (Dynamic Table Size Update)
@@ -500,10 +606,8 @@ namespace System.Net.Http.Unit.Tests.HPack
             string string8191 = new string('a', MaxHeaderFieldSize - 1);
             string string8193 = new string('a', MaxHeaderFieldSize + 1);
             string string8194 = new string('a', MaxHeaderFieldSize + 2);
-
             var bytes = new byte[3];
             var success = IntegerEncoder.Encode(8194, 7, bytes, out var written);
-
             byte[] encoded = _literalHeaderFieldWithoutIndexingNewName
                 .Concat(new byte[] { 0x7f, 0x80, 0x3f }) // 8191 encoded with 7-bit prefix, no Huffman encoding
                 .Concat(Encoding.ASCII.GetBytes(string8191))
@@ -520,14 +624,12 @@ namespace System.Net.Http.Unit.Tests.HPack
                 .Concat(new byte[] { 0x7f, 0x83, 0x3f }) // 8194 encoded with 7-bit prefix, no Huffman encoding
                 .Concat(Encoding.ASCII.GetBytes(string8194))
                 .ToArray();
-
             var ex = Assert.Throws<HPackDecodingException>(() => decoder.Decode(encoded, endHeaders: true, handler: _handler));
             Assert.Equal(SR.Format(SR.net_http_headers_exceeded_length, MaxHeaderFieldSize + 1), ex.Message);
             Assert.Equal(string8191, _handler.DecodedHeaders[string8191]);
             Assert.Equal(string8193, _handler.DecodedHeaders[string8193]);
             Assert.False(_handler.DecodedHeaders.ContainsKey(string8194));
         }
-
         [Fact]
         public void DecodesStringLength_IndividualBytes()
         {


### PR DESCRIPTION
Manual backport of #47793
Backport of runtime PR in main https://github.com/dotnet/runtime/pull/78862
Port of runtime 6.0 PR https://github.com/dotnet/runtime/pull/85341

Fixes https://github.com/dotnet/runtime/issues/78516

/cc @Tratcher @JamesNK 

# Fix HTTTP/2 header decoder buffer allocation

## Description

We resize an internal buffer by an incorrect amount, and subsequent copies to that buffer will throw. The problem occurs in HPack since 5.0.

## Customer Impact

Reliability problem in HTTP/2 (HPack), where some requests/responses with large headers (4KB+) that should be accepted might end up throwing exception.

This is a shared code with runtime so this affects both client and server - existing PR in runtime: https://github.com/dotnet/runtime/pull/85341.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Low, as this affects only (rare) case of 4KB+ headers data buffers in HTTP/2 (HPack).

## Verification

- [ ] Manual (required)
- [x] Automated

Added tests for the root cause and similar scenarios, increasing test coverage. All of those are ran in CI.

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A