### PR TITLE
Remove support for name attribute when hash routing

### DIFF
--- a/src/Components/Web.JS/src/Services/NavigationManager.ts
+++ b/src/Components/Web.JS/src/Services/NavigationManager.ts
@@ -55,8 +55,7 @@ function setHasLocationChangingListeners(hasListeners: boolean) {
 }
 
 export function scrollToElement(identifier: string): boolean {
-  const element = document.getElementById(identifier)
-    || document.getElementsByName(identifier)[0];
+  const element = document.getElementById(identifier);
 
     if (element) {
       element.scrollIntoView();

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -1547,7 +1547,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
     }
 
     [Fact]
-    public void AnchorWithHrefContainingHashSamePage_ScrollsToElementWithIdOnTheSamePage()
+    public void AnchorWithHrefContainingHashSamePage_ScrollsToElementOnTheSamePage()
     {
         SetUrlViaPushState("/");
         var app = Browser.MountTestComponent<TestRouter>();
@@ -1563,7 +1563,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
     }
 
     [Fact]
-    public void AnchorWithHrefContainingHashAnotherPage_NavigatesToPageAndScrollsToElementWithName()
+    public void AnchorWithHrefContainingHashAnotherPage_NavigatesToPageAndScrollsToElement()
     {
         SetUrlViaPushState("/");
         var app = Browser.MountTestComponent<TestRouter>();
@@ -1579,7 +1579,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
     }
 
     [Fact]
-    public void NavigatationManagerNavigateToSameUrlWithHash_ScrollsToElementWithIdOnTheSamePage()
+    public void NavigatationManagerNavigateToSameUrlWithHash_ScrollsToElementOnTheSamePage()
     {
         SetUrlViaPushState("/");
         var app = Browser.MountTestComponent<TestRouter>();
@@ -1595,7 +1595,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
     }
 
     [Fact]
-    public void NavigatationManagerNavigateToAnotherUrlWithHash_NavigatesToPageAndScrollsToElementWithName()
+    public void NavigatationManagerNavigateToAnotherUrlWithHash_NavigatesToPageAndScrollsToElement()
     {
         SetUrlViaPushState("/");
         var app = Browser.MountTestComponent<TestRouter>();

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/LongPageWithHash2.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/LongPageWithHash2.razor
@@ -5,7 +5,7 @@
     Scroll past me to find the links
 </div>
 
-<p name="test2">Test2</p>
+<p id="test2">Test2</p>
 
 <div style="border: 2px dashed blue; margin: 1rem; padding: 1rem; height: 1500px;">
     Scroll past me to find the links


### PR DESCRIPTION
# Remove support for name attribute for hash routing


Fixes #47953
