### PR TITLE
for CI purposes: try on-by-default

### DIFF
--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -121,7 +121,7 @@ public class HttpSysOptions
     /// Applications that use asynchronous I/O and that may have more than one send outstanding at a time should not use this flag.
     /// Enabling this can results in higher CPU and memory usage by Http.Sys.
     /// </summary>
-    public bool EnableKernelResponseBuffering { get; set; } // internal via app-context for non-public release
+    public bool EnableKernelResponseBuffering { get; set; }
 
     /// <summary>
     /// Gets or sets the maximum number of concurrent connections to accept. Set `-1` for infinite.

--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -34,6 +34,10 @@ public class HttpSysOptions
     /// </summary>
     public HttpSysOptions()
     {
+        // this feature is being back-ported to net6/net7 via an app-context switch; respect that even on net8+ to avoid
+        // surprises when upgrading TFMs
+        const string EnableKernelResponseBufferingSwitch = "Microsoft.AspNetCore.Server.HttpSys.EnableKernelResponseBuffering";
+        EnableKernelResponseBuffering = AppContext.TryGetSwitch(EnableKernelResponseBufferingSwitch, out var enabled) && enabled;
     }
 
     /// <summary>
@@ -109,6 +113,15 @@ public class HttpSysOptions
     /// The default is `false` (complete normally).
     /// </summary>
     public bool ThrowWriteExceptions { get; set; }
+
+    /// <summary>
+    /// Enable buffering of response data in the Kernel.
+    /// It should be used by an application doing synchronous I/O or by an application doing asynchronous I/O with
+    /// no more than one outstanding write at a time, and can significantly improve throughput over high-latency connections.
+    /// Applications that use asynchronous I/O and that may have more than one send outstanding at a time should not use this flag.
+    /// Enabling this can results in higher CPU and memory usage by Http.Sys.
+    /// </summary>
+    public bool EnableKernelResponseBuffering { get; set; } // internal via app-context for non-public release
 
     /// <summary>
     /// Gets or sets the maximum number of concurrent connections to accept. Set `-1` for infinite.

--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -34,10 +34,6 @@ public class HttpSysOptions
     /// </summary>
     public HttpSysOptions()
     {
-        // this feature is being back-ported to net6/net7 via an app-context switch; respect that even on net8+ to avoid
-        // surprises when upgrading TFMs
-        const string EnableKernelResponseBufferingSwitch = "Microsoft.AspNetCore.Server.HttpSys.EnableKernelResponseBuffering";
-        EnableKernelResponseBuffering = AppContext.TryGetSwitch(EnableKernelResponseBufferingSwitch, out var enabled) && enabled;
     }
 
     /// <summary>
@@ -115,7 +111,7 @@ public class HttpSysOptions
     public bool ThrowWriteExceptions { get; set; }
 
     /// <summary>
-    /// Enable buffering of response data in the Kernel.
+    /// Enable buffering of response data in the Kernel. The default value is <code>false</code>.
     /// It should be used by an application doing synchronous I/O or by an application doing asynchronous I/O with
     /// no more than one outstanding write at a time, and can significantly improve throughput over high-latency connections.
     /// Applications that use asynchronous I/O and that may have more than one send outstanding at a time should not use this flag.

--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -111,13 +111,13 @@ public class HttpSysOptions
     public bool ThrowWriteExceptions { get; set; }
 
     /// <summary>
-    /// Enable buffering of response data in the Kernel. The default value is <code>false</code>.
+    /// Enable buffering of response data in the Kernel. The default value is <code>true</code>.
     /// It should be used by an application doing synchronous I/O or by an application doing asynchronous I/O with
     /// no more than one outstanding write at a time, and can significantly improve throughput over high-latency connections.
     /// Applications that use asynchronous I/O and that may have more than one send outstanding at a time should not use this flag.
     /// Enabling this can results in higher CPU and memory usage by Http.Sys.
     /// </summary>
-    public bool EnableKernelResponseBuffering { get; set; }
+    public bool EnableKernelResponseBuffering { get; set; } = true;
 
     /// <summary>
     /// Gets or sets the maximum number of concurrent connections to accept. Set `-1` for infinite.

--- a/src/Servers/HttpSys/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/HttpSys/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Server.HttpSys.HttpSysOptions.EnableKernelResponseBuffering.get -> bool
+Microsoft.AspNetCore.Server.HttpSys.HttpSysOptions.EnableKernelResponseBuffering.set -> void

--- a/src/Servers/HttpSys/src/RequestProcessing/Response.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Response.cs
@@ -275,8 +275,6 @@ internal sealed class Response
     // This will give us more control of the bytes that hit the wire, including encodings, HTTP 1.0, etc..
     // It may also be faster to do this work in managed code and then pass down only one buffer.
     // What would we loose by bypassing HttpSendHttpResponse?
-    //
-    // TODO: Consider using the HTTP_SEND_RESPONSE_FLAG_BUFFER_DATA flag for most/all responses rather than just Opaque.
     internal unsafe uint SendHeaders(ref UnmanagedBufferAllocator allocator,
         Span<HttpApiTypes.HTTP_DATA_CHUNK> dataChunks,
         ResponseStreamAsyncResult? asyncResult,


### PR DESCRIPTION
(spike of https://github.com/dotnet/aspnetcore/pull/47776, on by default, for CI purposes)