### PR TITLE
Run helix matrix tests on AlmaLinux 8

### DIFF
--- a/docs/Helix.md
+++ b/docs/Helix.md
@@ -19,7 +19,7 @@ This will restore, and then publish all the test project including some bootstra
 ## Overview of the helix usage in our pipelines
 
 - Required queues: Windows10, OSX, Ubuntu1804
-- Full queue matrix: Windows[10, 11], Ubuntu[1804, 2004], Debian11, Redhat7, Arm64 (Win10, Debian11)
+- Full queue matrix: Windows[10, 11], Ubuntu[1804, 2004], Debian11, AlmaLinux8, Arm64 (Win10, Debian11)
 - The queues are defined in [Helix.Common.props](https://github.com/dotnet/aspnetcore/blob/main/eng/targets/Helix.Common.props)
 
 [aspnetcore-ci](https://dev.azure.com/dnceng/public/_build?definitionId=278) runs non quarantined tests against the required helix queues as a required PR check and all builds on all branches.
@@ -149,7 +149,7 @@ WorkItems
 | where JobName == "bc108374-750c-4084-853e-bc5b9b0d553e"
 | where Name != JobName
 | extend RunTime = Finished-Started
-| top 20 by RunTime desc  
+| top 20 by RunTime desc
 | project FriendlyName, RunTime
 ```
 

--- a/eng/scripts/RunHelix.ps1
+++ b/eng/scripts/RunHelix.ps1
@@ -10,7 +10,7 @@
     Some supported queues:
     Debian.11.Amd64.Open
     Mariner
-    Redhat.7.Amd64.Open
+    AlmaLinux.8.Amd64.Open
     Ubuntu.2004.Amd64.Open
     OSX.1100.Amd64.Open
     Windows.10.Amd64.Server20H2.Open

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -37,7 +37,7 @@
       <!-- aspnetcore-quarantined-tests (quarantined-tests.yml) and RunHelix.ps1 -RunQuarantinedTests -->
       <ItemGroup>
         <!-- Linux -->
-        <HelixAvailableTargetQueue Include="(AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@svencontainers.azurecr.io/ubuntu-22.04-arm64v8/almalinux" Platform="Linux" />
+        <HelixAvailableTargetQueue Include="(AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@svencontainers.azurecr.io/almalinux" Platform="Linux" />
 
         <!-- Containers -->
         <HelixAvailableTargetQueue Include="$(HelixQueueAlpine316)" Platform="Linux" />

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -1,6 +1,7 @@
 <Project>
   <!-- This file is shared between Helix.proj and .csproj files. -->
   <PropertyGroup>
+    <HelixQueueAlmaLinux8>(AlmaLinux.8.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-8-helix-amd64</HelixQueueAlmaLinux8>
     <HelixQueueAlpine316>(Alpine.316.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.16-helix-amd64</HelixQueueAlpine316>
     <HelixQueueDebian11>(Debian.11.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64</HelixQueueDebian11>
     <HelixQueueFedora34>(Fedora.34.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-helix</HelixQueueFedora34>
@@ -37,7 +38,7 @@
       <!-- aspnetcore-quarantined-tests (quarantined-tests.yml) and RunHelix.ps1 -RunQuarantinedTests -->
       <ItemGroup>
         <!-- Linux -->
-        <HelixAvailableTargetQueue Include="(AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-8-helix-amd64" Platform="Linux" />
+        <HelixAvailableTargetQueue Include="$(HelixQueueAlmaLinux8)" Platform="Linux" />
 
         <!-- Containers -->
         <HelixAvailableTargetQueue Include="$(HelixQueueAlpine316)" Platform="Linux" />

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -37,7 +37,7 @@
       <!-- aspnetcore-quarantined-tests (quarantined-tests.yml) and RunHelix.ps1 -RunQuarantinedTests -->
       <ItemGroup>
         <!-- Linux -->
-        <HelixAvailableTargetQueue Include="Redhat.7.Amd64.Open" Platform="Linux" />
+        <HelixAvailableTargetQueue Include="(AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@svencontainers.azurecr.io/ubuntu-22.04-arm64v8/almalinux" Platform="Linux" />
 
         <!-- Containers -->
         <HelixAvailableTargetQueue Include="$(HelixQueueAlpine316)" Platform="Linux" />

--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -37,7 +37,7 @@
       <!-- aspnetcore-quarantined-tests (quarantined-tests.yml) and RunHelix.ps1 -RunQuarantinedTests -->
       <ItemGroup>
         <!-- Linux -->
-        <HelixAvailableTargetQueue Include="(AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@svencontainers.azurecr.io/almalinux" Platform="Linux" />
+        <HelixAvailableTargetQueue Include="(AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-8-helix-amd64" Platform="Linux" />
 
         <!-- Containers -->
         <HelixAvailableTargetQueue Include="$(HelixQueueAlpine316)" Platform="Linux" />

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -20,7 +20,7 @@
       $(HelixQueueDebian11);
       $(HelixQueueFedora34);
       $(HelixQueueMariner);
-      (AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@svencontainers.azurecr.io/ubuntu-22.04-arm64v8/almalinux;
+      (AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@svencontainers.azurecr.io/almalinux;
       Ubuntu.2004.Amd64.Open;
     </SkipHelixQueues>
     <SkipHelixArm>true</SkipHelixArm>

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -20,7 +20,7 @@
       $(HelixQueueDebian11);
       $(HelixQueueFedora34);
       $(HelixQueueMariner);
-      Redhat.7.Amd64.Open;
+      (AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@svencontainers.azurecr.io/ubuntu-22.04-arm64v8/almalinux;
       Ubuntu.2004.Amd64.Open;
     </SkipHelixQueues>
     <SkipHelixArm>true</SkipHelixArm>

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -16,11 +16,11 @@
 
   <PropertyGroup Condition="'$(TestDependsOnPlaywright)' == 'true'">
     <SkipHelixQueues>
+      $(HelixQueueAlmaLinux8);
       $(HelixQueueAlpine316);
       $(HelixQueueDebian11);
       $(HelixQueueFedora34);
       $(HelixQueueMariner);
-      (AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-8-helix-amd64;
       Ubuntu.2004.Amd64.Open;
     </SkipHelixQueues>
     <SkipHelixArm>true</SkipHelixArm>

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -20,7 +20,7 @@
       $(HelixQueueDebian11);
       $(HelixQueueFedora34);
       $(HelixQueueMariner);
-      (AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@svencontainers.azurecr.io/almalinux;
+      (AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-8-helix-amd64;
       Ubuntu.2004.Amd64.Open;
     </SkipHelixQueues>
     <SkipHelixArm>true</SkipHelixArm>

--- a/src/Security/Authentication/test/CertificateTests.cs
+++ b/src/Security/Authentication/test/CertificateTests.cs
@@ -155,7 +155,7 @@ public class ClientCertificateAuthenticationTests
     }
 
     [ConditionalFact]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/32813", Queues = $"All.Ubuntu;{HelixConstants.RedhatAmd64}")]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/32813", Queues = $"All.Ubuntu;{HelixConstants.AlmaLinuxAmd64}")]
     public async Task VerifyExpiredSelfSignedFails()
     {
         using var host = await CreateHost(
@@ -190,7 +190,7 @@ public class ClientCertificateAuthenticationTests
     }
 
     [ConditionalFact]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/32813", Queues = $"All.Ubuntu;{HelixConstants.RedhatAmd64}")]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/32813", Queues = $"All.Ubuntu;{HelixConstants.AlmaLinuxAmd64}")]
     public async Task VerifyNotYetValidSelfSignedFails()
     {
         using var host = await CreateHost(

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -565,7 +565,7 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
     [InlineData(HttpProtocols.Http1AndHttp2)] // Make sure turning on Http/2 doesn't regress HTTP/1
     [TlsAlpnSupported]
     [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing platform support.")]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/33566#issuecomment-892031659", Queues = HelixConstants.RedhatAmd64)] // Outdated OpenSSL client
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/33566#issuecomment-892031659", Queues = HelixConstants.AlmaLinuxAmd64)] // Outdated OpenSSL client
     public async Task CanRenegotiateForClientCertificate(HttpProtocols httpProtocols)
     {
         void ConfigureListenOptions(ListenOptions listenOptions)
@@ -691,7 +691,7 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
     [ConditionalFact]
     [TlsAlpnSupported]
     [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing platform support.")]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/33566#issuecomment-892031659", Queues = HelixConstants.RedhatAmd64)] // Outdated OpenSSL client
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/33566#issuecomment-892031659", Queues = HelixConstants.AlmaLinuxAmd64)] // Outdated OpenSSL client
     public async Task CanRenegotiateForTlsCallbackOptions()
     {
         void ConfigureListenOptions(ListenOptions listenOptions)
@@ -739,7 +739,7 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
     [ConditionalFact]
     [TlsAlpnSupported]
     [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing platform support.")]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/33566#issuecomment-892031659", Queues = HelixConstants.RedhatAmd64)] // Outdated OpenSSL client
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/33566#issuecomment-892031659", Queues = HelixConstants.AlmaLinuxAmd64)] // Outdated OpenSSL client
     public async Task CanRenegotiateForClientCertificateOnHttp1CanReturnNoCert()
     {
         void ConfigureListenOptions(ListenOptions listenOptions)
@@ -863,7 +863,7 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
     // then the connection is aborted.
     [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing platform support.")]
     [TlsAlpnSupported]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/33566#issuecomment-892031659", Queues = HelixConstants.RedhatAmd64)] // Outdated OpenSSL client
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/33566#issuecomment-892031659", Queues = HelixConstants.AlmaLinuxAmd64)] // Outdated OpenSSL client
     public async Task RenegotiateForClientCertificateOnPostWithoutBufferingThrows()
     {
         void ConfigureListenOptions(ListenOptions listenOptions)
@@ -1000,7 +1000,7 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
     [ConditionalFact]
     [TlsAlpnSupported]
     [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing platform support.")]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/33566#issuecomment-892031659", Queues = HelixConstants.RedhatAmd64)] // Outdated OpenSSL client
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/33566#issuecomment-892031659", Queues = HelixConstants.AlmaLinuxAmd64)] // Outdated OpenSSL client
     public async Task CanRenegotiateForClientCertificateOnPostIfDrained()
     {
         void ConfigureListenOptions(ListenOptions listenOptions)
@@ -1047,7 +1047,7 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
     [ConditionalFact]
     [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "Missing platform support.")]
     [TlsAlpnSupported]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/33566#issuecomment-892031659", Queues = HelixConstants.RedhatAmd64)] // Outdated OpenSSL client
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/33566#issuecomment-892031659", Queues = HelixConstants.AlmaLinuxAmd64)] // Outdated OpenSSL client
     public async Task RenegotationFailureCausesConnectionClose()
     {
         void ConfigureListenOptions(ListenOptions listenOptions)

--- a/src/Testing/src/xunit/HelixConstants.cs
+++ b/src/Testing/src/xunit/HelixConstants.cs
@@ -8,5 +8,5 @@ public static class HelixConstants
     public const string Windows10Arm64 = "Windows.10.Arm64v8.Open;";
     public const string DebianAmd64 = "Debian.11.Amd64.Open;";
     public const string DebianArm64 = "Debian.11.Arm64.Open;";
-    public const string AlmaLinuxAmd64 = "(AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@svencontainers.azurecr.io/almalinux;";
+    public const string AlmaLinuxAmd64 = "(AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-8-helix-amd64;";
 }

--- a/src/Testing/src/xunit/HelixConstants.cs
+++ b/src/Testing/src/xunit/HelixConstants.cs
@@ -8,5 +8,5 @@ public static class HelixConstants
     public const string Windows10Arm64 = "Windows.10.Arm64v8.Open;";
     public const string DebianAmd64 = "Debian.11.Amd64.Open;";
     public const string DebianArm64 = "Debian.11.Arm64.Open;";
-    public const string AlmaLinuxAmd64 = "(AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@svencontainers.azurecr.io/ubuntu-22.04-arm64v8/almalinux;";
+    public const string AlmaLinuxAmd64 = "(AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@svencontainers.azurecr.io/almalinux;";
 }

--- a/src/Testing/src/xunit/HelixConstants.cs
+++ b/src/Testing/src/xunit/HelixConstants.cs
@@ -8,5 +8,5 @@ public static class HelixConstants
     public const string Windows10Arm64 = "Windows.10.Arm64v8.Open;";
     public const string DebianAmd64 = "Debian.11.Amd64.Open;";
     public const string DebianArm64 = "Debian.11.Arm64.Open;";
-    public const string RedhatAmd64 = "Redhat.7.Amd64.Open;";
+    public const string AlmaLinuxAmd64 = "(AlmaLinux.8.Amd64.Open)Ubuntu.1804.Amd64.Open@svencontainers.azurecr.io/ubuntu-22.04-arm64v8/almalinux;";
 }


### PR DESCRIPTION
This uses the new AlmaLinux 8 images added in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/860 for testing.

helix-matrix run: https://dev.azure.com/dnceng-public/public/_build/results?buildId=256645&view=results