### PR TITLE
Remove debug check from fabric bot labeling automation

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -3685,17 +3685,23 @@
               }
             },
             {
-              "name": "bodyContains",
-              "parameters": {
-                "bodyPattern": "[Aa][Oo][Tt]",
-                "isRegex": true
-              }
-            },
-            {
-              "name": "hasLabel",
-              "parameters": {
-                "label": "INTERNAL: Debug"
-              }
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa][Oo][Tt]",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "isRegex": true,
+                    "titlePattern": "[Aa][Oo][Tt]"
+                  }
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
Here is a test that the current regex worked: https://github.com/dotnet/aspnetcore/issues/47971
<img width="452" alt="image" src="https://user-images.githubusercontent.com/34246760/235255967-ac48a671-0627-4bc5-8018-300c47c5573e.png">
