### PR TITLE
Update PropertyColumn.cs

### DIFF
--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Columns/PropertyColumn.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Columns/PropertyColumn.cs
@@ -70,7 +70,10 @@ public class PropertyColumn<TGridItem, TProp> : ColumnBase<TGridItem>
 
         if (Title is null && Property.Body is MemberExpression memberExpression)
         {
-            Title = memberExpression.Member.Name;
+            var memberInfo = memberExpression.Member;
+            var displayName = memberInfo?.GetCustomAttribute(typeof(DisplayNameAttribute)) as DisplayNameAttribute;
+            var display = memberInfo?.GetCustomAttribute(typeof(DisplayAttribute)) as DisplayAttribute;
+            Title = displayName?.DisplayName ?? display?.Name ?? memberInfo?.Name ?? "";
         }
     }
 


### PR DESCRIPTION
This code uses the DisplayName and Display attributes to obtain the display name of a property. It starts by getting the member information from the provided member expression using the Member property of the memberExpression object. Then, it uses the GetCustomAttribute method to get the DisplayName and Display attributes associated with this member. If the DisplayName attribute is present, its value is used as the title. Otherwise, if the Display attribute is present, its Name property is used as the title. If neither of these attributes is present, the name of the member itself is used as the title. Finally, the value of the title is assigned to the Title property.

# {PR title}

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

{Detail}

Fixes #{bug number} (in this specific format)
