### PR TITLE
Fixes grammar mistake in AuthenticateResult class

### DIFF
--- a/src/Http/Authentication.Abstractions/src/AuthenticateResult.cs
+++ b/src/Http/Authentication.Abstractions/src/AuthenticateResult.cs
@@ -30,7 +30,7 @@ public class AuthenticateResult
     public AuthenticationTicket? Ticket { get; protected set; }
 
     /// <summary>
-    /// Gets the claims-principal with authenticated user identities.
+    /// Gets the claims-principal with which the authenticated user identities.
     /// </summary>
     public ClaimsPrincipal? Principal => Ticket?.Principal;
 


### PR DESCRIPTION
# Minor Grammar Mistake Fix

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

This PR fixes a minor grammar mistake in the AuthenticateResult.cs file. The mistake can be found in the XML documentation summary tag [AuthenticateResult.cs](https://github.com/dotnet/aspnetcore/blob/7f4ee4ac2fc945eab33d004581e7b633bdceb475/src/Http/Authentication.Abstractions/src/AuthenticateResult.cs#L33)

I have updated the comments to say "Gets the claims-principal with which the authenticated user identities." which improves the readability and clarity of the code. 

Fixes #48015 
