### PR TITLE
 Fix SupportedRuntimeIdentifiers substitution in Directory.Build.targets.in.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -157,23 +157,9 @@
   <PropertyGroup>
     <BuildArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</BuildArchitecture>
 
-    <!-- This defines the list of RIDs supported by the ASP.NET Core shared framework. -->
-    <SupportedRuntimeIdentifiers>
-      win-x64;
-      win-x86;
-      win-arm;
-      win-arm64;
-      osx-x64;
-      osx-arm64;
-      linux-musl-x64;
-      linux-musl-arm;
-      linux-musl-arm64;
-      linux-x64;
-      linux-arm;
-      linux-arm64;
-      freebsd-x64
-    </SupportedRuntimeIdentifiers>
-
+    <!-- This defines the list of RIDs supported by the ASP.NET Core shared framework.
+         The list is a semicolon separated list of RIDs. Whitespace may not be added to the property. -->
+    <SupportedRuntimeIdentifiers>win-x64;win-x86;win-arm;win-arm64;osx-x64;osx-arm64;linux-musl-x64;linux-musl-arm;linux-musl-arm64;linux-x64;linux-arm;linux-arm64;freebsd-x64</SupportedRuntimeIdentifiers>
     <SupportedRuntimeIdentifiers Condition=" '$(PortableBuild)' == 'false' ">$(SupportedRuntimeIdentifiers);$(TargetRuntimeIdentifier)</SupportedRuntimeIdentifiers>
 
     <!-- Playwright provides binaries for Windows (x86 and x64), macOS (x64) and Linux (x64, non musl). We can't use it on other architectures. -->

--- a/eng/tools/GenerateFiles/GenerateFiles.csproj
+++ b/eng/tools/GenerateFiles/GenerateFiles.csproj
@@ -26,7 +26,7 @@
         MicrosoftNETCoreAppRuntimeVersion=$(MicrosoftNETCoreAppRuntimeVersion);
         MicrosoftPlaywrightCLIVersion=$(MicrosoftPlaywrightCLIVersion);
         LibNetHostAppPackVersion=$(BundledNETCoreAppPackageVersion);
-        SupportedRuntimeIdentifiers=$(SupportedRuntimeIdentifiers.Trim());
+        SupportedRuntimeIdentifiers=$([MSBuild]::Escape($(SupportedRuntimeIdentifiers)));
         ArtifactsShippingPackagesDir=$(ArtifactsShippingPackagesDir)
       </_TemplateProperties>
     </PropertyGroup>


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/pull/47247 enabled AOT template tests.
From the comments on the PR, it seems the tests are known to fail on Linux.

This adds attributes to skip those tests on Linux, like when running on a Linux developer machine, or our internal CI machines.

@JamesNK @dougbu @eerhardt ptal.