### PR TITLE
Update selenium dependencies

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -297,9 +297,9 @@
     <MicrosoftPlaywrightVersion>1.28.0</MicrosoftPlaywrightVersion>
     <PollyExtensionsHttpVersion>3.0.0</PollyExtensionsHttpVersion>
     <PollyVersion>7.2.3</PollyVersion>
-    <SeleniumSupportVersion>4.8.2</SeleniumSupportVersion>
+    <SeleniumSupportVersion>4.9.0</SeleniumSupportVersion>
     <SeleniumWebDriverChromeDriverVersion>112.0.5615.4900</SeleniumWebDriverChromeDriverVersion>
-    <SeleniumWebDriverVersion>4.8.2</SeleniumWebDriverVersion>
+    <SeleniumWebDriverVersion>4.9.0</SeleniumWebDriverVersion>
     <SerilogExtensionsLoggingVersion>1.4.0</SerilogExtensionsLoggingVersion>
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
     <StackExchangeRedisVersion>2.6.90</StackExchangeRedisVersion>


### PR DESCRIPTION
This is the monthly update of Selenium dependencies. The stable chrome dependencies are all still 112.0.

(Waiting for packages to get added to the feed)