### PR TITLE
Add infrastructure for trimming and NativeAOT test apps.

### DIFF
--- a/Directory.Build.BeforeCommonTargets.targets
+++ b/Directory.Build.BeforeCommonTargets.targets
@@ -15,6 +15,7 @@
     <ExcludeFromBuild Condition="'$(IsPackable)' != 'true' and
         '$(SkipTestBuild)' == 'true' and
         ($(IsTestProject) or
+         '$(IsPublishedAppTestProject)' == 'true' or
          '$(IsTestAssetProject)' == 'true' or
          '$(IsBenchmarkProject)' == 'true' or
          '$(IsSampleProject)' == 'true' or

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -262,9 +262,9 @@
   <Import Project="eng\targets\Wix.Common.props"  Condition="'$(MSBuildProjectExtension)' == '.wixproj'" />
   <Import Project="eng\targets\Npm.Common.props"  Condition="'$(MSBuildProjectExtension)' == '.npmproj'" />
   <Import Project="eng\targets\Java.Common.props"  Condition="'$(MSBuildProjectExtension)' == '.javaproj'" />
+  <Import Project="eng\testing\linker\trimmingTests.props" Condition="'$(IsPublishedAppTestProject)' == 'true'" />
   <Import Project="eng\targets\Helix.props" Condition=" $(IsTestProject) " />
   <Import Project="eng\targets\FunctionalTestWithAssets.props" Condition=" $(IsTestProject) " />
-  <Import Project="eng\testing\linker\trimmingTests.props" Condition="'$(IsPublishedAppTestProject)' == 'true'" />
 
   <!-- Keys used by InternalsVisibleTo attributes. -->
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <Import Project="eng\Common.props" />
 
   <PropertyGroup>
@@ -30,6 +30,9 @@
           $(MSBuildProjectName.EndsWith('.Test')) OR
           $(MSBuildProjectName.EndsWith('.FunctionalTest')) ) ">true</IsUnitTestProject>
     <IsUnitTestProject Condition=" '$(IsUnitTestProject)' == '' ">false</IsUnitTestProject>
+    <IsTrimmingTestProject Condition="$(MSBuildProjectName.EndsWith('.TrimmingTests'))">true</IsTrimmingTestProject>
+    <IsNativeAotTestProject Condition="$(MSBuildProjectName.EndsWith('.NativeAotTests'))">true</IsNativeAotTestProject>
+    <IsPublishedAppTestProject Condition="'$(IsTrimmingTestProject)' == 'true' or '$(IsNativeAotTestProject)' == 'true'">true</IsPublishedAppTestProject>
     <IsTestAssetProject Condition=" $(RepoRelativeProjectDir.Contains('testassets')) OR $(MSBuildProjectName.Contains('TestCommon'))">true</IsTestAssetProject>
     <IsProjectTemplateProject Condition=" ($(RepoRelativeProjectDir.Contains('ProjectTemplates')) OR $(MSBuildProjectName.Contains('ProjectTemplates')) ) AND
         '$(IsUnitTestProject)' != 'true' AND
@@ -39,6 +42,7 @@
     <IsShipping Condition=" '$(IsSampleProject)' == 'true' OR
         '$(IsTestAssetProject)' == 'true' OR
         '$(IsBenchmarkProject)' == 'true' OR
+        '$(IsPublishedAppTestProject)' == 'true' OR
         $(IsUnitTestProject) ">false</IsShipping>
 
     <!--
@@ -260,6 +264,7 @@
   <Import Project="eng\targets\Java.Common.props"  Condition="'$(MSBuildProjectExtension)' == '.javaproj'" />
   <Import Project="eng\targets\Helix.props" Condition=" $(IsTestProject) " />
   <Import Project="eng\targets\FunctionalTestWithAssets.props" Condition=" $(IsTestProject) " />
+  <Import Project="eng\testing\linker\trimmingTests.props" Condition="'$(IsPublishedAppTestProject)' == 'true'" />
 
   <!-- Keys used by InternalsVisibleTo attributes. -->
   <PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -182,4 +182,5 @@
   <Import Project="eng\targets\Helix.targets" Condition=" $(IsTestProject) " />
   <Import Project="eng\targets\FunctionalTestWithAssets.targets"
       Condition=" $(IsTestProject) AND $(ContainsFunctionalTestAssets) " />
+  <Import Project="eng\testing\linker\trimmingTests.targets" Condition="'$(IsPublishedAppTestProject)' == 'true'" />
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -179,8 +179,8 @@
   <Import Project="eng\targets\Wix.Common.targets"  Condition="'$(MSBuildProjectExtension)' == '.wixproj'" />
   <Import Project="eng\targets\Npm.Common.targets"  Condition="'$(MSBuildProjectExtension)' == '.npmproj'" />
   <Import Project="eng\targets\Java.Common.targets"  Condition="'$(MSBuildProjectExtension)' == '.javaproj'" />
+  <Import Project="eng\testing\linker\trimmingTests.targets" Condition="'$(IsPublishedAppTestProject)' == 'true'" />
   <Import Project="eng\targets\Helix.targets" Condition=" $(IsTestProject) " />
   <Import Project="eng\targets\FunctionalTestWithAssets.targets"
       Condition=" $(IsTestProject) AND $(ContainsFunctionalTestAssets) " />
-  <Import Project="eng\testing\linker\trimmingTests.targets" Condition="'$(IsPublishedAppTestProject)' == 'true'" />
 </Project>

--- a/eng/RequiresDelayedBuildProjects.props
+++ b/eng/RequiresDelayedBuildProjects.props
@@ -17,5 +17,6 @@
     <RequiresDelayedBuild Include="$(RepoRoot)src\Grpc\JsonTranscoding\test\testassets\IntegrationTestsWebsite\IntegrationTestsWebsite.csproj" />
     <RequiresDelayedBuild Include="$(RepoRoot)src\Grpc\JsonTranscoding\test\testassets\Sandbox\Sandbox.csproj" />
     <RequiresDelayedBuild Include="$(RepoRoot)src\ProjectTemplates\test\Templates.Blazor.Tests\Templates.Blazor.Tests.csproj" />
+    <RequiresDelayedBuild Include="$(RepoRoot)src\**\*NativeAotTests.proj" />
   </ItemGroup>
 </Project>

--- a/eng/RequiresDelayedBuildProjects.props
+++ b/eng/RequiresDelayedBuildProjects.props
@@ -17,6 +17,6 @@
     <RequiresDelayedBuild Include="$(RepoRoot)src\Grpc\JsonTranscoding\test\testassets\IntegrationTestsWebsite\IntegrationTestsWebsite.csproj" />
     <RequiresDelayedBuild Include="$(RepoRoot)src\Grpc\JsonTranscoding\test\testassets\Sandbox\Sandbox.csproj" />
     <RequiresDelayedBuild Include="$(RepoRoot)src\ProjectTemplates\test\Templates.Blazor.Tests\Templates.Blazor.Tests.csproj" />
-    <RequiresDelayedBuild Include="$(RepoRoot)src\**\*NativeAotTests.proj" />
+    <RequiresDelayedBuild Include="$(RepoRoot)src\DefaultBuilder\test\Microsoft.AspNetCore.NativeAotTests\Microsoft.AspNetCore.NativeAotTests.proj" />
   </ItemGroup>
 </Project>

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -399,7 +399,9 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
   # Locate Visual Studio installation or download x-copy msbuild.
   $vsInfo = LocateVisualStudio $vsRequirements
   if ($vsInfo -ne $null) {
-    $vsInstallDir = $vsInfo.installationPath
+    # Needed until we get https://github.com/dotnet/arcade/pull/13406/
+    # Ensure vsInstallDir has a trailing slash
+    $vsInstallDir = Join-path $vsInfo.installationPath "\"
     $vsMajorVersion = $vsInfo.installationVersion.Split('.')[0]
 
     InitializeVisualStudioEnvironmentVariables $vsInstallDir $vsMajorVersion

--- a/eng/testing/linker/SupportFiles/Directory.Build.props
+++ b/eng/testing/linker/SupportFiles/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project>
+  <PropertyGroup>
+    <!-- Workaround while there is no SDK available that understands the TFM; suppress unsupported version errors. -->
+    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
+
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>full</TrimMode>
+    <PublishSelfContained>true</PublishSelfContained>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Enable NuGet static graph evaluation to optimize incremental restore -->
+    <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
+  </PropertyGroup>
+</Project>

--- a/eng/testing/linker/SupportFiles/Directory.Build.targets
+++ b/eng/testing/linker/SupportFiles/Directory.Build.targets
@@ -1,0 +1,25 @@
+<Project>
+  
+  <PropertyGroup>
+    <!-- Used to silence the warning caused by the workaround for https://github.com/dotnet/runtime/issues/81382 -->
+    <SuppressGenerateILCompilerExplicitPackageReferenceWarning>true</SuppressGenerateILCompilerExplicitPackageReferenceWarning>
+  </PropertyGroup>
+
+  <!-- needed to reference a specific version of NetCoreApp. Workaround https://github.com/dotnet/runtime/issues/81382 -->
+  <ItemGroup>
+    <FrameworkReference Update="Microsoft.NETCore.App"
+                        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimeVersion)" />
+
+    <PackageReference Include="Microsoft.Dotnet.ILCompiler"
+                      Version="$(MicrosoftNETCoreAppRuntimeVersion)" />
+  </ItemGroup>
+
+  <!--
+  Reference the Microsoft.AspNetCore.App shared framework assemblies with ProjectReference.
+  This allows for easy dev workflow. Just need to update the product code, and re-run the tests.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)src\DefaultBuilder\src\Microsoft.AspNetCore.csproj" />
+  </ItemGroup>
+  
+</Project>

--- a/eng/testing/linker/project.csproj.template
+++ b/eng/testing/linker/project.csproj.template
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>{TargetFramework}</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RuntimeIdentifier>{RuntimeIdentifier}</RuntimeIdentifier>
+    <PublishAot>{PublishAot}</PublishAot>
+    <MicrosoftNETCoreAppRuntimeVersion>{MicrosoftNETCoreAppRuntimeVersion}</MicrosoftNETCoreAppRuntimeVersion>
+    <RepoRoot>{RepoRoot}</RepoRoot>
+    <_ExtraTrimmerArgs>{ExtraTrimmerArgs} $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
+    {AdditionalProperties}
+  </PropertyGroup>
+
+  <ItemGroup>
+    {RuntimeHostConfigurationOptions}
+  </ItemGroup>
+
+  <ItemGroup>
+    {AdditionalProjectReferences}
+  </ItemGroup>
+
+</Project>

--- a/eng/testing/linker/trimmingTests.props
+++ b/eng/testing/linker/trimmingTests.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <TrimmingTestDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'trimmingTests'))</TrimmingTestDir>
+    <TrimmingTestProjectsDir>$([MSBuild]::NormalizeDirectory('$(TrimmingTestDir)', 'projects'))</TrimmingTestProjectsDir>
+    <ProjectTemplate>$(MSBuildThisFileDirectory)project.csproj.template</ProjectTemplate>
+  </PropertyGroup>
+</Project>

--- a/eng/testing/linker/trimmingTests.props
+++ b/eng/testing/linker/trimmingTests.props
@@ -9,15 +9,8 @@
     <!-- Microsoft.NET.Sdk needs a TFM set. Set a default one. -->
     <TargetFramework Condition="'$(TargetFramework)' == '' and '$(TargetFrameworks)' == ''">$(DefaultNetCoreTargetFramework)</TargetFramework>
 
+    <!-- Enforce build order. Ensure the Shared Fx is built before generating and publishing the test apps. -->
     <RequiresDelayedBuild>true</RequiresDelayedBuild>
   </PropertyGroup>
-
-  <ItemGroup>
-    <!-- Enforce build order. Ensure the Shared Fx is built before generating and publishing the test apps. -->
-    <ProjectReference Include="$(RepoRoot)src\DefaultBuilder\src\Microsoft.AspNetCore.csproj"
-                      Private="false"
-                      ReferenceOutputAssembly="false"
-                      SkipGetTargetFrameworkProperties="true" />
-  </ItemGroup>
 
 </Project>

--- a/eng/testing/linker/trimmingTests.props
+++ b/eng/testing/linker/trimmingTests.props
@@ -4,4 +4,10 @@
     <TrimmingTestProjectsDir>$([MSBuild]::NormalizeDirectory('$(TrimmingTestDir)', 'projects'))</TrimmingTestProjectsDir>
     <ProjectTemplate>$(MSBuildThisFileDirectory)project.csproj.template</ProjectTemplate>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Microsoft.NET.Sdk needs a TFM set. Set a default one. -->
+    <TargetFramework Condition="'$(TargetFramework)' == '' and '$(TargetFrameworks)' == ''">$(DefaultNetCoreTargetFramework)</TargetFramework>
+  </PropertyGroup>
+
 </Project>

--- a/eng/testing/linker/trimmingTests.props
+++ b/eng/testing/linker/trimmingTests.props
@@ -10,4 +10,12 @@
     <TargetFramework Condition="'$(TargetFramework)' == '' and '$(TargetFrameworks)' == ''">$(DefaultNetCoreTargetFramework)</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- Enforce build order. Ensure the Shared Fx is built before generating and publishing the test apps. -->
+    <ProjectReference Include="$(RepoRoot)\src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
+                      Private="false"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+
 </Project>

--- a/eng/testing/linker/trimmingTests.props
+++ b/eng/testing/linker/trimmingTests.props
@@ -3,6 +3,10 @@
     <TrimmingTestDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'trimmingTests'))</TrimmingTestDir>
     <TrimmingTestProjectsDir>$([MSBuild]::NormalizeDirectory('$(TrimmingTestDir)', 'projects'))</TrimmingTestProjectsDir>
     <ProjectTemplate>$(MSBuildThisFileDirectory)project.csproj.template</ProjectTemplate>
+
+    <!-- These test projects cannot be run in helix, since there is nothing to publish. -->
+    <BuildHelixPayload>false</BuildHelixPayload>
+    <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/testing/linker/trimmingTests.props
+++ b/eng/testing/linker/trimmingTests.props
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <!-- Enforce build order. Ensure the Shared Fx is built before generating and publishing the test apps. -->
-    <ProjectReference Include="$(RepoRoot)\src\Framework\App.Ref\src\Microsoft.AspNetCore.App.Ref.csproj"
+    <ProjectReference Include="$(RepoRoot)src\DefaultBuilder\src\Microsoft.AspNetCore.csproj"
                       Private="false"
                       ReferenceOutputAssembly="false"
                       SkipGetTargetFrameworkProperties="true" />

--- a/eng/testing/linker/trimmingTests.props
+++ b/eng/testing/linker/trimmingTests.props
@@ -8,6 +8,8 @@
   <PropertyGroup>
     <!-- Microsoft.NET.Sdk needs a TFM set. Set a default one. -->
     <TargetFramework Condition="'$(TargetFramework)' == '' and '$(TargetFrameworks)' == ''">$(DefaultNetCoreTargetFramework)</TargetFramework>
+
+    <RequiresDelayedBuild>true</RequiresDelayedBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -1,0 +1,133 @@
+<Project>
+  <ItemGroup>
+    <TestConsoleAppSourceFiles Condition="'@(TestConsoleAppSourceFiles)' == ''" Include="$(MSBuildProjectDirectory)\*.cs" />
+
+    <TestSupportFiles Include="$(MSBuildThisFileDirectory)SupportFiles\Directory.Build.*">
+      <DestinationFolder>$(TrimmingTestDir)</DestinationFolder>
+    </TestSupportFiles>
+  </ItemGroup>
+
+  <Target Name="CreateTestDir"
+          Inputs="@(TestSupportFiles)"
+          Outputs="@(TestSupportFiles->'%(DestinationFolder)\%(FileName)%(Extension)')">
+    <MakeDir Directories="%(TestSupportFiles.DestinationFolder)" />
+    <Copy SourceFiles="@(TestSupportFiles)" DestinationFolder="%(TestSupportFiles.DestinationFolder)" />
+  </Target>
+
+  <Target Name="GetTestConsoleApps">
+    <ItemGroup>
+      <TestConsoleAppSourceFiles>
+        <ProjectDir>$([MSBuild]::NormalizeDirectory('$(TrimmingTestProjectsDir)', '$(MSBuildProjectName)', '%(Filename)', '$(PackageRID)'))</ProjectDir>
+        <TestRuntimeIdentifier>$(TargetRuntimeIdentifier)</TestRuntimeIdentifier>
+        <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+        <TargetFramework Condition="'%(TestConsoleAppSourceFiles.TargetOS)' != ''">$(DefaultNetCoreTargetFramework)-%(TestConsoleAppSourceFiles.TargetOS)</TargetFramework>
+      </TestConsoleAppSourceFiles>
+      <!-- We need to separate Item metadata declaration in two in order to be able to use ProjectDir and TestRuntimeIdentifier below -->
+      <TestConsoleAppSourceFiles>
+        <ProjectFile>%(ProjectDir)project.csproj</ProjectFile>
+        <TestCommand>$([MSBuild]::NormalizePath('%(ProjectDir)', 'bin', '$(Configuration)', '%(TargetFramework)', '%(TestRuntimeIdentifier)', 'publish', 'project'))</TestCommand>
+        <TestExecutionDirectory>$([MSBuild]::NormalizeDirectory('%(ProjectDir)', 'bin', '$(Configuration)', '%(TargetFramework)', '%(TestRuntimeIdentifier)', 'publish'))</TestExecutionDirectory>
+      </TestConsoleAppSourceFiles>
+    </ItemGroup>
+
+    <ItemGroup>
+      <TestConsoleApps Include="@(TestConsoleAppSourceFiles->'%(ProjectFile)')">
+        <ProjectCompileItems>%(FullPath)</ProjectCompileItems>
+      </TestConsoleApps>
+      <TestConsoleApps AdditionalProperties="MSBuildEnableWorkloadResolver=$(MSBuildEnableWorkloadResolver)" Condition="'$(MSBuildEnableWorkloadResolver)' != ''" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GenerateProjects"
+          DependsOnTargets="GetTestConsoleApps;CreateTestDir"
+          Inputs="@(TestConsoleAppSourceFiles);$(ProjectTemplate);@(TestSupportFiles)"
+          Outputs="%(TestConsoleApps.Identity)">
+    <PropertyGroup>
+      <_projectDir>%(TestConsoleApps.ProjectDir)\</_projectDir>
+      <_projectFile>%(TestConsoleApps.ProjectFile)</_projectFile>
+      <_projectSourceFile>%(TestConsoleApps.ProjectCompileItems)</_projectSourceFile>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(AdditionalProjectReferences)' != ''">
+      <_additionalProjectReferenceTemp Include="$(AdditionalProjectReferences)" />
+      <_additionalProjectReference Include="&lt;ProjectReference Include=&quot;$(LibrariesProjectRoot)%(_additionalProjectReferenceTemp.Identity)\src\%(_additionalProjectReferenceTemp.Identity).csproj&quot; SkipUseReferenceAssembly=&quot;true&quot; /&gt;" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_additionalProjectReferencesString>@(_additionalProjectReference, '%0a')</_additionalProjectReferencesString>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_additionalProjectSourceFiles Include="%(TestConsoleApps.AdditionalSourceFiles)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_switchesAsItems Include="%(TestConsoleApps.DisabledFeatureSwitches)" Value="false" />
+      <_switchesAsItems Include="%(TestConsoleApps.EnabledFeatureSwitches)" Value="true" />
+
+      <_propertiesAsItems Include="%(TestConsoleApps.DisabledProperties)" Value="false" />
+      <_propertiesAsItems Include="%(TestConsoleApps.EnabledProperties)" Value="true" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_runtimeHostConfigurationOptionsString>@(_switchesAsItems->'&lt;RuntimeHostConfigurationOption Include=&quot;%(Identity)&quot; Value=&quot;%(Value)&quot; Trim=&quot;true&quot; /&gt;', '%0a    ')</_runtimeHostConfigurationOptionsString>
+      <_additionalPropertiesString>@(_propertiesAsItems->'&lt;%(Identity)&gt;%(Value)&lt;/%(Identity)&gt;', '%0a    ')</_additionalPropertiesString>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(_projectDir)" />
+    <WriteLinesToFile File="$(_projectFile)"
+                      Lines="$([System.IO.File]::ReadAllText('$(ProjectTemplate)')
+                                                 .Replace('{TargetFramework}', '%(TestConsoleApps.TargetFramework)')
+                                                 .Replace('{RuntimeIdentifier}','%(TestConsoleApps.TestRuntimeIdentifier)')
+                                                 .Replace('{PublishAot}','$(IsNativeAotTestProject)')
+                                                 .Replace('{MicrosoftNETCoreAppRuntimeVersion}','$(MicrosoftNETCoreAppRuntimeVersion)')
+                                                 .Replace('{RepoRoot}', '$(RepoRoot)')
+                                                 .Replace('{ExtraTrimmerArgs}', '%(TestConsoleApps.ExtraTrimmerArgs)')
+                                                 .Replace('{AdditionalProperties}', '$(_additionalPropertiesString)')
+                                                 .Replace('{RuntimeHostConfigurationOptions}', '$(_runtimeHostConfigurationOptionsString)')
+                                                 .Replace('{AdditionalProjectReferences}', '$(_additionalProjectReferencesString)')
+                                                 )"
+                      Overwrite="true" />
+    <Copy SourceFiles="$(_projectSourceFile);
+                       @(_additionalProjectSourceFiles)"
+          DestinationFolder="$(_projectDir)" />
+    <Message Text="Generated $(_projectFile)" />
+  </Target>
+
+  <Target Name="GetTrimmingProjectsToRestore"
+          DependsOnTargets="GenerateProjects"
+          Returns="@(TestConsoleApps)" />
+
+  <Target Name="PublishTrimmedProjects"
+          DependsOnTargets="GenerateProjects">
+
+    <MSBuild Projects="@(TestConsoleApps)"
+             Targets="Restore"
+             Condition="'$(SkipTrimmingProjectsRestore)' != 'true'"
+             Properties="MSBuildRestoreSessionId=$([System.Guid]::NewGuid());Configuration=$(Configuration)" />
+
+    <MSBuild Projects="@(TestConsoleApps)"
+             Targets="Publish"
+             Properties="Configuration=$(Configuration);BuildProjectReferences=false" />
+  </Target>
+
+  <Target Name="ExecuteApplications"
+          DependsOnTargets="PublishTrimmedProjects"
+          Inputs="%(TestConsoleApps.Identity)"
+          Outputs="_unused"
+          Condition="'$(ArchiveTests)' != 'true'">
+
+    <Message Importance="High" Text="[Trimming Tests] Running test: %(TestConsoleApps.ProjectCompileItems) ..." />
+    <Exec IgnoreExitCode="true" Command="%(TestConsoleApps.TestCommand)" StandardOutputImportance="Low" WorkingDirectory="%(TestConsoleApps.TestExecutionDirectory)">
+      <Output TaskParameter="ExitCode" PropertyName="ExecutionExitCode" />
+    </Exec>
+
+    <Error Condition="'$(ExecutionExitCode)' != '100'" Text="Error: [Failed Test]: %(TestConsoleApps.ProjectCompileItems). The Command %(TestConsoleApps.TestCommand) return a non-success exit code." ContinueOnError="ErrorAndContinue" />
+  </Target>
+
+  <Target Name="Build" DependsOnTargets="ExecuteApplications" />
+
+  <!-- define test to do nothing, for this project Build does all the testing -->
+  <Target Name="Test" DependsOnTargets="Build" />
+  <Target Name="VSTest" DependsOnTargets="Build" />
+</Project>

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -1,4 +1,6 @@
 <Project>
+  <Import Project="$(RepoRoot)eng\targets\ResolveReferences.targets" />
+
   <ItemGroup>
     <TestConsoleAppSourceFiles Condition="'@(TestConsoleAppSourceFiles)' == ''" Include="$(MSBuildProjectDirectory)\*.cs" />
 
@@ -94,10 +96,6 @@
     <Message Text="Generated $(_projectFile)" />
   </Target>
 
-  <Target Name="GetTrimmingProjectsToRestore"
-          DependsOnTargets="GenerateProjects"
-          Returns="@(TestConsoleApps)" />
-
   <Target Name="PublishTrimmedProjects"
           DependsOnTargets="GenerateProjects">
 
@@ -126,7 +124,6 @@
   </Target>
 
   <Target Name="CoreBuild" DependsOnTargets="ExecuteApplications" />
-
   <Target Name="Restore" />
 
   <!-- define test to do nothing, for this project Build does all the testing -->

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -123,10 +123,10 @@
     <Error Condition="'$(ExecutionExitCode)' != '100'" Text="Error: [Failed Test]: %(TestConsoleApps.ProjectCompileItems). The Command %(TestConsoleApps.TestCommand) return a non-success exit code." ContinueOnError="ErrorAndContinue" />
   </Target>
 
-  <Target Name="CoreBuild" DependsOnTargets="ExecuteApplications" />
-  <Target Name="Restore" />
+  <Target Name="Test" DependsOnTargets="ExecuteApplications" />
+  <Target Name="VSTest" DependsOnTargets="Test" />
 
-  <!-- define test to do nothing, for this project Build does all the testing -->
-  <Target Name="Test" DependsOnTargets="Build" />
-  <Target Name="VSTest" DependsOnTargets="Build" />
+  <!-- define Restore/Build to do nothing, for this project only Test does the testing -->
+  <Target Name="Restore" />
+  <Target Name="Build" />
 </Project>

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -125,7 +125,9 @@
     <Error Condition="'$(ExecutionExitCode)' != '100'" Text="Error: [Failed Test]: %(TestConsoleApps.ProjectCompileItems). The Command %(TestConsoleApps.TestCommand) return a non-success exit code." ContinueOnError="ErrorAndContinue" />
   </Target>
 
-  <Target Name="Build" DependsOnTargets="ExecuteApplications" />
+  <Target Name="CoreBuild" DependsOnTargets="ExecuteApplications" />
+
+  <Target Name="Restore" />
 
   <!-- define test to do nothing, for this project Build does all the testing -->
   <Target Name="Test" DependsOnTargets="Build" />

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.NativeAotTests/Microsoft.AspNetCore.NativeAotTests.proj
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.NativeAotTests/Microsoft.AspNetCore.NativeAotTests.proj
@@ -1,0 +1,9 @@
+<Project DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <ItemGroup>
+    <TestConsoleAppSourceFiles Include="UseStartupThrowsForStructContainersTest.cs" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+</Project>

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.NativeAotTests/Microsoft.AspNetCore.NativeAotTests.proj
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.NativeAotTests/Microsoft.AspNetCore.NativeAotTests.proj
@@ -1,9 +1,7 @@
-<Project DefaultTargets="Build">
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <TestConsoleAppSourceFiles Include="UseStartupThrowsForStructContainersTest.cs" />
   </ItemGroup>
 
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.NativeAotTests/UseStartupThrowsForStructContainersTest.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.NativeAotTests/UseStartupThrowsForStructContainersTest.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System;
+
+int classTestResult = RunClassTest();
+if (classTestResult != 100)
+{
+    return classTestResult;
+}
+
+return RunStructTest();
+
+static int RunClassTest()
+{
+    var builder = Host.CreateDefaultBuilder();
+    builder.UseServiceProviderFactory(new MyContainerClassFactory());
+
+    builder.ConfigureWebHost(webBuilder =>
+    {
+        webBuilder.UseStartup(typeof(MyStartupWithClass));
+    });
+
+    builder.Build();
+
+    if (!MyStartupWithClass.ConfigureServicesCalled)
+    {
+        return -1;
+    }
+    if (!MyStartupWithClass.ConfigureContainerCalled)
+    {
+        return -2;
+    }
+
+    return 100;
+}
+
+static int RunStructTest()
+{
+    var builder = Host.CreateDefaultBuilder();
+    builder.UseServiceProviderFactory(new MyContainerStructFactory());
+
+    builder.ConfigureWebHost(webBuilder =>
+    {
+        webBuilder.UseStartup(typeof(MyStartupWithStruct));
+    });
+
+    try
+    {
+        builder.Build();
+        return -3;
+    }
+    catch (InvalidOperationException e)
+    {
+        if (!e.Message.StartsWith("A ValueType TContainerBuilder isn't supported with AOT", StringComparison.Ordinal))
+        {
+            return -4;
+        }
+    }
+
+    if (!MyStartupWithStruct.ConfigureServicesCalled)
+    {
+        return -5;
+    }
+
+    // ConfigureContainer should not have been called, since the exception should have been raised
+    if (MyStartupWithStruct.ConfigureContainerCalled)
+    {
+        return -6;
+    }
+
+    return 100;
+}
+
+public class MyStartupWithClass
+{
+    public static bool ConfigureServicesCalled;
+    public static bool ConfigureContainerCalled;
+
+    public void ConfigureServices(IServiceCollection _) => ConfigureServicesCalled = true;
+    public void ConfigureContainer(MyContainerClass _) => ConfigureContainerCalled = true;
+    public void Configure(IApplicationBuilder _) { }
+}
+
+public class MyContainerClassFactory : IServiceProviderFactory<MyContainerClass>
+{
+    public MyContainerClass CreateBuilder(IServiceCollection services) => new MyContainerClass(services);
+
+    public IServiceProvider CreateServiceProvider(MyContainerClass containerBuilder)
+    {
+        containerBuilder.Build();
+        return containerBuilder;
+    }
+}
+
+public class MyContainerClass : IServiceProvider
+{
+    private IServiceProvider _inner;
+    private IServiceCollection _services;
+
+    public MyContainerClass(IServiceCollection services) => _services = services;
+    public void Build() => _inner = _services.BuildServiceProvider();
+    public object GetService(Type serviceType) => _inner.GetService(serviceType);
+}
+
+public class MyStartupWithStruct
+{
+    public static bool ConfigureServicesCalled;
+    public static bool ConfigureContainerCalled;
+
+    public void ConfigureServices(IServiceCollection _) => ConfigureServicesCalled = true;
+    public void ConfigureContainer(MyContainerStruct _) => ConfigureContainerCalled = true;
+    public void Configure(IApplicationBuilder _) { }
+}
+
+public class MyContainerStructFactory : IServiceProviderFactory<MyContainerStruct>
+{
+    public MyContainerStruct CreateBuilder(IServiceCollection services) => new MyContainerStruct(services);
+
+    public IServiceProvider CreateServiceProvider(MyContainerStruct containerBuilder)
+    {
+        containerBuilder.Build();
+        return containerBuilder;
+    }
+}
+
+public struct MyContainerStruct : IServiceProvider
+{
+    private IServiceProvider _inner;
+    private IServiceCollection _services;
+
+    public MyContainerStruct(IServiceCollection services) => _services = services;
+    public void Build() => _inner = _services.BuildServiceProvider();
+    public object GetService(Type serviceType) => _inner.GetService(serviceType);
+}

--- a/src/Hosting/Hosting/src/Infrastructure/ISupportsStartup.cs
+++ b/src/Hosting/Hosting/src/Infrastructure/ISupportsStartup.cs
@@ -40,6 +40,6 @@ public interface ISupportsStartup
     /// </summary>
     /// <param name="startupFactory">A delegate that specifies a factory for the startup class.</param>
     /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
-    /// <remarks>When using the IL linker, all public methods of <typeparamref name="TStartup"/> are preserved. This should match the Startup type directly (and not a base type).</remarks>
+    /// <remarks>When in a trimmed app, all public methods of <typeparamref name="TStartup"/> are preserved. This should match the Startup type directly (and not a base type).</remarks>
     IWebHostBuilder UseStartup<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TStartup>(Func<WebHostBuilderContext, TStartup> startupFactory);
 }

--- a/src/Hosting/Hosting/src/WebHostBuilderExtensions.cs
+++ b/src/Hosting/Hosting/src/WebHostBuilderExtensions.cs
@@ -86,7 +86,7 @@ public static class WebHostBuilderExtensions
     /// <param name="hostBuilder">The <see cref="IWebHostBuilder"/> to configure.</param>
     /// <param name="startupFactory">A delegate that specifies a factory for the startup class.</param>
     /// <returns>The <see cref="IWebHostBuilder"/>.</returns>
-    /// <remarks>When using the il linker, all public methods of <typeparamref name="TStartup"/> are preserved. This should match the Startup type directly (and not a base type).</remarks>
+    /// <remarks>When in a trimmed app, all public methods of <typeparamref name="TStartup"/> are preserved. This should match the Startup type directly (and not a base type).</remarks>
     public static IWebHostBuilder UseStartup<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] TStartup>(this IWebHostBuilder hostBuilder, Func<WebHostBuilderContext, TStartup> startupFactory) where TStartup : class
     {
         ArgumentNullException.ThrowIfNull(startupFactory);


### PR DESCRIPTION
This infrastructure was taken from https://github.com/dotnet/runtime/tree/c62f69be1405a8e41b56ffc05f22d791bf4c7d2d/eng/testing/linker and modified to work in dotnet/aspnetcore.

Added the first test:
- Generic host + value type container builder (verify that error is thrown)

Contributes to #45860

It is probably easiest to compare the files in `eng/testing/linker` to the files in dotnet/runtime to see what I changed. I can prepare that in a repo if people want. Or just use Beyond Compare (or similar) to diff between the two repos.

Working on hooking this into CI now.