### PR TITLE
Introduce ListenOptions.GetServerCertificate

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -734,4 +734,7 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="NeedHttpsConfigurationToBindHttpsAddresses" xml:space="preserve">
     <value>Call UseKestrelHttpsConfiguration() on IWebHostBuilder to automatically enable HTTPS when an https:// address is used.</value>
   </data>
+  <data name="NeedConfigurationToRetrieveServerCertificate" xml:space="preserve">
+    <value>Call KestrelConfigurationLoader.Load() before retrieving the server certificate.</value>
+  </data>
 </root>

--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -18,7 +18,7 @@ public class KestrelConfigurationLoader
 {
     private readonly IHttpsConfigurationService _httpsConfigurationService;
 
-    private bool _loaded;
+    internal bool IsLoaded { get; private set; }
 
     internal KestrelConfigurationLoader(
         KestrelServerOptions options,
@@ -234,12 +234,12 @@ public class KestrelConfigurationLoader
     /// </summary>
     public void Load()
     {
-        if (_loaded)
+        if (IsLoaded)
         {
             // The loader has already been run.
             return;
         }
-        _loaded = true;
+        IsLoaded = true;
 
         Reload();
 

--- a/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
@@ -4,3 +4,4 @@ Microsoft.AspNetCore.Server.Kestrel.Core.Features.ISslStreamFeature.SslStream.ge
 Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenNamedPipe(string! pipeName) -> void
 Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenNamedPipe(string! pipeName, System.Action<Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions!>! configure) -> void
 Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.PipeName.get -> string?
+static Microsoft.AspNetCore.Hosting.ListenOptionsHttpsExtensions.GetServerCertificate(this Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions! listenOptions) -> System.Security.Cryptography.X509Certificates.X509Certificate2!

--- a/src/Servers/Kestrel/Kestrel/test/HttpsConfigurationTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/HttpsConfigurationTests.cs
@@ -184,6 +184,32 @@ public class HttpsConfigurationTests
     }
 
     [Fact]
+    public async Task GetServerCertificateJustWorks()
+    {
+        var hostBuilder = new WebHostBuilder()
+            .UseKestrelCore()
+            .ConfigureKestrel(serverOptions =>
+            {
+                var testCertificate = new X509Certificate2(Path.Combine("shared", "TestCertificates", "aspnetdevcert.pfx"), "testPassword");
+                serverOptions.TestOverrideDefaultCertificate = testCertificate;
+
+                serverOptions.ListenAnyIP(0, listenOptions =>
+                {
+                    Assert.Equal(testCertificate, listenOptions.GetServerCertificate());
+                });
+            })
+            .Configure(app => { });
+
+        var host = hostBuilder.Build();
+
+        // Binding succeeds
+        await host.StartAsync();
+        await host.StopAsync();
+
+        Assert.True(host.Services.GetRequiredService<IHttpsConfigurationService>().IsInitialized);
+    }
+
+    [Fact]
     public async Task UseHttpsJustWorks()
     {
         var hostBuilder = new WebHostBuilder()


### PR DESCRIPTION
# Introduce ListenOptions.GetServerCertificate

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

An API to retrieve the cert for an endpoint

## Description

Introduce ListenOptions.GetServerCertificate as a way to retrieve the server certificate eagerly (assuming the configuration has been loaded), rather than having to wait until bind-time.

Fixes #28120
Unblocks #45801
