### PR TITLE
Defer search for dev cert until build bind time

### DIFF
--- a/src/Servers/Kestrel/Core/src/HttpsConfigurationService.cs
+++ b/src/Servers/Kestrel/Core/src/HttpsConfigurationService.cs
@@ -147,7 +147,7 @@ internal sealed class HttpsConfigurationService : IHttpsConfigurationService
         // The QUIC transport will check if TlsConnectionCallbackOptions is missing.
         if (listenOptions.HttpsOptions != null)
         {
-            var sslServerAuthenticationOptions = HttpsConnectionMiddleware.CreateHttp3Options(listenOptions.HttpsOptions, logger);
+            var sslServerAuthenticationOptions = HttpsConnectionMiddleware.CreateHttp3Options(listenOptions.HttpsOptions.Value, logger);
             features.Set(new TlsConnectionCallbackOptions
             {
                 ApplicationProtocols = sslServerAuthenticationOptions.ApplicationProtocols ?? new List<SslApplicationProtocol> { SslApplicationProtocol.Http3 },

--- a/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
+++ b/src/Servers/Kestrel/Core/src/HttpsConnectionAdapterOptions.cs
@@ -78,12 +78,6 @@ public class HttpsConnectionAdapterOptions
     public SslProtocols SslProtocols { get; set; }
 
     /// <summary>
-    /// The protocols enabled on this endpoint.
-    /// </summary>
-    /// <remarks>Defaults to HTTP/1.x only.</remarks>
-    internal HttpProtocols HttpProtocols { get; set; }
-
-    /// <summary>
     /// Specifies whether the certificate revocation list is checked during authentication.
     /// </summary>
     public bool CheckCertificateRevocation { get; set; }

--- a/src/Servers/Kestrel/Core/src/ListenOptions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptions.cs
@@ -140,7 +140,7 @@ public class ListenOptions : IConnectionBuilder, IMultiplexedConnectionBuilder
     }
 
     internal bool IsTls { get; set; }
-    internal HttpsConnectionAdapterOptions? HttpsOptions { get; set; }
+    internal Lazy<HttpsConnectionAdapterOptions>? HttpsOptions { get; set; }
     internal TlsHandshakeCallbackOptions? HttpsCallbackOptions { get; set; }
 
     /// <summary>

--- a/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
@@ -206,13 +206,14 @@ public static class ListenOptionsHttpsExtensions
         listenOptions.IsTls = true;
         listenOptions.HttpsOptions = lazyHttpsOptions;
 
+        var loggerFactory = listenOptions.KestrelServerOptions.ApplicationServices.GetRequiredService<ILoggerFactory>();
+        var metrics = listenOptions.KestrelServerOptions.ApplicationServices.GetRequiredService<KestrelMetrics>();
+
         // NB: This lambda will only be invoked if either HTTP/1.* or HTTP/2 is being used
         listenOptions.Use(next =>
         {
             // Evaluate the HttpsConnectionAdapterOptions, now that the configuration, if any, has been loaded
             var httpsOptions = lazyHttpsOptions.Value;
-            var loggerFactory = listenOptions.KestrelServerOptions.ApplicationServices.GetRequiredService<ILoggerFactory>();
-            var metrics = listenOptions.KestrelServerOptions.ApplicationServices.GetRequiredService<KestrelMetrics>();
             var middleware = new HttpsConnectionMiddleware(next, httpsOptions, listenOptions.Protocols, loggerFactory, metrics);
             return middleware.OnConnectionAsync;
         });

--- a/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/ListenOptionsHttpsExtensions.cs
@@ -196,9 +196,7 @@ public static class ListenOptionsHttpsExtensions
 
         listenOptions.Use(next =>
         {
-            // Set the list of protocols from listen options
-            httpsOptions.HttpProtocols = listenOptions.Protocols;
-            var middleware = new HttpsConnectionMiddleware(next, httpsOptions, loggerFactory, metrics);
+            var middleware = new HttpsConnectionMiddleware(next, httpsOptions, listenOptions.Protocols, loggerFactory, metrics);
             return middleware.OnConnectionAsync;
         });
 

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -33,6 +33,9 @@ internal sealed class HttpsConnectionMiddleware
     private readonly ILogger<HttpsConnectionMiddleware> _logger;
     private readonly Func<Stream, SslStream> _sslStreamFactory;
 
+    // Internal for testing
+    internal readonly HttpProtocols _httpProtocols;
+
     // The following fields are only set by HttpsConnectionAdapterOptions ctor.
     private readonly HttpsConnectionAdapterOptions? _options;
     private readonly KestrelMetrics _metrics;
@@ -43,17 +46,16 @@ internal sealed class HttpsConnectionMiddleware
     // The following fields are only set by TlsHandshakeCallbackOptions ctor.
     private readonly Func<TlsHandshakeCallbackContext, ValueTask<SslServerAuthenticationOptions>>? _tlsCallbackOptions;
     private readonly object? _tlsCallbackOptionsState;
-    private readonly HttpProtocols _httpProtocols;
 
     // Pool for cancellation tokens that cancel the handshake
     private readonly CancellationTokenSourcePool _ctsPool = new();
 
-    public HttpsConnectionMiddleware(ConnectionDelegate next, HttpsConnectionAdapterOptions options, KestrelMetrics metrics)
-      : this(next, options, loggerFactory: NullLoggerFactory.Instance, metrics: metrics)
+    public HttpsConnectionMiddleware(ConnectionDelegate next, HttpsConnectionAdapterOptions options, HttpProtocols httpProtocols, KestrelMetrics metrics)
+      : this(next, options, httpProtocols, loggerFactory: NullLoggerFactory.Instance, metrics: metrics)
     {
     }
 
-    public HttpsConnectionMiddleware(ConnectionDelegate next, HttpsConnectionAdapterOptions options, ILoggerFactory loggerFactory, KestrelMetrics metrics)
+    public HttpsConnectionMiddleware(ConnectionDelegate next, HttpsConnectionAdapterOptions options, HttpProtocols httpProtocols, ILoggerFactory loggerFactory, KestrelMetrics metrics)
     {
         ArgumentNullException.ThrowIfNull(options);
 
@@ -74,7 +76,7 @@ internal sealed class HttpsConnectionMiddleware
         //_sslStreamFactory = s => new SslStream(s);
 
         _options = options;
-        _options.HttpProtocols = ValidateAndNormalizeHttpProtocols(_options.HttpProtocols, _logger);
+        _httpProtocols = ValidateAndNormalizeHttpProtocols(httpProtocols, _logger);
 
         // capture the certificate now so it can't be switched after validation
         _serverCertificate = options.ServerCertificate;
@@ -331,7 +333,7 @@ internal sealed class HttpsConnectionMiddleware
             CertificateRevocationCheckMode = _options.CheckCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
         };
 
-        ConfigureAlpn(sslOptions, _options.HttpProtocols);
+        ConfigureAlpn(sslOptions, _httpProtocols);
 
         _options.OnAuthenticate?.Invoke(context, sslOptions);
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -264,7 +264,7 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
     [Fact]
     public void ThrowsWhenNoServerCertificateIsProvided()
     {
-        Assert.Throws<ArgumentException>(() => CreateMiddleware(new HttpsConnectionAdapterOptions()));
+        Assert.Throws<ArgumentException>(() => CreateMiddleware(new HttpsConnectionAdapterOptions(), ListenOptions.DefaultHttpProtocols));
     }
 
     [Fact]
@@ -1318,7 +1318,8 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         CreateMiddleware(new HttpsConnectionAdapterOptions
         {
             ServerCertificate = cert,
-        });
+        },
+        ListenOptions.DefaultHttpProtocols);
     }
 
     [Theory]
@@ -1337,7 +1338,8 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
             CreateMiddleware(new HttpsConnectionAdapterOptions
             {
                 ServerCertificate = cert,
-            }));
+            },
+            ListenOptions.DefaultHttpProtocols));
 
         Assert.Equal(CoreStrings.FormatInvalidServerCertificateEku(cert.Thumbprint), ex.Message);
     }
@@ -1357,6 +1359,7 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
             {
                 ServerCertificate = cert,
             },
+            ListenOptions.DefaultHttpProtocols,
             testLogger);
 
         Assert.Single(testLogger.Messages.Where(log => log.EventId == 9));
@@ -1404,11 +1407,10 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         var httpConnectionAdapterOptions = new HttpsConnectionAdapterOptions
         {
             ServerCertificate = _x509Certificate2,
-            HttpProtocols = HttpProtocols.Http1AndHttp2
         };
-        CreateMiddleware(httpConnectionAdapterOptions);
+        var middleware = CreateMiddleware(httpConnectionAdapterOptions, HttpProtocols.Http1AndHttp2);
 
-        Assert.Equal(HttpProtocols.Http1, httpConnectionAdapterOptions.HttpProtocols);
+        Assert.Equal(HttpProtocols.Http1, middleware._httpProtocols);
     }
 
     [ConditionalFact]
@@ -1419,11 +1421,10 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         var httpConnectionAdapterOptions = new HttpsConnectionAdapterOptions
         {
             ServerCertificate = _x509Certificate2,
-            HttpProtocols = HttpProtocols.Http1AndHttp2
         };
-        CreateMiddleware(httpConnectionAdapterOptions);
+        var middleware = CreateMiddleware(httpConnectionAdapterOptions, HttpProtocols.Http1AndHttp2);
 
-        Assert.Equal(HttpProtocols.Http1AndHttp2, httpConnectionAdapterOptions.HttpProtocols);
+        Assert.Equal(HttpProtocols.Http1AndHttp2, middleware._httpProtocols);
     }
 
     [ConditionalFact]
@@ -1434,10 +1435,9 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         var httpConnectionAdapterOptions = new HttpsConnectionAdapterOptions
         {
             ServerCertificate = _x509Certificate2,
-            HttpProtocols = HttpProtocols.Http2
         };
 
-        Assert.Throws<NotSupportedException>(() => CreateMiddleware(httpConnectionAdapterOptions));
+        Assert.Throws<NotSupportedException>(() => CreateMiddleware(httpConnectionAdapterOptions, HttpProtocols.Http2));
     }
 
     [ConditionalFact]
@@ -1448,11 +1448,10 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         var httpConnectionAdapterOptions = new HttpsConnectionAdapterOptions
         {
             ServerCertificate = _x509Certificate2,
-            HttpProtocols = HttpProtocols.Http2
         };
 
         // Does not throw
-        CreateMiddleware(httpConnectionAdapterOptions);
+        CreateMiddleware(httpConnectionAdapterOptions, HttpProtocols.Http2);
     }
 
     private static HttpsConnectionMiddleware CreateMiddleware(X509Certificate2 serverCertificate)
@@ -1460,18 +1459,19 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         return CreateMiddleware(new HttpsConnectionAdapterOptions
         {
             ServerCertificate = serverCertificate,
-        });
+        },
+        ListenOptions.DefaultHttpProtocols);
     }
 
-    private static HttpsConnectionMiddleware CreateMiddleware(HttpsConnectionAdapterOptions options, TestApplicationErrorLogger testLogger = null)
+    private static HttpsConnectionMiddleware CreateMiddleware(HttpsConnectionAdapterOptions options, HttpProtocols httpProtocols, TestApplicationErrorLogger testLogger = null)
     {
         var loggerFactory = testLogger is null ? (ILoggerFactory)NullLoggerFactory.Instance : new LoggerFactory(new[] { new KestrelTestLoggerProvider(testLogger) });
-        return new HttpsConnectionMiddleware(context => Task.CompletedTask, options, loggerFactory, new KestrelMetrics(new TestMeterFactory()));
+        return new HttpsConnectionMiddleware(context => Task.CompletedTask, options, httpProtocols, loggerFactory, new KestrelMetrics(new TestMeterFactory()));
     }
 
-    private static HttpsConnectionMiddleware CreateMiddleware(HttpsConnectionAdapterOptions options)
+    private static HttpsConnectionMiddleware CreateMiddleware(HttpsConnectionAdapterOptions options, HttpProtocols httpProtocols)
     {
-        return new HttpsConnectionMiddleware(context => Task.CompletedTask, options, new KestrelMetrics(new TestMeterFactory()));
+        return new HttpsConnectionMiddleware(context => Task.CompletedTask, options, httpProtocols, new KestrelMetrics(new TestMeterFactory()));
     }
 
     private static async Task App(HttpContext httpContext)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
@@ -64,14 +64,18 @@ public class HttpsTests : LoggedTest
 
         Assert.False(serverOptions.IsDevelopmentCertificateLoaded);
 
+        var ranUseHttpsAction = false;
         serverOptions.ListenLocalhost(5001, options =>
         {
             options.UseHttps(opt =>
             {
                 // The default cert is applied after UseHttps.
                 Assert.Null(opt.ServerCertificate);
+                ranUseHttpsAction = true;
             });
         });
+        _ = serverOptions.CodeBackedListenOptions[1].HttpsOptions.Value; // Force evaluation
+        Assert.True(ranUseHttpsAction);
         Assert.False(serverOptions.IsDevelopmentCertificateLoaded);
     }
 
@@ -117,14 +121,20 @@ public class HttpsTests : LoggedTest
             options.ServerCertificate = _x509Certificate2;
             options.ClientCertificateMode = ClientCertificateMode.RequireCertificate;
         });
+        var ranUseHttpsAction = false;
         serverOptions.ListenLocalhost(5000, options =>
         {
             options.UseHttps(opt =>
             {
                 Assert.Equal(_x509Certificate2, opt.ServerCertificate);
                 Assert.Equal(ClientCertificateMode.RequireCertificate, opt.ClientCertificateMode);
+                ranUseHttpsAction = true;
             });
         });
+
+        _ = serverOptions.CodeBackedListenOptions.Single().HttpsOptions.Value; // Force evaluation
+        Assert.True(ranUseHttpsAction);
+
         // Never lazy loaded
         Assert.False(serverOptions.IsDevelopmentCertificateLoaded);
         Assert.Null(serverOptions.DevelopmentCertificate);
@@ -144,6 +154,7 @@ public class HttpsTests : LoggedTest
             };
             options.ClientCertificateMode = ClientCertificateMode.RequireCertificate;
         });
+        var ranUseHttpsAction = false;
         serverOptions.ListenLocalhost(5000, options =>
         {
             options.UseHttps(opt =>
@@ -151,8 +162,13 @@ public class HttpsTests : LoggedTest
                 Assert.Null(opt.ServerCertificate);
                 Assert.NotNull(opt.ServerCertificateSelector);
                 Assert.Equal(ClientCertificateMode.RequireCertificate, opt.ClientCertificateMode);
+                ranUseHttpsAction = true;
             });
         });
+
+        _ = serverOptions.CodeBackedListenOptions.Single().HttpsOptions.Value; // Force evaluation
+        Assert.True(ranUseHttpsAction);
+
         // Never lazy loaded
         Assert.False(serverOptions.IsDevelopmentCertificateLoaded);
         Assert.Null(serverOptions.DevelopmentCertificate);

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3TlsTests.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Quic;
 using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
@@ -25,6 +26,7 @@ public class Http3TlsTests : LoggedTest
     [MsQuicSupported]
     public async Task ServerCertificateSelector_Invoked()
     {
+        var serverCertificateSelectorActionCalled = false;
         var builder = CreateHostBuilder(async context =>
         {
             await context.Response.WriteAsync("Hello World");
@@ -37,6 +39,7 @@ public class Http3TlsTests : LoggedTest
                 {
                     httpsOptions.ServerCertificateSelector = (context, host) =>
                     {
+                        serverCertificateSelectorActionCalled = true;
                         Assert.Null(context); // The context isn't available durring the quic handshake.
                         Assert.Equal("testhost", host);
                         return TestResources.GetTestCertificate();
@@ -60,6 +63,8 @@ public class Http3TlsTests : LoggedTest
         var result = await response.Content.ReadAsStringAsync();
         Assert.Equal(HttpVersion.Version30, response.Version);
         Assert.Equal("Hello World", result);
+
+        Assert.True(serverCertificateSelectorActionCalled);
 
         await host.StopAsync().DefaultTimeout();
     }
@@ -420,6 +425,93 @@ public class Http3TlsTests : LoggedTest
 
         // This *could* work (in some cases) if `UseQuic` implied `UseKestrelHttpsConfiguration`
         Assert.Throws<InvalidOperationException>(host.Run);
+    }
+
+    [ConditionalFact]
+    [MsQuicSupported]
+    public async Task LoadDevelopmentCertificateViaConfiguration()
+    {
+        var expectedCertificate = new X509Certificate2(TestResources.GetCertPath("aspnetdevcert.pfx"), "testPassword", X509KeyStorageFlags.Exportable);
+        var bytes = expectedCertificate.Export(X509ContentType.Pkcs12, "1234");
+        var path = GetCertificatePath();
+        Directory.CreateDirectory(Path.GetDirectoryName(path));
+        File.WriteAllBytes(path, bytes);
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new[]
+        {
+            new KeyValuePair<string, string>("Certificates:Development:Password", "1234"),
+        }).Build();
+
+        var ranConfigureKestrelAction = false;
+        var ranUseHttpsAction = false;
+        var hostBuilder = CreateHostBuilder(async context =>
+        {
+            await context.Response.WriteAsync("Hello World");
+        }, configureKestrel: kestrelOptions =>
+        {
+            ranConfigureKestrelAction = true;
+            kestrelOptions.Configure(config);
+
+            kestrelOptions.ListenAnyIP(0, listenOptions =>
+            {
+                listenOptions.Protocols = HttpProtocols.Http3;
+                listenOptions.UseHttps(_ =>
+                {
+                    ranUseHttpsAction = true;
+                });
+            });
+        });
+
+        Assert.False(ranConfigureKestrelAction);
+        Assert.False(ranUseHttpsAction);
+
+        using var host = hostBuilder.Build();
+        await host.StartAsync().DefaultTimeout();
+
+        Assert.True(ranConfigureKestrelAction);
+        Assert.True(ranUseHttpsAction);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"https://127.0.0.1:{host.GetPort()}/");
+        request.Version = HttpVersion.Version30;
+        request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+        request.Headers.Host = "testhost";
+
+        var ranCertificateValidation = false;
+        var httpHandler = new SocketsHttpHandler();
+        httpHandler.SslOptions = new SslClientAuthenticationOptions
+        {
+            RemoteCertificateValidationCallback = (object _sender, X509Certificate actualCertificate, X509Chain _chain, SslPolicyErrors _sslPolicyErrors) =>
+            {
+                ranCertificateValidation = true;
+                Assert.Equal(expectedCertificate.GetSerialNumberString(), actualCertificate.GetSerialNumberString());
+                return true;
+            },
+            TargetHost = "targethost",
+        };
+        using var client = new HttpMessageInvoker(httpHandler);
+
+        var response = await client.SendAsync(request, CancellationToken.None).DefaultTimeout();
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadAsStringAsync();
+        Assert.Equal(HttpVersion.Version30, response.Version);
+        Assert.Equal("Hello World", result);
+
+        Assert.True(ranCertificateValidation);
+
+        await host.StopAsync().DefaultTimeout();
+    }
+
+    ///<remarks>
+    /// This is something of a hack - we should actually be calling
+    /// <see cref="Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader.TryGetCertificatePath"/>.
+    /// </remarks>
+    private static string GetCertificatePath()
+    {
+        var appData = Environment.GetEnvironmentVariable("APPDATA");
+        var home = Environment.GetEnvironmentVariable("HOME");
+        var basePath = appData != null ? Path.Combine(appData, "ASP.NET", "https") : null;
+        basePath = basePath ?? (home != null ? Path.Combine(home, ".aspnet", "https") : null);
+        return Path.Combine(basePath, $"{typeof(Http3TlsTests).Assembly.GetName().Name}.pfx");
     }
 
     private IHostBuilder CreateHostBuilder(RequestDelegate requestDelegate, HttpProtocols? protocol = null, Action<KestrelServerOptions> configureKestrel = null)


### PR DESCRIPTION
# Defer search for dev cert until build bind time

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

...so that it can occur after IConfiguration is read. (In particular, so that it occurs during AddressBinder.BindAsync which happens strictly after KestrelConfigurationLoader.Load.) This is important in Docker scenarios since the Docker tools use IConfiguration to tell us where the dev cert directory is mounted.# with '#' will be ignored, and an empty message aborts the commit.

Was #46296
Fixes #45801
