### PR TITLE
Introduce KestrelServerOptions.CheckDefaultCertificate

### DIFF
--- a/src/Servers/Kestrel/Core/src/CoreStrings.resx
+++ b/src/Servers/Kestrel/Core/src/CoreStrings.resx
@@ -734,4 +734,7 @@ For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?l
   <data name="NeedHttpsConfigurationToBindHttpsAddresses" xml:space="preserve">
     <value>Call UseKestrelHttpsConfiguration() on IWebHostBuilder to automatically enable HTTPS when an https:// address is used.</value>
   </data>
+  <data name="NeedConfigurationToRetrieveServerCertificate" xml:space="preserve">
+    <value>Call KestrelConfigurationLoader.Load() before retrieving the server certificate.</value>
+  </data>
 </root>

--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -18,7 +18,7 @@ public class KestrelConfigurationLoader
 {
     private readonly IHttpsConfigurationService _httpsConfigurationService;
 
-    private bool _loaded;
+    internal bool IsLoaded { get; private set; }
 
     internal KestrelConfigurationLoader(
         KestrelServerOptions options,
@@ -234,12 +234,12 @@ public class KestrelConfigurationLoader
     /// </summary>
     public void Load()
     {
-        if (_loaded)
+        if (IsLoaded)
         {
             // The loader has already been run.
             return;
         }
-        _loaded = true;
+        IsLoaded = true;
 
         Reload();
 

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -592,23 +592,20 @@ public class KestrelServerOptions
     /// </summary>
     /// <returns>True if there is a default or development server certificate, false otherwise.</returns>
     /// <exception cref="InvalidOperationException">If there is a configuration and it has not been loaded.</exception>
-    public bool HasDefaultOrDevelopmentCertificate
+    public bool CheckDefaultCertificate()
     {
-        get
+        if (ConfigurationLoader is { IsLoaded: false })
         {
-            if (ConfigurationLoader is { IsLoaded: false })
-            {
-                throw new InvalidOperationException(CoreStrings.NeedConfigurationToRetrieveServerCertificate);
-            }
-
-            // We consider calls to `HasDefaultOrDevelopmentCertificate.get` to be a clear expression of user intent to pull in HTTPS configuration support
-            EnableHttpsConfiguration();
-
-            var httpsOptions = new HttpsConnectionAdapterOptions();
-            ApplyHttpsDefaults(httpsOptions);
-            ApplyDefaultCertificate(httpsOptions);
-
-            return httpsOptions.ServerCertificate is not null;
+            throw new InvalidOperationException(CoreStrings.NeedConfigurationToRetrieveServerCertificate);
         }
+
+        // We consider calls to `CheckDefaultCertificate` to be a clear expression of user intent to pull in HTTPS configuration support
+        EnableHttpsConfiguration();
+
+        var httpsOptions = new HttpsConnectionAdapterOptions();
+        ApplyHttpsDefaults(httpsOptions);
+        ApplyDefaultCertificate(httpsOptions);
+
+        return httpsOptions.ServerCertificate is not null;
     }
 }

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -585,4 +585,30 @@ public class KestrelServerOptions
         configure(listenOptions);
         CodeBackedListenOptions.Add(listenOptions);
     }
+
+    /// <summary>
+    /// Return true if there is a default or development server certificate.
+    /// Should not be called before the configuration is loaded, if there is one.
+    /// </summary>
+    /// <returns>True if there is a default or development server certificate, false otherwise.</returns>
+    /// <exception cref="InvalidOperationException">If there is a configuration and it has not been loaded.</exception>
+    public bool HasDefaultOrDevelopmentCertificate
+    {
+        get
+        {
+            if (ConfigurationLoader is { IsLoaded: false })
+            {
+                throw new InvalidOperationException(CoreStrings.NeedConfigurationToRetrieveServerCertificate);
+            }
+
+            // We consider calls to `GetServerCertificate` to be a clear expression of user intent to pull in HTTPS configuration support
+            EnableHttpsConfiguration();
+
+            var httpsOptions = new HttpsConnectionAdapterOptions();
+            ApplyHttpsDefaults(httpsOptions);
+            ApplyDefaultCertificate(httpsOptions);
+
+            return httpsOptions.ServerCertificate is not null;
+        }
+    }
 }

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -601,7 +601,7 @@ public class KestrelServerOptions
                 throw new InvalidOperationException(CoreStrings.NeedConfigurationToRetrieveServerCertificate);
             }
 
-            // We consider calls to `GetServerCertificate` to be a clear expression of user intent to pull in HTTPS configuration support
+            // We consider calls to `HasDefaultOrDevelopmentCertificate.get` to be a clear expression of user intent to pull in HTTPS configuration support
             EnableHttpsConfiguration();
 
             var httpsOptions = new HttpsConnectionAdapterOptions();

--- a/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Microsoft.AspNetCore.Server.Kestrel.Core.Features.ISslStreamFeature
 Microsoft.AspNetCore.Server.Kestrel.Core.Features.ISslStreamFeature.SslStream.get -> System.Net.Security.SslStream!
+Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.HasDefaultOrDevelopmentCertificate.get -> bool
 Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenNamedPipe(string! pipeName) -> void
 Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenNamedPipe(string! pipeName, System.Action<Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions!>! configure) -> void
 Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.PipeName.get -> string?

--- a/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
 Microsoft.AspNetCore.Server.Kestrel.Core.Features.ISslStreamFeature
 Microsoft.AspNetCore.Server.Kestrel.Core.Features.ISslStreamFeature.SslStream.get -> System.Net.Security.SslStream!
-Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.HasDefaultOrDevelopmentCertificate.get -> bool
+Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.CheckDefaultCertificate() -> bool
 Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenNamedPipe(string! pipeName) -> void
 Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenNamedPipe(string! pipeName, System.Action<Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions!>! configure) -> void
 Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.PipeName.get -> string?

--- a/src/Servers/Kestrel/Kestrel/test/HttpsConfigurationTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/HttpsConfigurationTests.cs
@@ -184,6 +184,29 @@ public class HttpsConfigurationTests
     }
 
     [Fact]
+    public async Task HasDefaultOrDevelopmentCertificateJustWorks()
+    {
+        var hostBuilder = new WebHostBuilder()
+            .UseKestrelCore()
+            .ConfigureKestrel(serverOptions =>
+            {
+                var testCertificate = new X509Certificate2(Path.Combine("shared", "TestCertificates", "aspnetdevcert.pfx"), "testPassword");
+                serverOptions.TestOverrideDefaultCertificate = testCertificate;
+
+                Assert.True(serverOptions.HasDefaultOrDevelopmentCertificate);
+            })
+            .Configure(app => { });
+
+        var host = hostBuilder.Build();
+
+        // Binding succeeds
+        await host.StartAsync();
+        await host.StopAsync();
+
+        Assert.True(host.Services.GetRequiredService<IHttpsConfigurationService>().IsInitialized);
+    }
+
+    [Fact]
     public async Task UseHttpsJustWorks()
     {
         var hostBuilder = new WebHostBuilder()

--- a/src/Servers/Kestrel/Kestrel/test/HttpsConfigurationTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/HttpsConfigurationTests.cs
@@ -184,7 +184,7 @@ public class HttpsConfigurationTests
     }
 
     [Fact]
-    public async Task HasDefaultOrDevelopmentCertificateJustWorks()
+    public async Task CheckDefaultCertificateJustWorks()
     {
         var hostBuilder = new WebHostBuilder()
             .UseKestrelCore()
@@ -193,7 +193,7 @@ public class HttpsConfigurationTests
                 var testCertificate = new X509Certificate2(Path.Combine("shared", "TestCertificates", "aspnetdevcert.pfx"), "testPassword");
                 serverOptions.TestOverrideDefaultCertificate = testCertificate;
 
-                Assert.True(serverOptions.HasDefaultOrDevelopmentCertificate);
+                Assert.True(serverOptions.CheckDefaultCertificate());
             })
             .Configure(app => { });
 

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -385,7 +385,7 @@ public class KestrelConfigurationLoaderTests
     }
 
     [Fact]
-    public void HasDefaultOrDevelopmentCertificate_DevelopmentCertificate()
+    public void CheckDefaultCertificate_DevelopmentCertificate()
     {
         try
         {
@@ -404,7 +404,7 @@ public class KestrelConfigurationLoaderTests
             serverOptions.Configure(config);
             serverOptions.ConfigurationLoader.Load();
 
-            Assert.True(serverOptions.HasDefaultOrDevelopmentCertificate);
+            Assert.True(serverOptions.CheckDefaultCertificate());
         }
         finally
         {
@@ -416,7 +416,7 @@ public class KestrelConfigurationLoaderTests
     }
 
     [Fact]
-    public void HasDefaultOrDevelopmentCertificate_DefaultCertificate()
+    public void CheckDefaultCertificate_DefaultCertificate()
     {
         var certificate = new X509Certificate2(TestResources.TestCertificatePath, "testPassword", X509KeyStorageFlags.Exportable);
 
@@ -431,7 +431,7 @@ public class KestrelConfigurationLoaderTests
         serverOptions.Configure(config);
         serverOptions.ConfigurationLoader.Load();
 
-        Assert.True(serverOptions.HasDefaultOrDevelopmentCertificate);
+        Assert.True(serverOptions.CheckDefaultCertificate());
     }
 
     [Fact]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
@@ -776,18 +776,18 @@ public class HttpsTests : LoggedTest
     }
 
     [Fact]
-    public void HasDefaultOrDevelopmentCertificate_ConfigurationNotLoaded()
+    public void CheckDefaultCertificate_ConfigurationNotLoaded()
     {
         var serverOptions = CreateServerOptions();
         serverOptions.TestOverrideDefaultCertificate = _x509Certificate2;
 
         serverOptions.Configure();
 
-        Assert.Throws<InvalidOperationException>(() => serverOptions.HasDefaultOrDevelopmentCertificate);
+        Assert.Throws<InvalidOperationException>(() => serverOptions.CheckDefaultCertificate);
     }
 
     [Fact]
-    public void HasDefaultOrDevelopmentCertificate_ConfigurationLoaded()
+    public void CheckDefaultCertificate_ConfigurationLoaded()
     {
         var serverOptions = CreateServerOptions();
         serverOptions.TestOverrideDefaultCertificate = _x509Certificate2;
@@ -795,29 +795,29 @@ public class HttpsTests : LoggedTest
         serverOptions.Configure();
         serverOptions.ConfigurationLoader.Load();
 
-        Assert.True(serverOptions.HasDefaultOrDevelopmentCertificate);
+        Assert.True(serverOptions.CheckDefaultCertificate());
     }
 
     [Fact]
-    public void HasDefaultOrDevelopmentCertificate_NoConfiguration()
+    public void CheckDefaultCertificate_NoConfiguration()
     {
         var serverOptions = CreateServerOptions();
         serverOptions.TestOverrideDefaultCertificate = _x509Certificate2;
 
-        Assert.True(serverOptions.HasDefaultOrDevelopmentCertificate);
+        Assert.True(serverOptions.CheckDefaultCertificate());
     }
 
     [Fact]
-    public void HasDefaultOrDevelopmentCertificate_NoCertificate()
+    public void CheckDefaultCertificate_NoCertificate()
     {
         var serverOptions = CreateServerOptions();
         serverOptions.IsDevelopmentCertificateLoaded = true; // Prevent the system default from being loaded
 
-        Assert.False(serverOptions.HasDefaultOrDevelopmentCertificate);
+        Assert.False(serverOptions.CheckDefaultCertificate());
     }
 
     [Fact]
-    public void HasDefaultOrDevelopmentCertificate_FromHttpsDefaults()
+    public void CheckDefaultCertificate_FromHttpsDefaults()
     {
         var serverOptions = CreateServerOptions();
         serverOptions.ConfigureHttpsDefaults(httpsOptions =>
@@ -825,7 +825,7 @@ public class HttpsTests : LoggedTest
             httpsOptions.ServerCertificate = _x509Certificate2;
         });
 
-        Assert.True(serverOptions.HasDefaultOrDevelopmentCertificate);
+        Assert.True(serverOptions.CheckDefaultCertificate());
     }
 
     private class HandshakeErrorLoggerProvider : ILoggerProvider

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
@@ -775,6 +775,59 @@ public class HttpsTests : LoggedTest
         Assert.True(onAuthenticateCalled, "onAuthenticateCalled");
     }
 
+    [Fact]
+    public void HasDefaultOrDevelopmentCertificate_ConfigurationNotLoaded()
+    {
+        var serverOptions = CreateServerOptions();
+        serverOptions.TestOverrideDefaultCertificate = _x509Certificate2;
+
+        serverOptions.Configure();
+
+        Assert.Throws<InvalidOperationException>(() => serverOptions.HasDefaultOrDevelopmentCertificate);
+    }
+
+    [Fact]
+    public void HasDefaultOrDevelopmentCertificate_ConfigurationLoaded()
+    {
+        var serverOptions = CreateServerOptions();
+        serverOptions.TestOverrideDefaultCertificate = _x509Certificate2;
+
+        serverOptions.Configure();
+        serverOptions.ConfigurationLoader.Load();
+
+        Assert.True(serverOptions.HasDefaultOrDevelopmentCertificate);
+    }
+
+    [Fact]
+    public void HasDefaultOrDevelopmentCertificate_NoConfiguration()
+    {
+        var serverOptions = CreateServerOptions();
+        serverOptions.TestOverrideDefaultCertificate = _x509Certificate2;
+
+        Assert.True(serverOptions.HasDefaultOrDevelopmentCertificate);
+    }
+
+    [Fact]
+    public void HasDefaultOrDevelopmentCertificate_NoCertificate()
+    {
+        var serverOptions = CreateServerOptions();
+        serverOptions.IsDevelopmentCertificateLoaded = true; // Prevent the system default from being loaded
+
+        Assert.False(serverOptions.HasDefaultOrDevelopmentCertificate);
+    }
+
+    [Fact]
+    public void HasDefaultOrDevelopmentCertificate_FromHttpsDefaults()
+    {
+        var serverOptions = CreateServerOptions();
+        serverOptions.ConfigureHttpsDefaults(httpsOptions =>
+        {
+            httpsOptions.ServerCertificate = _x509Certificate2;
+        });
+
+        Assert.True(serverOptions.HasDefaultOrDevelopmentCertificate);
+    }
+
     private class HandshakeErrorLoggerProvider : ILoggerProvider
     {
         public HttpsConnectionFilterLogger FilterLogger { get; set; } = new HttpsConnectionFilterLogger();

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsTests.cs
@@ -783,7 +783,7 @@ public class HttpsTests : LoggedTest
 
         serverOptions.Configure();
 
-        Assert.Throws<InvalidOperationException>(() => serverOptions.CheckDefaultCertificate);
+        Assert.Throws<InvalidOperationException>(() => serverOptions.CheckDefaultCertificate());
     }
 
     [Fact]


### PR DESCRIPTION
# Introduce KestrelServerOptions.HasDefaultOrDevelopmentCertificate

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.


## Description

Introduce `KestrelServerOptions.HasDefaultOrDevelopmentCertificate` as a way to determine whether a certificate is available before invoking `KestrelServerOptions.Listen` and possibly failing in `ListenOptions.UseHttps`.

Replaces #48054
Fixes #28120