### PR TITLE
Rename IndexOfAnyValues to SearchValues

### DIFF
--- a/src/Components/Components/src/Routing/TemplateParser.cs
+++ b/src/Components/Components/src/Routing/TemplateParser.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Components.Routing;
 // * Catch-all parameters (Like /blog/{*slug})
 internal sealed class TemplateParser
 {
-    private static readonly IndexOfAnyValues<char> _invalidParameterNameCharacters = IndexOfAnyValues.Create("{}=.");
+    private static readonly SearchValues<char> _invalidParameterNameCharacters = SearchValues.Create("{}=.");
 
     internal static RouteTemplate ParseTemplate(string template)
     {

--- a/src/Http/Headers/src/ContentDispositionHeaderValue.cs
+++ b/src/Http/Headers/src/ContentDispositionHeaderValue.cs
@@ -37,8 +37,8 @@ public class ContentDispositionHeaderValue
 
     // attr-char definition from RFC5987
     // Same as token except ( "*" / "'" / "%" )
-    private static readonly IndexOfAnyValues<char> AttrChar =
-        IndexOfAnyValues.Create("!#$&+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~");
+    private static readonly SearchValues<char> AttrChar =
+        SearchValues.Create("!#$&+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~");
 
     private static readonly HttpHeaderParser<ContentDispositionHeaderValue> Parser
         = new GenericHeaderParser<ContentDispositionHeaderValue>(false, GetDispositionTypeLength);

--- a/src/Http/Routing/src/Patterns/RoutePatternParser.cs
+++ b/src/Http/Routing/src/Patterns/RoutePatternParser.cs
@@ -16,7 +16,7 @@ internal static class RoutePatternParser
     private const char QuestionMark = '?';
     private const string PeriodString = ".";
 
-    internal static readonly IndexOfAnyValues<char> InvalidParameterNameChars = IndexOfAnyValues.Create("/{}?*");
+    internal static readonly SearchValues<char> InvalidParameterNameChars = SearchValues.Create("/{}?*");
 
     public static RoutePattern Parse(string pattern)
     {

--- a/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
+++ b/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
@@ -25,17 +25,17 @@ public class ForwardedHeadersMiddleware
     private IList<StringSegment>? _allowedHosts;
 
     // RFC 3986 scheme = ALPHA * (ALPHA / DIGIT / "+" / "-" / ".")
-    private static readonly IndexOfAnyValues<char> SchemeChars =
-        IndexOfAnyValues.Create("+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
+    private static readonly SearchValues<char> SchemeChars =
+        SearchValues.Create("+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz");
 
     // Host Matches Http.Sys and Kestrel
     // Host Matches RFC 3986 except "*" / "+" / "," / ";" / "=" and "%" HEXDIG HEXDIG which are not allowed by Http.Sys
-    private static readonly IndexOfAnyValues<char> HostChars =
-        IndexOfAnyValues.Create("!$&'()-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~");
+    private static readonly SearchValues<char> HostChars =
+        SearchValues.Create("!$&'()-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~");
 
     // 0-9 / A-F / a-f / ":" / "."
-    private static readonly IndexOfAnyValues<char> Ipv6HostChars =
-        IndexOfAnyValues.Create(".0123456789:ABCDEFabcdef");
+    private static readonly SearchValues<char> Ipv6HostChars =
+        SearchValues.Create(".0123456789:ABCDEFabcdef");
 
     /// <summary>
     /// Create a new <see cref="ForwardedHeadersMiddleware"/>.

--- a/src/Shared/HttpRuleParser.cs
+++ b/src/Shared/HttpRuleParser.cs
@@ -13,8 +13,8 @@ internal static class HttpRuleParser
 {
     // token = 1*<any CHAR except CTLs or separators>
     // CTL = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
-    private static readonly IndexOfAnyValues<char> TokenChars =
-        IndexOfAnyValues.Create("!#$%&'*+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~");
+    private static readonly SearchValues<char> TokenChars =
+        SearchValues.Create("!#$%&'*+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~");
 
     private const int MaxNestedCount = 5;
     private static readonly string[] DateFormats = new string[]

--- a/src/Shared/ServerInfrastructure/HttpCharacters.cs
+++ b/src/Shared/ServerInfrastructure/HttpCharacters.cs
@@ -19,22 +19,22 @@ internal static class HttpCharacters
     // 127.0.0.1
     // user@host.com
     // user:password@host.com
-    private static readonly IndexOfAnyValues<byte> _allowedAuthorityBytes = IndexOfAnyValues.Create(":.-[]@0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"u8);
+    private static readonly SearchValues<byte> _allowedAuthorityBytes = SearchValues.Create(":.-[]@0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"u8);
 
     // Matches Http.Sys
     // Matches RFC 3986 except "*" / "+" / "," / ";" / "=" and "%" HEXDIG HEXDIG which are not allowed by Http.Sys
-    private static readonly IndexOfAnyValues<char> _allowedHostChars = IndexOfAnyValues.Create("!$&'()-._~" + AlphaNumeric);
+    private static readonly SearchValues<char> _allowedHostChars = SearchValues.Create("!$&'()-._~" + AlphaNumeric);
 
     // tchar https://tools.ietf.org/html/rfc7230#appendix-B
-    private static readonly IndexOfAnyValues<char> _allowedTokenChars = IndexOfAnyValues.Create("!#$%&'*+-.^_`|~" + AlphaNumeric);
-    private static readonly IndexOfAnyValues<byte> _allowedTokenBytes = IndexOfAnyValues.Create("!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"u8);
+    private static readonly SearchValues<char> _allowedTokenChars = SearchValues.Create("!#$%&'*+-.^_`|~" + AlphaNumeric);
+    private static readonly SearchValues<byte> _allowedTokenBytes = SearchValues.Create("!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"u8);
 
     // field-value https://tools.ietf.org/html/rfc7230#section-3.2
     // HTAB, [VCHAR, SP]
-    private static readonly IndexOfAnyValues<char> _allowedFieldChars = IndexOfAnyValues.Create("\t !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~" + AlphaNumeric);
+    private static readonly SearchValues<char> _allowedFieldChars = SearchValues.Create("\t !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~" + AlphaNumeric);
 
     // Values are [0x00, 0x1F] without 0x09 (HTAB) and with 0x7F.
-    private static readonly IndexOfAnyValues<char> _invalidFieldChars = IndexOfAnyValues.Create(
+    private static readonly SearchValues<char> _invalidFieldChars = SearchValues.Create(
         "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u000A\u000B\u000C\u000D\u000E\u000F\u0010" +
         "\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F\u007F");
 


### PR DESCRIPTION
Merging against the `darc-main-6d293505-ab46-4893-aaa8-3f1828bbdebf` branch for https://github.com/dotnet/aspnetcore/pull/48014
This reacts to the breaking change in runtime to rename `IndexOfAnyValues` to `SearchValues`: https://github.com/dotnet/runtime/issues/82622, https://github.com/dotnet/runtime/pull/85686
