### PR TITLE
http.sys: short-circuit empty writes (if we've started)

### DIFF
--- a/src/Servers/HttpSys/test/FunctionalTests/ResponseBodyTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/ResponseBodyTests.cs
@@ -377,7 +377,7 @@ public class ResponseBodyTests
         var completion = new TaskCompletionSource<bool>();
         using (Utilities.CreateHttpServer(out address, async httpContext =>
         {
-            byte[] data = Encoding.UTF8.GetBytes("hello, world");
+            var data = Encoding.UTF8.GetBytes("hello, world");
             if (setContentLength)
             {
                 httpContext.Response.ContentLength = data.Length;


### PR DESCRIPTION
# http.sys: short-circuit empty write

Treat empty writes (after headers have been written) as no-ops

## Description

Related to https://github.com/dotnet/runtime/issues/85733 - there are scenarios where empty writes may occur; as long as we have started the response (an initial empty write has meaning - it forces headers etc), we should short-circuit this *even in the disposed scenario* (because in a content-length scenario where the entire payload has already been written and no trailers are expected, we will have marked ourselves as disposed)

(observed in the wild)
