### PR TITLE
http.sys (6.0 backport): new option for response buffering

### DIFF
--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -118,7 +118,7 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         /// Applications that use asynchronous I/O and that may have more than one send outstanding at a time should not use this flag.
         /// Enabling this can results in higher CPU and memory usage by Http.Sys.
         /// </summary>
-        internal bool EnableKernelResponseBuffering { get; set; } // internal via app-context for non-public release
+        internal bool EnableKernelResponseBuffering { get; set; } // internal via app-context in pre-8.0
 
         /// <summary>
         /// Gets or sets the maximum number of concurrent connections to accept, -1 for infinite, or null to

--- a/src/Servers/HttpSys/src/HttpSysOptions.cs
+++ b/src/Servers/HttpSys/src/HttpSysOptions.cs
@@ -35,6 +35,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         /// </summary>
         public HttpSysOptions()
         {
+            const string EnableKernelResponseBufferingSwitch = "Microsoft.AspNetCore.Server.HttpSys.EnableKernelResponseBuffering";
+            EnableKernelResponseBuffering = AppContext.TryGetSwitch(EnableKernelResponseBufferingSwitch, out var enabled) && enabled;
         }
 
         /// <summary>
@@ -108,6 +110,15 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         /// complete normally. The default is false.
         /// </summary>
         public bool ThrowWriteExceptions { get; set; }
+
+        /// <summary>
+        /// Enable buffering of response data in the Kernel.
+        /// It should be used by an application doing synchronous I/O or by an application doing asynchronous I/O with
+        /// no more than one outstanding write at a time, and can significantly improve throughput over high-latency connections.
+        /// Applications that use asynchronous I/O and that may have more than one send outstanding at a time should not use this flag.
+        /// Enabling this can results in higher CPU and memory usage by Http.Sys.
+        /// </summary>
+        internal bool EnableKernelResponseBuffering { get; set; } // internal via app-context for non-public release
 
         /// <summary>
         /// Gets or sets the maximum number of concurrent connections to accept, -1 for infinite, or null to

--- a/src/Servers/HttpSys/src/RequestProcessing/Response.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Response.cs
@@ -280,8 +280,6 @@ namespace Microsoft.AspNetCore.Server.HttpSys
         // This will give us more control of the bytes that hit the wire, including encodings, HTTP 1.0, etc..
         // It may also be faster to do this work in managed code and then pass down only one buffer.
         // What would we loose by bypassing HttpSendHttpResponse?
-        //
-        // TODO: Consider using the HTTP_SEND_RESPONSE_FLAG_BUFFER_DATA flag for most/all responses rather than just Opaque.
         internal unsafe uint SendHeaders(HttpApiTypes.HTTP_DATA_CHUNK[]? dataChunks,
             ResponseStreamAsyncResult? asyncResult,
             HttpApiTypes.HTTP_FLAGS flags,

--- a/src/Servers/HttpSys/src/RequestProcessing/ResponseBody.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/ResponseBody.cs
@@ -42,6 +42,8 @@ namespace Microsoft.AspNetCore.Server.HttpSys
 
         internal bool ThrowWriteExceptions => RequestContext.Server.Options.ThrowWriteExceptions;
 
+        internal bool EnableKernelResponseBuffering => RequestContext.Server.Options.EnableKernelResponseBuffering;
+
         internal bool IsDisposed => _disposed;
 
         public override bool CanSeek
@@ -465,6 +467,13 @@ namespace Microsoft.AspNetCore.Server.HttpSys
                 && (_leftToWrite != writeCount || _requestContext.Response.TrailersExpected))
             {
                 flags |= HttpApiTypes.HTTP_FLAGS.HTTP_SEND_RESPONSE_FLAG_MORE_DATA;
+            }
+            if (EnableKernelResponseBuffering)
+            {
+                // "When this flag is set, it should also be used consistently in calls to the HttpSendResponseEntityBody function."
+                // so: make sure we add it in *all* scenarios where it applies - our "close" could be at the end of a bunch
+                // of buffered chunks
+                flags |= HttpApiTypes.HTTP_FLAGS.HTTP_SEND_RESPONSE_FLAG_BUFFER_DATA;
             }
 
             // Update _leftToWrite now so we can queue up additional async writes.


### PR DESCRIPTION
# HttpSys: new option for response buffering

8.0 feature: https://github.com/dotnet/aspnetcore/pull/47776

(note: this is a cherry-pick from the internal experimental/validation environment)

## Description

As per [old PR 418](https://github.com/aspnet/HttpSysServer/pull/418) (direct copy), enables kernel mode response-buffering in http.sys - with modification to use app-context switch rather than public API change

## Customer Impact

Without this buffer, writes are sent as-written direct thru http.sys; this has two problems:

- fragmentation if writes are small
- issues with latency

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low - opt in, no impact to consumers not using this flag

[Justify the selection above]

## Verification

- [x] Manual (required) - will try to verify with internal MSFT consumer (targeting net6.0)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props
