### PR TITLE
Code Fix for AfterOnResourceExecution Diagnostic Event.

### DIFF
--- a/src/Mvc/Mvc.Core/src/Infrastructure/ResourceInvoker.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ResourceInvoker.cs
@@ -504,19 +504,18 @@ internal abstract partial class ResourceInvoker
                             Canceled = true,
                             Result = _resourceExecutingContext.Result,
                         };
-
-                        _diagnosticListener.AfterOnResourceExecution(_resourceExecutedContext, filter);
-                        _logger.AfterExecutingMethodOnFilter(
-                            FilterTypeConstants.ResourceFilter,
-                            nameof(IAsyncResourceFilter.OnResourceExecutionAsync),
-                            filter);
-
-                        // A filter could complete a Task without setting a result
-                        if (_resourceExecutingContext.Result != null)
-                        {
-                            goto case State.ResourceShortCircuit;
-                        }
                     }
+                    _diagnosticListener.AfterOnResourceExecution(_resourceExecutedContext, filter);
+                    _logger.AfterExecutingMethodOnFilter(
+                        FilterTypeConstants.ResourceFilter,
+                        nameof(IAsyncResourceFilter.OnResourceExecutionAsync),
+                        filter);
+
+                    // A filter could complete a Task without setting a result
+                    if (_resourceExecutingContext.Result != null)
+                    {
+                        goto case State.ResourceShortCircuit;
+                    }                   
 
                     goto case State.ResourceEnd;
                 }


### PR DESCRIPTION
As per Issue #47698 Made necessary code changes

# Code Fix for AfterOnResourceExecution Diagnostic Event.
The AfterOnResourceExecution diagnostic event is only emitted if the resource filter short-circuits the request. The analogous action filter event, AfterOnActionExecution, is emitted regardless if the request is short-circuited or not.

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [Yes] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [NA] You've included unit or integration tests for your change, where applicable.
- [NA ] You've included inline docs for your change, where applicable.
- [#47698] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

 

Summary of the changes  
In ResourceInvoker.cs file code changes have been made. The line of code that emits the AfterOnResourceExecution event is within an if (_resourceExecutedContext == null) block, but that block should likely end prior to the event being emitted.

Code Changes have been done to close the if block before the AfterOnResourceExecution is fired

Fixes #47698 
