### PR TITLE
Make EndpointHtmlRenderer track the HttpContext

### DIFF
--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.PrerenderingState.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.PrerenderingState.cs
@@ -16,10 +16,12 @@ internal partial class EndpointHtmlRenderer
 
     public async ValueTask<IHtmlContent> PrerenderPersistedStateAsync(HttpContext httpContext, PersistedStateSerializationMode serializationMode)
     {
+        SetHttpContext(httpContext);
+
         // First we resolve "infer" mode to a specific mode
         if (serializationMode == PersistedStateSerializationMode.Infer)
         {
-            switch (GetPersistStateRenderMode(httpContext))
+            switch (GetPersistStateRenderMode(_httpContext))
             {
                 case InvokedRenderModes.Mode.None:
                     return ComponentStateHtmlContent.Empty;
@@ -41,7 +43,7 @@ internal partial class EndpointHtmlRenderer
         var store = serializationMode switch
         {
             PersistedStateSerializationMode.Server =>
-                new ProtectedPrerenderComponentApplicationStore(httpContext.RequestServices.GetRequiredService<IDataProtectionProvider>()),
+                new ProtectedPrerenderComponentApplicationStore(_httpContext.RequestServices.GetRequiredService<IDataProtectionProvider>()),
             PersistedStateSerializationMode.WebAssembly =>
                 new PrerenderComponentApplicationStore(),
             _ =>
@@ -49,7 +51,7 @@ internal partial class EndpointHtmlRenderer
         };
 
         // Finally, persist the state and return the HTML content
-        var manager = httpContext.RequestServices.GetRequiredService<ComponentStatePersistenceManager>();
+        var manager = _httpContext.RequestServices.GetRequiredService<ComponentStatePersistenceManager>();
         await manager.PersistStateAsync(store, Dispatcher);
         return new ComponentStateHtmlContent(store);
     }

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs
@@ -18,6 +18,8 @@ internal partial class EndpointHtmlRenderer
 
     public async Task SendStreamingUpdatesAsync(HttpContext httpContext, Task untilTaskCompleted, TextWriter writer)
     {
+        SetHttpContext(httpContext);
+
         if (_streamingUpdatesWriter is not null)
         {
             // The framework is the only caller, so it's OK to have a nonobvious restriction like this
@@ -37,7 +39,7 @@ internal partial class EndpointHtmlRenderer
         }
         catch (Exception ex)
         {
-            HandleExceptionAfterResponseStarted(httpContext, writer, ex);
+            HandleExceptionAfterResponseStarted(_httpContext, writer, ex);
 
             // The rest of the pipeline can treat this as a regular unhandled exception
             // TODO: Is this really right? I think we'll terminate the response in an invalid way.

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
@@ -36,6 +36,7 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
     private readonly IServiceProvider _services;
     private Task? _servicesInitializedTask;
 
+    private HttpContext _httpContext = default!; // Always set at the start of an inbound call
     private string? _formHandler;
     private NamedEvent _capturedNamedEvent;
 
@@ -49,6 +50,18 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
         : base(serviceProvider, loggerFactory)
     {
         _services = serviceProvider;
+    }
+
+    private void SetHttpContext(HttpContext httpContext)
+    {
+        if (_httpContext is null)
+        {
+            _httpContext = httpContext;
+        }
+        else if (_httpContext != httpContext)
+        {
+            throw new InvalidOperationException("The HttpContext cannot change value once assigned.");
+        }
     }
 
     internal static async Task InitializeStandardComponentServicesAsync(


### PR DESCRIPTION
This is a really minor detail but I'm splitting it out from my larger PR about render modes just to try to keep the bigger one more practical to review clearly.

EndpointHtmlRenderer will need access to the HttpContext when writing out the HTML content to the response writer because this is used as part of generating the Server/WebAssembly markers for interactive components (e.g., to track per-response marker sequence numbers and to use DataProtection for formatting the server component markers).

Currently, it doesn't have access to the HttpContext at the right time, so this PR makes it treat HttpContext as an instance field, rather than something that just lives transiently in the call stack. This is perfectly fine to do because EndpointHtmlRender is scoped to the request anyway.