### PR TITLE
Change access modifier of ForceSignOut()

### DIFF
--- a/src/Components/Server/src/Circuits/RevalidatingServerAuthenticationStateProvider.cs
+++ b/src/Components/Server/src/Circuits/RevalidatingServerAuthenticationStateProvider.cs
@@ -99,7 +99,7 @@ public abstract class RevalidatingServerAuthenticationStateProvider
         }
     }
 
-    private void ForceSignOut()
+    protected virtual void ForceSignOut()
     {
         var anonymousUser = new ClaimsPrincipal(new ClaimsIdentity());
         var anonymousState = new AuthenticationState(anonymousUser);


### PR DESCRIPTION
Change access modifier of ForceSignOut() to protected virtual for improved extensibility and custom exception handling

# Change access modifier of ForceSignOut()

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Change ForceSignOut() access modifier to protected virtual

## Description



This commit changes the access modifier of the ForceSignOut() method in the RevalidatingServerAuthenticationStateProvider class from private to protected virtual, which will allow subclasses to safely and flexibly override the method functionality as needed. The commit also includes an updated issue to reflect the potential for subclasses to handle custom exceptions during revalidation and improve the overall robustness of the authentication system.

Fixes #48101
