### PR TITLE
Add a HelixQueues attribute.

### DIFF
--- a/src/Testing/src/xunit/HelixQueues.cs
+++ b/src/Testing/src/xunit/HelixQueues.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Testing;
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
+public class HelixQueues : Attribute, ITestCondition
+{
+    public HelixQueues()
+    {
+    }
+
+    public string Includes { get; set; }
+    public string Excludes { get; set; }
+
+    public bool IsMet
+    {
+        get
+        {
+            return HelixHelper.OnHelix() && IsQueueMatch(Includes) && !IsQueueMatch(Excludes);
+        }
+    }
+
+    public string SkipReason => "Queue is filtered by Includes/Excludes.";
+
+    private bool IsQueueMatch(string queues)
+    {
+        if (string.IsNullOrEmpty(queues))
+        {
+            return false;
+        }
+
+        if (queues == "*")
+        {
+            return true;
+        }
+
+        var targetQueue = HelixHelper.GetTargetHelixQueue();
+
+        if (queues.Contains("All.Windows") && targetQueue.StartsWith("windows", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (queues.Contains("All.OSX") && targetQueue.StartsWith("osx", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (queues.Contains("All.Ubuntu") && targetQueue.StartsWith("ubuntu", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return queues.ToLowerInvariant().Split(';').Contains(targetQueue);
+    }
+
+    public static bool OnHelix() => HelixHelper.OnHelix();
+}

--- a/src/Testing/src/xunit/SkipOnHelixAttribute.cs
+++ b/src/Testing/src/xunit/SkipOnHelixAttribute.cs
@@ -52,6 +52,11 @@ public class SkipOnHelixAttribute : Attribute, ITestCondition
 
         var targetQueue = GetTargetHelixQueue().ToLowerInvariant();
 
+        if (Queues.Contains("All.Windows") && targetQueue.StartsWith("windows", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
         if (Queues.Contains("All.OSX") && targetQueue.StartsWith("osx", StringComparison.OrdinalIgnoreCase))
         {
             return true;

--- a/src/Testing/test/HelixQueuesTests.cs
+++ b/src/Testing/test/HelixQueuesTests.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.AspNetCore.Testing;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Testing.Tests;
+
+public class HelixQueuesTests
+{
+    [ConditionalFact]
+    [HelixQueues(Includes = "*", Excludes = "All.Windows")] // Run everywhere except for Windows.
+    public void Test_Should_Be_Skipped_On_Windows()
+    {
+        var queue = HelixHelper.GetTargetHelixQueue();
+
+        if (queue.StartsWith("windows", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("This test should not run on Windows!");
+        }
+    }
+
+    [ConditionalFact]
+    [HelixQueues(Includes = "*", Excludes = "All.OSX")]
+    public void Test_Should_Be_Skipped_On_OSX()
+    {
+        var queue = HelixHelper.GetTargetHelixQueue();
+
+        if (queue.StartsWith("osx", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("This test should not run on OSX!");
+        }
+    }
+
+    [ConditionalFact]
+    [HelixQueues(Includes = "*", Excludes = "All.Ubuntu")]
+    public void Test_Should_Be_Skipped_On_Ubuntu()
+    {
+        var queue = HelixHelper.GetTargetHelixQueue();
+
+        if (queue.StartsWith("ubuntu", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("This test should not run on Ubuntu!");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a `[HelixQueues]` attribute. The goal of this attribute is to allow us to succinctly opt-in to a specific queue once without having to exclude all other queues - that said, the usage is a bit more flexible than that and it could potentially replace the existing `[SkipOnHelix]` attribute. Usage:

```csharp
[HelixQueues(Includes = HelixConstants.NativeAotSupportedQueues)]
public void MyTestMethod()
{
}
```

You can also specify excludes:

```csharp
[HelixQueues(Includes = "*", Excludes = "All.Windows")]
public void MyTestMethod()
{
}
```

This PR also adds "All.Windows" as a special value along-side the existing "All.OSX" and "All.Ubuntu" values.