### PR TITLE
Make KestrelConfigurationLoader.Load safe to re-call

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -304,7 +304,8 @@ internal sealed class KestrelServerImpl : IServer
                 reloadToken = Options.ConfigurationLoader.Configuration.GetReloadToken();
             }
 
-            Options.ConfigurationLoader?.Load();
+            Options.ConfigurationLoader?.LoadInternal();
+            Options.ConfigurationLoader?.ProcessEndpointsToAdd();
 
             await AddressBinder.BindAsync(Options.GetListenOptions(), AddressBindContext!, _httpsConfigurationService.UseHttpsWithDefaults, cancellationToken).ConfigureAwait(false);
             _configChangedRegistration = reloadToken?.RegisterChangeCallback(TriggerRebind, this);

--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
-using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;

--- a/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
@@ -958,8 +958,6 @@ public class KestrelServerTests
         mockTransportFactory.Verify(f => f.BindAsync(new IPEndPoint(IPAddress.IPv6Any, 5000), It.IsAny<CancellationToken>()), Times.Once);
         mockTransportFactory.Verify(f => f.BindAsync(new IPEndPoint(IPAddress.IPv6Any, 5001), It.IsAny<CancellationToken>()), Times.Once);
 
-        mockConfig.Verify(c => c.GetReloadToken(), Times.Once); // Grabbed on Load
-
         await server.StopAsync(CancellationToken.None).DefaultTimeout();
     }
 

--- a/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
@@ -958,7 +958,7 @@ public class KestrelServerTests
         mockTransportFactory.Verify(f => f.BindAsync(new IPEndPoint(IPAddress.IPv6Any, 5000), It.IsAny<CancellationToken>()), Times.Once);
         mockTransportFactory.Verify(f => f.BindAsync(new IPEndPoint(IPAddress.IPv6Any, 5001), It.IsAny<CancellationToken>()), Times.Once);
 
-        mockConfig.Verify(c => c.GetReloadToken(), Times.Never);
+        mockConfig.Verify(c => c.GetReloadToken(), Times.Once); // Grabbed on Load
 
         await server.StopAsync(CancellationToken.None).DefaultTimeout();
     }

--- a/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
@@ -958,6 +958,8 @@ public class KestrelServerTests
         mockTransportFactory.Verify(f => f.BindAsync(new IPEndPoint(IPAddress.IPv6Any, 5000), It.IsAny<CancellationToken>()), Times.Once);
         mockTransportFactory.Verify(f => f.BindAsync(new IPEndPoint(IPAddress.IPv6Any, 5001), It.IsAny<CancellationToken>()), Times.Once);
 
+        mockConfig.Verify(c => c.GetReloadToken(), Times.Never);
+
         await server.StopAsync(CancellationToken.None).DefaultTimeout();
     }
 

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -1285,7 +1285,7 @@ public class KestrelConfigurationLoaderTests
 
         serverOptions.ConfigurationLoader.Load();
 
-        mockReloadToken.VerifyGet(t => t.HasChanged, Times.AtLeastOnce);
+        mockReloadToken.VerifyGet(t => t.HasChanged, Times.Never);
         mockConfig.Verify(c => c.GetSection(It.IsAny<string>()), Times.AtLeastOnce);
 
         mockReloadToken.SetupGet(t => t.HasChanged).Returns(changeAfterInitialLoad);


### PR DESCRIPTION
If it is called again and nothing has changed, it should do nothing.

Part of #45801