### PR TITLE
Missing dot.

### DIFF
--- a/src/Security/Authentication/Cookies/src/CookieAuthenticationOptions.cs
+++ b/src/Security/Authentication/Cookies/src/CookieAuthenticationOptions.cs
@@ -123,7 +123,7 @@ public class CookieAuthenticationOptions : AuthenticationSchemeOptions
 
     /// <summary>
     /// <para>
-    /// Controls how much time the authentication ticket stored in the cookie will remain valid from the point it is created
+    /// Controls how much time the authentication ticket stored in the cookie will remain valid from the point it is created.
     /// The expiration information is stored in the protected cookie ticket. Because of that an expired cookie will be ignored
     /// even if it is passed to the server after the browser should have purged it.
     /// </para>


### PR DESCRIPTION
Hi. Dot is missing in the explanation "ExpireTimeSpan" property of the "CookieAuthenticationOptions" class:
![image](https://github.com/dotnet/aspnetcore/assets/66569047/0daa755b-5e62-4c2b-adc3-aee1d8a3bd78)

Also missing in the [documentation](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.cookies.cookieauthenticationoptions?view=aspnetcore-7.0):
![image](https://github.com/dotnet/aspnetcore/assets/66569047/2a425a0a-3c35-4f45-9453-9d339fba95b4)
