### PR TITLE
Revert Microsoft.CodeAnalysis package changes in prebuilt baseline

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -11,6 +11,12 @@
 
     <!-- These are what the analyzers are built against. They are overridden in full source build.
          It may be possible to generate SBRPs -->
+    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.Analyzers/*2.9.4*" />
+    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.AnalyzerUtilities/*3.3.0*" />
+    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.Common/*3.3.1*" />
+    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.CSharp/*3.3.1*" />
+    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.CSharp.Workspaces/*3.3.1*" />
+    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.Workspaces.Common/*3.3.1*" />
     <UsagePattern IdentityGlob="System.Composition/*1.0.31*" />
     <UsagePattern IdentityGlob="System.Threading.Tasks.Extensions/*4.5.3*" />
 

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -11,14 +11,9 @@
 
     <!-- These are what the analyzers are built against. They are overridden in full source build.
          It may be possible to generate SBRPs -->
-    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.AnalyzerUtilities/*3.3.0*" />
-    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.Analyzers*" />
-    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.Common*" />
-    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.CSharp*" />
-    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.CSharp.Workspaces*" />
-    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis.Workspaces.Common*" />
     <UsagePattern IdentityGlob="System.Composition/*1.0.31*" />
     <UsagePattern IdentityGlob="System.Threading.Tasks.Extensions/*4.5.3*" />
+
     <!-- Added to unblock dependency flow, needs review. -->
     <UsagePattern IdentityGlob="System.Security.Cryptography.Xml/*6.0.0*" />
 


### PR DESCRIPTION
The changes that were made to the prebuilt baseline in https://github.com/dotnet/aspnetcore/pull/48179 can be reverted now that SBRPs for the offending packages have been defined in https://github.com/dotnet/source-build-reference-packages/pull/666 and been flowed into aspnetcore.