### PR TITLE
Change API template to only use Invariant Globalization in Native AOT…

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/Api-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/Api-CSharp.csproj.in
@@ -7,8 +7,8 @@
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">true</NoDefaultLaunchSettingsFile>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
     <ServerGarbageCollection>false</ServerGarbageCollection>
-    <InvariantGlobalization>true</InvariantGlobalization>
     <!--#if (NativeAot) -->
+    <InvariantGlobalization>true</InvariantGlobalization>
     <PublishAot>true</PublishAot>
     <!--#endif -->
   </PropertyGroup>

--- a/src/ProjectTemplates/Web.ProjectTemplates/GrpcService-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/GrpcService-CSharp.csproj.in
@@ -4,8 +4,8 @@
     <TargetFramework>${DefaultNetCoreTargetFramework}</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <InvariantGlobalization>true</InvariantGlobalization>
     <!--#if (NativeAot) -->
+    <InvariantGlobalization>true</InvariantGlobalization>
     <PublishAot>true</PublishAot>
     <!--#endif -->
   </PropertyGroup>

--- a/src/ProjectTemplates/Web.ProjectTemplates/Worker-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/Worker-CSharp.csproj.in
@@ -4,8 +4,8 @@
     <TargetFramework>${DefaultNetCoreTargetFramework}</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <InvariantGlobalization>true</InvariantGlobalization>
     <!--#if (NativeAot) -->
+    <InvariantGlobalization>true</InvariantGlobalization>
     <PublishAot>true</PublishAot>
     <!--#endif -->
     <UserSecretsId>dotnet-Company.Application1-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>

--- a/src/ProjectTemplates/test/Templates.Tests/ApiTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/ApiTemplateTest.cs
@@ -73,7 +73,10 @@ public class ApiTemplateTest : LoggedTest
             : new[] { "http", "IIS Express" };
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
-        await project.VerifyHasProperty("InvariantGlobalization", "true");
+        if (nativeAot)
+        {
+            await project.VerifyHasProperty("InvariantGlobalization", "true");
+        }
 
         // Avoid the F# compiler. See https://github.com/dotnet/aspnetcore/issues/14022
         if (languageOverride != null)

--- a/src/ProjectTemplates/test/Templates.Tests/GrpcTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/GrpcTemplateTest.cs
@@ -85,7 +85,10 @@ public class GrpcTemplateTest : LoggedTest
         var expectedLaunchProfileNames = new[] { "http", "https" };
         await project.VerifyLaunchSettings(expectedLaunchProfileNames);
 
-        await project.VerifyHasProperty("InvariantGlobalization", "true");
+        if (nativeAot)
+        {
+            await project.VerifyHasProperty("InvariantGlobalization", "true");
+        }
 
         // Force a restore if native AOT so that RID-specific assets are restored
         await project.RunDotNetPublishAsync(noRestore: !nativeAot);

--- a/src/ProjectTemplates/test/Templates.Tests/WorkerTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/WorkerTemplateTest.cs
@@ -58,7 +58,10 @@ public class WorkerTemplateTest : LoggedTest
 
         await project.RunDotNetNewAsync("worker", language: language, args: args);
 
-        await project.VerifyHasProperty("InvariantGlobalization", "true");
+        if (nativeAot)
+        {
+            await project.VerifyHasProperty("InvariantGlobalization", "true");
+        }
 
         // Force a restore if native AOT so that RID-specific assets are restored
         await project.RunDotNetPublishAsync(noRestore: !nativeAot);


### PR DESCRIPTION
Addresses #48186 

I don't think we want to make it painful for people using the API template when they aren't doing native AOT. Longer term I think SqlClient will need to figure out how to work with invariant globalization. I think this provides a gradual ramp for folks where we get the size benefits for an AOT project out of the box - but if they want to use SqlClient then they need to opt into globalization so it can work (but non native AOT folks don't even need to consider it).