### PR TITLE
Ship Microsoft.AspNetCore.WebUtilities, Microsoft.Net.Http.Headers as packages

### DIFF
--- a/eng/SharedFramework.Local.props
+++ b/eng/SharedFramework.Local.props
@@ -13,7 +13,9 @@
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.DataProtection" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.DataProtection.Extensions" />
+    <AspNetCoreAppReferenceAndPackage Include="Microsoft.Net.Http.Headers" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Metadata" />
+    <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.WebUtilities" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.Extensions.Identity.Core" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.Extensions.Identity.Stores" />
     <AspNetCoreAppReferenceAndPackage Include="Microsoft.AspNetCore.Connections.Abstractions" />
@@ -44,7 +46,6 @@
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Authentication.Abstractions" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Authentication.Core" />
-    <AspNetCoreAppReference Include="Microsoft.Net.Http.Headers" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Http.Extensions" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Http.Features" />
@@ -52,7 +53,6 @@
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Http" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Routing.Abstractions" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Routing" />
-    <AspNetCoreAppReference Include="Microsoft.AspNetCore.WebUtilities" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Html.Abstractions" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Identity" />
     <AspNetCoreAppReference Include="Microsoft.AspNetCore.Server.HttpSys" />

--- a/src/Http/Headers/src/Microsoft.Net.Http.Headers.csproj
+++ b/src/Http/Headers/src/Microsoft.Net.Http.Headers.csproj
@@ -6,7 +6,7 @@
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>http</PackageTags>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>

--- a/src/Http/Headers/src/Microsoft.Net.Http.Headers.csproj
+++ b/src/Http/Headers/src/Microsoft.Net.Http.Headers.csproj
@@ -19,6 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <SupportedPlatform Include="browser" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Net.Http.Headers.Tests" />
   </ItemGroup>
 </Project>

--- a/src/Http/WebUtilities/src/Microsoft.AspNetCore.WebUtilities.csproj
+++ b/src/Http/WebUtilities/src/Microsoft.AspNetCore.WebUtilities.csproj
@@ -27,6 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <SupportedPlatform Include="browser" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.AspNetCore.WebUtilities.Tests" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.WebUtilities.Microbenchmarks" />
   </ItemGroup>

--- a/src/Http/WebUtilities/src/Microsoft.AspNetCore.WebUtilities.csproj
+++ b/src/Http/WebUtilities/src/Microsoft.AspNetCore.WebUtilities.csproj
@@ -8,7 +8,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/48068. WebUtilities is used by blazor wasm projects that don't have access to the SharedFx (and it depends on Headers)