### PR TITLE
explicitly identifying button type in QuickGrid columnbase

### DIFF
--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Columns/ColumnBase.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Columns/ColumnBase.razor
@@ -19,12 +19,12 @@
         {
             @if (ColumnOptions is not null && (Align != Align.Right && Align != Align.End))
             {
-                <button class="col-options-button" @onclick="@(() => Grid.ShowColumnOptionsAsync(this))"></button>
+                <button class="col-options-button" type="button" @onclick="@(() => Grid.ShowColumnOptionsAsync(this))"></button>
             }
 
             if (Sortable.HasValue ? Sortable.Value : IsSortableByDefault())
             {
-                <button class="col-title" @onclick="@(() => Grid.SortByColumnAsync(this))">
+                <button class="col-title" type="button" @onclick="@(() => Grid.SortByColumnAsync(this))">
                     <div class="col-title-text">@Title</div>
                     <div class="sort-indicator" aria-hidden="true"></div>
                 </button>
@@ -38,7 +38,7 @@
 
             @if (ColumnOptions is not null && (Align == Align.Right || Align == Align.End))
             {
-                <button class="col-options-button" @onclick="@(() => Grid.ShowColumnOptionsAsync(this))"></button>
+                <button class="col-options-button" type="button" @onclick="@(() => Grid.ShowColumnOptionsAsync(this))"></button>
             }
         }
     }


### PR DESCRIPTION
# explicitly identifying button type in QuickGrid columnbase

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)
Explicitly making `ColumnBase` buttons of `type=button`.

## Description

Making Header Column buttons explicitly of `type=button`

This will ensure that when the default QuickGrid Header which has `ColumnOptions` and/or Sorting enabled inside an `EditForm`, it will no longer trigger the `EditContext` submit validation.

Fixes #45216 
