### PR TITLE
Remove static analysis for route parameter in RDG

### DIFF
--- a/src/Http/Http.Extensions/gen/RequestDelegateGenerator.cs
+++ b/src/Http/Http.Extensions/gen/RequestDelegateGenerator.cs
@@ -155,7 +155,7 @@ public sealed class RequestDelegateGenerator : IIncrementalGenerator
                     }
                     else
                     {
-                        codeWriter.WriteLine($"{SymbolDisplay.FormatLiteral(endpoint.RoutePattern!, true)},");
+                        codeWriter.WriteLine($"{SymbolDisplay.FormatLiteral("{*path:nonfile}", true)},");
                     }
                     codeWriter.WriteLine("handler,");
                     codeWriter.WriteLine($"{endpoint.EmitVerb()},");

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Endpoint.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Endpoint.cs
@@ -22,14 +22,6 @@ internal class Endpoint
         HttpMethod = GetHttpMethod(operation);
         EmitterContext = new EmitterContext();
 
-        if (!operation.TryGetRouteHandlerPattern(out var routeToken))
-        {
-            Diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.UnableToResolveRoutePattern, Operation.Syntax.GetLocation()));
-            return;
-        }
-
-        RoutePattern = routeToken;
-
         if (!operation.TryGetRouteHandlerMethod(semanticModel, out var method))
         {
             Diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.UnableToResolveMethod, Operation.Syntax.GetLocation()));

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/InvocationOperationExtensions.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/InvocationOperationExtensions.cs
@@ -10,7 +10,6 @@ namespace Microsoft.AspNetCore.Http.RequestDelegateGenerator.StaticRouteHandlerM
 
 internal static class InvocationOperationExtensions
 {
-    private const int RoutePatternArgumentOrdinal = 1;
     public static readonly string[] KnownMethods =
     {
         "MapGet",
@@ -60,33 +59,6 @@ internal static class InvocationOperationExtensions
         {
             methodName = method;
             return true;
-        }
-        return false;
-    }
-
-    public static bool TryGetRouteHandlerPattern(this IInvocationOperation invocation, [NotNullWhen(true)] out string? token)
-    {
-        token = default;
-        if (invocation.Syntax.TryGetMapMethodName(out var methodName))
-        {
-            if (methodName == "MapFallback" && invocation.Arguments.Length == 2)
-            {
-                token = "{*path:nonfile}";
-                return true;
-            }
-            foreach (var argument in invocation.Arguments)
-            {
-                if (argument.Parameter?.Ordinal == RoutePatternArgumentOrdinal)
-                {
-                    if (argument?.Syntax is not ArgumentSyntax routePatternArgumentSyntax ||
-                        routePatternArgumentSyntax.Expression is not LiteralExpressionSyntax routePatternArgumentLiteralSyntax)
-                    {
-                        return false;
-                    }
-                    token = routePatternArgumentLiteralSyntax.Token.ValueText;
-                    return true;
-                }
-            }
         }
         return false;
     }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/CompileTimeCreationTests.Routes.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/CompileTimeCreationTests.Routes.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+namespace Microsoft.AspNetCore.Http.Generators.Tests;
+
+public partial class CompileTimeCreationTests : RequestDelegateCreationTests
+{
+    [Fact]
+    public async Task SupportsRoutePatternInVariable()
+    {
+        var source = """
+var route = "/hello";
+app.MapGet(route, () =>
+{
+    return "Hello world!";
+});
+""";
+        var (result, compilation) = await RunGeneratorAsync(source);
+        var endpoint = GetEndpointFromCompilation(compilation);
+
+        VerifyStaticEndpointModel(result, endpointModel =>
+        {
+            Assert.Equal("MapGet", endpointModel.HttpMethod);
+        });
+
+        var httpContext = CreateHttpContext();
+        await endpoint.RequestDelegate(httpContext);
+        await VerifyResponseBodyAsync(httpContext, "Hello world!");
+    }
+
+    [Fact]
+    public async Task SupportsRoutePatternInConst()
+    {
+        var source = """
+const string route = "/hello";
+app.MapGet(route, () =>
+{
+    return "Hello world!";
+});
+""";
+        var (result, compilation) = await RunGeneratorAsync(source);
+        var endpoint = GetEndpointFromCompilation(compilation);
+
+        VerifyStaticEndpointModel(result, endpointModel =>
+        {
+            Assert.Equal("MapGet", endpointModel.HttpMethod);
+        });
+
+        var httpContext = CreateHttpContext();
+        await endpoint.RequestDelegate(httpContext);
+        await VerifyResponseBodyAsync(httpContext, "Hello world!");
+    }
+
+    [Fact]
+    public async Task SupportsComputedRoutePattern()
+    {
+        var source = """
+for (int i = 0; i < 5; i++)
+{
+    var route = $"/hello/{i}";
+    app.MapGet(route, () =>
+    {
+        return $"Hello world!";
+    });
+}
+""";
+        var (result, compilation) = await RunGeneratorAsync(source);
+        var endpoints = GetEndpointsFromCompilation(compilation);
+
+        VerifyStaticEndpointModel(result, endpointModel =>
+        {
+            Assert.Equal("MapGet", endpointModel.HttpMethod);
+        });
+
+        for (int i = 0; i < 5; i++)
+        {
+            var endpoint = endpoints[i];
+            var httpContext = CreateHttpContext();
+            await endpoint.RequestDelegate(httpContext);
+            await VerifyResponseBodyAsync(httpContext, $"Hello world!");
+        }
+
+    }
+}

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/CompileTimeCreationTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/CompileTimeCreationTests.cs
@@ -39,7 +39,6 @@ app.MapGet("/hello", (HttpContext context) => Task.CompletedTask);
 
         VerifyStaticEndpointModel(result, endpointModel =>
         {
-            Assert.Equal("/", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             Assert.Equal(expectedContentType, endpointModel.Response.ContentType);
         });
@@ -56,28 +55,5 @@ app.MapGet("/hello", (HttpContext context) => Task.CompletedTask);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => endpoint.RequestDelegate(httpContext));
         Assert.Equal("'invalidName' is not a route parameter.", exception.Message);
-    }
-
-    [Fact]
-    public async Task MapAction_WarnsForUnsupportedRouteVariable()
-    {
-        var source = """
-var route = "/hello";
-app.MapGet(route, () => "Hello world!");
-""";
-        var (generatorRunResult, compilation) = await RunGeneratorAsync(source);
-
-        // Emits diagnostic but generates no source
-        var result = Assert.IsType<GeneratorRunResult>(generatorRunResult);
-        var diagnostic = Assert.Single(result.Diagnostics);
-        Assert.Equal(DiagnosticDescriptors.UnableToResolveRoutePattern.Id, diagnostic.Id);
-        Assert.Empty(result.GeneratedSources);
-
-        // Falls back to runtime-generated endpoint
-        var endpoint = GetEndpointFromCompilation(compilation, false);
-
-        var httpContext = CreateHttpContext();
-        await endpoint.RequestDelegate(httpContext);
-        await VerifyResponseBodyAsync(httpContext, "Hello world!");
     }
 }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.Arrays.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.Arrays.cs
@@ -28,7 +28,6 @@ app.MapGet("/hello", ([FromQuery]ParsableTodo[] p) => p.Length);
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
         });
 
@@ -50,7 +49,6 @@ app.MapGet("/hello", ([FromHeader]ParsableTodo[] p) => p.Length);
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
         });
 
@@ -72,7 +70,6 @@ app.MapGet("/hello", ([FromHeader]string[] p) => p.Length);
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
         });
 
@@ -94,7 +91,6 @@ app.MapGet("/hello", ([FromHeader]string?[] p) => p.Length);
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
         });
 
@@ -168,7 +164,6 @@ app.MapGet("/hello", (HttpContext context, {{typeName}} tryParsable) => {
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
         });
 
@@ -194,7 +189,6 @@ app.MapGet("/hello", (ParsableTodo[] p) => p.Length);
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
         });
 
@@ -216,7 +210,6 @@ app.MapGet("/hello", ([FromQuery]string[] p) => p.Length);
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
         });
 
@@ -238,7 +231,6 @@ app.MapGet("/hello", (string[] p) => p.Length);
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
         });
 
@@ -260,7 +252,6 @@ app.MapGet("/hello", (string?[] p) => p.Length);
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
         });
 
@@ -281,7 +272,6 @@ app.MapGet("/hello", (string?[] p) => p.Length);
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
         });
 
@@ -303,7 +293,6 @@ app.MapGet("/hello", ([FromQuery]string?[] p) => p.Length);
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
         });
 
@@ -325,7 +314,6 @@ app.MapGet("/hello", (string?[] p) => p.Length);
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
         });
 
@@ -347,7 +335,6 @@ app.MapPost("/hello", (string[] p) => p.Length);
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapPost", endpointModel.HttpMethod);
         });
 
@@ -369,7 +356,6 @@ app.MapPost("/hello", (string[] p) => p[0]);
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapPost", endpointModel.HttpMethod);
         });
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.QueryParameters.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.QueryParameters.cs
@@ -90,7 +90,6 @@ app.MapGet("/hello", ([FromQuery]string? p) => p == string.Empty ? "No value, bu
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             var p = Assert.Single(endpointModel.Parameters);
             Assert.Equal(EndpointParameterSource.Query, p.Source);
@@ -115,7 +114,6 @@ app.MapGet("/hello", ([FromQuery]string p1, [FromQuery]string p2) => $"{p1} {p2}
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
         });
 
@@ -156,7 +154,6 @@ app.MapGet("/hello", ([FromQuery]string p1, [FromQuery]string p2) => $"{p1} {p2}
 
         VerifyStaticEndpointModel(results, (endpointModel) =>
         {
-            Assert.Equal("/", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             var p = Assert.Single(endpointModel.Parameters);
             Assert.Equal(EndpointParameterSource.Query, p.Source);

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.Responses.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.Responses.cs
@@ -27,7 +27,6 @@ public abstract partial class RequestDelegateCreationTests
 
         VerifyStaticEndpointModel(result, (endpointModel) =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal(httpMethod, endpointModel.HttpMethod);
         });
 
@@ -53,7 +52,7 @@ app.MapGet("/hello", () => "Hello world!")
         await VerifyAgainstBaselineUsingFile(compilation);
         VerifyStaticEndpointModel(result, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
+            Assert.Equal("MapGet", endpointModel.HttpMethod);
         });
 
         var httpContext = CreateHttpContext();
@@ -72,7 +71,6 @@ app.MapGet("/hello", () => "Hello world!")
 
         VerifyStaticEndpointModel(result, endpointModel =>
         {
-            Assert.Equal("/", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
         });
 
@@ -101,7 +99,6 @@ app.MapGet("/", GetTodo);
 
         VerifyStaticEndpointModel(result, endpointModel =>
         {
-            Assert.Equal("/", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
         });
 
@@ -126,7 +123,6 @@ app.MapGet("/", GetTodo);
 
         VerifyStaticEndpointModel(result, endpointModel =>
         {
-            Assert.Equal("/", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
         });
 
@@ -151,7 +147,6 @@ app.MapGet("/", GetTodo);
 
         VerifyStaticEndpointModel(result, endpointModel =>
         {
-            Assert.Equal("/", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             Assert.True(endpointModel.Response.IsAwaitable);
         });
@@ -177,7 +172,6 @@ app.MapGet("/", GetTodo);
 
         VerifyStaticEndpointModel(result, endpointModel =>
         {
-            Assert.Equal("/", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             Assert.True(endpointModel.Response.IsAwaitable);
         });
@@ -206,7 +200,6 @@ app.MapGet("/", GetTodo);
 
         VerifyStaticEndpointModel(result, endpointModel =>
         {
-            Assert.Equal("/", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             Assert.True(endpointModel.Response.IsAwaitable);
         });
@@ -229,14 +222,12 @@ app.MapGet("/value-task", () => ValueTask.CompletedTask);
         VerifyStaticEndpointModels(result, endpointModels => Assert.Collection(endpointModels,
             endpointModel =>
             {
-                Assert.Equal("/task", endpointModel.RoutePattern);
                 Assert.Equal("MapGet", endpointModel.HttpMethod);
                 Assert.True(endpointModel.Response.IsAwaitable);
                 Assert.True(endpointModel.Response.HasNoResponse);
             },
             endpointModel =>
             {
-                Assert.Equal("/value-task", endpointModel.RoutePattern);
                 Assert.Equal("MapGet", endpointModel.HttpMethod);
                 Assert.True(endpointModel.Response.IsAwaitable);
                 Assert.True(endpointModel.Response.HasNoResponse);

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.TryParse.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.TryParse.cs
@@ -161,7 +161,6 @@ app.MapGet("/hello", ([FromQuery]{{parameterType}} p) => p.MagicValue);
 
         VerifyStaticEndpointModel(results, (endpointModel) =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             var p = Assert.Single(endpointModel.Parameters);
             Assert.Equal(EndpointParameterSource.Query, p.Source);
@@ -185,7 +184,6 @@ app.MapGet("/hello", ([FromQuery]TryParseTodo p) => p.Name!);
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             var p = Assert.Single(endpointModel.Parameters);
             Assert.Equal(EndpointParameterSource.Query, p.Source);
@@ -210,7 +208,6 @@ app.MapGet("/hello", ([FromQuery]TodoStatus p) => p.ToString());
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             var p = Assert.Single(endpointModel.Parameters);
             Assert.Equal(EndpointParameterSource.Query, p.Source);

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.cs
@@ -38,7 +38,6 @@ app.MapGet("/hello", ({parameterType} p) => p == null ? "null!" : "Hello world!"
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
             var p = Assert.Single(endpointModel.Parameters);
             Assert.Equal(EndpointParameterSource.SpecialType, p.Source);
@@ -60,7 +59,6 @@ app.MapGet("/hello", (HttpRequest req, HttpResponse res) => req is null || res i
 
         VerifyStaticEndpointModel(results, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
             Assert.Equal("MapGet", endpointModel.HttpMethod);
 
             Assert.Collection(endpointModel.Parameters,
@@ -96,7 +94,7 @@ app.MapGet("/hello", () =>
 
         VerifyStaticEndpointModel(result, endpointModel =>
         {
-            Assert.Equal("/hello", endpointModel.RoutePattern);
+            Assert.Equal("MapGet", endpointModel.HttpMethod);
         });
 
         var httpContext = CreateHttpContext();
@@ -133,7 +131,6 @@ app.MapGet("/zh", (HttpRequest req, HttpResponse res) => "你好世界！");
         VerifyStaticEndpointModels(results, endpointModels => Assert.Collection(endpointModels,
             endpointModel =>
             {
-                Assert.Equal("/en", endpointModel.RoutePattern);
                 Assert.Equal("MapGet", endpointModel.HttpMethod);
                 var reqParam = Assert.Single(endpointModel.Parameters);
                 Assert.Equal(EndpointParameterSource.SpecialType, reqParam.Source);
@@ -141,7 +138,6 @@ app.MapGet("/zh", (HttpRequest req, HttpResponse res) => "你好世界！");
             },
             endpointModel =>
             {
-                Assert.Equal("/es", endpointModel.RoutePattern);
                 Assert.Equal("MapGet", endpointModel.HttpMethod);
                 var reqParam = Assert.Single(endpointModel.Parameters);
                 Assert.Equal(EndpointParameterSource.SpecialType, reqParam.Source);
@@ -149,7 +145,6 @@ app.MapGet("/zh", (HttpRequest req, HttpResponse res) => "你好世界！");
             },
             endpointModel =>
             {
-                Assert.Equal("/zh", endpointModel.RoutePattern);
                 Assert.Equal("MapGet", endpointModel.HttpMethod);
                 Assert.Collection(endpointModel.Parameters,
                     reqParam =>


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/48307.

We currently only analyze the route pattern at startup to examine which parameters might be bound from the route. As such, we can remove the requirement that we be able to statically analyze the route.