### PR TITLE
Use `Type.IsByRefLike`.

### DIFF
--- a/src/Shared/PropertyHelper/PropertyHelper.cs
+++ b/src/Shared/PropertyHelper/PropertyHelper.cs
@@ -550,20 +550,14 @@ internal sealed class PropertyHelper
             property.GetMethod.IsPublic &&
             !property.GetMethod.IsStatic &&
 
-            // PropertyHelper can't work with ref structs.
-            !IsRefStructProperty(property) &&
+            // PropertyHelper can't really interact with ref-struct properties since they can't be
+            // boxed and can't be used as generic types. We just ignore them.
+            //
+            // see: https://github.com/aspnet/Mvc/issues/8545
+            !property.PropertyType.IsByRefLike &&
 
             // Indexed properties are not useful (or valid) for grabbing properties off an object.
             property.GetMethod.GetParameters().Length == 0;
-    }
-
-    // PropertyHelper can't really interact with ref-struct properties since they can't be
-    // boxed and can't be used as generic types. We just ignore them.
-    //
-    // see: https://github.com/aspnet/Mvc/issues/8545
-    private static bool IsRefStructProperty(PropertyInfo property)
-    {
-        return property.PropertyType.IsByRefLike;
     }
 
     internal static class MetadataUpdateHandler

--- a/src/Shared/PropertyHelper/PropertyHelper.cs
+++ b/src/Shared/PropertyHelper/PropertyHelper.cs
@@ -42,8 +42,6 @@ internal sealed class PropertyHelper
 
     private static readonly ConcurrentDictionary<Type, PropertyHelper[]> VisiblePropertiesCache = new();
 
-    private static readonly Type IsByRefLikeAttribute = typeof(System.Runtime.CompilerServices.IsByRefLikeAttribute);
-
     private Action<object, object?>? _valueSetter;
     private Func<object, object?>? _valueGetter;
 
@@ -565,10 +563,7 @@ internal sealed class PropertyHelper
     // see: https://github.com/aspnet/Mvc/issues/8545
     private static bool IsRefStructProperty(PropertyInfo property)
     {
-        return
-            IsByRefLikeAttribute != null &&
-            property.PropertyType.IsValueType &&
-            property.PropertyType.IsDefined(IsByRefLikeAttribute);
+        return property.PropertyType.IsByRefLike;
     }
 
     internal static class MetadataUpdateHandler


### PR DESCRIPTION
# Use `Type.IsByRefLike`.

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Use the `Type.IsByRefLike` property to check if a type is a ref struct.

## Description

In `PropertyHelper.cs` we check if the property's type is a ref struct by checking if it is a value type and has the `System.Runtime.CompilerServices.IsByRefLikeAttribute` applied to it. This is inefficient and unreliable in edge cases (such as a ref struct defined in an assembly targeting .NET Standard).

This PR changes the code to just call `property.PropertyType.IsByRefLike`, which is more efficient and returns the authoritative answer on whether the runtime considers a type to be a ref struct. `RequestBuilder.cs` already uses this property.

`PropertyHelpers.cs` is used only on projects targeting modern frameworks so there is no need to `#if` the change.