### PR TITLE
[release/6.0] Don't run publish-specific Mvc.Testing tasks if project is not publishable

### DIFF
--- a/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
+++ b/src/Mvc/Mvc.Testing/src/Microsoft.AspNetCore.Mvc.Testing.targets
@@ -46,7 +46,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="_GeneratePublishTestManifest" BeforeTargets="Publish" DependsOnTargets="_ResolveMvcTestProjectReferences">
+  <Target Name="_GeneratePublishTestManifest" Condition="$(IsPublishable) == 'true'" BeforeTargets="Publish" DependsOnTargets="_ResolveMvcTestProjectReferences">
     <ItemGroup>
       <_PublishManifestProjects Include="%(_ContentRootProjectReferences.FusionName)">
         <ContentRoot>~</ContentRoot>


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/43329 to release/6.0.

## Description

Resolves an issue where Mvc.Testing MSBuild targets that were designed to run before publish would not respect the `IsPublishable` attribute.

Closes https://github.com/dotnet/aspnetcore/issues/48189

## Customer Impact

Allows users to use `Mvc.Testing` package in non-publishable test projects within build errors, particularly users who are limited to using LTS versions of .NET.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

**Low** risk because change only impacts:
- Developers using the Mvc.Testing package in their application on non-publishable test projects

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A