### PR TITLE
Unquarantine `IHttpActivityFeatureIsPopulated`

### DIFF
--- a/src/Hosting/Hosting/test/HostingApplicationTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationTests.cs
@@ -92,7 +92,6 @@ public class HostingApplicationTests
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/35142")]
     public void IHttpActivityFeatureIsPopulated()
     {
         var testSource = new ActivitySource(Path.GetRandomFileName());


### PR DESCRIPTION
# Unquarantine `IHttpActivityFeatureIsPopulated`

`IHttpActivityFeatureIsPopulated` has been passing successfully for the last 30 days, so it's ready to be unquarantined.

Fixes #35142