### PR TITLE
Quarantine ResponseCachingMiddlewareTests.FinalizeCacheHeadersAsync_ResponseValidity_UseExpiryIfAvailable

### DIFF
--- a/src/Middleware/ResponseCaching/test/ResponseCachingMiddlewareTests.cs
+++ b/src/Middleware/ResponseCaching/test/ResponseCachingMiddlewareTests.cs
@@ -441,6 +441,7 @@ public class ResponseCachingMiddlewareTests
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/48373")]
     public void FinalizeCacheHeadersAsync_ResponseValidity_UseExpiryIfAvailable()
     {
         var timeProvider = new MockTimeProvider();

--- a/src/Middleware/ResponseCaching/test/ResponseCachingMiddlewareTests.cs
+++ b/src/Middleware/ResponseCaching/test/ResponseCachingMiddlewareTests.cs
@@ -446,7 +446,7 @@ public class ResponseCachingMiddlewareTests
     {
         var timeProvider = new MockTimeProvider();
         var now = timeProvider.GetUtcNow();
-        now = new DateTimeOffset(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second + 1, now.Offset); // Round up to seconds.
+        now = new DateTimeOffset(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second, now.Offset).AddSeconds(1); // Round up to seconds.
         timeProvider.AdvanceTo(now);
         var sink = new TestSink();
         var middleware = TestUtils.CreateTestMiddleware(testSink: sink, options: new ResponseCachingOptions


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/48373