### PR TITLE
Rename ASP.NET Core metrics

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
@@ -23,11 +23,11 @@ internal sealed class HostingMetrics : IDisposable
         _meter = meterFactory.Create(MeterName);
 
         _currentRequestsCounter = _meter.CreateUpDownCounter<long>(
-            "current-requests",
+            "http-server-current-requests",
             description: "Number of HTTP requests that are currently active on the server.");
 
         _requestDuration = _meter.CreateHistogram<double>(
-            "request-duration",
+            "http-server-request-duration",
             unit: "s",
             description: "The duration of HTTP requests on the server.");
 

--- a/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
@@ -32,7 +32,7 @@ internal sealed class HostingMetrics : IDisposable
             description: "The duration of HTTP requests on the server.");
 
         _unhandledRequestsCounter = _meter.CreateCounter<long>(
-            "unhandled-requests",
+            "http-server-unhandled-requests",
             description: "Number of HTTP requests that reached the end of the middleware pipeline without being handled by application code.");
     }
 

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -52,10 +52,10 @@ public class HostingApplicationDiagnosticsTests
         var hostingApplication1 = CreateApplication(out var features1, eventSource: hostingEventSource, meterFactory: testMeterFactory1);
         var hostingApplication2 = CreateApplication(out var features2, eventSource: hostingEventSource, meterFactory: testMeterFactory2);
 
-        using var currentRequestsRecorder1 = new InstrumentRecorder<long>(testMeterFactory1, HostingMetrics.MeterName, "current-requests");
-        using var currentRequestsRecorder2 = new InstrumentRecorder<long>(testMeterFactory2, HostingMetrics.MeterName, "current-requests");
-        using var requestDurationRecorder1 = new InstrumentRecorder<double>(testMeterFactory1, HostingMetrics.MeterName, "request-duration");
-        using var requestDurationRecorder2 = new InstrumentRecorder<double>(testMeterFactory2, HostingMetrics.MeterName, "request-duration");
+        using var currentRequestsRecorder1 = new InstrumentRecorder<long>(testMeterFactory1, HostingMetrics.MeterName, "http-server-current-requests");
+        using var currentRequestsRecorder2 = new InstrumentRecorder<long>(testMeterFactory2, HostingMetrics.MeterName, "http-server-current-requests");
+        using var requestDurationRecorder1 = new InstrumentRecorder<double>(testMeterFactory1, HostingMetrics.MeterName, "http-server-request-duration");
+        using var requestDurationRecorder2 = new InstrumentRecorder<double>(testMeterFactory2, HostingMetrics.MeterName, "http-server-request-duration");
 
         // Act/Assert 1
         var context1 = hostingApplication1.CreateContext(features1);

--- a/src/Hosting/Hosting/test/HostingMetricsTests.cs
+++ b/src/Hosting/Hosting/test/HostingMetricsTests.cs
@@ -25,9 +25,9 @@ public class HostingMetricsTests
         var httpContext = new DefaultHttpContext();
         var meter = meterFactory.Meters.Single();
 
-        using var requestDurationRecorder = new InstrumentRecorder<double>(meterFactory, HostingMetrics.MeterName, "request-duration");
-        using var currentRequestsRecorder = new InstrumentRecorder<long>(meterFactory, HostingMetrics.MeterName, "current-requests");
-        using var unhandledRequestsRecorder = new InstrumentRecorder<long>(meterFactory, HostingMetrics.MeterName, "unhandled-requests");
+        using var requestDurationRecorder = new InstrumentRecorder<double>(meterFactory, HostingMetrics.MeterName, "http-server-request-duration");
+        using var currentRequestsRecorder = new InstrumentRecorder<long>(meterFactory, HostingMetrics.MeterName, "http-server-current-requests");
+        using var unhandledRequestsRecorder = new InstrumentRecorder<long>(meterFactory, HostingMetrics.MeterName, "http-server-unhandled-requests");
 
         // Act/Assert
         Assert.Equal(HostingMetrics.MeterName, meter.Name);
@@ -132,8 +132,8 @@ public class HostingMetricsTests
 
         await syncPoint.WaitForSyncPoint().DefaultTimeout();
 
-        using var requestDurationRecorder = new InstrumentRecorder<double>(meterFactory, HostingMetrics.MeterName, "request-duration");
-        using var currentRequestsRecorder = new InstrumentRecorder<long>(meterFactory, HostingMetrics.MeterName, "current-requests");
+        using var requestDurationRecorder = new InstrumentRecorder<double>(meterFactory, HostingMetrics.MeterName, "http-server-request-duration");
+        using var currentRequestsRecorder = new InstrumentRecorder<long>(meterFactory, HostingMetrics.MeterName, "http-server-current-requests");
         context1.HttpContext.Response.StatusCode = StatusCodes.Status200OK;
 
         syncPoint.Continue();
@@ -154,8 +154,8 @@ public class HostingMetricsTests
         var httpContext = new DefaultHttpContext();
         var meter = meterFactory.Meters.Single();
 
-        using var requestDurationRecorder = new InstrumentRecorder<double>(meterFactory, HostingMetrics.MeterName, "request-duration");
-        using var currentRequestsRecorder = new InstrumentRecorder<long>(meterFactory, HostingMetrics.MeterName, "current-requests");
+        using var requestDurationRecorder = new InstrumentRecorder<double>(meterFactory, HostingMetrics.MeterName, "http-server-request-duration");
+        using var currentRequestsRecorder = new InstrumentRecorder<long>(meterFactory, HostingMetrics.MeterName, "http-server-current-requests");
 
         // Act/Assert
         Assert.Equal(HostingMetrics.MeterName, meter.Name);

--- a/src/Middleware/Diagnostics/test/UnitTests/DeveloperExceptionPageMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/DeveloperExceptionPageMiddlewareTest.cs
@@ -541,8 +541,8 @@ public class DeveloperExceptionPageMiddlewareTest : LoggedTest
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var meterFactory = new TestMeterFactory();
-        using var instrumentRecorder = new InstrumentRecorder<double>(meterFactory, "Microsoft.AspNetCore.Hosting", "http-server-request-duration");
-        using var diagnosticsRequestExceptionRecorder = new InstrumentRecorder<long>(meterFactory, DiagnosticsMetrics.MeterName, "diagnostics-handler-exception");
+        using var requestDurationRecorder = new InstrumentRecorder<double>(meterFactory, "Microsoft.AspNetCore.Hosting", "http-server-request-duration");
+        using var requestExceptionRecorder = new InstrumentRecorder<long>(meterFactory, DiagnosticsMetrics.MeterName, "diagnostics-handler-exception");
         using var measurementReporter = new MeasurementReporter<double>(meterFactory, "Microsoft.AspNetCore.Hosting", "http-server-request-duration");
         measurementReporter.Register(m =>
         {
@@ -588,7 +588,7 @@ public class DeveloperExceptionPageMiddlewareTest : LoggedTest
                 Assert.Equal(500, (int)m.Tags.ToArray().Single(t => t.Key == "status-code").Value);
                 Assert.Equal("System.Exception", (string)m.Tags.ToArray().Single(t => t.Key == "exception-name").Value);
             });
-        Assert.Collection(diagnosticsRequestExceptionRecorder.GetMeasurements(),
+        Assert.Collection(requestExceptionRecorder.GetMeasurements(),
             m => AssertRequestException(m, "System.Exception", "Unhandled"));
     }
 

--- a/src/Middleware/Diagnostics/test/UnitTests/DeveloperExceptionPageMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/DeveloperExceptionPageMiddlewareTest.cs
@@ -541,9 +541,9 @@ public class DeveloperExceptionPageMiddlewareTest : LoggedTest
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var meterFactory = new TestMeterFactory();
-        using var requestDurationRecorder = new InstrumentRecorder<double>(meterFactory, "Microsoft.AspNetCore.Hosting", "request-duration");
+        using var instrumentRecorder = new InstrumentRecorder<double>(meterFactory, "Microsoft.AspNetCore.Hosting", "http-server-request-duration");
         using var diagnosticsRequestExceptionRecorder = new InstrumentRecorder<long>(meterFactory, DiagnosticsMetrics.MeterName, "diagnostics-handler-exception");
-        using var measurementReporter = new MeasurementReporter<double>(meterFactory, "Microsoft.AspNetCore.Hosting", "request-duration");
+        using var measurementReporter = new MeasurementReporter<double>(meterFactory, "Microsoft.AspNetCore.Hosting", "http-server-request-duration");
         measurementReporter.Register(m =>
         {
             tcs.SetResult();

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
@@ -918,8 +918,8 @@ public class ExceptionHandlerTest
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var meterFactory = new TestMeterFactory();
-        using var instrumentRecorder = new InstrumentRecorder<double>(meterFactory, "Microsoft.AspNetCore.Hosting", "request-duration");
-        using var measurementReporter = new MeasurementReporter<double>(meterFactory, "Microsoft.AspNetCore.Hosting", "request-duration");
+        using var instrumentRecorder = new InstrumentRecorder<double>(meterFactory, "Microsoft.AspNetCore.Hosting", "http-server-request-duration");
+        using var measurementReporter = new MeasurementReporter<double>(meterFactory, "Microsoft.AspNetCore.Hosting", "http-server-request-duration");
         measurementReporter.Register(m =>
         {
             tcs.SetResult();

--- a/src/Middleware/RateLimiting/src/RateLimitingMetrics.cs
+++ b/src/Middleware/RateLimiting/src/RateLimitingMetrics.cs
@@ -24,25 +24,25 @@ internal sealed class RateLimitingMetrics : IDisposable
         _meter = meterFactory.Create(MeterName);
 
         _currentLeasedRequestsCounter = _meter.CreateUpDownCounter<long>(
-            "current-leased-requests",
+            "rate-limiting-current-leased-requests",
             description: "Number of HTTP requests that are currently active on the server that hold a rate limiting lease.");
 
         _leasedRequestDurationCounter = _meter.CreateHistogram<double>(
-            "leased-request-duration",
+            "rate-limiting-leased-request-duration",
             unit: "s",
             description: "The duration of rate limiting leases held by HTTP requests on the server.");
 
         _currentQueuedRequestsCounter = _meter.CreateUpDownCounter<long>(
-            "current-queued-requests",
+            "rate-limiting-current-queued-requests",
             description: "Number of HTTP requests that are currently queued, waiting to acquire a rate limiting lease.");
 
         _queuedRequestDurationCounter = _meter.CreateHistogram<double>(
-            "queued-request-duration",
+            "rate-limiting-queued-request-duration",
             unit: "s",
             description: "The duration of HTTP requests in a queue, waiting to acquire a rate limiting lease.");
 
         _leaseFailedRequestsCounter = _meter.CreateCounter<long>(
-            "lease-failed-requests",
+            "rate-limiting-lease-failed-requests",
             description: "Number of HTTP requests that failed to acquire a rate limiting lease. Requests could be rejected by global or endpoint rate limiting policies. Or the request could be canceled while waiting for the lease.");
     }
 

--- a/src/Middleware/RateLimiting/test/RateLimitingMetricsTests.cs
+++ b/src/Middleware/RateLimiting/test/RateLimitingMetricsTests.cs
@@ -34,11 +34,11 @@ public class RateLimitingMetricsTests
 
         var context = new DefaultHttpContext();
 
-        using var leaseRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "leased-request-duration");
-        using var currentLeaseRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "current-leased-requests");
-        using var currentRequestsQueuedRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "current-queued-requests");
-        using var queuedRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "queued-request-duration");
-        using var leaseFailedRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "lease-failed-requests");
+        using var leaseRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-leased-request-duration");
+        using var currentLeaseRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-leased-requests");
+        using var currentRequestsQueuedRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-queued-requests");
+        using var queuedRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-queued-request-duration");
+        using var leaseFailedRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-lease-failed-requests");
 
         // Act
         await middleware.Invoke(context).DefaultTimeout();
@@ -81,11 +81,11 @@ public class RateLimitingMetricsTests
         var context = new DefaultHttpContext();
         context.Request.Method = "GET";
 
-        using var leaseRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "leased-request-duration");
-        using var currentLeaseRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "current-leased-requests");
-        using var currentRequestsQueuedRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "current-queued-requests");
-        using var queuedRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "queued-request-duration");
-        using var leaseFailedRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "lease-failed-requests");
+        using var leaseRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-leased-request-duration");
+        using var currentLeaseRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-leased-requests");
+        using var currentRequestsQueuedRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-queued-requests");
+        using var queuedRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-queued-request-duration");
+        using var leaseFailedRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-lease-failed-requests");
 
         // Act
         var middlewareTask = middleware.Invoke(context);
@@ -141,11 +141,11 @@ public class RateLimitingMetricsTests
 
         await syncPoint.WaitForSyncPoint().DefaultTimeout();
 
-        using var leaseRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "leased-request-duration");
-        using var currentLeaseRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "current-leased-requests");
-        using var currentRequestsQueuedRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "current-queued-requests");
-        using var queuedRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "queued-request-duration");
-        using var leaseFailedRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "lease-failed-requests");
+        using var leaseRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-leased-request-duration");
+        using var currentLeaseRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-leased-requests");
+        using var currentRequestsQueuedRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-queued-requests");
+        using var queuedRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-queued-request-duration");
+        using var leaseFailedRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-lease-failed-requests");
 
         syncPoint.Continue();
 
@@ -192,11 +192,11 @@ public class RateLimitingMetricsTests
         routeEndpointBuilder.Metadata.Add(new EnableRateLimitingAttribute("concurrencyPolicy"));
         var endpoint = routeEndpointBuilder.Build();
 
-        using var leaseRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "leased-request-duration");
-        using var currentLeaseRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "current-leased-requests");
-        using var currentRequestsQueuedRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "current-queued-requests");
-        using var queuedRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "queued-request-duration");
-        using var leaseFailedRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "lease-failed-requests");
+        using var leaseRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-leased-request-duration");
+        using var currentLeaseRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-leased-requests");
+        using var currentRequestsQueuedRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-queued-requests");
+        using var queuedRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-queued-request-duration");
+        using var leaseFailedRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-lease-failed-requests");
 
         // Act
         var context1 = new DefaultHttpContext();
@@ -279,11 +279,11 @@ public class RateLimitingMetricsTests
 
         // Start listening while the second request is queued.
 
-        using var leaseRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "leased-request-duration");
-        using var currentLeaseRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "current-leased-requests");
-        using var currentRequestsQueuedRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "current-queued-requests");
-        using var queuedRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "queued-request-duration");
-        using var leaseFailedRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "lease-failed-requests");
+        using var leaseRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-leased-request-duration");
+        using var currentLeaseRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-leased-requests");
+        using var currentRequestsQueuedRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-queued-requests");
+        using var queuedRequestDurationRecorder = new InstrumentRecorder<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-queued-request-duration");
+        using var leaseFailedRequestsRecorder = new InstrumentRecorder<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-lease-failed-requests");
 
         Assert.Empty(currentRequestsQueuedRecorder.GetMeasurements());
         Assert.Empty(queuedRequestDurationRecorder.GetMeasurements());

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelMetrics.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelMetrics.cs
@@ -30,37 +30,37 @@ internal sealed class KestrelMetrics
         _meter = meterFactory.Create(MeterName);
 
         _currentConnectionsCounter = _meter.CreateUpDownCounter<long>(
-           "current-connections",
+           "kestrel-current-connections",
             description: "Number of connections that are currently active on the server.");
 
         _connectionDuration = _meter.CreateHistogram<double>(
-            "connection-duration",
+            "kestrel-connection-duration",
             unit: "s",
             description: "The duration of connections on the server.");
 
         _rejectedConnectionsCounter = _meter.CreateCounter<long>(
-           "rejected-connections",
+           "kestrel-rejected-connections",
             description: "Number of connections rejected by the server. Connections are rejected when the currently active count exceeds the value configured with MaxConcurrentConnections.");
 
         _queuedConnectionsCounter = _meter.CreateUpDownCounter<long>(
-           "queued-connections",
+           "kestrel-queued-connections",
             description: "Number of connections that are currently queued and are waiting to start.");
 
         _queuedRequestsCounter = _meter.CreateUpDownCounter<long>(
-           "queued-requests",
+           "kestrel-queued-requests",
             description: "Number of HTTP requests on multiplexed connections (HTTP/2 and HTTP/3) that are currently queued and are waiting to start.");
 
         _currentUpgradedRequestsCounter = _meter.CreateUpDownCounter<long>(
-           "current-upgraded-connections",
+           "kestrel-current-upgraded-connections",
             description: "Number of HTTP connections that are currently upgraded (WebSockets). The number only tracks HTTP/1.1 connections.");
 
         _tlsHandshakeDuration = _meter.CreateHistogram<double>(
-            "tls-handshake-duration",
+            "kestrel-tls-handshake-duration",
             unit: "s",
             description: "The duration of TLS handshakes on the server.");
 
         _currentTlsHandshakesCounter = _meter.CreateUpDownCounter<long>(
-           "current-tls-handshakes",
+           "kestrel-current-tls-handshakes",
             description: "Number of TLS handshakes that are currently in progress on the server.");
     }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionLimitTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionLimitTests.cs
@@ -102,7 +102,7 @@ public class ConnectionLimitTests : LoggedTest
     public async Task RejectsConnectionsWhenLimitReached()
     {
         var testMeterFactory = new TestMeterFactory();
-        using var rejectedConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "rejected-connections");
+        using var rejectedConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-rejected-connections");
 
         const int max = 10;
         var requestTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
@@ -46,9 +46,9 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         });
 
         var testMeterFactory = new TestMeterFactory();
-        using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "connection-duration");
-        using var currentConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "current-connections");
-        using var queuedConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "queued-connections");
+        using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-connection-duration");
+        using var currentConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-current-connections");
+        using var queuedConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-queued-connections");
 
         var serviceContext = new TestServiceContext(LoggerFactory, metrics: new KestrelMetrics(testMeterFactory));
 
@@ -122,9 +122,9 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
             // Wait for connection to start on the server.
             await sync.WaitForSyncPoint();
 
-            using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "connection-duration");
-            using var currentConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "current-connections");
-            using var queuedConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "queued-connections");
+            using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-connection-duration");
+            using var currentConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-current-connections");
+            using var queuedConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-queued-connections");
 
             // Signal that connection can continue.
             sync.Continue();
@@ -169,9 +169,9 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         });
 
         var testMeterFactory = new TestMeterFactory();
-        using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "connection-duration");
-        using var currentConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "current-connections");
-        using var queuedConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "queued-connections");
+        using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-connection-duration");
+        using var currentConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-current-connections");
+        using var queuedConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-queued-connections");
 
         var serviceContext = new TestServiceContext(LoggerFactory, metrics: new KestrelMetrics(testMeterFactory));
 
@@ -244,9 +244,9 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         });
 
         var testMeterFactory = new TestMeterFactory();
-        using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "connection-duration");
-        using var currentConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "current-connections");
-        using var queuedConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "queued-connections");
+        using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-connection-duration");
+        using var currentConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-current-connections");
+        using var queuedConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-queued-connections");
 
         var serviceContext = new TestServiceContext(LoggerFactory, metrics: new KestrelMetrics(testMeterFactory));
 
@@ -287,9 +287,9 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         var listenOptions = new ListenOptions(new IPEndPoint(IPAddress.Loopback, 0));
 
         var testMeterFactory = new TestMeterFactory();
-        using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "connection-duration");
-        using var currentConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "current-connections");
-        using var currentUpgradedRequests = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "current-upgraded-connections");
+        using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-connection-duration");
+        using var currentConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-current-connections");
+        using var currentUpgradedRequests = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-current-upgraded-connections");
 
         var serviceContext = new TestServiceContext(LoggerFactory, metrics: new KestrelMetrics(testMeterFactory));
 
@@ -331,12 +331,12 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         var requestsReceived = 0;
 
         var testMeterFactory = new TestMeterFactory();
-        using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "connection-duration");
-        using var currentConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "current-connections");
-        using var queuedConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "queued-connections");
-        using var queuedRequests = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "queued-requests");
-        using var tlsHandshakeDuration = new InstrumentRecorder<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "tls-handshake-duration");
-        using var currentTlsHandshakes = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "current-tls-handshakes");
+        using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-connection-duration");
+        using var currentConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-current-connections");
+        using var queuedConnections = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-queued-connections");
+        using var queuedRequests = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-queued-requests");
+        using var tlsHandshakeDuration = new InstrumentRecorder<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-tls-handshake-duration");
+        using var currentTlsHandshakes = new InstrumentRecorder<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-current-tls-handshakes");
 
         await using (var server = new TestServer(context =>
         {

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
@@ -38,8 +38,8 @@ public class Http2RequestTests : LoggedTest
             var meterFactory = host.Services.GetRequiredService<IMeterFactory>();
 
             var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            using var connectionDuration = new InstrumentRecorder<double>(meterFactory, "Microsoft.AspNetCore.Server.Kestrel", "connection-duration");
-            using var measurementReporter = new MeasurementReporter<double>(meterFactory, "Microsoft.AspNetCore.Server.Kestrel", "connection-duration");
+            using var connectionDuration = new InstrumentRecorder<double>(meterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-connection-duration");
+            using var measurementReporter = new MeasurementReporter<double>(meterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-connection-duration");
             measurementReporter.Register(m =>
             {
                 tcs.SetResult();

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -82,8 +82,8 @@ public class Http3RequestTests : LoggedTest
             var meterFactory = host.Services.GetRequiredService<IMeterFactory>();
 
             var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            using var connectionDuration = new InstrumentRecorder<double>(meterFactory, "Microsoft.AspNetCore.Server.Kestrel", "connection-duration");
-            using var measurementReporter = new MeasurementReporter<double>(meterFactory, "Microsoft.AspNetCore.Server.Kestrel", "connection-duration");
+            using var connectionDuration = new InstrumentRecorder<double>(meterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-connection-duration");
+            using var measurementReporter = new MeasurementReporter<double>(meterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-connection-duration");
             measurementReporter.Register(m =>
             {
                 tcs.SetResult();

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -553,7 +553,7 @@ internal sealed partial class HttpConnectionDispatcher
         if (connection.TransportType == HttpTransportType.None)
         {
             connection.TransportType = transportType;
-            _metrics.TransportStart(connection.MetricsContext, transportType);
+            _metrics.ConnectionTransportStart(connection.MetricsContext, transportType);
         }
         else if (connection.TransportType != transportType)
         {

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
@@ -88,7 +88,6 @@ internal sealed partial class HttpConnectionManager
 
         Log.CreatedNewConnection(_logger, id);
         HttpConnectionsEventSource.Log.ConnectionStart(id);
-        _metrics.ConnectionStart(metricsContext);
 
         var pair = CreateConnectionPair(options.TransportPipeOptions, options.AppPipeOptions);
         var connection = new HttpConnectionContext(id, connectionToken, _connectionLogger, metricsContext, pair.Application, pair.Transport, options, useAck);

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionsMetrics.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionsMetrics.cs
@@ -9,16 +9,14 @@ namespace Microsoft.AspNetCore.Http.Connections.Internal;
 
 internal readonly struct MetricsContext
 {
-    public MetricsContext(bool currentConnectionsCounterEnabled, bool connectionDurationEnabled, bool currentTransportsCounterEnabled)
+    public MetricsContext(bool connectionDurationEnabled, bool currentNegotiatedConnectionsCounterEnabled)
     {
-        CurrentConnectionsCounterEnabled = currentConnectionsCounterEnabled;
         ConnectionDurationEnabled = connectionDurationEnabled;
-        CurrentTransportsCounterEnabled = currentTransportsCounterEnabled;
+        CurrentNegotiatedConnectionsCounterEnabled = currentNegotiatedConnectionsCounterEnabled;
     }
 
-    public bool CurrentConnectionsCounterEnabled { get; }
     public bool ConnectionDurationEnabled { get; }
-    public bool CurrentTransportsCounterEnabled { get; }
+    public bool CurrentNegotiatedConnectionsCounterEnabled { get; }
 }
 
 internal sealed class HttpConnectionsMetrics : IDisposable
@@ -26,45 +24,25 @@ internal sealed class HttpConnectionsMetrics : IDisposable
     public const string MeterName = "Microsoft.AspNetCore.Http.Connections";
 
     private readonly Meter _meter;
-    private readonly UpDownCounter<long> _currentConnectionsCounter;
     private readonly Histogram<double> _connectionDuration;
-    private readonly UpDownCounter<long> _currentTransportsCounter;
+    private readonly UpDownCounter<long> _currentNegotiatedConnectionsCounter;
 
     public HttpConnectionsMetrics(IMeterFactory meterFactory)
     {
         _meter = meterFactory.Create(MeterName);
 
-        _currentConnectionsCounter = _meter.CreateUpDownCounter<long>(
-            "current-connections",
-            description: "Number of connections that are currently active on the server.");
-
         _connectionDuration = _meter.CreateHistogram<double>(
-            "connection-duration",
+            "signalr-http-transport-connection-duration",
             unit: "s",
             description: "The duration of connections on the server.");
 
-        _currentTransportsCounter = _meter.CreateUpDownCounter<long>(
-            "current-transports",
-            description: "Number of negotiated transports that are currently active on the server.");
-    }
-
-    public void ConnectionStart(in MetricsContext metricsContext)
-    {
-        // Tags must match connection end.
-        if (metricsContext.CurrentConnectionsCounterEnabled)
-        {
-            _currentConnectionsCounter.Add(1);
-        }
+        _currentNegotiatedConnectionsCounter = _meter.CreateUpDownCounter<long>(
+            "signalr-http-transport-current-negotiated-connections",
+            description: "Number of negotiated connections that are currently active on the server.");
     }
 
     public void ConnectionStop(in MetricsContext metricsContext, HttpTransportType transportType, HttpConnectionStopStatus status, long startTimestamp, long currentTimestamp)
     {
-        // Tags must match connection start.
-        if (metricsContext.CurrentConnectionsCounterEnabled)
-        {
-            _currentConnectionsCounter.Add(-1);
-        }
-
         if (metricsContext.ConnectionDurationEnabled)
         {
             var duration = Stopwatch.GetElapsedTime(startTimestamp, currentTimestamp);
@@ -74,26 +52,26 @@ internal sealed class HttpConnectionsMetrics : IDisposable
         }
     }
 
-    public void TransportStart(in MetricsContext metricsContext, HttpTransportType transportType)
+    public void ConnectionTransportStart(in MetricsContext metricsContext, HttpTransportType transportType)
     {
         Debug.Assert(transportType != HttpTransportType.None);
 
         // Tags must match transport end.
-        if (metricsContext.CurrentTransportsCounterEnabled)
+        if (metricsContext.CurrentNegotiatedConnectionsCounterEnabled)
         {
-            _currentTransportsCounter.Add(1, new KeyValuePair<string, object?>("transport", transportType.ToString()));
+            _currentNegotiatedConnectionsCounter.Add(1, new KeyValuePair<string, object?>("transport", transportType.ToString()));
         }
     }
 
     public void TransportStop(in MetricsContext metricsContext, HttpTransportType transportType)
     {
-        if (metricsContext.CurrentTransportsCounterEnabled)
+        if (metricsContext.CurrentNegotiatedConnectionsCounterEnabled)
         {
             // Tags must match transport start.
             // If the transport type is none then the transport was never started for this connection.
             if (transportType != HttpTransportType.None)
             {
-                _currentTransportsCounter.Add(-1, new KeyValuePair<string, object?>("transport", transportType.ToString()));
+                _currentNegotiatedConnectionsCounter.Add(-1, new KeyValuePair<string, object?>("transport", transportType.ToString()));
             }
         }
     }
@@ -105,6 +83,6 @@ internal sealed class HttpConnectionsMetrics : IDisposable
 
     public MetricsContext CreateContext()
     {
-        return new MetricsContext(_currentConnectionsCounter.Enabled, _connectionDuration.Enabled, _currentTransportsCounter.Enabled);
+        return new MetricsContext(_connectionDuration.Enabled, _currentNegotiatedConnectionsCounter.Enabled);
     }
 }

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -1090,9 +1090,8 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         using (StartVerifiableLog())
         {
             var testMeterFactory = new TestMeterFactory();
-            using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, HttpConnectionsMetrics.MeterName, "connection-duration");
-            using var currentConnections = new InstrumentRecorder<long>(testMeterFactory, HttpConnectionsMetrics.MeterName, "current-connections");
-            using var currentTransports = new InstrumentRecorder<long>(testMeterFactory, HttpConnectionsMetrics.MeterName, "current-transports");
+            using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr-http-transport-connection-duration");
+            using var currentNegotiatedConnections = new InstrumentRecorder<long>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr-http-transport-current-negotiated-connections");
 
             var metrics = new HttpConnectionsMetrics(testMeterFactory);
             var manager = CreateConnectionManager(LoggerFactory, metrics);
@@ -1119,9 +1118,8 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             var exists = manager.TryGetConnection(connection.ConnectionId, out _);
             Assert.False(exists);
 
-            Assert.Collection(currentConnections.GetMeasurements(), m => Assert.Equal(1, m.Value), m => Assert.Equal(-1, m.Value));
             Assert.Collection(connectionDuration.GetMeasurements(), m => AssertDuration(m, HttpConnectionStopStatus.NormalClosure, HttpTransportType.LongPolling));
-            Assert.Collection(currentTransports.GetMeasurements(), m => AssertTransport(m, 1, HttpTransportType.LongPolling), m => AssertTransport(m, -1, HttpTransportType.LongPolling));
+            Assert.Collection(currentNegotiatedConnections.GetMeasurements(), m => AssertTransport(m, 1, HttpTransportType.LongPolling), m => AssertTransport(m, -1, HttpTransportType.LongPolling));
         }
 
         static void AssertTransport(Measurement<long> measurement, long expected, HttpTransportType transportType)

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -1091,7 +1091,7 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         {
             var testMeterFactory = new TestMeterFactory();
             using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr-http-transport-connection-duration");
-            using var currentNegotiatedConnections = new InstrumentRecorder<long>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr-http-transport-current-negotiated-connections");
+            using var currentConnections = new InstrumentRecorder<long>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr-http-transport-current-connections");
 
             var metrics = new HttpConnectionsMetrics(testMeterFactory);
             var manager = CreateConnectionManager(LoggerFactory, metrics);
@@ -1119,7 +1119,7 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             Assert.False(exists);
 
             Assert.Collection(connectionDuration.GetMeasurements(), m => AssertDuration(m, HttpConnectionStopStatus.NormalClosure, HttpTransportType.LongPolling));
-            Assert.Collection(currentNegotiatedConnections.GetMeasurements(), m => AssertTransport(m, 1, HttpTransportType.LongPolling), m => AssertTransport(m, -1, HttpTransportType.LongPolling));
+            Assert.Collection(currentConnections.GetMeasurements(), m => AssertTransport(m, 1, HttpTransportType.LongPolling), m => AssertTransport(m, -1, HttpTransportType.LongPolling));
         }
 
         static void AssertTransport(Measurement<long> measurement, long expected, HttpTransportType transportType)

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionManagerTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionManagerTests.cs
@@ -431,8 +431,7 @@ public class HttpConnectionManagerTests : VerifiableLoggedTest
         using (StartVerifiableLog())
         {
             var testMeterFactory = new TestMeterFactory();
-            using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, HttpConnectionsMetrics.MeterName, "connection-duration");
-            using var currentConnections = new InstrumentRecorder<long>(testMeterFactory, HttpConnectionsMetrics.MeterName, "current-connections");
+            using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr-http-transport-connection-duration");
 
             var connectionManager = CreateConnectionManager(LoggerFactory, metrics: new HttpConnectionsMetrics(testMeterFactory));
             var connection = connectionManager.CreateConnection();
@@ -440,13 +439,11 @@ public class HttpConnectionManagerTests : VerifiableLoggedTest
             Assert.NotNull(connection.ConnectionId);
 
             Assert.Empty(connectionDuration.GetMeasurements());
-            Assert.Collection(currentConnections.GetMeasurements(), m => Assert.Equal(1, m.Value));
 
             connection.TransportType = HttpTransportType.WebSockets;
 
             connectionManager.RemoveConnection(connection.ConnectionId, connection.TransportType, HttpConnectionStopStatus.NormalClosure);
 
-            Assert.Collection(currentConnections.GetMeasurements(), m => Assert.Equal(1, m.Value), m => Assert.Equal(-1, m.Value));
             Assert.Collection(connectionDuration.GetMeasurements(), m => AssertDuration(m, HttpConnectionStopStatus.NormalClosure, HttpTransportType.WebSockets));
         }
     }
@@ -460,8 +457,8 @@ public class HttpConnectionManagerTests : VerifiableLoggedTest
             var connectionManager = CreateConnectionManager(LoggerFactory, metrics: new HttpConnectionsMetrics(testMeterFactory));
             var connection = connectionManager.CreateConnection();
 
-            using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, HttpConnectionsMetrics.MeterName, "connection-duration");
-            using var currentConnections = new InstrumentRecorder<long>(testMeterFactory, HttpConnectionsMetrics.MeterName, "current-connections");
+            using var connectionDuration = new InstrumentRecorder<double>(testMeterFactory, HttpConnectionsMetrics.MeterName, "http-server-connection-duration");
+            using var currentConnections = new InstrumentRecorder<long>(testMeterFactory, HttpConnectionsMetrics.MeterName, "http-server-current-connections");
 
             Assert.NotNull(connection.ConnectionId);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/48309
Fixes https://github.com/dotnet/aspnetcore/issues/48536

Renaming counters needs discussion in API review.

Summary of changes:
* `Microsoft.AspNetCore.Hosting` counters are prefixed with `http-server`
* `Microsoft.AspNetCore.Http.Connections` counters are prefixed with `http-server`
* `Microsoft.AspNetCore.Servers.Kestrel` counters are prefixed with `kestrel`
* `Microsoft.AspNetCore.RateLimiting` counters are prefixed with `rate-limiting`

Also, I'm unsure about `Microsoft.AspNetCore.Http.Connections` counters being prefixed by `http-server`. Are these counters used by anything other than SignalR? Should they include SignalR in the name instead of being very generic? @BrennanConroy

If the `Microsoft.AspNetCore.Http.Connections` counters are changed to not use the `http-server` prefix then we could consider making `Microsoft.AspNetCore.Servers.Kestrel` counters prefixed with `http-server`.