### PR TITLE
Update project resolution and app settings writes in `dotnet user-jwts`

### DIFF
--- a/src/Tools/dotnet-user-jwts/src/Commands/CreateCommand.cs
+++ b/src/Tools/dotnet-user-jwts/src/Commands/CreateCommand.cs
@@ -109,7 +109,8 @@ internal sealed class CreateCommand
         CommandOption claimsOption)
     {
         var isValid = true;
-        var project = DevJwtCliHelpers.GetProject(projectOption.Value());
+        var finder = new MsBuildProjectFinder(projectOption.Value() ?? Directory.GetCurrentDirectory());
+        var project = finder.FindMsBuildProject(projectOption.Value());
 
         if (project == null)
         {

--- a/src/Tools/dotnet-user-jwts/src/Helpers/DevJwtCliHelpers.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/DevJwtCliHelpers.cs
@@ -25,26 +25,10 @@ internal static class DevJwtCliHelpers
         return id;
     }
 
-    public static string GetProject(string projectPath = null)
-    {
-        if (projectPath is not null)
-        {
-            return projectPath;
-        }
-
-        var csprojFiles = Directory.EnumerateFileSystemEntries(Directory.GetCurrentDirectory(), "*.*proj", SearchOption.TopDirectoryOnly)
-                .Where(f => !".xproj".Equals(Path.GetExtension(f), StringComparison.OrdinalIgnoreCase))
-                .ToList();
-        if (csprojFiles is [var path])
-        {
-            return path;
-        }
-        return null;
-    }
-
     public static bool GetProjectAndSecretsId(string projectPath, IReporter reporter, out string project, out string userSecretsId)
     {
-        project = GetProject(projectPath);
+        var finder = new MsBuildProjectFinder(projectPath ?? Directory.GetCurrentDirectory());
+        project = finder.FindMsBuildProject(projectPath);
         userSecretsId = null;
         if (project == null)
         {

--- a/src/Tools/dotnet-user-jwts/src/Helpers/JwtAuthenticationSchemeSettings.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/JwtAuthenticationSchemeSettings.cs
@@ -57,7 +57,7 @@ internal sealed record JwtAuthenticationSchemeSettings(string SchemeName, List<s
             };
         }
 
-        using var writer = new FileStream(filePath, FileMode.Open, FileAccess.Write);
+        using var writer = File.Create(filePath);
         JsonSerializer.Serialize(writer, config, _jsonSerializerOptions);
     }
 

--- a/src/Tools/dotnet-user-jwts/src/Helpers/JwtAuthenticationSchemeSettings.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/JwtAuthenticationSchemeSettings.cs
@@ -57,7 +57,12 @@ internal sealed record JwtAuthenticationSchemeSettings(string SchemeName, List<s
             };
         }
 
-        using var writer = File.Create(filePath);
+        var streamOptions = new FileStreamOptions { Access = FileAccess.Write, Mode = FileMode.Create };
+        if (!OperatingSystem.IsWindows())
+        {
+            streamOptions.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        }
+        using var writer = new FileStream(filePath, streamOptions);
         JsonSerializer.Serialize(writer, config, _jsonSerializerOptions);
     }
 

--- a/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
+++ b/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
@@ -1,23 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Text;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Configuration.UserSecrets;
 using Microsoft.Extensions.Tools.Internal;
-using Microsoft.AspNetCore.Authentication.JwtBearer.Tools;
-using Xunit;
 using Xunit.Abstractions;
 using System.Text.RegularExpressions;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.IdentityModel.Tokens.Jwt;
-using System.Reflection;
-using System.Numerics;
 
 namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools.Tests;
 
@@ -78,6 +69,22 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
         app.Run(new[] { "create", "--project", project });
         Assert.Contains("New JWT saved", _console.GetOutput());
         Assert.Contains("dotnet-user-jwts", File.ReadAllText(appsettings));
+    }
+
+    [Fact]
+    public void Create_CanModifyExistingScheme()
+    {
+        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var appsettings = Path.Combine(Path.GetDirectoryName(project), "appsettings.Development.json");
+        var app = new Program(_console);
+
+        app.Run(new[] { "create", "--project", project });
+        Assert.Contains("New JWT saved", _console.GetOutput());
+        var exception = Record.Exception(() => JsonSerializer.Deserialize<Dictionary<string, Jwt>>(File.ReadAllText(appsettings)));
+        Assert.Null(exception);
+        app.Run(new[] { "create", "--project", project, "--issuer", "new-issuer"  });
+        exception = Record.Exception(() => JsonSerializer.Deserialize<Dictionary<string, Jwt>>(File.ReadAllText(appsettings)));
+        Assert.Null(exception);
     }
 
     [Fact]

--- a/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
+++ b/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
@@ -80,11 +80,14 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
 
         app.Run(new[] { "create", "--project", project });
         Assert.Contains("New JWT saved", _console.GetOutput());
-        var exception = Record.Exception(() => JsonSerializer.Deserialize<Dictionary<string, Jwt>>(File.ReadAllText(appsettings)));
-        Assert.Null(exception);
+        var matches = Regex.Matches(_console.GetOutput(), "New JWT saved with ID '(.*?)'");
+        var id = matches.SingleOrDefault().Groups[1].Value;
+
+        var appSettings = JsonSerializer.Deserialize<JsonObject>(File.ReadAllText(appsettings));
+        Assert.Equal("dotnet-user-jwts", appSettings["Authentication"]["Schemes"]["Bearer"]["ValidIssuer"].GetValue<string>());
         app.Run(new[] { "create", "--project", project, "--issuer", "new-issuer"  });
-        exception = Record.Exception(() => JsonSerializer.Deserialize<Dictionary<string, Jwt>>(File.ReadAllText(appsettings)));
-        Assert.Null(exception);
+        appSettings = JsonSerializer.Deserialize<JsonObject>(File.ReadAllText(appsettings));
+        Assert.Equal("new-issuer", appSettings["Authentication"]["Schemes"]["Bearer"]["ValidIssuer"].GetValue<string>());
     }
 
     [Fact]

--- a/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
+++ b/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
@@ -594,7 +594,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
         var app = new Program(_console);
         app.Run(new[] { "create" });
 
-        Assert.Contains("No project found at `-p|--project` path or current directory.", _console.GetOutput());
+        Assert.Contains($"Could not find a MSBuild project file in '{Directory.GetCurrentDirectory()}'. Specify which project to use with the --project option.", _console.GetOutput());
         Assert.DoesNotContain(Resources.CreateCommand_NoAudience_Error, _console.GetOutput());
     }
 
@@ -607,7 +607,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
         var app = new Program(_console);
         app.Run(new[] { "remove", "some-id" });
 
-        Assert.Contains("No project found at `-p|--project` path or current directory.", _console.GetOutput());
+        Assert.Contains($"Could not find a MSBuild project file in '{Directory.GetCurrentDirectory()}'. Specify which project to use with the --project option.", _console.GetOutput());
     }
 
     [Fact]
@@ -619,7 +619,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
         var app = new Program(_console);
         app.Run(new[] { "clear" });
 
-        Assert.Contains("No project found at `-p|--project` path or current directory.", _console.GetOutput());
+        Assert.Contains($"Could not find a MSBuild project file in '{Directory.GetCurrentDirectory()}'. Specify which project to use with the --project option.", _console.GetOutput());
     }
 
     [Fact]
@@ -631,7 +631,19 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
         var app = new Program(_console);
         app.Run(new[] { "list" });
 
-        Assert.Contains("No project found at `-p|--project` path or current directory.", _console.GetOutput());
+        Assert.Contains($"Could not find a MSBuild project file in '{Directory.GetCurrentDirectory()}'. Specify which project to use with the --project option.", _console.GetOutput());
+    }
+
+    [Fact]
+    public void List_CanHandleProjectOptionAsPath()
+    {
+        var projectPath = _fixture.CreateProject();
+        var project = Path.Combine(projectPath, "TestProject.csproj");
+
+        var app = new Program(_console);
+        app.Run(new[] { "list", "--project", projectPath });
+
+        Assert.Contains(Path.Combine(projectPath, project), _console.GetOutput());
     }
 
     [ConditionalFact]


### PR DESCRIPTION
- Updates `dotnet user-jwts` to use the same project finder logic as the `dotnet user-secrets` key
- Use `File.Create` to open write stream when writing file to open file with `FileMode.Create` and `FileShare.None` to support overwriting contents correctly