### PR TITLE
DO NOT REVIEW Add a trimming test that always fails for experimental purposes

### DIFF
--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.TrimmingTests/AlwaysFailsTest.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.TrimmingTests/AlwaysFailsTest.cs
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+return 19;

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.TrimmingTests/Microsoft.AspNetCore.TrimmingTests.proj
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.TrimmingTests/Microsoft.AspNetCore.TrimmingTests.proj
@@ -9,6 +9,7 @@
       <DisabledFeatureSwitches>System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault</DisabledFeatureSwitches>
       <AdditionalSourceFiles>X509Utilities.cs</AdditionalSourceFiles>
     </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="AlwaysFailsTest.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I'm going to run CI a bunch of times to see whether msbuild consistently passes when this test fails.