### PR TITLE
Transitive package to provide coherency in dotnet/extensions

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -305,6 +305,27 @@
       <Sha>43c337012443bb42d4baf97b4232dd04b443b5ef</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
+    <!-- Transitive package to provide coherency in dotnet/extensions -->
+    <Dependency Name="Microsoft.Bcl.TimeProvider" Version="8.0.0-preview.5.23273.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>1e421670a6456d9c5b924b7ffea14cab8559a2e9</Sha>
+    </Dependency>
+    <Dependency Name="System.Collections.Immutable" Version="8.0.0-preview.5.23273.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>1e421670a6456d9c5b924b7ffea14cab8559a2e9</Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="8.0.0-preview.5.23273.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>1e421670a6456d9c5b924b7ffea14cab8559a2e9</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.Hashing" Version="8.0.0-preview.5.23273.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>1e421670a6456d9c5b924b7ffea14cab8559a2e9</Sha>
+    </Dependency>
+    <Dependency Name="System.Runtime.Caching" Version="8.0.0-preview.5.23273.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>1e421670a6456d9c5b924b7ffea14cab8559a2e9</Sha>
+    </Dependency>
     <!-- Not updated automatically -->
     <Dependency Name="Microsoft.CodeAnalysis.Common" Version="4.4.0-4.22520.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -278,6 +278,27 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>1e421670a6456d9c5b924b7ffea14cab8559a2e9</Sha>
     </Dependency>
+    <!-- Transitive package to provide coherency in dotnet/extensions -->
+    <Dependency Name="Microsoft.Bcl.TimeProvider" Version="8.0.0-preview.5.23273.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>1e421670a6456d9c5b924b7ffea14cab8559a2e9</Sha>
+    </Dependency>
+    <Dependency Name="System.Collections.Immutable" Version="8.0.0-preview.5.23273.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>1e421670a6456d9c5b924b7ffea14cab8559a2e9</Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="8.0.0-preview.5.23273.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>1e421670a6456d9c5b924b7ffea14cab8559a2e9</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.Hashing" Version="8.0.0-preview.5.23273.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>1e421670a6456d9c5b924b7ffea14cab8559a2e9</Sha>
+    </Dependency>
+    <Dependency Name="System.Runtime.Caching" Version="8.0.0-preview.5.23273.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>1e421670a6456d9c5b924b7ffea14cab8559a2e9</Sha>
+    </Dependency>
     <!--
          Win-x64 is used here because we have picked an arbitrary runtime identifier to flow the version of the latest NETCore.App runtime.
          All Runtime.$rid packages should have the same version.
@@ -304,27 +325,6 @@
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
       <Sha>43c337012443bb42d4baf97b4232dd04b443b5ef</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
-    </Dependency>
-    <!-- Transitive package to provide coherency in dotnet/extensions -->
-    <Dependency Name="Microsoft.Bcl.TimeProvider" Version="8.0.0-preview.5.23273.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>1e421670a6456d9c5b924b7ffea14cab8559a2e9</Sha>
-    </Dependency>
-    <Dependency Name="System.Collections.Immutable" Version="8.0.0-preview.5.23273.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>1e421670a6456d9c5b924b7ffea14cab8559a2e9</Sha>
-    </Dependency>
-    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="8.0.0-preview.5.23273.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>1e421670a6456d9c5b924b7ffea14cab8559a2e9</Sha>
-    </Dependency>
-    <Dependency Name="System.IO.Hashing" Version="8.0.0-preview.5.23273.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>1e421670a6456d9c5b924b7ffea14cab8559a2e9</Sha>
-    </Dependency>
-    <Dependency Name="System.Runtime.Caching" Version="8.0.0-preview.5.23273.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>1e421670a6456d9c5b924b7ffea14cab8559a2e9</Sha>
     </Dependency>
     <!-- Not updated automatically -->
     <Dependency Name="Microsoft.CodeAnalysis.Common" Version="4.4.0-4.22520.2">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -126,6 +126,12 @@
     <!-- Only listed explicitly to workaround https://github.com/dotnet/cli/issues/10528 -->
     <MicrosoftNETCorePlatformsVersion>8.0.0-preview.5.23273.1</MicrosoftNETCorePlatformsVersion>
     <MicrosoftBclAsyncInterfacesVersion>8.0.0-preview.5.23273.1</MicrosoftBclAsyncInterfacesVersion>
+    <!-- Transitive package to provide coherency in dotnet/extensions -->
+    <MicrosoftBclTimeProviderVersion>8.0.0-preview.5.23273.1</MicrosoftBclTimeProviderVersion>
+    <SystemCollectionsImmutableVersion>8.0.0-preview.5.23273.1</SystemCollectionsImmutableVersion>
+    <SystemDiagnosticsPerformanceCounterVersion>8.0.0-preview.5.23273.1</SystemDiagnosticsPerformanceCounterVersion>
+    <SystemIOHashingVersion>8.0.0-preview.5.23273.1</SystemIOHashingVersion>
+    <SystemRuntimeCachingVersion>8.0.0-preview.5.23273.1</SystemRuntimeCachingVersion>
     <!-- Packages from dotnet/efcore -->
     <dotnetefVersion>8.0.0-preview.5.23273.2</dotnetefVersion>
     <MicrosoftEntityFrameworkCoreInMemoryVersion>8.0.0-preview.5.23273.2</MicrosoftEntityFrameworkCoreInMemoryVersion>


### PR DESCRIPTION
I'm trying to eliminate a dependency on dotnet/runtime and pull updates from dotnet/aspnetcore only. However, few packages dotnet/extensions depend on aren't in the coherency tree:
```
Checking for coherency updates...
Using 'Strict' coherency mode. If this fails, a second attempt utilizing 'Legacy' Coherency mode will be made.
Coherency updates failed for the following dependencies:
  Unable to update Microsoft.Bcl.TimeProvider to have coherency with Microsoft.AspNetCore.App.Runtime.win-x64: https://github.com/dotnet/aspnetcore @ 6c49e7b2eb66a5f492e577fc0d13ca21ebb7db00 does not contain dependency Microsoft.Bcl.TimeProvider
    - Add the dependency to https://github.com/dotnet/aspnetcore.
    - Pin the dependenency.
    - Remove the CoherentParentDependency attribute.
  Unable to update System.Collections.Immutable to have coherency with Microsoft.AspNetCore.App.Runtime.win-x64: https://github.com/dotnet/aspnetcore @ 6c49e7b2eb66a5f492e577fc0d13ca21ebb7db00 does not contain dependency System.Collections.Immutable
    - Add the dependency to https://github.com/dotnet/aspnetcore.
    - Pin the dependenency.
    - Remove the CoherentParentDependency attribute.
  Unable to update System.Diagnostics.PerformanceCounter to have coherency with Microsoft.AspNetCore.App.Runtime.win-x64: https://github.com/dotnet/aspnetcore @ 6c49e7b2eb66a5f492e577fc0d13ca21ebb7db00 does not contain dependency System.Diagnostics.PerformanceCounter
    - Add the dependency to https://github.com/dotnet/aspnetcore.
    - Pin the dependenency.
    - Remove the CoherentParentDependency attribute.
  Unable to update System.IO.Hashing to have coherency with Microsoft.AspNetCore.App.Runtime.win-x64: https://github.com/dotnet/aspnetcore @ 6c49e7b2eb66a5f492e577fc0d13ca21ebb7db00 does not contain dependency System.IO.Hashing
    - Add the dependency to https://github.com/dotnet/aspnetcore.
    - Pin the dependenency.
    - Remove the CoherentParentDependency attribute.
  Unable to update System.Runtime.Caching to have coherency with Microsoft.AspNetCore.App.Runtime.win-x64: https://github.com/dotnet/aspnetcore @ 6c49e7b2eb66a5f492e577fc0d13ca21ebb7db00 does not contain dependency System.Runtime.Caching
    - Add the dependency to https://github.com/dotnet/aspnetcore.
    - Pin the dependenency.
    - Remove the CoherentParentDependency attribute.
```

This solution was suggested by @wtgodbe.