### PR TITLE
Disable debugger support in trimming tests

### DIFF
--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.TrimmingTests/Microsoft.AspNetCore.TrimmingTests.proj
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.TrimmingTests/Microsoft.AspNetCore.TrimmingTests.proj
@@ -2,11 +2,11 @@
 
   <ItemGroup>
     <TestConsoleAppSourceFiles Include="SlimBuilderDoesNotDependOnX509Test.cs">
-      <DisabledFeatureSwitches>System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault</DisabledFeatureSwitches>
+      <DisabledFeatureSwitches>System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault;System.Diagnostics.Debugger.IsSupported</DisabledFeatureSwitches>
       <AdditionalSourceFiles>X509Utilities.cs</AdditionalSourceFiles>
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="UseHttpsDoesDependOnX509Test.cs">
-      <DisabledFeatureSwitches>System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault</DisabledFeatureSwitches>
+      <DisabledFeatureSwitches>System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault;System.Diagnostics.Debugger.IsSupported</DisabledFeatureSwitches>
       <AdditionalSourceFiles>X509Utilities.cs</AdditionalSourceFiles>
     </TestConsoleAppSourceFiles>
   </ItemGroup>

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.TrimmingTests/X509Utilities.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.TrimmingTests/X509Utilities.cs
@@ -11,30 +11,13 @@ using Microsoft.AspNetCore.Builder;
 
 public static class X509Utilities
 {
-    public static bool HasCertificateType
-    {
-        get
-        {
-            var certificateType = GetType("System.Security.Cryptography", "System.Security.Cryptography.X509Certificates.X509Certificate");
-
-            // We're checking for members, rather than just the presence of the type,
-            // because Debugger Display types may reference it without actually
-            // causing a meaningful binary size increase.
-            return certificateType is not null && GetMembers(certificateType).Any();
-        }
-    }
+    public static bool HasCertificateType =>
+        GetType("System.Security.Cryptography", "System.Security.Cryptography.X509Certificates.X509Certificate") is not null;
 
     [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2057:UnrecognizedReflectionPattern",
         Justification = "Returning null when the type is unreferenced is desirable")]
     private static Type? GetType(string assemblyName, string typeName)
     {
         return Type.GetType($"{typeName}, {assemblyName}");
-    }
-
-    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
-        Justification = "Returning null when the type is unreferenced is desirable")]
-    private static MemberInfo[] GetMembers(Type type)
-    {
-        return type.GetMembers(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly);
     }
 }


### PR DESCRIPTION
...to avoid false positive from debugger display types and simplify test for `X509Certificate`.

From https://github.com/dotnet/aspnetcore/pull/48295#discussion_r1203054796.