### PR TITLE
[7.0] Allow overriding the host header if doesn't match the absolute-form host

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -629,7 +629,22 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
                 if (!_absoluteRequestTarget.IsDefaultPort
                     || hostText != _absoluteRequestTarget.Authority + ":" + _absoluteRequestTarget.Port.ToString(CultureInfo.InvariantCulture))
                 {
-                    KestrelBadHttpRequestException.Throw(RequestRejectionReason.InvalidHostHeader, hostText);
+                    // Superseded by RFC 7230, but notable for back-compat.
+                    // https://datatracker.ietf.org/doc/html/rfc2616/#section-5.2
+                    //    1. If Request-URI is an absoluteURI, the host is part of the
+                    // Request-URI. Any Host header field value in the request MUST be
+                    // ignored.
+                    // We don't want to leave the invalid value for the app to accidentally consume,
+                    // replace it with the value from the request line.
+                    if (_context.ServiceContext.ServerOptions.EnableInsecureAbsoluteFormHostOverride)
+                    {
+                        hostText = _absoluteRequestTarget.Authority + ":" + _absoluteRequestTarget.Port.ToString(CultureInfo.InvariantCulture);
+                        HttpRequestHeaders.HeaderHost = hostText;
+                    }
+                    else
+                    {
+                        KestrelBadHttpRequestException.Throw(RequestRejectionReason.InvalidHostHeader, hostText);
+                    }
                 }
             }
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -636,6 +636,9 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
                     // ignored.
                     // We don't want to leave the invalid value for the app to accidentally consume,
                     // replace it with the value from the request line.
+                    // This is insecure in the sense that we would ordinarily regard a mismatched
+                    // request target and host as suspicious (e.g. indicative of a spoofing attempt)
+                    // and reject the request.
                     if (_context.ServiceContext.ServerOptions.EnableInsecureAbsoluteFormHostOverride)
                     {
                         hostText = _absoluteRequestTarget.Authority + ":" + _absoluteRequestTarget.Port.ToString(CultureInfo.InvariantCulture);

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -34,6 +34,21 @@ public class KestrelServerOptions
 
     private Func<string, Encoding?> _responseHeaderEncodingSelector = DefaultHeaderEncodingSelector;
 
+    private bool? _enableInsecureAbsoluteFormHostOverride;
+    internal bool EnableInsecureAbsoluteFormHostOverride
+    {
+        get
+        {
+            if (!_enableInsecureAbsoluteFormHostOverride.HasValue)
+            {
+                _enableInsecureAbsoluteFormHostOverride =
+                    AppContext.TryGetSwitch("Microsoft.AspNetCore.Server.Kestrel.EnableInsecureAbsoluteFormHostOverride", out var enabled) && enabled;
+            }
+            return _enableInsecureAbsoluteFormHostOverride.Value;
+        }
+        set => _enableInsecureAbsoluteFormHostOverride = value;
+    }
+
     // The following two lists configure the endpoints that Kestrel should listen to. If both lists are empty, the "urls" config setting (e.g. UseUrls) is used.
     internal List<ListenOptions> CodeBackedListenOptions { get; } = new List<ListenOptions>();
     internal List<ListenOptions> ConfigurationBackedListenOptions { get; } = new List<ListenOptions>();

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport
 using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
 using Moq;
 using Xunit;
 using BadHttpRequestException = Microsoft.AspNetCore.Http.BadHttpRequestException;
@@ -138,6 +139,30 @@ public class BadHttpRequestTests : LoggedTest
             $"{requestTarget} HTTP/1.1\r\nHost: {host}\r\n\r\n",
             "400 Bad Request",
             CoreStrings.FormatBadRequest_InvalidHostHeader_Detail(host.Trim()));
+    }
+
+    [Fact]
+    public async Task CanOptOutOfBadRequestIfHostHeaderDoesNotMatchRequestTarget()
+    {
+        var receivedHost = StringValues.Empty;
+        await using var server = new TestServer(context =>
+        {
+            receivedHost = context.Request.Headers.Host;
+            return Task.CompletedTask;
+        }, new TestServiceContext(LoggerFactory)
+        {
+            ServerOptions = new KestrelServerOptions()
+            {
+                EnableInsecureAbsoluteFormHostOverride = true,
+            }
+        });
+        using var client = server.CreateConnection();
+
+        await client.SendAll($"GET http://www.foo.com/api/data HTTP/1.1\r\nHost: www.foo.comConnection: keep-alive\r\n\r\n");
+
+        await client.Receive("HTTP/1.1 200 OK");
+
+        Assert.Equal("www.foo.com:80", receivedHost);
     }
 
     [Fact]


### PR DESCRIPTION
# Allow overriding the host header if doesn't match the absolute-form host

## Description

Allow overriding the host header if doesn't match the absolute-form host.

This is a cherry-pick of #39334 (plus an explanatory comment).

The same partner that requested this for 6.0 needs it in 7.0 (see #39335).

## Customer Impact

Some clients send malformed host headers and the server wants to use the value from the request target instead, as in IIS/httpsys.

## Regression?

- [x] Yes
- [ ] No

Kind of - it was added to 6.0 in servicing and deliberately not ported to 7.0 until there was a request.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The merge was very easy - just some whitespace changes - and the functionality is opt-in.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
