### PR TITLE
Fix display format for type.

### DIFF
--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
@@ -10,6 +10,7 @@ using System.Text;
 using Microsoft.AspNetCore.Analyzers.Infrastructure;
 using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
 using Microsoft.AspNetCore.App.Analyzers.Infrastructure;
+using Microsoft.AspNetCore.Http.RequestDelegateGenerator.StaticRouteHandlerModel.Emitters;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using WellKnownType = Microsoft.AspNetCore.App.Analyzers.Infrastructure.WellKnownTypeData.WellKnownType;
@@ -343,7 +344,7 @@ internal class EndpointParameter
         {
             parsingBlockEmitter = (writer, inputArgument, outputArgument) =>
             {
-                writer.WriteLine($"""{typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)} {outputArgument} = default;""");
+                writer.WriteLine($"""{typeSymbol.ToDisplayString(EmitterConstants.DisplayFormat)} {outputArgument} = default;""");
                 writer.WriteLine($$"""if ({{preferredTryParseInvocation(inputArgument, $"{inputArgument}_parsed_non_nullable")}})""");
                 writer.StartBlock();
                 writer.WriteLine($$"""{{outputArgument}} = {{$"{inputArgument}_parsed_non_nullable"}};""");

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/VerifyAsParametersBaseline.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/VerifyAsParametersBaseline.generated.txt
@@ -198,7 +198,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                         }
                         var Value_raw = (string?)httpContext.Request.RouteValues["Value"];
                         var Value_temp = (string?)Value_raw;
-                        int Value_parsed_temp = default;
+                        global::System.Int32 Value_parsed_temp = default;
                         if (GeneratedRouteBuilderExtensionsCore.TryParseExplicit<int>(Value_temp!, CultureInfo.InvariantCulture, out var Value_temp_parsed_non_nullable))
                         {
                             Value_parsed_temp = Value_temp_parsed_non_nullable;
@@ -236,7 +236,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                         }
                         var Value_raw = (string?)httpContext.Request.RouteValues["Value"];
                         var Value_temp = (string?)Value_raw;
-                        int Value_parsed_temp = default;
+                        global::System.Int32 Value_parsed_temp = default;
                         if (GeneratedRouteBuilderExtensionsCore.TryParseExplicit<int>(Value_temp!, CultureInfo.InvariantCulture, out var Value_temp_parsed_non_nullable))
                         {
                             Value_parsed_temp = Value_temp_parsed_non_nullable;

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTestBase.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTestBase.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Http.Generators.Tests;
 public abstract class RequestDelegateCreationTestBase : LoggedTest
 {
     // Change this to true and run tests in development to regenerate baseline files.
-    public bool RegenerateBaselines ;
+    public bool RegenerateBaselines;
 
     protected abstract bool IsGeneratorEnabled { get; }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.TryParse.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.TryParse.cs
@@ -21,7 +21,7 @@ public abstract partial class RequestDelegateCreationTests
 
             return new[]
             {
-                //// string is not technically "TryParsable", but it's the special case.
+                // string is not technically "TryParsable", but it's the special case.
                 new object[] { "string", "plain string", "plain string" },
                 new object[] { "int", "-42", -42 },
                 new object[] { "uint", "42", 42U },
@@ -37,6 +37,8 @@ public abstract partial class RequestDelegateCreationTests
                 new object[] { "Half", "0.5", (Half)0.5f },
                 new object[] { "decimal", "0.5", 0.5m },
                 new object[] { "Uri", "https://example.org", new Uri("https://example.org") },
+                new object[] { "Uri?", "https://example.org", new Uri("https://example.org") },
+                new object[] { "Uri?", null, null },
                 new object[] { "DateTime", now.ToString("o"), now.ToUniversalTime() },
                 new object[] { "DateTimeOffset", "1970-01-01T00:00:00.0000000+00:00", DateTimeOffset.UnixEpoch },
                 new object[] { "TimeSpan", "00:00:42", TimeSpan.FromSeconds(42) },


### PR DESCRIPTION
Fixes #48378 

The issue was that we were not using our own instance of `SymbolDisplayFormat` from `EmitterContext`.