### PR TITLE
Introduce KestrelServerOptions.AllowUnsafeHostHeaderOverride

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -626,17 +626,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
                 if (!_absoluteRequestTarget.IsDefaultPort
                     || hostText != _absoluteRequestTarget.Authority + ":" + _absoluteRequestTarget.Port.ToString(CultureInfo.InvariantCulture))
                 {
-                    // Superseded by RFC 7230, but notable for back-compat.
-                    // https://datatracker.ietf.org/doc/html/rfc2616/#section-5.2
-                    //    1. If Request-URI is an absoluteURI, the host is part of the
-                    // Request-URI. Any Host header field value in the request MUST be
-                    // ignored.
-                    // We don't want to leave the invalid value for the app to accidentally consume,
-                    // replace it with the value from the request line.
-                    // This is insecure in the sense that we would ordinarily regard a mismatched
-                    // request target and host as suspicious (e.g. indicative of a spoofing attempt)
-                    // and reject the request.
-                    if (_context.ServiceContext.ServerOptions.EnableInsecureAbsoluteFormHostOverride)
+                    if (_context.ServiceContext.ServerOptions.AllowUnsafeHostHeaderOverride)
                     {
                         hostText = _absoluteRequestTarget.Authority + ":" + _absoluteRequestTarget.Port.ToString(CultureInfo.InvariantCulture);
                         HttpRequestHeaders.HeaderHost = hostText;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -633,6 +633,9 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
                     // ignored.
                     // We don't want to leave the invalid value for the app to accidentally consume,
                     // replace it with the value from the request line.
+                    // This is insecure in the sense that we would ordinarily regard a mismatched
+                    // request target and host as suspicious (e.g. indicative of a spoofing attempt)
+                    // and reject the request.
                     if (_context.ServiceContext.ServerOptions.EnableInsecureAbsoluteFormHostOverride)
                     {
                         hostText = _absoluteRequestTarget.Authority + ":" + _absoluteRequestTarget.Port.ToString(CultureInfo.InvariantCulture);

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -626,7 +626,22 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
                 if (!_absoluteRequestTarget.IsDefaultPort
                     || hostText != _absoluteRequestTarget.Authority + ":" + _absoluteRequestTarget.Port.ToString(CultureInfo.InvariantCulture))
                 {
-                    KestrelBadHttpRequestException.Throw(RequestRejectionReason.InvalidHostHeader, hostText);
+                    // Superseded by RFC 7230, but notable for back-compat.
+                    // https://datatracker.ietf.org/doc/html/rfc2616/#section-5.2
+                    //    1. If Request-URI is an absoluteURI, the host is part of the
+                    // Request-URI. Any Host header field value in the request MUST be
+                    // ignored.
+                    // We don't want to leave the invalid value for the app to accidentally consume,
+                    // replace it with the value from the request line.
+                    if (_context.ServiceContext.ServerOptions.EnableInsecureAbsoluteFormHostOverride)
+                    {
+                        hostText = _absoluteRequestTarget.Authority + ":" + _absoluteRequestTarget.Port.ToString(CultureInfo.InvariantCulture);
+                        HttpRequestHeaders.HeaderHost = hostText;
+                    }
+                    else
+                    {
+                        KestrelBadHttpRequestException.Throw(RequestRejectionReason.InvalidHostHeader, hostText);
+                    }
                 }
             }
         }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -626,7 +626,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
                 if (!_absoluteRequestTarget.IsDefaultPort
                     || hostText != _absoluteRequestTarget.Authority + ":" + _absoluteRequestTarget.Port.ToString(CultureInfo.InvariantCulture))
                 {
-                    if (_context.ServiceContext.ServerOptions.AllowUnsafeHostHeaderOverride)
+                    if (_context.ServiceContext.ServerOptions.AllowHostHeaderOverride)
                     {
                         hostText = _absoluteRequestTarget.Authority + ":" + _absoluteRequestTarget.Port.ToString(CultureInfo.InvariantCulture);
                         HttpRequestHeaders.HeaderHost = hostText;

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -35,6 +35,21 @@ public class KestrelServerOptions
 
     private Func<string, Encoding?> _responseHeaderEncodingSelector = DefaultHeaderEncodingSelector;
 
+    private bool? _enableInsecureAbsoluteFormHostOverride;
+    internal bool EnableInsecureAbsoluteFormHostOverride
+    {
+        get
+        {
+            if (!_enableInsecureAbsoluteFormHostOverride.HasValue)
+            {
+                _enableInsecureAbsoluteFormHostOverride =
+                    AppContext.TryGetSwitch("Microsoft.AspNetCore.Server.Kestrel.EnableInsecureAbsoluteFormHostOverride", out var enabled) && enabled;
+            }
+            return _enableInsecureAbsoluteFormHostOverride.Value;
+        }
+        set => _enableInsecureAbsoluteFormHostOverride = value;
+    }
+
     // The following two lists configure the endpoints that Kestrel should listen to. If both lists are empty, the "urls" config setting (e.g. UseUrls) is used.
     internal List<ListenOptions> CodeBackedListenOptions { get; } = new List<ListenOptions>();
     internal List<ListenOptions> ConfigurationBackedListenOptions { get; } = new List<ListenOptions>();

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -53,7 +53,7 @@ public class KestrelServerOptions
     /// from the request target.
     /// </summary>
     /// <remarks>
-    /// This does not apply to HTTP/2 or HTTP/3 because the Host header is not sent in requests.
+    /// This option does not apply to HTTP/2 or HTTP/3.
     /// </remarks>
     /// <seealso href="https://datatracker.ietf.org/doc/html/rfc9112#section-3.2.2-8"/>
     public bool AllowHostHeaderOverride { get; set; }

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -35,20 +35,25 @@ public class KestrelServerOptions
 
     private Func<string, Encoding?> _responseHeaderEncodingSelector = DefaultHeaderEncodingSelector;
 
-    private bool? _enableInsecureAbsoluteFormHostOverride;
-    internal bool EnableInsecureAbsoluteFormHostOverride
-    {
-        get
-        {
-            if (!_enableInsecureAbsoluteFormHostOverride.HasValue)
-            {
-                _enableInsecureAbsoluteFormHostOverride =
-                    AppContext.TryGetSwitch("Microsoft.AspNetCore.Server.Kestrel.EnableInsecureAbsoluteFormHostOverride", out var enabled) && enabled;
-            }
-            return _enableInsecureAbsoluteFormHostOverride.Value;
-        }
-        set => _enableInsecureAbsoluteFormHostOverride = value;
-    }
+    /// <summary>
+    /// In HTTP/1.x, when a request target is in absolute-form (see RFC 9112 Section 3.2.2),
+    /// for example
+    /// <code>
+    /// GET http://www.example.com/path/to/index.html HTTP/1.1
+    /// </code>
+    /// the Host header is redundant.  In fact, the RFC says
+    ///
+    ///   When an origin server receives a request with an absolute-form of request-target,
+    ///   the origin server MUST ignore the received Host header field (if any) and instead
+    ///   use the host information of the request-target.
+    ///
+    /// However, it is still sensible to check whether the request target and Host header match
+    /// because a mismatch might indicate, for example, a spoofing attempt.  Setting this property
+    /// to true bypasses that check and unconditionally overwrites the Host header with the value
+    /// from the request target.
+    /// </summary>
+    /// <seealso href="https://datatracker.ietf.org/doc/html/rfc9112#section-3.2.2-8"/>
+    public bool AllowUnsafeHostHeaderOverride { get; set; }
 
     // The following two lists configure the endpoints that Kestrel should listen to. If both lists are empty, the "urls" config setting (e.g. UseUrls) is used.
     internal List<ListenOptions> CodeBackedListenOptions { get; } = new List<ListenOptions>();

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -52,8 +52,11 @@ public class KestrelServerOptions
     /// to true bypasses that check and unconditionally overwrites the Host header with the value
     /// from the request target.
     /// </summary>
+    /// <remarks>
+    /// This does not apply to HTTP/2 or HTTP/3 because the Host header is not sent in requests.
+    /// </remarks>
     /// <seealso href="https://datatracker.ietf.org/doc/html/rfc9112#section-3.2.2-8"/>
-    public bool AllowUnsafeHostHeaderOverride { get; set; }
+    public bool AllowHostHeaderOverride { get; set; }
 
     // The following two lists configure the endpoints that Kestrel should listen to. If both lists are empty, the "urls" config setting (e.g. UseUrls) is used.
     internal List<ListenOptions> CodeBackedListenOptions { get; } = new List<ListenOptions>();

--- a/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 Microsoft.AspNetCore.Server.Kestrel.Core.Features.ISslStreamFeature
 Microsoft.AspNetCore.Server.Kestrel.Core.Features.ISslStreamFeature.SslStream.get -> System.Net.Security.SslStream!
+Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.AllowUnsafeHostHeaderOverride.get -> bool
+Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.AllowUnsafeHostHeaderOverride.set -> void
 Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenNamedPipe(string! pipeName) -> void
 Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenNamedPipe(string! pipeName, System.Action<Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions!>! configure) -> void
 Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.PipeName.get -> string?

--- a/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Servers/Kestrel/Core/src/PublicAPI.Unshipped.txt
@@ -1,8 +1,8 @@
 #nullable enable
 Microsoft.AspNetCore.Server.Kestrel.Core.Features.ISslStreamFeature
 Microsoft.AspNetCore.Server.Kestrel.Core.Features.ISslStreamFeature.SslStream.get -> System.Net.Security.SslStream!
-Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.AllowUnsafeHostHeaderOverride.get -> bool
-Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.AllowUnsafeHostHeaderOverride.set -> void
+Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.AllowHostHeaderOverride.get -> bool
+Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.AllowHostHeaderOverride.set -> void
 Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenNamedPipe(string! pipeName) -> void
 Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenNamedPipe(string! pipeName, System.Action<Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions!>! configure) -> void
 Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.PipeName.get -> string?

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
@@ -153,11 +153,12 @@ public class BadHttpRequestTests : LoggedTest
         {
             ServerOptions = new KestrelServerOptions()
             {
-                EnableInsecureAbsoluteFormHostOverride = true,
+                AllowUnsafeHostHeaderOverride = true,
             }
         });
         using var client = server.CreateConnection();
 
+        // Note the missing line-reak between the Host and Connection headers
         await client.SendAll($"GET http://www.foo.com/api/data HTTP/1.1\r\nHost: www.foo.comConnection: keep-alive\r\n\r\n");
 
         await client.Receive("HTTP/1.1 200 OK");

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
@@ -155,7 +155,7 @@ public class BadHttpRequestTests : LoggedTest
         {
             ServerOptions = new KestrelServerOptions()
             {
-                AllowUnsafeHostHeaderOverride = true,
+                AllowHostHeaderOverride = true,
             }
         });
         using var client = server.CreateConnection();

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/BadHttpRequestTests.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport
 using Microsoft.AspNetCore.Testing;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
 using Moq;
 using Xunit;
 using BadHttpRequestException = Microsoft.AspNetCore.Http.BadHttpRequestException;
@@ -138,6 +139,30 @@ public class BadHttpRequestTests : LoggedTest
             $"{requestTarget} HTTP/1.1\r\nHost: {host}\r\n\r\n",
             "400 Bad Request",
             CoreStrings.FormatBadRequest_InvalidHostHeader_Detail(host.Trim()));
+    }
+
+    [Fact]
+    public async Task CanOptOutOfBadRequestIfHostHeaderDoesNotMatchRequestTarget()
+    {
+        var receivedHost = StringValues.Empty;
+        await using var server = new TestServer(context =>
+        {
+            receivedHost = context.Request.Headers.Host;
+            return Task.CompletedTask;
+        }, new TestServiceContext(LoggerFactory)
+        {
+            ServerOptions = new KestrelServerOptions()
+            {
+                EnableInsecureAbsoluteFormHostOverride = true,
+            }
+        });
+        using var client = server.CreateConnection();
+
+        await client.SendAll($"GET http://www.foo.com/api/data HTTP/1.1\r\nHost: www.foo.comConnection: keep-alive\r\n\r\n");
+
+        await client.Receive("HTTP/1.1 200 OK");
+
+        Assert.Equal("www.foo.com:80", receivedHost);
     }
 
     [Fact]


### PR DESCRIPTION
# Introduce KestrelServerOptions.AllowUnsafeHostHeaderOverride

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Make it possible to skip validation that the request-target and host header match.

## Description

This builds on #48415 (which is itself a port of #39334).  That PR introduced an internal API and corresponding appcontext switch that made it possible to overwrite an incorrect Host header with a value derived from an absolute-form request target to handle the surprisingly common client behavior of missing the line-break after the host header, as IIS/Http.Sys did.  This PR upgrades it to a public API since those clients aren't going away.  The behavior is the same, it just has a name and a doc comment intended for broader consumption.

Fixes #39335 (with #48415).
Fixes #48461