### PR TITLE
Avoid repetitive GCHandles in IIS WebSocket operations

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.cs
@@ -763,6 +763,8 @@ internal abstract partial class IISHttpContext : NativeRequestContext, IThreadPo
             localAbortCts?.Dispose();
 
             disposedValue = true;
+
+            AsyncIO?.Dispose();
         }
     }
 

--- a/src/Servers/IIS/IIS/src/Core/IO/AsyncIOEngine.cs
+++ b/src/Servers/IIS/IIS/src/Core/IO/AsyncIOEngine.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace Microsoft.AspNetCore.Server.IIS.Core.IO;
 
-internal sealed partial class AsyncIOEngine : IAsyncIOEngine
+internal sealed partial class AsyncIOEngine : IAsyncIOEngine, IDisposable
 {
     private const ushort ResponseMaxChunks = 65533;
 
@@ -243,5 +243,10 @@ internal sealed partial class AsyncIOEngine : IAsyncIOEngine
     private void ReturnOperation(AsyncFlushOperation operation)
     {
         Volatile.Write(ref _cachedAsyncFlushOperation, operation);
+    }
+
+    public void Dispose()
+    {
+        _stopped = true;
     }
 }

--- a/src/Servers/IIS/IIS/src/Core/IO/AsyncIOOperation.cs
+++ b/src/Servers/IIS/IIS/src/Core/IO/AsyncIOOperation.cs
@@ -134,6 +134,8 @@ internal abstract class AsyncIOOperation : IValueTaskSource<int>, IValueTaskSour
         _continuation = null;
     }
 
+    public bool InUse() => _continuation is not null;
+
     public readonly struct AsyncContinuation
     {
         public Action<object?> Continuation { get; }

--- a/src/Servers/IIS/IIS/src/Core/IO/IAsyncIOEngine.cs
+++ b/src/Servers/IIS/IIS/src/Core/IO/IAsyncIOEngine.cs
@@ -5,7 +5,7 @@ using System.Buffers;
 
 namespace Microsoft.AspNetCore.Server.IIS.Core.IO;
 
-internal interface IAsyncIOEngine
+internal interface IAsyncIOEngine : IDisposable
 {
     ValueTask<int> ReadAsync(Memory<byte> memory);
     ValueTask<int> WriteAsync(ReadOnlySequence<byte> data);

--- a/src/Servers/IIS/IIS/src/Core/IO/WebSocketsAsyncIOEngine.Initialize.cs
+++ b/src/Servers/IIS/IIS/src/Core/IO/WebSocketsAsyncIOEngine.Initialize.cs
@@ -36,7 +36,6 @@ internal partial class WebSocketsAsyncIOEngine
             base.ResetOperation();
 
             _requestHandler = default;
-            _engine.ReturnOperation(this);
         }
     }
 }

--- a/src/Servers/IIS/IIS/src/Core/IO/WebSocketsAsyncIOEngine.Read.cs
+++ b/src/Servers/IIS/IIS/src/Core/IO/WebSocketsAsyncIOEngine.Read.cs
@@ -74,8 +74,6 @@ internal partial class WebSocketsAsyncIOEngine
             _inputHandle.Dispose();
             _inputHandle = default;
             _requestHandler = default;
-
-            _engine.ReturnOperation(this);
         }
 
         protected override bool IsSuccessfulResult(int hr) => hr == NativeMethods.ERROR_HANDLE_EOF;

--- a/src/Servers/IIS/IIS/src/Core/IO/WebSocketsAsyncIOEngine.Write.cs
+++ b/src/Servers/IIS/IIS/src/Core/IO/WebSocketsAsyncIOEngine.Write.cs
@@ -40,8 +40,6 @@ internal partial class WebSocketsAsyncIOEngine
         protected override void ResetOperation()
         {
             base.ResetOperation();
-
-            _engine.ReturnOperation(this);
         }
 
         public void Dispose()

--- a/src/Servers/IIS/IIS/src/Core/IO/WebSocketsAsyncIOEngine.Write.cs
+++ b/src/Servers/IIS/IIS/src/Core/IO/WebSocketsAsyncIOEngine.Write.cs
@@ -41,7 +41,6 @@ internal partial class WebSocketsAsyncIOEngine
         {
             base.ResetOperation();
 
-
             _engine.ReturnOperation(this);
         }
 

--- a/src/Servers/IIS/IIS/src/Core/IO/WebSocketsAsyncIOEngine.Write.cs
+++ b/src/Servers/IIS/IIS/src/Core/IO/WebSocketsAsyncIOEngine.Write.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Server.IIS.Core.IO;
 
 internal partial class WebSocketsAsyncIOEngine
 {
-    internal sealed class WebSocketWriteOperation : AsyncWriteOperationBase
+    internal sealed class WebSocketWriteOperation : AsyncWriteOperationBase, IDisposable
     {
         [UnmanagedCallersOnly]
         private static NativeMethods.REQUEST_NOTIFICATION_STATUS WriteCallback(IntPtr httpContext, IntPtr completionInfo, IntPtr completionContext)
@@ -24,16 +24,16 @@ internal partial class WebSocketsAsyncIOEngine
         }
 
         private readonly WebSocketsAsyncIOEngine _engine;
-        private GCHandle _thisHandle;
+        private readonly GCHandle _thisHandle;
 
         public WebSocketWriteOperation(WebSocketsAsyncIOEngine engine)
         {
+            _thisHandle = GCHandle.Alloc(this);
             _engine = engine;
         }
 
         protected override unsafe int WriteChunks(NativeSafeHandle requestHandler, int chunkCount, HttpApiTypes.HTTP_DATA_CHUNK* dataChunks, out bool completionExpected)
         {
-            _thisHandle = GCHandle.Alloc(this);
             return NativeMethods.HttpWebsocketsWriteBytes(requestHandler, dataChunks, chunkCount, &WriteCallback, (IntPtr)_thisHandle, out completionExpected);
         }
 
@@ -41,9 +41,13 @@ internal partial class WebSocketsAsyncIOEngine
         {
             base.ResetOperation();
 
-            _thisHandle.Free();
 
             _engine.ReturnOperation(this);
+        }
+
+        public void Dispose()
+        {
+            _thisHandle.Free();
         }
     }
 }

--- a/src/Servers/IIS/IIS/src/Core/IO/WebSocketsAsyncIOEngine.cs
+++ b/src/Servers/IIS/IIS/src/Core/IO/WebSocketsAsyncIOEngine.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Diagnostics;
 
 namespace Microsoft.AspNetCore.Server.IIS.Core.IO;
 
@@ -15,11 +16,9 @@ internal sealed partial class WebSocketsAsyncIOEngine : IAsyncIOEngine
 
     private AsyncInitializeOperation? _initializationFlush;
 
-    private WebSocketWriteOperation? _cachedWebSocketWriteOperation;
+    private WebSocketWriteOperation? _webSocketWriteOperation;
 
-    private WebSocketReadOperation? _cachedWebSocketReadOperation;
-
-    private AsyncInitializeOperation? _cachedAsyncInitializeOperation;
+    private WebSocketReadOperation? _webSocketReadOperation;
 
     public WebSocketsAsyncIOEngine(IISHttpContext context, NativeSafeHandle handler)
     {
@@ -33,7 +32,10 @@ internal sealed partial class WebSocketsAsyncIOEngine : IAsyncIOEngine
         {
             ThrowIfNotInitialized();
 
-            var read = GetReadOperation();
+            var read = _webSocketReadOperation ??= new WebSocketReadOperation(this);
+
+            Debug.Assert(!read.InUse());
+
             read.Initialize(_handler, memory);
             read.Invoke();
             return new ValueTask<int>(read, 0);
@@ -46,7 +48,10 @@ internal sealed partial class WebSocketsAsyncIOEngine : IAsyncIOEngine
         {
             ThrowIfNotInitialized();
 
-            var write = GetWriteOperation();
+            var write = _webSocketWriteOperation ??= new WebSocketWriteOperation(this);
+
+            Debug.Assert(!write.InUse());
+
             write.Initialize(_handler, data);
             write.Invoke();
             return new ValueTask<int>(write, 0);
@@ -64,7 +69,7 @@ internal sealed partial class WebSocketsAsyncIOEngine : IAsyncIOEngine
 
             NativeMethods.HttpEnableWebsockets(_handler);
 
-            var init = GetInitializeOperation();
+            var init = new AsyncInitializeOperation(this);
             init.Initialize(_handler);
 
             var continuation = init.Invoke();
@@ -119,30 +124,9 @@ internal sealed partial class WebSocketsAsyncIOEngine : IAsyncIOEngine
         }
     }
 
-    private WebSocketReadOperation GetReadOperation() =>
-        Interlocked.Exchange(ref _cachedWebSocketReadOperation, null) ??
-        new WebSocketReadOperation(this);
-
-    private WebSocketWriteOperation GetWriteOperation() =>
-        Interlocked.Exchange(ref _cachedWebSocketWriteOperation, null) ??
-        new WebSocketWriteOperation(this);
-
-    private AsyncInitializeOperation GetInitializeOperation() =>
-        Interlocked.Exchange(ref _cachedAsyncInitializeOperation, null) ??
-        new AsyncInitializeOperation(this);
-
-    private void ReturnOperation(AsyncInitializeOperation operation) =>
-        Volatile.Write(ref _cachedAsyncInitializeOperation, operation);
-
-    private void ReturnOperation(WebSocketWriteOperation operation) =>
-        Volatile.Write(ref _cachedWebSocketWriteOperation, operation);
-
-    private void ReturnOperation(WebSocketReadOperation operation) =>
-        Volatile.Write(ref _cachedWebSocketReadOperation, operation);
-
     public void Dispose()
     {
-        _cachedWebSocketWriteOperation?.Dispose();
-        _cachedWebSocketReadOperation?.Dispose();
+        _webSocketWriteOperation?.Dispose();
+        _webSocketReadOperation?.Dispose();
     }
 }

--- a/src/Servers/IIS/IIS/src/Core/IO/WebSocketsAsyncIOEngine.cs
+++ b/src/Servers/IIS/IIS/src/Core/IO/WebSocketsAsyncIOEngine.cs
@@ -139,4 +139,10 @@ internal sealed partial class WebSocketsAsyncIOEngine : IAsyncIOEngine
 
     private void ReturnOperation(WebSocketReadOperation operation) =>
         Volatile.Write(ref _cachedWebSocketReadOperation, operation);
+
+    public void Dispose()
+    {
+        _cachedWebSocketWriteOperation?.Dispose();
+        _cachedWebSocketReadOperation?.Dispose();
+    }
 }


### PR DESCRIPTION
Make the `AsyncIOEngine` in IIS disposable so we can avoid creating a new `GCHandle` for every WebSocket read and write operation.