### PR TITLE
Fix redundant use of compounding bitwise |= true

### DIFF
--- a/src/Components/Components/src/ComponentBase.cs
+++ b/src/Components/Components/src/ComponentBase.cs
@@ -327,7 +327,7 @@ public abstract class ComponentBase : IComponent, IHandleEvent, IHandleAfterRend
     Task IHandleAfterRender.OnAfterRenderAsync()
     {
         var firstRender = !_hasCalledOnAfterRender;
-        _hasCalledOnAfterRender |= true;
+        _hasCalledOnAfterRender = true;
 
         OnAfterRender(firstRender);
 


### PR DESCRIPTION
# Fix redundant use of compounding bitwise |= true

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

Fix redundant use of compounding bitwise |= true

Fixes #48464 
