### PR TITLE
Make problemdetails settable in problemdetailscontext

### DIFF
--- a/src/Http/Http.Abstractions/src/ProblemDetails/ProblemDetailsContext.cs
+++ b/src/Http/Http.Abstractions/src/ProblemDetails/ProblemDetailsContext.cs
@@ -29,7 +29,7 @@ public sealed class ProblemDetailsContext
     public ProblemDetails ProblemDetails
     {
         get => _problemDetails ??= new ProblemDetails();
-        init => _problemDetails = value;
+        set => _problemDetails = value;
     }
 
     /// <summary>

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -10,6 +10,7 @@ Microsoft.AspNetCore.Http.Metadata.IRouteDiagnosticsMetadata
 Microsoft.AspNetCore.Http.Metadata.IRouteDiagnosticsMetadata.Route.get -> string!
 Microsoft.AspNetCore.Http.ProblemDetailsContext.Exception.get -> System.Exception?
 Microsoft.AspNetCore.Http.ProblemDetailsContext.Exception.init -> void
+*REMOVED*Microsoft.AspNetCore.Http.ProblemDetailsContext.ProblemDetails.init -> void
 Microsoft.AspNetCore.Http.ProblemDetailsContext.ProblemDetails.set -> void
 Microsoft.AspNetCore.Mvc.ProblemDetails.Extensions.set -> void
 static Microsoft.AspNetCore.Http.EndpointFilterInvocationContext.Create(Microsoft.AspNetCore.Http.HttpContext! httpContext) -> Microsoft.AspNetCore.Http.EndpointFilterInvocationContext!

--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -10,6 +10,7 @@ Microsoft.AspNetCore.Http.Metadata.IRouteDiagnosticsMetadata
 Microsoft.AspNetCore.Http.Metadata.IRouteDiagnosticsMetadata.Route.get -> string!
 Microsoft.AspNetCore.Http.ProblemDetailsContext.Exception.get -> System.Exception?
 Microsoft.AspNetCore.Http.ProblemDetailsContext.Exception.init -> void
+Microsoft.AspNetCore.Http.ProblemDetailsContext.ProblemDetails.set -> void
 Microsoft.AspNetCore.Mvc.ProblemDetails.Extensions.set -> void
 static Microsoft.AspNetCore.Http.EndpointFilterInvocationContext.Create(Microsoft.AspNetCore.Http.HttpContext! httpContext) -> Microsoft.AspNetCore.Http.EndpointFilterInvocationContext!
 static Microsoft.AspNetCore.Http.EndpointFilterInvocationContext.Create<T1, T2, T3, T4, T5, T6, T7, T8>(Microsoft.AspNetCore.Http.HttpContext! httpContext, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) -> Microsoft.AspNetCore.Http.EndpointFilterInvocationContext!

--- a/src/Http/Http.Abstractions/test/ProblemDetailsContextTests.cs
+++ b/src/Http/Http.Abstractions/test/ProblemDetailsContextTests.cs
@@ -4,7 +4,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Microsoft.AspNetCore.Http;
+namespace Microsoft.AspNetCore.Http.Abstractions.Tests;
 
 public class ProblemDetailsContextTests
 {

--- a/src/Http/Http.Abstractions/test/ProblemDetailsContextTests.cs
+++ b/src/Http/Http.Abstractions/test/ProblemDetailsContextTests.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Microsoft.AspNetCore.Http;
+
+public class ProblemDetailsContextTests
+{
+    [Fact]
+    public void ProblemDetailsPropertySetter_Should_SetProblemDetails()
+    {
+        // Arrange
+        ProblemDetailsContext context = new() { HttpContext = new DefaultHttpContext() };
+        ProblemDetails problemDetails = new();
+
+        // Act
+        context.ProblemDetails = problemDetails;
+
+        // Assert
+        Assert.Equal(problemDetails, context.ProblemDetails);
+    }
+}

--- a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
+++ b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
@@ -55,12 +55,14 @@ public partial class DefaultProblemDetailsWriterTest
     }
 
     [Fact]
-    public async Task WriteAsync_Works_WhenUsingProblemDetailsSetter()
+    public async Task WriteAsync_Works_WhenReplacingProblemDetailsUsingSetter()
     {
         // Arrange
         var writer = GetWriter();
         var stream = new MemoryStream();
         var context = CreateContext(stream);
+        var originalProblemDetails = new ProblemDetails();
+
         var expectedProblem = new ProblemDetails()
         {
             Detail = "Custom Bad Request",
@@ -71,7 +73,8 @@ public partial class DefaultProblemDetailsWriterTest
         };
         var problemDetailsContext = new ProblemDetailsContext()
         {
-            HttpContext = context
+            HttpContext = context,
+            ProblemDetails = originalProblemDetails
         };
 
         problemDetailsContext.ProblemDetails = expectedProblem;

--- a/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
+++ b/src/Http/Http.Extensions/test/ProblemDetailsDefaultWriterTest.cs
@@ -55,6 +55,42 @@ public partial class DefaultProblemDetailsWriterTest
     }
 
     [Fact]
+    public async Task WriteAsync_Works_WhenUsingProblemDetailsSetter()
+    {
+        // Arrange
+        var writer = GetWriter();
+        var stream = new MemoryStream();
+        var context = CreateContext(stream);
+        var expectedProblem = new ProblemDetails()
+        {
+            Detail = "Custom Bad Request",
+            Instance = "Custom Bad Request",
+            Status = StatusCodes.Status400BadRequest,
+            Type = "https://tools.ietf.org/html/rfc9110#section-15.5.1-custom",
+            Title = "Custom Bad Request",
+        };
+        var problemDetailsContext = new ProblemDetailsContext()
+        {
+            HttpContext = context
+        };
+
+        problemDetailsContext.ProblemDetails = expectedProblem;
+
+        //Act
+        await writer.WriteAsync(problemDetailsContext);
+
+        //Assert
+        stream.Position = 0;
+        var problemDetails = await JsonSerializer.DeserializeAsync<ProblemDetails>(stream, SerializerOptions);
+        Assert.NotNull(problemDetails);
+        Assert.Equal(expectedProblem.Status, problemDetails.Status);
+        Assert.Equal(expectedProblem.Type, problemDetails.Type);
+        Assert.Equal(expectedProblem.Title, problemDetails.Title);
+        Assert.Equal(expectedProblem.Detail, problemDetails.Detail);
+        Assert.Equal(expectedProblem.Instance, problemDetails.Instance);
+    }
+
+    [Fact]
     public async Task WriteAsync_Works_WithJsonContext()
     {
         // Arrange

--- a/src/Mvc/Mvc.Core/test/Infrastructure/DefaultApiProblemDetailsWriterTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/DefaultApiProblemDetailsWriterTest.cs
@@ -51,6 +51,43 @@ public class DefaultApiProblemDetailsWriterTest
         Assert.Equal(expectedProblem.Instance, problemDetails.Instance);
     }
 
+        [Fact]
+    public async Task WriteAsync_Works_WhenUsingProblemDetailsSetter()
+    {
+        // Arrange
+        var writer = GetWriter();
+        var stream = new MemoryStream();
+        var context = CreateContext(stream);
+
+        var expectedProblem = new ProblemDetails()
+        {
+            Detail = "Custom Bad Request",
+            Instance = "Custom Bad Request",
+            Status = StatusCodes.Status400BadRequest,
+            Type = "https://tools.ietf.org/html/rfc9110#section-15.5.1-custom",
+            Title = "Custom Bad Request",
+        };
+        var problemDetailsContext = new ProblemDetailsContext()
+        {
+            HttpContext = context
+        };
+
+        problemDetailsContext.ProblemDetails = expectedProblem;
+
+        //Act
+        await writer.WriteAsync(problemDetailsContext);
+
+        //Assert
+        stream.Position = 0;
+        var problemDetails = await JsonSerializer.DeserializeAsync<ProblemDetails>(stream, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        Assert.NotNull(problemDetails);
+        Assert.Equal(expectedProblem.Status, problemDetails.Status);
+        Assert.Equal(expectedProblem.Type, problemDetails.Type);
+        Assert.Equal(expectedProblem.Title, problemDetails.Title);
+        Assert.Equal(expectedProblem.Detail, problemDetails.Detail);
+        Assert.Equal(expectedProblem.Instance, problemDetails.Instance);
+    }
+
     [Fact]
     public async Task WriteAsync_AddExtensions()
     {

--- a/src/Mvc/Mvc.Core/test/Infrastructure/DefaultApiProblemDetailsWriterTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/DefaultApiProblemDetailsWriterTest.cs
@@ -52,12 +52,13 @@ public class DefaultApiProblemDetailsWriterTest
     }
 
         [Fact]
-    public async Task WriteAsync_Works_WhenUsingProblemDetailsSetter()
+    public async Task WriteAsync_Works_WhenReplacingProblemDetailsUsingSetter()
     {
         // Arrange
         var writer = GetWriter();
         var stream = new MemoryStream();
         var context = CreateContext(stream);
+        var originalProblemDetails = new ProblemDetails();
 
         var expectedProblem = new ProblemDetails()
         {
@@ -69,7 +70,8 @@ public class DefaultApiProblemDetailsWriterTest
         };
         var problemDetailsContext = new ProblemDetailsContext()
         {
-            HttpContext = context
+            HttpContext = context,
+            ProblemDetails = originalProblemDetails
         };
 
         problemDetailsContext.ProblemDetails = expectedProblem;


### PR DESCRIPTION
- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

# Make ProblemDetails settable in ProblemDetailsContext

## Description

The ProblemDetails property in ProblemDetailsContext is now settable which makes it possible to
replace the current ProblemDetails instance when using the customize problem details feature.

Fixes #47633
