### PR TITLE
[wasm][debugging] Enable debugging when Device Toolbar is enabled and Iphone is selected

### DIFF
--- a/src/Components/Web.JS/src/Platform/Mono/MonoDebugger.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoDebugger.ts
@@ -8,7 +8,7 @@ const brands = navigatorUA.userAgentData && navigatorUA.userAgentData.brands;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const currentBrowserIsChromeOrEdge = brands
   ? brands.some(b => b.brand === 'Google Chrome' || b.brand === 'Microsoft Edge' || b.brand === 'Chromium')
-  : (window as any).chrome;
+  : (window as any).chrome || navigator.userAgent.includes('Chrome');
 const platform = navigatorUA.userAgentData?.platform ?? navigator.platform;
 
 let hasReferencedPdbs = false;

--- a/src/Components/Web.JS/src/Platform/Mono/MonoDebugger.ts
+++ b/src/Components/Web.JS/src/Platform/Mono/MonoDebugger.ts
@@ -6,9 +6,9 @@ import { WebAssemblyResourceLoader } from '../WebAssemblyResourceLoader';
 const navigatorUA = navigator as MonoNavigatorUserAgent;
 const brands = navigatorUA.userAgentData && navigatorUA.userAgentData.brands;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const currentBrowserIsChromeOrEdge = brands
+const currentBrowserIsChromeOrEdge = brands && brands.length > 0
   ? brands.some(b => b.brand === 'Google Chrome' || b.brand === 'Microsoft Edge' || b.brand === 'Chromium')
-  : (window as any).chrome || navigator.userAgent.includes('Chrome');
+  : (window as any).chrome;
 const platform = navigatorUA.userAgentData?.platform ?? navigator.platform;
 
 let hasReferencedPdbs = false;


### PR DESCRIPTION
When DevTools is enabled and iPhone 12 is selected, navigatorUA.userAgentData.brands has length = 0 and Debugger was disabled.
With this PR is possible to debug when Device iPhone is selected.
![image](https://github.com/dotnet/aspnetcore/assets/4503299/4b6125bb-2599-4879-bf6d-c83777d6b519)

Fixes:
https://github.com/dotnet/runtime/issues/84171#issuecomment-1567730864