### PR TITLE
Verify response json body

### DIFF
--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -1314,57 +1314,6 @@ public partial class RequestDelegateFactoryTests : LoggedTest
         Assert.Equal(httpContext.Response, httpResponseArgument);
     }
 
-    public static IEnumerable<object[]> ComplexResult
-    {
-        get
-        {
-            Todo originalTodo = new()
-            {
-                Name = "Write even more tests!"
-            };
-
-            Todo TestAction() => originalTodo;
-            Task<Todo> TaskTestAction() => Task.FromResult(originalTodo);
-            ValueTask<Todo> ValueTaskTestAction() => ValueTask.FromResult(originalTodo);
-
-            static Todo StaticTestAction() => new Todo { Name = "Write even more tests!" };
-            static Task<Todo> StaticTaskTestAction() => Task.FromResult(new Todo { Name = "Write even more tests!" });
-            static ValueTask<Todo> StaticValueTaskTestAction() => ValueTask.FromResult(new Todo { Name = "Write even more tests!" });
-
-            return new List<object[]>
-                {
-                    new object[] { (Func<Todo>)TestAction },
-                    new object[] { (Func<Task<Todo>>)TaskTestAction},
-                    new object[] { (Func<ValueTask<Todo>>)ValueTaskTestAction},
-                    new object[] { (Func<Todo>)StaticTestAction},
-                    new object[] { (Func<Task<Todo>>)StaticTaskTestAction},
-                    new object[] { (Func<ValueTask<Todo>>)StaticValueTaskTestAction},
-                };
-        }
-    }
-
-    [Fact]
-    public async Task RequestDelegateWritesComplexStructReturnValueAsJsonResponseBody()
-    {
-        var httpContext = CreateHttpContext();
-        var responseBodyStream = new MemoryStream();
-        httpContext.Response.Body = responseBodyStream;
-
-        var factoryResult = RequestDelegateFactory.Create(() => new TodoStruct(42, "Bob", true));
-        var requestDelegate = factoryResult.RequestDelegate;
-
-        await requestDelegate(httpContext);
-
-        var deserializedResponseBody = JsonSerializer.Deserialize<TodoStruct>(responseBodyStream.ToArray(), new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true
-        });
-
-        Assert.Equal(42, deserializedResponseBody.Id);
-        Assert.Equal("Bob", deserializedResponseBody.Name);
-        Assert.True(deserializedResponseBody.IsComplete);
-    }
-
     public static IEnumerable<object[]> ChildResult
     {
         get

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -1343,27 +1343,28 @@ public partial class RequestDelegateFactoryTests : LoggedTest
         }
     }
 
-    [Theory]
-    [MemberData(nameof(ComplexResult))]
-    public async Task RequestDelegateWritesComplexReturnValueAsJsonResponseBody(Delegate @delegate)
-    {
-        var httpContext = CreateHttpContext();
-        var responseBodyStream = new MemoryStream();
-        httpContext.Response.Body = responseBodyStream;
+    // TODO: Remove once test is migrated.
+    //[Theory]
+    //[MemberData(nameof(ComplexResult))]
+    //public async Task RequestDelegateWritesComplexReturnValueAsJsonResponseBody(Delegate @delegate)
+    //{
+    //    var httpContext = CreateHttpContext();
+    //    var responseBodyStream = new MemoryStream();
+    //    httpContext.Response.Body = responseBodyStream;
 
-        var factoryResult = RequestDelegateFactory.Create(@delegate);
-        var requestDelegate = factoryResult.RequestDelegate;
+    //    var factoryResult = RequestDelegateFactory.Create(@delegate);
+    //    var requestDelegate = factoryResult.RequestDelegate;
 
-        await requestDelegate(httpContext);
+    //    await requestDelegate(httpContext);
 
-        var deserializedResponseBody = JsonSerializer.Deserialize<Todo>(responseBodyStream.ToArray(), new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true
-        });
+    //    var deserializedResponseBody = JsonSerializer.Deserialize<Todo>(responseBodyStream.ToArray(), new JsonSerializerOptions
+    //    {
+    //        PropertyNameCaseInsensitive = true
+    //    });
 
-        Assert.NotNull(deserializedResponseBody);
-        Assert.Equal("Write even more tests!", deserializedResponseBody!.Name);
-    }
+    //    Assert.NotNull(deserializedResponseBody);
+    //    Assert.Equal("Write even more tests!", deserializedResponseBody!.Name);
+    //}
 
     [Fact]
     public async Task RequestDelegateWritesComplexStructReturnValueAsJsonResponseBody()

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -1343,29 +1343,6 @@ public partial class RequestDelegateFactoryTests : LoggedTest
         }
     }
 
-    // TODO: Remove once test is migrated.
-    //[Theory]
-    //[MemberData(nameof(ComplexResult))]
-    //public async Task RequestDelegateWritesComplexReturnValueAsJsonResponseBody(Delegate @delegate)
-    //{
-    //    var httpContext = CreateHttpContext();
-    //    var responseBodyStream = new MemoryStream();
-    //    httpContext.Response.Body = responseBodyStream;
-
-    //    var factoryResult = RequestDelegateFactory.Create(@delegate);
-    //    var requestDelegate = factoryResult.RequestDelegate;
-
-    //    await requestDelegate(httpContext);
-
-    //    var deserializedResponseBody = JsonSerializer.Deserialize<Todo>(responseBodyStream.ToArray(), new JsonSerializerOptions
-    //    {
-    //        PropertyNameCaseInsensitive = true
-    //    });
-
-    //    Assert.NotNull(deserializedResponseBody);
-    //    Assert.Equal("Write even more tests!", deserializedResponseBody!.Name);
-    //}
-
     [Fact]
     public async Task RequestDelegateWritesComplexStructReturnValueAsJsonResponseBody()
     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTestBase.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTestBase.cs
@@ -3,7 +3,6 @@
 
 using System.Globalization;
 using System.IO.Pipelines;
-using System.Net.Http;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
@@ -11,7 +10,6 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.Http.RequestDelegateGenerator;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Testing;
@@ -22,7 +20,6 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyModel;
 using Microsoft.Extensions.DependencyModel.Resolution;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Http.Generators.Tests;
 


### PR DESCRIPTION
This PR adds a new method (`VerifyResponseJsonBodyAsync`) to the `RequestDelegateCreationTestBase` harness.  I migrated the `RequestDelegateWritesComplexReturnValueAsJsonResponseBody` test as an example but figured this might be useful so wanted to get this merged in so others could use it.