### PR TITLE
Update method modifiers to address CA1822

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/RoutePatternParser.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/RoutePatternParser.cs
@@ -373,7 +373,7 @@ internal partial struct RoutePatternParser
         }
     }
 
-    private void CollectDiagnostics(RoutePatternNode node, HashSet<EmbeddedDiagnostic> seenDiagnostics, IList<EmbeddedDiagnostic> diagnostics)
+    private static void CollectDiagnostics(RoutePatternNode node, HashSet<EmbeddedDiagnostic> seenDiagnostics, IList<EmbeddedDiagnostic> diagnostics)
     {
         foreach (var child in node)
         {

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
@@ -455,30 +455,6 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
         }
     }
 
-    private (RoutePatternNode parent, RoutePatternToken Token)? FindToken(RoutePatternNode parent, VirtualChar ch)
-    {
-        foreach (var child in parent)
-        {
-            if (child.IsNode)
-            {
-                var result = FindToken(child.Node, ch);
-                if (result != null)
-                {
-                    return result;
-                }
-            }
-            else
-            {
-                if (child.Token.VirtualChars.Contains(ch))
-                {
-                    return (parent, child.Token);
-                }
-            }
-        }
-
-        return null;
-    }
-
     private readonly struct RoutePatternItem
     {
         public readonly string DisplayText;

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternCompletionProvider.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternCompletionProvider.cs
@@ -163,7 +163,7 @@ public class RoutePatternCompletionProvider : CompletionProvider
         context.IsExclusive = true;
     }
 
-    private void ProvideCompletions(EmbeddedCompletionContext context)
+    private static void ProvideCompletions(EmbeddedCompletionContext context)
     {
         var result = GetCurrentToken(context);
         if (result == null)
@@ -216,7 +216,7 @@ public class RoutePatternCompletionProvider : CompletionProvider
         }
     }
 
-    private (RoutePatternNode Parent, RoutePatternToken Token)? GetCurrentToken(EmbeddedCompletionContext context)
+    private static (RoutePatternNode Parent, RoutePatternToken Token)? GetCurrentToken(EmbeddedCompletionContext context)
     {
         var previousVirtualCharOpt = context.RouteUsage.RoutePattern.Text.Find(context.Position - 1);
         if (previousVirtualCharOpt == null)

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternCompletionProvider.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternCompletionProvider.cs
@@ -279,7 +279,7 @@ If there are two arguments then the string length must be greater than, or equal
         }
     }
 
-    private (RoutePatternNode Parent, RoutePatternToken Token)? FindToken(RoutePatternNode parent, VirtualChar ch)
+    private static (RoutePatternNode Parent, RoutePatternToken Token)? FindToken(RoutePatternNode parent, VirtualChar ch)
     {
         foreach (var child in parent)
         {

--- a/src/Http/Routing/src/Tree/LinkGenerationDecisionTree.cs
+++ b/src/Http/Routing/src/Tree/LinkGenerationDecisionTree.cs
@@ -104,7 +104,7 @@ internal sealed class LinkGenerationDecisionTree
     //  match.
     //
     // The decision tree uses a tree data structure to execute these rules across all candidates at once.
-    private void Walk(
+    private static void Walk(
         List<OutboundMatchResult> results,
         RouteValueDictionary values,
         RouteValueDictionary ambientValues,
@@ -233,7 +233,7 @@ internal sealed class LinkGenerationDecisionTree
         }
     }
 
-    private void FlattenTree(Stack<string> branchStack, StringBuilder sb, DecisionTreeNode<OutboundMatch> node)
+    private static void FlattenTree(Stack<string> branchStack, StringBuilder sb, DecisionTreeNode<OutboundMatch> node)
     {
         // leaf node
         if (node.Criteria.Count == 0)


### PR DESCRIPTION
# Update method modifiers to address CA1822

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

When attempting to build the aspnetcore repo with the latest build of .NET 8 Preview 6 SDK, it produces the following errors:

```
/vmr/src/aspnetcore/artifacts/source-build/self/src/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/RoutePatternCompletionProvider.cs(282,65): error CA1822: Member 'FindToken' does not access instance data and can be marked as static (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822) [/vmr/src/aspnetcore/artifacts/source-build/self/src/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Microsoft.AspNetCore.App.Analyzers.csproj]
/vmr/src/aspnetcore/artifacts/source-build/self/src/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs(458,65): error CA1822: Member 'FindToken' does not access instance data and can be marked as static (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822) [/vmr/src/aspnetcore/artifacts/source-build/self/src/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Microsoft.AspNetCore.App.Analyzers.csproj]
/vmr/src/aspnetcore/artifacts/source-build/self/src/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/RoutePatternParser.cs(376,18): error CA1822: Member 'CollectDiagnostics' does not access instance data and can be marked as static (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822) [/vmr/src/aspnetcore/artifacts/source-build/self/src/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Microsoft.AspNetCore.App.Analyzers.csproj]
/vmr/src/aspnetcore/artifacts/source-build/self/src/src/Http/Routing/src/Tree/LinkGenerationDecisionTree.cs(107,18): error CA1822: Member 'Walk' does not access instance data and can be marked as static (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822) [/vmr/src/aspnetcore/artifacts/source-build/self/src/src/Http/Routing/src/Microsoft.AspNetCore.Routing.csproj]
/vmr/src/aspnetcore/artifacts/source-build/self/src/src/Http/Routing/src/Tree/LinkGenerationDecisionTree.cs(236,18): error CA1822: Member 'FlattenTree' does not access instance data and can be marked as static (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822) [/vmr/src/aspnetcore/artifacts/source-build/self/src/src/Http/Routing/src/Microsoft.AspNetCore.Routing.csproj]
```

This build scenario is required to pass for .NET source-build.

This is fixed by adding `static` to the relevant methods and removing one affected method that is not referenced.

Related issue: https://github.com/dotnet/source-build/issues/3489