### PR TITLE
Expose SNI hostname in ITlsHandshakeFeature for Kestrel/HttpSys

### DIFF
--- a/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
@@ -26,7 +26,7 @@ public interface ITlsHandshakeFeature
     TlsCipherSuite? NegotiatedCipherSuite => null;
 
     /// <summary>
-    /// Gets the host name from the "server_name" extension of the client hello if present.
+    /// Gets the host name from the "server_name" (SNI) extension of the client hello if present.
     /// See <see href="https://www.rfc-editor.org/rfc/rfc6066#section-3">RFC 6066</see>.
     /// </summary>
     string? HostName => null;

--- a/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
@@ -24,6 +24,12 @@ public interface ITlsHandshakeFeature
     /// Gets the <see cref="TlsCipherSuite"/>.
     /// </summary>
     TlsCipherSuite? NegotiatedCipherSuite => null;
+
+    /// <summary>
+    /// Gets the host name from the "server_name" extension of the client hello if present.
+    /// See <see href="https://www.rfc-editor.org/rfc/rfc6066#section-3">RFC 6066</see>.
+    /// </summary>
+    string? HostName => null;
 #endif
 
     /// <summary>

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.AspNetCore.Connections.Features.IConnectionMetricsTagsFeature
 Microsoft.AspNetCore.Connections.Features.IConnectionMetricsTagsFeature.Tags.get -> System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string!, object?>>!
 Microsoft.AspNetCore.Connections.Features.IConnectionNamedPipeFeature
 Microsoft.AspNetCore.Connections.Features.IConnectionNamedPipeFeature.NamedPipe.get -> System.IO.Pipes.NamedPipeServerStream!
+Microsoft.AspNetCore.Connections.Features.ITlsHandshakeFeature.HostName.get -> string?
 Microsoft.AspNetCore.Connections.Features.ITlsHandshakeFeature.NegotiatedCipherSuite.get -> System.Net.Security.TlsCipherSuite?
 Microsoft.AspNetCore.Connections.IConnectionListenerFactorySelector
 Microsoft.AspNetCore.Connections.IConnectionListenerFactorySelector.CanBind(System.Net.EndPoint! endpoint) -> bool

--- a/src/Servers/HttpSys/src/NativeInterop/HttpApi.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/HttpApi.cs
@@ -81,6 +81,10 @@ internal static unsafe partial class HttpApi
     internal static unsafe partial uint HttpDelegateRequestEx(SafeHandle pReqQueueHandle, SafeHandle pDelegateQueueHandle, ulong requestId,
         ulong delegateUrlGroupId, ulong propertyInfoSetSize, HTTP_DELEGATE_REQUEST_PROPERTY_INFO* pRequestPropertyBuffer);
 
+    [LibraryImport(HTTPAPI, SetLastError = true)]
+    internal static unsafe partial uint HttpQueryRequestProperty(SafeHandle requestQueueHandle, ulong requestId, HTTP_REQUEST_PROPERTY propertyId,
+        void* qualifier, ulong qualifierSize, void* output, ulong outputSize, ulong* bytesReturned, IntPtr overlapped);
+
     internal delegate uint HttpSetRequestPropertyInvoker(SafeHandle requestQueueHandle, ulong requestId, HTTP_REQUEST_PROPERTY propertyId, void* input, uint inputSize, IntPtr overlapped);
 
     private static HTTPAPI_VERSION version;

--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -327,7 +327,7 @@ internal sealed partial class Request
 
     internal WindowsPrincipal User { get; }
 
-    public string? HostName { get; private set; }
+    public string? SniHostName { get; private set; }
 
     public SslProtocols Protocol { get; private set; }
 
@@ -432,11 +432,7 @@ internal sealed partial class Request
         KeyExchangeStrength = (int)handshake.KeyExchangeStrength;
 
         var sni = RequestContext.GetClientSni();
-        var clientSentSni = !sni.Flags.HasFlag(HttpApiTypes.HTTP_REQUEST_PROPERTY_SNI_FLAGS.HTTP_REQUEST_PROPERTY_SNI_FLAG_NO_SNI);
-        if (clientSentSni)
-        {
-            HostName = sni.Hostname;
-        }
+        SniHostName = sni.Hostname;
     }
 
     public X509Certificate2? ClientCertificate

--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -327,6 +327,8 @@ internal sealed partial class Request
 
     internal WindowsPrincipal User { get; }
 
+    public string? HostName { get; private set; }
+
     public SslProtocols Protocol { get; private set; }
 
     public CipherAlgorithmType CipherAlgorithm { get; private set; }
@@ -428,6 +430,13 @@ internal sealed partial class Request
         HashStrength = (int)handshake.HashStrength;
         KeyExchangeAlgorithm = handshake.KeyExchangeType;
         KeyExchangeStrength = (int)handshake.KeyExchangeStrength;
+
+        var sni = RequestContext.GetClientSni();
+        var clientSentSni = !sni.Flags.HasFlag(HttpApiTypes.HTTP_REQUEST_PROPERTY_SNI_FLAGS.HTTP_REQUEST_PROPERTY_SNI_FLAG_NO_SNI);
+        if (clientSentSni)
+        {
+            HostName = sni.Hostname;
+        }
     }
 
     public X509Certificate2? ClientCertificate

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.FeatureCollection.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.FeatureCollection.cs
@@ -587,6 +587,8 @@ internal partial class RequestContext :
 
     int ITlsHandshakeFeature.KeyExchangeStrength => Request.KeyExchangeStrength;
 
+    string? ITlsHandshakeFeature.HostName => Request.HostName;
+
     IReadOnlyDictionary<int, ReadOnlyMemory<byte>> IHttpSysRequestInfoFeature.RequestInfo => Request.RequestInfo;
 
     ReadOnlySpan<long> IHttpSysRequestTimingFeature.Timestamps => Request.RequestTimestamps;

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.FeatureCollection.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.FeatureCollection.cs
@@ -587,7 +587,7 @@ internal partial class RequestContext :
 
     int ITlsHandshakeFeature.KeyExchangeStrength => Request.KeyExchangeStrength;
 
-    string? ITlsHandshakeFeature.HostName => Request.HostName;
+    string? ITlsHandshakeFeature.HostName => Request.SniHostName;
 
     IReadOnlyDictionary<int, ReadOnlyMemory<byte>> IHttpSysRequestInfoFeature.RequestInfo => Request.RequestInfo;
 

--- a/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
@@ -16,7 +16,6 @@ using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.HttpSys.Internal;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 

--- a/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
@@ -185,6 +185,9 @@ public class HttpsTests
 
             var keyExchangeStrength = result.GetProperty("keyExchangeStrength").GetInt32();
             Assert.True(keyExchangeStrength >= 0, "KeyExchangeStrength: " + keyExchangeStrength);
+
+            var hostName = result.GetProperty("hostName").ToString();
+            Assert.Equal("localhost", hostName);
         }
     }
 

--- a/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Data.Common;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
@@ -15,6 +16,7 @@ using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.HttpSys.Internal;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 using Microsoft.AspNetCore.Testing;
 using Xunit;
 
@@ -186,8 +188,11 @@ public class HttpsTests
             var keyExchangeStrength = result.GetProperty("keyExchangeStrength").GetInt32();
             Assert.True(keyExchangeStrength >= 0, "KeyExchangeStrength: " + keyExchangeStrength);
 
-            var hostName = result.GetProperty("hostName").ToString();
-            Assert.Equal("localhost", hostName);
+            if (Environment.OSVersion.Version > new Version(10, 0, 19043, 0))
+            {
+                var hostName = result.GetProperty("hostName").ToString();
+                Assert.Equal("localhost", hostName);
+            }
         }
     }
 

--- a/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
@@ -42,7 +42,6 @@ internal sealed class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicat
         }
     }
 
-    // Used for event source, not part of any of the feature interfaces.
     public string? HostName { get; set; }
 
     public ReadOnlyMemory<byte> ApplicationProtocol => _sslStream.NegotiatedApplicationProtocol.Protocol;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -135,6 +135,7 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
         {
             var tlsFeature = context.Features.Get<ITlsHandshakeFeature>();
             Assert.NotNull(tlsFeature);
+            Assert.NotNull(tlsFeature.HostName);
             Assert.True(tlsFeature.Protocol > SslProtocols.None, "Protocol");
             Assert.True(tlsFeature.NegotiatedCipherSuite >= TlsCipherSuite.TLS_NULL_WITH_NULL_NULL, "NegotiatedCipherSuite");
             Assert.True(tlsFeature.CipherAlgorithm > CipherAlgorithmType.Null, "Cipher");

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -126,16 +126,25 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
     [Fact]
     public async Task HandshakeDetailsAreAvailable()
     {
+        string expectedHostname = null;
         void ConfigureListenOptions(ListenOptions listenOptions)
         {
-            listenOptions.UseHttps(new HttpsConnectionAdapterOptions { ServerCertificate = _x509Certificate2 });
+            listenOptions.UseHttps(
+                new HttpsConnectionAdapterOptions
+                {
+                    ServerCertificateSelector = (connection, name) =>
+                    {
+                        expectedHostname = name;
+                        return _x509Certificate2;
+                    }
+                });
         };
 
         await using (var server = new TestServer(context =>
         {
             var tlsFeature = context.Features.Get<ITlsHandshakeFeature>();
             Assert.NotNull(tlsFeature);
-            Assert.NotNull(tlsFeature.HostName);
+            Assert.Equal(expectedHostname, tlsFeature.HostName);
             Assert.True(tlsFeature.Protocol > SslProtocols.None, "Protocol");
             Assert.True(tlsFeature.NegotiatedCipherSuite >= TlsCipherSuite.TLS_NULL_WITH_NULL_NULL, "NegotiatedCipherSuite");
             Assert.True(tlsFeature.CipherAlgorithm > CipherAlgorithmType.Null, "Cipher");

--- a/src/Shared/HttpSys/NativeInterop/HttpApiTypes.cs
+++ b/src/Shared/HttpSys/NativeInterop/HttpApiTypes.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using Microsoft.AspNetCore.Http;
@@ -106,6 +107,28 @@ internal static unsafe class HttpApiTypes
     internal struct HTTP_REQUEST_PROPERTY_STREAM_ERROR
     {
         internal uint ErrorCode;
+    }
+
+    internal const int HTTP_REQUEST_PROPERTY_SNI_HOST_MAX_LENGTH = 255;
+    internal const int SniPropertySizeInBytes = (sizeof(ushort) * (HTTP_REQUEST_PROPERTY_SNI_HOST_MAX_LENGTH + 1)) + sizeof(ulong);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode, Size = SniPropertySizeInBytes)]
+    internal struct HTTP_REQUEST_PROPERTY_SNI
+    {
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = HTTP_REQUEST_PROPERTY_SNI_HOST_MAX_LENGTH + 1)]
+        internal string Hostname;
+
+        internal HTTP_REQUEST_PROPERTY_SNI_FLAGS Flags;
+    }
+
+    [Flags]
+    internal enum HTTP_REQUEST_PROPERTY_SNI_FLAGS : uint
+    {
+        // Indicates that SNI was used for successful endpoint lookup during handshake.
+        // If client sent the SNI but Http.sys still decided to use IP endpoint binding then this flag will not be set.
+        HTTP_REQUEST_PROPERTY_SNI_FLAG_SNI_USED = 0x00000001,
+        // Indicates that client did not send the SNI.
+        HTTP_REQUEST_PROPERTY_SNI_FLAG_NO_SNI = 0x00000002,
     }
 
     internal const int MaxTimeout = 6;


### PR DESCRIPTION
# Expose SNI hostname in ITlsHandshakeFeature for Kestrel/HttpSys

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

Exposing SNI HostName in the ITlsHandshakeFeature interface.

## Description

Exposing SNI HostName in the ITlsHandshakeFeature interface to allow users to retrieve the server_name used in the ClientHello of the TLS handshake. This PR applies to both Kestrel and HttpSys servers.

Issue opened and API approved here: https://github.com/dotnet/aspnetcore/issues/34525 
