### PR TITLE
Update WebHostOptions.ShutdownTimeout to 30 seconds

### DIFF
--- a/src/Hosting/Hosting/src/Internal/WebHostOptions.cs
+++ b/src/Hosting/Hosting/src/Internal/WebHostOptions.cs
@@ -63,7 +63,7 @@ internal sealed class WebHostOptions
 
     public string? ContentRootPath { get; }
 
-    public TimeSpan ShutdownTimeout { get; } = TimeSpan.FromSeconds(5);
+    public TimeSpan ShutdownTimeout { get; } = TimeSpan.FromSeconds(30);
 
     public string? ServerUrls { get; }
 


### PR DESCRIPTION
# Update `WebHostOptions.ShutdownTimeout` to 30 seconds

Updates `WebHostOptions.ShutdownTimeout` to 30 seconds to match `Microsoft.Extensions.Hosting.HostOptions.ShutdownTimeout`

## Description

Updates `WebHostOptions.ShutdownTimeout` to 30 seconds to match `Microsoft.Extensions.Hosting.HostOptions.ShutdownTimeout`
which was changed to fix [this](https://github.com/dotnet/runtime/issues/63709) issue.

Fixes #48605
