### PR TITLE
Use FirstPipeInstance setting in named pipes transport

### DIFF
--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
@@ -198,6 +198,10 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
             var pipeOptions = NamedPipeOptions.Asynchronous | NamedPipeOptions.WriteThrough;
             if (!_hasFirstPipeStarted)
             {
+                // It's important to validate no one else is listening to pipe:
+                // 1. Some settings, such as ACL, are chosen by the first pipe to start with a given name.
+                // 2. It's easy to run two Kestrel app instances. Want to avoid two apps listening on the same pipe and creating confusion.
+                //    The second launched app instance should immediately fail with an error message, just like port binding conflicts.
                 pipeOptions |= NamedPipeOptions.FirstPipeInstance;
             }
             if (_options.CurrentUserOnly)

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
@@ -198,10 +198,10 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
             var pipeOptions = NamedPipeOptions.Asynchronous | NamedPipeOptions.WriteThrough;
             if (!_hasFirstPipeStarted)
             {
-                // It's important to validate no one else is listening to pipe:
-                // 1. Some settings, such as ACL, are chosen by the first pipe to start with a given name.
-                // 2. It's easy to run two Kestrel app instances. Want to avoid two apps listening on the same pipe and creating confusion.
-                //    The second launched app instance should immediately fail with an error message, just like port binding conflicts.
+                // The first server stream created should validate that no one else is listening with a given name.
+                // Only the first server stream should make this test. The listener will almost always create multiple streams
+                // to listen on multiple threads and to handle parallel requests. The pool policy must be updated that the
+                // setting isn't needed after the first stream.
                 pipeOptions |= NamedPipeOptions.FirstPipeInstance;
             }
             if (_options.CurrentUserOnly)

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeConnectionListener.cs
@@ -27,7 +27,7 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
     private readonly MemoryPool<byte> _memoryPool;
     private readonly PipeOptions _inputOptions;
     private readonly PipeOptions _outputOptions;
-    private readonly Mutex _mutex;
+    private readonly NamedPipeServerStreamPoolPolicy _poolPolicy;
     private Task? _completeListeningTask;
     private int _disposed;
 
@@ -35,17 +35,16 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
         NamedPipeEndPoint endpoint,
         NamedPipeTransportOptions options,
         ILoggerFactory loggerFactory,
-        ObjectPoolProvider objectPoolProvider,
-        Mutex mutex)
+        ObjectPoolProvider objectPoolProvider)
     {
         _log = loggerFactory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes");
         _endpoint = endpoint;
         _options = options;
-        _mutex = mutex;
         _memoryPool = options.MemoryPoolFactory();
         _listeningToken = _listeningTokenSource.Token;
         // Have to create the pool here (instead of DI) because the pool is specific to an endpoint.
-        _namedPipeServerStreamPool = objectPoolProvider.Create(new NamedPipeServerStreamPoolPolicy(endpoint, options));
+        _poolPolicy = new NamedPipeServerStreamPoolPolicy(endpoint, options);
+        _namedPipeServerStreamPool = objectPoolProvider.Create(_poolPolicy);
 
         // The OS maintains a backlog of clients that are waiting to connect, so the app queue only stores a single connection.
         // We want to have a queue plus a background task that populates the queue, rather than creating NamedPipeServerStream
@@ -77,6 +76,7 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
         {
             // Start first stream inline to catch creation errors.
             var initialStream = _namedPipeServerStreamPool.Get();
+            _poolPolicy.SetFirstPipeStarted();
 
             listeningTasks[i] = Task.Run(() => StartAsync(initialStream));
         }
@@ -170,7 +170,6 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
         }
 
         _listeningTokenSource.Dispose();
-        _mutex.Dispose();
         if (_completeListeningTask != null)
         {
             await _completeListeningTask;
@@ -185,6 +184,7 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
     {
         private readonly NamedPipeEndPoint _endpoint;
         private readonly NamedPipeTransportOptions _options;
+        private bool _hasFirstPipeStarted;
 
         public NamedPipeServerStreamPoolPolicy(NamedPipeEndPoint endpoint, NamedPipeTransportOptions options)
         {
@@ -196,6 +196,10 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
         {
             NamedPipeServerStream stream;
             var pipeOptions = NamedPipeOptions.Asynchronous | NamedPipeOptions.WriteThrough;
+            if (!_hasFirstPipeStarted)
+            {
+                pipeOptions |= NamedPipeOptions.FirstPipeInstance;
+            }
             if (_options.CurrentUserOnly)
             {
                 pipeOptions |= NamedPipeOptions.CurrentUserOnly;
@@ -228,5 +232,10 @@ internal sealed class NamedPipeConnectionListener : IConnectionListener
         }
 
         public bool Return(NamedPipeServerStream obj) => !obj.IsConnected;
+
+        public void SetFirstPipeStarted()
+        {
+            _hasFirstPipeStarted = true;
+        }
     }
 }

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeTransportFactory.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeTransportFactory.cs
@@ -46,6 +46,13 @@ internal sealed class NamedPipeTransportFactory : IConnectionListenerFactory, IC
         }
 
         var listener = new NamedPipeConnectionListener(namedPipeEndPoint, _options, _loggerFactory, _objectPoolProvider);
+
+        // Start the listener and create NamedPipeServerStream instances immediately.
+        // The first server stream is created with the FirstPipeInstance flag. The FirstPipeInstance flag ensures
+        // that no other apps have a running pipe with the configured name. This check is important because:
+        // 1. Some settings, such as ACL, are chosen by the first pipe to start with a given name.
+        // 2. It's easy to run two Kestrel app instances. Want to avoid two apps listening on the same pipe and creating confusion.
+        //    The second launched app instance should immediately fail with an error message, just like port binding conflicts.
         try
         {
             listener.Start();

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeTransportFactory.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/Internal/NamedPipeTransportFactory.cs
@@ -59,7 +59,7 @@ internal sealed class NamedPipeTransportFactory : IConnectionListenerFactory, IC
         }
         catch (UnauthorizedAccessException ex)
         {
-            throw new AddressInUseException($"Named pipe '{namedPipeEndPoint.PipeName}' is already in use by Kestrel.", ex);
+            throw new AddressInUseException($"Named pipe '{namedPipeEndPoint.PipeName}' is already in use.", ex);
         }
 
         return new ValueTask<IConnectionListener>(listener);


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/14207

Use [new FirstPipeInstance setting](https://github.com/dotnet/runtime/issues/76984) in named pipes transport.

Works well. FYI @Jozkee @adamsitnik @jeffhandley