### PR TITLE
Handle methods that never return in Api Analyzers

### DIFF
--- a/src/Mvc/Mvc.Api.Analyzers/src/ActualApiResponseMetadataFactory.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/src/ActualApiResponseMetadataFactory.cs
@@ -74,15 +74,15 @@ public static class ActualApiResponseMetadataFactory
 
         var statementReturnType = returnedValue.Type;
 
-        if (!symbolCache.IActionResult.IsAssignableFrom(statementReturnType))
+        if (statementReturnType is not null && !symbolCache.IActionResult.IsAssignableFrom(statementReturnType))
         {
             // Return expression is not an instance of IActionResult. Must be returning the "model".
             return new ActualApiResponseMetadata(returnOperation, statementReturnType);
         }
 
         var defaultStatusCodeAttribute = statementReturnType
-            .GetAttributes(defaultStatusCodeAttributeSymbol, inherit: true)
-            .FirstOrDefault();
+            ?.GetAttributes(defaultStatusCodeAttributeSymbol, inherit: true)
+            ?.FirstOrDefault();
 
         // If the type is not annotated with a default status code, then examine
         // the attributes on any invoked method returning the type.
@@ -225,7 +225,7 @@ public static class ActualApiResponseMetadataFactory
         return false;
     }
 
-    internal static int? GetDefaultStatusCode(AttributeData attribute)
+    internal static int? GetDefaultStatusCode(AttributeData? attribute)
     {
         if (attribute != null &&
             attribute.ConstructorArguments.Length == 1 &&

--- a/src/Mvc/Mvc.Api.Analyzers/test/ApiConventionAnalyzerIntegrationTest.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/ApiConventionAnalyzerIntegrationTest.cs
@@ -41,6 +41,10 @@ public class ApiConventionAnalyzerIntegrationTest
         => RunNoDiagnosticsAreReturned();
 
     [Fact]
+    public Task NoDiagnosticsAreReturned_ForApiController_WhenMethodNeverReturns()
+        => RunNoDiagnosticsAreReturned();
+
+    [Fact]
     public async Task DiagnosticsAreReturned_ForIncompleteActionResults()
     {
         // Arrange

--- a/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForApiController_WhenMethodNeverReturns.cs
+++ b/src/Mvc/Mvc.Api.Analyzers/test/TestFiles/ApiConventionAnalyzerIntegrationTest/NoDiagnosticsAreReturned_ForApiController_WhenMethodNeverReturns.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Mvc.Api.Analyzers;
+
+using System;
+
+[ApiController]
+[Route("[controller]/[action]")]
+public class NoDiagnosticsAreReturned_ForApiController_WhenMethodNeverReturns : ControllerBase
+{
+    public IActionResult GetItem() => throw new NotImplementedException();
+}


### PR DESCRIPTION
# Handle methods that never return in Api Analyzers

## Description
Fixes a null ref when an action method always throws and has no return statement.

Fixes #48528