### PR TITLE
Minor debugging visualizer cleanup

### DIFF
--- a/src/Http/Http.Abstractions/src/ConnectionInfo.cs
+++ b/src/Http/Http.Abstractions/src/ConnectionInfo.cs
@@ -64,7 +64,13 @@ public abstract class ConnectionInfo
     {
         var remoteEndpoint = RemoteIpAddress == null ? "(null)" : new IPEndPoint(RemoteIpAddress, RemotePort).ToString();
         var localEndpoint = LocalIpAddress == null ? "(null)" : new IPEndPoint(LocalIpAddress, LocalPort).ToString();
-        return $"Id = {Id ?? "(null)"}, Remote = {remoteEndpoint}, Local = {localEndpoint}, ClientCertificate = {ClientCertificate?.Subject ?? "(null)"}";
+
+        var s = $"Id = {Id ?? "(null)"}, Remote = {remoteEndpoint}, Local = {localEndpoint}";
+        if (ClientCertificate != null)
+        {
+            s += $", ClientCertificate = {ClientCertificate.Subject}";
+        }
+        return s;
     }
 
     private sealed class ConnectionInfoDebugView(ConnectionInfo info)

--- a/src/Http/Http.Abstractions/src/WebSocketManager.cs
+++ b/src/Http/Http.Abstractions/src/WebSocketManager.cs
@@ -50,8 +50,8 @@ public abstract class WebSocketManager
     {
         return IsWebSocketRequest switch
         {
-            false => "IsWebSocketRequest = False",
-            true => $"IsWebSocketRequest = True, RequestedProtocols = {string.Join(",", WebSocketRequestedProtocols)}",
+            false => "IsWebSocketRequest = false",
+            true => $"IsWebSocketRequest = true, RequestedProtocols = {string.Join(",", WebSocketRequestedProtocols)}",
         };
     }
 


### PR DESCRIPTION
* Only display client certificate if present. Most apps don't use client certificates
* Boolean is lowercase in debug strings. Make web socket DebuggerToString consistent.