### PR TITLE
Add routing metrics

### DIFF
--- a/src/Http/Routing/perf/Microbenchmarks/EndpointRoutingShortCircuitBenchmark.cs
+++ b/src/Http/Routing/perf/Microbenchmarks/EndpointRoutingShortCircuitBenchmark.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.AspNetCore.Routing.ShortCircuit;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
@@ -21,6 +22,7 @@ public class EndpointRoutingShortCircuitBenchmark
     [GlobalSetup]
     public void Setup()
     {
+        var routingMetrics = new RoutingMetrics(new TestMeterFactory());
         var normalEndpoint = new Endpoint(context => Task.CompletedTask, new EndpointMetadataCollection(), "normal");
 
         _normalEndpointMiddleware = new EndpointRoutingMiddleware(
@@ -30,6 +32,7 @@ public class EndpointRoutingShortCircuitBenchmark
             new BenchmarkEndpointDataSource(),
             new DiagnosticListener("benchmark"),
             Options.Create(new RouteOptions()),
+            routingMetrics,
             context => Task.CompletedTask);
 
         var shortCircuitEndpoint = new Endpoint(context => Task.CompletedTask, new EndpointMetadataCollection(new ShortCircuitMetadata(200)), "shortcircuit");
@@ -41,8 +44,8 @@ public class EndpointRoutingShortCircuitBenchmark
             new BenchmarkEndpointDataSource(),
             new DiagnosticListener("benchmark"),
             Options.Create(new RouteOptions()),
+            routingMetrics,
             context => Task.CompletedTask);
-
     }
 
     [Benchmark]

--- a/src/Http/Routing/perf/Microbenchmarks/Microsoft.AspNetCore.Routing.Microbenchmarks.csproj
+++ b/src/Http/Routing/perf/Microbenchmarks/Microsoft.AspNetCore.Routing.Microbenchmarks.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
@@ -31,6 +31,7 @@
     <Compile Include="..\..\test\UnitTests\Matching\TreeRouterMatcherBuilder.cs">
       <Link>Matching\TreeRouterMatcherBuilder.cs</Link>
     </Compile>
+    <Compile Include="$(SharedSourceRoot)Metrics\TestMeterFactory.cs" LinkBase="shared" />
     <Compile Include="..\..\test\UnitTests\TestObjects\TestServiceProvider.cs" Link="Matching\TestServiceProvider.cs" />
   </ItemGroup>
 
@@ -39,6 +40,7 @@
     <Reference Include="Microsoft.AspNetCore.Http" />
     <Reference Include="Microsoft.AspNetCore.Routing" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Reference Include="Microsoft.Extensions.Diagnostics" />
     <Reference Include="Microsoft.Extensions.Logging" />
 
     <Compile Include="$(SharedSourceRoot)BenchmarkRunner\*.cs" />

--- a/src/Http/Routing/src/DependencyInjection/RoutingServiceCollectionExtensions.cs
+++ b/src/Http/Routing/src/DependencyInjection/RoutingServiceCollectionExtensions.cs
@@ -108,6 +108,7 @@ public static class RoutingServiceCollectionExtensions
         //
         services.TryAddSingleton<TemplateBinderFactory, DefaultTemplateBinderFactory>();
         services.TryAddSingleton<RoutePatternTransformer, DefaultRoutePatternTransformer>();
+        services.TryAddSingleton<RoutingMetrics>();
 
         // Set RouteHandlerOptions.ThrowOnBadRequest in development
         services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<RouteHandlerOptions>, ConfigureRouteHandlerOptions>());

--- a/src/Http/Routing/src/EndpointRoutingMiddleware.cs
+++ b/src/Http/Routing/src/EndpointRoutingMiddleware.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.AspNetCore.Routing.ShortCircuit;
 using Microsoft.Extensions.Logging;
@@ -22,6 +23,7 @@ internal sealed partial class EndpointRoutingMiddleware
     private readonly ILogger _logger;
     private readonly EndpointDataSource _endpointDataSource;
     private readonly DiagnosticListener _diagnosticListener;
+    private readonly RoutingMetrics _metrics;
     private readonly RequestDelegate _next;
     private readonly RouteOptions _routeOptions;
     private Task<Matcher>? _initializationTask;
@@ -33,6 +35,7 @@ internal sealed partial class EndpointRoutingMiddleware
         EndpointDataSource rootCompositeEndpointDataSource,
         DiagnosticListener diagnosticListener,
         IOptions<RouteOptions> routeOptions,
+        RoutingMetrics metrics,
         RequestDelegate next)
     {
         ArgumentNullException.ThrowIfNull(endpointRouteBuilder);
@@ -40,6 +43,7 @@ internal sealed partial class EndpointRoutingMiddleware
         _matcherFactory = matcherFactory ?? throw new ArgumentNullException(nameof(matcherFactory));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _diagnosticListener = diagnosticListener ?? throw new ArgumentNullException(nameof(diagnosticListener));
+        _metrics = metrics;
         _next = next ?? throw new ArgumentNullException(nameof(next));
         _routeOptions = routeOptions.Value;
 
@@ -98,6 +102,7 @@ internal sealed partial class EndpointRoutingMiddleware
         if (endpoint == null)
         {
             Log.MatchFailure(_logger);
+            _metrics.MatchFailure();
         }
         else
         {
@@ -107,12 +112,21 @@ internal sealed partial class EndpointRoutingMiddleware
                 Write(_diagnosticListener, httpContext);
             }
 
-            Log.MatchSuccess(_logger, endpoint);
-
-            if (_logger.IsEnabled(LogLevel.Debug)
-                && endpoint.Metadata.GetMetadata<FallbackMetadata>() is not null)
+            if (_logger.IsEnabled(LogLevel.Debug) || _metrics.MatchSuccessCounterEnabled)
             {
-                Log.FallbackMatch(_logger, endpoint);
+                var isFallback = endpoint.Metadata.GetMetadata<FallbackMetadata>() is not null;
+
+                Log.MatchSuccess(_logger, endpoint);
+
+                if (isFallback)
+                {
+                    Log.FallbackMatch(_logger, endpoint);
+                }
+
+                // It shouldn't be possible for a route to be matched via the route matcher and not have a route.
+                // Just in case, add a special (unknown) value as the route tag to metrics.
+                var route = endpoint.Metadata.GetMetadata<IRouteDiagnosticsMetadata>()?.Route ?? "(unknown)";
+                _metrics.MatchSuccess(route, isFallback);
             }
 
             var shortCircuitMetadata = endpoint.Metadata.GetMetadata<ShortCircuitMetadata>();
@@ -290,7 +304,7 @@ internal sealed partial class EndpointRoutingMiddleware
         [LoggerMessage(6, LogLevel.Information, "The endpoint '{EndpointName}' is being short circuited without running additional middleware or producing a response.", EventName = "ShortCircuitedEndpoint")]
         public static partial void ShortCircuitedEndpoint(ILogger logger, Endpoint endpointName);
 
-        [LoggerMessage(7, LogLevel.Debug, "Matched endpoint '{EndpointName}' is a fallback endpoint.", EventName = "FallbackMatch", SkipEnabledCheck = true)]
+        [LoggerMessage(7, LogLevel.Debug, "Matched endpoint '{EndpointName}' is a fallback endpoint.", EventName = "FallbackMatch")]
         public static partial void FallbackMatch(ILogger logger, Endpoint endpointName);
     }
 }

--- a/src/Http/Routing/src/EndpointRoutingMiddleware.cs
+++ b/src/Http/Routing/src/EndpointRoutingMiddleware.cs
@@ -124,8 +124,8 @@ internal sealed partial class EndpointRoutingMiddleware
                 }
 
                 // It shouldn't be possible for a route to be matched via the route matcher and not have a route.
-                // Just in case, add a special (unknown) value as the route tag to metrics.
-                var route = endpoint.Metadata.GetMetadata<IRouteDiagnosticsMetadata>()?.Route ?? "(unknown)";
+                // Just in case, add a special (missing) value as the route tag to metrics.
+                var route = endpoint.Metadata.GetMetadata<IRouteDiagnosticsMetadata>()?.Route ?? "(missing)";
                 _metrics.MatchSuccess(route, isFallback);
             }
 

--- a/src/Http/Routing/src/Microsoft.AspNetCore.Routing.csproj
+++ b/src/Http/Routing/src/Microsoft.AspNetCore.Routing.csproj
@@ -42,6 +42,7 @@
     <Reference Include="Microsoft.AspNetCore.Authorization" />
     <Reference Include="Microsoft.AspNetCore.Http.Extensions" />
     <Reference Include="Microsoft.AspNetCore.Routing.Abstractions" />
+    <Reference Include="Microsoft.Extensions.Diagnostics.Abstractions" />
     <Reference Include="Microsoft.Extensions.ObjectPool" />
     <Reference Include="Microsoft.Extensions.Options" />
   </ItemGroup>

--- a/src/Http/Routing/src/RoutingMetrics.cs
+++ b/src/Http/Routing/src/RoutingMetrics.cs
@@ -22,11 +22,11 @@ internal sealed class RoutingMetrics
 
         _matchSuccessCounter = _meter.CreateCounter<long>(
            "routing-match-success",
-            description: "Number of connections rejected by the server. Connections are rejected when the currently active count exceeds the value configured with MaxConcurrentConnections.");
+            description: "Number of requests successfully matched to an endpoint by routing.");
 
         _matchFailureCounter = _meter.CreateCounter<long>(
            "routing-match-failure",
-            description: "Number of connections rejected by the server. Connections are rejected when the currently active count exceeds the value configured with MaxConcurrentConnections.");
+            description: "Number of requests that failed to match to an endpoint by routing.");
     }
 
     public bool MatchSuccessCounterEnabled => _matchSuccessCounter.Enabled;

--- a/src/Http/Routing/src/RoutingMetrics.cs
+++ b/src/Http/Routing/src/RoutingMetrics.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Diagnostics.Metrics;
-using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Diagnostics.Metrics;
 
 namespace Microsoft.AspNetCore.Routing;

--- a/src/Http/Routing/src/RoutingMetrics.cs
+++ b/src/Http/Routing/src/RoutingMetrics.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Diagnostics.Metrics;
+
+namespace Microsoft.AspNetCore.Routing;
+
+internal sealed class RoutingMetrics
+{
+    public const string MeterName = "Microsoft.AspNetCore.Routing";
+
+    private readonly Meter _meter;
+    private readonly Counter<long> _matchSuccessCounter;
+    private readonly Counter<long> _matchFailureCounter;
+
+    public RoutingMetrics(IMeterFactory meterFactory)
+    {
+        _meter = meterFactory.Create(MeterName);
+
+        _matchSuccessCounter = _meter.CreateCounter<long>(
+           "routing-match-success",
+            description: "Number of connections rejected by the server. Connections are rejected when the currently active count exceeds the value configured with MaxConcurrentConnections.");
+
+        _matchFailureCounter = _meter.CreateCounter<long>(
+           "routing-match-failure",
+            description: "Number of connections rejected by the server. Connections are rejected when the currently active count exceeds the value configured with MaxConcurrentConnections.");
+    }
+
+    public bool MatchSuccessCounterEnabled => _matchSuccessCounter.Enabled;
+
+    public void MatchSuccess(string route, bool isFallback)
+    {
+        _matchSuccessCounter.Add(1,
+            new KeyValuePair<string, object?>("route", route),
+            new KeyValuePair<string, object?>("fallback", isFallback));
+    }
+
+    public void MatchFailure()
+    {
+        _matchFailureCounter.Add(1);
+    }
+}

--- a/src/Http/Routing/src/RoutingMetrics.cs
+++ b/src/Http/Routing/src/RoutingMetrics.cs
@@ -20,11 +20,11 @@ internal sealed class RoutingMetrics
 
         _matchSuccessCounter = _meter.CreateCounter<long>(
            "routing-match-success",
-            description: "Number of requests successfully matched to an endpoint by routing.");
+            description: "Number of requests that successfully matched to an endpoint.");
 
         _matchFailureCounter = _meter.CreateCounter<long>(
            "routing-match-failure",
-            description: "Number of requests that failed to match to an endpoint by routing.");
+            description: "Number of requests that failed to match to an endpoint.");
     }
 
     public bool MatchSuccessCounterEnabled => _matchSuccessCounter.Enabled;

--- a/src/Http/Routing/src/RoutingMetrics.cs
+++ b/src/Http/Routing/src/RoutingMetrics.cs
@@ -24,7 +24,7 @@ internal sealed class RoutingMetrics
 
         _matchFailureCounter = _meter.CreateCounter<long>(
            "routing-match-failure",
-            description: "Number of requests that failed to match to an endpoint.");
+            description: "Number of requests that failed to match to an endpoint. An unmatched request may be handled by later middleware, such as the static files or authentication middleware.");
     }
 
     public bool MatchSuccessCounterEnabled => _matchSuccessCounter.Enabled;

--- a/src/Http/Routing/test/UnitTests/Builder/EndpointRoutingApplicationBuilderExtensionsTest.cs
+++ b/src/Http/Routing/test/UnitTests/Builder/EndpointRoutingApplicationBuilderExtensionsTest.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.AspNetCore.Routing.TestObjects;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -354,6 +355,7 @@ public class EndpointRoutingApplicationBuilderExtensionsTest
             services.AddSingleton<MatcherFactory>(matcherFactory);
         }
 
+        services.AddMetrics();
         services.AddLogging();
         services.AddOptions();
         services.AddRouting();

--- a/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
+++ b/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.AspNetCore.Routing.TestObjects;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
@@ -90,7 +91,6 @@ public class EndpointRoutingMiddlewareTest
     {
         // Arrange
         var httpContext = CreateHttpContext();
-
         var middleware = CreateMiddleware();
 
         // Act
@@ -282,6 +282,7 @@ public class EndpointRoutingMiddlewareTest
         logger ??= new Logger<EndpointRoutingMiddleware>(NullLoggerFactory.Instance);
         matcherFactory ??= new TestMatcherFactory(true);
         listener ??= new DiagnosticListener("Microsoft.AspNetCore");
+        var metrics = new RoutingMetrics(new TestMeterFactory());
 
         var middleware = new EndpointRoutingMiddleware(
             matcherFactory,
@@ -290,6 +291,7 @@ public class EndpointRoutingMiddlewareTest
             new DefaultEndpointDataSource(),
             listener,
             Options.Create(new RouteOptions()),
+            metrics,
             next);
 
         return middleware;

--- a/src/Http/Routing/test/UnitTests/Microsoft.AspNetCore.Routing.Tests.csproj
+++ b/src/Http/Routing/test/UnitTests/Microsoft.AspNetCore.Routing.Tests.csproj
@@ -12,9 +12,12 @@
     <Reference Include="Microsoft.AspNetCore.Routing" />
     <Reference Include="Microsoft.AspNetCore.Http.Results" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Reference Include="Microsoft.Extensions.Diagnostics" />
     <Reference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="Microsoft.Extensions.WebEncoders" />
+
+    <Compile Include="$(SharedSourceRoot)Metrics\TestMeterFactory.cs" LinkBase="shared" />
   </ItemGroup>
 
 </Project>

--- a/src/Http/Routing/test/UnitTests/RoutingMetricsTests.cs
+++ b/src/Http/Routing/test/UnitTests/RoutingMetricsTests.cs
@@ -1,0 +1,146 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing.Matching;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.AspNetCore.Routing.TestObjects;
+using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.Diagnostics.Metrics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Microsoft.AspNetCore.Routing;
+
+public class RoutingMetricsTests
+{
+    [Fact]
+    public async Task Match_Success()
+    {
+        // Arrange
+        var routeEndpointBuilder = new RouteEndpointBuilder(c => Task.CompletedTask, RoutePatternFactory.Parse("/{hi}"), order: 0);
+        var meterFactory = new TestMeterFactory();
+        var middleware = CreateMiddleware(
+            matcherFactory: new TestMatcherFactory(true, c =>
+            {
+                c.SetEndpoint(routeEndpointBuilder.Build());
+            }),
+            meterFactory: meterFactory);
+        var httpContext = new DefaultHttpContext();
+        var meter = meterFactory.Meters.Single();
+
+        using var routingMatchSuccessRecorder = new InstrumentRecorder<long>(meterFactory, RoutingMetrics.MeterName, "routing-match-success");
+        using var routingMatchFailureRecorder = new InstrumentRecorder<long>(meterFactory, RoutingMetrics.MeterName, "routing-match-failure");
+
+        // Act
+        await middleware.Invoke(httpContext);
+
+        // Assert
+        Assert.Equal(RoutingMetrics.MeterName, meter.Name);
+        Assert.Null(meter.Version);
+
+        Assert.Collection(routingMatchSuccessRecorder.GetMeasurements(),
+            m => AssertSuccess(m, "/{hi}", fallback: false));
+        Assert.Empty(routingMatchFailureRecorder.GetMeasurements());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Match_SuccessFallback_SetTagIfPresent(bool hasFallbackMetadata)
+    {
+        // Arrange
+        var routeEndpointBuilder = new RouteEndpointBuilder(c => Task.CompletedTask, RoutePatternFactory.Parse("/{hi}"), order: 0);
+        if (hasFallbackMetadata)
+        {
+            routeEndpointBuilder.Metadata.Add(FallbackMetadata.Instance);
+        }
+        var meterFactory = new TestMeterFactory();
+        var middleware = CreateMiddleware(
+            matcherFactory: new TestMatcherFactory(true, c =>
+            {
+                c.SetEndpoint(routeEndpointBuilder.Build());
+            }),
+            meterFactory: meterFactory);
+        var httpContext = new DefaultHttpContext();
+        var meter = meterFactory.Meters.Single();
+
+        using var routingMatchSuccessRecorder = new InstrumentRecorder<long>(meterFactory, RoutingMetrics.MeterName, "routing-match-success");
+        using var routingMatchFailureRecorder = new InstrumentRecorder<long>(meterFactory, RoutingMetrics.MeterName, "routing-match-failure");
+
+        // Act
+        await middleware.Invoke(httpContext);
+
+        // Assert
+        Assert.Equal(RoutingMetrics.MeterName, meter.Name);
+        Assert.Null(meter.Version);
+
+        Assert.Collection(routingMatchSuccessRecorder.GetMeasurements(),
+            m => AssertSuccess(m, "/{hi}", fallback: hasFallbackMetadata));
+        Assert.Empty(routingMatchFailureRecorder.GetMeasurements());
+    }
+
+    [Fact]
+    public async Task Match_Failure()
+    {
+        // Arrange
+        var meterFactory = new TestMeterFactory();
+        var middleware = CreateMiddleware(
+            matcherFactory: new TestMatcherFactory(false),
+            meterFactory: meterFactory);
+        var httpContext = new DefaultHttpContext();
+        var meter = meterFactory.Meters.Single();
+
+        using var routingMatchSuccessRecorder = new InstrumentRecorder<long>(meterFactory, RoutingMetrics.MeterName, "routing-match-success");
+        using var routingMatchFailureRecorder = new InstrumentRecorder<long>(meterFactory, RoutingMetrics.MeterName, "routing-match-failure");
+
+        // Act
+        await middleware.Invoke(httpContext);
+
+        // Assert
+        Assert.Equal(RoutingMetrics.MeterName, meter.Name);
+        Assert.Null(meter.Version);
+
+        Assert.Empty(routingMatchSuccessRecorder.GetMeasurements());
+        Assert.Collection(routingMatchFailureRecorder.GetMeasurements(),
+            m => Assert.Equal(1, m.Value));
+    }
+
+    private void AssertSuccess(Measurement<long> measurement, string route, bool fallback)
+    {
+        Assert.Equal(1, measurement.Value);
+        Assert.Equal(route, (string)measurement.Tags.ToArray().Single(t => t.Key == "route").Value);
+        Assert.Equal(fallback, (bool)measurement.Tags.ToArray().Single(t => t.Key == "fallback").Value);
+    }
+
+    private EndpointRoutingMiddleware CreateMiddleware(
+        ILogger<EndpointRoutingMiddleware> logger = null,
+        MatcherFactory matcherFactory = null,
+        DiagnosticListener listener = null,
+        IMeterFactory meterFactory = null,
+        RequestDelegate next = null)
+    {
+        next ??= c => Task.CompletedTask;
+        logger ??= new Logger<EndpointRoutingMiddleware>(NullLoggerFactory.Instance);
+        matcherFactory ??= new TestMatcherFactory(true);
+        listener ??= new DiagnosticListener("Microsoft.AspNetCore");
+        var metrics = new RoutingMetrics(meterFactory ?? new TestMeterFactory());
+
+        var middleware = new EndpointRoutingMiddleware(
+            matcherFactory,
+            logger,
+            new DefaultEndpointRouteBuilder(Mock.Of<IApplicationBuilder>()),
+            new DefaultEndpointDataSource(),
+            listener,
+            Options.Create(new RouteOptions()),
+            metrics,
+            next);
+
+        return middleware;
+    }
+}

--- a/src/Mvc/Mvc/test/Microsoft.AspNetCore.Mvc.Test.csproj
+++ b/src/Mvc/Mvc/test/Microsoft.AspNetCore.Mvc.Test.csproj
@@ -13,5 +13,6 @@
     <Reference Include="Microsoft.AspNetCore.Mvc" />
     <Reference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" />
     <Reference Include="Microsoft.Extensions.Logging" />
+    <Reference Include="Microsoft.Extensions.Diagnostics" />
   </ItemGroup>
 </Project>

--- a/src/Mvc/Mvc/test/MvcServiceCollectionExtensionsTest.cs
+++ b/src/Mvc/Mvc/test/MvcServiceCollectionExtensionsTest.cs
@@ -25,6 +25,7 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures.Filters;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -382,6 +383,7 @@ public class MvcServiceCollectionExtensionsTest
         services.AddSingleton<DiagnosticSource>(diagnosticListener);
         services.AddSingleton<DiagnosticListener>(diagnosticListener);
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddMetrics();
         services.AddLogging();
         services.AddOptions();
         services.AddMvc();


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/46404

Note that the route is still added as a tag to the hosting HTTP request counter. The intent of the new routing counters is to provide additional detail:

* Request successfully matched (available today)
* Request successfully matched to a fallback route
* Request failed to match a route

Ready for review but blocked on merging until API review of counter names/description is done.