### PR TITLE
Added ppc64le architecture to support testcases on power machine. 

### DIFF
--- a/src/Hosting/Server.IntegrationTesting/src/Common/RuntimeArchitecture.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/RuntimeArchitecture.cs
@@ -7,5 +7,6 @@ public enum RuntimeArchitecture
 {
     arm64,
     x64,
-    x86
+    x86,
+    ppc64le
 }

--- a/src/Hosting/Server.IntegrationTesting/src/Common/RuntimeArchitecture.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/RuntimeArchitecture.cs
@@ -8,5 +8,5 @@ public enum RuntimeArchitecture
     arm64,
     x64,
     x86,
-    ppc64le
+    ppc64le //Power Architecture
 }

--- a/src/Hosting/Server.IntegrationTesting/src/Common/RuntimeArchitectures.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/RuntimeArchitectures.cs
@@ -16,6 +16,7 @@ public class RuntimeArchitectures
                 Architecture.Arm64 => RuntimeArchitecture.arm64,
                 Architecture.X64 => RuntimeArchitecture.x64,
                 Architecture.X86 => RuntimeArchitecture.x86,
+		Architecture.Ppc64le => RuntimeArchitecture.ppc64le,
                 _ => throw new NotImplementedException($"Unknown RuntimeInformation.OSArchitecture: {RuntimeInformation.OSArchitecture.ToString()}"),
             };
         }

--- a/src/Hosting/Server.IntegrationTesting/src/Common/RuntimeArchitectures.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/RuntimeArchitectures.cs
@@ -16,7 +16,7 @@ public class RuntimeArchitectures
                 Architecture.Arm64 => RuntimeArchitecture.arm64,
                 Architecture.X64 => RuntimeArchitecture.x64,
                 Architecture.X86 => RuntimeArchitecture.x86,
-		Architecture.Ppc64le => RuntimeArchitecture.ppc64le,
+                Architecture.Ppc64le => RuntimeArchitecture.ppc64le,
                 _ => throw new NotImplementedException($"Unknown RuntimeInformation.OSArchitecture: {RuntimeInformation.OSArchitecture.ToString()}"),
             };
         }


### PR DESCRIPTION
Some testcases were failing with "unknown architecture ppc64le" error.
Below testcases were failing due to missing ppc64le architecture.
1. Microsoft.AspNetCore.FunctionalTests.dll
2. Microsoft.AspNetCore.Hosting.FunctionalTests.dll
3. ServerComparison.FunctionalTests.dll

So, we have added the power architecture to support those testcases.
Now all the testcases related to power architecture are passing.