### PR TITLE
[skip-ci]Add links to video for contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 One of the easiest ways to contribute is to participate in discussions on GitHub issues. You can also contribute by submitting pull requests with code changes.
 
+Here are videos where members of the AspNetCore Team provide guidance, advice and samples on how to contribute to this project.
+* For ASP.NET Core - https://www.youtube.com/watch?v=hVdwb41FPvU
+* For Blazor - https://www.youtube.com/watch?v=gRg0xxK8L6w
+
 ## General feedback and discussions?
 
 Start a discussion on the [repository issue tracker](https://github.com/dotnet/aspnetcore/issues).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,6 @@
 
 One of the easiest ways to contribute is to participate in discussions on GitHub issues. You can also contribute by submitting pull requests with code changes.
 
-Here are videos where members of the AspNetCore Team provide guidance, advice and samples on how to contribute to this project.
-* For ASP.NET Core - https://www.youtube.com/watch?v=hVdwb41FPvU
-* For Blazor - https://www.youtube.com/watch?v=gRg0xxK8L6w
-
 ## General feedback and discussions?
 
 Start a discussion on the [repository issue tracker](https://github.com/dotnet/aspnetcore/issues).
@@ -115,6 +111,12 @@ Your pull request will now go through extensive checks by the subject matter exp
 When your pull request has had all feedback addressed, it has been signed off by one or more reviewers with commit access, and all checks are green, we will commit it.
 
 We commit pull requests as a single Squash commit unless there are special circumstances. This creates a simpler history than a Merge or Rebase commit. "Special circumstances" are rare, and typically mean that there are a series of cleanly separated changes that will be too hard to understand if squashed together, or for some reason we want to preserve the ability to bisect them.
+
+## Additional Resources
+
+Here are videos (partially outdated) where members of the ASP.NET Core team provide guidance, advice and samples on how to contribute to this project.
+* For ASP.NET Core - https://www.youtube.com/watch?v=hVdwb41FPvU
+* For Blazor - https://www.youtube.com/watch?v=gRg0xxK8L6w
 
 ## Code of conduct
 


### PR DESCRIPTION
# Update CONTRIBUTING.md

## Description

Adds links to community standup videos covering project setup and workflow guidelines. These videos helped me in understanding the repo and thought it might also help someone who is looking to start contributing. We have it in EF repo ([here](https://github.com/dotnet/efcore/blob/main/.github/CONTRIBUTING.md)) as well.