### PR TITLE
Add diagnostics exception handling metrics

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingApplication.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplication.cs
@@ -160,7 +160,7 @@ internal sealed class HostingApplication : IHttpApplication<HostingApplication.C
             StartTimestamp = 0;
             HasDiagnosticListener = false;
             EventLogOrMetricsEnabled = false;
-            MetricsTagsFeature?.Tags.Clear();
+            MetricsTagsFeature?.TagsList.Clear();
         }
     }
 }

--- a/src/Hosting/Hosting/src/Internal/HttpMetricsTagsFeature.cs
+++ b/src/Hosting/Hosting/src/Internal/HttpMetricsTagsFeature.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNetCore.Hosting;
 
 internal sealed class HttpMetricsTagsFeature : IHttpMetricsTagsFeature
 {
-    public ICollection<KeyValuePair<string, object?>> Tags => TagsList;
+    ICollection<KeyValuePair<string, object?>> IHttpMetricsTagsFeature.Tags => TagsList;
 
     public List<KeyValuePair<string, object?>> TagsList { get; } = new List<KeyValuePair<string, object?>>();
 }

--- a/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/DeveloperExceptionPage/DeveloperExceptionPageMiddleware.cs
@@ -41,6 +41,7 @@ public class DeveloperExceptionPageMiddleware
             hostingEnvironment,
             diagnosticSource,
             filters,
+            new DummyMeterFactory(),
             problemDetailsService: null);
     }
 

--- a/src/Middleware/Diagnostics/src/DiagnosticsMetrics.cs
+++ b/src/Middleware/Diagnostics/src/DiagnosticsMetrics.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Diagnostics.Metrics;
+
+namespace Microsoft.AspNetCore.Diagnostics;
+
+// There are multiple instances of this metrics type. Each middleware creates an instance because there isn't a central place to register it in DI.
+// Multiple instances is ok because the meter and counter names are consistent.
+// DefaultMeterFactory caches instances meters by name, and meter caches instances of counters by name.
+internal sealed class DiagnosticsMetrics
+{
+    public const string MeterName = "Microsoft.AspNetCore.Diagnostics";
+
+    private readonly Meter _meter;
+    private readonly Counter<long> _handlerExceptionCounter;
+
+    public DiagnosticsMetrics(IMeterFactory meterFactory)
+    {
+        _meter = meterFactory.Create(MeterName);
+
+        _handlerExceptionCounter = _meter.CreateCounter<long>(
+           "diagnostics-handler-exception",
+            description: "Number of exceptions caught by exception handling middleware.");
+    }
+
+    public void RequestException(string exceptionName, ExceptionResult result, string? handler)
+    {
+        if (_handlerExceptionCounter.Enabled)
+        {
+            RequestExceptionCore(exceptionName, result, handler);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void RequestExceptionCore(string exceptionName, ExceptionResult result, string? handler)
+    {
+        var tags = new TagList();
+        tags.Add("exception-name", exceptionName);
+        tags.Add("result", result.ToString());
+        if (handler != null)
+        {
+            tags.Add("handler", handler);
+        }
+        _handlerExceptionCounter.Add(1, tags);
+    }
+}
+
+internal enum ExceptionResult
+{
+    Skipped,
+    Handled,
+    Unhandled,
+    Aborted
+}

--- a/src/Middleware/Diagnostics/src/DummyMeterFactory.cs
+++ b/src/Middleware/Diagnostics/src/DummyMeterFactory.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Diagnostics.Metrics;
+
+namespace Microsoft.AspNetCore.Diagnostics;
+
+internal sealed class DummyMeterFactory : IMeterFactory
+{
+    public Meter Create(MeterOptions options) => new Meter(options);
+
+    public void Dispose() { }
+}

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerExtensions.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -98,6 +99,7 @@ public static class ExceptionHandlerExtensions
                 var loggerFactory = app.ApplicationServices.GetRequiredService<ILoggerFactory>();
                 var diagnosticListener = app.ApplicationServices.GetRequiredService<DiagnosticListener>();
                 var exceptionHandlers = app.ApplicationServices.GetRequiredService<IEnumerable<IExceptionHandler>>();
+                var meterFactory = app.ApplicationServices.GetRequiredService<IMeterFactory>();
 
                 if (options is null)
                 {
@@ -111,7 +113,7 @@ public static class ExceptionHandlerExtensions
                     options.Value.ExceptionHandler = newNext;
                 }
 
-                return new ExceptionHandlerMiddlewareImpl(next, loggerFactory, options, diagnosticListener, exceptionHandlers, problemDetailsService).Invoke;
+                return new ExceptionHandlerMiddlewareImpl(next, loggerFactory, options, diagnosticListener, exceptionHandlers, meterFactory, problemDetailsService).Invoke;
             });
         }
 

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddleware.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddleware.cs
@@ -36,6 +36,7 @@ public class ExceptionHandlerMiddleware
             options,
             diagnosticListener,
             Enumerable.Empty<IExceptionHandler>(),
+            new DummyMeterFactory(),
             problemDetailsService: null);
     }
 

--- a/src/Middleware/Diagnostics/test/UnitTests/DeveloperExceptionPageMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/DeveloperExceptionPageMiddlewareTest.cs
@@ -541,7 +541,8 @@ public class DeveloperExceptionPageMiddlewareTest : LoggedTest
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var meterFactory = new TestMeterFactory();
-        using var instrumentRecorder = new InstrumentRecorder<double>(meterFactory, "Microsoft.AspNetCore.Hosting", "request-duration");
+        using var requestDurationRecorder = new InstrumentRecorder<double>(meterFactory, "Microsoft.AspNetCore.Hosting", "request-duration");
+        using var diagnosticsRequestExceptionRecorder = new InstrumentRecorder<long>(meterFactory, DiagnosticsMetrics.MeterName, "diagnostics-handler-exception");
         using var measurementReporter = new MeasurementReporter<double>(meterFactory, "Microsoft.AspNetCore.Hosting", "request-duration");
         measurementReporter.Register(m =>
         {
@@ -580,13 +581,30 @@ public class DeveloperExceptionPageMiddlewareTest : LoggedTest
 
         // Assert
         Assert.Collection(
-            instrumentRecorder.GetMeasurements(),
+            requestDurationRecorder.GetMeasurements(),
             m =>
             {
                 Assert.True(m.Value > 0);
                 Assert.Equal(500, (int)m.Tags.ToArray().Single(t => t.Key == "status-code").Value);
                 Assert.Equal("System.Exception", (string)m.Tags.ToArray().Single(t => t.Key == "exception-name").Value);
             });
+        Assert.Collection(diagnosticsRequestExceptionRecorder.GetMeasurements(),
+            m => AssertRequestException(m, "System.Exception", "Unhandled"));
+    }
+
+    private static void AssertRequestException(Measurement<long> measurement, string exceptionName, string result, string handler = null)
+    {
+        Assert.Equal(1, measurement.Value);
+        Assert.Equal(exceptionName, (string)measurement.Tags.ToArray().Single(t => t.Key == "exception-name").Value);
+        Assert.Equal(result, measurement.Tags.ToArray().Single(t => t.Key == "result").Value.ToString());
+        if (handler == null)
+        {
+            Assert.DoesNotContain(measurement.Tags.ToArray(), t => t.Key == "handler");
+        }
+        else
+        {
+            Assert.Equal(handler, (string)measurement.Tags.ToArray().Single(t => t.Key == "handler").Value);
+        }
     }
 
     public class CustomCompilationException : Exception, ICompilationException


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/48625

Adds a new meter and counter. The counter is used by developer exception middleware _and_ exception handler middleware.

Result of handler:

* Aborted - Error occurred because the request was aborted (`OperationCanceledException` + `RequestAborted.IsCancellationRequested`)
* Skipped - Response has already started. Middleware can't do anything with the response so skips doing anything.
* Handled
  * ExceptionHandlerMiddleware has some interesting rules here. An exception is considered handled if an `IExceptionHandler` returns true, `IProblemDetailsService` returns true, or the status code is anything other than 404. If an `IExceptionHandler` or `IProblemDetailsService` return true then the type name is set for the `handler` tag.
  * DeveloperExceptionMiddleware never reports exceptions it catches as handled
* Unhandled - All of the above are false.

Note: The `exception-name` is still enriched onto the main HTTP request counter. Other detail (result, handler) is only available on the new counter.