### PR TITLE
Support IHttpSysRequestInfoFeature and IHttpSysRequestTimingFeature in IIS in proc server

### DIFF
--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -33,8 +33,6 @@ internal sealed partial class Request
     private AspNetCore.HttpSys.Internal.SocketAddress? _localEndPoint;
     private AspNetCore.HttpSys.Internal.SocketAddress? _remoteEndPoint;
 
-    private IReadOnlyDictionary<int, ReadOnlyMemory<byte>>? _requestInfo;
-
     private bool _isDisposed;
 
     internal Request(RequestContext requestContext)
@@ -342,49 +340,6 @@ internal sealed partial class Request
     public ExchangeAlgorithmType KeyExchangeAlgorithm { get; private set; }
 
     public int KeyExchangeStrength { get; private set; }
-
-    public IReadOnlyDictionary<int, ReadOnlyMemory<byte>> RequestInfo
-    {
-        get
-        {
-            if (_requestInfo == null)
-            {
-                _requestInfo = RequestContext.GetRequestInfo();
-            }
-            return _requestInfo;
-        }
-    }
-
-    public ReadOnlySpan<long> RequestTimestamps
-    {
-        get
-        {
-            /*
-                Below is the definition of the timing info structure we are accessing the memory for.
-                ULONG is 32-bit and maps to int. ULONGLONG is 64-bit and maps to long.
-
-                typedef struct _HTTP_REQUEST_TIMING_INFO
-                {
-                    ULONG RequestTimingCount;
-                    ULONGLONG RequestTiming[HttpRequestTimingTypeMax];
-
-                } HTTP_REQUEST_TIMING_INFO, *PHTTP_REQUEST_TIMING_INFO;
-            */
-
-            if (!RequestInfo.TryGetValue((int)HttpApiTypes.HTTP_REQUEST_INFO_TYPE.HttpRequestInfoTypeRequestTiming, out var timingInfo))
-            {
-                return ReadOnlySpan<long>.Empty;
-            }
-
-            var timingCount = MemoryMarshal.Read<int>(timingInfo.Span);
-
-            // Note that even though RequestTimingCount is an int, the compiler enforces alignment of data in the struct which causes 4 bytes
-            // of padding to be added after RequestTimingCount, so we need to skip 64-bits before we get to the start of the RequestTiming array
-            return MemoryMarshal.CreateReadOnlySpan(
-                ref Unsafe.As<byte, long>(ref MemoryMarshal.GetReference(timingInfo.Span.Slice(sizeof(long)))),
-                timingCount);
-        }
-    }
 
     private void GetTlsHandshakeResults()
     {

--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -3,7 +3,6 @@
 
 using System.Globalization;
 using System.Net;
-using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography;

--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -3,7 +3,6 @@
 
 using System.Globalization;
 using System.Net;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Authentication;

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.FeatureCollection.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.FeatureCollection.cs
@@ -589,10 +589,6 @@ internal partial class RequestContext :
 
     string? ITlsHandshakeFeature.HostName => Request.SniHostName;
 
-    IReadOnlyDictionary<int, ReadOnlyMemory<byte>> IHttpSysRequestInfoFeature.RequestInfo => Request.RequestInfo;
-
-    ReadOnlySpan<long> IHttpSysRequestTimingFeature.Timestamps => Request.RequestTimestamps;
-
     IHeaderDictionary IHttpResponseTrailersFeature.Trailers
     {
         get => _responseTrailers ??= Response.Trailers;
@@ -602,32 +598,6 @@ internal partial class RequestContext :
     public bool CanDelegate => Request.CanDelegate;
 
     CancellationToken IConnectionLifetimeNotificationFeature.ConnectionClosedRequested { get; set; }
-
-    bool IHttpSysRequestTimingFeature.TryGetTimestamp(HttpSysRequestTimingType timestampType, out long timestamp)
-    {
-        int index = (int)timestampType;
-        if (index < Request.RequestTimestamps.Length && Request.RequestTimestamps[index] > 0)
-        {
-            timestamp = Request.RequestTimestamps[index];
-            return true;
-        }
-
-        timestamp = default;
-        return false;
-    }
-
-    bool IHttpSysRequestTimingFeature.TryGetElapsedTime(HttpSysRequestTimingType startingTimestampType, HttpSysRequestTimingType endingTimestampType, out TimeSpan elapsed)
-    {
-        var timingFeature = (IHttpSysRequestTimingFeature)this;
-        if (timingFeature.TryGetTimestamp(startingTimestampType, out long startTimestamp) && timingFeature.TryGetTimestamp(endingTimestampType, out long endTimestamp))
-        {
-            elapsed = Stopwatch.GetElapsedTime(startTimestamp, endTimestamp);
-            return true;
-        }
-
-        elapsed = default;
-        return false;
-    }
 
     internal async Task OnResponseStart()
     {

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Features.Authentication;
+using Microsoft.AspNetCore.Server.HttpSys;
 using Microsoft.AspNetCore.Server.IIS.Core.IO;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
@@ -31,7 +32,9 @@ internal partial class IISHttpContext : IFeatureCollection,
                                         IHttpMaxRequestBodySizeFeature,
                                         IHttpResponseTrailersFeature,
                                         IHttpResetFeature,
-                                        IConnectionLifetimeNotificationFeature
+                                        IConnectionLifetimeNotificationFeature,
+                                        IHttpSysRequestInfoFeature,
+                                        IHttpSysRequestTimingFeature
 {
     private int _featureRevision;
     private string? _httpProtocolVersion;

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.Features.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.Features.cs
@@ -30,6 +30,8 @@ internal partial class IISHttpContext
     private static readonly Type IHttpResetFeature = typeof(global::Microsoft.AspNetCore.Http.Features.IHttpResetFeature);
     private static readonly Type IConnectionLifetimeNotificationFeature = typeof(global::Microsoft.AspNetCore.Connections.Features.IConnectionLifetimeNotificationFeature);
     private static readonly Type IHttpActivityFeature = typeof(global::Microsoft.AspNetCore.Http.Features.IHttpActivityFeature);
+    private static readonly Type IHttpSysRequestInfoFeature = typeof(global::Microsoft.AspNetCore.Server.HttpSys.IHttpSysRequestInfoFeature);
+    private static readonly Type IHttpSysRequestTimingFeature = typeof(global::Microsoft.AspNetCore.Server.HttpSys.IHttpSysRequestTimingFeature);
 
     private object? _currentIHttpRequestFeature;
     private object? _currentIHttpRequestBodyDetectionFeature;
@@ -55,6 +57,8 @@ internal partial class IISHttpContext
     private object? _currentIHttpResetFeature;
     private object? _currentIConnectionLifetimeNotificationFeature;
     private object? _currentIHttpActivityFeature;
+    private object? _currentIHttpSysRequestInfoFeature;
+    private object? _currentIHttpSysRequestTimingFeature;
 
     private void Initialize()
     {
@@ -74,6 +78,8 @@ internal partial class IISHttpContext
         _currentIHttpResponseTrailersFeature = GetResponseTrailersFeature();
         _currentIHttpResetFeature = GetResetFeature();
         _currentIConnectionLifetimeNotificationFeature = this;
+        _currentIHttpSysRequestInfoFeature = this;
+        _currentIHttpSysRequestTimingFeature = this;
 
         _currentIHttpActivityFeature = null;
     }
@@ -179,6 +185,14 @@ internal partial class IISHttpContext
         if (key == IHttpActivityFeature)
         {
             return _currentIHttpActivityFeature;
+        }
+        if (key == IHttpSysRequestInfoFeature)
+        {
+            return _currentIHttpSysRequestInfoFeature;
+        }
+        if (key == IHttpSysRequestTimingFeature)
+        {
+            return _currentIHttpSysRequestTimingFeature;
         }
 
         return ExtraFeatureGet(key);
@@ -309,6 +323,16 @@ internal partial class IISHttpContext
         if (key == IConnectionLifetimeNotificationFeature)
         {
             _currentIConnectionLifetimeNotificationFeature = feature;
+            return;
+        }
+        if (key == IHttpSysRequestInfoFeature)
+        {
+            _currentIHttpSysRequestInfoFeature = feature;
+            return;
+        }
+        if (key == IHttpSysRequestTimingFeature)
+        {
+            _currentIHttpSysRequestTimingFeature = feature;
             return;
         }
         ExtraFeatureSet(key, feature);

--- a/src/Servers/IIS/IIS/src/Microsoft.AspNetCore.Server.IIS.csproj
+++ b/src/Servers/IIS/IIS/src/Microsoft.AspNetCore.Server.IIS.csproj
@@ -47,6 +47,7 @@
     <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
     <Reference Include="Microsoft.AspNetCore.Http.Extensions" />
     <Reference Include="Microsoft.AspNetCore.Http.Features" />
+    <Reference Include="Microsoft.AspNetCore.Server.HttpSys" />
     <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
     <Reference Include="System.IO.Pipelines" />
   </ItemGroup>

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/HttpSysRequestInfoTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Inprocess/HttpSysRequestInfoTests.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
+using Microsoft.AspNetCore.Testing;
+using Microsoft.AspNetCore.Server.HttpSys;
+
+#if !IIS_FUNCTIONALS
+using Microsoft.AspNetCore.Server.IIS.FunctionalTests;
+
+#if IISEXPRESS_FUNCTIONALS
+namespace Microsoft.AspNetCore.Server.IIS.IISExpress.FunctionalTests.InProcess;
+#endif
+
+#else
+namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests.InProcess;
+#endif
+
+[Collection(PublishedSitesCollection.Name)]
+public class HttpSysRequestInfoTests: IISFunctionalTestBase
+{
+    public HttpSysRequestInfoTests(PublishedSitesFixture fixture) : base(fixture)
+    {
+    }
+
+    [ConditionalFact]
+    [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win10_20H2)]
+    public async Task TimingInfo()
+    {
+        var deploymentParameters = Fixture.GetBaseDeploymentParameters();
+        var deploymentResult = await DeployAsync(deploymentParameters);
+
+        var response = await deploymentResult.HttpClient.GetAsync("/HttpSysRequestTimingInfo");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var timings = await response.Content.ReadFromJsonAsync<long[]>();
+
+        Assert.True(timings.Length > (int)HttpSysRequestTimingType.Http3HeaderDecodeEnd);
+
+        var headerStart = timings[(int)HttpSysRequestTimingType.RequestHeaderParseStart];
+        var headerEnd = timings[(int)HttpSysRequestTimingType.RequestHeaderParseEnd];
+
+        Assert.True(headerStart > 0);
+        Assert.True(headerEnd > 0);
+        Assert.True(headerEnd > headerStart);
+    }
+}

--- a/src/Servers/IIS/IIS/test/IIS.FunctionalTests/IIS.FunctionalTests.csproj
+++ b/src/Servers/IIS/IIS/test/IIS.FunctionalTests/IIS.FunctionalTests.csproj
@@ -16,6 +16,7 @@
   <Import Project="../FunctionalTest.props" />
 
   <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore.Server.HttpSys" />
     <ProjectReference Include="..\testassets\IIS.Common.TestLib\IIS.Common.TestLib.csproj" />
     <ProjectReference Include="..\testassets\InProcessWebSite\InProcessWebSite.csproj"
       Private="false"

--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.HttpSysRequestInfo.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.HttpSysRequestInfo.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !FORWARDCOMPAT
+
+using Microsoft.AspNetCore.Server.HttpSys;
+
+namespace TestSite;
+
+public partial class Startup
+{
+    private async Task HttpSysRequestTimingInfo(HttpContext ctx)
+    {
+        await ctx.Response.WriteAsJsonAsync(GetTimings(ctx));
+
+        static long[] GetTimings(HttpContext ctx)
+        {
+            var timingFeature = ctx.Features.Get<IHttpSysRequestTimingFeature>()
+                ?? throw new NotSupportedException($"Failed to get {nameof(IHttpSysRequestTimingFeature)}");
+
+            return timingFeature.Timestamps.ToArray();
+        }
+    }
+}
+#endif

--- a/src/Servers/IIS/IISIntegration.slnf
+++ b/src/Servers/IIS/IISIntegration.slnf
@@ -22,6 +22,7 @@
       "src\\Middleware\\ResponseCompression\\src\\Microsoft.AspNetCore.ResponseCompression.csproj",
       "src\\ObjectPool\\src\\Microsoft.Extensions.ObjectPool.csproj",
       "src\\Servers\\Connections.Abstractions\\src\\Microsoft.AspNetCore.Connections.Abstractions.csproj",
+      "src\\Servers\\HttpSys\\src\\Microsoft.AspNetCore.Server.HttpSys.csproj",
       "src\\Servers\\IIS\\AspNetCoreModuleV2\\AspNetCore\\AspNetCore.vcxproj",
       "src\\Servers\\IIS\\AspNetCoreModuleV2\\CommonLibTests\\CommonLibTests.vcxproj",
       "src\\Servers\\IIS\\AspNetCoreModuleV2\\CommonLib\\CommonLib.vcxproj",

--- a/src/Shared/Shared.slnf
+++ b/src/Shared/Shared.slnf
@@ -10,6 +10,7 @@
       "src\\Http\\WebUtilities\\src\\Microsoft.AspNetCore.WebUtilities.csproj",
       "src\\ObjectPool\\src\\Microsoft.Extensions.ObjectPool.csproj",
       "src\\Servers\\Connections.Abstractions\\src\\Microsoft.AspNetCore.Connections.Abstractions.csproj",
+       "src\\Servers\\HttpSys\\src\\Microsoft.AspNetCore.Server.HttpSys.csproj",
       "src\\Shared\\BrowserTesting\\src\\Microsoft.AspNetCore.BrowserTesting.csproj",
       "src\\Shared\\test\\Shared.Tests\\Microsoft.AspNetCore.Shared.Tests.csproj",
       "src\\Testing\\src\\Microsoft.AspNetCore.Testing.csproj"

--- a/src/Shared/test/Shared.Tests/Microsoft.AspNetCore.Shared.Tests.csproj
+++ b/src/Shared/test/Shared.Tests/Microsoft.AspNetCore.Shared.Tests.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.Threading.Tasks.Extensions" />
     <Reference Include="Microsoft.AspNetCore.Http.Features" />
     <Reference Include="Microsoft.AspNetCore.Http" />
+    <Reference Include="Microsoft.AspNetCore.Server.HttpSys" />
     <Reference Include="Microsoft.Net.Http.Headers" />
   </ItemGroup>
 


### PR DESCRIPTION
# Support IHttpSysRequestInfoFeature and IHttpSysRequestTimingFeature in IIS in proc server

IHttpSysRequestInfoFeature and IHttpSysRequestTimingFeature features are currently only supported in the Http.Sys server implementation. This change moves the implementation of these feature down to the shared layer and adds these features to the IIS in proc server.

## Description

Access the detailed Http.sys request info is useful to applications regardless of where they are hosted (Http.sys standalone or IIS in proc). Currently this information is only exposed in the Http.sys standalone sever. This change updates the IIS in proc server to take a dependency on Microsoft.AspNetCore.Server.HttpSys.dll so it has access to the existing feature interfaces and moves the implementation of these interfaces into NativeRequestContext.cs which is shared between the two servers. Future changes to address adding APIs for the Http.sys information (tracked by #35012) can easily add support for both servers at the same time.

Fixes #3842
