### PR TITLE
Remove route and method tags from rate limiting

### DIFF
--- a/src/Middleware/RateLimiting/src/MetricsContext.cs
+++ b/src/Middleware/RateLimiting/src/MetricsContext.cs
@@ -6,16 +6,12 @@ namespace Microsoft.AspNetCore.RateLimiting;
 internal readonly struct MetricsContext
 {
     public readonly string? PolicyName;
-    public readonly string? Method;
-    public readonly string? Route;
     public readonly bool CurrentLeasedRequestsCounterEnabled;
     public readonly bool CurrentQueuedRequestsCounterEnabled;
 
-    public MetricsContext(string? policyName, string? method, string? route, bool currentLeasedRequestsCounterEnabled, bool currentQueuedRequestsCounterEnabled)
+    public MetricsContext(string? policyName, bool currentLeasedRequestsCounterEnabled, bool currentQueuedRequestsCounterEnabled)
     {
         PolicyName = policyName;
-        Method = method;
-        Route = route;
         CurrentLeasedRequestsCounterEnabled = currentLeasedRequestsCounterEnabled;
         CurrentQueuedRequestsCounterEnabled = currentQueuedRequestsCounterEnabled;
     }

--- a/src/Middleware/RateLimiting/src/RateLimitingMetrics.cs
+++ b/src/Middleware/RateLimiting/src/RateLimitingMetrics.cs
@@ -162,18 +162,10 @@ internal sealed class RateLimitingMetrics : IDisposable
         {
             tags.Add("policy", metricsContext.PolicyName);
         }
-        if (metricsContext.Method is not null)
-        {
-            tags.Add("method", metricsContext.Method);
-        }
-        if (metricsContext.Route is not null)
-        {
-            tags.Add("route", metricsContext.Route);
-        }
     }
 
-    public MetricsContext CreateContext(string? policyName, string? method, string? route)
+    public MetricsContext CreateContext(string? policyName)
     {
-        return new MetricsContext(policyName, method, route, _currentLeasedRequestsCounter.Enabled, _currentQueuedRequestsCounter.Enabled);
+        return new MetricsContext(policyName, _currentLeasedRequestsCounter.Enabled, _currentQueuedRequestsCounter.Enabled);
     }
 }

--- a/src/Middleware/RateLimiting/test/RateLimitingMetricsTests.cs
+++ b/src/Middleware/RateLimiting/test/RateLimitingMetricsTests.cs
@@ -93,7 +93,7 @@ public class RateLimitingMetricsTests
         await syncPoint.WaitForSyncPoint().DefaultTimeout();
 
         Assert.Collection(currentLeaseRequestsRecorder.GetMeasurements(),
-            m => AssertCounter(m, 1, null, null, null));
+            m => AssertCounter(m, 1, null));
         Assert.Empty(leaseRequestDurationRecorder.GetMeasurements());
 
         syncPoint.Continue();
@@ -104,10 +104,10 @@ public class RateLimitingMetricsTests
         Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
 
         Assert.Collection(currentLeaseRequestsRecorder.GetMeasurements(),
-            m => AssertCounter(m, 1, null, null, null),
-            m => AssertCounter(m, -1, null, null, null));
+            m => AssertCounter(m, 1, null),
+            m => AssertCounter(m, -1, null));
         Assert.Collection(leaseRequestDurationRecorder.GetMeasurements(),
-            m => AssertDuration(m, null, null, null));
+            m => AssertDuration(m, null));
         Assert.Empty(currentRequestsQueuedRecorder.GetMeasurements());
         Assert.Empty(queuedRequestDurationRecorder.GetMeasurements());
         Assert.Empty(leaseFailedRequestsRecorder.GetMeasurements());
@@ -156,7 +156,7 @@ public class RateLimitingMetricsTests
 
         Assert.Empty(currentLeaseRequestsRecorder.GetMeasurements());
         Assert.Collection(leaseRequestDurationRecorder.GetMeasurements(),
-            m => AssertDuration(m, null, null, null));
+            m => AssertDuration(m, null));
     }
 
     [Fact]
@@ -214,7 +214,7 @@ public class RateLimitingMetricsTests
 
         // Assert second request is queued.
         Assert.Collection(currentRequestsQueuedRecorder.GetMeasurements(),
-            m => AssertCounter(m, 1, "GET", "/", "concurrencyPolicy"));
+            m => AssertCounter(m, 1, "concurrencyPolicy"));
         Assert.Empty(queuedRequestDurationRecorder.GetMeasurements());
 
         // Allow both requests to finish.
@@ -224,10 +224,10 @@ public class RateLimitingMetricsTests
         await middlewareTask2.DefaultTimeout();
 
         Assert.Collection(currentRequestsQueuedRecorder.GetMeasurements(),
-            m => AssertCounter(m, 1, "GET", "/", "concurrencyPolicy"),
-            m => AssertCounter(m, -1, "GET", "/", "concurrencyPolicy"));
+            m => AssertCounter(m, 1, "concurrencyPolicy"),
+            m => AssertCounter(m, -1, "concurrencyPolicy"));
         Assert.Collection(queuedRequestDurationRecorder.GetMeasurements(),
-            m => AssertDuration(m, "GET", "/", "concurrencyPolicy"));
+            m => AssertDuration(m, "concurrencyPolicy"));
     }
 
     [Fact]
@@ -296,22 +296,18 @@ public class RateLimitingMetricsTests
 
         Assert.Empty(currentRequestsQueuedRecorder.GetMeasurements());
         Assert.Collection(queuedRequestDurationRecorder.GetMeasurements(),
-            m => AssertDuration(m, "GET", "/", "concurrencyPolicy"));
+            m => AssertDuration(m, "concurrencyPolicy"));
     }
 
-    private static void AssertCounter(Measurement<long> measurement, long value, string method, string route, string policy)
+    private static void AssertCounter(Measurement<long> measurement, long value, string policy)
     {
         Assert.Equal(value, measurement.Value);
-        AssertTag(measurement.Tags, "method", method);
-        AssertTag(measurement.Tags, "route", route);
         AssertTag(measurement.Tags, "policy", policy);
     }
 
-    private static void AssertDuration(Measurement<double> measurement, string method, string route, string policy)
+    private static void AssertDuration(Measurement<double> measurement, string policy)
     {
         Assert.True(measurement.Value > 0);
-        AssertTag(measurement.Tags, "method", method);
-        AssertTag(measurement.Tags, "route", route);
         AssertTag(measurement.Tags, "policy", policy);
     }
 


### PR DESCRIPTION
This PR removes route and method tags from rate-limiting metrics.

Three reasons:
* Route information isn't specific to rate limiting. It doesn't fit (unless we decide that all asp.net core metrics should have this information).
* Rate limiting has a policy name to identify rate-limiting metrics. For example, you can see a count of queued requests against a policy name.
* We can add route tags back in the future if there is feedback that it's wanted.