### PR TITLE
NavLink component is active on wrong path potential fix #48627

### DIFF
--- a/src/Components/Web/src/Routing/NavLink.cs
+++ b/src/Components/Web/src/Routing/NavLink.cs
@@ -201,6 +201,6 @@ public class NavLink : ComponentBase, IDisposable
 
     private static bool IsAllowedUriSeparator(char separator)
     {
-        return separator is '/' or '?';
+        return separator is '/';
     }
 }

--- a/src/Components/Web/src/Routing/NavLink.cs
+++ b/src/Components/Web/src/Routing/NavLink.cs
@@ -178,22 +178,29 @@ public class NavLink : ComponentBase, IDisposable
     private static bool IsStrictlyPrefixWithSeparator(string value, string prefix)
     {
         var prefixLength = prefix.Length;
+
         if (value.Length > prefixLength)
         {
             return value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
-                && (
-                    // Only match when there's a separator character either at the end of the
-                    // prefix or right after it.
-                    // Example: "/abc" is treated as a prefix of "/abc/def" but not "/abcdef"
-                    // Example: "/abc/" is treated as a prefix of "/abc/def" but not "/abcdef"
-                    prefixLength == 0
-                    || !char.IsLetterOrDigit(prefix[prefixLength - 1])
-                    || !char.IsLetterOrDigit(value[prefixLength])
-                );
+                   && (
+                       // Only match when there's a separator character either at the end of the
+                       // prefix or right after it.
+                       // Example: "/abc" is treated as a prefix of "/abc/def" but not "/abcdef"
+                       // Example: "/abc/" is treated as a prefix of "/abc/def" but not "/abcdef"
+                       // Example: "/abc?" is treated as a prefix of "/abc?def" but not "/abcdef"
+                       prefixLength == 0
+                       || (!char.IsLetterOrDigit(prefix[prefixLength - 1]) && IsAllowedUriSeparator(prefix[prefixLength - 1]))
+                       || (!char.IsLetterOrDigit(value[prefixLength]) && IsAllowedUriSeparator(value[prefixLength]))
+                   );
         }
         else
         {
             return false;
         }
+    }
+
+    private static bool IsAllowedUriSeparator(char separator)
+    {
+        return separator is '/' or '?';
     }
 }

--- a/src/Components/Web/src/Routing/NavLink.cs
+++ b/src/Components/Web/src/Routing/NavLink.cs
@@ -188,8 +188,8 @@ public class NavLink : ComponentBase, IDisposable
                        // Example: "/abc/" is treated as a prefix of "/abc/def" but not "/abcdef"
                        // Example: "/abc?" is treated as a prefix of "/abc?def" but not "/abcdef"
                        prefixLength == 0
-                       || (!char.IsLetterOrDigit(prefix[prefixLength - 1]) && IsAllowedSeparator(prefix[prefixLength-1]))
-                       || !char.IsLetterOrDigit(value[prefixLength])
+                       || (!char.IsLetterOrDigit(prefix[prefixLength - 1]) && IsAllowedSeparator(prefix[prefixLength - 1]))
+                       || (!char.IsLetterOrDigit(value[prefixLength]) && IsAllowedSeparator(value[prefixLength]))
                    );
         }
         else

--- a/src/Components/Web/src/Routing/NavLink.cs
+++ b/src/Components/Web/src/Routing/NavLink.cs
@@ -178,7 +178,6 @@ public class NavLink : ComponentBase, IDisposable
     private static bool IsStrictlyPrefixWithSeparator(string value, string prefix)
     {
         var prefixLength = prefix.Length;
-
         if (value.Length > prefixLength)
         {
             return value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
@@ -189,8 +188,8 @@ public class NavLink : ComponentBase, IDisposable
                        // Example: "/abc/" is treated as a prefix of "/abc/def" but not "/abcdef"
                        // Example: "/abc?" is treated as a prefix of "/abc?def" but not "/abcdef"
                        prefixLength == 0
-                       || (!char.IsLetterOrDigit(prefix[prefixLength - 1]) && IsAllowedUriSeparator(prefix[prefixLength - 1]))
-                       || (!char.IsLetterOrDigit(value[prefixLength]) && IsAllowedUriSeparator(value[prefixLength]))
+                       || (!char.IsLetterOrDigit(prefix[prefixLength - 1]) && IsAllowedSeparator(prefix[prefixLength-1]))
+                       || !char.IsLetterOrDigit(value[prefixLength])
                    );
         }
         else
@@ -199,8 +198,8 @@ public class NavLink : ComponentBase, IDisposable
         }
     }
 
-    private static bool IsAllowedUriSeparator(char separator)
+    private static bool IsAllowedSeparator(char separator)
     {
-        return separator is '/';
+        return separator is '/' or '?' or '#';
     }
 }


### PR DESCRIPTION
# NavLink component is active on the wrong path potential fix #48627

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Added an additional check for the separator character, to check if it is an allowed char in a URI, such as '/' or '?'.
Check the attachment file for some testing evidence.

![image](https://github.com/dotnet/aspnetcore/assets/49108526/1819c9f5-775d-40a3-ba18-d59e83e63867)

Fixes #48627 
