### PR TITLE
Fixes #48627 NavLink component is active on wrong path

### DIFF
--- a/src/Components/Web/src/Routing/NavLink.cs
+++ b/src/Components/Web/src/Routing/NavLink.cs
@@ -187,13 +187,26 @@ public class NavLink : ComponentBase, IDisposable
                     // Example: "/abc" is treated as a prefix of "/abc/def" but not "/abcdef"
                     // Example: "/abc/" is treated as a prefix of "/abc/def" but not "/abcdef"
                     prefixLength == 0
-                    || !char.IsLetterOrDigit(prefix[prefixLength - 1])
-                    || !char.IsLetterOrDigit(value[prefixLength])
+                    || !IsUnreservedCharacter(prefix[prefixLength - 1])
+                    || !IsUnreservedCharacter(value[prefixLength])
                 );
         }
         else
         {
             return false;
         }
+    }
+
+    private static bool IsUnreservedCharacter(char c) 
+    {
+        // Checks whether it is an unreserved character according to 
+        // https://datatracker.ietf.org/doc/html/rfc3986#section-2.3
+        // Those are characters that are allowed in a URI but do not have a reserved
+        // purpose (e.g. they do not separate the components of the URI)
+        return char.IsLetterOrDigit(c) ||
+                c == '-' ||
+                c == '.' ||
+                c == '_' ||
+                c == '~';
     }
 }

--- a/src/Components/Web/src/Routing/NavLink.cs
+++ b/src/Components/Web/src/Routing/NavLink.cs
@@ -197,7 +197,7 @@ public class NavLink : ComponentBase, IDisposable
         }
     }
 
-    private static bool IsUnreservedCharacter(char c) 
+    private static bool IsUnreservedCharacter(char c)
     {
         // Checks whether it is an unreserved character according to 
         // https://datatracker.ietf.org/doc/html/rfc3986#section-2.3

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -624,6 +624,20 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
         AssertHighlightedLinks("Default (matches all)", "Default with base-relative URL (matches all)");
     }
 
+    [Theory]
+    [InlineData("/Other-With-Hyphens", "Other with hyphens")]
+    [InlineData("/Other.With.Dots", "Other with dots")]
+    [InlineData("/Other_With_Underscores", "Other with underscores")]
+    [InlineData("/Other~With~Tildes", "Other with tildes")]
+    public void RoutePrefixDoesNotMatchWithNonSeparatorCharacters(string url, string linkText)
+    {
+        SetUrlViaPushState(url);
+
+        var app = Browser.MountTestComponent<TestRouter>();
+        Assert.Equal("This is another page.", app.FindElement(By.Id("test-info")).Text);
+        AssertHighlightedLinks(linkText); // The 'Other' link text should not be highlighted.
+    }
+
     [Fact]
     public void UsingNavigationManagerWithoutRouterWorks()
     {

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/Links.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/Links.razor
@@ -19,6 +19,10 @@
     <li><NavLink href="Other" Match=NavLinkMatch.All>Other with base-relative URL (matches all)</NavLink></li>
     <li><NavLink href="/subdir/other?abc=123">Other with query</NavLink></li>
     <li><NavLink href="/subdir/Other#blah">Other with hash</NavLink></li>
+    <li><NavLink href="/subdir/other-with-hyphens">Other with hyphens</NavLink></li>
+    <li><NavLink href="/subdir/other.with.dots">Other with dots</NavLink></li>
+    <li><NavLink href="/subdir/other_with_underscores">Other with underscores</NavLink></li>
+    <li><NavLink href="/subdir/other~with~tildes">Other with tildes</NavLink></li>
     <li><NavLink href="/subdir/WithParameters/name/Abc">With parameters</NavLink></li>
     <li><NavLink href="/subdir/WithParameters/Name/Abc/LastName/McDef">With more parameters</NavLink></li>
     <li><NavLink href="/subdir/WithQueryParameters/Abc">With query parameters (none)</NavLink></li>

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/Other.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/Other.razor
@@ -1,4 +1,8 @@
 ﻿@page "/Other"
+@page "/Other-With-Hyphens"
+@page "/Other.With.Dots"
+@page "/Other_With_Underscores"
+@page "/Other~With~Tildes"
 @inject NavigationManager Navigation
 <div id="test-info">This is another page.</div>
 <div id="test-state">@Navigation.HistoryEntryState</div>


### PR DESCRIPTION
# Fixes #48627 NavLink component is active on wrong path

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

The current code just uses `char.IsLetterOrDigit` to detect separator characters. I added additonal characters to check whether the given character is an [unreserved character](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3). 


Fixes #48627
