### PR TITLE
Add TLS and HTTP protocol to kestrel-connection-duration counter

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
+using HttpProtocol = Microsoft.AspNetCore.Http.HttpProtocol;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 
@@ -59,6 +60,7 @@ internal sealed class HttpConnection : ITimeoutHandler
                     // _http1Connection must be initialized before adding the connection to the connection manager
                     requestProcessor = _http1Connection = new Http1Connection<TContext>((HttpConnectionContext)_context);
                     _protocolSelectionState = ProtocolSelectionState.Selected;
+                    AddMetricsHttpProtocolTag(HttpProtocol.Http11);
                     break;
                 case HttpProtocols.Http2:
                     // _http2Connection must be initialized before yielding control to the transport thread,
@@ -66,10 +68,12 @@ internal sealed class HttpConnection : ITimeoutHandler
                     // _http2Connection is about to be initialized.
                     requestProcessor = new Http2Connection((HttpConnectionContext)_context);
                     _protocolSelectionState = ProtocolSelectionState.Selected;
+                    AddMetricsHttpProtocolTag(HttpProtocol.Http2);
                     break;
                 case HttpProtocols.Http3:
                     requestProcessor = new Http3Connection((HttpMultiplexedConnectionContext)_context);
                     _protocolSelectionState = ProtocolSelectionState.Selected;
+                    AddMetricsHttpProtocolTag(HttpProtocol.Http3);
                     break;
                 case HttpProtocols.None:
                     // An error was already logged in SelectProtocol(), but we should close the connection.
@@ -109,6 +113,14 @@ internal sealed class HttpConnection : ITimeoutHandler
         catch (Exception ex)
         {
             Log.LogCritical(0, ex, $"Unexpected exception in {nameof(HttpConnection)}.{nameof(ProcessRequestsAsync)}.");
+        }
+    }
+
+    private void AddMetricsHttpProtocolTag(string httpProtocol)
+    {
+        if (_context.ConnectionContext.Features.Get<IConnectionMetricsTagsFeature>() is { } metricsTags)
+        {
+            metricsTags.Tags.Add(new KeyValuePair<string, object?>("http-protocol", httpProtocol));
         }
     }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelConnectionOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelConnectionOfT.cs
@@ -100,7 +100,7 @@ internal sealed class KestrelConnection<T> : KestrelConnection, IThreadPoolWorkI
 
     private sealed class ConnectionMetricsTagsFeature : IConnectionMetricsTagsFeature
     {
-        public ICollection<KeyValuePair<string, object?>> Tags => TagsList;
+        ICollection<KeyValuePair<string, object?>> IConnectionMetricsTagsFeature.Tags => TagsList;
 
         public List<KeyValuePair<string, object?>> TagsList { get; } = new List<KeyValuePair<string, object?>>();
     }

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpConnectionMiddleware.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
-using System.Security.Authentication;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting.Server;

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpConnectionMiddleware.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
+using System.Security.Authentication;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting.Server;

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpMultiplexedConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpMultiplexedConnectionMiddleware.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
+using System.Security.Authentication;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting.Server;
@@ -40,6 +41,12 @@ internal sealed class HttpMultiplexedConnectionMiddleware<TContext> where TConte
             memoryPoolFeature?.MemoryPool ?? System.Buffers.MemoryPool<byte>.Shared,
             localEndPoint,
             connectionContext.RemoteEndPoint as IPEndPoint);
+
+        if (connectionContext.Features.Get<IConnectionMetricsTagsFeature>() is { } metricsTags)
+        {
+            // HTTP/3 is always TLS 1.3. If multiple versions are support in the future then this value will need to be detected.
+            metricsTags.Tags.Add(new KeyValuePair<string, object?>("tls-protocol", SslProtocols.Tls13.ToString()));
+        }
 
         var connection = new HttpConnection(httpConnectionContext);
 

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -202,6 +202,11 @@ internal sealed class HttpsConnectionMiddleware
 
         _logger.HttpsConnectionEstablished(context.ConnectionId, sslStream.SslProtocol);
 
+        if (context.Features.Get<IConnectionMetricsTagsFeature>() is { } metricsTags)
+        {
+            metricsTags.Tags.Add(new KeyValuePair<string, object?>("tls-protocol", sslStream.SslProtocol.ToString()));
+        }
+
         var originalTransport = context.Transport;
 
         try

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
@@ -1,16 +1,19 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.Metrics;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Security.Authentication;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Headers;
 using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -19,6 +22,61 @@ namespace Interop.FunctionalTests.Http2;
 [Collection(nameof(NoParallelCollection))]
 public class Http2RequestTests : LoggedTest
 {
+    [Fact]
+    public async Task GET_Metrics_HttpProtocolAndTlsSet()
+    {
+        // Arrange
+        var protocolTcs = new TaskCompletionSource<SslProtocols>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var builder = CreateHostBuilder(c =>
+        {
+            protocolTcs.SetResult(c.Features.Get<ISslStreamFeature>().SslStream.SslProtocol);
+            return Task.CompletedTask;
+        }, protocol: HttpProtocols.Http2, plaintext: false);
+
+        using (var host = builder.Build())
+        {
+            var meterFactory = host.Services.GetRequiredService<IMeterFactory>();
+
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var connectionDuration = new InstrumentRecorder<double>(meterFactory, "Microsoft.AspNetCore.Server.Kestrel", "connection-duration");
+            using var measurementReporter = new MeasurementReporter<double>(meterFactory, "Microsoft.AspNetCore.Server.Kestrel", "connection-duration");
+            measurementReporter.Register(m =>
+            {
+                tcs.SetResult();
+            });
+
+            await host.StartAsync();
+            var client = HttpHelpers.CreateClient();
+
+            // Act
+            var request1 = new HttpRequestMessage(HttpMethod.Get, $"https://127.0.0.1:{host.GetPort()}/");
+            request1.Version = HttpVersion.Version20;
+            request1.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+
+            var response1 = await client.SendAsync(request1, CancellationToken.None);
+            response1.EnsureSuccessStatusCode();
+
+            var protocol = await protocolTcs.Task.DefaultTimeout();
+
+            // Dispose the client to end the connection.
+            client.Dispose();
+            // Wait for measurement to be available.
+            await tcs.Task.DefaultTimeout();
+
+            // Assert
+            Assert.Collection(connectionDuration.GetMeasurements(),
+                m =>
+                {
+                    Assert.True(m.Value > 0);
+                    Assert.Equal(protocol.ToString(), m.Tags.ToArray().Single(t => t.Key == "tls-protocol").Value);
+                    Assert.Equal("HTTP/2", m.Tags.ToArray().Single(t => t.Key == "http-protocol").Value);
+                    Assert.Equal($"127.0.0.1:{host.GetPort()}", m.Tags.ToArray().Single(t => t.Key == "endpoint").Value);
+                });
+
+            await host.StopAsync();
+        }
+    }
+
     [Fact]
     public async Task GET_NoTLS_Http11RequestToHttp2Endpoint_400Result()
     {

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -100,8 +100,9 @@ public class Http3RequestTests : LoggedTest
             var response1 = await client.SendAsync(request1, CancellationToken.None);
             response1.EnsureSuccessStatusCode();
 
+            // Dispose the client to end the connection.
             client.Dispose();
-
+            // Wait for measurement to be available.
             await tcs.Task.DefaultTimeout();
 
             // Assert

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Globalization;
 using System.Net;
 using System.Net.Http;
@@ -18,6 +19,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
@@ -67,6 +69,54 @@ public class Http3RequestTests : LoggedTest
     }
 
     private static readonly byte[] TestData = Encoding.UTF8.GetBytes("Hello world");
+
+    [ConditionalFact]
+    [MsQuicSupported]
+    public async Task GET_Metrics_HttpProtocolAndTlsSet()
+    {
+        // Arrange
+        var builder = CreateHostBuilder(context => Task.CompletedTask);
+
+        using (var host = builder.Build())
+        {
+            var meterFactory = host.Services.GetRequiredService<IMeterFactory>();
+
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var connectionDuration = new InstrumentRecorder<double>(meterFactory, "Microsoft.AspNetCore.Server.Kestrel", "connection-duration");
+            using var measurementReporter = new MeasurementReporter<double>(meterFactory, "Microsoft.AspNetCore.Server.Kestrel", "connection-duration");
+            measurementReporter.Register(m =>
+            {
+                tcs.SetResult();
+            });
+
+            await host.StartAsync();
+            var client = HttpHelpers.CreateClient();
+
+            // Act
+            var request1 = new HttpRequestMessage(HttpMethod.Get, $"https://127.0.0.1:{host.GetPort()}/");
+            request1.Version = HttpVersion.Version30;
+            request1.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+
+            var response1 = await client.SendAsync(request1, CancellationToken.None);
+            response1.EnsureSuccessStatusCode();
+
+            client.Dispose();
+
+            await tcs.Task.DefaultTimeout();
+
+            // Assert
+            Assert.Collection(connectionDuration.GetMeasurements(),
+                m =>
+                {
+                    Assert.True(m.Value > 0);
+                    Assert.Equal("Tls13", m.Tags.ToArray().Single(t => t.Key == "tls-protocol").Value);
+                    Assert.Equal("HTTP/3", m.Tags.ToArray().Single(t => t.Key == "http-protocol").Value);
+                    Assert.Equal($"127.0.0.1:{host.GetPort()}", m.Tags.ToArray().Single(t => t.Key == "endpoint").Value);
+                });
+
+            await host.StopAsync();
+        }
+    }
 
     // Verify HTTP/2 and HTTP/3 match behavior
     [ConditionalTheory]

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Interop.FunctionalTests.csproj
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Interop.FunctionalTests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="$(SharedSourceRoot)HttpClient\HttpEventSourceListener.cs" LinkBase="shared" />
     <Content Include="$(SharedSourceRoot)TestCertificates\*.pfx" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />
     <Compile Include="$(SharedSourceRoot)TransportTestHelpers\MsQuicSupportedAttribute.cs" LinkBase="shared\TransportTestHelpers\MsQuicSupportedAttribute.cs" />
+    <Compile Include="$(SharedSourceRoot)Metrics\TestMeterFactory.cs" LinkBase="shared" />
     <Compile Include="$(KestrelSharedSourceRoot)test\TransportTestHelpers\TlsAlpnSupportedAttribute.cs" Link="shared\TransportTestHelpers\TlsAlpnSupportedAttribute.cs" />
     <Compile Include="$(KestrelSharedSourceRoot)test\ServerRetryHelper.cs" LinkBase="shared" />
   </ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/47831

New tags:
* `tls-protocol` - The TLS protocol of the connection.
  * Value is [SslProtocols](https://learn.microsoft.com/en-us/dotnet/api/system.security.authentication.sslprotocols?view=net-7.0) converted to a string.
  * Only present if the connection is SSL/TLS.

* `http-protocol` - The HTTP protocol of the connection.
  * Value is `HTTP/1.1`, `HTTP/2`, `HTTP/3`.
  * Only present if the connection is HTTP.
  * Note that the value here doesn't necessarily match the version in the HTTP request. For example, the client could send `HTTP/1.0` request, and the HTTP/1.1 server connection will process it.