### PR TITLE
Add test to Helix retry list

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -19,6 +19,7 @@
     {"testName": {"contains": "ServerReset_BeforeRequestBody_ClientBodyThrows"}},
     {"testName": {"contains": "InjectedStartup_DefaultApplicationNameIsEntryAssembly"}},
     {"testName": {"contains": "HEADERS_Received_SecondRequest_ConnectProtocolReset"}},
+    {"testName": {"contains": "ClientUsingOldCallWithNewProtocol"}},
     {"testAssembly": {"contains": "IIS"}},
     {"testAssembly": {"contains": "Template"}},
     {"failureMessage": {"contains":"(Site is started but no worker process found)"}},


### PR DESCRIPTION
HubProtocolVersionTests.ClientUsingOldCallWithNewProtocol had a helix-only [failure](https://dev.azure.com/dnceng-public/public/_build/results?buildId=302221)