### PR TITLE
Add test to helix retry list

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -4,6 +4,7 @@
   "localRerunCount" : 3,
   "retryOnRules": [
     {"testName": {"contains": "FlakyTestToEnsureRetryWorks" }},
+    {"testName": {"contains": "ConfigureEndpointDevelopmentCertificateGetsLoadedWhenPresent" }},
     {"testName": {"contains": "MaxRequestBufferSizeTests.LargeUpload" }},
     {"testName": {"contains": "Http3RequestTests"}},
     {"testName": {"contains": "Http3TlsTests"}},


### PR DESCRIPTION
`KestrelConfigurationLoaderTests.ConfigureEndpointDevelopmentCertificateGetsLoadedWhenPresent` [failed](https://dev.azure.com/dnceng-public/public/_build/results?buildId=303767).  I can't explain how a retry would help with `X509Certificate2.Export`, but subsequent tests in the same run passed, so maybe?