### PR TITLE
Deflake Http2WebSocket tests

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2WebSocketTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2WebSocketTests.cs
@@ -155,7 +155,6 @@ public class Http2WebSocketTests : Http2TestBase
     [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/42133")]
     public async Task HEADERS_Received_SecondRequest_Accepted()
     {
-        // Add stream to Http2Connection._completedStreams inline with SetResult().
         var appDelegateTcs = new TaskCompletionSource();
         await InitializeConnectionAsync(async context =>
         {
@@ -180,6 +179,19 @@ public class Http2WebSocketTests : Http2TestBase
             await stream.WriteAsync(new byte[] { 0x01 });
             await appDelegateTcs.Task;
         });
+
+        var originalHandler = _connection._streamLifetimeHandler;
+        var tcs = new TaskCompletionSource();
+        var streamLifetimeHandler = new Mock<IHttp2StreamLifetimeHandler>();
+        streamLifetimeHandler.Setup(o => o.OnStreamCompleted(It.IsAny<Http2Stream>())).Callback((Http2Stream stream) =>
+        {
+            // Add stream to Http2Connection._completedStreams.
+            originalHandler.OnStreamCompleted(stream);
+
+            // Unblock test code that will call TriggerTick and return the stream to the pool
+            tcs.TrySetResult();
+        });
+        _connection._streamLifetimeHandler = streamLifetimeHandler.Object;
 
         // HEADERS + END_HEADERS
         // :method = CONNECT
@@ -224,6 +236,7 @@ public class Http2WebSocketTests : Http2TestBase
         Assert.Equal(0x01, dataFrame.Payload.Span[0]);
 
         appDelegateTcs.TrySetResult();
+        await tcs.Task.DefaultTimeout();
 
         dataFrame = await ExpectAsync(Http2FrameType.DATA,
             withLength: 0,
@@ -595,8 +608,23 @@ public class Http2WebSocketTests : Http2TestBase
                 // We've done the test. Now just return the normal echo server behavior.
                 await _echoApplication(context);
             }
-
         });
+
+        var originalHandler = _connection._streamLifetimeHandler;
+        var tcs = new TaskCompletionSource();
+        var streamLifetimeHandler = new Mock<IHttp2StreamLifetimeHandler>();
+        streamLifetimeHandler.Setup(o => o.OnStreamCompleted(It.IsAny<Http2Stream>())).Callback((Http2Stream stream) =>
+        {
+            // Add stream to Http2Connection._completedStreams.
+            originalHandler.OnStreamCompleted(stream);
+
+            if (requestCount == 1)
+            {
+                // Unblock test code that will call TriggerTick and return the stream to the pool
+                tcs.TrySetResult();
+            }
+        });
+        _connection._streamLifetimeHandler = streamLifetimeHandler.Object;
 
         // HEADERS + END_HEADERS
         // :method = CONNECT
@@ -636,6 +664,8 @@ public class Http2WebSocketTests : Http2TestBase
         Assert.Equal(0x01, dataFrame.Payload.Span[0]);
 
         appDelegateTcs.TrySetResult();
+        await tcs.Task.DefaultTimeout();
+
         dataFrame = await ExpectAsync(Http2FrameType.DATA,
             withLength: 0,
             withFlags: (byte)Http2DataFrameFlags.END_STREAM,


### PR DESCRIPTION
Deflakes https://github.com/dotnet/aspnetcore/issues/42133 and https://github.com/dotnet/aspnetcore/issues/48737

The issue was that if the test code got to `await appDelegateTcs.Task;` but hadn't actually registered a continuation yet, then when the main test body called `appDelegateTcs.TrySetResult();` which was relying on the continuation running inline, it wouldn't run inline because there is no continuation yet. Which means that the main test body will continue on to `TriggerTick()` which might not add the stream back to the pool yet because the "application" code hasn't finished the stream yet.