### PR TITLE
Move SignalR connection start telemetry to transport start

### DIFF
--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionContext.cs
@@ -114,6 +114,8 @@ internal sealed partial class HttpConnectionContext : ConnectionContext,
 
     public HttpTransportType TransportType { get; set; }
 
+    internal long StartTimestamp { get; set; }
+
     public SemaphoreSlim WriteLock { get; } = new SemaphoreSlim(1, 1);
 
     // Used for testing only

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Diagnostics;
 using System.Security.Claims;
 using System.Security.Principal;
 using Microsoft.AspNetCore.Authentication;
@@ -552,7 +553,14 @@ internal sealed partial class HttpConnectionDispatcher
 
         if (connection.TransportType == HttpTransportType.None)
         {
+            if (HttpConnectionsEventSource.Log.IsEnabled() || connection.MetricsContext.ConnectionDurationEnabled)
+            {
+                connection.StartTimestamp = Stopwatch.GetTimestamp();
+            }
+
             connection.TransportType = transportType;
+
+            HttpConnectionsEventSource.Log.ConnectionStart(connection.ConnectionId);
             _metrics.ConnectionTransportStart(connection.MetricsContext, transportType);
         }
         else if (connection.TransportType != transportType)

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
@@ -90,7 +90,7 @@ internal sealed partial class HttpConnectionManager
         // Remove the connection completely
         if (_connections.TryRemove(id, out var connection))
         {
-            // A connection is considered started when the transport is negotated.
+            // A connection is considered started when the transport is negotiated.
             // You can't stop something that hasn't started so only log connection stop events if there is a transport.
             if (connection.TransportType != HttpTransportType.None)
             {


### PR DESCRIPTION
This PR changes when SignalR connection start telemetry to the point where the connection's transport starts.

Telemetry includes:
 - Current connections metric
 - Current connections event counter
 - Connection duration interval

Follow up to https://github.com/dotnet/aspnetcore/pull/48375