### PR TITLE
Revert SDK update

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.6.23312.4"
+    "version": "8.0.100-preview.6.23305.3"
   },
   "tools": {
-    "dotnet": "8.0.100-preview.6.23312.4",
+    "dotnet": "8.0.100-preview.6.23305.3",
     "runtimes": {
       "dotnet/x86": [
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"


### PR DESCRIPTION
We are hitting an issue with MSBuild that fails ~50% of our builds on Mac machines.
See https://github.com/dotnet/msbuild/issues/6215