### PR TITLE
Update ITlsHandshakeFeature.HostName API + misc. improvements in HttpSys calls

### DIFF
--- a/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
+++ b/src/Servers/Connections.Abstractions/src/Features/ITlsHandshakeFeature.cs
@@ -29,7 +29,7 @@ public interface ITlsHandshakeFeature
     /// Gets the host name from the "server_name" (SNI) extension of the client hello if present.
     /// See <see href="https://www.rfc-editor.org/rfc/rfc6066#section-3">RFC 6066</see>.
     /// </summary>
-    string? HostName => null;
+    string HostName => string.Empty;
 #endif
 
     /// <summary>

--- a/src/Servers/Connections.Abstractions/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Servers/Connections.Abstractions/src/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -6,7 +6,7 @@ Microsoft.AspNetCore.Connections.Features.IConnectionMetricsTagsFeature
 Microsoft.AspNetCore.Connections.Features.IConnectionMetricsTagsFeature.Tags.get -> System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string!, object?>>!
 Microsoft.AspNetCore.Connections.Features.IConnectionNamedPipeFeature
 Microsoft.AspNetCore.Connections.Features.IConnectionNamedPipeFeature.NamedPipe.get -> System.IO.Pipes.NamedPipeServerStream!
-Microsoft.AspNetCore.Connections.Features.ITlsHandshakeFeature.HostName.get -> string?
+Microsoft.AspNetCore.Connections.Features.ITlsHandshakeFeature.HostName.get -> string!
 Microsoft.AspNetCore.Connections.Features.ITlsHandshakeFeature.NegotiatedCipherSuite.get -> System.Net.Security.TlsCipherSuite?
 Microsoft.AspNetCore.Connections.IConnectionListenerFactorySelector
 Microsoft.AspNetCore.Connections.IConnectionListenerFactorySelector.CanBind(System.Net.EndPoint! endpoint) -> bool

--- a/src/Servers/HttpSys/src/NativeInterop/HttpApi.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/HttpApi.cs
@@ -79,11 +79,10 @@ internal static unsafe partial class HttpApi
 
     [LibraryImport(HTTPAPI, SetLastError = true)]
     internal static unsafe partial uint HttpDelegateRequestEx(SafeHandle pReqQueueHandle, SafeHandle pDelegateQueueHandle, ulong requestId,
-        ulong delegateUrlGroupId, ulong propertyInfoSetSize, HTTP_DELEGATE_REQUEST_PROPERTY_INFO* pRequestPropertyBuffer);
+        ulong delegateUrlGroupId, uint propertyInfoSetSize, HTTP_DELEGATE_REQUEST_PROPERTY_INFO* pRequestPropertyBuffer);
 
-    [LibraryImport(HTTPAPI, SetLastError = true)]
-    internal static unsafe partial uint HttpQueryRequestProperty(SafeHandle requestQueueHandle, ulong requestId, HTTP_REQUEST_PROPERTY propertyId,
-        void* qualifier, ulong qualifierSize, void* output, ulong outputSize, ulong* bytesReturned, IntPtr overlapped);
+    internal delegate uint HttpGetRequestPropertyInvoker(SafeHandle requestQueueHandle, ulong requestId, HTTP_REQUEST_PROPERTY propertyId,
+        void* qualifier, uint qualifierSize, void* output, uint outputSize, uint* bytesReturned, IntPtr overlapped);
 
     internal delegate uint HttpSetRequestPropertyInvoker(SafeHandle requestQueueHandle, ulong requestId, HTTP_REQUEST_PROPERTY propertyId, void* input, uint inputSize, IntPtr overlapped);
 
@@ -123,6 +122,7 @@ internal static unsafe partial class HttpApi
     }
 
     internal static SafeLibraryHandle? HttpApiModule { get; private set; }
+    internal static HttpGetRequestPropertyInvoker? HttpGetRequestProperty { get; private set; }
     internal static HttpSetRequestPropertyInvoker? HttpSetRequestProperty { get; private set; }
     [MemberNotNullWhen(true, nameof(HttpSetRequestProperty))]
     internal static bool SupportsTrailers { get; private set; }
@@ -147,6 +147,7 @@ internal static unsafe partial class HttpApi
         if (supported)
         {
             HttpApiModule = SafeLibraryHandle.Open(HTTPAPI);
+            HttpGetRequestProperty = HttpApiModule.GetProcAddress<HttpGetRequestPropertyInvoker>("HttpQueryRequestProperty", throwIfNotFound: false);
             HttpSetRequestProperty = HttpApiModule.GetProcAddress<HttpSetRequestPropertyInvoker>("HttpSetRequestProperty", throwIfNotFound: false);
             SupportsReset = HttpSetRequestProperty != null;
             SupportsTrailers = IsFeatureSupported(HTTP_FEATURE_ID.HttpFeatureResponseTrailers);

--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -169,6 +169,7 @@ internal sealed partial class Request
 
         User = RequestContext.GetUser();
 
+        SniHostName = string.Empty;
         if (IsHttps)
         {
             GetTlsHandshakeResults();

--- a/src/Servers/HttpSys/src/RequestProcessing/Request.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/Request.cs
@@ -327,7 +327,7 @@ internal sealed partial class Request
 
     internal WindowsPrincipal User { get; }
 
-    public string? SniHostName { get; private set; }
+    public string SniHostName { get; private set; }
 
     public SslProtocols Protocol { get; private set; }
 

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.FeatureCollection.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.FeatureCollection.cs
@@ -587,7 +587,7 @@ internal partial class RequestContext :
 
     int ITlsHandshakeFeature.KeyExchangeStrength => Request.KeyExchangeStrength;
 
-    string? ITlsHandshakeFeature.HostName => Request.SniHostName;
+    string ITlsHandshakeFeature.HostName => Request.SniHostName;
 
     IReadOnlyDictionary<int, ReadOnlyMemory<byte>> IHttpSysRequestInfoFeature.RequestInfo => Request.RequestInfo;
 

--- a/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
+++ b/src/Servers/HttpSys/src/RequestProcessing/RequestContext.cs
@@ -8,7 +8,6 @@ using System.Security.Principal;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpSys.Internal;
 using Microsoft.Extensions.Logging;
-using static Microsoft.AspNetCore.HttpSys.Internal.UnsafeNclNativeMethods;
 
 namespace Microsoft.AspNetCore.Server.HttpSys;
 
@@ -228,25 +227,28 @@ internal partial class RequestContext : NativeRequestContext, IThreadPoolWorkIte
 
     internal unsafe HttpApiTypes.HTTP_REQUEST_PROPERTY_SNI GetClientSni()
     {
+        if (HttpApi.HttpGetRequestProperty != null)
+        {
             var buffer = new byte[HttpApiTypes.SniPropertySizeInBytes];
             fixed (byte* pBuffer = buffer)
             {
-                var statusCode = HttpApi.HttpQueryRequestProperty(
+                var statusCode = HttpApi.HttpGetRequestProperty(
                     Server.RequestQueue.Handle,
                     RequestId,
                     HttpApiTypes.HTTP_REQUEST_PROPERTY.HttpRequestPropertySni,
                     qualifier: null,
                     qualifierSize: 0,
                     (void*)pBuffer,
-                    (ulong)buffer.Length,
+                    (uint)buffer.Length,
                     bytesReturned: null,
                     IntPtr.Zero);
 
-                if (statusCode == ErrorCodes.ERROR_SUCCESS)
+                if (statusCode == UnsafeNclNativeMethods.ErrorCodes.ERROR_SUCCESS)
                 {
                     return Marshal.PtrToStructure<HttpApiTypes.HTTP_REQUEST_PROPERTY_SNI>((IntPtr)pBuffer);
                 }
             }
+        }
 
         return default;
     }

--- a/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
+++ b/src/Servers/HttpSys/test/FunctionalTests/HttpsTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Data.Common;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http;

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
@@ -194,7 +194,7 @@ internal sealed class KestrelEventSource : EventSource
             // TODO: Write this without a string allocation using WriteEventData
             var applicationProtocol = feature == null ? string.Empty : Encoding.UTF8.GetString(feature.ApplicationProtocol.Span);
             var sslProtocols = feature?.Protocol.ToString() ?? string.Empty;
-            var hostName = feature?.HostName;
+            var hostName = feature?.HostName ?? string.Empty;
             TlsHandshakeStop(connectionContext.ConnectionId, sslProtocols, applicationProtocol, hostName);
         }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
@@ -194,7 +194,7 @@ internal sealed class KestrelEventSource : EventSource
             // TODO: Write this without a string allocation using WriteEventData
             var applicationProtocol = feature == null ? string.Empty : Encoding.UTF8.GetString(feature.ApplicationProtocol.Span);
             var sslProtocols = feature?.Protocol.ToString() ?? string.Empty;
-            var hostName = feature?.HostName ?? string.Empty;
+            var hostName = feature?.HostName;
             TlsHandshakeStop(connectionContext.ConnectionId, sslProtocols, applicationProtocol, hostName);
         }
     }

--- a/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
@@ -42,7 +42,7 @@ internal sealed class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicat
         }
     }
 
-    public string? HostName { get; set; }
+    public string HostName { get; set; }
 
     public ReadOnlyMemory<byte> ApplicationProtocol => _sslStream.NegotiatedApplicationProtocol.Protocol;
 

--- a/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/TlsConnectionFeature.cs
@@ -42,7 +42,7 @@ internal sealed class TlsConnectionFeature : ITlsConnectionFeature, ITlsApplicat
         }
     }
 
-    public string HostName { get; set; }
+    public string HostName { get; set; } = string.Empty;
 
     public ReadOnlyMemory<byte> ApplicationProtocol => _sslStream.NegotiatedApplicationProtocol.Protocol;
 

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -313,7 +313,7 @@ internal sealed class HttpsConnectionMiddleware
         {
             selector = (sender, name) =>
             {
-                feature.HostName = name;
+                feature.HostName = name ?? string.Empty;
                 var cert = _serverCertificateSelector(context, name);
                 if (cert != null)
                 {

--- a/src/Shared/HttpSys/NativeInterop/HttpApiTypes.cs
+++ b/src/Shared/HttpSys/NativeInterop/HttpApiTypes.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using Microsoft.AspNetCore.Http;
@@ -109,8 +108,8 @@ internal static unsafe class HttpApiTypes
         internal uint ErrorCode;
     }
 
-    internal const int HTTP_REQUEST_PROPERTY_SNI_HOST_MAX_LENGTH = 255;
-    internal const int SniPropertySizeInBytes = (sizeof(ushort) * (HTTP_REQUEST_PROPERTY_SNI_HOST_MAX_LENGTH + 1)) + sizeof(ulong);
+    private const int HTTP_REQUEST_PROPERTY_SNI_HOST_MAX_LENGTH = 255;
+    internal const int SniPropertySizeInBytes = (sizeof(ushort) * (HTTP_REQUEST_PROPERTY_SNI_HOST_MAX_LENGTH + 1)) + sizeof(uint);
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode, Size = SniPropertySizeInBytes)]
     internal struct HTTP_REQUEST_PROPERTY_SNI


### PR DESCRIPTION
# Update ITlsHandshakeFeature.HostName API + misc. improvements in HttpSys calls

Summary of the changes (Less than 80 chars)

Updating the ITlsHandshakeFeature.HostName API as discussed in https://github.com/dotnet/aspnetcore/issues/34525 and miscellaneous improvements in HttpQueryRequestProperty calls + cleanup

## Description

The PR does the following changes:
- Updates the ITlsHandshakeFeature.HostName property to be non-nullable and updates all references accordingly.
- Changes HTTPAPI HttpQueryRequestProperty method definition to have an invoker similar to HttpSetRequestPropertyInvoker.  This API might not be present on older OS's so it'll be guarded by an Invoker and null check to ensure backwards compatibility.
- Updates the HttpQueryRequestProperty parameters `qualifierSize`, `outputSize` and `bytesReturned` to be `uint` instead of `ulong`. Based on the HttpSys API (shown below), these are [ULONG](https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types) which are 32 bits in Windows. Also updated the `propertyInfoSetSize` parameter in `HttpDelegateRequestEx` for the same reason.

```
HttpQueryRequestProperty(
    _In_ HANDLE RequestQueueHandle,
    _In_ HTTP_OPAQUE_ID Id,
    _In_ HTTP_REQUEST_PROPERTY PropertyId,
    _In_reads_bytes_opt_(QualifierSize) PVOID Qualifier,
    _In_ ULONG QualifierSize,
    _Out_writes_bytes_to_opt_(OutputBufferSize, *BytesReturned) PVOID Output,
    _In_ ULONG OutputBufferSize,
    _Out_opt_ PULONG BytesReturned,
    _In_ LPOVERLAPPED Overlapped
    );
```

- Cleans up extra namespaces introduced in previous PR and changes `HTTP_REQUEST_PROPERTY_SNI_HOST_MAX_LENGTH` to private

Link to previous PR: https://github.com/dotnet/aspnetcore/pull/48572