### PR TITLE
Bump Polly to 7.2.4

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -308,7 +308,7 @@
     <PhotinoNETVersion>1.1.6</PhotinoNETVersion>
     <MicrosoftPlaywrightVersion>1.28.0</MicrosoftPlaywrightVersion>
     <PollyExtensionsHttpVersion>3.0.0</PollyExtensionsHttpVersion>
-    <PollyVersion>7.2.3</PollyVersion>
+    <PollyVersion>7.2.4</PollyVersion>
     <SeleniumSupportVersion>4.10.0</SeleniumSupportVersion>
     <SeleniumWebDriverChromeDriverVersion>114.0.5735.9000</SeleniumWebDriverChromeDriverVersion>
     <SeleniumWebDriverVersion>4.10.0</SeleniumWebDriverVersion>


### PR DESCRIPTION

# Bump Polly to 7.2.4

Update the reference for Polly to the latest release, 7.2.4.

## Description

At the request of some internal Microsoft teams, we recently published a [new version of Polly](https://github.com/App-vNext/Polly/releases/tag/7.2.4) that is Authenticode signed using a certificate provided to the Polly project by the .NET Foundation.

You can see this in the below screenshot from NuGet Package Explorer for the 7.2.4 `nupkg` file.

![image](https://github.com/dotnet/aspnetcore/assets/1439341/04c4368e-b77b-4e4b-ba8a-f977dc43eba8)

This PR updates ASP.NET Core 8 to depend on this version to improve supply-chain security without requiring applications to specifically update their reference to Polly if using the `Microsoft.Extensions.Http.Polly` package.

If this change is accepted, the new package will need to be added to AzDo so that NuGet package restore succeeds.

/cc @geeknoid @richlander
