### PR TITLE
[skip-ci] Add missing xml docs for ExceptionHandler

### DIFF
--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerServiceCollectionExtensions.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerServiceCollectionExtensions.cs
@@ -42,7 +42,8 @@ public static class ExceptionHandlerServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Adds services and options for the exception handler middleware.
+    /// Adds an `IExceptionHandler` implementation to services. `IExceptionHandler` implementations are used by the exception handler middleware to handle unexpected request exceptions.
+    /// Multiple handlers can be added and they're called by the middleware in the order they're added.
     /// </summary>
     /// <typeparam name="T">The type of the exception handler implementation.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/> for adding services.</param>

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerServiceCollectionExtensions.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerServiceCollectionExtensions.cs
@@ -42,12 +42,11 @@ public static class ExceptionHandlerServiceCollectionExtensions
     }
 
     /// <summary>
-    /// 
+    /// Adds services and options for the exception handler middleware.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="services"></param>
-    /// <returns></returns>
-
+    /// <typeparam name="T">The type of the exception handler implementation.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> for adding services.</param>
+    /// <returns>The modified <see cref="IServiceCollection"/>.</returns>
     public static IServiceCollection AddExceptionHandler<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services) where T : class, IExceptionHandler
     {
         return services.AddSingleton<IExceptionHandler, T>();

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/IExceptionHandler.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/IExceptionHandler.cs
@@ -6,7 +6,9 @@ using Microsoft.AspNetCore.Http;
 namespace Microsoft.AspNetCore.Diagnostics;
 
 /// <summary>
-/// 
+/// Represents an interface for handling exceptions in ASP.NET Core applications.
+/// Implementations of this interface can provide custom exception handling logic for
+/// different scenarios in the application.
 /// </summary>
 public interface IExceptionHandler
 {

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/IExceptionHandler.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/IExceptionHandler.cs
@@ -12,11 +12,16 @@ namespace Microsoft.AspNetCore.Diagnostics;
 public interface IExceptionHandler
 {
     /// <summary>
-    /// 
+    /// Tries to handle the specified exception asynchronously within the ASP.NET Core pipeline.
+    /// Implementations of this method can provide custom exception handling logic for different scenarios. 
     /// </summary>
     /// <param name="httpContext"></param>
     /// <param name="exception"></param>
     /// <param name="cancellationToken"></param>
-    /// <returns></returns>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> representing the asynchronous handling operation indicating 
+    /// <see langword="true"/> if the exception was
+    /// handled successfully; otherwise <see langword="false"/>.
+    /// </returns>
     ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken);
 }

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/IExceptionHandler.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/IExceptionHandler.cs
@@ -7,8 +7,7 @@ namespace Microsoft.AspNetCore.Diagnostics;
 
 /// <summary>
 /// Represents an interface for handling exceptions in ASP.NET Core applications.
-/// Implementations of this interface can provide custom exception handling logic for
-/// different scenarios in the application.
+/// `IExceptionHandler` implementations are used by the exception handler middleware.
 /// </summary>
 public interface IExceptionHandler
 {


### PR DESCRIPTION
## Description

Adds missing inline xml docs for IExceptionHandler and AddExceptionHandler method

Fixes #48640 