### PR TITLE
Fix Blazor WebAssembly Benchmarks

### DIFF
--- a/src/Components/benchmarkapps/Wasm.Performance/Driver/Wasm.Performance.Driver.csproj
+++ b/src/Components/benchmarkapps/Wasm.Performance/Driver/Wasm.Performance.Driver.csproj
@@ -9,6 +9,7 @@
     <SignAssembly>false</SignAssembly>
     <IsTestAssetProject>true</IsTestAssetProject>
     <RuntimeIdentifier Condition=" '$(DotNetBuildFromSource)' != 'true' ">linux-x64</RuntimeIdentifier>
+    <SelfContained Condition=" '$(DotNetBuildFromSource)' != 'true' ">true</SelfContained>
     <Nullable>annotations</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
# Fix Blazor WebAssembly Benchmarks

Fixes the Blazor WebAssembly benchmarks which were broken by https://github.com/dotnet/docs/issues/33726.

Fixes #48815
