### PR TITLE
Fix missing metadata for AsParameters parameter when using RDG.

### DIFF
--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/StaticRouteHandlerModel.Emitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/StaticRouteHandlerModel.Emitter.cs
@@ -228,10 +228,10 @@ internal static class StaticRouteHandlerModelEmitter
                     ProcessParameter(innerParameter, codeWriter);
                 }
             }
-            else
-            {
-                ProcessParameter(parameter, codeWriter);
-            }
+
+            // Even if a parameter is decorated with the AsParameters attribute, we still need
+            // to fetch metadata on the parameter itself (as well as the properties).
+            ProcessParameter(parameter, codeWriter);
         }
 
         static void ProcessParameter(EndpointParameter parameter, CodeWriter codeWriter)

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.cs
@@ -2502,29 +2502,6 @@ public partial class RequestDelegateFactoryTests : LoggedTest
     }
 
     [Fact]
-    public void Create_CombinesPropertiesAsParameterMetadata_AndTopLevelParameter()
-    {
-        // Arrange
-        var @delegate = ([AsParameters] AddsCustomParameterMetadata param1) => new CountsDefaultEndpointMetadataResult();
-        var options = new RequestDelegateFactoryOptions
-        {
-            EndpointBuilder = CreateEndpointBuilder(new List<object>
-            {
-                new CustomEndpointMetadata { Source = MetadataSource.Caller }
-            }),
-        };
-
-        // Act
-        var result = RequestDelegateFactory.Create(@delegate, options);
-
-        // Assert
-        Assert.Contains(result.EndpointMetadata, m => m is CustomEndpointMetadata { Source: MetadataSource.Parameter });
-        Assert.Contains(result.EndpointMetadata, m => m is ParameterNameMetadata { Name: "param1" });
-        Assert.Contains(result.EndpointMetadata, m => m is CustomEndpointMetadata { Source: MetadataSource.Property });
-        Assert.Contains(result.EndpointMetadata, m => m is ParameterNameMetadata { Name: nameof(AddsCustomParameterMetadata.Data) });
-    }
-
-    [Fact]
     public void Create_CombinesAllMetadata_InCorrectOrder()
     {
         // Arrange


### PR DESCRIPTION
Whilst migrating tests, I came across a scenario where a test case failed because the endpoint metadata was missing metadata when the parameter was decorated with `[AsParameters]`. The issue was that in RDG we fork based on whether a parameter has AsParameters and then enumerate the properties and fetch metadata - but we still need to emit metadata for the parameter itself.