### PR TITLE
Improve WebApplication debugging

### DIFF
--- a/src/DefaultBuilder/src/WebApplication.cs
+++ b/src/DefaultBuilder/src/WebApplication.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;

--- a/src/DefaultBuilder/src/WebApplication.cs
+++ b/src/DefaultBuilder/src/WebApplication.cs
@@ -260,7 +260,7 @@ public sealed class WebApplication : IHost, IApplicationBuilder, IEndpointRouteB
         public IHostApplicationLifetime Lifetime => _webApplication.Lifetime;
         public ILogger Logger => _webApplication.Logger;
         public string Urls => string.Join(", ", _webApplication.Urls);
-        public IList<Endpoint> Endpoints => _webApplication.DataSources.SelectMany(ds => ds.Endpoints).ToList();
+        public IReadOnlyList<Endpoint> Endpoints => _webApplication.Services.GetRequiredService<EndpointDataSource>().Endpoints;
         public bool IsRunning => _webApplication.IsRunning;
         public IList<string>? Middleware
         {

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -424,6 +424,8 @@ public sealed class WebApplicationBuilder : IHostApplicationBuilder
         //
         // This method updates the middleware descriptions to include automatically added middleware.
         // The app's middleware list is inserted into the new pipeline to create the best representation possible of the middleware pipeline.
+        //
+        // If the debugger isn't attached then there won't be middleware description collections in the properties and this does nothing.
 
         Debug.Assert(_builtApplication is not null);
 

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -386,17 +387,16 @@ public sealed class WebApplicationBuilder : IHostApplicationBuilder
         }
 
         // Wire the source pipeline to run in the destination pipeline
-        app.Use(next =>
-        {
-            _builtApplication.Run(next);
-            return _builtApplication.BuildRequestDelegate();
-        });
+        var wireSourcePipeline = new WireSourcePipeline(_builtApplication);
+        app.Use(wireSourcePipeline.CreateMiddleware);
 
         if (_builtApplication.DataSources.Count > 0)
         {
             // We don't know if user code called UseEndpoints(), so we will call it just in case, UseEndpoints() will ignore duplicate DataSources
             app.UseEndpoints(_ => { });
         }
+
+        MergeMiddlewareDescriptions(app);
 
         // Copy the properties to the destination app builder
         foreach (var item in _builtApplication.Properties)
@@ -416,4 +416,43 @@ public sealed class WebApplicationBuilder : IHostApplicationBuilder
 
     void IHostApplicationBuilder.ConfigureContainer<TContainerBuilder>(IServiceProviderFactory<TContainerBuilder> factory, Action<TContainerBuilder>? configure) =>
         _hostApplicationBuilder.ConfigureContainer(factory, configure);
+
+    private void MergeMiddlewareDescriptions(IApplicationBuilder app)
+    {
+        // A user's app builds up a list of middleware. Then when the WebApplication is started, middleware is automatically added
+        // if it is required. For example, the app has mapped endpoints but hasn't configured UseRouting/UseEndpoints.
+        //
+        // This method updates the middleware descriptions to include automatically added middleware.
+        // The app's middleware list is inserted into the new pipeline to create the best representation possible of the middleware pipeline.
+
+        Debug.Assert(_builtApplication is not null);
+
+        const string MiddlewareDescriptionsKey = "__MiddlewareDescriptions";
+        if (_builtApplication.Properties.TryGetValue(MiddlewareDescriptionsKey, out var sourceValue) &&
+            app.Properties.TryGetValue(MiddlewareDescriptionsKey, out var destinationValue) &&
+            sourceValue is List<string> sourceDescriptions &&
+            destinationValue is List<string> destinationDescriptions)
+        {
+            var wireUpIndex = destinationDescriptions.IndexOf(typeof(WireSourcePipeline).FullName!);
+            if (wireUpIndex != -1)
+            {
+                destinationDescriptions.RemoveAt(wireUpIndex);
+                destinationDescriptions.InsertRange(wireUpIndex, sourceDescriptions);
+
+                _builtApplication.Properties[MiddlewareDescriptionsKey] = destinationDescriptions;
+            }
+        }
+    }
+
+    // This type exists so the place where the source pipeline is wired into the destination pipeline can be identified.
+    private sealed class WireSourcePipeline(IApplicationBuilder builtApplication)
+    {
+        private readonly IApplicationBuilder _builtApplication = builtApplication;
+
+        public RequestDelegate CreateMiddleware(RequestDelegate next)
+        {
+            _builtApplication.Run(next);
+            return _builtApplication.Build();
+        }
+    }
 }

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -1729,6 +1729,7 @@ public class WebApplicationTests
     public async Task EndpointDataSourceOnlyAddsOnce(CreateBuilderFunc createBuilder)
     {
         var builder = createBuilder();
+        builder.WebHost.UseTestServer();
         await using var app = builder.Build();
 
         app.UseRouting();
@@ -1883,6 +1884,7 @@ public class WebApplicationTests
     public async Task PropertiesPreservedFromInnerApplication(CreateBuilderFunc createBuilder)
     {
         var builder = createBuilder();
+        builder.WebHost.UseTestServer();
         builder.Services.AddSingleton<IStartupFilter, PropertyFilter>();
         await using var app = builder.Build();
 
@@ -2557,13 +2559,14 @@ public class WebApplicationTests
     }
 
     [Fact]
-    public void UseMiddleware_HasEndpointsAndAuth_Run_DebugView_HasAutomaticMiddleware()
+    public async Task UseMiddleware_HasEndpointsAndAuth_Run_DebugView_HasAutomaticMiddleware()
     {
         var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
         builder.Services.AddAuthenticationCore();
         builder.Services.AddAuthorization();
 
-        var app = builder.Build();
+        await using var app = builder.Build();
 
         app.UseMiddleware<MiddlewareWithInterface>();
         app.MapGet("/hello", () => "hello world");
@@ -2583,11 +2586,12 @@ public class WebApplicationTests
     }
 
     [Fact]
-    public void NoMiddleware_Run_DebugView_HasAutomaticMiddleware()
+    public async Task NoMiddleware_Run_DebugView_HasAutomaticMiddleware()
     {
         var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
 
-        var app = builder.Build();
+        await using var app = builder.Build();
 
         // Starting the app automatically adds middleware as needed.
         _ = app.RunAsync();

--- a/src/Hosting/Hosting/src/Internal/ApplicationLifetime.cs
+++ b/src/Hosting/Hosting/src/Internal/ApplicationLifetime.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -9,6 +10,9 @@ namespace Microsoft.AspNetCore.Hosting;
 /// <summary>
 /// Allows consumers to perform cleanup during a graceful shutdown.
 /// </summary>
+[DebuggerDisplay("ApplicationStarted = {ApplicationStarted.IsCancellationRequested}, " +
+    "ApplicationStopping = {ApplicationStopping.IsCancellationRequested}, " +
+    "ApplicationStopped = {ApplicationStopped.IsCancellationRequested}")]
 #pragma warning disable CS0618 // Type or member is obsolete
 internal sealed class ApplicationLifetime : IApplicationLifetime, Extensions.Hosting.IApplicationLifetime, IHostApplicationLifetime
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Hosting/Hosting/src/Internal/HostingEnvironment.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingEnvironment.cs
@@ -1,9 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.AspNetCore.Hosting;
+
+[DebuggerDisplay("ApplicationName = {ApplicationName}, EnvironmentName = {EnvironmentName}")]
 #pragma warning disable CS0618 // Type or member is obsolete
 internal sealed class HostingEnvironment : IHostingEnvironment, Extensions.Hosting.IHostingEnvironment, IWebHostEnvironment
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Http/Http/src/Builder/ApplicationBuilder.cs
+++ b/src/Http/Http/src/Builder/ApplicationBuilder.cs
@@ -46,6 +46,7 @@ public partial class ApplicationBuilder : IApplicationBuilder
 
         SetProperty(ServerFeaturesKey, server);
 
+        // IDebugger service can optionally be added by tests to simulate the debugger being attached.
         _debugger = (IDebugger?)serviceProvider.GetService(typeof(IDebugger)) ?? DebuggerWrapper.Instance;
 
         if (_debugger.IsAttached)

--- a/src/Http/Http/src/Builder/ApplicationBuilder.cs
+++ b/src/Http/Http/src/Builder/ApplicationBuilder.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Internal;
@@ -10,13 +11,17 @@ namespace Microsoft.AspNetCore.Builder;
 /// <summary>
 /// Default implementation for <see cref="IApplicationBuilder"/>.
 /// </summary>
+[DebuggerDisplay("Middleware = {MiddlewareCount}")]
+[DebuggerTypeProxy(typeof(ApplicationBuilderDebugView))]
 public partial class ApplicationBuilder : IApplicationBuilder
 {
     private const string ServerFeaturesKey = "server.Features";
     private const string ApplicationServicesKey = "application.Services";
+    private const string MiddlewareDescriptionsKey = "__MiddlewareDescriptions";
     private const string RequestUnhandledKey = "__RequestUnhandled";
 
     private readonly List<Func<RequestDelegate, RequestDelegate>> _components = new();
+    private readonly List<string> _descriptions = new();
 
     /// <summary>
     /// Initializes a new instance of <see cref="ApplicationBuilder"/>.
@@ -25,6 +30,8 @@ public partial class ApplicationBuilder : IApplicationBuilder
     public ApplicationBuilder(IServiceProvider serviceProvider) : this(serviceProvider, new FeatureCollection())
     {
     }
+
+    private int MiddlewareCount => _components.Count;
 
     /// <summary>
     /// Initializes a new instance of <see cref="ApplicationBuilder"/>.
@@ -37,6 +44,10 @@ public partial class ApplicationBuilder : IApplicationBuilder
         ApplicationServices = serviceProvider;
 
         SetProperty(ServerFeaturesKey, server);
+
+        // Add component descriptions collection to properties so debugging tools can display
+        // a list of configured middleware for an application.
+        SetProperty(MiddlewareDescriptionsKey, _descriptions);
     }
 
     private ApplicationBuilder(ApplicationBuilder builder)
@@ -96,7 +107,28 @@ public partial class ApplicationBuilder : IApplicationBuilder
     public IApplicationBuilder Use(Func<RequestDelegate, RequestDelegate> middleware)
     {
         _components.Add(middleware);
+        _descriptions.Add(CreateMiddlewareDescription(middleware));
+
         return this;
+    }
+
+    private static string CreateMiddlewareDescription(Func<RequestDelegate, RequestDelegate> middleware)
+    {
+        if (middleware.Target != null)
+        {
+            // To IApplicationBuilder, middleware is just a func. Getting a good description is hard.
+            // Inspect the incoming func and attempt to resolve it back to a middleware type if possible.
+            // UseMiddlewareExtensions adds middleware via a method with the name CreateMiddleware.
+            // If this pattern is matched, then ToString on the target returns the middleware type name.
+            if (middleware.Method.Name == "CreateMiddleware")
+            {
+                return middleware.Target.ToString()!;
+            }
+
+            return middleware.Target.GetType().FullName + "." + middleware.Method.Name;
+        }
+
+        return middleware.Method.Name.ToString();
     }
 
     /// <summary>
@@ -153,5 +185,27 @@ public partial class ApplicationBuilder : IApplicationBuilder
         }
 
         return app;
+    }
+
+    private sealed class ApplicationBuilderDebugView(ApplicationBuilder applicationBuilder)
+    {
+        private readonly ApplicationBuilder _applicationBuilder = applicationBuilder;
+
+        public IServiceProvider ApplicationServices => _applicationBuilder.ApplicationServices;
+        public IDictionary<string, object?> Properties => _applicationBuilder.Properties;
+        public IFeatureCollection ServerFeatures => _applicationBuilder.ServerFeatures;
+        public IList<string>? Middleware
+        {
+            get
+            {
+                if (_applicationBuilder.Properties.TryGetValue("__MiddlewareDescriptions", out var value) &&
+                    value is IList<string> descriptions)
+                {
+                    return descriptions;
+                }
+
+                throw new NotSupportedException("Unable to get configured middleware.");
+            }
+        }
     }
 }

--- a/src/Http/Http/src/Builder/ApplicationBuilder.cs
+++ b/src/Http/Http/src/Builder/ApplicationBuilder.cs
@@ -47,7 +47,7 @@ public partial class ApplicationBuilder : IApplicationBuilder
         SetProperty(ServerFeaturesKey, server);
 
         // IDebugger service can optionally be added by tests to simulate the debugger being attached.
-        _debugger = (IDebugger?)serviceProvider.GetService(typeof(IDebugger)) ?? DebuggerWrapper.Instance;
+        _debugger = (IDebugger?)serviceProvider?.GetService(typeof(IDebugger)) ?? DebuggerWrapper.Instance;
 
         if (_debugger.IsAttached)
         {

--- a/src/Http/Http/src/Internal/IDebugger.cs
+++ b/src/Http/Http/src/Internal/IDebugger.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Http;
+
+internal interface IDebugger
+{
+    bool IsAttached { get; }
+}
+
+internal sealed class DebuggerWrapper : IDebugger
+{
+    public static readonly DebuggerWrapper Instance = new DebuggerWrapper();
+
+    private DebuggerWrapper() { }
+
+    public bool IsAttached => Debugger.IsAttached;
+}

--- a/src/Http/Http/src/Microsoft.AspNetCore.Http.csproj
+++ b/src/Http/Http/src/Microsoft.AspNetCore.Http.csproj
@@ -35,6 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.Tests" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Http.Tests" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Hosting.Tests" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Http.MicroBenchmarks" />

--- a/src/Servers/Kestrel/Core/src/Internal/ServerAddressesCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ServerAddressesCollection.cs
@@ -96,6 +96,7 @@ internal sealed class ServerAddressesCollection : ICollection<string>
         return GetEnumerator();
     }
 
+    [DebuggerDisplay("Count = {Count}")]
     private sealed class PublicServerAddressesCollection : ICollection<string>
     {
         private readonly ServerAddressesCollection _addressesCollection;


### PR DESCRIPTION
This PR adds various debugging improvements around WebApplication.

Notable improvements:

* Add an `IsRunning` property calculated from lifetime events to quickly understand state of the app
* Made it easier to see app name and environment (i.e. development or release)
* Mapped endpoints are available in a collection
* Configured middleware descriptions are available in a collection.
    * This was **hard**. The app builder sees middleware as a list of delegates, and delegates don't provide a nice debugging experience. Mapping middleware delegates back to middleware types required some **_creative_** problem-solving. I'd like to know whether people think the hacks here are worth it.
    * ~Note that the collection doesn't include middleware automatically added by WebApplication. Good or bad?~ Middleware automatically added when the web app starts is included.
    * ~More testing is needed to ensure it hangs together when branching the app pipeline.~ Done
* Improve `ApplicationLifetime`. It lives in dotnet/runtime. ~Will improve it later.~ https://github.com/dotnet/runtime/pull/87599

## Before:

![image](https://github.com/dotnet/aspnetcore/assets/303201/c3fff6c2-c4b1-4851-a54e-658b217868f1)

## After:

![image](https://github.com/dotnet/aspnetcore/assets/303201/aee1107e-2fb2-4342-b056-123fcf1269dc)

App endpoints:

![image](https://github.com/dotnet/aspnetcore/assets/303201/3ca0badb-88f0-487c-8a33-a95044fff139)

App middleware:

![image](https://github.com/dotnet/aspnetcore/assets/303201/e1331f09-7e1d-4bba-95e5-32c1348b3463)

More complex example:

![image](https://user-images.githubusercontent.com/303201/246308180-040c6d10-bee5-4515-aed4-78ff19a027c7.png)

