### PR TITLE
Allow non-NetFramework tests to be skipped with Mono

### DIFF
--- a/src/Testing/src/xunit/FrameworkSkipConditionAttribute.cs
+++ b/src/Testing/src/xunit/FrameworkSkipConditionAttribute.cs
@@ -32,13 +32,13 @@ public class FrameworkSkipConditionAttribute : Attribute, ITestCondition
             return true;
         }
 
-#if NETFRAMEWORK
         if (excludedFrameworks.HasFlag(RuntimeFrameworks.Mono) &&
             TestPlatformHelper.IsMono)
         {
             return false;
         }
 
+#if NETFRAMEWORK
         if (excludedFrameworks.HasFlag(RuntimeFrameworks.CLR))
         {
             return false;


### PR DESCRIPTION
### Allow non-NetFramework tests to be skipped on Mono

Updates the `FrameworkSkipConditionAttribute` to allow for non-NetFramework tests to be skipped with Mono runtime.

Fixes #48688
