### PR TITLE
Fix 48934 test quarantine.

### DIFF
--- a/src/Middleware/WebSockets/test/UnitTests/WebSocketMiddlewareTests.cs
+++ b/src/Middleware/WebSockets/test/UnitTests/WebSocketMiddlewareTests.cs
@@ -503,9 +503,13 @@ public class WebSocketMiddlewareTests : LoggedTest
     {
         WebSocket serverSocket = null;
 
+        // Events that we want to sequence execution across client and server.
         var socketWasAccepted = new ManualResetEventSlim();
         var socketWasAborted = new ManualResetEventSlim();
         var firstReceiveOccured = new ManualResetEventSlim();
+        var secondReceiveInitiated = new ManualResetEventSlim();
+
+        Exception receiveException = null;
 
         await using (var server = KestrelWebSocketHelpers.CreateServer(LoggerFactory, out var port, async context =>
         {
@@ -515,24 +519,36 @@ public class WebSocketMiddlewareTests : LoggedTest
 
             var serverBuffer = new byte[1024];
 
-            var finishedWithConnectionAborted = false;
-
             try
             {
                 while (serverSocket.State is WebSocketState.Open or WebSocketState.CloseSent)
                 {
-                    var response = await serverSocket.ReceiveAsync(serverBuffer, default);
-                    firstReceiveOccured.Set();
+                    if (firstReceiveOccured.IsSet)
+                    {
+                        var pendingResponse = serverSocket.ReceiveAsync(serverBuffer, default);
+                        secondReceiveInitiated.Set();
+                        var response = await pendingResponse;
+                    }
+                    else
+                    {
+                        var response = await serverSocket.ReceiveAsync(serverBuffer, default);
+                        firstReceiveOccured.Set();
+                    }
                 }
             }
-            catch (ConnectionAbortedException)
+            catch (ConnectionAbortedException ex)
             {
                 socketWasAborted.Set();
-                finishedWithConnectionAborted = true;
+                receiveException = ex;
+            }
+            catch (Exception ex)
+            {
+                // Capture this exception so a test failure can give us more information.
+                receiveException = ex;
             }
             finally
             {
-                Assert.True(finishedWithConnectionAborted);
+                Assert.IsType<ConnectionAbortedException>(receiveException);
             }
         }))
         {
@@ -549,6 +565,9 @@ public class WebSocketMiddlewareTests : LoggedTest
 
                 var firstReceiveOccuredDidNotTimeout = firstReceiveOccured.Wait(10000);
                 Assert.True(firstReceiveOccuredDidNotTimeout, "First receive did not occur within the allotted time.");
+
+                var secondReceiveInitiatedDidNotTimeout = secondReceiveInitiated.Wait(10000);
+                Assert.True(secondReceiveInitiatedDidNotTimeout, "Second receive was not initiated within the allotted time.");
 
                 serverSocket.Abort();
 


### PR DESCRIPTION
This PR fixes the reason why we had to quarantine the ```WebSocket_Abort_Interrupts_Pending_ReceiveAsync``` test case in issue #48934 

The test in its original form was very timing sensitive in that if ```WebSocket.Abort(...)``` was called before ```WebSocket.ReceiveAsync(...)``` the exception thrown would change.

This change in the test case exerts more control over the exact sequence of events so that the call to ```ReceiveAsync(...)``` is made before ```WebSocket.Abort(...)``` is called so we are not subject to timing issues.