### PR TITLE
[Blazor] Allow properties marked with both `[Parameter]` and `[SupplyParameterFromQuery]` to receive values directly

### DIFF
--- a/src/Components/Components/src/ParameterView.cs
+++ b/src/Components/Components/src/ParameterView.cs
@@ -16,7 +16,7 @@ public readonly struct ParameterView
 {
     private static readonly RenderTreeFrame[] _emptyFrames = new RenderTreeFrame[]
     {
-            RenderTreeFrame.Element(0, string.Empty).WithComponentSubtreeLength(1)
+        RenderTreeFrame.Element(0, string.Empty).WithComponentSubtreeLength(1)
     };
 
     private static readonly ParameterView _empty = new ParameterView(ParameterViewLifetime.Unbound, _emptyFrames, 0, Array.Empty<CascadingParameterState>());
@@ -130,6 +130,20 @@ public readonly struct ParameterView
 
     internal ParameterView WithCascadingParameters(IReadOnlyList<CascadingParameterState> cascadingParameters)
         => new ParameterView(_lifetime, _frames, _ownerIndex, cascadingParameters);
+
+    internal bool HasDirectParameter(string parameterName)
+    {
+        var directParameterEnumerator = new RenderTreeFrameParameterEnumerator(_frames, _ownerIndex);
+        while (directParameterEnumerator.MoveNext())
+        {
+            if (string.Equals(directParameterEnumerator.Current.Name, parameterName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     // It's internal because there isn't a known use case for user code comparing
     // ParameterView instances, and even if there was, it's unlikely it should

--- a/src/Components/Components/src/Reflection/ComponentProperties.cs
+++ b/src/Components/Components/src/Reflection/ComponentProperties.cs
@@ -66,7 +66,7 @@ internal static class ComponentProperties
                 else if (parameter.Cascading && writer.AcceptsDirectParameters && writer.AcceptsCascadingParameters)
                 {
                     // It's possible that the writer accepts both cascading and direct parameters. In that case,
-                    // we want to prefer the direct parameter if it exists. TODO: Explanation.
+                    // we want to prefer the direct parameter, if it exists.
                     if (parameters.HasDirectParameter(parameterName))
                     {
                         continue;

--- a/src/Components/Components/src/Reflection/PropertySetter.cs
+++ b/src/Components/Components/src/Reflection/PropertySetter.cs
@@ -36,7 +36,9 @@ internal sealed class PropertySetter
             callPropertySetterClosedGenericMethod.CreateDelegate(typeof(Action<object, object>), propertySetterAsAction);
     }
 
-    public bool Cascading { get; init; }
+    public bool AcceptsDirectParameters { get; init; }
+
+    public bool AcceptsCascadingParameters { get; init; }
 
     public void SetValue(object target, object value) => _setterDelegate(target, value);
 

--- a/src/Components/Components/test/ParameterViewTest.Assignment.cs
+++ b/src/Components/Components/test/ParameterViewTest.Assignment.cs
@@ -237,8 +237,8 @@ public partial class ParameterViewTest
 
         // Assert
         Assert.Equal(
-            $"Object of type '{typeof(HasCascadingParameter).FullName}' has a property matching the name '{nameof(HasCascadingParameter.Cascading)}', " +
-            $"but it does not have [{nameof(ParameterAttribute)}] applied.",
+            $"The property '{nameof(HasCascadingParameter.Cascading)}' on component type '{typeof(HasCascadingParameter).FullName}' " +
+            $"cannot be set explicitly because it only accepts cascading values.",
             ex.Message);
     }
 
@@ -262,7 +262,7 @@ public partial class ParameterViewTest
     }
 
     [Fact]
-    public void IncomingNonCascadingValueMatchesParameterThatIsBothCascadingAndNonCascading_Works()
+    public void IncomingNonCascadingValueMatchesParameterThatIsBothCascadingAndNonCascading_Throws()
     {
         // Arrange
         var target = new HasPropertyWithParameterAndCascadingParameterAttributes();
@@ -271,10 +271,14 @@ public partial class ParameterViewTest
         var parameters = builder.Build();
 
         // Act
-        parameters.SetParameterProperties(target);
+        var ex = Assert.Throws<InvalidOperationException>(() => parameters.SetParameterProperties(target));
 
         // Assert
-        Assert.Equal("Hello", target.Parameter);
+        Assert.Equal(
+            $"The property '{nameof(HasPropertyWithParameterAndCascadingParameterAttributes.Parameter)}' on component type " +
+            $"'{typeof(HasPropertyWithParameterAndCascadingParameterAttributes).FullName}' cannot be set explicitly because it " +
+            $"only accepts cascading values.",
+            ex.Message);
     }
 
     [Fact]
@@ -294,13 +298,13 @@ public partial class ParameterViewTest
     }
 
     [Fact]
-    public void ParameterThatIsBothCascadingAndNonCascading_PrefersNonCascadingValue()
+    public void ParameterThatCanBeSuppliedFromQueryOrNonCascadingValue_PrefersNonCascadingValue()
     {
         // Arrange
-        var target = new HasPropertyWithParameterAndCascadingParameterAttributes();
+        var target = new HasPropertyWithParameterAndSupplyParameterFromQueryAttributes();
         var builder = new ParameterViewBuilder();
-        builder.Add(nameof(HasPropertyWithParameterAndCascadingParameterAttributes.Parameter), "Non-cascading", cascading: false);
-        builder.Add(nameof(HasPropertyWithParameterAndCascadingParameterAttributes.Parameter), "Cascading", cascading: true);
+        builder.Add(nameof(HasPropertyWithParameterAndSupplyParameterFromQueryAttributes.Parameter), "Non-cascading", cascading: false);
+        builder.Add(nameof(HasPropertyWithParameterAndSupplyParameterFromQueryAttributes.Parameter), "Cascading", cascading: true);
         var parameters = builder.Build();
 
         // Act
@@ -696,6 +700,11 @@ public partial class ParameterViewTest
     class HasPropertyWithParameterAndCascadingParameterAttributes
     {
         [Parameter, CascadingParameter] public string Parameter { get; set; }
+    }
+
+    class HasPropertyWithParameterAndSupplyParameterFromQueryAttributes
+    {
+        [Parameter, SupplyParameterFromQuery] public string Parameter { get; set; }
     }
 
     class ParameterViewBuilder : IEnumerable

--- a/src/Components/Components/test/ParameterViewTest.Assignment.cs
+++ b/src/Components/Components/test/ParameterViewTest.Assignment.cs
@@ -262,6 +262,55 @@ public partial class ParameterViewTest
     }
 
     [Fact]
+    public void IncomingNonCascadingValueMatchesParameterThatIsBothCascadingAndNonCascading_Works()
+    {
+        // Arrange
+        var target = new HasPropertyWithParameterAndCascadingParameterAttributes();
+        var builder = new ParameterViewBuilder();
+        builder.Add(nameof(HasPropertyWithParameterAndCascadingParameterAttributes.Parameter), "Hello", cascading: false);
+        var parameters = builder.Build();
+
+        // Act
+        parameters.SetParameterProperties(target);
+
+        // Assert
+        Assert.Equal("Hello", target.Parameter);
+    }
+
+    [Fact]
+    public void IncomingCascadingValueMatchesParameterThatIsBothCascadingAndNonCascading_Works()
+    {
+        // Arrange
+        var target = new HasPropertyWithParameterAndCascadingParameterAttributes();
+        var builder = new ParameterViewBuilder();
+        builder.Add(nameof(HasPropertyWithParameterAndCascadingParameterAttributes.Parameter), "Hello", cascading: true);
+        var parameters = builder.Build();
+
+        // Act
+        parameters.SetParameterProperties(target);
+
+        // Assert
+        Assert.Equal("Hello", target.Parameter);
+    }
+
+    [Fact]
+    public void ParameterThatIsBothCascadingAndNonCascading_PrefersNonCascadingValue()
+    {
+        // Arrange
+        var target = new HasPropertyWithParameterAndCascadingParameterAttributes();
+        var builder = new ParameterViewBuilder();
+        builder.Add(nameof(HasPropertyWithParameterAndCascadingParameterAttributes.Parameter), "Non-cascading", cascading: false);
+        builder.Add(nameof(HasPropertyWithParameterAndCascadingParameterAttributes.Parameter), "Cascading", cascading: true);
+        var parameters = builder.Build();
+
+        // Act
+        parameters.SetParameterProperties(target);
+
+        // Assert
+        Assert.Equal("Non-cascading", target.Parameter);
+    }
+
+    [Fact]
     public void SettingCaptureUnmatchedValuesParameterExplicitlyWorks()
     {
         // Arrange
@@ -642,6 +691,11 @@ public partial class ParameterViewTest
         [CascadingParameter] private string Cascading { get; set; }
 
         public string GetCascadingValue() => Cascading;
+    }
+
+    class HasPropertyWithParameterAndCascadingParameterAttributes
+    {
+        [Parameter, CascadingParameter] public string Parameter { get; set; }
     }
 
     class ParameterViewBuilder : IEnumerable


### PR DESCRIPTION
# Allow properties marked with both `[Parameter]` and `[SupplyParameterFromQuery]` to receive values directly

Fixes an issue where if a component parameter was marked with both `[Parameter]` and `[SupplyParameterFromQuery]`, a misleading exception message would be thrown when the parameter's value was set directly.

## Description

Since #48554 was merged, marking a component parameter with both `[Parameter]` and `[SupplyParameterFromQuery]` would cause the following exception to be thrown if the parameter was set directly:

```
Object of type 'MyComponent' has a property matching the name 'MyParameter', but it does not have [ParameterAttribute] applied.
```

This error is misleading, because the parameter _does_ have `ParameterAttribute` applied. The existing parameter setting logic had assumed that if a component's property was marked with a cascading parameter attribute, it must not have also had the `[Parameter]` attribute applied, hence the misleading error message. Since `[SupplyParameterFromQuery]` recently became a cascading parameter attribute, it inherited that behavior.

## Solution

This PR fixes the issue by allowing `[Parameter]` and `[SupplyParameterFromQuery]` to both exist on a single property without causing an exception to be thrown. If both direct and cascading parameter values are supplied, the direct parameter value is preferred.

Fixes #48937
