### PR TITLE
[release/8.0-preview6] [Blazor] Allow properties marked with both `[Parameter]` and `[SupplyParameterFromQuery]` to receive values directly

### DIFF
--- a/src/Components/Components/src/ParameterView.cs
+++ b/src/Components/Components/src/ParameterView.cs
@@ -16,7 +16,7 @@ public readonly struct ParameterView
 {
     private static readonly RenderTreeFrame[] _emptyFrames = new RenderTreeFrame[]
     {
-            RenderTreeFrame.Element(0, string.Empty).WithComponentSubtreeLength(1)
+        RenderTreeFrame.Element(0, string.Empty).WithComponentSubtreeLength(1)
     };
 
     private static readonly ParameterView _empty = new ParameterView(ParameterViewLifetime.Unbound, _emptyFrames, 0, Array.Empty<CascadingParameterState>());
@@ -130,6 +130,20 @@ public readonly struct ParameterView
 
     internal ParameterView WithCascadingParameters(IReadOnlyList<CascadingParameterState> cascadingParameters)
         => new ParameterView(_lifetime, _frames, _ownerIndex, cascadingParameters);
+
+    internal bool HasDirectParameter(string parameterName)
+    {
+        var directParameterEnumerator = new RenderTreeFrameParameterEnumerator(_frames, _ownerIndex);
+        while (directParameterEnumerator.MoveNext())
+        {
+            if (string.Equals(directParameterEnumerator.Current.Name, parameterName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     // It's internal because there isn't a known use case for user code comparing
     // ParameterView instances, and even if there was, it's unlikely it should

--- a/src/Components/Components/src/Reflection/ComponentProperties.cs
+++ b/src/Components/Components/src/Reflection/ComponentProperties.cs
@@ -45,9 +45,9 @@ internal static class ComponentProperties
                     ThrowForUnknownIncomingParameterName(targetType, parameterName);
                     throw null; // Unreachable
                 }
-                else if (writer.Cascading && !parameter.Cascading)
+                else if (!writer.AcceptsDirectParameters && !parameter.Cascading)
                 {
-                    // We don't allow you to set a cascading parameter with a non-cascading value. Put another way:
+                    // We don't allow you to set a cascading parameter with a non-cascading (direct) value. Put another way:
                     // cascading parameters are not part of the public API of a component, so it's not reasonable
                     // for someone to set it directly.
                     //
@@ -56,12 +56,22 @@ internal static class ComponentProperties
                     ThrowForSettingCascadingParameterWithNonCascadingValue(targetType, parameterName);
                     throw null; // Unreachable
                 }
-                else if (!writer.Cascading && parameter.Cascading)
+                else if (!writer.AcceptsCascadingParameters && parameter.Cascading)
                 {
                     // We're giving a more specific error here because trying to set a non-cascading parameter
                     // with a cascading value is likely deliberate (but not supported), or is a bug in our code.
                     ThrowForSettingParameterWithCascadingValue(targetType, parameterName);
                     throw null; // Unreachable
+                }
+                else if (parameter.Cascading && writer.AcceptsDirectParameters && writer.AcceptsCascadingParameters)
+                {
+                    // Today, the only case where this is possible is when a property is annotated with both
+                    // ParameterAttribute and SupplyParameterFromQueryAttribute. If that happens, we want to
+                    // prefer the directly supplied value over the cascading value.
+                    if (parameters.HasDirectParameter(parameterName))
+                    {
+                        continue;
+                    }
                 }
 
                 SetProperty(target, writer, parameterName, parameter.Value);
@@ -82,7 +92,7 @@ internal static class ComponentProperties
 
                 if (writers.TryGetValue(parameterName, out var writer))
                 {
-                    if (!writer.Cascading && parameter.Cascading)
+                    if (!writer.AcceptsCascadingParameters && parameter.Cascading)
                     {
                         // Don't allow an "extra" cascading value to be collected - or don't allow a non-cascading
                         // parameter to be set with a cascading value.
@@ -91,7 +101,7 @@ internal static class ComponentProperties
                         ThrowForSettingParameterWithCascadingValue(targetType, parameterName);
                         throw null; // Unreachable
                     }
-                    else if (writer.Cascading && !parameter.Cascading)
+                    else if (writer.AcceptsCascadingParameters && !parameter.Cascading)
                     {
                         // Allow unmatched parameters to collide with the names of cascading parameters. This is
                         // valid because cascading parameter names are not part of the public API. There's no
@@ -196,8 +206,8 @@ internal static class ComponentProperties
     private static void ThrowForSettingCascadingParameterWithNonCascadingValue(Type targetType, string parameterName)
     {
         throw new InvalidOperationException(
-            $"Object of type '{targetType.FullName}' has a property matching the name '{parameterName}', " +
-            $"but it does not have [{nameof(ParameterAttribute)}] applied.");
+            $"The property '{parameterName}' on component type '{targetType.FullName}' cannot be set " +
+            $"explicitly because it only accepts cascading values.");
     }
 
     [DoesNotReturn]
@@ -279,8 +289,12 @@ internal static class ComponentProperties
                     }
                 }
 
-                var isParameter = parameterAttribute != null || cascadingParameterAttribute != null;
-                if (!isParameter)
+                // A property cannot accept direct parameters if it's annotated with a cascading value attribute, unless it's a
+                // SupplyParameterFromQueryAttribute. This is to retain backwards compatibility with previous versions of the
+                // SupplyParameterFromQuery feature that did not utilize cascading values, and thus did not have this limitation.
+                var acceptsDirectParameters = parameterAttribute is not null && cascadingParameterAttribute is null or SupplyParameterFromQueryAttribute;
+                var acceptsCascadingParameters = cascadingParameterAttribute is not null;
+                if (!acceptsDirectParameters && !acceptsCascadingParameters)
                 {
                     continue;
                 }
@@ -294,7 +308,8 @@ internal static class ComponentProperties
 
                 var propertySetter = new PropertySetter(targetType, propertyInfo)
                 {
-                    Cascading = cascadingParameterAttribute != null,
+                    AcceptsDirectParameters = acceptsDirectParameters,
+                    AcceptsCascadingParameters = acceptsCascadingParameters,
                 };
 
                 if (_underlyingWriters.ContainsKey(propertyName))

--- a/src/Components/Components/src/Reflection/PropertySetter.cs
+++ b/src/Components/Components/src/Reflection/PropertySetter.cs
@@ -36,7 +36,9 @@ internal sealed class PropertySetter
             callPropertySetterClosedGenericMethod.CreateDelegate(typeof(Action<object, object>), propertySetterAsAction);
     }
 
-    public bool Cascading { get; init; }
+    public bool AcceptsDirectParameters { get; init; }
+
+    public bool AcceptsCascadingParameters { get; init; }
 
     public void SetValue(object target, object value) => _setterDelegate(target, value);
 


### PR DESCRIPTION
# Allow properties marked with both `[Parameter]` and `[SupplyParameterFromQuery]` to receive values directly

Fixes an issue where if a component parameter was marked with both `[Parameter]` and `[SupplyParameterFromQuery]`, a misleading exception message would be thrown when the parameter's value was set directly.

Backport of #48954

## Description

Since #48554 was merged, marking a component parameter with both `[Parameter]` and `[SupplyParameterFromQuery]` would cause the following exception to be thrown if the parameter was set directly:

```
Object of type 'MyComponent' has a property matching the name 'MyParameter', but it does not have [ParameterAttribute] applied.
```

This is a breaking change because prior to the recent changes, component parameters annotated with both attributes could receive values directly without throwing an exception.

This PR fixes the issue by allowing `[Parameter]` and `[SupplyParameterFromQuery]` to both exist on a single property without causing an exception to be thrown. If both direct and cascading parameter values are supplied, the direct parameter value is preferred.

Fixes #48937

## Customer Impact

Moderate. It's somewhat uncommon to need to do this, but the original issue report did mention a [component library](https://github.com/dotnetcore/BootstrapBlazor) that was impacted by this change.

## Regression?

- [X] Yes
- [ ] No

Regressed from .NET 8.0 Preview 5

## Risk

- [ ] High
- [ ] Medium
- [X] Low

This is a straightforward change in a well-tested area, and new tests have been added to verify that the fix works correctly.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A