### PR TITLE
Pass in parameter name

### DIFF
--- a/src/Mvc/Mvc.Core/src/ModelBinding/Validation/DefaultComplexObjectValidationStrategy.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Validation/DefaultComplexObjectValidationStrategy.cs
@@ -96,7 +96,7 @@ internal sealed class DefaultComplexObjectValidationStrategy : IValidationStrate
                     if (!_modelMetadata.BoundConstructorParameterMapping.TryGetValue(parameter, out var property))
                     {
                         throw new InvalidOperationException(
-                            Resources.FormatValidationStrategy_MappedPropertyNotFound(parameter, _modelMetadata.ModelType));
+                            Resources.FormatValidationStrategy_MappedPropertyNotFound(parameterName, _modelMetadata.ModelType));
                     }
 
                     _entry = new ValidationEntry(parameter, key, () => GetModel(_model, property));


### PR DESCRIPTION
# Pass in parameter name to exception message

## Description

When attempting to bind to the primary constructor of a record type, if there is no mapping from a parameter to its property, the framework throws an exception. There is a placeholder in the exception for the parameter name, but the parameter (`ModelMetadata`) is being passed in instead.

I'm not sure how that code path would normally be reached. We've hit it in production code ourselves, but never managed to debug it (partly down to this issue).

Fixes #48853
