### PR TITLE
Ignore pings on sendsCloseMessageOnStop

### DIFF
--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
@@ -4028,7 +4028,7 @@ class HubConnectionTest {
     @Disabled
     @Test
     public void sendsCloseMessageOnStop() throws InterruptedException {
-        MockTransport mockTransport = new MockTransport(true, false);
+        MockTransport mockTransport = new MockTransport(true, true);
         HubConnection hubConnection = TestUtils.createHubConnection("http://example.com", mockTransport);
 
         hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
@@ -4025,7 +4025,6 @@ class HubConnectionTest {
     }
 
     // https://github.com/dotnet/aspnetcore/issues/49043
-    @Disabled
     @Test
     public void sendsCloseMessageOnStop() throws InterruptedException {
         MockTransport mockTransport = new MockTransport(true, true);


### PR DESCRIPTION
Fixes #49043 

This test was failing because in the time it took the test case to run _sometimes_ a ping message would manage to get sent by the client. If it did then the contents of the sent message would have an extra message. The order of the second and third message could change as well.

@BrennanConroy -- should we disable sending ping messages entirely after a close has been sent? Seems odd that the client has decided to close the connection but then sends a ping (ping before close is logical).