### PR TITLE
[Blazor] Fix condition for including the service worker assets in the project

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/Components-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/Components-CSharp.csproj.in
@@ -11,7 +11,7 @@
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">ComponentsWebAssembly-CSharp.Server</RootNamespace>
     <AssemblyName Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">`$(AssemblyName.Replace(' ', '_'))</AssemblyName>
-    <!--#if UseWebAssembly && PWA -->
+    <!--#if (UseWebAssembly && PWA) -->
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <!--#endif -->
   </PropertyGroup>
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="${MicrosoftAspNetCoreComponentsWebAssemblyServerVersion}" />
   </ItemGroup>
   <!--#endif -->
-  <!--#if UseWebAssembly && PWA -->
+  <!--#if (UseWebAssembly && PWA) -->
 
   <ItemGroup>
     <ServiceWorker Include="wwwroot\service-worker.js" PublishedContent="wwwroot\service-worker.published.js" />


### PR DESCRIPTION
Adds parenthesis around the condition so that it gets correctly evaluated by the build engine.