### PR TITLE
Fix invalid catch block in StringUtilities

### DIFF
--- a/src/Shared/ServerInfrastructure/StringUtilities.cs
+++ b/src/Shared/ServerInfrastructure/StringUtilities.cs
@@ -683,10 +683,13 @@ internal static class StringUtilities
             new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true).GetByteCount(value);
             return !value.Contains('\0');
         }
-        catch (ArgumentOutOfRangeException) // 'value' too large to compute a UTF-8 byte count
-        catch (EncoderFallbackException) // 'value' cannot be converted losslessly to UTF-8
+        catch (ArgumentOutOfRangeException)
         {
-            return false;
+            return false; // 'value' too large to compute a UTF-8 byte count
+        }
+        catch (EncoderFallbackException)
+        {
+            return false; // 'value' cannot be converted losslessly to UTF-8
         }
     }
 

--- a/src/Shared/ServerInfrastructure/StringUtilities.cs
+++ b/src/Shared/ServerInfrastructure/StringUtilities.cs
@@ -683,7 +683,8 @@ internal static class StringUtilities
             new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true).GetByteCount(value);
             return !value.Contains('\0');
         }
-        catch (DecoderFallbackException)
+        catch (ArgumentOutOfRangeException) // 'value' too large to compute a UTF-8 byte count
+        catch (EncoderFallbackException) // 'value' cannot be converted losslessly to UTF-8
         {
             return false;
         }


### PR DESCRIPTION
The method `Encoding.GetByteCount` will never throw `DecoderFallbackException`. Instead, the two exceptions it can throw which are relevant here are:

- `ArgumentOutOfRangeException`, when the input is so large that it the UTF-8 byte count can't be represented in a 32-bit integer; and
- `EncoderFallbackException`, when the input is not valid UTF-16.

This PR corrects the catch block to detect these two exceptional cases.