### PR TITLE
Use correct casing for WebAssembly in template text

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Components-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Components-CSharp/.template.config/template.json
@@ -222,7 +222,7 @@
       "datatype": "bool",
       "defaultValue": "false",
       "displayName": "_Use interactive WebAssembly components",
-      "description": "If specified, configures the project to render components interactively on the browser using WebAssembly."
+      "description": "If specified, configures the project to render components interactively in the browser using WebAssembly."
     },
     "UseServer": {
       "type": "parameter",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Components-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Components-CSharp/.template.config/template.json
@@ -221,8 +221,8 @@
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false",
-      "displayName": "_Use interactive webassembly components",
-      "description": "If specified, configures the project to render components interactively on the browser using webassembly."
+      "displayName": "_Use interactive WebAssembly components",
+      "description": "If specified, configures the project to render components interactively on the browser using WebAssembly."
     },
     "UseServer": {
       "type": "parameter",


### PR DESCRIPTION
Should be WebAssembly instead of webassembly.