### PR TITLE
Fix endpoints not being available in debug view until after WebApplication starts

### DIFF
--- a/src/DefaultBuilder/src/WebApplication.cs
+++ b/src/DefaultBuilder/src/WebApplication.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -259,7 +260,29 @@ public sealed class WebApplication : IHost, IApplicationBuilder, IEndpointRouteB
         public IHostApplicationLifetime Lifetime => _webApplication.Lifetime;
         public ILogger Logger => _webApplication.Logger;
         public string Urls => string.Join(", ", _webApplication.Urls);
-        public IReadOnlyList<Endpoint> Endpoints => _webApplication.Services.GetRequiredService<EndpointDataSource>().Endpoints;
+        public IReadOnlyList<Endpoint> Endpoints
+        {
+            get
+            {
+                var dataSource = _webApplication.Services.GetRequiredService<EndpointDataSource>();
+                if (dataSource is CompositeEndpointDataSource compositeEndpointDataSource)
+                {
+                    // The web app's data sources aren't registered until the routing middleware is.
+                    // That often happens when the app is run. If the data sources are registered then use
+                    // the central endpoint data source.
+                    if (compositeEndpointDataSource.DataSources.Intersect(_webApplication.DataSources).Count() == _webApplication.DataSources.Count)
+                    {
+                        return dataSource.Endpoints;
+                    }
+                    else
+                    {
+                        return new CompositeEndpointDataSource(_webApplication.DataSources).Endpoints;
+                    }
+                }
+
+                return dataSource.Endpoints;
+            }
+        }
         public bool IsRunning => _webApplication.IsRunning;
         public IList<string>? Middleware
         {

--- a/src/DefaultBuilder/src/WebApplication.cs
+++ b/src/DefaultBuilder/src/WebApplication.cs
@@ -267,15 +267,16 @@ public sealed class WebApplication : IHost, IApplicationBuilder, IEndpointRouteB
                 var dataSource = _webApplication.Services.GetRequiredService<EndpointDataSource>();
                 if (dataSource is CompositeEndpointDataSource compositeEndpointDataSource)
                 {
-                    // The web app's data sources aren't registered until the routing middleware is.
-                    // That often happens when the app is run. If the data sources are registered then use
-                    // the central endpoint data source.
+                    // The web app's data sources aren't registered until the routing middleware is. That often happens when the app is run.
+                    // We want endpoints to be available in the debug view before the app starts. Test if all the web app's the data sources are registered.
                     if (compositeEndpointDataSource.DataSources.Intersect(_webApplication.DataSources).Count() == _webApplication.DataSources.Count)
                     {
+                        // Data sources are centrally registered.
                         return dataSource.Endpoints;
                     }
                     else
                     {
+                        // Fallback to just the web app's data sources to support debugging before the web app starts.
                         return new CompositeEndpointDataSource(_webApplication.DataSources).Endpoints;
                     }
                 }

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -2676,6 +2676,30 @@ public class WebApplicationTests
             ep => Assert.Equal("/hello", ep.Metadata.GetRequiredMetadata<IRouteDiagnosticsMetadata>().Route));
     }
 
+    [Fact]
+    public async Task DebugView_Endpoints_UseEndpoints_AvailableBeforeAndAfterStart()
+    {
+        var builder = WebApplication.CreateBuilder();
+
+        await using var app = builder.Build();
+        app.UseRouting();
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapGet("/hello", () => "hello world");
+        });
+
+        var debugView = new WebApplication.WebApplicationDebugView(app);
+
+        Assert.Collection(debugView.Endpoints,
+            ep => Assert.Equal("/hello", ep.Metadata.GetRequiredMetadata<IRouteDiagnosticsMetadata>().Route));
+
+        // Starting the app registers endpoint data sources with routing.
+        _ = app.RunAsync();
+
+        Assert.Collection(debugView.Endpoints,
+            ep => Assert.Equal("/hello", ep.Metadata.GetRequiredMetadata<IRouteDiagnosticsMetadata>().Route));
+    }
+
     private class MiddlewareWithInterface : IMiddleware
     {
         public Task InvokeAsync(HttpContext context, RequestDelegate next)


### PR DESCRIPTION
I noticed that endpoints weren't available in the debug view until after the app had started. That happens because routing middleware needs to be registered for the WebApplication's endpoint data source to be in the global data source.

The debug view falls back to using the WebApplication's endpoint data sources until they're registered to make them available before app start.