### PR TITLE
Fix Http MinimalSample

### DIFF
--- a/src/Http/samples/MinimalSample/Program.cs
+++ b/src/Http/samples/MinimalSample/Program.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
-using System.Runtime;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Http/samples/MinimalSample/Program.cs
+++ b/src/Http/samples/MinimalSample/Program.cs
@@ -1,8 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Reflection;
+using System.Runtime;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc;
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Mvc;
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
-app.Logger.LogInformation($"Current process ID: {Process.GetCurrentProcess().Id}");
+app.Logger.LogInformation($"Current process ID: {Environment.ProcessId}");
 
 string Plaintext() => "Hello, World!";
 app.MapGet("/plaintext", Plaintext);

--- a/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
@@ -183,7 +183,7 @@ public static class MvcCoreServiceCollectionExtensions
         //
         // Action Invoker
         //
-        // The IActionInvokerFactory is cachable
+        // The IActionInvokerFactory is cacheable
         services.TryAddSingleton<IActionInvokerFactory, ActionInvokerFactory>();
         services.TryAddEnumerable(
             ServiceDescriptor.Transient<IActionInvokerProvider, ControllerActionInvokerProvider>());


### PR DESCRIPTION
# Fix `CA1837` in Http MinimalSample

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

Fixes an issue in HTTP MinimalSample, as per https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1837 `Environment.ProcessId` should be used instead of `Process.GetCurrentProcess().Id`