### PR TITLE
Cleanup blazor wasm template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -118,7 +118,6 @@
           },
           "exclude": [
             "Pages/CallWebApi.razor",
-            "Shared/NavMenu.CallsMicrosoftGraph.razor",
             "Shared/NavMenu.CallsWebApi.razor"
           ]
         },
@@ -128,8 +127,7 @@
             "Shared/NavMenu.CallsWebApi.razor": "Shared/NavMenu.razor"
           },
           "exclude": [
-            "Shared/NavMenu.NoApi.razor",
-            "Shared/NavMenu.CallsMicrosoftGraph.razor"
+            "Shared/NavMenu.NoApi.razor"
           ]
         },
         {
@@ -432,12 +430,6 @@
       "replaces": "[WebApiUrl]",
       "defaultValue": "https://graph.microsoft.com/v1.0",
       "description": "URL of the API to call from the web app. This option only applies if --auth SingleOrg, --auth MultiOrg or --auth IndividualB2C without and ASP.NET Core host is specified."
-    },
-    "CallsMicrosoftGraph": {
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "false",
-      "description": "Specifies if the web app calls Microsoft Graph. This option only applies if --auth SingleOrg or --auth MultiOrg is specified."
     },
     "CalledApiScopes": {
       "type": "parameter",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Shared/NavMenu.NoApi.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Shared/NavMenu.NoApi.razor
@@ -24,11 +24,6 @@
                 <span class="bi bi-list-nested" aria-hidden="true"></span> Fetch data
             </NavLink>
         </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="showProfile">
-                <span class="bi bi-person-fill" aria-hidden="true"></span> Show Profile
-            </NavLink>
-        </div>
     </nav>
 </div>
 


### PR DESCRIPTION
# Cleanup blazor wasm template

Forgot to remove NavMenu.CallsMicrosoftGraph.razor from template.json and show profile in the previous PR https://github.com/dotnet/aspnetcore/pull/48922




