### PR TITLE
Add RequestServices to HttpContext debugging

### DIFF
--- a/src/Http/Http.Abstractions/src/HttpContext.cs
+++ b/src/Http/Http.Abstractions/src/HttpContext.cs
@@ -96,6 +96,7 @@ public abstract class HttpContext
         public ClaimsPrincipal User => _context.User;
         public IDictionary<object, object?> Items => _context.Items;
         public CancellationToken RequestAborted => _context.RequestAborted;
+        public IServiceProvider RequestServices => _context.RequestServices;
         public string TraceIdentifier => _context.TraceIdentifier;
         // The normal session property throws if accessed before/without the session middleware.
         public ISession? Session => _context.Features.Get<ISessionFeature>()?.Session;


### PR DESCRIPTION
`HttpContext.RequestServices` should be included in `HttpContext` debug view now that DI's debug display has improved.

See https://github.com/dotnet/runtime/pull/88082 for more info.