### PR TITLE
[Blazor] Adds support for updating the parameter names as well as generating names inside child components

### DIFF
--- a/src/Components/Components/src/ComponentBase.cs
+++ b/src/Components/Components/src/ComponentBase.cs
@@ -37,8 +37,13 @@ public abstract class ComponentBase : IComponent, IHandleEvent, IHandleAfterRend
         {
             _hasPendingQueuedRender = false;
             _hasNeverRendered = false;
-            BuildRenderTree(builder);
+            RenderCore(builder);
         };
+    }
+
+    private protected virtual void RenderCore(RenderTreeBuilder builder)
+    {
+        BuildRenderTree(builder);
     }
 
     /// <summary>

--- a/src/Components/Components/src/ComponentBase.cs
+++ b/src/Components/Components/src/ComponentBase.cs
@@ -37,13 +37,8 @@ public abstract class ComponentBase : IComponent, IHandleEvent, IHandleAfterRend
         {
             _hasPendingQueuedRender = false;
             _hasNeverRendered = false;
-            RenderCore(builder);
+            BuildRenderTree(builder);
         };
-    }
-
-    private protected virtual void RenderCore(RenderTreeBuilder builder)
-    {
-        BuildRenderTree(builder);
     }
 
     /// <summary>

--- a/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
+++ b/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
@@ -177,7 +177,7 @@ public sealed class RenderTreeBuilder : IDisposable
 
         if (TrackNamedEventHandlers && string.Equals(name, "@onsubmit:name", StringComparison.Ordinal))
         {
-            _entries.AppendAttribute(sequence, name, "");
+            SetEventHandlerName("");
         }
 
         _entries.AppendAttribute(sequence, name, BoxedTrue);
@@ -385,10 +385,12 @@ public sealed class RenderTreeBuilder : IDisposable
                 {
                     if (TrackNamedEventHandlers && string.Equals(name, "@onsubmit:name", StringComparison.Ordinal))
                     {
-                        _entries.AppendAttribute(sequence, name, value);
+                        SetEventHandlerName("");
                     }
-
-                    _entries.AppendAttribute(sequence, name, BoxedTrue);
+                    else
+                    {
+                        _entries.AppendAttribute(sequence, name, BoxedTrue);
+                    }
                 }
                 else
                 {

--- a/src/Components/Components/test/CascadingParameterStateTest.cs
+++ b/src/Components/Components/test/CascadingParameterStateTest.cs
@@ -468,7 +468,7 @@ public class CascadingParameterStateTest
 
     class FormParametersComponentWithName : TestComponentBase
     {
-        [SupplyParameterFromForm(Name = "some-name")] public string FormParameter { get; set; }
+        [SupplyParameterFromForm(Handler = "some-name")] public string FormParameter { get; set; }
     }
 
     class ComponentWithNoCascadingParams : TestComponentBase
@@ -554,4 +554,10 @@ public sealed class SupplyParameterFromFormAttribute : CascadingParameterAttribu
     /// the form data and decide whether or not the value needs to be bound.
     /// </summary>
     public override string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name for the handler. The name is used to match
+    /// the form data and decide whether or not the value needs to be bound.
+    /// </summary>
+    public string Handler { get; set; }
 }

--- a/src/Components/Samples/BlazorUnitedApp/Data/Address.cs
+++ b/src/Components/Samples/BlazorUnitedApp/Data/Address.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace BlazorUnitedApp.Data;
+
+public class Address
+{
+    public string Street { get; set; } = string.Empty;
+    public string City { get; set; } = string.Empty;
+    public string State { get; set; } = string.Empty;
+    public string Zip { get; set; } = string.Empty;
+}

--- a/src/Components/Samples/BlazorUnitedApp/Data/Customer.cs
+++ b/src/Components/Samples/BlazorUnitedApp/Data/Customer.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace BlazorUnitedApp.Data;
+
+public class Customer
+{
+    public string Name { get; set; } = string.Empty;
+    public Address BillingAddress { get; set; } = new Address();
+}

--- a/src/Components/Samples/BlazorUnitedApp/Pages/AddressEditor.razor
+++ b/src/Components/Samples/BlazorUnitedApp/Pages/AddressEditor.razor
@@ -1,0 +1,31 @@
+﻿@inherits Editor<Address>
+@using BlazorUnitedApp.Data
+
+<div>
+    <label>
+        <span>Street</span>
+        <InputText @bind-Value="Value.Street" />
+        <ValidationMessage For="() => Value.Street" />
+    </label>
+</div>
+<div>
+    <label>
+        <span>State</span>
+        <InputText @bind-Value="Value.State" />
+        <ValidationMessage For="() => Value.State" />
+    </label>
+</div>
+<div>
+    <label>
+        <span>Zip</span>
+        <InputText @bind-Value="Value.Zip" />
+        <ValidationMessage For="() => Value.Zip" />
+    </label>
+</div>
+<div>
+    <label>
+        <span>City</span>
+        <InputText @bind-Value="Value.City" />
+        <ValidationMessage For="() => Value.City" />
+    </label>
+</div>

--- a/src/Components/Samples/BlazorUnitedApp/Pages/Index.razor
+++ b/src/Components/Samples/BlazorUnitedApp/Pages/Index.razor
@@ -1,28 +1,40 @@
 ﻿@page "/"
+@using BlazorUnitedApp.Data;
 <PageTitle>Index</PageTitle>
 
-<h1>@Value?.Parameter</h1>
-
-<EditForm Model="Value?.Parameter">
-    <InputText @bind-Value="Value!.Parameter" />
+<EditForm Model="Value" method="POST" OnSubmit="DisplayCustomer">  
+    <div>
+        <label>
+            <span>Name</span>
+            <InputText @bind-Value="Value!.Name" />
+        </label>
+    </div>
+    <AddressEditor @bind-Value="Value.BillingAddress" />
     <input type="submit" value="Send" />
 </EditForm>
 
 @if (_submitted)
 {
-    <p>Submited.</p>
+    <!-- Display customer data -->
+    <h3>Customer</h3>
+    <p>Name: @Value!.Name</p>
+    <p>Street: @Value.BillingAddress.Street</p>
+    <p>City: @Value.BillingAddress.City</p>
+    <p>State: @Value.BillingAddress.State</p>
+    <p>Zip: @Value.BillingAddress.Zip</p>
 }
 
-@code{
-    [SupplyParameterFromForm] Data? Value { get; set; }
+@code {
+
+    public void DisplayCustomer()
+    {
+        _submitted = true;
+    }
+
+    [SupplyParameterFromForm] Customer? Value { get; set; }
 
     protected override void OnInitialized() => Value ??= new();
 
     bool _submitted = false;
     public void Submit() => _submitted = true;
-
-    public class Data
-    {
-        public string Parameter { get; set; } = "";
-    }
 }

--- a/src/Components/Shared/src/ExpressionFormatting/ReverseStringBuilder.cs
+++ b/src/Components/Shared/src/ExpressionFormatting/ReverseStringBuilder.cs
@@ -33,6 +33,8 @@ internal ref struct ReverseStringBuilder
         _nextEndIndex = _currentBuffer.Length;
     }
 
+    public bool Empty => _nextEndIndex == _currentBuffer.Length;
+
     public void InsertFront(scoped ReadOnlySpan<char> span)
     {
         var startIndex = _nextEndIndex - span.Length;

--- a/src/Components/Web/src/Forms/Editor.cs
+++ b/src/Components/Web/src/Forms/Editor.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq.Expressions;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Microsoft.AspNetCore.Components.Forms;
+public abstract class Editor<T> : ComponentBase
+{
+    private HtmlFieldPrefix _value;
+
+    [Parameter] public T Value { get; set; } = default!;
+    [Parameter] public Expression<Func<T>> ValueExpression { get; set; } = default!;
+    [Parameter] public EventCallback<T> ValueChanged { get; set; } = default!;
+
+    [CascadingParameter] private HtmlFieldPrefix FieldPrefix { get; set; } = default!;
+
+    protected override void OnParametersSet()
+    {
+        _value = FieldPrefix != null ? FieldPrefix.Combine(ValueExpression) : new HtmlFieldPrefix(ValueExpression);
+    }
+
+    private protected override void RenderCore(RenderTreeBuilder builder)
+    {
+        builder.OpenComponent<CascadingValue<HtmlFieldPrefix>>(0);
+        builder.AddAttribute(1, "Value", _value);
+        builder.AddAttribute(2, "IsFixed", true);
+        builder.AddAttribute(3, "ChildContent", (RenderFragment)BuildRenderTree);
+        builder.CloseComponent();
+    }
+}

--- a/src/Components/Web/src/Forms/Editor.cs
+++ b/src/Components/Web/src/Forms/Editor.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Components.Forms;
 /// A component used for editing a value of type <typeparamref name="T"/>.
 /// </summary>
 /// <typeparam name="T"></typeparam>
-public abstract class Editor<T> : ComponentBase
+public abstract class Editor<T> : ComponentBase, ICascadingValueSupplier
 {
     private HtmlFieldPrefix? _value;
 
@@ -30,6 +30,8 @@ public abstract class Editor<T> : ComponentBase
     [Parameter] public EventCallback<T> ValueChanged { get; set; } = default!;
 
     [CascadingParameter] private HtmlFieldPrefix FieldPrefix { get; set; } = default!;
+
+    bool ICascadingValueSupplier.IsFixed => true;
 
     /// <summary>
     /// Returns the name for the specified <paramref name="expression"/> in the current context.
@@ -51,12 +53,21 @@ public abstract class Editor<T> : ComponentBase
         _value = FieldPrefix != null ? FieldPrefix.Combine(ValueExpression) : new HtmlFieldPrefix(ValueExpression);
     }
 
-    private protected override void RenderCore(RenderTreeBuilder builder)
+    bool ICascadingValueSupplier.CanSupplyValue(in CascadingParameterInfo parameterInfo) =>
+        parameterInfo.PropertyType == typeof(HtmlFieldPrefix);
+
+    object? ICascadingValueSupplier.GetCurrentValue(in CascadingParameterInfo parameterInfo)
     {
-        builder.OpenComponent<CascadingValue<HtmlFieldPrefix>>(0);
-        builder.AddAttribute(1, "Value", _value);
-        builder.AddAttribute(2, "IsFixed", true);
-        builder.AddAttribute(3, "ChildContent", (RenderFragment)BuildRenderTree);
-        builder.CloseComponent();
+        return ((ICascadingValueSupplier)this).CanSupplyValue(parameterInfo) ? _value : null;
+    }
+
+    void ICascadingValueSupplier.Subscribe(ComponentState subscriber, in CascadingParameterInfo parameterInfo)
+    {
+        throw new InvalidOperationException($"Cannot subscribe to a {typeof(HtmlFieldPrefix).Name}.");
+    }
+
+    void ICascadingValueSupplier.Unsubscribe(ComponentState subscriber, in CascadingParameterInfo parameterInfo)
+    {
+        throw new InvalidOperationException($"Cannot subscribe to a {typeof(HtmlFieldPrefix).Name}.");
     }
 }

--- a/src/Components/Web/src/Forms/Editor.cs
+++ b/src/Components/Web/src/Forms/Editor.cs
@@ -5,18 +5,49 @@ using System.Linq.Expressions;
 using Microsoft.AspNetCore.Components.Rendering;
 
 namespace Microsoft.AspNetCore.Components.Forms;
+
+/// <summary>
+/// A component used for editing a value of type <typeparamref name="T"/>.
+/// </summary>
+/// <typeparam name="T"></typeparam>
 public abstract class Editor<T> : ComponentBase
 {
-    private HtmlFieldPrefix _value;
+    private HtmlFieldPrefix? _value;
 
+    /// <summary>
+    /// The value for the component.
+    /// </summary>
     [Parameter] public T Value { get; set; } = default!;
+
+    /// <summary>
+    /// An expression that represents the value for the component.
+    /// </summary>
     [Parameter] public Expression<Func<T>> ValueExpression { get; set; } = default!;
+
+    /// <summary>
+    /// A callback that gets invoked when the value changes.
+    /// </summary>
     [Parameter] public EventCallback<T> ValueChanged { get; set; } = default!;
 
     [CascadingParameter] private HtmlFieldPrefix FieldPrefix { get; set; } = default!;
 
+    /// <summary>
+    /// Returns the name for the specified <paramref name="expression"/> in the current context.
+    /// </summary>
+    /// <param name="expression">The expression to use to compute the name.</param>
+    /// <returns>The name for the specified <paramref name="expression"/> in the current context.</returns>
+    /// <remarks>The provided <paramref name="expression"/> must be a member expression with <see cref="Editor{T}.Value"/> as it source.</remarks>
+    protected string NameFor(LambdaExpression expression) => _value!.GetFieldName(expression);
+
+    /// <inheritdoc />
     protected override void OnParametersSet()
     {
+        if (ValueExpression == null)
+        {
+            throw new InvalidOperationException($"{GetType()} requires a value for the 'ValueExpression' " +
+                "parameter. Normally this is provided automatically when using 'bind-Value'.");
+        }
+
         _value = FieldPrefix != null ? FieldPrefix.Combine(ValueExpression) : new HtmlFieldPrefix(ValueExpression);
     }
 

--- a/src/Components/Web/src/Forms/HtmlFieldPrefix.cs
+++ b/src/Components/Web/src/Forms/HtmlFieldPrefix.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq.Expressions;
+
+namespace Microsoft.AspNetCore.Components.Forms;
+
+internal class HtmlFieldPrefix(LambdaExpression initial)
+{
+    private readonly LambdaExpression[] _rest;
+
+    internal HtmlFieldPrefix(LambdaExpression expression, params LambdaExpression[] rest)
+        : this(expression)
+    {
+        _rest = rest;
+    }
+
+    public string GetPrefix()
+    {
+        return "prefix";
+    }
+
+    public HtmlFieldPrefix Combine(LambdaExpression other)
+    {
+        var restLength = _rest?.Length ?? 0;
+        var length = restLength + 1;
+        var expressions = new LambdaExpression[length];
+        for (var i = 0; i < restLength - 1; i++)
+        {
+            expressions[i] = _rest![i];
+        }
+
+        expressions[length - 1] = other;
+
+        return new HtmlFieldPrefix(initial, expressions);
+    }
+
+    public string GetFieldName(LambdaExpression expression)
+    {
+        string prefix = ExpressionFormatter.FormatLambda(initial);
+        var restLength = _rest?.Length ?? 0;
+        for (int i = 0; i < restLength; i++)
+        {
+            prefix = ExpressionFormatter.FormatLambda(_rest![i], prefix);
+        }
+
+        return ExpressionFormatter.FormatLambda(expression, prefix);
+    }
+}

--- a/src/Components/Web/src/Forms/HtmlFieldPrefix.cs
+++ b/src/Components/Web/src/Forms/HtmlFieldPrefix.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq.Expressions;
@@ -7,17 +7,12 @@ namespace Microsoft.AspNetCore.Components.Forms;
 
 internal class HtmlFieldPrefix(LambdaExpression initial)
 {
-    private readonly LambdaExpression[] _rest;
+    private readonly LambdaExpression[] _rest = Array.Empty<LambdaExpression>();
 
     internal HtmlFieldPrefix(LambdaExpression expression, params LambdaExpression[] rest)
         : this(expression)
     {
         _rest = rest;
-    }
-
-    public string GetPrefix()
-    {
-        return "prefix";
     }
 
     public HtmlFieldPrefix Combine(LambdaExpression other)
@@ -37,9 +32,9 @@ internal class HtmlFieldPrefix(LambdaExpression initial)
 
     public string GetFieldName(LambdaExpression expression)
     {
-        string prefix = ExpressionFormatter.FormatLambda(initial);
+        var prefix = ExpressionFormatter.FormatLambda(initial);
         var restLength = _rest?.Length ?? 0;
-        for (int i = 0; i < restLength; i++)
+        for (var i = 0; i < restLength; i++)
         {
             prefix = ExpressionFormatter.FormatLambda(_rest![i], prefix);
         }

--- a/src/Components/Web/src/Forms/InputBase.cs
+++ b/src/Components/Web/src/Forms/InputBase.cs
@@ -26,6 +26,8 @@ public abstract class InputBase<TValue> : ComponentBase, IDisposable
 
     [CascadingParameter] private EditContext? CascadedEditContext { get; set; }
 
+    [CascadingParameter] private HtmlFieldPrefix FieldPrefix { get; set; } = default!;
+
     /// <summary>
     /// Gets or sets a collection of additional attributes that will be applied to the created element.
     /// </summary>
@@ -205,7 +207,8 @@ public abstract class InputBase<TValue> : ComponentBase, IDisposable
             {
                 if (_formattedValueExpression is null && ValueExpression is not null)
                 {
-                    _formattedValueExpression = ExpressionFormatter.FormatLambda(ValueExpression);
+                    _formattedValueExpression = FieldPrefix != null ? FieldPrefix.GetFieldName(ValueExpression) :
+                        ExpressionFormatter.FormatLambda(ValueExpression);
                 }
 
                 return _formattedValueExpression ?? string.Empty;

--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -29,6 +29,8 @@ Microsoft.AspNetCore.Components.HtmlRendering.Infrastructure.StaticHtmlRenderer.
 Microsoft.AspNetCore.Components.HtmlRendering.Infrastructure.StaticHtmlRenderer.StaticHtmlRenderer(System.IServiceProvider! serviceProvider, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
 Microsoft.AspNetCore.Components.RenderTree.WebRenderer.WaitUntilAttachedAsync() -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.SupplyParameterFromFormAttribute
+Microsoft.AspNetCore.Components.SupplyParameterFromFormAttribute.Handler.get -> string?
+Microsoft.AspNetCore.Components.SupplyParameterFromFormAttribute.Handler.set -> void
 Microsoft.AspNetCore.Components.SupplyParameterFromFormAttribute.SupplyParameterFromFormAttribute() -> void
 Microsoft.AspNetCore.Components.Web.AutoRenderMode
 Microsoft.AspNetCore.Components.Web.AutoRenderMode.AutoRenderMode() -> void

--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -13,6 +13,15 @@ Microsoft.AspNetCore.Components.Forms.AntiforgeryStateProvider
 Microsoft.AspNetCore.Components.Forms.AntiforgeryStateProvider.AntiforgeryStateProvider() -> void
 Microsoft.AspNetCore.Components.Forms.AntiforgeryToken
 Microsoft.AspNetCore.Components.Forms.AntiforgeryToken.AntiforgeryToken() -> void
+Microsoft.AspNetCore.Components.Forms.Editor<T>
+Microsoft.AspNetCore.Components.Forms.Editor<T>.Editor() -> void
+Microsoft.AspNetCore.Components.Forms.Editor<T>.NameFor(System.Linq.Expressions.LambdaExpression! expression) -> string!
+Microsoft.AspNetCore.Components.Forms.Editor<T>.Value.get -> T
+Microsoft.AspNetCore.Components.Forms.Editor<T>.Value.set -> void
+Microsoft.AspNetCore.Components.Forms.Editor<T>.ValueChanged.get -> Microsoft.AspNetCore.Components.EventCallback<T>
+Microsoft.AspNetCore.Components.Forms.Editor<T>.ValueChanged.set -> void
+Microsoft.AspNetCore.Components.Forms.Editor<T>.ValueExpression.get -> System.Linq.Expressions.Expression<System.Func<T>!>!
+Microsoft.AspNetCore.Components.Forms.Editor<T>.ValueExpression.set -> void
 Microsoft.AspNetCore.Components.Forms.FormDataProvider
 Microsoft.AspNetCore.Components.Forms.FormDataProvider.FormDataProvider() -> void
 Microsoft.AspNetCore.Components.Forms.FormDataProvider.IsFormDataAvailable.get -> bool
@@ -73,6 +82,7 @@ Microsoft.AspNetCore.Components.Web.WebAssemblyRenderMode
 Microsoft.AspNetCore.Components.Web.WebAssemblyRenderMode.Prerender.get -> bool
 Microsoft.AspNetCore.Components.Web.WebAssemblyRenderMode.WebAssemblyRenderMode() -> void
 Microsoft.AspNetCore.Components.Web.WebAssemblyRenderMode.WebAssemblyRenderMode(bool prerender) -> void
+override Microsoft.AspNetCore.Components.Forms.Editor<T>.OnParametersSet() -> void
 override Microsoft.AspNetCore.Components.HtmlRendering.Infrastructure.StaticHtmlRenderer.Dispatcher.get -> Microsoft.AspNetCore.Components.Dispatcher!
 override Microsoft.AspNetCore.Components.HtmlRendering.Infrastructure.StaticHtmlRenderer.HandleException(System.Exception! exception) -> void
 override Microsoft.AspNetCore.Components.HtmlRendering.Infrastructure.StaticHtmlRenderer.UpdateDisplayAsync(in Microsoft.AspNetCore.Components.RenderTree.RenderBatch renderBatch) -> System.Threading.Tasks.Task!

--- a/src/Components/Web/src/SupplyParameterFromFormAttribute.cs
+++ b/src/Components/Web/src/SupplyParameterFromFormAttribute.cs
@@ -11,8 +11,15 @@ namespace Microsoft.AspNetCore.Components;
 public sealed class SupplyParameterFromFormAttribute : CascadingParameterAttributeBase
 {
     /// <summary>
-    /// Gets or sets the name for the parameter. The name is used to match
-    /// the form data and decide whether or not the value needs to be bound.
+    /// Gets or sets the name for the parameter. The name is used to determine
+    /// the prefix to use to match the form data and decide whether or not the
+    /// value needs to be bound.
     /// </summary>
     public override string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name for the handler. The name is used to match
+    /// the form data and decide whether or not the value needs to be bound.
+    /// </summary>
+    public string? Handler { get; set; }
 }

--- a/src/Components/Web/test/Forms/HtmlFieldPrefixTest.cs
+++ b/src/Components/Web/test/Forms/HtmlFieldPrefixTest.cs
@@ -1,12 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Components.Forms;
 public class HtmlFieldPrefixTest

--- a/src/Components/Web/test/Forms/HtmlFieldPrefixTest.cs
+++ b/src/Components/Web/test/Forms/HtmlFieldPrefixTest.cs
@@ -1,0 +1,123 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Components.Forms;
+public class HtmlFieldPrefixTest
+{
+    [Fact]
+    public void CanCombineTwoExpressions()
+    {
+        // Arrange
+        Person person = null!;
+        Address value = null!;
+        LambdaExpression parent = () => person.Children[0].BillingAddress;
+        LambdaExpression valueExpression = () => value.City;
+
+        // Act
+        var prefix = new HtmlFieldPrefix(parent);
+
+        // Assert
+        Assert.Equal("person.Children[0].BillingAddress.City", prefix.GetFieldName(valueExpression));
+    }
+
+    [Fact]
+    public void CanCombineMultipleExpressions()
+    {
+        // Arrange
+        Person person = null!;
+        Address value = null!;
+        Person value2 = null!;
+        LambdaExpression parent = () => person.Children[0];
+        LambdaExpression child = () => value2.Children[1].BillingAddress;
+        LambdaExpression valueExpression = () => value.City;
+
+        // Act
+        var prefix = new HtmlFieldPrefix(parent).Combine(child);
+
+        // Assert
+        Assert.Equal("person.Children[0].Children[1].BillingAddress.City", prefix.GetFieldName(valueExpression));
+    }
+
+    [Fact]
+    public void CanCombineMultipleExpressionsPropertyAccess()
+    {
+        // Arrange
+        Person person = null!;
+        Address value = null!;
+        LambdaExpression parent = () => person.BillingAddress;
+        LambdaExpression valueExpression = () => value.City;
+
+        // Act
+        var prefix = new HtmlFieldPrefix(parent);
+
+        // Assert
+        Assert.Equal("person.BillingAddress.City", prefix.GetFieldName(valueExpression));
+    }
+
+    [Fact]
+    public void CanCombineTwoExpressionsIndexers()
+    {
+        // Arrange
+        Person person = null!;
+        IReadOnlyList<string> value = null!;
+        LambdaExpression parent = () => person.Nicknames;
+        LambdaExpression valueExpression = () => value[0];
+
+        // Act
+        var prefix = new HtmlFieldPrefix(parent);
+
+        // Assert
+        Assert.Equal("person.Nicknames[0]", prefix.GetFieldName(valueExpression));
+    }
+
+    [Fact]
+    public void CanCombineMultipleExpressionsIndexers()
+    {
+        // Arrange
+        Person person = null!;
+        Person[] children = null!;
+        IReadOnlyList<string> value = null!;
+        LambdaExpression parent = () => person.Children;
+        LambdaExpression childrenExpression = () => children[0].Nicknames;
+        LambdaExpression valueExpression = () => value[1];
+
+        // Act
+        var prefix = new HtmlFieldPrefix(parent).Combine(childrenExpression);
+
+        // Assert
+        Assert.Equal("person.Children[0].Nicknames[1]", prefix.GetFieldName(valueExpression));
+    }
+
+    private class Person
+    {
+        public string Name { get; init; }
+
+        public int Age { get; init; }
+
+        public Address BillingAddress { get; set; }
+
+        public Person Parent { get; init; }
+
+        public Person[] Children { get; init; } = Array.Empty<Person>();
+
+        public IReadOnlyList<string> Nicknames { get; init; } = Array.Empty<string>();
+    }
+
+    private class Address
+    {
+        public string Street { get; init; }
+
+        public string City { get; init; }
+
+        public string State { get; init; }
+
+        public string ZipCode { get; init; }
+    }
+}

--- a/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
@@ -157,6 +157,32 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
+    public void CanChangeFormParameterNames(bool suppressEnhancedNavigation)
+    {
+        var dispatchToForm = new DispatchToForm(this)
+        {
+            Url = "forms/default-form-bound-multiple-primitive-parameters-changed-names",
+            FormCssSelector = "form",
+            ExpectedActionValue = null,
+            UpdateFormAction = () =>
+            {
+                Browser.Exists(By.CssSelector("input[name=UpdatedParameter]")).Clear();
+                Browser.Exists(By.CssSelector("input[name=UpdatedParameter]")).SendKeys("10");
+
+                Browser.Exists(By.CssSelector("input[name=UpdatedOtherParameter]")).Clear();
+                Browser.Exists(By.CssSelector("input[name=UpdatedOtherParameter]")).SendKeys("true");
+            },
+            SuppressEnhancedNavigation = suppressEnhancedNavigation,
+        };
+        DispatchToFormCore(dispatchToForm);
+
+        Browser.Exists(By.Id("ParameterValue")).Text.Contains("10");
+        Browser.Exists(By.Id("OtherParameterValue")).Text.Contains("True");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
     public void CanDisplayErrorsFromMultipleParametersToTheDefaultForm(bool suppressEnhancedNavigation)
     {
         var dispatchToForm = new DispatchToForm(this)

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Components/ComponentWithFormBoundParameter.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Components/ComponentWithFormBoundParameter.razor
@@ -13,5 +13,5 @@
 @code{
     bool _submitted = false;
 
-    [SupplyParameterFromForm(Name = "named-form-handler")] public string Parameter { get; set; } = "";
+    [SupplyParameterFromForm(Handler = "named-form-handler")] public string Parameter { get; set; } = "";
 }

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/AddressEditor.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/AddressEditor.razor
@@ -1,0 +1,25 @@
+﻿@using Microsoft.AspNetCore.Components.Forms;
+@using static Components.TestServer.RazorComponents.Pages.Forms.DefaultFormBoundComplexTypeParameterMultipleComponents;
+@inherits Editor<Address>
+
+<div>
+    <label>
+        Street:
+        <InputText @bind-Value="Value.Street" />
+    </label>
+    <ValidationMessage For="() => Value.Street" />
+</div>
+<div>
+    <label>
+        City:
+        <InputText @bind-Value="Value.City" />
+    </label>
+    <ValidationMessage For="() => Value.City" />
+</div>
+<div>
+    <label>
+        Area Code:
+        <CustomNumberInput @bind-Value="Value.AreaCode" />
+    </label>
+    <ValidationMessage For="() => Value.AreaCode" />
+</div>

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/CustomNumberInput.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/CustomNumberInput.razor
@@ -1,4 +1,5 @@
 ﻿@using System.Diagnostics.CodeAnalysis;
+@using System.Globalization;
 @inherits Microsoft.AspNetCore.Components.Forms.InputBase<int>
 
 <input name="@NameAttributeValue" @attributes="AdditionalAttributes" type="text" class="@CssClass" @bind="CurrentValueAsString" />
@@ -6,6 +7,15 @@
 @code {
     protected override bool TryParseValueFromString(string value, [MaybeNullWhen(false)] out int result, [NotNullWhen(false)] out string validationErrorMessage)
     {
-        throw new NotImplementedException();
+        if (BindConverter.TryConvertTo<int>(value, CultureInfo.InvariantCulture, out result))
+        {
+            validationErrorMessage = null;
+            return true;
+        }
+        else
+        {
+            validationErrorMessage = string.Format(CultureInfo.InvariantCulture, "The {0} field must be a number.", DisplayName ?? FieldIdentifier.FieldName);
+            return false;
+        }
     }
 }

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/DefaultFormBoundComplexTypeParameterMultipleComponents.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/DefaultFormBoundComplexTypeParameterMultipleComponents.razor
@@ -1,0 +1,82 @@
+﻿@page "/forms/default-form-bound-complextype-multiple-components"
+@using Microsoft.AspNetCore.Components.Forms
+
+<h2>Default form with bound complex type parameter broken into multiple components</h2>
+
+<EditForm Model="Model" method="POST" OnValidSubmit="DisplayCustomer">
+    <ValidationSummary />
+    <div>
+        <label for="Model.Name">
+            Name:
+            <InputText @bind-Value="Model.Name" />
+        </label>
+        <ValidationMessage For="() => Model.Name" />
+    </div>
+    <div>
+        <label for="Model.Email">
+            Email:
+            <InputText @bind-Value="Model.Email" />
+        </label>
+        <ValidationMessage For="() => Model.Email" />
+    </div>
+    <div>
+        <label for="Model.IsPreferred">
+            Preferred:
+            <InputCheckbox @bind-Value="Model.IsPreferred" />
+        </label>
+        <ValidationMessage For="() => Model.IsPreferred" />
+    </div>
+    <fieldset>
+        <legend>Billing Address</legend>
+        <AddressEditor @bind-Value="Model.BillingAddress" />
+    </fieldset>
+    <fieldset>
+        <legend>Shipping Address</legend>
+        <AddressEditor @bind-Value="Model.ShippingAddress" />
+    </fieldset>
+
+    <input id="send" type="submit" value="Send" />
+</EditForm>
+
+@if (_shouldDisplayCustomer)
+{
+    <p id="name">Customer: @Model.Name</p>
+    <p id="email">Email: @Model.Email</p>
+    <p id="preferred">Preferred: @Model.IsPreferred</p>
+    <p id="billing-address-street">Billing Street: @Model.BillingAddress.Street</p>
+    <p id="billing-address-city">Billing City: @Model.BillingAddress.City</p>
+    <p id="billing-address-area-code">Billing Area Code: @Model.BillingAddress.AreaCode</p>
+    <p id="shipping-address-street">Shipping Street: @Model.ShippingAddress.Street</p>
+    <p id="shipping-address-city">Shipping City: @Model.ShippingAddress.City</p>
+    <p id="shipping-address-area-code">Shipping Area Code: @Model.ShippingAddress.AreaCode</p>
+}
+
+@code {
+
+    bool _shouldDisplayCustomer = false;
+
+    public void DisplayCustomer() => _shouldDisplayCustomer = true;
+
+    [SupplyParameterFromForm] public Customer Model { get; set; }
+
+    [CascadingParameter] public ModelBindingContext Context { get; set; }
+
+    protected override void OnInitialized() => Model ??= new Customer();
+
+    public class Customer
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Email { get; set; }
+        public bool IsPreferred { get; set; }
+        public Address BillingAddress { get; set; } = new();
+        public Address ShippingAddress { get; set; } = new();
+    }
+
+    public class Address
+    {
+        public string Street { get; set; }
+        public string City { get; set; }
+        public int AreaCode { get; set; }
+    }
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/DefaultFormBoundMultiplePrimitiveParametersChangedNames.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/DefaultFormBoundMultiplePrimitiveParametersChangedNames.razor
@@ -1,0 +1,54 @@
+﻿@page "/forms/default-form-bound-multiple-primitive-parameters-changed-names"
+@using Microsoft.AspNetCore.Components.Forms
+
+<h2>Default form with bound parameter</h2>
+
+<ActionForm OnSubmit="() => _submitted = true">
+    <input type="text" name="UpdatedParameter" value="@(_attemptedParameterValue ?? Parameter.ToString())" />
+    <input type="text" name="UpdatedOtherParameter" value="@(_attemptedOtherValue ?? OtherParameter.ToString())" />
+    <AntiforgeryToken />
+    <input id="send" type="submit" value="Send" />
+</ActionForm>
+
+@if (_submitted)
+{
+    if (_errors.Count == 0)
+    {
+        <p id="ParameterValue">Your number is @Parameter!</p>
+        <p id="OtherParameterValue">Your other value is @OtherParameter!</p>
+    }
+    else
+    {
+        <p>There were errors:</p>
+        <ul id="errors">
+            @foreach (var error in _errors)
+            {
+                <li>@error</li>
+            }
+        </ul>
+    }
+}
+@code {
+    bool _submitted = false;
+    string _attemptedParameterValue = null;
+    string _attemptedOtherValue = null;
+
+    IList<FormattableString> _errors;
+
+    [SupplyParameterFromForm(Name = "UpdatedParameter")] public int Parameter { get; set; } = 0;
+    [SupplyParameterFromForm(Name = "UpdatedOtherParameter")] public bool OtherParameter { get; set; } = false;
+
+    [CascadingParameter] public ModelBindingContext Context { get; set; }
+
+    protected override void OnInitialized()
+    {
+        _errors = (Context.GetErrors("UpdatedParameter")?.ErrorMessages ?? Array.Empty<FormattableString>())
+            .Concat(Context.GetErrors("UpdatedOtherParameter")?.ErrorMessages ?? Array.Empty<FormattableString>()).ToList();
+
+        if (_errors.Count > 0)
+        {
+            _attemptedParameterValue = Context.GetAttemptedValue("UpdatedParameter");
+            _attemptedOtherValue = Context.GetAttemptedValue("UpdatedOtherParameter");
+        }
+    }
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/FormThatBindsGuid.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/FormThatBindsGuid.razor
@@ -31,7 +31,7 @@
     string _attemptedValue = null;
     IReadOnlyList<FormattableString> _errors;
 
-    [SupplyParameterFromForm(Name = "bind-guid")] public Guid Id { get; set; } = Guid.NewGuid();
+    [SupplyParameterFromForm(Handler = "bind-guid")] public Guid Id { get; set; } = Guid.NewGuid();
 
     [CascadingParameter] public ModelBindingContext Context { get; set; }
 

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/FormThatBindsInteger.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/FormThatBindsInteger.razor
@@ -31,7 +31,7 @@
     string _attemptedValue = null;
     IReadOnlyList<FormattableString> _errors;
 
-    [SupplyParameterFromForm(Name = "bind-integer")] public int Id { get; set; } = 0;
+    [SupplyParameterFromForm(Handler = "bind-integer")] public int Id { get; set; } = 0;
 
     [CascadingParameter] public ModelBindingContext Context { get; set; }
 

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/NamedFormBoundParameter.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/NamedFormBoundParameter.razor
@@ -16,5 +16,5 @@
 @code{
     bool _submitted = false;
 
-    [SupplyParameterFromForm(Name = "named-form-handler")] public string Parameter { get; set; } = "";
+    [SupplyParameterFromForm(Handler = "named-form-handler")] public string Parameter { get; set; } = "";
 }

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/NamedFormBoundPrimitiveParameter.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/NamedFormBoundPrimitiveParameter.razor
@@ -33,7 +33,7 @@
     string _attemptedValue = null;
     IReadOnlyList<FormattableString> _errors;
 
-    [SupplyParameterFromForm(Name = "named-form-handler")] public int Parameter { get; set; } = 0;
+    [SupplyParameterFromForm(Handler = "named-form-handler")] public int Parameter { get; set; } = 0;
 
     [CascadingParameter] public ModelBindingContext Context { get; set; }
 

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/NamedFormBoundPrimitiveParameterValidatorIntegration.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/NamedFormBoundPrimitiveParameterValidatorIntegration.razor
@@ -20,7 +20,7 @@
 @code {
     bool _submitted = false;
 
-    [SupplyParameterFromForm(Name = "named-form-handler")] public DataModel Model { get; set; }
+    [SupplyParameterFromForm(Handler = "named-form-handler")] public DataModel Model { get; set; }
 
     [CascadingParameter] public ModelBindingContext Context { get; set; }
 


### PR DESCRIPTION
* `Editor<T>` is a new component that can be used to created nested components that generate the name using SSR.
  * When breaking forms into multiple components, the guidance is to use `Editor<T>` as the base for those.
* Adds support for defining the `Name` for bound parameters.
* The old `Name` which referred to the form handler name, has been renamed to `Handler`.