### PR TITLE
Add WebApplication.CreateEmptyBuilder

### DIFF
--- a/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
+++ b/src/DefaultBuilder/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+static Microsoft.AspNetCore.Builder.WebApplication.CreateEmptyBuilder(Microsoft.AspNetCore.Builder.WebApplicationOptions! options) -> Microsoft.AspNetCore.Builder.WebApplicationBuilder!
 static Microsoft.AspNetCore.Builder.WebApplication.CreateSlimBuilder() -> Microsoft.AspNetCore.Builder.WebApplicationBuilder!
 static Microsoft.AspNetCore.Builder.WebApplication.CreateSlimBuilder(Microsoft.AspNetCore.Builder.WebApplicationOptions! options) -> Microsoft.AspNetCore.Builder.WebApplicationBuilder!
 static Microsoft.AspNetCore.Builder.WebApplication.CreateSlimBuilder(string![]! args) -> Microsoft.AspNetCore.Builder.WebApplicationBuilder!

--- a/src/DefaultBuilder/src/WebApplication.cs
+++ b/src/DefaultBuilder/src/WebApplication.cs
@@ -142,6 +142,14 @@ public sealed class WebApplication : IHost, IApplicationBuilder, IEndpointRouteB
         new(options, slim: true);
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="WebApplicationBuilder"/> class with no defaults.
+    /// </summary>
+    /// <param name="options">The <see cref="WebApplicationOptions"/> to configure the <see cref="WebApplicationBuilder"/>.</param>
+    /// <returns>The <see cref="WebApplicationBuilder"/>.</returns>
+    public static WebApplicationBuilder CreateEmptyBuilder(WebApplicationOptions options) =>
+        new(options, slim: false, empty: true);
+
+    /// <summary>
     /// Start the application.
     /// </summary>
     /// <param name="cancellationToken"></param>

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -65,10 +65,7 @@ public sealed class WebApplicationBuilder : IHostApplicationBuilder
             // Runs inline.
             webHostBuilder.Configure(ConfigureApplication);
 
-            webHostBuilder.UseSetting(WebHostDefaults.ApplicationKey, _hostApplicationBuilder.Environment.ApplicationName ?? "");
-            webHostBuilder.UseSetting(WebHostDefaults.PreventHostingStartupKey, Configuration[WebHostDefaults.PreventHostingStartupKey]);
-            webHostBuilder.UseSetting(WebHostDefaults.HostingStartupAssembliesKey, Configuration[WebHostDefaults.HostingStartupAssembliesKey]);
-            webHostBuilder.UseSetting(WebHostDefaults.HostingStartupExcludeAssembliesKey, Configuration[WebHostDefaults.HostingStartupExcludeAssembliesKey]);
+            InitializeWebHostSettings(webHostBuilder);
         },
         options =>
         {
@@ -134,10 +131,7 @@ public sealed class WebApplicationBuilder : IHostApplicationBuilder
                 // Runs inline.
                 webHostBuilder.Configure(ConfigureApplication);
 
-                webHostBuilder.UseSetting(WebHostDefaults.ApplicationKey, _hostApplicationBuilder.Environment.ApplicationName ?? "");
-                webHostBuilder.UseSetting(WebHostDefaults.PreventHostingStartupKey, Configuration[WebHostDefaults.PreventHostingStartupKey]);
-                webHostBuilder.UseSetting(WebHostDefaults.HostingStartupAssembliesKey, Configuration[WebHostDefaults.HostingStartupAssembliesKey]);
-                webHostBuilder.UseSetting(WebHostDefaults.HostingStartupExcludeAssembliesKey, Configuration[WebHostDefaults.HostingStartupExcludeAssembliesKey]);
+                InitializeWebHostSettings(webHostBuilder);
             },
             options =>
             {
@@ -192,13 +186,7 @@ public sealed class WebApplicationBuilder : IHostApplicationBuilder
                 // Runs inline.
                 webHostBuilder.Configure((context, app) => ConfigureApplication(context, app, allowDeveloperExceptionPage: false));
 
-                webHostBuilder.UseSetting(WebHostDefaults.ApplicationKey, _hostApplicationBuilder.Environment.ApplicationName ?? "");
-
-                // NOTE: There is no way to add Configuration before this gets called, so it is unnecessary
-                // to set the following properties from the Configuration:
-                // - WebHostDefaults.PreventHostingStartupKey
-                // - WebHostDefaults.HostingStartupAssembliesKey
-                // - WebHostDefaults.HostingStartupExcludeAssembliesKey
+                InitializeWebHostSettings(webHostBuilder);
             },
             options =>
             {
@@ -225,6 +213,14 @@ public sealed class WebApplicationBuilder : IHostApplicationBuilder
         WebHost = new ConfigureWebHostBuilder(webHostContext, Configuration, Services);
 
         return genericWebHostServiceDescriptor;
+    }
+
+    private void InitializeWebHostSettings(IWebHostBuilder webHostBuilder)
+    {
+        webHostBuilder.UseSetting(WebHostDefaults.ApplicationKey, _hostApplicationBuilder.Environment.ApplicationName ?? "");
+        webHostBuilder.UseSetting(WebHostDefaults.PreventHostingStartupKey, Configuration[WebHostDefaults.PreventHostingStartupKey]);
+        webHostBuilder.UseSetting(WebHostDefaults.HostingStartupAssembliesKey, Configuration[WebHostDefaults.HostingStartupAssembliesKey]);
+        webHostBuilder.UseSetting(WebHostDefaults.HostingStartupExcludeAssembliesKey, Configuration[WebHostDefaults.HostingStartupExcludeAssembliesKey]);
     }
 
     private static DefaultServiceProviderFactory GetServiceProviderFactory(HostApplicationBuilder hostApplicationBuilder)

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -185,7 +185,9 @@ public sealed class WebApplicationBuilder : IHostApplicationBuilder
         bootstrapHostBuilder.ConfigureSlimWebHost(
             webHostBuilder =>
             {
-                AspNetCore.WebHost.ConfigureWebDefaultsEmpty(webHostBuilder);
+                // Note this doesn't configure any WebHost server - Kestrel or otherwise.
+                // It also doesn't register Routing, HostFiltering, or ForwardedHeaders.
+                // It is "empty" and up to the caller to configure these services.
 
                 // Runs inline.
                 webHostBuilder.Configure((context, app) => ConfigureApplication(context, app, allowDeveloperExceptionPage: false));

--- a/src/DefaultBuilder/src/WebHost.cs
+++ b/src/DefaultBuilder/src/WebHost.cs
@@ -236,9 +236,17 @@ public static class WebHost
             .UseIISIntegration();
     }
 
-    internal static void ConfigureWebDefaultsCore(IWebHostBuilder builder)
+    internal static void ConfigureWebDefaultsSlim(IWebHostBuilder builder)
     {
         ConfigureWebDefaultsWorker(builder.UseKestrelCore().ConfigureKestrel(ConfigureKestrel), configureRouting: null);
+    }
+
+    internal static void ConfigureWebDefaultsEmpty(IWebHostBuilder builder)
+    {
+        // Note this doesn't configure any server - Kestrel or otherwise.
+        // It is "empty" and up to the caller to configure a server.
+
+        ConfigureWebDefaultsWorker(builder, configureRouting: null);
     }
 
     private static void ConfigureKestrel(WebHostBuilderContext builderContext, KestrelServerOptions options)

--- a/src/DefaultBuilder/src/WebHost.cs
+++ b/src/DefaultBuilder/src/WebHost.cs
@@ -244,9 +244,15 @@ public static class WebHost
     internal static void ConfigureWebDefaultsEmpty(IWebHostBuilder builder)
     {
         // Note this doesn't configure any server - Kestrel or otherwise.
-        // It is "empty" and up to the caller to configure a server.
+        // It also doesn't register HostFiltering or ForwardedHeaders.
+        // It is "empty" and up to the caller to configure these services.
 
-        ConfigureWebDefaultsWorker(builder, configureRouting: null);
+        builder.ConfigureServices((hostingContext, services) =>
+        {
+            // Routing services need to be registered in order for WebApplication to
+            // implement IEndpointRouteBuilder (i.e. MapGet, etc) correctly.
+            services.AddRoutingCore();
+        });
     }
 
     private static void ConfigureKestrel(WebHostBuilderContext builderContext, KestrelServerOptions options)

--- a/src/DefaultBuilder/src/WebHost.cs
+++ b/src/DefaultBuilder/src/WebHost.cs
@@ -241,20 +241,6 @@ public static class WebHost
         ConfigureWebDefaultsWorker(builder.UseKestrelCore().ConfigureKestrel(ConfigureKestrel), configureRouting: null);
     }
 
-    internal static void ConfigureWebDefaultsEmpty(IWebHostBuilder builder)
-    {
-        // Note this doesn't configure any server - Kestrel or otherwise.
-        // It also doesn't register HostFiltering or ForwardedHeaders.
-        // It is "empty" and up to the caller to configure these services.
-
-        builder.ConfigureServices((hostingContext, services) =>
-        {
-            // Routing services need to be registered in order for WebApplication to
-            // implement IEndpointRouteBuilder (i.e. MapGet, etc) correctly.
-            services.AddRoutingCore();
-        });
-    }
-
     private static void ConfigureKestrel(WebHostBuilderContext builderContext, KestrelServerOptions options)
     {
         options.Configure(builderContext.Configuration.GetSection("Kestrel"), reloadOnChange: true);

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -1345,7 +1345,7 @@ public class WebApplicationTests
     }
 
     [Theory]
-    [MemberData(nameof(CreateBuilderFuncs))]
+    [MemberData(nameof(CreateNonEmptyBuilderFuncs))] // empty builder doesn't enable HostFiltering
     public async Task WebApplicationConfiguration_HostFilterOptionsAreReloadable(CreateBuilderFunc createBuilder)
     {
         var builder = createBuilder();
@@ -1431,7 +1431,7 @@ public class WebApplicationTests
     }
 
     [Theory]
-    [MemberData(nameof(CreateBuilderFuncs))]
+    [MemberData(nameof(CreateNonEmptyBuilderFuncs))] // empty builder doesn't enable ForwardedHeaders
     public async Task WebApplicationConfiguration_EnablesForwardedHeadersFromConfig(CreateBuilderFunc createBuilder)
     {
         var builder = createBuilder();
@@ -1752,6 +1752,7 @@ public class WebApplicationTests
         Assert.Single(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IWebHostEnvironment)));
         Assert.Single(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IOptionsChangeTokenSource<HostFilteringOptions>)));
         Assert.Single(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IServer)));
+        Assert.Single(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(EndpointDataSource)));
 
         await using var app = builder.Build();
 
@@ -1768,10 +1769,11 @@ public class WebApplicationTests
 
         Assert.Empty(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IConfigureOptions<LoggerFactoryOptions>)));
         Assert.Empty(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IServer)));
+        Assert.Empty(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IOptionsChangeTokenSource<HostFilteringOptions>)));
 
         // These services are still necessary
         Assert.Single(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IWebHostEnvironment)));
-        Assert.Single(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IOptionsChangeTokenSource<HostFilteringOptions>)));
+        Assert.Single(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(EndpointDataSource)));
     }
 
     [Theory]

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -50,7 +50,8 @@ public class WebApplicationTests
     private static WebApplicationBuilder CreateEmptyBuilder()
     {
         var builder = WebApplication.CreateEmptyBuilder(new());
-        // CreateEmptyBuilder doesn't register an IServer.
+        // CreateEmptyBuilder doesn't register an IServer or Routing.
+        builder.Services.AddRoutingCore();
         builder.WebHost.UseKestrelCore();
         return builder;
     }
@@ -79,7 +80,8 @@ public class WebApplicationTests
     private static WebApplicationBuilder CreateEmptyBuilderArgs(string[] args)
     {
         var builder = WebApplication.CreateEmptyBuilder(new() { Args = args });
-        // CreateEmptyBuilder doesn't register an IServer.
+        // CreateEmptyBuilder doesn't register an IServer or Routing.
+        builder.Services.AddRoutingCore();
         builder.WebHost.UseKestrelCore();
         return builder;
     }
@@ -108,7 +110,8 @@ public class WebApplicationTests
     private static WebApplicationBuilder CreateEmptyBuilderOptions(WebApplicationOptions options)
     {
         var builder = WebApplication.CreateEmptyBuilder(options);
-        // CreateEmptyBuilder doesn't register an IServer.
+        // CreateEmptyBuilder doesn't register an IServer or Routing.
+        builder.Services.AddRoutingCore();
         builder.WebHost.UseKestrelCore();
         return builder;
     }
@@ -1768,12 +1771,12 @@ public class WebApplicationTests
         var builder = WebApplication.CreateEmptyBuilder(new());
 
         Assert.Empty(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IConfigureOptions<LoggerFactoryOptions>)));
-        Assert.Empty(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IServer)));
         Assert.Empty(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IOptionsChangeTokenSource<HostFilteringOptions>)));
+        Assert.Empty(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IServer)));
+        Assert.Empty(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(EndpointDataSource)));
 
         // These services are still necessary
         Assert.Single(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IWebHostEnvironment)));
-        Assert.Single(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(EndpointDataSource)));
     }
 
     [Theory]

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -47,8 +47,25 @@ public class WebApplicationTests
 
     private static WebApplicationBuilder CreateBuilder() => WebApplication.CreateBuilder();
     private static WebApplicationBuilder CreateSlimBuilder() => WebApplication.CreateSlimBuilder();
+    private static WebApplicationBuilder CreateEmptyBuilder()
+    {
+        var builder = WebApplication.CreateEmptyBuilder(new());
+        // CreateEmptyBuilder doesn't register an IServer.
+        builder.WebHost.UseKestrelCore();
+        return builder;
+    }
 
     public static IEnumerable<object[]> CreateBuilderFuncs
+    {
+        get
+        {
+            yield return new[] { (CreateBuilderFunc)CreateBuilder };
+            yield return new[] { (CreateBuilderFunc)CreateSlimBuilder };
+            yield return new[] { (CreateBuilderFunc)CreateEmptyBuilder };
+        }
+    }
+
+    public static IEnumerable<object[]> CreateNonEmptyBuilderFuncs
     {
         get
         {
@@ -59,8 +76,25 @@ public class WebApplicationTests
 
     private static WebApplicationBuilder CreateBuilderArgs(string[] args) => WebApplication.CreateBuilder(args);
     private static WebApplicationBuilder CreateSlimBuilderArgs(string[] args) => WebApplication.CreateSlimBuilder(args);
+    private static WebApplicationBuilder CreateEmptyBuilderArgs(string[] args)
+    {
+        var builder = WebApplication.CreateEmptyBuilder(new() { Args = args });
+        // CreateEmptyBuilder doesn't register an IServer.
+        builder.WebHost.UseKestrelCore();
+        return builder;
+    }
 
     public static IEnumerable<object[]> CreateBuilderArgsFuncs
+    {
+        get
+        {
+            yield return new[] { (CreateBuilderArgsFunc)CreateBuilderArgs };
+            yield return new[] { (CreateBuilderArgsFunc)CreateSlimBuilderArgs };
+            yield return new[] { (CreateBuilderArgsFunc)CreateEmptyBuilderArgs };
+        }
+    }
+
+    public static IEnumerable<object[]> CreateNonEmptyBuilderArgsFuncs
     {
         get
         {
@@ -71,8 +105,25 @@ public class WebApplicationTests
 
     private static WebApplicationBuilder CreateBuilderOptions(WebApplicationOptions options) => WebApplication.CreateBuilder(options);
     private static WebApplicationBuilder CreateSlimBuilderOptions(WebApplicationOptions options) => WebApplication.CreateSlimBuilder(options);
+    private static WebApplicationBuilder CreateEmptyBuilderOptions(WebApplicationOptions options)
+    {
+        var builder = WebApplication.CreateEmptyBuilder(options);
+        // CreateEmptyBuilder doesn't register an IServer.
+        builder.WebHost.UseKestrelCore();
+        return builder;
+    }
 
     public static IEnumerable<object[]> CreateBuilderOptionsFuncs
+    {
+        get
+        {
+            yield return new[] { (CreateBuilderOptionsFunc)CreateBuilderOptions };
+            yield return new[] { (CreateBuilderOptionsFunc)CreateSlimBuilderOptions };
+            yield return new[] { (CreateBuilderOptionsFunc)CreateEmptyBuilderOptions };
+        }
+    }
+
+    public static IEnumerable<object[]> CreateNonEmptyBuilderOptionsFuncs
     {
         get
         {
@@ -85,6 +136,13 @@ public class WebApplicationTests
         => new WebApplicationBuilder(options, configureDefaults);
     private static WebApplicationBuilder WebApplicationSlimBuilderConstructor(WebApplicationOptions options, Action<IHostBuilder> configureDefaults)
         => new WebApplicationBuilder(options, slim: true, configureDefaults);
+    private static WebApplicationBuilder WebApplicationEmptyBuilderConstructor(WebApplicationOptions options, Action<IHostBuilder> configureDefaults)
+    {
+        var builder = new WebApplicationBuilder(options, slim: false, empty: true, configureDefaults);
+        // CreateEmptyBuilder doesn't register an IServer.
+        builder.WebHost.UseKestrelCore();
+        return builder;
+    }
 
     public static IEnumerable<object[]> WebApplicationBuilderConstructorFuncs
     {
@@ -92,6 +150,7 @@ public class WebApplicationTests
         {
             yield return new[] { (WebApplicationBuilderConstructorFunc)WebApplicationBuilderConstructor };
             yield return new[] { (WebApplicationBuilderConstructorFunc)WebApplicationSlimBuilderConstructor };
+            yield return new[] { (WebApplicationBuilderConstructorFunc)WebApplicationEmptyBuilderConstructor };
         }
     }
 
@@ -426,6 +485,7 @@ public class WebApplicationTests
             {
                 yield return new object[] { webRoot, (CreateBuilderOptionsFunc)CreateBuilderOptions };
                 yield return new object[] { webRoot, (CreateBuilderOptionsFunc)CreateSlimBuilderOptions };
+                yield return new object[] { webRoot, (CreateBuilderOptionsFunc)CreateEmptyBuilderOptions };
             }
         }
     }
@@ -496,6 +556,7 @@ public class WebApplicationTests
             {
                 yield return new object[] { webRoot, (CreateBuilderOptionsFunc)CreateBuilderOptions };
                 yield return new object[] { webRoot, (CreateBuilderOptionsFunc)CreateSlimBuilderOptions };
+                yield return new object[] { webRoot, (CreateBuilderOptionsFunc)CreateEmptyBuilderOptions };
             }
         }
     }
@@ -538,6 +599,7 @@ public class WebApplicationTests
             {
                 yield return new object[] { path, (CreateBuilderOptionsFunc)CreateBuilderOptions };
                 yield return new object[] { path, (CreateBuilderOptionsFunc)CreateSlimBuilderOptions };
+                yield return new object[] { path, (CreateBuilderOptionsFunc)CreateEmptyBuilderOptions };
             }
         }
     }
@@ -617,6 +679,7 @@ public class WebApplicationTests
     {
         get
         {
+            // Note: CreateEmptyBuilder doesn't enable appsettings.json configuration by default
             yield return new object[] { (CreateBuilderOptionsFunc)CreateBuilderOptions, true };
             yield return new object[] { (CreateBuilderOptionsFunc)CreateBuilderOptions, false };
             yield return new object[] { (CreateBuilderOptionsFunc)CreateSlimBuilderOptions, true };
@@ -649,6 +712,22 @@ public class WebApplicationTests
     }
 
     [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void EmptyWebApplicationBuilderDoesNotEnableAppSettingsConfiguration(bool isDevelopment)
+    {
+        var options = new WebApplicationOptions
+        {
+            EnvironmentName = isDevelopment ? Environments.Development : Environments.Production
+        };
+
+        var webApplication = CreateEmptyBuilderOptions(options).Build();
+
+        var config = Assert.IsType<ConfigurationManager>(webApplication.Configuration);
+        Assert.DoesNotContain(config.Sources, source => source is JsonConfigurationSource jsonSource);
+    }
+
+    [Theory]
     [MemberData(nameof(CreateBuilderOptionsFuncs))]
     public void WebApplicationBuilderSettingInvalidApplicationDoesNotThrowWhenAssemblyLoadForUserSecretsFail(CreateBuilderOptionsFunc createBuilder)
     {
@@ -666,7 +745,7 @@ public class WebApplicationTests
     }
 
     [Theory]
-    [MemberData(nameof(CreateBuilderOptionsFuncs))]
+    [MemberData(nameof(CreateNonEmptyBuilderOptionsFuncs))] // empty builder doesn't enable UserSecrets
     public void WebApplicationBuilderEnablesUserSecretsInDevelopment(CreateBuilderOptionsFunc createBuilder)
     {
         var options = new WebApplicationOptions
@@ -679,6 +758,22 @@ public class WebApplicationTests
 
         var config = Assert.IsType<ConfigurationManager>(webApplication.Configuration);
         Assert.Contains(config.Sources, source => source is JsonConfigurationSource jsonSource && jsonSource.Path == "secrets.json");
+    }
+
+    [Fact]
+    public void EmptyWebApplicationBuilderDoesNotEnableUserSecretsInDevelopment()
+    {
+        var options = new WebApplicationOptions
+        {
+            ApplicationName = typeof(WebApplicationTests).Assembly.GetName().Name,
+            EnvironmentName = Environments.Development
+        };
+
+        var webApplication = CreateEmptyBuilderOptions(options).Build();
+
+        var config = Assert.IsType<ConfigurationManager>(webApplication.Configuration);
+        // empty builder doesn't contain any Json sources (user secrets or otherwise) by default
+        Assert.DoesNotContain(config.Sources, source => source is JsonConfigurationSource jsonSource);
     }
 
     [Theory]
@@ -922,7 +1017,8 @@ public class WebApplicationTests
         using var remoteHandle = RemoteExecutor.Invoke(static () =>
         {
             var args = new[] { "--one=command_line_one" };
-            foreach (object[] data in CreateBuilderArgsFuncs)
+            // empty builder doesn't enable environment variable configuration by default
+            foreach (object[] data in CreateNonEmptyBuilderArgsFuncs)
             {
                 var createBuilder = (CreateBuilderArgsFunc)data[0];
                 var builder = createBuilder(args);
@@ -1646,12 +1742,11 @@ public class WebApplicationTests
     }
 
     [Theory]
-    [MemberData(nameof(CreateBuilderFuncs))]
+    [MemberData(nameof(CreateNonEmptyBuilderFuncs))]
     public async Task WebApplicationBuilder_OnlyAddsDefaultServicesOnce(CreateBuilderFunc createBuilder)
     {
         var builder = createBuilder();
 
-        // IWebHostEnvironment is added by ConfigureDefaults
         Assert.Single(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IConfigureOptions<LoggerFactoryOptions>)));
         // IWebHostEnvironment is added by ConfigureWebHostDefaults
         Assert.Single(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IWebHostEnvironment)));
@@ -1666,8 +1761,21 @@ public class WebApplicationTests
         Assert.Single(app.Services.GetRequiredService<IEnumerable<IServer>>());
     }
 
+    [Fact]
+    public void EmptyWebApplicationBuilder_OnlyContainsMinimalServices()
+    {
+        var builder = WebApplication.CreateEmptyBuilder(new());
+
+        Assert.Empty(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IConfigureOptions<LoggerFactoryOptions>)));
+        Assert.Empty(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IServer)));
+
+        // These services are still necessary
+        Assert.Single(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IWebHostEnvironment)));
+        Assert.Single(builder.Services.Where(descriptor => descriptor.ServiceType == typeof(IOptionsChangeTokenSource<HostFilteringOptions>)));
+    }
+
     [Theory]
-    [MemberData(nameof(CreateBuilderArgsFuncs))]
+    [MemberData(nameof(CreateNonEmptyBuilderArgsFuncs))] // empty builder doesn't enable DI validation
     public void WebApplicationBuilder_EnablesServiceScopeValidationByDefaultInDevelopment(CreateBuilderArgsFunc createBuilder)
     {
         // The environment cannot be reconfigured after the builder is created currently.
@@ -1679,6 +1787,19 @@ public class WebApplicationTests
         // This currently throws an AggregateException, but any Exception from Build() is enough to make this test pass.
         // If this is throwing for any reason other than service scope validation, we'll likely see it in other tests.
         Assert.ThrowsAny<Exception>(() => builder.Build());
+    }
+
+    [Fact]
+    public void EmptyWebApplicationBuilder_DoesNotEnableServiceScopeValidationByDefaultInDevelopment()
+    {
+        // The environment cannot be reconfigured after the builder is created currently.
+        var builder = CreateEmptyBuilderArgs(new[] { "--environment", "Development" });
+
+        builder.Services.AddScoped<Service>();
+        builder.Services.AddSingleton<Service2>();
+
+        // This shouldn't throw at all since DI validation is not enabled
+        Assert.NotNull(builder.Build());
     }
 
     [Theory]
@@ -1895,7 +2016,7 @@ public class WebApplicationTests
     }
 
     [Theory]
-    [MemberData(nameof(CreateBuilderOptionsFuncs))]
+    [MemberData(nameof(CreateNonEmptyBuilderOptionsFuncs))] // empty builder doesn't enable the DeveloperExceptionPage
     public async Task DeveloperExceptionPageIsOnByDefaultInDevelopment(CreateBuilderOptionsFunc createBuilder)
     {
         var builder = createBuilder(new WebApplicationOptions() { EnvironmentName = Environments.Development });
@@ -1939,6 +2060,18 @@ public class WebApplicationTests
     public async Task DeveloperExceptionPageIsNotOnInProduction(CreateBuilderOptionsFunc createBuilder)
     {
         var builder = createBuilder(new WebApplicationOptions() { EnvironmentName = Environments.Production });
+        await DeveloperExceptionPageIsNotOn(builder);
+    }
+
+    [Fact]
+    public async Task DeveloperExceptionPageIsNotOnInDevelopmentWithEmptyBuilder()
+    {
+        var builder = CreateEmptyBuilderOptions(new WebApplicationOptions() { EnvironmentName = Environments.Development });
+        await DeveloperExceptionPageIsNotOn(builder);
+    }
+
+    private async Task DeveloperExceptionPageIsNotOn(WebApplicationBuilder builder)
+    {
         builder.WebHost.UseTestServer();
         await using var app = builder.Build();
 
@@ -1989,8 +2122,8 @@ public class WebApplicationTests
     }
 
     [Theory]
-    [MemberData(nameof(CreateBuilderOptionsFuncs))]
-    public async Task DeveloperExceptionPageWritesBadRequestDetailsToResponseByDefaltInDevelopment(CreateBuilderOptionsFunc createBuilder)
+    [MemberData(nameof(CreateNonEmptyBuilderOptionsFuncs))] // empty builder doesn't enable the DeveloperExceptionPage
+    public async Task DeveloperExceptionPageWritesBadRequestDetailsToResponseByDefaultInDevelopment(CreateBuilderOptionsFunc createBuilder)
     {
         var builder = createBuilder(new WebApplicationOptions() { EnvironmentName = Environments.Development });
         builder.WebHost.UseTestServer();


### PR DESCRIPTION
Allow an empty WebApplicationBuilder to be created without default behavior. There is no default configuration sources (ex. environment variables or appsettings.json files), no logging, and no web server (ex. Kestrel) configured by default. These can all be added explicitly by the app.

The following middleware can be enabled by the app:

- Routing and Endpoints, if the app calls Services.AddRouting, and then MapXXX or registers an EndpointDataSource manually
- AuthN/Z, if the app adds the corresponding Auth services

Fix #48811

cc @DamianEdwards @davidfowl 