### PR TITLE
Support for X-Forwarded-Prefix in ForwardedHeadersMiddleware

### DIFF
--- a/src/Middleware/HttpOverrides/src/ForwardedHeaders.cs
+++ b/src/Middleware/HttpOverrides/src/ForwardedHeaders.cs
@@ -26,7 +26,11 @@ public enum ForwardedHeaders
     /// </summary>
     XForwardedProto = 1 << 2,
     /// <summary>
-    /// Process X-Forwarded-For, X-Forwarded-Host and X-Forwarded-Proto.
+    /// Process X-Forwarded-Prefix, which identifies the original path base used by the client.
     /// </summary>
-    All = XForwardedFor | XForwardedHost | XForwardedProto
+    XForwardedPrefix = 1 << 3,
+    /// <summary>
+    /// Process X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Proto and X-Forwarded-Prefix.
+    /// </summary>
+    All = XForwardedFor | XForwardedHost | XForwardedProto | XForwardedPrefix
 }

--- a/src/Middleware/HttpOverrides/src/ForwardedHeadersDefaults.cs
+++ b/src/Middleware/HttpOverrides/src/ForwardedHeadersDefaults.cs
@@ -25,6 +25,11 @@ public static class ForwardedHeadersDefaults
     public static string XForwardedProtoHeaderName { get; } = "X-Forwarded-Proto";
 
     /// <summary>
+    /// X-Forwarded-Prefix
+    /// </summary>
+    public static string XForwardedPrefixHeaderName { get; } = "X-Forwarded-Prefix";
+
+    /// <summary>
     /// X-Original-For
     /// </summary>
     public static string XOriginalForHeaderName { get; } = "X-Original-For";
@@ -38,4 +43,9 @@ public static class ForwardedHeadersDefaults
     /// X-Original-Proto
     /// </summary>
     public static string XOriginalProtoHeaderName { get; } = "X-Original-Proto";
+
+    /// <summary>
+    /// X-Original-Prefix
+    /// </summary>
+    public static string XOriginalPrefixHeaderName { get; } = "X-Original-Prefix";
 }

--- a/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
+++ b/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
@@ -367,9 +367,11 @@ public class ForwardedHeadersMiddleware
 
             if (checkPrefix && currentValues.Prefix != null)
             {
-                // Save the original
-                requestHeaders[_options.OriginalPrefixHeaderName] =
-                    request.PathBase.HasValue ? request.PathBase.ToString() : "/";
+                if (request.PathBase.HasValue)
+                {
+                    // Save the original
+                    requestHeaders[_options.OriginalPrefixHeaderName] = request.PathBase.ToString();
+                }
 
                 if (forwardedPrefix!.Length > entriesConsumed)
                 {
@@ -382,7 +384,7 @@ public class ForwardedHeadersMiddleware
                     requestHeaders.Remove(_options.ForwardedPrefixHeaderName);
                 }
 
-                request.PathBase = PathString.FromUriComponent(currentValues.Prefix.TrimEnd('/'));
+                request.PathBase = PathString.FromUriComponent(currentValues.Prefix);
             }
         }
     }

--- a/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
+++ b/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
@@ -320,7 +320,8 @@ public class ForwardedHeadersMiddleware
                 if (forwardedFor!.Length > entriesConsumed)
                 {
                     // Truncate the consumed header values
-                    requestHeaders[_options.ForwardedForHeaderName] = forwardedFor.Take(forwardedFor.Length - entriesConsumed).ToArray();
+                    requestHeaders[_options.ForwardedForHeaderName] =
+                        TruncateConsumedHeaderValues(forwardedFor, entriesConsumed);
                 }
                 else
                 {
@@ -338,7 +339,8 @@ public class ForwardedHeadersMiddleware
                 if (forwardedProto!.Length > entriesConsumed)
                 {
                     // Truncate the consumed header values
-                    requestHeaders[_options.ForwardedProtoHeaderName] = forwardedProto.Take(forwardedProto.Length - entriesConsumed).ToArray();
+                    requestHeaders[_options.ForwardedProtoHeaderName] =
+                        TruncateConsumedHeaderValues(forwardedProto, entriesConsumed);
                 }
                 else
                 {
@@ -355,7 +357,8 @@ public class ForwardedHeadersMiddleware
                 if (forwardedHost!.Length > entriesConsumed)
                 {
                     // Truncate the consumed header values
-                    requestHeaders[_options.ForwardedHostHeaderName] = forwardedHost.Take(forwardedHost.Length - entriesConsumed).ToArray();
+                    requestHeaders[_options.ForwardedHostHeaderName] =
+                        TruncateConsumedHeaderValues(forwardedHost, entriesConsumed);
                 }
                 else
                 {

--- a/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
+++ b/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
@@ -376,7 +376,8 @@ public class ForwardedHeadersMiddleware
                 if (forwardedPrefix!.Length > entriesConsumed)
                 {
                     // Truncate the consumed header values
-                    requestHeaders[_options.ForwardedPrefixHeaderName] = forwardedPrefix.Take(forwardedPrefix.Length - entriesConsumed).ToArray();
+                    requestHeaders[_options.ForwardedPrefixHeaderName] =
+                        TruncateConsumedHeaderValues(forwardedPrefix, entriesConsumed);
                 }
                 else
                 {
@@ -480,5 +481,13 @@ public class ForwardedHeadersMiddleware
         }
 
         return hostText.AsSpan(offset + 1).IndexOfAnyExceptInRange('0', '9') < 0;
+    }
+
+    private static string[] TruncateConsumedHeaderValues(string[] forwarded, int entriesConsumed)
+    {
+        var newLength = forwarded.Length - entriesConsumed;
+        var remaining = new string[newLength];
+        Array.Copy(forwarded, remaining, newLength);
+        return remaining;
     }
 }

--- a/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
+++ b/src/Middleware/HttpOverrides/src/ForwardedHeadersMiddleware.cs
@@ -368,7 +368,9 @@ public class ForwardedHeadersMiddleware
             if (checkPrefix && currentValues.Prefix != null)
             {
                 // Save the original
-                requestHeaders[_options.OriginalPrefixHeaderName] = request.PathBase.ToString();
+                requestHeaders[_options.OriginalPrefixHeaderName] =
+                    request.PathBase.HasValue ? request.PathBase.ToString() : "/";
+
                 if (forwardedPrefix!.Length > entriesConsumed)
                 {
                     // Truncate the consumed header values
@@ -379,6 +381,7 @@ public class ForwardedHeadersMiddleware
                     // All values were consumed
                     requestHeaders.Remove(_options.ForwardedPrefixHeaderName);
                 }
+
                 request.PathBase = PathString.FromUriComponent(currentValues.Prefix.TrimEnd('/'));
             }
         }

--- a/src/Middleware/HttpOverrides/src/ForwardedHeadersOptions.cs
+++ b/src/Middleware/HttpOverrides/src/ForwardedHeadersOptions.cs
@@ -30,6 +30,12 @@ public class ForwardedHeadersOptions
     public string ForwardedProtoHeaderName { get; set; } = ForwardedHeadersDefaults.XForwardedProtoHeaderName;
 
     /// <summary>
+    /// Gets or sets the header used to retrieve the value for the path base.
+    /// Defaults to the value specified by <see cref="ForwardedHeadersDefaults.XForwardedPrefixHeaderName"/>
+    /// </summary>
+    public string ForwardedPrefixHeaderName { get; set; } = ForwardedHeadersDefaults.XForwardedPrefixHeaderName;
+
+    /// <summary>
     /// Gets or sets the header used to store the original value of client IP before applying forwarded headers.
     /// Defaults to the value specified by <see cref="ForwardedHeadersDefaults.XOriginalForHeaderName"/>
     /// </summary>
@@ -49,6 +55,13 @@ public class ForwardedHeadersOptions
     /// </summary>
     /// <seealso cref="ForwardedHeadersDefaults"/>
     public string OriginalProtoHeaderName { get; set; } = ForwardedHeadersDefaults.XOriginalProtoHeaderName;
+
+    /// <summary>
+    /// Gets or sets the header used to store the original path base before applying forwarded headers.
+    /// Defaults to the value specified by <see cref="ForwardedHeadersDefaults.XOriginalPrefixHeaderName"/>
+    /// </summary>
+    /// <seealso cref="ForwardedHeadersDefaults"/>
+    public string OriginalPrefixHeaderName { get; set; } = ForwardedHeadersDefaults.XOriginalPrefixHeaderName;
 
     /// <summary>
     /// Identifies which forwarders should be processed.

--- a/src/Middleware/HttpOverrides/src/PublicAPI.Shipped.txt
+++ b/src/Middleware/HttpOverrides/src/PublicAPI.Shipped.txt
@@ -15,11 +15,9 @@
 ~static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XForwardedForHeaderName.get -> string
 ~static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XForwardedHostHeaderName.get -> string
 ~static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XForwardedProtoHeaderName.get -> string
-~static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XForwardedPrefixHeaderName.get -> string
 ~static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XOriginalForHeaderName.get -> string
 ~static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XOriginalHostHeaderName.get -> string
 ~static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XOriginalProtoHeaderName.get -> string
-~static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XOriginalPrefixHeaderName.get -> string
 ~static Microsoft.Extensions.DependencyInjection.CertificateForwardingServiceExtensions.AddCertificateForwarding(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.HttpOverrides.CertificateForwardingOptions> configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
 Microsoft.AspNetCore.Builder.CertificateForwardingBuilderExtensions
 Microsoft.AspNetCore.Builder.ForwardedHeadersExtensions
@@ -35,8 +33,6 @@ Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.ForwardedHostHeaderName.get
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.ForwardedHostHeaderName.set -> void
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.ForwardedProtoHeaderName.get -> string!
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.ForwardedProtoHeaderName.set -> void
-Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.ForwardedPrefixHeaderName.get -> string!
-Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.ForwardedPrefixHeaderName.set -> void
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.ForwardLimit.get -> int?
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.ForwardLimit.set -> void
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.KnownNetworks.get -> System.Collections.Generic.IList<Microsoft.AspNetCore.HttpOverrides.IPNetwork!>!
@@ -47,8 +43,6 @@ Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.OriginalHostHeaderName.get 
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.OriginalHostHeaderName.set -> void
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.OriginalProtoHeaderName.get -> string!
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.OriginalProtoHeaderName.set -> void
-Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.OriginalPrefixHeaderName.get -> string!
-Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.OriginalPrefixHeaderName.set -> void
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.RequireHeaderSymmetry.get -> bool
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.RequireHeaderSymmetry.set -> void
 Microsoft.AspNetCore.Builder.HttpMethodOverrideExtensions
@@ -65,12 +59,11 @@ Microsoft.AspNetCore.HttpOverrides.CertificateForwardingOptions.CertificateHeade
 Microsoft.AspNetCore.HttpOverrides.CertificateForwardingOptions.CertificateHeader.set -> void
 Microsoft.AspNetCore.HttpOverrides.CertificateForwardingOptions.HeaderConverter -> System.Func<string!, System.Security.Cryptography.X509Certificates.X509Certificate2!>!
 Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
-Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.All = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedFor | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedHost | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedPrefix -> Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
+Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.All = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedFor | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedHost | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto -> Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
 Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.None = 0 -> Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
 Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedFor = 1 -> Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
 Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedHost = 2 -> Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
 Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto = 4 -> Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
-Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedPrefix = 8 -> Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
 Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults
 Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersMiddleware
 Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersMiddleware.ApplyForwarders(Microsoft.AspNetCore.Http.HttpContext! context) -> void
@@ -93,9 +86,7 @@ static Microsoft.AspNetCore.Builder.HttpMethodOverrideExtensions.UseHttpMethodOv
 static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XForwardedForHeaderName.get -> string!
 static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XForwardedHostHeaderName.get -> string!
 static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XForwardedProtoHeaderName.get -> string!
-static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XForwardedPrefixHeaderName.get -> string!
 static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XOriginalForHeaderName.get -> string!
 static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XOriginalHostHeaderName.get -> string!
 static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XOriginalProtoHeaderName.get -> string!
-static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XOriginalPrefixHeaderName.get -> string!
 static Microsoft.Extensions.DependencyInjection.CertificateForwardingServiceExtensions.AddCertificateForwarding(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Microsoft.AspNetCore.HttpOverrides.CertificateForwardingOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Middleware/HttpOverrides/src/PublicAPI.Shipped.txt
+++ b/src/Middleware/HttpOverrides/src/PublicAPI.Shipped.txt
@@ -15,9 +15,11 @@
 ~static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XForwardedForHeaderName.get -> string
 ~static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XForwardedHostHeaderName.get -> string
 ~static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XForwardedProtoHeaderName.get -> string
+~static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XForwardedPrefixHeaderName.get -> string
 ~static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XOriginalForHeaderName.get -> string
 ~static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XOriginalHostHeaderName.get -> string
 ~static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XOriginalProtoHeaderName.get -> string
+~static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XOriginalPrefixHeaderName.get -> string
 ~static Microsoft.Extensions.DependencyInjection.CertificateForwardingServiceExtensions.AddCertificateForwarding(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Microsoft.AspNetCore.HttpOverrides.CertificateForwardingOptions> configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
 Microsoft.AspNetCore.Builder.CertificateForwardingBuilderExtensions
 Microsoft.AspNetCore.Builder.ForwardedHeadersExtensions
@@ -33,6 +35,8 @@ Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.ForwardedHostHeaderName.get
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.ForwardedHostHeaderName.set -> void
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.ForwardedProtoHeaderName.get -> string!
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.ForwardedProtoHeaderName.set -> void
+Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.ForwardedPrefixHeaderName.get -> string!
+Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.ForwardedPrefixHeaderName.set -> void
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.ForwardLimit.get -> int?
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.ForwardLimit.set -> void
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.KnownNetworks.get -> System.Collections.Generic.IList<Microsoft.AspNetCore.HttpOverrides.IPNetwork!>!
@@ -43,6 +47,8 @@ Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.OriginalHostHeaderName.get 
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.OriginalHostHeaderName.set -> void
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.OriginalProtoHeaderName.get -> string!
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.OriginalProtoHeaderName.set -> void
+Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.OriginalPrefixHeaderName.get -> string!
+Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.OriginalPrefixHeaderName.set -> void
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.RequireHeaderSymmetry.get -> bool
 Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.RequireHeaderSymmetry.set -> void
 Microsoft.AspNetCore.Builder.HttpMethodOverrideExtensions
@@ -59,11 +65,12 @@ Microsoft.AspNetCore.HttpOverrides.CertificateForwardingOptions.CertificateHeade
 Microsoft.AspNetCore.HttpOverrides.CertificateForwardingOptions.CertificateHeader.set -> void
 Microsoft.AspNetCore.HttpOverrides.CertificateForwardingOptions.HeaderConverter -> System.Func<string!, System.Security.Cryptography.X509Certificates.X509Certificate2!>!
 Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
-Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.All = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedFor | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedHost | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto -> Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
+Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.All = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedFor | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedHost | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedPrefix -> Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
 Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.None = 0 -> Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
 Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedFor = 1 -> Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
 Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedHost = 2 -> Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
 Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto = 4 -> Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
+Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedPrefix = 8 -> Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
 Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults
 Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersMiddleware
 Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersMiddleware.ApplyForwarders(Microsoft.AspNetCore.Http.HttpContext! context) -> void
@@ -86,7 +93,9 @@ static Microsoft.AspNetCore.Builder.HttpMethodOverrideExtensions.UseHttpMethodOv
 static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XForwardedForHeaderName.get -> string!
 static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XForwardedHostHeaderName.get -> string!
 static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XForwardedProtoHeaderName.get -> string!
+static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XForwardedPrefixHeaderName.get -> string!
 static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XOriginalForHeaderName.get -> string!
 static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XOriginalHostHeaderName.get -> string!
 static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XOriginalProtoHeaderName.get -> string!
+static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XOriginalPrefixHeaderName.get -> string!
 static Microsoft.Extensions.DependencyInjection.CertificateForwardingServiceExtensions.AddCertificateForwarding(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Microsoft.AspNetCore.HttpOverrides.CertificateForwardingOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Middleware/HttpOverrides/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/HttpOverrides/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,14 @@
 #nullable enable
+~static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XForwardedPrefixHeaderName.get -> string
+~static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XOriginalPrefixHeaderName.get -> string
+Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.ForwardedPrefixHeaderName.get -> string!
+Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.ForwardedPrefixHeaderName.set -> void
+Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.OriginalPrefixHeaderName.get -> string!
+Microsoft.AspNetCore.Builder.ForwardedHeadersOptions.OriginalPrefixHeaderName.set -> void
+*REMOVED*Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.All = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedFor | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedHost | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto -> Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
+Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.All = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedFor | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedHost | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedPrefix -> Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
+Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedPrefix = 8 -> Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders
+static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XForwardedPrefixHeaderName.get -> string!
+static Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersDefaults.XOriginalPrefixHeaderName.get -> string!
 static Microsoft.AspNetCore.HttpOverrides.IPNetwork.Parse(System.ReadOnlySpan<char> networkSpan) -> Microsoft.AspNetCore.HttpOverrides.IPNetwork!
 static Microsoft.AspNetCore.HttpOverrides.IPNetwork.TryParse(System.ReadOnlySpan<char> networkSpan, out Microsoft.AspNetCore.HttpOverrides.IPNetwork? network) -> bool

--- a/src/Middleware/HttpOverrides/test/ForwardedHeadersMiddlewareTest.cs
+++ b/src/Middleware/HttpOverrides/test/ForwardedHeadersMiddlewareTest.cs
@@ -1164,10 +1164,10 @@ public class ForwardedHeadersMiddlewareTests
     }
 
     [Theory]
-    [InlineData("", "invalid")]
-    [InlineData("", "invalid/")]
-    [InlineData("", "%2Finvalid")]
-    public async Task XForwardedPrefixInvalidPath(string pathBase, string forwardedPrefix)
+    [InlineData("invalid")]
+    [InlineData("invalid/")]
+    [InlineData("%2Finvalid")]
+    public async Task XForwardedPrefixInvalidPath(string forwardedPrefix)
     {
         using var host = new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>
@@ -1189,11 +1189,10 @@ public class ForwardedHeadersMiddlewareTests
 
         var context = await server.SendAsync(c =>
         {
-            c.Request.PathBase = pathBase;
             c.Request.Headers["X-Forwarded-Prefix"] = forwardedPrefix;
         });
 
-        Assert.Equal(pathBase, context.Request.PathBase);
+        Assert.Equal(PathString.Empty, context.Request.PathBase);
         Assert.False(context.Request.Headers.ContainsKey("X-Original-Prefix"));
         Assert.True(context.Request.Headers.ContainsKey("X-Forwarded-Prefix"));
     }

--- a/src/Middleware/HttpOverrides/test/ForwardedHeadersMiddlewareTest.cs
+++ b/src/Middleware/HttpOverrides/test/ForwardedHeadersMiddlewareTest.cs
@@ -1131,6 +1131,7 @@ public class ForwardedHeadersMiddlewareTests
     [InlineData("", "/foo%2F/", "/foo%2F", "/")]
     [InlineData("/foo", "/bar", "/bar", "/foo")]
     [InlineData("/foo", "/", "", "/foo")]
+    [InlineData("/foo bar", "/", "", "/foo%20bar")]
     public async Task XForwardedPrefix(
         string pathBase,
         string forwardedPrefix,
@@ -1157,7 +1158,7 @@ public class ForwardedHeadersMiddlewareTests
 
         var context = await server.SendAsync(c =>
         {
-            c.Request.PathBase = pathBase;
+            c.Request.PathBase = new PathString(pathBase);
             c.Request.Headers["X-Forwarded-Prefix"] = forwardedPrefix;
         });
 

--- a/src/Middleware/HttpOverrides/test/ForwardedHeadersMiddlewareTest.cs
+++ b/src/Middleware/HttpOverrides/test/ForwardedHeadersMiddlewareTest.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Net;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -892,7 +893,7 @@ public class ForwardedHeadersMiddlewareTests
     }
 
     [Fact]
-    public async Task AllForwardsEnabledChangeRequestRemoteIpHostandProtocol()
+    public async Task AllForwardsEnabledChangeRequestRemoteIpHostProtocolAndPathBase()
     {
         using var host = new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>
@@ -917,11 +918,13 @@ public class ForwardedHeadersMiddlewareTests
             c.Request.Headers["X-Forwarded-Proto"] = "Protocol";
             c.Request.Headers["X-Forwarded-For"] = "11.111.111.11";
             c.Request.Headers["X-Forwarded-Host"] = "testhost";
+            c.Request.Headers["X-Forwarded-Prefix"] = "/pathbase";
         });
 
         Assert.Equal("11.111.111.11", context.Connection.RemoteIpAddress.ToString());
         Assert.Equal("testhost", context.Request.Host.ToString());
         Assert.Equal("Protocol", context.Request.Scheme);
+        Assert.Equal("/pathbase", context.Request.PathBase);
     }
 
     [Fact]
@@ -950,11 +953,13 @@ public class ForwardedHeadersMiddlewareTests
             c.Request.Headers["X-Forwarded-Proto"] = "Protocol";
             c.Request.Headers["X-Forwarded-For"] = "11.111.111.11";
             c.Request.Headers["X-Forwarded-Host"] = "otherhost";
+            c.Request.Headers["X-Forwarded-Prefix"] = "/pathbase";
         });
 
         Assert.Null(context.Connection.RemoteIpAddress);
         Assert.Equal("localhost", context.Request.Host.ToString());
         Assert.Equal("http", context.Request.Scheme);
+        Assert.Equal(PathString.Empty, context.Request.PathBase);
     }
 
     [Fact]
@@ -1115,5 +1120,81 @@ public class ForwardedHeadersMiddlewareTests
 
         Assert.Equal(expectedScheme, context.Request.Scheme);
         Assert.Equal(remainingHeader, context.Request.Headers["X-Forwarded-Proto"].ToString());
+    }
+
+    [Theory]
+    [InlineData("", "/foo", "/foo")]
+    [InlineData("", "/foo/", "/foo")]
+    [InlineData("", "/foo%20bar", "/foo bar")]
+    [InlineData("", "/foo?bar?", "/foo?bar?")]
+    [InlineData("", "/foo%2F", "/foo%2F")]
+    [InlineData("", "/foo%2F/", "/foo%2F")]
+    [InlineData("/foo", "/bar", "/bar")]
+    [InlineData("/foo", "/", "")]
+    public async Task XForwardedPrefix(string pathBase, string forwardedPrefix, string expectedUnescapedPathBase)
+    {
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                .UseTestServer()
+                .Configure(app =>
+                {
+                    app.UseForwardedHeaders(new ForwardedHeadersOptions
+                    {
+                        ForwardedHeaders = ForwardedHeaders.XForwardedPrefix,
+                    });
+                });
+            }).Build();
+
+        await host.StartAsync();
+
+        var server = host.GetTestServer();
+
+        var context = await server.SendAsync(c =>
+        {
+            c.Request.PathBase = pathBase;
+            c.Request.Headers["X-Forwarded-Prefix"] = forwardedPrefix;
+        });
+
+        Assert.Equal(expectedUnescapedPathBase, context.Request.PathBase.Value);
+        Assert.Equal(pathBase, context.Request.Headers["X-Original-Prefix"]);
+        // Should have been consumed and removed
+        Assert.False(context.Request.Headers.ContainsKey("X-Forwarded-Prefix"));
+    }
+
+    [Theory]
+    [InlineData("", "invalid")]
+    [InlineData("", "invalid/")]
+    [InlineData("", "%2Finvalid")]
+    public async Task XForwardedPrefixInvalidPath(string pathBase, string forwardedPrefix)
+    {
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                .UseTestServer()
+                .Configure(app =>
+                {
+                    app.UseForwardedHeaders(new ForwardedHeadersOptions
+                    {
+                        ForwardedHeaders = ForwardedHeaders.XForwardedPrefix,
+                    });
+                });
+            }).Build();
+
+        await host.StartAsync();
+
+        var server = host.GetTestServer();
+
+        var context = await server.SendAsync(c =>
+        {
+            c.Request.PathBase = pathBase;
+            c.Request.Headers["X-Forwarded-Prefix"] = forwardedPrefix;
+        });
+
+        Assert.Equal(pathBase, context.Request.PathBase);
+        Assert.False(context.Request.Headers.ContainsKey("X-Original-Prefix"));
+        Assert.True(context.Request.Headers.ContainsKey("X-Forwarded-Prefix"));
     }
 }

--- a/src/Middleware/HttpOverrides/test/ForwardedHeadersMiddlewareTest.cs
+++ b/src/Middleware/HttpOverrides/test/ForwardedHeadersMiddlewareTest.cs
@@ -1123,15 +1123,19 @@ public class ForwardedHeadersMiddlewareTests
     }
 
     [Theory]
-    [InlineData("", "/foo", "/foo")]
-    [InlineData("", "/foo/", "/foo")]
-    [InlineData("", "/foo%20bar", "/foo bar")]
-    [InlineData("", "/foo?bar?", "/foo?bar?")]
-    [InlineData("", "/foo%2F", "/foo%2F")]
-    [InlineData("", "/foo%2F/", "/foo%2F")]
-    [InlineData("/foo", "/bar", "/bar")]
-    [InlineData("/foo", "/", "")]
-    public async Task XForwardedPrefix(string pathBase, string forwardedPrefix, string expectedUnescapedPathBase)
+    [InlineData("", "/foo", "/foo", "/")]
+    [InlineData("", "/foo/", "/foo", "/")]
+    [InlineData("", "/foo%20bar", "/foo bar", "/")]
+    [InlineData("", "/foo?bar?", "/foo?bar?", "/")]
+    [InlineData("", "/foo%2F", "/foo%2F", "/")]
+    [InlineData("", "/foo%2F/", "/foo%2F", "/")]
+    [InlineData("/foo", "/bar", "/bar", "/foo")]
+    [InlineData("/foo", "/", "", "/foo")]
+    public async Task XForwardedPrefix(
+        string pathBase,
+        string forwardedPrefix,
+        string expectedUnescapedPathBase,
+        string expectedOriginalPrefix)
     {
         using var host = new HostBuilder()
             .ConfigureWebHost(webHostBuilder =>
@@ -1158,7 +1162,7 @@ public class ForwardedHeadersMiddlewareTests
         });
 
         Assert.Equal(expectedUnescapedPathBase, context.Request.PathBase.Value);
-        Assert.Equal(pathBase, context.Request.Headers["X-Original-Prefix"]);
+        Assert.Equal(expectedOriginalPrefix, context.Request.Headers["X-Original-Prefix"]);
         // Should have been consumed and removed
         Assert.False(context.Request.Headers.ContainsKey("X-Forwarded-Prefix"));
     }


### PR DESCRIPTION
# Support for X-Forwarded-Prefix in ForwardedHeadersMiddleware

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Adds the option to change PathBase based on the X-Forwarded-Prefix header.

Fixes #23263
