### PR TITLE
Fix for Async resource filter AfterOnResourceExecution diagnostic event only emitted on short-circuit

### DIFF
--- a/src/Mvc/Mvc.Core/src/Infrastructure/ResourceInvoker.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ResourceInvoker.cs
@@ -496,28 +496,33 @@ internal abstract partial class ResourceInvoker
                     Debug.Assert(_resourceExecutingContext != null);
 
                     var filter = (IAsyncResourceFilter)state;
-                    if (_resourceExecutedContext == null)
+                    try
                     {
-                        // If we get here then the filter didn't call 'next' indicating a short circuit.
-                        _resourceExecutedContext = new ResourceExecutedContextSealed(_resourceExecutingContext, _filters)
+                        if (_resourceExecutedContext == null)
                         {
-                            Canceled = true,
-                            Result = _resourceExecutingContext.Result,
-                        };
+                            // If we get here then the filter didn't call 'next' indicating a short circuit.
+                            _resourceExecutedContext = new ResourceExecutedContextSealed(_resourceExecutingContext, _filters)
+                            {
+                                Canceled = true,
+                                Result = _resourceExecutingContext.Result,
+                            };
 
+                            // A filter could complete a Task without setting a result
+                            if (_resourceExecutingContext.Result != null)
+                            {
+                                goto case State.ResourceShortCircuit;
+                            }
+                        }
+                    }
+                    finally
+                    {
                         _diagnosticListener.AfterOnResourceExecution(_resourceExecutedContext, filter);
                         _logger.AfterExecutingMethodOnFilter(
                             FilterTypeConstants.ResourceFilter,
                             nameof(IAsyncResourceFilter.OnResourceExecutionAsync),
                             filter);
-
-                        // A filter could complete a Task without setting a result
-                        if (_resourceExecutingContext.Result != null)
-                        {
-                            goto case State.ResourceShortCircuit;
-                        }
                     }
-
+                    
                     goto case State.ResourceEnd;
                 }
 

--- a/src/Mvc/Mvc.Core/src/Infrastructure/ResourceInvoker.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ResourceInvoker.cs
@@ -522,7 +522,6 @@ internal abstract partial class ResourceInvoker
                             nameof(IAsyncResourceFilter.OnResourceExecutionAsync),
                             filter);
                     }
-                    
                     goto case State.ResourceEnd;
                 }
 

--- a/src/Mvc/Mvc.Core/test/Infrastructure/ControllerActionInvokerTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ControllerActionInvokerTest.cs
@@ -98,6 +98,99 @@ public class ControllerActionInvokerTest : CommonResourceInvokerTest
         Assert.NotNull(listener.AfterAction?.HttpContext);
     }
 
+    [Fact]
+    public async Task InvokeAction_ResourceFilter_WritesDiagnostic_Not_ShortCircuited()
+    {
+        // Arrange
+        var actionDescriptor = new ControllerActionDescriptor()
+        {
+            FilterDescriptors = new List<FilterDescriptor>(),
+            Parameters = new List<ParameterDescriptor>(),
+            BoundProperties = new List<ParameterDescriptor>(),
+        };
+
+        actionDescriptor.MethodInfo = typeof(TestController).GetMethod(nameof(TestController.ActionMethod));
+        actionDescriptor.ControllerTypeInfo = typeof(TestController).GetTypeInfo();
+
+        var listener = new TestDiagnosticListener();        
+        var resourceFilter = new Mock<IAsyncResourceFilter>(MockBehavior.Strict);
+        resourceFilter
+            .Setup(f => f.OnResourceExecutionAsync(It.IsAny<ResourceExecutingContext>(), It.IsAny<ResourceExecutionDelegate>()))
+            .Returns<ResourceExecutingContext, ResourceExecutionDelegate>(async (c, next) =>
+            {
+                await next();
+            })
+            .Verifiable();
+
+        var invoker = CreateInvoker(
+            new IFilterMetadata[] { resourceFilter.Object },
+            actionDescriptor,
+            controller: new TestController(),
+            diagnosticListener: listener);
+
+        // Act
+        await invoker.InvokeAsync();
+
+        // Assert
+        resourceFilter.Verify(f => f.OnResourceExecutionAsync(It.IsAny<ResourceExecutingContext>(), It.IsAny<ResourceExecutionDelegate>()), Times.Once);
+        Assert.NotNull(listener.BeforeResource?.ActionDescriptor);
+        Assert.NotNull(listener.BeforeResource?.ExecutingContext);
+        Assert.NotNull(listener.BeforeResource?.Filter);
+        Assert.NotNull(listener.AfterResource?.ActionDescriptor);
+        Assert.NotNull(listener.AfterResource?.ExecutedContext);
+        Assert.NotNull(listener.AfterResource?.Filter);
+    }
+
+    [Fact]
+    public async Task InvokeAction_ResourceFilter_WritesDiagnostic_ShortCircuited()
+    {
+        // Arrange
+        var actionDescriptor = new ControllerActionDescriptor()
+        {
+            FilterDescriptors = new List<FilterDescriptor>(),
+            Parameters = new List<ParameterDescriptor>(),
+            BoundProperties = new List<ParameterDescriptor>(),
+        };
+
+        var expected = new Mock<IActionResult>(MockBehavior.Strict);
+        expected
+            .Setup(r => r.ExecuteResultAsync(It.IsAny<ActionContext>()))
+            .Returns(Task.FromResult(true))
+            .Verifiable();
+
+        actionDescriptor.MethodInfo = typeof(TestController).GetMethod(nameof(TestController.ActionMethod));
+        actionDescriptor.ControllerTypeInfo = typeof(TestController).GetTypeInfo();
+
+        var listener = new TestDiagnosticListener();        
+        var resourceFilter = new Mock<IAsyncResourceFilter>(MockBehavior.Strict);
+        resourceFilter
+            .Setup(f => f.OnResourceExecutionAsync(It.IsAny<ResourceExecutingContext>(), It.IsAny<ResourceExecutionDelegate>()))
+            .Returns<ResourceExecutingContext, ResourceExecutionDelegate>((c, next) =>
+            {
+                c.Result = expected.Object;
+                return Task.FromResult(true);
+            })
+            .Verifiable();
+
+        var invoker = CreateInvoker(
+            new IFilterMetadata[] { resourceFilter.Object },
+            actionDescriptor,
+            controller: new TestController(),
+            diagnosticListener: listener);
+
+        // Act
+        await invoker.InvokeAsync();
+
+        // Assert
+        resourceFilter.Verify(f => f.OnResourceExecutionAsync(It.IsAny<ResourceExecutingContext>(), It.IsAny<ResourceExecutionDelegate>()), Times.Once());
+        Assert.NotNull(listener.BeforeResource?.ActionDescriptor);
+        Assert.NotNull(listener.BeforeResource?.ExecutingContext);
+        Assert.NotNull(listener.BeforeResource?.Filter);
+        Assert.NotNull(listener.AfterResource?.ActionDescriptor);
+        Assert.NotNull(listener.AfterResource?.ExecutedContext);
+        Assert.NotNull(listener.AfterResource?.Filter);
+    }
+
     #endregion
 
     #region Controller Context

--- a/src/Mvc/shared/Mvc.TestDiagnosticListener/TestDiagnosticListener.cs
+++ b/src/Mvc/shared/Mvc.TestDiagnosticListener/TestDiagnosticListener.cs
@@ -7,6 +7,52 @@ namespace Microsoft.AspNetCore.Mvc;
 
 public class TestDiagnosticListener
 {
+    public class OnBeforeResourceEventData
+    {        
+        public IProxyActionDescriptor ActionDescriptor { get; set;  }        
+        public object ExecutingContext { get; set; }        
+        public object Filter { get; set; }
+    }
+
+    public OnBeforeResourceEventData BeforeResource { get; set; }
+
+    [DiagnosticName("Microsoft.AspNetCore.Mvc.BeforeOnResourceExecution")]
+    public virtual void OnBeforeResource(
+        IProxyActionDescriptor actionDescriptor,
+        object resourceExecutingContext,
+        object filter)
+    {        
+        BeforeResource = new OnBeforeResourceEventData()
+        {
+            ActionDescriptor = actionDescriptor,
+            ExecutingContext = resourceExecutingContext,
+            Filter = filter
+        };
+    }
+
+    public class OnAfterResourceEventData
+    {
+        public IProxyActionDescriptor ActionDescriptor { get; set; }
+        public object ExecutedContext { get; set; }
+        public object Filter { get; set; }
+    }
+
+    public OnAfterResourceEventData AfterResource { get; set; }
+
+    [DiagnosticName("Microsoft.AspNetCore.Mvc.AfterOnResourceExecution")]
+    public virtual void OnAfterResource(
+        IProxyActionDescriptor actionDescriptor,
+        object resourceExecutedContext,
+        object filter)
+    {
+        AfterResource = new OnAfterResourceEventData()
+        {
+            ActionDescriptor = actionDescriptor,
+            ExecutedContext = resourceExecutedContext,
+            Filter = filter
+        };
+    }    
+
     public class OnBeforeActionEventData
     {
         public IProxyActionDescriptor ActionDescriptor { get; set; }


### PR DESCRIPTION
Async resource filter AfterOnResourceExecution diagnostic event only emitted on short-circuit  #47698

# Fix for #47698

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

Update ResourceInvoker.cs to meet expected behavior: the AfterOnResourceExecution diagnostic event should be emitted upon completion of all async resource filters, regardless if the request was short-circuited or not.

Fixes #47698
