### PR TITLE
Remove stack overflow in EndpointFilterInvocationContexts

### DIFF
--- a/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.cs
+++ b/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.cs
@@ -68,6 +68,8 @@ internal sealed class EndpointFilterInvocationContext<T0> : EndpointFilterInvoca
                 return true;
             }
         }
+
+        return false;
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -194,6 +196,8 @@ internal sealed class EndpointFilterInvocationContext<T0, T1> : EndpointFilterIn
                 return true;
             }
         }
+
+        return false;
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -327,6 +331,8 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2> : EndpointFilt
                 return true;
             }
         }
+
+        return false;
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -467,6 +473,8 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3> : Endpoint
                 return true;
             }
         }
+
+        return false;
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -614,6 +622,8 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4> : Endp
                 return true;
             }
         }
+
+        return false;
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -768,6 +778,8 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5> : 
                 return true;
             }
         }
+
+        return false;
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -929,6 +941,8 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
                 return true;
             }
         }
+
+        return false;
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -1097,6 +1111,8 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
                 return true;
             }
         }
+
+        return false;
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -1272,6 +1288,8 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
                 return true;
             }
         }
+
+        return false;
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -1454,6 +1472,8 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
                 return true;
             }
         }
+
+        return false;
     }
 
     public void CopyTo(object?[] array, int arrayIndex)

--- a/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.cs
+++ b/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.cs
@@ -61,7 +61,13 @@ internal sealed class EndpointFilterInvocationContext<T0> : EndpointFilterInvoca
 
     public bool Contains(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return true;
+            }
+        }
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -91,7 +97,15 @@ internal sealed class EndpointFilterInvocationContext<T0> : EndpointFilterInvoca
 
     public int IndexOf(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     public void Insert(int index, object? item)
@@ -173,7 +187,13 @@ internal sealed class EndpointFilterInvocationContext<T0, T1> : EndpointFilterIn
 
     public bool Contains(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return true;
+            }
+        }
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -204,7 +224,15 @@ internal sealed class EndpointFilterInvocationContext<T0, T1> : EndpointFilterIn
 
     public int IndexOf(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     public void Insert(int index, object? item)
@@ -292,7 +320,13 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2> : EndpointFilt
 
     public bool Contains(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return true;
+            }
+        }
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -324,7 +358,15 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2> : EndpointFilt
 
     public int IndexOf(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     public void Insert(int index, object? item)
@@ -418,7 +460,13 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3> : Endpoint
 
     public bool Contains(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return true;
+            }
+        }
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -451,7 +499,15 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3> : Endpoint
 
     public int IndexOf(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     public void Insert(int index, object? item)
@@ -551,7 +607,13 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4> : Endp
 
     public bool Contains(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return true;
+            }
+        }
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -585,7 +647,15 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4> : Endp
 
     public int IndexOf(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     public void Insert(int index, object? item)
@@ -691,7 +761,13 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5> : 
 
     public bool Contains(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return true;
+            }
+        }
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -726,7 +802,15 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5> : 
 
     public int IndexOf(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     public void Insert(int index, object? item)
@@ -838,7 +922,13 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
 
     public bool Contains(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return true;
+            }
+        }
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -874,7 +964,15 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
 
     public int IndexOf(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     public void Insert(int index, object? item)
@@ -992,7 +1090,13 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
 
     public bool Contains(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return true;
+            }
+        }
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -1029,7 +1133,15 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
 
     public int IndexOf(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     public void Insert(int index, object? item)
@@ -1153,7 +1265,13 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
 
     public bool Contains(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return true;
+            }
+        }
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -1191,7 +1309,15 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
 
     public int IndexOf(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     public void Insert(int index, object? item)
@@ -1321,7 +1447,13 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
 
     public bool Contains(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return true;
+            }
+        }
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -1360,7 +1492,15 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
 
     public int IndexOf(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     public void Insert(int index, object? item)

--- a/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.cs
+++ b/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.cs
@@ -42,7 +42,7 @@ internal sealed class EndpointFilterInvocationContext<T0> : EndpointFilterInvoca
     public override IList<object?> Arguments => this;
 
     public T0 Arg0 { get; set; }
-    
+
     public int Count => 1;
 
     public bool IsReadOnly => false;
@@ -61,7 +61,7 @@ internal sealed class EndpointFilterInvocationContext<T0> : EndpointFilterInvoca
 
     public bool Contains(object? item)
     {
-        return IndexOf(item) >= 0;
+        throw new NotSupportedException();
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -91,7 +91,7 @@ internal sealed class EndpointFilterInvocationContext<T0> : EndpointFilterInvoca
 
     public int IndexOf(object? item)
     {
-        return Arguments.IndexOf(item);
+        throw new NotSupportedException();
     }
 
     public void Insert(int index, object? item)
@@ -154,7 +154,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1> : EndpointFilterIn
 
     public T0 Arg0 { get; set; }
     public T1 Arg1 { get; set; }
-    
+
     public int Count => 2;
 
     public bool IsReadOnly => false;
@@ -173,7 +173,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1> : EndpointFilterIn
 
     public bool Contains(object? item)
     {
-        return IndexOf(item) >= 0;
+        throw new NotSupportedException();
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -204,7 +204,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1> : EndpointFilterIn
 
     public int IndexOf(object? item)
     {
-        return Arguments.IndexOf(item);
+        throw new NotSupportedException();
     }
 
     public void Insert(int index, object? item)
@@ -273,7 +273,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2> : EndpointFilt
     public T0 Arg0 { get; set; }
     public T1 Arg1 { get; set; }
     public T2 Arg2 { get; set; }
-    
+
     public int Count => 3;
 
     public bool IsReadOnly => false;
@@ -292,7 +292,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2> : EndpointFilt
 
     public bool Contains(object? item)
     {
-        return IndexOf(item) >= 0;
+        throw new NotSupportedException();
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -324,7 +324,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2> : EndpointFilt
 
     public int IndexOf(object? item)
     {
-        return Arguments.IndexOf(item);
+        throw new NotSupportedException();
     }
 
     public void Insert(int index, object? item)
@@ -399,7 +399,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3> : Endpoint
     public T1 Arg1 { get; set; }
     public T2 Arg2 { get; set; }
     public T3 Arg3 { get; set; }
-    
+
     public int Count => 4;
 
     public bool IsReadOnly => false;
@@ -418,7 +418,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3> : Endpoint
 
     public bool Contains(object? item)
     {
-        return IndexOf(item) >= 0;
+        throw new NotSupportedException();
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -451,7 +451,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3> : Endpoint
 
     public int IndexOf(object? item)
     {
-        return Arguments.IndexOf(item);
+        throw new NotSupportedException();
     }
 
     public void Insert(int index, object? item)
@@ -532,7 +532,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4> : Endp
     public T2 Arg2 { get; set; }
     public T3 Arg3 { get; set; }
     public T4 Arg4 { get; set; }
-    
+
     public int Count => 5;
 
     public bool IsReadOnly => false;
@@ -551,7 +551,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4> : Endp
 
     public bool Contains(object? item)
     {
-        return IndexOf(item) >= 0;
+        throw new NotSupportedException();
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -585,7 +585,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4> : Endp
 
     public int IndexOf(object? item)
     {
-        return Arguments.IndexOf(item);
+        throw new NotSupportedException();
     }
 
     public void Insert(int index, object? item)
@@ -672,7 +672,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5> : 
     public T3 Arg3 { get; set; }
     public T4 Arg4 { get; set; }
     public T5 Arg5 { get; set; }
-    
+
     public int Count => 6;
 
     public bool IsReadOnly => false;
@@ -691,7 +691,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5> : 
 
     public bool Contains(object? item)
     {
-        return IndexOf(item) >= 0;
+        throw new NotSupportedException();
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -726,7 +726,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5> : 
 
     public int IndexOf(object? item)
     {
-        return Arguments.IndexOf(item);
+        throw new NotSupportedException();
     }
 
     public void Insert(int index, object? item)
@@ -819,7 +819,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
     public T4 Arg4 { get; set; }
     public T5 Arg5 { get; set; }
     public T6 Arg6 { get; set; }
-    
+
     public int Count => 7;
 
     public bool IsReadOnly => false;
@@ -838,7 +838,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
 
     public bool Contains(object? item)
     {
-        return IndexOf(item) >= 0;
+        throw new NotSupportedException();
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -874,7 +874,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
 
     public int IndexOf(object? item)
     {
-        return Arguments.IndexOf(item);
+        throw new NotSupportedException();
     }
 
     public void Insert(int index, object? item)
@@ -973,7 +973,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
     public T5 Arg5 { get; set; }
     public T6 Arg6 { get; set; }
     public T7 Arg7 { get; set; }
-    
+
     public int Count => 8;
 
     public bool IsReadOnly => false;
@@ -992,7 +992,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
 
     public bool Contains(object? item)
     {
-        return IndexOf(item) >= 0;
+        throw new NotSupportedException();
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -1029,7 +1029,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
 
     public int IndexOf(object? item)
     {
-        return Arguments.IndexOf(item);
+        throw new NotSupportedException();
     }
 
     public void Insert(int index, object? item)
@@ -1134,7 +1134,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
     public T6 Arg6 { get; set; }
     public T7 Arg7 { get; set; }
     public T8 Arg8 { get; set; }
-    
+
     public int Count => 9;
 
     public bool IsReadOnly => false;
@@ -1153,7 +1153,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
 
     public bool Contains(object? item)
     {
-        return IndexOf(item) >= 0;
+        throw new NotSupportedException();
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -1191,7 +1191,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
 
     public int IndexOf(object? item)
     {
-        return Arguments.IndexOf(item);
+        throw new NotSupportedException();
     }
 
     public void Insert(int index, object? item)
@@ -1302,7 +1302,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
     public T7 Arg7 { get; set; }
     public T8 Arg8 { get; set; }
     public T9 Arg9 { get; set; }
-    
+
     public int Count => 10;
 
     public bool IsReadOnly => false;
@@ -1321,7 +1321,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
 
     public bool Contains(object? item)
     {
-        return IndexOf(item) >= 0;
+        throw new NotSupportedException();
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -1360,7 +1360,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
 
     public int IndexOf(object? item)
     {
-        return Arguments.IndexOf(item);
+        throw new NotSupportedException();
     }
 
     public void Insert(int index, object? item)

--- a/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.cs
+++ b/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.cs
@@ -42,7 +42,7 @@ internal sealed class EndpointFilterInvocationContext<T0> : EndpointFilterInvoca
     public override IList<object?> Arguments => this;
 
     public T0 Arg0 { get; set; }
-
+    
     public int Count => 1;
 
     public bool IsReadOnly => false;

--- a/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.cs
+++ b/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.cs
@@ -42,7 +42,7 @@ internal sealed class EndpointFilterInvocationContext<T0> : EndpointFilterInvoca
     public override IList<object?> Arguments => this;
 
     public T0 Arg0 { get; set; }
-    
+
     public int Count => 1;
 
     public bool IsReadOnly => false;

--- a/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.cs
+++ b/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.cs
@@ -63,7 +63,7 @@ internal sealed class EndpointFilterInvocationContext<T0> : EndpointFilterInvoca
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return true;
             }
@@ -99,7 +99,7 @@ internal sealed class EndpointFilterInvocationContext<T0> : EndpointFilterInvoca
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return i;
             }
@@ -189,7 +189,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1> : EndpointFilterIn
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return true;
             }
@@ -226,7 +226,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1> : EndpointFilterIn
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return i;
             }
@@ -322,7 +322,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2> : EndpointFilt
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return true;
             }
@@ -360,7 +360,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2> : EndpointFilt
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return i;
             }
@@ -462,7 +462,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3> : Endpoint
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return true;
             }
@@ -501,7 +501,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3> : Endpoint
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return i;
             }
@@ -609,7 +609,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4> : Endp
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return true;
             }
@@ -649,7 +649,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4> : Endp
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return i;
             }
@@ -763,7 +763,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5> : 
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return true;
             }
@@ -804,7 +804,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5> : 
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return i;
             }
@@ -924,7 +924,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return true;
             }
@@ -966,7 +966,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return i;
             }
@@ -1092,7 +1092,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return true;
             }
@@ -1135,7 +1135,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return i;
             }
@@ -1267,7 +1267,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return true;
             }
@@ -1311,7 +1311,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return i;
             }
@@ -1449,7 +1449,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return true;
             }
@@ -1494,7 +1494,7 @@ internal sealed class EndpointFilterInvocationContext<T0, T1, T2, T3, T4, T5, T6
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return i;
             }

--- a/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.tt
+++ b/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.tt
@@ -80,6 +80,8 @@ internal sealed class EndpointFilterInvocationContext<<# foreach (var argumentCo
                 return true;
             }
         }
+
+        return false;
     }
 
     public void CopyTo(object?[] array, int arrayIndex)

--- a/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.tt
+++ b/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.tt
@@ -73,7 +73,7 @@ internal sealed class EndpointFilterInvocationContext<<# foreach (var argumentCo
 
     public bool Contains(object? item)
     {
-        return IndexOf(item) >= 0;
+        throw new NotSupportedException();
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -104,7 +104,7 @@ internal sealed class EndpointFilterInvocationContext<<# foreach (var argumentCo
 
     public int IndexOf(object? item)
     {
-        return Arguments.IndexOf(item);
+        throw new NotSupportedException();
     }
 
     public void Insert(int index, object? item)

--- a/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.tt
+++ b/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.tt
@@ -75,7 +75,7 @@ internal sealed class EndpointFilterInvocationContext<<# foreach (var argumentCo
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return true;
             }
@@ -112,7 +112,7 @@ internal sealed class EndpointFilterInvocationContext<<# foreach (var argumentCo
     {
         for (int i = 0; i < Arguments.Count; i++)
         {
-            if (Arguments[i].Equals(item))
+            if (Arguments[i]?.Equals(item) == true)
             {
                 return i;
             }

--- a/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.tt
+++ b/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.tt
@@ -73,7 +73,13 @@ internal sealed class EndpointFilterInvocationContext<<# foreach (var argumentCo
 
     public bool Contains(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return true;
+            }
+        }
     }
 
     public void CopyTo(object?[] array, int arrayIndex)
@@ -104,7 +110,15 @@ internal sealed class EndpointFilterInvocationContext<<# foreach (var argumentCo
 
     public int IndexOf(object? item)
     {
-        throw new NotSupportedException();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (Arguments[i].Equals(item))
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     public void Insert(int index, object? item)

--- a/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.tt
+++ b/src/Http/Http.Abstractions/src/EndpointFilterInvocationContextOfT.Generated.tt
@@ -52,8 +52,8 @@ internal sealed class EndpointFilterInvocationContext<<# foreach (var argumentCo
 
     public override IList<object?> Arguments => this;
 
-    <# foreach (var argumentCount in Enumerable.Range(0, arity)) { #>public T<#=argumentCount#> Arg<#=argumentCount#> { get; set; }
-    <# } #>
+<# foreach (var argumentCount in Enumerable.Range(0, arity)) { #>    public T<#=argumentCount#> Arg<#=argumentCount#> { get; set; }
+<# } #>
 
     public int Count => <#=arity#>;
 

--- a/src/Http/Http.Abstractions/test/EndpointFilterInvocationContextOfTTests.cs
+++ b/src/Http/Http.Abstractions/test/EndpointFilterInvocationContextOfTTests.cs
@@ -62,7 +62,7 @@ public class EndpointFilterInvocationContextOfTTests
         var context = new EndpointFilterInvocationContext<string, int, bool>(new DefaultHttpContext(), "This is a test", 42, false);
         Assert.True(context.Contains("This is a test"));
         Assert.False(context.Contains("This does not exist"));
-        Assert.Equal(1, context.IndexOf(0));
+        Assert.Equal(1, context.IndexOf(42));
         Assert.Equal(-1, context.IndexOf(21));
     }
 

--- a/src/Http/Http.Abstractions/test/EndpointFilterInvocationContextOfTTests.cs
+++ b/src/Http/Http.Abstractions/test/EndpointFilterInvocationContextOfTTests.cs
@@ -60,8 +60,10 @@ public class EndpointFilterInvocationContextOfTTests
     public void HandlesIListReadOperations()
     {
         var context = new EndpointFilterInvocationContext<int?, string, int, bool>(new DefaultHttpContext(), (int?)null, "This is a test", 42, false);
+#pragma warning disable xUnit2017 // Do not use Contains() to check if a value exists in a collection
         Assert.True(context.Contains("This is a test"));
         Assert.False(context.Contains("This does not exist"));
+#pragma warning restore xUnit2017 // Do not use Contains() to check if a value exists in a collection
         Assert.Equal(2, context.IndexOf(42));
         Assert.Equal(-1, context.IndexOf(21));
     }

--- a/src/Http/Http.Abstractions/test/EndpointFilterInvocationContextOfTTests.cs
+++ b/src/Http/Http.Abstractions/test/EndpointFilterInvocationContextOfTTests.cs
@@ -18,14 +18,6 @@ public class EndpointFilterInvocationContextOfTTests
     }
 
     [Fact]
-    public void ProhibitsUnsupportedListOperations()
-    {
-        var context = new EndpointFilterInvocationContext<string, int, bool>(new DefaultHttpContext(), "This is a test", 42, false);
-        Assert.Throws<NotSupportedException>(() => context.Contains("string"));
-        Assert.Throws<NotSupportedException>(() => context.IndexOf(0));
-    }
-
-    [Fact]
     public void ThrowsExceptionForInvalidCastOnGetArgument()
     {
         var context = new EndpointFilterInvocationContext<string, int, bool, Todo>(new DefaultHttpContext(), "This is a test", 42, false, new Todo());
@@ -62,6 +54,16 @@ public class EndpointFilterInvocationContextOfTTests
             enumeratedCount++;
         }
         Assert.Equal(4, enumeratedCount);
+    }
+
+    [Fact]
+    public void HandlesIListReadOperations()
+    {
+        var context = new EndpointFilterInvocationContext<string, int, bool>(new DefaultHttpContext(), "This is a test", 42, false);
+        Assert.True(context.Contains("This is a test"));
+        Assert.False(context.Contains("This does not exist"));
+        Assert.Equal(1, context.IndexOf(0));
+        Assert.Equal(-1, context.IndexOf(21));
     }
 
     // Test for https://github.com/dotnet/aspnetcore/issues/41489

--- a/src/Http/Http.Abstractions/test/EndpointFilterInvocationContextOfTTests.cs
+++ b/src/Http/Http.Abstractions/test/EndpointFilterInvocationContextOfTTests.cs
@@ -59,10 +59,10 @@ public class EndpointFilterInvocationContextOfTTests
     [Fact]
     public void HandlesIListReadOperations()
     {
-        var context = new EndpointFilterInvocationContext<string, int, bool>(new DefaultHttpContext(), "This is a test", 42, false);
+        var context = new EndpointFilterInvocationContext<int?, string, int, bool>(new DefaultHttpContext(), (int?)null, "This is a test", 42, false);
         Assert.True(context.Contains("This is a test"));
         Assert.False(context.Contains("This does not exist"));
-        Assert.Equal(1, context.IndexOf(42));
+        Assert.Equal(2, context.IndexOf(42));
         Assert.Equal(-1, context.IndexOf(21));
     }
 

--- a/src/Http/Http.Abstractions/test/EndpointFilterInvocationContextOfTTests.cs
+++ b/src/Http/Http.Abstractions/test/EndpointFilterInvocationContextOfTTests.cs
@@ -18,6 +18,14 @@ public class EndpointFilterInvocationContextOfTTests
     }
 
     [Fact]
+    public void ProhibitsUnsupportedListOperations()
+    {
+        var context = new EndpointFilterInvocationContext<string, int, bool>(new DefaultHttpContext(), "This is a test", 42, false);
+        Assert.Throws<NotSupportedException>(() => context.Contains("string"));
+        Assert.Throws<NotSupportedException>(() => context.IndexOf(0));
+    }
+
+    [Fact]
     public void ThrowsExceptionForInvalidCastOnGetArgument()
     {
         var context = new EndpointFilterInvocationContext<string, int, bool, Todo>(new DefaultHttpContext(), "This is a test", 42, false, new Todo());


### PR DESCRIPTION
# Remove potential stack overflow in EndpointFilterInvocationContexts

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

This change replaces the infinite recursive behaviour of the properties on the `EndpointFilterInvocationContext` types, and implement the `Contains` and `IndexOf` method explicitly instead.

Fixes #49284
