### PR TITLE
Ignore NullableContextAttribute on convention methods.

### DIFF
--- a/src/Mvc/Mvc.Core/src/ApiConventionTypeAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ApiConventionTypeAttribute.cs
@@ -83,6 +83,7 @@ public sealed class ApiConventionTypeAttribute : Attribute
     {
         return attribute is ProducesResponseTypeAttribute ||
             attribute is ProducesDefaultResponseTypeAttribute ||
-            attribute is ApiConventionNameMatchAttribute;
+            attribute is ApiConventionNameMatchAttribute ||
+            attribute.GetType().FullName == "System.Runtime.CompilerServices.NullableContextAttribute";
     }
 }

--- a/src/Mvc/Mvc.Core/test/ApiConventionMethodAttributeTest.cs
+++ b/src/Mvc/Mvc.Core/test/ApiConventionMethodAttributeTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
@@ -44,6 +44,41 @@ public class ApiConventionMethodAttributeTest
             () => new ApiConventionMethodAttribute(typeof(object), nameof(object.ToString)),
             "conventionType",
             expected);
+    }
+
+    public static class ConventionWithNullableContextAttribute
+    {
+#nullable enable
+        public static void Get(Foo? foo) { }
+#nullable restore
+    }
+
+    public class Foo { }
+
+    [Fact]
+    public void Convention_With_NullableContextAttribute_Has_NullableContextAttribute_On_Get_Method()
+    {
+        // Arrange
+        var type = typeof(ConventionWithNullableContextAttribute);
+        var method = type.GetMethod(nameof(ConventionWithNullableContextAttribute.Get));
+        var attributes = method.GetCustomAttributes(false);
+
+        // Act & Assert
+        Assert.Contains(attributes, (a) =>
+        {
+            var attributeType = a.GetType();
+            return attributeType.FullName == "System.Runtime.CompilerServices.NullableContextAttribute";
+        });
+    }
+
+    [Fact]
+    public void Convention_With_NullableContextAttribute_With_NullableContextAttribute_On_Get_Method_Does_Not_Throw()
+    {
+        // Arrange
+        var methodName = typeof(ConventionWithNullableContextAttribute).FullName + '.' + nameof(ConventionWithNullableContextAttribute.Get);
+        var attribute = typeof(ProducesAttribute);
+
+        new ApiConventionMethodAttribute(typeof(ConventionWithNullableContextAttribute), nameof(ConventionWithNullableContextAttribute.Get));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #17761 

Developers don't have a choice as to whether the `NullableContextAttribute` is emitted and decorates their method, it's a side effect of the arguments. This adds logic to ignore that attribute when considering whether a convention method is valid or not.