### PR TITLE
Add support for explicit IParsable<T>.TryParse in RDF.

### DIFF
--- a/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
+++ b/src/Http/Http.Extensions/test/ParameterBindingMethodCacheTests.cs
@@ -3,7 +3,6 @@
 
 #nullable enable
 
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -163,6 +162,14 @@ public class ParameterBindingMethodCacheTests
     public void HasTryParseStringMethod_ReturnsTrueWhenMethodExists(ParameterInfo parameterInfo)
     {
         Assert.True(new ParameterBindingMethodCache().HasTryParseMethod(parameterInfo.ParameterType));
+    }
+
+    [Fact]
+    public void FindTryParseStringMethod_FindsExplicitlyImplementedIParsable()
+    {
+        var type = typeof(TodoWithExplicitIParsable);
+        var methodFound = new ParameterBindingMethodCache().FindTryParseMethod(type);
+        Assert.NotNull(methodFound);
     }
 
     [Fact]
@@ -1514,6 +1521,19 @@ public class ParameterBindingMethodCacheTests
         {
             ClassImpl = type;
             NameImpl = name;
+        }
+    }
+
+    public class TodoWithExplicitIParsable : IParsable<TodoWithExplicitIParsable>
+    {
+        static TodoWithExplicitIParsable IParsable<TodoWithExplicitIParsable>.Parse(string s, IFormatProvider? provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        static bool IParsable<TodoWithExplicitIParsable>.TryParse(string? s, IFormatProvider? provider, out TodoWithExplicitIParsable result)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.TryParse.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.TryParse.cs
@@ -55,7 +55,7 @@ public abstract partial class RequestDelegateCreationTests
                 new object[] { "MyEnum", "ValueB", MyEnum.ValueB },
                 new object[] { "MyTryParseRecord", "https://example.org", new MyTryParseRecord(new Uri("https://example.org")) },
                 new object[] { "int?", "42", 42 },
-                new object[] { "int?", null, null },
+                new object[] { "int?", null, null }
             };
         }
     }
@@ -198,6 +198,23 @@ app.MapGet("/hello", ([FromQuery]TryParseTodo p) => p.Name!);
         await endpoint.RequestDelegate(httpContext);
         await VerifyResponseBodyAsync(httpContext, "Knit kitten mittens.");
         await VerifyAgainstBaselineUsingFile(compilation);
+    }
+
+    [Fact]
+    public async Task MapAction_ExplicitIParsable()
+    {
+        var (results, compilation) = await RunGeneratorAsync("""
+app.MapGet("/hello", ([FromQuery]TodoWithExplicitIParsable p, HttpContext context) => context.Items["p"] = p);
+""");
+        var endpoint = GetEndpointFromCompilation(compilation);
+
+        var httpContext = CreateHttpContext();
+        httpContext.Request.QueryString = new QueryString("?p=1");
+
+        await endpoint.RequestDelegate(httpContext);
+        var p = httpContext.Items["p"];
+
+        Assert.NotNull(p);
     }
 
     [Fact]

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.Diagnostics.Runtime.Interop;
 
 namespace Microsoft.AspNetCore.Http.Generators.Tests;
 
@@ -1018,12 +1019,12 @@ public class TodoChild : Todo
 
 public class TodoWithExplicitIParsable : IParsable<TodoWithExplicitIParsable>
 {
-    public static TodoWithExplicitIParsable Parse(string s, IFormatProvider provider)
+    static TodoWithExplicitIParsable IParsable<TodoWithExplicitIParsable>.Parse(string s, IFormatProvider provider)
     {
         return new TodoWithExplicitIParsable();
     }
 
-    public static bool TryParse(string s, IFormatProvider provider, out TodoWithExplicitIParsable result)
+    static bool IParsable<TodoWithExplicitIParsable>.TryParse(string s, IFormatProvider provider, out TodoWithExplicitIParsable result)
     {
         result = new TodoWithExplicitIParsable();
         return true;

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Http.Generators.Tests;
 
@@ -1014,3 +1015,17 @@ public class TodoChild : Todo
     public string? Child { get; set; }
 }
 #nullable restore
+
+public class TodoWithExplicitIParsable : IParsable<TodoWithExplicitIParsable>
+{
+    public static TodoWithExplicitIParsable Parse(string s, IFormatProvider provider)
+    {
+        return new TodoWithExplicitIParsable();
+    }
+
+    public static bool TryParse(string s, IFormatProvider provider, out TodoWithExplicitIParsable result)
+    {
+        result = new TodoWithExplicitIParsable();
+        return true;
+    }
+}

--- a/src/Shared/ParameterBindingMethodCache.cs
+++ b/src/Shared/ParameterBindingMethodCache.cs
@@ -80,6 +80,11 @@ internal sealed class ParameterBindingMethodCache
         {
             MethodInfo? methodInfo;
 
+            if (TryGetExplicitIParsableTryParseMethod(type, out var explicitIParsableTryParseMethod))
+            {
+                return (expression, formatProvider) => Expression.Call(explicitIParsableTryParseMethod, TempSourceStringExpr, formatProvider, expression);
+            }
+
             if (type.IsEnum)
             {
                 if (_enumTryParseMethod.IsGenericMethod)
@@ -414,6 +419,17 @@ internal sealed class ParameterBindingMethodCache
         where TValue : class?, IBindableFromHttpContext<TValue>
     {
         return TValue.BindAsync(httpContext, parameter);
+    }
+
+    [RequiresUnreferencedCode("Performs reflection on type hierarchy. This cannot be statically analyzed.")]
+    private static bool TryGetExplicitIParsableTryParseMethod(Type type, out MethodInfo methodInfo)
+    {
+        // Nested types by default use + as the delimeter between the containing type and the
+        // inner type. However when doing a method search this '+' symbol needs to be a '.' symbol.
+        var typeName = TypeNameHelper.GetTypeDisplayName(type, fullName: true, nestedTypeDelimiter: '.');
+        var name = $"System.IParsable<{typeName}>.TryParse";
+        methodInfo = type.GetMethod(name, BindingFlags.Static | BindingFlags.NonPublic)!;
+        return methodInfo is not null;
     }
 
     [RequiresUnreferencedCode("Performs reflection on type hierarchy. This cannot be statically analyzed.")]


### PR DESCRIPTION
This PR adds support for `IParsable<T>` in RDF. Currently RDF really relies on the fact that `TryParse` from `IParsable<T>` fits the pattern that we search for - we aren't really calling it through the interface. This change introduces logic to search for explicitly implemented `TryParse` methods and allows them to be called.

Implements: https://github.com/dotnet/aspnetcore/issues/42286