### PR TITLE
fix: Account for form attribute on checkbox tag input helper #49201

### DIFF
--- a/src/Mvc/Mvc.TagHelpers/src/InputTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/InputTagHelper.cs
@@ -116,6 +116,13 @@ public class InputTagHelper : TagHelper
     [HtmlAttributeName("type")]
     public string InputTypeName { get; set; }
 
+
+    /// <summary>
+    /// The name of the associated form
+    /// </summary>
+    /// <remarks>
+    /// Used to associate a hidden checkbox tag to the respecting form when <see cref="CheckBoxHiddenInputRenderMode"/> is not <see cref="CheckBoxHiddenInputRenderMode.None"/>.
+    /// </remarks>
     [HtmlAttributeName("form")]
     public string FormName { get; set; }
 

--- a/src/Mvc/Mvc.TagHelpers/src/InputTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/InputTagHelper.cs
@@ -116,6 +116,9 @@ public class InputTagHelper : TagHelper
     [HtmlAttributeName("type")]
     public string InputTypeName { get; set; }
 
+    [HtmlAttributeName("form")]
+    public string FormName { get; set; }
+
     /// <summary>
     /// The name of the &lt;input&gt; element.
     /// </summary>
@@ -159,6 +162,11 @@ public class InputTagHelper : TagHelper
         if (Value != null)
         {
             output.CopyHtmlAttribute(nameof(Value), context);
+        }
+
+        if (FormName != null)
+        {
+            output.CopyHtmlAttribute("form", context);
         }
 
         // Note null or empty For.Name is allowed because TemplateInfo.HtmlFieldPrefix may be sufficient.
@@ -326,6 +334,16 @@ public class InputTagHelper : TagHelper
                     // match if both are present because both have a generated value. Reach here in the special case
                     // where user provided a non-empty fallback name.
                     hiddenForCheckboxTag.MergeAttribute("name", Name);
+                }
+
+                if (output.Attributes.TryGetAttribute("form", out var formAttribute))
+                {
+                    // If the original checkbox has a form attribute, the hidden field should respect it and the
+                    // attribute should be passed on
+                    if (formAttribute.Value is string formAttributeString)
+                    {
+                        hiddenForCheckboxTag.MergeAttribute("form", formAttributeString);
+                    }
                 }
 
                 if (ViewContext.CheckBoxHiddenInputRenderMode == CheckBoxHiddenInputRenderMode.EndOfForm && ViewContext.FormContext.CanRenderAtEndOfForm)

--- a/src/Mvc/Mvc.TagHelpers/src/InputTagHelper.cs
+++ b/src/Mvc/Mvc.TagHelpers/src/InputTagHelper.cs
@@ -116,7 +116,6 @@ public class InputTagHelper : TagHelper
     [HtmlAttributeName("type")]
     public string InputTypeName { get; set; }
 
-
     /// <summary>
     /// The name of the associated form
     /// </summary>

--- a/src/Mvc/Mvc.TagHelpers/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.TagHelpers/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+~Microsoft.AspNetCore.Mvc.TagHelpers.InputTagHelper.FormName.get -> string
+~Microsoft.AspNetCore.Mvc.TagHelpers.InputTagHelper.FormName.set -> void


### PR DESCRIPTION
# Fix for accounting the well-known form HTML-Attribute on Checkbox Tag-Helper when CheckBoxHiddenInputRenderMode isn't None

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Added a unit test and added checks for the presence of the form attribute with according attribute merging.

## Description

For the bug fix I used the convention used for the other well-known HTML-Attributes like type and name.
The attribute is getting passed over to the TagHelperOutput and in ProcessAsync the Attribute is passed to the TagBuilder for the hidden field.

Fixes #49201 
