### PR TITLE
Simplify BoxedStatusCodes storage in HostingMetrics.cs

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Frozen;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Microsoft.AspNetCore.Http;

--- a/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Frozen;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Microsoft.AspNetCore.Http;
@@ -116,85 +115,13 @@ internal sealed class HostingMetrics : IDisposable
         }
     }
 
-    // Status Codes listed at http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
-    private static readonly FrozenDictionary<int, object> BoxedStatusCodes = FrozenDictionary.ToFrozenDictionary(new[]
-    {
-        KeyValuePair.Create<int, object>(100, 100),
-        KeyValuePair.Create<int, object>(101, 101),
-        KeyValuePair.Create<int, object>(102, 102),
-
-        KeyValuePair.Create<int, object>(200, 200),
-        KeyValuePair.Create<int, object>(201, 201),
-        KeyValuePair.Create<int, object>(202, 202),
-        KeyValuePair.Create<int, object>(203, 203),
-        KeyValuePair.Create<int, object>(204, 204),
-        KeyValuePair.Create<int, object>(205, 205),
-        KeyValuePair.Create<int, object>(206, 206),
-        KeyValuePair.Create<int, object>(207, 207),
-        KeyValuePair.Create<int, object>(208, 208),
-        KeyValuePair.Create<int, object>(226, 226),
-
-        KeyValuePair.Create<int, object>(300, 300),
-        KeyValuePair.Create<int, object>(301, 301),
-        KeyValuePair.Create<int, object>(302, 302),
-        KeyValuePair.Create<int, object>(303, 303),
-        KeyValuePair.Create<int, object>(304, 304),
-        KeyValuePair.Create<int, object>(305, 305),
-        KeyValuePair.Create<int, object>(306, 306),
-        KeyValuePair.Create<int, object>(307, 307),
-        KeyValuePair.Create<int, object>(308, 308),
-
-        KeyValuePair.Create<int, object>(400, 400),
-        KeyValuePair.Create<int, object>(401, 401),
-        KeyValuePair.Create<int, object>(402, 402),
-        KeyValuePair.Create<int, object>(403, 403),
-        KeyValuePair.Create<int, object>(404, 404),
-        KeyValuePair.Create<int, object>(405, 405),
-        KeyValuePair.Create<int, object>(406, 406),
-        KeyValuePair.Create<int, object>(407, 407),
-        KeyValuePair.Create<int, object>(408, 408),
-        KeyValuePair.Create<int, object>(409, 409),
-        KeyValuePair.Create<int, object>(410, 410),
-        KeyValuePair.Create<int, object>(411, 411),
-        KeyValuePair.Create<int, object>(412, 412),
-        KeyValuePair.Create<int, object>(413, 413),
-        KeyValuePair.Create<int, object>(414, 414),
-        KeyValuePair.Create<int, object>(415, 415),
-        KeyValuePair.Create<int, object>(416, 416),
-        KeyValuePair.Create<int, object>(417, 417),
-        KeyValuePair.Create<int, object>(418, 418),
-        KeyValuePair.Create<int, object>(419, 419),
-        KeyValuePair.Create<int, object>(421, 421),
-        KeyValuePair.Create<int, object>(422, 422),
-        KeyValuePair.Create<int, object>(423, 423),
-        KeyValuePair.Create<int, object>(424, 424),
-        KeyValuePair.Create<int, object>(426, 426),
-        KeyValuePair.Create<int, object>(428, 428),
-        KeyValuePair.Create<int, object>(429, 429),
-        KeyValuePair.Create<int, object>(431, 431),
-        KeyValuePair.Create<int, object>(451, 451),
-        KeyValuePair.Create<int, object>(499, 499),
-
-        KeyValuePair.Create<int, object>(500, 500),
-        KeyValuePair.Create<int, object>(501, 501),
-        KeyValuePair.Create<int, object>(502, 502),
-        KeyValuePair.Create<int, object>(503, 503),
-        KeyValuePair.Create<int, object>(504, 504),
-        KeyValuePair.Create<int, object>(505, 505),
-        KeyValuePair.Create<int, object>(506, 506),
-        KeyValuePair.Create<int, object>(507, 507),
-        KeyValuePair.Create<int, object>(508, 508),
-        KeyValuePair.Create<int, object>(510, 510),
-        KeyValuePair.Create<int, object>(511, 511)
-    });
+    private static readonly object[] BoxedStatusCodes = new object[512];
 
     private static object GetBoxedStatusCode(int statusCode)
     {
-        if (BoxedStatusCodes.TryGetValue(statusCode, out var result))
-        {
-            return result;
-        }
-
-        return statusCode;
+        object[] boxes = BoxedStatusCodes;
+        return (uint)statusCode < (uint)boxes.Length
+            ? boxes[statusCode] ??= statusCode
+            : statusCode;
     }
 }


### PR DESCRIPTION
# Simplify BoxedStatusCodes storage in HostingMetrics.cs

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

This is faster and way simpler. All credit goes to @MihaZupan, see https://github.com/dotnet/runtime/pull/87319#discussion_r1259708379.

```
|                  Method |       Mean |     Error |    StdDev |   Gen0 | Allocated |
|------------------------ |-----------:|----------:|----------:|-------:|----------:|
|   Get1_FrozenDictionary |   2.026 ns | 0.0293 ns | 0.0245 ns |      - |         - |
|          Get1_LazyArray |   1.229 ns | 0.0156 ns | 0.0138 ns |      - |         - |
|   Get4_FrozenDictionary |  11.499 ns | 0.0521 ns | 0.0487 ns |      - |         - |
|          Get4_LazyArray |   3.799 ns | 0.0228 ns | 0.0190 ns |      - |         - |
| Get100_FrozenDictionary | 391.628 ns | 1.8277 ns | 1.7096 ns | 0.2222 |    2328 B |
|        Get100_LazyArray |  45.834 ns | 0.2373 ns | 0.2219 ns |      - |         - |
```

Benchmark code: https://gist.github.com/antonfirsov/a312e1199110e03ec818f4b9097dc7df