### PR TITLE
Option to use JsonWebTokenHandler in oidc handler

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,6 +11,7 @@
     <AspNetCorePatchVersion>0</AspNetCorePatchVersion>
     <PreReleaseVersionIteration>6</PreReleaseVersionIteration>
     <ValidateBaseline>true</ValidateBaseline>
+    <IdentityModelVersion>7.0.0-preview</IdentityModelVersion>
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->
@@ -248,15 +249,15 @@
     <MicrosoftCodeAnalysisCSharpAnalyzerTestingXUnitVersion>1.1.2-beta1.22531.1</MicrosoftCodeAnalysisCSharpAnalyzerTestingXUnitVersion>
     <MicrosoftCodeAnalysisCSharpCodeFixTestingXUnitVersion>1.1.2-beta1.22531.1</MicrosoftCodeAnalysisCSharpCodeFixTestingXUnitVersion>
     <MicrosoftCssParserVersion>1.0.0-20230414.1</MicrosoftCssParserVersion>
-    <MicrosoftIdentityModelLoggingVersion>7.0.0-preview</MicrosoftIdentityModelLoggingVersion>
-    <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>7.0.0-preview</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
-    <MicrosoftIdentityModelProtocolsWsFederationVersion>7.0.0-preview</MicrosoftIdentityModelProtocolsWsFederationVersion>
+    <MicrosoftIdentityModelLoggingVersion>$(IdentityModelVersion)</MicrosoftIdentityModelLoggingVersion>
+    <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>$(IdentityModelVersion)</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
+    <MicrosoftIdentityModelProtocolsWsFederationVersion>$(IdentityModelVersion)</MicrosoftIdentityModelProtocolsWsFederationVersion>
     <MicrosoftInternalAspNetCoreH2SpecAllVersion>2.2.1</MicrosoftInternalAspNetCoreH2SpecAllVersion>
     <MicrosoftNETCoreWindowsApiSetsVersion>1.0.1</MicrosoftNETCoreWindowsApiSetsVersion>
     <MicrosoftOwinSecurityCookiesVersion>3.0.1</MicrosoftOwinSecurityCookiesVersion>
     <MicrosoftOwinTestingVersion>3.0.1</MicrosoftOwinTestingVersion>
     <MicrosoftWebAdministrationVersion>11.1.0</MicrosoftWebAdministrationVersion>
-    <SystemIdentityModelTokensJwtVersion>7.0.0-preview</SystemIdentityModelTokensJwtVersion>
+    <SystemIdentityModelTokensJwtVersion>$(IdentityModelVersion)</SystemIdentityModelTokensJwtVersion>
     <SystemComponentModelAnnotationsVersion>5.0.0</SystemComponentModelAnnotationsVersion>
     <SystemNetExperimentalMsQuicVersion>5.0.0-alpha.20560.6</SystemNetExperimentalMsQuicVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -248,15 +248,15 @@
     <MicrosoftCodeAnalysisCSharpAnalyzerTestingXUnitVersion>1.1.2-beta1.22531.1</MicrosoftCodeAnalysisCSharpAnalyzerTestingXUnitVersion>
     <MicrosoftCodeAnalysisCSharpCodeFixTestingXUnitVersion>1.1.2-beta1.22531.1</MicrosoftCodeAnalysisCSharpCodeFixTestingXUnitVersion>
     <MicrosoftCssParserVersion>1.0.0-20230414.1</MicrosoftCssParserVersion>
-    <MicrosoftIdentityModelLoggingVersion>6.31.0</MicrosoftIdentityModelLoggingVersion>
-    <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>6.31.0</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
-    <MicrosoftIdentityModelProtocolsWsFederationVersion>6.31.0</MicrosoftIdentityModelProtocolsWsFederationVersion>
+    <MicrosoftIdentityModelLoggingVersion>7.0.0-preview</MicrosoftIdentityModelLoggingVersion>
+    <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>7.0.0-preview</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
+    <MicrosoftIdentityModelProtocolsWsFederationVersion>7.0.0-preview</MicrosoftIdentityModelProtocolsWsFederationVersion>
     <MicrosoftInternalAspNetCoreH2SpecAllVersion>2.2.1</MicrosoftInternalAspNetCoreH2SpecAllVersion>
     <MicrosoftNETCoreWindowsApiSetsVersion>1.0.1</MicrosoftNETCoreWindowsApiSetsVersion>
     <MicrosoftOwinSecurityCookiesVersion>3.0.1</MicrosoftOwinSecurityCookiesVersion>
     <MicrosoftOwinTestingVersion>3.0.1</MicrosoftOwinTestingVersion>
     <MicrosoftWebAdministrationVersion>11.1.0</MicrosoftWebAdministrationVersion>
-    <SystemIdentityModelTokensJwtVersion>6.31.0</SystemIdentityModelTokensJwtVersion>
+    <SystemIdentityModelTokensJwtVersion>7.0.0-preview</SystemIdentityModelTokensJwtVersion>
     <SystemComponentModelAnnotationsVersion>5.0.0</SystemComponentModelAnnotationsVersion>
     <SystemNetExperimentalMsQuicVersion>5.0.0-alpha.20560.6</SystemNetExperimentalMsQuicVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -248,15 +248,15 @@
     <MicrosoftCodeAnalysisCSharpAnalyzerTestingXUnitVersion>1.1.2-beta1.22531.1</MicrosoftCodeAnalysisCSharpAnalyzerTestingXUnitVersion>
     <MicrosoftCodeAnalysisCSharpCodeFixTestingXUnitVersion>1.1.2-beta1.22531.1</MicrosoftCodeAnalysisCSharpCodeFixTestingXUnitVersion>
     <MicrosoftCssParserVersion>1.0.0-20230414.1</MicrosoftCssParserVersion>
-    <MicrosoftIdentityModelLoggingVersion>6.15.1</MicrosoftIdentityModelLoggingVersion>
-    <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>6.15.1</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
-    <MicrosoftIdentityModelProtocolsWsFederationVersion>6.15.1</MicrosoftIdentityModelProtocolsWsFederationVersion>
+    <MicrosoftIdentityModelLoggingVersion>6.31.0</MicrosoftIdentityModelLoggingVersion>
+    <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>6.31.0</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
+    <MicrosoftIdentityModelProtocolsWsFederationVersion>6.31.0</MicrosoftIdentityModelProtocolsWsFederationVersion>
     <MicrosoftInternalAspNetCoreH2SpecAllVersion>2.2.1</MicrosoftInternalAspNetCoreH2SpecAllVersion>
     <MicrosoftNETCoreWindowsApiSetsVersion>1.0.1</MicrosoftNETCoreWindowsApiSetsVersion>
     <MicrosoftOwinSecurityCookiesVersion>3.0.1</MicrosoftOwinSecurityCookiesVersion>
     <MicrosoftOwinTestingVersion>3.0.1</MicrosoftOwinTestingVersion>
     <MicrosoftWebAdministrationVersion>11.1.0</MicrosoftWebAdministrationVersion>
-    <SystemIdentityModelTokensJwtVersion>6.21.0</SystemIdentityModelTokensJwtVersion>
+    <SystemIdentityModelTokensJwtVersion>6.31.0</SystemIdentityModelTokensJwtVersion>
     <SystemComponentModelAnnotationsVersion>5.0.0</SystemComponentModelAnnotationsVersion>
     <SystemNetExperimentalMsQuicVersion>5.0.0-alpha.20560.6</SystemNetExperimentalMsQuicVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>

--- a/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Startup.cs
+++ b/src/Security/Authentication/OpenIdConnect/samples/OpenIdConnectSample/Startup.cs
@@ -266,7 +266,7 @@ public class Startup
                     // Persist the new acess token
                     props.UpdateTokenValue("access_token", payload.RootElement.GetString("access_token"));
                     props.UpdateTokenValue("refresh_token", payload.RootElement.GetString("refresh_token"));
-                    if (payload.RootElement.TryGetProperty("expires_in", out var property) && property.TryGetInt32(out var seconds))
+                    if (payload.RootElement.TryGetProperty("expires_in", out var property) && int.TryParse(property.GetString(), out var seconds))
                     {
                         var expiresAt = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(seconds);
                         props.UpdateTokenValue("expires_at", expiresAt.ToString("o", CultureInfo.InvariantCulture));
@@ -283,7 +283,7 @@ public class Startup
                         await WriteTableHeader(res, new string[] { "Token Type", "Value" }, props.GetTokens().Select(token => new string[] { token.Name, token.Value }));
 
                         await res.WriteAsync("<h2>Payload:</h2>");
-                        await res.WriteAsync(HtmlEncoder.Default.Encode(payload.ToString()).Replace(",", ",<br>") + "<br>");
+                        await res.WriteAsync(HtmlEncoder.Default.Encode(payload.RootElement.ToString()).Replace(",", ",<br>") + "<br>");
                     });
                 }
 

--- a/src/Security/Authentication/OpenIdConnect/src/LoggingExtensions.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/LoggingExtensions.cs
@@ -164,4 +164,10 @@ internal static partial class LoggingExtensions
     [LoggerMessage(55, LogLevel.Error, "The remote signout request was ignored because the 'iss' parameter didn't match " +
                          "the expected value, which may indicate an unsolicited logout.", EventName = "RemoteSignOutIssuerInvalid")]
     public static partial void RemoteSignOutIssuerInvalid(this ILogger logger);
+
+    [LoggerMessage(56, LogLevel.Error, "Unable to validate the 'id_token', no suitable TokenHandler was found for: '{IdToken}'.", EventName = "UnableToValidateIdTokenFromHandler")]
+    public static partial void UnableToValidateIdTokenFromHandler(this ILogger logger, string idToken);
+
+    [LoggerMessage(57, LogLevel.Error, "The Validated Security Token must be of type JsonWebToken, but instead its type is: '{SecurityTokenType}'", EventName = "InvalidSecurityTokenTypeFromHandler")]
+    public static partial void InvalidSecurityTokenTypeFromHandler(this ILogger logger, string? securityTokenType);
 }

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -656,8 +656,7 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
                 {
                     var tokenValidationResult = await ValidateTokenUsingHandlerAsync(authorizationResponse.IdToken, properties, validationParameters);
                     user = new ClaimsPrincipal(tokenValidationResult.ClaimsIdentity);
-                    // todo: need to use converter in 7x branch here
-                    jwt = new JwtSecurityToken();
+                    jwt = JwtSecurityTokenConverter.Convert(tokenValidationResult.SecurityToken as JsonWebToken);
                 }
                 else
                 {
@@ -737,8 +736,7 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
                 {
                     var tokenValidationResult = await ValidateTokenUsingHandlerAsync(tokenEndpointResponse.IdToken, properties, validationParameters);
                     tokenEndpointUser = new ClaimsPrincipal(tokenValidationResult.ClaimsIdentity);
-                    // TODO: need to use converter to create jwt
-                    tokenEndpointJwt = new JwtSecurityToken();
+                    tokenEndpointJwt = JwtSecurityTokenConverter.Convert(tokenValidationResult.SecurityToken as JsonWebToken);
                 }
                 else
                 {
@@ -1323,7 +1321,11 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
     // Note this modifies properties if Options.UseTokenLifetime
     private async Task<TokenValidationResult> ValidateTokenUsingHandlerAsync(string idToken, AuthenticationProperties properties, TokenValidationParameters validationParameters)
     {
-        if (_configuration != null)
+        if (Options.ConfigurationManager is BaseConfigurationManager baseConfigurationManager)
+        {
+            validationParameters.ConfigurationManager = baseConfigurationManager;
+        }
+        else if (_configuration != null)
         {
             var issuer = new[] { _configuration.Issuer };
             validationParameters.ValidIssuers = validationParameters.ValidIssuers?.Concat(issuer) ?? issuer;

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -17,8 +17,10 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
+using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
+using JwtRegisteredClaimNames = Microsoft.IdentityModel.JsonWebTokens.JwtRegisteredClaimNames;
 
 namespace Microsoft.AspNetCore.Authentication.OpenIdConnect;
 
@@ -649,7 +651,18 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
             if (!string.IsNullOrEmpty(authorizationResponse.IdToken))
             {
                 Logger.ReceivedIdToken();
-                user = ValidateToken(authorizationResponse.IdToken, properties, validationParameters, out jwt);
+
+                if (Options.UseTokenHandler)
+                {
+                    var tokenValidationResult = await ValidateTokenUsingHandlerAsync(authorizationResponse.IdToken, properties, validationParameters);
+                    user = new ClaimsPrincipal(tokenValidationResult.ClaimsIdentity);
+                    // todo: need to use converter in 7x branch here
+                    jwt = new JwtSecurityToken();
+                }
+                else
+                {
+                    user = ValidateToken(authorizationResponse.IdToken, properties, validationParameters, out jwt);
+                }
 
                 nonce = jwt.Payload.Nonce;
                 if (!string.IsNullOrEmpty(nonce))
@@ -717,7 +730,20 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
 
                 // At least a cursory validation is required on the new IdToken, even if we've already validated the one from the authorization response.
                 // And we'll want to validate the new JWT in ValidateTokenResponse.
-                var tokenEndpointUser = ValidateToken(tokenEndpointResponse.IdToken, properties, validationParameters, out var tokenEndpointJwt);
+                ClaimsPrincipal tokenEndpointUser;
+                JwtSecurityToken tokenEndpointJwt;
+
+                if (Options.UseTokenHandler)
+                {
+                    var tokenValidationResult = await ValidateTokenUsingHandlerAsync(tokenEndpointResponse.IdToken, properties, validationParameters);
+                    tokenEndpointUser = new ClaimsPrincipal(tokenValidationResult.ClaimsIdentity);
+                    // TODO: need to use converter to create jwt
+                    tokenEndpointJwt = new JwtSecurityToken();
+                }
+                else
+                {
+                    tokenEndpointUser = ValidateToken(tokenEndpointResponse.IdToken, properties, validationParameters, out  tokenEndpointJwt);
+                }
 
                 // Avoid reading & deleting the nonce cookie, running the event, etc, if it was already done as part of the authorization response validation.
                 if (user == null)
@@ -1292,6 +1318,57 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
         }
 
         return principal;
+    }
+
+    // Note this modifies properties if Options.UseTokenLifetime
+    private async Task<TokenValidationResult> ValidateTokenUsingHandlerAsync(string idToken, AuthenticationProperties properties, TokenValidationParameters validationParameters)
+    {
+        if (_configuration != null)
+        {
+            var issuer = new[] { _configuration.Issuer };
+            validationParameters.ValidIssuers = validationParameters.ValidIssuers?.Concat(issuer) ?? issuer;
+
+            validationParameters.IssuerSigningKeys = validationParameters.IssuerSigningKeys?.Concat(_configuration.SigningKeys)
+                ?? _configuration.SigningKeys;
+        }
+
+        var validationResult = await Options.TokenHandler.ValidateTokenAsync(idToken, validationParameters);
+
+        if (validationResult.Exception != null)
+        {
+            throw validationResult.Exception;
+        }
+
+        var validatedToken = validationResult.SecurityToken;
+
+        if (!validationResult.IsValid || validatedToken == null)
+        {
+            Logger.UnableToValidateIdTokenFromHandler(idToken);
+            throw new SecurityTokenException(string.Format(CultureInfo.InvariantCulture, Resources.UnableToValidateTokenFromHandler, idToken));
+        }
+
+        if (validatedToken is not JsonWebToken)
+        {
+            Logger.InvalidSecurityTokenTypeFromHandler(validatedToken?.GetType().ToString());
+            throw new SecurityTokenException(string.Format(CultureInfo.InvariantCulture, Resources.ValidatedSecurityTokenNotJsonWebToken, validatedToken?.GetType()));
+        }
+
+        if (Options.UseTokenLifetime)
+        {
+            var issued = validatedToken.ValidFrom;
+            if (issued != DateTime.MinValue)
+            {
+                properties.IssuedUtc = issued;
+            }
+
+            var expires = validatedToken.ValidTo;
+            if (expires != DateTime.MinValue)
+            {
+                properties.ExpiresUtc = expires;
+            }
+        }
+
+        return validationResult;
     }
 
     /// <summary>

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -652,7 +652,7 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
             {
                 Logger.ReceivedIdToken();
 
-                if (Options.UseTokenHandler)
+                if (!Options.UseSecurityTokenValidator)
                 {
                     var tokenValidationResult = await ValidateTokenUsingHandlerAsync(authorizationResponse.IdToken, properties, validationParameters);
                     user = new ClaimsPrincipal(tokenValidationResult.ClaimsIdentity);
@@ -732,7 +732,7 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
                 ClaimsPrincipal tokenEndpointUser;
                 JwtSecurityToken tokenEndpointJwt;
 
-                if (Options.UseTokenHandler)
+                if (!Options.UseSecurityTokenValidator)
                 {
                     var tokenValidationResult = await ValidateTokenUsingHandlerAsync(tokenEndpointResponse.IdToken, properties, validationParameters);
                     tokenEndpointUser = new ClaimsPrincipal(tokenValidationResult.ClaimsIdentity);
@@ -1268,11 +1268,13 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
     // Note this modifies properties if Options.UseTokenLifetime
     private ClaimsPrincipal ValidateToken(string idToken, AuthenticationProperties properties, TokenValidationParameters validationParameters, out JwtSecurityToken jwt)
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         if (!Options.SecurityTokenValidator.CanReadToken(idToken))
         {
             Logger.UnableToReadIdToken(idToken);
             throw new SecurityTokenException(string.Format(CultureInfo.InvariantCulture, Resources.UnableToValidateToken, idToken));
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         if (_configuration != null)
         {
@@ -1283,7 +1285,9 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
                 ?? _configuration.SigningKeys;
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         var principal = Options.SecurityTokenValidator.ValidateToken(idToken, validationParameters, out SecurityToken validatedToken);
+#pragma warning restore CS0618 // Type or member is obsolete
         if (validatedToken is JwtSecurityToken validatedJwt)
         {
             jwt = validatedJwt;

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs
@@ -18,7 +18,12 @@ public class OpenIdConnectOptions : RemoteAuthenticationOptions
 {
     private CookieBuilder _nonceCookieBuilder;
     private readonly JwtSecurityTokenHandler _defaultHandler = new JwtSecurityTokenHandler();
-    private readonly JsonWebTokenHandler _defaultTokenHandler = new JsonWebTokenHandler();
+    private readonly JsonWebTokenHandler _defaultTokenHandler = new JsonWebTokenHandler
+    {
+        MapInboundClaims = JwtSecurityTokenHandler.DefaultMapInboundClaims
+    };
+
+    private bool _mapInboundClaims = JwtSecurityTokenHandler.DefaultMapInboundClaims;
 
     /// <summary>
     /// Initializes a new <see cref="OpenIdConnectOptions"/>
@@ -39,11 +44,10 @@ public class OpenIdConnectOptions : RemoteAuthenticationOptions
         CallbackPath = new PathString("/signin-oidc");
         SignedOutCallbackPath = new PathString("/signout-callback-oidc");
         RemoteSignOutPath = new PathString("/signout-oidc");
+#pragma warning disable CS0618 // Type or member is obsolete
         SecurityTokenValidator = _defaultHandler;
+#pragma warning restore CS0618 // Type or member is obsolete
         TokenHandler = _defaultTokenHandler;
-
-        // reconcile the difference between default values.
-        _defaultTokenHandler.MapInboundClaims = _defaultHandler.MapInboundClaims;
 
         Events = new OpenIdConnectEvents();
         Scope.Add("openid");
@@ -259,12 +263,13 @@ public class OpenIdConnectOptions : RemoteAuthenticationOptions
     /// <summary>
     /// Gets or sets the <see cref="ISecurityTokenValidator"/> used to validate identity tokens.
     /// </summary>
+    [Obsolete("SecurityTokenValidator is no longer used by default. Use TokenHandler instead. To continue using SecurityTokenValidator, set UseSecurityTokenValidator to true. See https://aka.ms/aspnetcore8/security-token-changes")]
     public ISecurityTokenValidator SecurityTokenValidator { get; set; }
 
     /// <summary>
     /// Gets or sets the <see cref="TokenHandler"/> used to validate identity tokens.
     /// <para>
-    /// This will be used instead of <see cref="SecurityTokenValidator"/> if <see cref="UseTokenHandler"/> is <see langword="true"/>
+    /// This will be used instead of <see cref="SecurityTokenValidator"/> if <see cref="UseSecurityTokenValidator"/> is <see langword="false"/>
     /// </para>
     /// </summary>
     public TokenHandler TokenHandler { get; set; }
@@ -367,31 +372,25 @@ public class OpenIdConnectOptions : RemoteAuthenticationOptions
     public TimeSpan RefreshInterval { get; set; } = ConfigurationManager<OpenIdConnectConfiguration>.DefaultRefreshInterval;
 
     /// <summary>
-    /// Gets or sets the <see cref="MapInboundClaims"/> property on the default instance of <see cref="JwtSecurityTokenHandler"/> in SecurityTokenValidator, which is used when determining
+    /// Gets or sets the <see cref="MapInboundClaims"/> property on the default instance of <see cref="JwtSecurityTokenHandler"/> in SecurityTokenValidator
+    /// and default instance of <see cref="JsonWebTokenHandler"/> in TokenHandler, which is used when determining
     /// whether or not to map claim types that are extracted when validating a <see cref="JwtSecurityToken"/>.
     /// <para>If this is set to true, the Claim Type is set to the JSON claim 'name' after translating using this mapping. Otherwise, no mapping occurs.</para>
     /// <para>The default value is true.</para>
     /// </summary>
     public bool MapInboundClaims
     {
-        get => _defaultHandler.MapInboundClaims;
-        set => _defaultHandler.MapInboundClaims = value;
-    }
-
-    /// <summary>
-    /// Gets or sets the <see cref="MapInboundClaims"/> property on the default instance of <see cref="JsonWebTokenHandler"/> in TokenHandler, which is used when determining
-    /// whether or not to map claim types that are extracted when validating a <see cref="JwtSecurityToken"/>.
-    /// <para>If this is set to true, the Claim Type is set to the JSON claim 'name' after translating using this mapping. Otherwise, no mapping occurs.</para>
-    /// <para>The default value is true.</para>
-    /// </summary>
-    public bool MapInboundClaimsTokenHandler
-    {
-        get => _defaultTokenHandler.MapInboundClaims;
-        set => _defaultTokenHandler.MapInboundClaims = value;
+        get => _mapInboundClaims;
+        set
+        {
+            _mapInboundClaims = value;
+            _defaultHandler.MapInboundClaims = value;
+            _defaultTokenHandler.MapInboundClaims = value;
+        }
     }
 
     /// <summary>
     /// Gets or sets whether to use the <see cref="TokenHandler"/> or the <see cref="SecurityTokenValidator"/> for validating identity tokens.
     /// </summary>
-    public bool UseTokenHandler { get; set; } = true;
+    public bool UseSecurityTokenValidator { get; set; }
 }

--- a/src/Security/Authentication/OpenIdConnect/src/PublicAPI.Shipped.txt
+++ b/src/Security/Authentication/OpenIdConnect/src/PublicAPI.Shipped.txt
@@ -210,3 +210,9 @@ virtual Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectHandler.H
 virtual Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectHandler.HandleSignOutCallbackAsync() -> System.Threading.Tasks.Task<bool>!
 virtual Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectHandler.RedeemAuthorizationCodeAsync(Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectMessage! tokenEndpointRequest) -> System.Threading.Tasks.Task<Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectMessage!>!
 virtual Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectHandler.SignOutAsync(Microsoft.AspNetCore.Authentication.AuthenticationProperties? properties) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.MapInboundClaimsTokenHandler.get -> bool
+Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.MapInboundClaimsTokenHandler.set -> void
+Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.TokenHandler.get -> Microsoft.IdentityModel.Tokens.TokenHandler!
+Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.TokenHandler.set -> void
+Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.UseTokenHandler.get -> bool
+Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.UseTokenHandler.set -> void

--- a/src/Security/Authentication/OpenIdConnect/src/PublicAPI.Shipped.txt
+++ b/src/Security/Authentication/OpenIdConnect/src/PublicAPI.Shipped.txt
@@ -210,9 +210,3 @@ virtual Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectHandler.H
 virtual Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectHandler.HandleSignOutCallbackAsync() -> System.Threading.Tasks.Task<bool>!
 virtual Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectHandler.RedeemAuthorizationCodeAsync(Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectMessage! tokenEndpointRequest) -> System.Threading.Tasks.Task<Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectMessage!>!
 virtual Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectHandler.SignOutAsync(Microsoft.AspNetCore.Authentication.AuthenticationProperties? properties) -> System.Threading.Tasks.Task!
-Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.MapInboundClaimsTokenHandler.get -> bool
-Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.MapInboundClaimsTokenHandler.set -> void
-Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.TokenHandler.get -> Microsoft.IdentityModel.Tokens.TokenHandler!
-Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.TokenHandler.set -> void
-Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.UseTokenHandler.get -> bool
-Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.UseTokenHandler.set -> void

--- a/src/Security/Authentication/OpenIdConnect/src/PublicAPI.Unshipped.txt
+++ b/src/Security/Authentication/OpenIdConnect/src/PublicAPI.Unshipped.txt
@@ -1,8 +1,6 @@
 #nullable enable
 Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectHandler.OpenIdConnectHandler(Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions!>! options, Microsoft.Extensions.Logging.ILoggerFactory! logger, System.Text.Encodings.Web.HtmlEncoder! htmlEncoder, System.Text.Encodings.Web.UrlEncoder! encoder) -> void
-Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.MapInboundClaimsTokenHandler.get -> bool
-Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.MapInboundClaimsTokenHandler.set -> void
 Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.TokenHandler.get -> Microsoft.IdentityModel.Tokens.TokenHandler!
 Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.TokenHandler.set -> void
-Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.UseTokenHandler.get -> bool
-Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.UseTokenHandler.set -> void
+Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.UseSecurityTokenValidator.get -> bool
+Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.UseSecurityTokenValidator.set -> void

--- a/src/Security/Authentication/OpenIdConnect/src/PublicAPI.Unshipped.txt
+++ b/src/Security/Authentication/OpenIdConnect/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,8 @@
 #nullable enable
 Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectHandler.OpenIdConnectHandler(Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions!>! options, Microsoft.Extensions.Logging.ILoggerFactory! logger, System.Text.Encodings.Web.HtmlEncoder! htmlEncoder, System.Text.Encodings.Web.UrlEncoder! encoder) -> void
+Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.MapInboundClaimsTokenHandler.get -> bool
+Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.MapInboundClaimsTokenHandler.set -> void
+Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.TokenHandler.get -> Microsoft.IdentityModel.Tokens.TokenHandler!
+Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.TokenHandler.set -> void
+Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.UseTokenHandler.get -> bool
+Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.UseTokenHandler.set -> void

--- a/src/Security/Authentication/OpenIdConnect/src/Resources.resx
+++ b/src/Security/Authentication/OpenIdConnect/src/Resources.resx
@@ -135,4 +135,10 @@
   <data name="IdTokenCodeMissing" xml:space="preserve">
     <value>Cannot process the message. Both id_token and code are missing.</value>
   </data>
+  <data name="ValidatedSecurityTokenNotJsonWebToken" xml:space="preserve">
+    <value>The Validated Security Token must be of type JsonWebToken, but instead its tye is '{0}'.</value>
+  </data>
+  <data name="UnableToValidateTokenFromHandler" xml:space="preserve">
+    <value>Unable to validate the 'id_token', no suitable TokenHandler was found for: '{0}'."</value>
+  </data>
 </root>

--- a/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectEventTests.cs
+++ b/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectEventTests.cs
@@ -1286,8 +1286,10 @@ public class OpenIdConnectEventTests
                             EndSessionEndpoint = "http://testhost/end"
                         };
                         o.StateDataFormat = new TestStateDataFormat();
+#pragma warning disable CS0618 // Type or member is obsolete
                         o.SecurityTokenValidator = new TestTokenValidator();
-                        o.UseTokenHandler = false;
+#pragma warning restore CS0618 // Type or member is obsolete
+                        o.UseSecurityTokenValidator = true;
                         o.ProtocolValidator = new TestProtocolValidator();
                         o.BackchannelHttpHandler = new TestBackchannel();
                     });

--- a/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectEventTests_Handler.cs
+++ b/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectEventTests_Handler.cs
@@ -23,7 +23,7 @@ using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Authentication.Test.OpenIdConnect;
 
-public class OpenIdConnectEventTests
+public class OpenIdConnectEventTests_Handlers
 {
     private readonly RequestDelegate AppWritePath = context => context.Response.WriteAsync(context.Request.Path);
     private readonly RequestDelegate AppNotImpl = context => { throw new NotImplementedException("App"); };
@@ -1286,8 +1286,8 @@ public class OpenIdConnectEventTests
                             EndSessionEndpoint = "http://testhost/end"
                         };
                         o.StateDataFormat = new TestStateDataFormat();
-                        o.SecurityTokenValidator = new TestTokenValidator();
-                        o.UseTokenHandler = false;
+                        o.UseTokenHandler = true;
+                        o.TokenHandler = new TestTokenHandler();
                         o.ProtocolValidator = new TestProtocolValidator();
                         o.BackchannelHttpHandler = new TestBackchannel();
                     });
@@ -1345,27 +1345,24 @@ public class OpenIdConnectEventTests
         }
     }
 
-    private class TestTokenValidator : ISecurityTokenValidator
+    private class TestTokenHandler : TokenHandler
     {
-        public bool CanValidateToken => true;
-
-        public int MaximumTokenSizeInBytes
+        public override Task<TokenValidationResult> ValidateTokenAsync(string token, TokenValidationParameters validationParameters)
         {
-            get { return 1024; }
-            set { throw new NotImplementedException(); }
+            Assert.Equal("my_id_token", token);
+            var jwt = new JwtSecurityToken();
+            return Task.FromResult(new TokenValidationResult()
+            {
+                SecurityToken = new JsonWebToken(jwt.EncodedHeader + "." + jwt.EncodedPayload + "."),
+                ClaimsIdentity = new ClaimsIdentity("customAuthType"),
+                IsValid = true
+            });
         }
 
-        public bool CanReadToken(string securityToken)
+        public override SecurityToken ReadToken(string token)
         {
-            Assert.Equal("my_id_token", securityToken);
-            return true;
-        }
-
-        public ClaimsPrincipal ValidateToken(string securityToken, TokenValidationParameters validationParameters, out SecurityToken validatedToken)
-        {
-            Assert.Equal("my_id_token", securityToken);
-            validatedToken = new JwtSecurityToken();
-            return new ClaimsPrincipal(new ClaimsIdentity("customAuthType"));
+            Assert.Equal("my_id_token", token);
+            return new JsonWebToken(token);
         }
     }
 

--- a/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectEventTests_Handler.cs
+++ b/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectEventTests_Handler.cs
@@ -1286,7 +1286,7 @@ public class OpenIdConnectEventTests_Handlers
                             EndSessionEndpoint = "http://testhost/end"
                         };
                         o.StateDataFormat = new TestStateDataFormat();
-                        o.UseTokenHandler = true;
+                        o.UseSecurityTokenValidator = false;
                         o.TokenHandler = new TestTokenHandler();
                         o.ProtocolValidator = new TestProtocolValidator();
                         o.BackchannelHttpHandler = new TestBackchannel();

--- a/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectTests.cs
+++ b/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectTests.cs
@@ -374,7 +374,9 @@ public class OpenIdConnectTests
     {
         var options = new OpenIdConnectOptions();
         Assert.True(options.MapInboundClaims);
+#pragma warning disable CS0618 // Type or member is obsolete
         var jwtHandler = options.SecurityTokenValidator as JwtSecurityTokenHandler;
+#pragma warning restore CS0618 // Type or member is obsolete
         Assert.NotNull(jwtHandler);
         Assert.True(jwtHandler.MapInboundClaims);
     }
@@ -385,7 +387,9 @@ public class OpenIdConnectTests
         var options = new OpenIdConnectOptions();
         options.MapInboundClaims = false;
         Assert.False(options.MapInboundClaims);
+#pragma warning disable CS0618 // Type or member is obsolete
         var jwtHandler = options.SecurityTokenValidator as JwtSecurityTokenHandler;
+#pragma warning restore CS0618 // Type or member is obsolete
         Assert.NotNull(jwtHandler);
         Assert.False(jwtHandler.MapInboundClaims);
     }


### PR DESCRIPTION
# Option to use JsonWebTokenHandler in oidc handler

## Description

Gives the option to use JsonWebTokenHandler instead of JwtSecurityTokenHandler in OIDC Handler. This gives an async model, last known good support for metadata, and better performance.