### PR TITLE
Return LockedOut from TwoFactorSignInAsync

### DIFF
--- a/src/Identity/Core/src/SignInManager.cs
+++ b/src/Identity/Core/src/SignInManager.cs
@@ -560,6 +560,11 @@ public class SignInManager<TUser> where TUser : class
                 // This is currently redundant, but it's here in case the code gets copied elsewhere.
                 return SignInResult.Failed;
             }
+
+            if (await UserManager.IsLockedOutAsync(user))
+            {
+                return await LockedOut(user);
+            }
         }
         return SignInResult.Failed;
     }

--- a/src/Identity/Core/src/SignInManager.cs
+++ b/src/Identity/Core/src/SignInManager.cs
@@ -602,6 +602,11 @@ public class SignInManager<TUser> where TUser : class
                 // This is currently redundant, but it's here in case the code gets copied elsewhere.
                 return SignInResult.Failed;
             }
+
+            if (await UserManager.IsLockedOutAsync(user))
+            {
+                return await LockedOut(user);
+            }
         }
         return SignInResult.Failed;
     }


### PR DESCRIPTION
# Return LockedOut result from TwoFactorSignInAsync after a failed call

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

`LockedOut` is not returned the moment it happens for two-factor authentication.

## Description

When a user reaches the failed access limit while doing 2FA verification, the initial response is `Failed` instead of `LockedOut`. Only subsequent authentication attempts result in the `LockedOut` response, because of a pre-sign check. I think the behavior of `TwoFactorSignInAsync` should be the same as the behavior of `CheckPasswordSignInAsync` and `LockedOut` should be returned immediately, not the n + 1 time.

Fixes #26429 - closed as a duplicate but that decision was IMO incorrect, it is a different issue
