### PR TITLE
Avoid file system for dataprotection in SignalR tests

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Microsoft.AspNetCore.SignalR.Client.FunctionalTests.csproj
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Microsoft.AspNetCore.SignalR.Client.FunctionalTests.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(SignalRSharedSourceRoot)EphemeralDataProtectionProvider.cs" />
     <Compile Include="$(SignalRSharedSourceRoot)TestCertificates.cs" Link="TestCertificates.cs" />
     <Content Include="$(SignalRSharedSourceRoot)*.pfx" LinkBase="TestCertificates" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Startup.cs
@@ -10,8 +10,10 @@ using Microsoft.AspNetCore.Authentication.Negotiate;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
@@ -60,8 +62,13 @@ public class Startup
         services.AddAuthentication(NegotiateDefaults.AuthenticationScheme).AddNegotiate();
 
         // Since tests run in parallel, it's possible multiple servers will startup,
-        // we use an ephemeral key provider to avoid filesystem contention issues
+        // we use an ephemeral key provider and repository to avoid filesystem contention issues
         services.AddSingleton<IDataProtectionProvider, EphemeralDataProtectionProvider>();
+
+        services.Configure<KeyManagementOptions>(options =>
+        {
+            options.XmlRepository = new EphemeralXmlRepository();
+        });
     }
 
     public void Configure(IApplicationBuilder app)

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/VersionStartup.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/VersionStartup.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
+using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -24,8 +26,13 @@ public class VersionStartup
         services.AddAuthentication();
 
         // Since tests run in parallel, it's possible multiple servers will startup,
-        // we use an ephemeral key provider to avoid filesystem contention issues
+        // we use an ephemeral key provider and repository to avoid filesystem contention issues
         services.AddSingleton<IDataProtectionProvider, EphemeralDataProtectionProvider>();
+
+        services.Configure<KeyManagementOptions>(options =>
+        {
+            options.XmlRepository = new EphemeralXmlRepository();
+        });
     }
 
     public void Configure(IApplicationBuilder app)

--- a/src/SignalR/clients/ts/FunctionalTests/SignalR.Client.FunctionalTestApp.csproj
+++ b/src/SignalR/clients/ts/FunctionalTests/SignalR.Client.FunctionalTestApp.csproj
@@ -37,6 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(SignalRSharedSourceRoot)EphemeralDataProtectionProvider.cs" />
     <Compile Include="$(SignalRSharedSourceRoot)TestCertificates.cs" Link="TestCertificates.cs" />
     <Content Include="$(SignalRSharedSourceRoot)*.pfx" LinkBase="TestCertificates" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/src/SignalR/clients/ts/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/ts/FunctionalTests/Startup.cs
@@ -7,8 +7,10 @@ using System.Reflection;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Primitives;
 using Microsoft.IdentityModel.Tokens;
@@ -94,8 +96,13 @@ public class Startup
             });
 
         // Since tests run in parallel, it's possible multiple servers will startup,
-        // we use an ephemeral key provider to avoid filesystem contention issues
+        // we use an ephemeral key provider and repository to avoid filesystem contention issues
         services.AddSingleton<IDataProtectionProvider, EphemeralDataProtectionProvider>();
+
+        services.Configure<KeyManagementOptions>(options =>
+        {
+            options.XmlRepository = new EphemeralXmlRepository();
+        });
     }
 
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger)

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -21,6 +21,7 @@ using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Abstractions;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -3303,8 +3304,13 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
                     services.AddConnections();
 
                     // Since tests run in parallel, it's possible multiple servers will startup,
-                    // we use an ephemeral key provider to avoid filesystem contention issues
+                    // we use an ephemeral key provider and repository to avoid filesystem contention issues
                     services.AddSingleton<IDataProtectionProvider, EphemeralDataProtectionProvider>();
+
+                    services.Configure<KeyManagementOptions>(options =>
+                    {
+                        options.XmlRepository = new EphemeralXmlRepository();
+                    });
                 })
                 .Configure(app =>
                 {
@@ -3448,8 +3454,13 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
                     services.AddAuthorization();
 
                     // Since tests run in parallel, it's possible multiple servers will startup,
-                    // we use an ephemeral key provider to avoid filesystem contention issues
+                    // we use an ephemeral key provider and repository to avoid filesystem contention issues
                     services.AddSingleton<IDataProtectionProvider, EphemeralDataProtectionProvider>();
+
+                    services.Configure<KeyManagementOptions>(options =>
+                    {
+                        options.XmlRepository = new EphemeralXmlRepository();
+                    });
                 })
                 .Configure(app =>
                 {

--- a/src/SignalR/common/Http.Connections/test/Microsoft.AspNetCore.Http.Connections.Tests.csproj
+++ b/src/SignalR/common/Http.Connections/test/Microsoft.AspNetCore.Http.Connections.Tests.csproj
@@ -9,6 +9,7 @@
     <Compile Include="$(SharedSourceRoot)SyncPoint\SyncPoint.cs" />
     <Compile Include="$(SharedSourceRoot)EventSource.Testing\TestEventListener.cs" />
     <Compile Include="$(SharedSourceRoot)Metrics\TestMeterFactory.cs" LinkBase="shared" />
+    <Compile Include="$(SignalRSharedSourceRoot)EphemeralDataProtectionProvider.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SignalR/common/Shared/EphemeralDataProtectionProvider.cs
+++ b/src/SignalR/common/Shared/EphemeralDataProtectionProvider.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Xml.Linq;
+using Microsoft.AspNetCore.DataProtection.Repositories;
+
+namespace Microsoft.AspNetCore.Internal;
+
+internal sealed class EphemeralXmlRepository : IXmlRepository
+{
+	private readonly List<XElement> _storedElements = new List<XElement>();
+
+	public EphemeralXmlRepository()
+	{
+	}
+
+	public IReadOnlyCollection<XElement> GetAllElements()
+	{
+		// force complete enumeration under lock for thread safety
+		lock (_storedElements)
+		{
+			return GetAllElementsCore().ToList().AsReadOnly();
+		}
+	}
+
+	private IEnumerable<XElement> GetAllElementsCore()
+	{
+		// this method must be called under lock
+		foreach (XElement element in _storedElements)
+		{
+			yield return new XElement(element); // makes a deep copy so caller doesn't inadvertently modify it
+		}
+	}
+
+	public void StoreElement(XElement element, string friendlyName)
+	{
+		var cloned = new XElement(element); // makes a deep copy so caller doesn't inadvertently modify it
+
+		// under lock for thread safety
+		lock (_storedElements)
+		{
+			_storedElements.Add(cloned);
+		}
+	}
+}

--- a/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests.csproj
+++ b/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)SyncPoint\SyncPoint.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)test\MockTimeProvider.cs" LinkBase="Shared" />
+    <Compile Include="$(SignalRSharedSourceRoot)EphemeralDataProtectionProvider.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SignalR/server/SignalR/test/Startup.cs
+++ b/src/SignalR/server/SignalR/test/Startup.cs
@@ -10,7 +10,9 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 
@@ -67,8 +69,13 @@ public class Startup
         services.AddSingleton<IAuthorizationHandler, TestAuthHandler>();
 
         // Since tests run in parallel, it's possible multiple servers will startup,
-        // we use an ephemeral key provider to avoid filesystem contention issues
+        // we use an ephemeral key provider and repository to avoid filesystem contention issues
         services.AddSingleton<IDataProtectionProvider, EphemeralDataProtectionProvider>();
+
+        services.Configure<KeyManagementOptions>(options =>
+        {
+            options.XmlRepository = new EphemeralXmlRepository();
+        });
     }
 
     public void Configure(IApplicationBuilder app)


### PR DESCRIPTION
Should de-flake https://github.com/dotnet/aspnetcore/issues/49315 and https://github.com/dotnet/aspnetcore/issues/48961