### PR TITLE
Removed redundant <title> tag

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/Components-CSharp/App.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/Components-CSharp/App.razor
@@ -4,7 +4,6 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <title>Components-CSharp</title>
     <base href="/" />
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
     <link rel="stylesheet" href="css/bootstrap-icons/bootstrap-icons.min.css" />


### PR DESCRIPTION
The HeadOutlet component which appears few lines below the removed <title> tag is responsible for setting the page title.

Fixes https://github.com/dotnet/aspnetcore/issues/49310