### PR TITLE
Improve MVC and RazorPages debugging

### DIFF
--- a/src/Http/Routing.Abstractions/src/RouteData.cs
+++ b/src/Http/Routing.Abstractions/src/RouteData.cs
@@ -1,15 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Diagnostics;
+using System.Linq;
 
 namespace Microsoft.AspNetCore.Routing;
 
 /// <summary>
 /// Information about the current routing path.
 /// </summary>
+[DebuggerDisplay("Count = {Values.Count}")]
+[DebuggerTypeProxy(typeof(RouteDataDebugView))]
 public class RouteData
 {
     private RouteValueDictionary? _dataTokens;
@@ -181,6 +182,14 @@ public class RouteData
         }
 
         return snapshot;
+    }
+
+    private sealed class RouteDataDebugView(RouteData routeData)
+    {
+        private readonly RouteData _routeData = routeData;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public KeyValuePair<string, object?>[] Items => _routeData.Values.ToArray();
     }
 
     /// <summary>

--- a/src/Http/Routing/src/DefaultLinkGenerator.cs
+++ b/src/Http/Routing/src/DefaultLinkGenerator.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Microsoft.AspNetCore.Http;
@@ -16,6 +17,8 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Routing;
 
+[DebuggerDisplay("Endpoints = {Endpoints.Count}")]
+[DebuggerTypeProxy(typeof(DefaultLinkGeneratorDebugView))]
 internal sealed partial class DefaultLinkGenerator : LinkGenerator, IDisposable
 {
     private readonly TemplateBinderFactory _binderFactory;
@@ -322,6 +325,16 @@ internal sealed partial class DefaultLinkGenerator : LinkGenerator, IDisposable
     public void Dispose()
     {
         _cache.Dispose();
+    }
+
+    private IReadOnlyList<Endpoint> Endpoints => _serviceProvider.GetRequiredService<EndpointDataSource>().Endpoints;
+
+    private sealed class DefaultLinkGeneratorDebugView(DefaultLinkGenerator generator)
+    {
+        private readonly DefaultLinkGenerator _generator = generator;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public Endpoint[] Items => _generator.Endpoints.ToArray();
     }
 
     private static partial class Log

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelStateDictionary.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelStateDictionary.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Formatters;
@@ -15,6 +16,8 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding;
 /// Represents the state of an attempt to bind values from an HTTP Request to an action method, which includes
 /// validation information.
 /// </summary>
+[DebuggerDisplay("Entries = {Count}, IsValid = {IsValid}")]
+[DebuggerTypeProxy(typeof(ModelStateDictionaryDebugView))]
 public class ModelStateDictionary : IReadOnlyDictionary<string, ModelStateEntry?>
 {
     // Make sure to update the doc headers if this value is changed.
@@ -820,7 +823,7 @@ public class ModelStateDictionary : IReadOnlyDictionary<string, ModelStateEntry?
         OpenBracket
     }
 
-    [DebuggerDisplay("SubKey={SubKey}, Key={Key}, ValidationState={ValidationState}")]
+    [DebuggerDisplay("SubKey = {SubKey.Value}, Key = {Key}, ValidationState = {ValidationState}")]
     private sealed class ModelStateNode : ModelStateEntry
     {
         private bool _isContainerNode = true;
@@ -1250,5 +1253,13 @@ public class ModelStateDictionary : IReadOnlyDictionary<string, ModelStateEntry?
             _prefixEnumerator.Reset();
             Current = default!;
         }
+    }
+
+    private sealed class ModelStateDictionaryDebugView(ModelStateDictionary dictionary)
+    {
+        private readonly ModelStateDictionary _dictionary = dictionary;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public KeyValuePair<string, ModelStateEntry?>[] Items => _dictionary.ToArray();
     }
 }

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelStateDictionary.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelStateDictionary.cs
@@ -823,7 +823,7 @@ public class ModelStateDictionary : IReadOnlyDictionary<string, ModelStateEntry?
         OpenBracket
     }
 
-    [DebuggerDisplay("SubKey = {SubKey.Value}, Key = {Key}, ValidationState = {ValidationState}")]
+    [DebuggerDisplay("SubKey = {SubKey}, Key = {Key}, ValidationState = {ValidationState}")]
     private sealed class ModelStateNode : ModelStateEntry
     {
         private bool _isContainerNode = true;

--- a/src/Mvc/Mvc.Core/src/ControllerBase.cs
+++ b/src/Mvc/Mvc.Core/src/ControllerBase.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Security.Claims;
@@ -87,6 +88,7 @@ public abstract class ControllerBase
     /// <summary>
     /// Gets or sets the <see cref="IModelMetadataProvider"/>.
     /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public IModelMetadataProvider MetadataProvider
     {
         get
@@ -109,6 +111,7 @@ public abstract class ControllerBase
     /// <summary>
     /// Gets or sets the <see cref="IModelBinderFactory"/>.
     /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public IModelBinderFactory ModelBinderFactory
     {
         get
@@ -131,6 +134,7 @@ public abstract class ControllerBase
     /// <summary>
     /// Gets or sets the <see cref="IUrlHelper"/>.
     /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public IUrlHelper Url
     {
         get
@@ -154,6 +158,7 @@ public abstract class ControllerBase
     /// <summary>
     /// Gets or sets the <see cref="IObjectModelValidator"/>.
     /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public IObjectModelValidator ObjectValidator
     {
         get
@@ -176,6 +181,7 @@ public abstract class ControllerBase
     /// <summary>
     /// Gets or sets the <see cref="ProblemDetailsFactory"/>.
     /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public ProblemDetailsFactory ProblemDetailsFactory
     {
         get

--- a/src/Mvc/Mvc.Core/src/ControllerContext.cs
+++ b/src/Mvc/Mvc.Core/src/ControllerContext.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Core;
@@ -12,6 +13,7 @@ namespace Microsoft.AspNetCore.Mvc;
 /// <summary>
 /// The context associated with the current request for a controller.
 /// </summary>
+[DebuggerDisplay("{DebuggerToString(),nq}")]
 public class ControllerContext : ActionContext
 {
     private IList<IValueProviderFactory>? _valueProviderFactories;
@@ -33,7 +35,7 @@ public class ControllerContext : ActionContext
     public ControllerContext(ActionContext context)
         : base(context)
     {
-        if (!(context.ActionDescriptor is ControllerActionDescriptor))
+        if (context.ActionDescriptor is not ControllerActionDescriptor)
         {
             throw new ArgumentException(Resources.FormatActionDescriptorMustBeBasedOnControllerAction(
                 typeof(ControllerActionDescriptor)),
@@ -85,4 +87,6 @@ public class ControllerContext : ActionContext
             _valueProviderFactories = value;
         }
     }
+
+    private string DebuggerToString() => ActionDescriptor?.DisplayName ?? $"{{{GetType().FullName}}}";
 }

--- a/src/Mvc/Mvc.Core/src/Controllers/ControllerActionDescriptor.cs
+++ b/src/Mvc/Mvc.Core/src/Controllers/ControllerActionDescriptor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.Controllers;
 /// <summary>
 /// A descriptor for an action of a controller.
 /// </summary>
-[DebuggerDisplay("{DisplayName}")]
+[DebuggerDisplay("{DisplayName,nq}")]
 public class ControllerActionDescriptor : ActionDescriptor
 {
     /// <summary>

--- a/src/Mvc/Mvc.Core/src/Infrastructure/CopyOnWriteList.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/CopyOnWriteList.cs
@@ -8,7 +8,7 @@ using System.Linq;
 namespace Microsoft.AspNetCore.Mvc.Infrastructure;
 
 [DebuggerDisplay("Count = {Count}")]
-[DebuggerTypeProxy(typeof(CopyOnWriteListDebugView<>))]
+[DebuggerTypeProxy(typeof(CopyOnWriteList<>.CopyOnWriteListDebugView))]
 internal sealed class CopyOnWriteList<T> : IList<T>
 {
     private readonly IReadOnlyList<T> _source;
@@ -115,13 +115,12 @@ internal sealed class CopyOnWriteList<T> : IList<T>
     {
         return GetEnumerator();
     }
-}
 
-// This debug view is not a nested private class to avoid a nested generic argument conflict.
-internal sealed class CopyOnWriteListDebugView<T>(CopyOnWriteList<T> collection)
-{
-    private readonly CopyOnWriteList<T> _collection = collection;
+    private sealed class CopyOnWriteListDebugView(CopyOnWriteList<T> collection)
+    {
+        private readonly CopyOnWriteList<T> _collection = collection;
 
-    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-    public T[] Items => _collection.ToArray();
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public T[] Items => _collection.ToArray();
+    }
 }

--- a/src/Mvc/Mvc.Core/src/Infrastructure/CopyOnWriteList.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/CopyOnWriteList.cs
@@ -1,12 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections;
+using System.Diagnostics;
+using System.Linq;
 
 namespace Microsoft.AspNetCore.Mvc.Infrastructure;
 
+[DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(CopyOnWriteListDebugView<>))]
 internal sealed class CopyOnWriteList<T> : IList<T>
 {
     private readonly IReadOnlyList<T> _source;
@@ -113,4 +115,13 @@ internal sealed class CopyOnWriteList<T> : IList<T>
     {
         return GetEnumerator();
     }
+}
+
+// This debug view is not a nested private class to avoid a nested generic argument conflict.
+internal sealed class CopyOnWriteListDebugView<T>(CopyOnWriteList<T> collection)
+{
+    private readonly CopyOnWriteList<T> _collection = collection;
+
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    public T[] Items => _collection.ToArray();
 }

--- a/src/Mvc/Mvc.Core/src/Routing/UrlHelperFactory.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/UrlHelperFactory.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Core;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Mvc.Routing;
 
@@ -46,12 +45,12 @@ public class UrlHelperFactory : IUrlHelperFactory
         {
             var services = httpContext.RequestServices;
             var linkGenerator = services.GetRequiredService<LinkGenerator>();
-            var logger = services.GetRequiredService<ILogger<EndpointRoutingUrlHelper>>();
+            var endpointDataSource = services.GetRequiredService<EndpointDataSource>();
 
             urlHelper = new EndpointRoutingUrlHelper(
                 context,
                 linkGenerator,
-                logger);
+                endpointDataSource);
         }
         else
         {

--- a/src/Mvc/Mvc.Razor/src/RazorPageBase.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorPageBase.cs
@@ -45,6 +45,7 @@ public abstract class RazorPageBase : IRazorPage
     /// <summary>
     /// Gets the <see cref="TextWriter"/> that the page is writing output to.
     /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public virtual TextWriter Output
     {
         get
@@ -63,6 +64,7 @@ public abstract class RazorPageBase : IRazorPage
     public string Path { get; set; } = default!;
 
     /// <inheritdoc />
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public IDictionary<string, RenderAsyncDelegate> SectionWriters { get; } =
         new Dictionary<string, RenderAsyncDelegate>(StringComparer.OrdinalIgnoreCase);
 
@@ -72,18 +74,22 @@ public abstract class RazorPageBase : IRazorPage
     public dynamic ViewBag => ViewContext?.ViewBag!;
 
     /// <inheritdoc />
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public bool IsLayoutBeingRendered { get; set; }
 
     /// <inheritdoc />
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public IHtmlContent? BodyContent { get; set; }
 
     /// <inheritdoc />
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public IDictionary<string, RenderAsyncDelegate> PreviousSectionWriters { get; set; } = default!;
 
     /// <summary>
     /// Gets or sets a <see cref="System.Diagnostics.DiagnosticSource"/> instance used to instrument the page execution.
     /// </summary>
     [RazorInject]
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public DiagnosticSource DiagnosticSource { get; set; } = default!;
 
     /// <summary>
@@ -91,6 +97,7 @@ public abstract class RazorPageBase : IRazorPage
     /// handles non-<see cref="IHtmlContent"/> C# expressions.
     /// </summary>
     [RazorInject]
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public HtmlEncoder HtmlEncoder { get; set; } = default!;
 
     /// <summary>

--- a/src/Mvc/Mvc.Razor/src/RazorView.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorView.cs
@@ -15,6 +15,7 @@ namespace Microsoft.AspNetCore.Mvc.Razor;
 /// Default implementation for <see cref="IView"/> that executes one or more <see cref="IRazorPage"/>
 /// as parts of its execution.
 /// </summary>
+[DebuggerDisplay("{Path,nq}")]
 public class RazorView : IView
 {
     private readonly IRazorViewEngine _viewEngine;

--- a/src/Mvc/Mvc.RazorPages/src/PageBase.cs
+++ b/src/Mvc/Mvc.RazorPages/src/PageBase.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Security.Claims;
@@ -63,6 +64,7 @@ public abstract class PageBase : RazorPageBase
     /// <summary>
     /// Gets or sets the <see cref="IModelMetadataProvider"/>.
     /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public IModelMetadataProvider MetadataProvider
     {
         get

--- a/src/Mvc/Mvc.RazorPages/src/PageContext.cs
+++ b/src/Mvc/Mvc.RazorPages/src/PageContext.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Razor;
@@ -12,6 +13,7 @@ namespace Microsoft.AspNetCore.Mvc.RazorPages;
 /// <summary>
 /// The context associated with the current request for a Razor page.
 /// </summary>
+[DebuggerDisplay("{DebuggerToString(),nq}")]
 public class PageContext : ActionContext
 {
     private CompiledPageActionDescriptor? _actionDescriptor;
@@ -117,4 +119,6 @@ public class PageContext : ActionContext
             _viewStartFactories = value;
         }
     }
+
+    private string DebuggerToString() => ActionDescriptor?.DisplayName ?? $"{{{GetType().FullName}}}";
 }

--- a/src/Mvc/Mvc.ViewFeatures/src/DynamicViewData.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/DynamicViewData.cs
@@ -1,10 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Dynamic;
+using System.Linq;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures;
 
+[DebuggerDisplay("Count = {ViewData.Count}")]
+[DebuggerTypeProxy(typeof(DynamicViewDataDebugView))]
 internal sealed class DynamicViewData : DynamicObject
 {
     private readonly Func<ViewDataDictionary> _viewDataFunc;
@@ -57,5 +61,13 @@ internal sealed class DynamicViewData : DynamicObject
 
         // Can always add / update a ViewDataDictionary value.
         return true;
+    }
+
+    private sealed class DynamicViewDataDebugView(DynamicViewData dictionary)
+    {
+        private readonly ViewDataDictionary _dictionary = dictionary.ViewData;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public KeyValuePair<string, object>[] Items => _dictionary.ToArray();
     }
 }

--- a/src/Mvc/Mvc.ViewFeatures/src/FormContext.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/FormContext.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Html;
+using System.Diagnostics;
 using System.Globalization;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures;
@@ -13,6 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures;
 /// Literal &lt;form&gt; elements in a view will share the default <see cref="FormContext"/> instance unless tag
 /// helpers are enabled.
 /// </remarks>
+[DebuggerDisplay("FormData = {FormData.Count}")]
 public class FormContext
 {
     private Dictionary<string, bool> _renderedFields;

--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/ViewContext.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/ViewContext.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
@@ -12,6 +13,7 @@ namespace Microsoft.AspNetCore.Mvc.Rendering;
 /// <summary>
 /// Context for view execution.
 /// </summary>
+[DebuggerDisplay("{DebuggerToString(),nq}")]
 public class ViewContext : ActionContext
 {
     private FormContext _formContext = default!;
@@ -212,4 +214,6 @@ public class ViewContext : ActionContext
     {
         return ClientValidationEnabled ? FormContext : null;
     }
+
+    private string DebuggerToString() => View?.Path ?? $"{{{GetType().FullName}}}";
 }

--- a/src/Mvc/Mvc.ViewFeatures/src/TempDataDictionary.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/TempDataDictionary.cs
@@ -6,12 +6,15 @@
 using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures;
 
 /// <inheritdoc />
+[DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(TempDataDictionaryDebugView))]
 public class TempDataDictionary : ITempDataDictionary
 {
     // Perf: Everything here is lazy because the TempDataDictionary is frequently created and passed around
@@ -309,5 +312,13 @@ public class TempDataDictionary : ITempDataDictionary
         {
             _enumerator.Dispose();
         }
+    }
+
+    private sealed class TempDataDictionaryDebugView(TempDataDictionary dictionary)
+    {
+        private readonly TempDataDictionary _dictionary = dictionary;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public KeyValuePair<string, object?>[] Items => _dictionary.ToArray();
     }
 }

--- a/src/Mvc/Mvc.ViewFeatures/src/ViewDataDictionary.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/ViewDataDictionary.cs
@@ -4,7 +4,9 @@
 #nullable enable
 
 using System.Collections;
+using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.Extensions.Internal;
@@ -14,6 +16,8 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures;
 /// <summary>
 /// A <see cref="IDictionary{TKey, TValue}"/> for view data.
 /// </summary>
+[DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(ViewDataDictionaryDebugView))]
 public class ViewDataDictionary : IDictionary<string, object?>
 {
     private readonly IDictionary<string, object?> _data;
@@ -590,4 +594,12 @@ public class ViewDataDictionary : IDictionary<string, object?>
         return _data.GetEnumerator();
     }
     #endregion
+
+    private sealed class ViewDataDictionaryDebugView(ViewDataDictionary dictionary)
+    {
+        private readonly ViewDataDictionary _dictionary = dictionary;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public KeyValuePair<string, object?>[] Items => _dictionary.ToArray();
+    }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/ServerAddressesCollection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ServerAddressesCollection.cs
@@ -1,14 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 
+[DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(ServerAddressesCollectionDebugView))]
 internal sealed class ServerAddressesCollection : ICollection<string>
 {
     private readonly List<string> _addresses = new List<string>();
@@ -96,7 +97,6 @@ internal sealed class ServerAddressesCollection : ICollection<string>
         return GetEnumerator();
     }
 
-    [DebuggerDisplay("Count = {Count}")]
     private sealed class PublicServerAddressesCollection : ICollection<string>
     {
         private readonly ServerAddressesCollection _addressesCollection;
@@ -167,5 +167,13 @@ internal sealed class ServerAddressesCollection : ICollection<string>
                 throw new InvalidOperationException($"{nameof(IServerAddressesFeature)}.{nameof(IServerAddressesFeature.Addresses)} cannot be modified after the server has started.");
             }
         }
+    }
+
+    private sealed class ServerAddressesCollectionDebugView(ServerAddressesCollection collection)
+    {
+        private readonly ServerAddressesCollection _collection = collection;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public string[] Items => _collection.ToArray();
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/ServerAddressesFeature.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ServerAddressesFeature.cs
@@ -1,14 +1,28 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using System.Linq;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 
+[DebuggerDisplay("{DebuggerToString(),nq}")]
+[DebuggerTypeProxy(typeof(ServerAddressesFeatureDebugView))]
 internal sealed class ServerAddressesFeature : IServerAddressesFeature
 {
     public ServerAddressesCollection InternalCollection { get; } = new ServerAddressesCollection();
 
     ICollection<string> IServerAddressesFeature.Addresses => InternalCollection.PublicCollection;
     public bool PreferHostingUrls { get; set; }
+
+    private string DebuggerToString() => $"Addresses = {InternalCollection.Count}";
+
+    private sealed class ServerAddressesFeatureDebugView(ServerAddressesFeature feature)
+    {
+        private readonly ServerAddressesFeature _feature = feature;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public string[] Items => _feature.InternalCollection.ToArray();
+    }
 }


### PR DESCRIPTION
## Controller

Before:

![image](https://github.com/dotnet/aspnetcore/assets/303201/dc71efdc-1ce6-4a85-adba-e34852bc1a7e)

After:

![image](https://github.com/dotnet/aspnetcore/assets/303201/8d27aa03-77b8-45ee-95c7-8cd2825bca65)

## RazorPage

Before:

![image](https://github.com/dotnet/aspnetcore/assets/303201/674364b4-1f09-4da7-aee8-ed131feaa094)

After:

![image](https://github.com/dotnet/aspnetcore/assets/303201/1b09a260-3b3f-45d1-b329-ba30174def5b)

In the RazorPage "After" screenshot, you'll see some page properties that aren't useful when debugging. For example, `Url`, `Component`, `Json`, `ModelExpressionProvider` don't have helpful info. These properties are clutter and should be hidden by the debugger to make it easier to find helpful information.

Razor generates these properties for each page. To hide them, we'll need to update the Razor code gen to place attributes on the generated properties. Issue for that: https://github.com/dotnet/razor/issues/8944
