### PR TITLE
Forms PRG and error handling fixes

### DIFF
--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -102,7 +102,7 @@ static Microsoft.Extensions.DependencyInjection.CascadingValueServiceCollectionE
 virtual Microsoft.AspNetCore.Components.Rendering.ComponentState.DisposeAsync() -> System.Threading.Tasks.ValueTask
 virtual Microsoft.AspNetCore.Components.RenderTree.Renderer.AddPendingTask(Microsoft.AspNetCore.Components.Rendering.ComponentState? componentState, System.Threading.Tasks.Task! task) -> void
 virtual Microsoft.AspNetCore.Components.RenderTree.Renderer.CreateComponentState(int componentId, Microsoft.AspNetCore.Components.IComponent! component, Microsoft.AspNetCore.Components.Rendering.ComponentState? parentComponentState) -> Microsoft.AspNetCore.Components.Rendering.ComponentState!
-virtual Microsoft.AspNetCore.Components.RenderTree.Renderer.DispatchEventAsync(ulong eventHandlerId, Microsoft.AspNetCore.Components.RenderTree.EventFieldInfo? fieldInfo, System.EventArgs! eventArgs, bool quiesce) -> System.Threading.Tasks.Task!
+virtual Microsoft.AspNetCore.Components.RenderTree.Renderer.DispatchEventAsync(ulong eventHandlerId, Microsoft.AspNetCore.Components.RenderTree.EventFieldInfo? fieldInfo, System.EventArgs! eventArgs, bool waitForQuiescence) -> System.Threading.Tasks.Task!
 virtual Microsoft.AspNetCore.Components.RenderTree.Renderer.ResolveComponentForRenderMode(System.Type! componentType, int? parentComponentId, Microsoft.AspNetCore.Components.IComponentActivator! componentActivator, Microsoft.AspNetCore.Components.IComponentRenderMode! renderMode) -> Microsoft.AspNetCore.Components.IComponent!
 ~Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.ComponentRenderMode.get -> Microsoft.AspNetCore.Components.IComponentRenderMode
 ~Microsoft.AspNetCore.Components.RenderTree.RenderTreeFrame.NamedEventAssignedName.get -> string

--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -380,7 +380,7 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
     /// </returns>
     public virtual Task DispatchEventAsync(ulong eventHandlerId, EventFieldInfo? fieldInfo, EventArgs eventArgs)
     {
-        return DispatchEventAsync(eventHandlerId, fieldInfo, eventArgs, quiesce: false);
+        return DispatchEventAsync(eventHandlerId, fieldInfo, eventArgs, waitForQuiescence: false);
     }
 
     /// <summary>
@@ -389,14 +389,19 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
     /// <param name="eventHandlerId">The <see cref="RenderTreeFrame.AttributeEventHandlerId"/> value from the original event attribute.</param>
     /// <param name="eventArgs">Arguments to be passed to the event handler.</param>
     /// <param name="fieldInfo">Information that the renderer can use to update the state of the existing render tree to match the UI.</param>
-    /// <param name="quiesce">Whether to wait for quiescence or not.</param>
+    /// <param name="waitForQuiescence">A flag indicating whether to wait for quiescence.</param>
     /// <returns>
     /// A <see cref="Task"/> which will complete once all asynchronous processing related to the event
     /// has completed.
     /// </returns>
-    public virtual Task DispatchEventAsync(ulong eventHandlerId, EventFieldInfo? fieldInfo, EventArgs eventArgs, bool quiesce)
+    public virtual Task DispatchEventAsync(ulong eventHandlerId, EventFieldInfo? fieldInfo, EventArgs eventArgs, bool waitForQuiescence)
     {
         Dispatcher.AssertAccess();
+
+        if (waitForQuiescence)
+        {
+            _pendingTasks ??= new();
+        }
 
         var callback = GetRequiredEventCallback(eventHandlerId);
         Log.HandlingEvent(_logger, eventHandlerId, eventArgs);
@@ -425,22 +430,9 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
             _isBatchInProgress = true;
 
             task = callback.InvokeAsync(eventArgs);
-            if (quiesce)
-            {
-                // If we are waiting for quiescence, the quiescence task will capture any async exception.
-                // If the exception is thrown synchronously, we just want it to flow to the callers, and
-                // not go through the ErrorBoundary.
-                _pendingTasks ??= new();
-                AddPendingTask(receiverComponentState, task);
-            }
         }
         catch (Exception e)
         {
-            if (quiesce)
-            {
-                // Exception filters are not AoT friendly.
-                throw;
-            }
             HandleExceptionViaErrorBoundary(e, receiverComponentState);
             return Task.CompletedTask;
         }
@@ -453,15 +445,19 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
             ProcessPendingRender();
         }
 
-        if (quiesce)
-        {
-            return WaitForQuiescence();
-        }
-
         // Task completed synchronously or is still running. We already processed all of the rendering
         // work that was queued so let our error handler deal with it.
-        var result = GetErrorHandledTask(task, receiverComponentState);
-        return result;
+        var errorHandledTask = GetErrorHandledTask(task, receiverComponentState);
+
+        if (waitForQuiescence)
+        {
+            AddPendingTask(receiverComponentState, errorHandledTask);
+            return WaitForQuiescence();
+        }
+        else
+        {
+            return errorHandledTask;
+        }
     }
 
     /// <summary>

--- a/src/Components/Endpoints/src/FormMapping/HttpContextFormValueMapper.cs
+++ b/src/Components/Endpoints/src/FormMapping/HttpContextFormValueMapper.cs
@@ -73,7 +73,7 @@ internal sealed class HttpContextFormValueMapper : IFormValueMapper
     public void Map(FormValueMappingContext context)
     {
         // This will func to a proper binder
-        if (!CanMap(context.ValueType, context.MappingScopeName, context.RestrictToFormName))
+        if (!CanMap(context.ValueType, context.AcceptMappingScopeName, context.AcceptFormName))
         {
             context.SetResult(null);
         }

--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -77,16 +77,29 @@ internal class RazorComponentEndpointInvoker
             ParameterView.Empty,
             waitForQuiescence: isPost);
 
-        var isBadRequest = false;
-        var quiesceTask = isPost ? _renderer.DispatchSubmitEventAsync(handler, out isBadRequest) : htmlContent.QuiescenceTask;
-        if (isBadRequest)
+        Task quiesceTask;
+        if (!isPost)
         {
-            return;
+            quiesceTask = htmlContent.QuiescenceTask;
         }
-
-        if (isPost)
+        else
         {
-            await Task.WhenAll(_renderer.NonStreamingPendingTasks);
+            try
+            {
+                var isBadRequest = false;
+                quiesceTask = _renderer.DispatchSubmitEventAsync(handler, out isBadRequest);
+                if (isBadRequest)
+                {
+                    return;
+                }
+
+                await Task.WhenAll(_renderer.NonStreamingPendingTasks);
+            }
+            catch (NavigationException ex)
+            {
+                await EndpointHtmlRenderer.HandleNavigationException(_context, ex);
+                quiesceTask = Task.CompletedTask;
+            }
         }
 
         // Importantly, we must not yield this thread (which holds exclusive access to the renderer sync context)

--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -95,7 +95,7 @@ internal class RazorComponentEndpointInvoker
         // renderer sync context and cause a batch that would get missed.
         htmlContent.WriteTo(writer, HtmlEncoder.Default); // Don't use WriteToAsync, as per the comment above
 
-        if (!quiesceTask.IsCompleted)
+        if (!quiesceTask.IsCompletedSuccessfully)
         {
             await _renderer.SendStreamingUpdatesAsync(_context, quiesceTask, writer);
         }

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.EventDispatch.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.EventDispatch.cs
@@ -48,7 +48,7 @@ internal partial class EndpointHtmlRenderer
         var frameLocation = locationsForName.Single();
         var eventHandlerId = FindEventHandlerIdForNamedEvent("onsubmit", frameLocation.ComponentId, frameLocation.FrameIndex);
         return eventHandlerId.HasValue
-            ? DispatchEventAsync(eventHandlerId.Value, null, EventArgs.Empty, quiesce: true)
+            ? DispatchEventAsync(eventHandlerId.Value, null, EventArgs.Empty, waitForQuiescence: true)
             : Task.CompletedTask;
     }
 

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
@@ -133,7 +133,7 @@ internal partial class EndpointHtmlRenderer
         }
     }
 
-    private static ValueTask<PrerenderedComponentHtmlContent> HandleNavigationException(HttpContext httpContext, NavigationException navigationException)
+    public static ValueTask<PrerenderedComponentHtmlContent> HandleNavigationException(HttpContext httpContext, NavigationException navigationException)
     {
         if (httpContext.Response.HasStarted)
         {

--- a/src/Components/Web/src/Forms/Mapping/FormValueMappingContext.cs
+++ b/src/Components/Web/src/Forms/Mapping/FormValueMappingContext.cs
@@ -13,31 +13,31 @@ public class FormValueMappingContext
     /// <summary>
     /// Initializes a new instance of <see cref="FormValueMappingContext"/>.
     /// </summary>
-    /// <param name="mappingScopeName">The name of the current <see cref="FormMappingScope"/>. Values will only be mapped if the incoming data corresponds to this scope name.</param>
-    /// <param name="restrictToFormName">If set, indicates that the mapping should only receive values if the incoming form matches this name. If null, the mapping should receive data from any form in the mapping scope.</param>
+    /// <param name="acceptMappingScopeName">The name of a <see cref="FormMappingScope"/>. Values will only be mapped if the incoming data corresponds to this scope name.</param>
+    /// <param name="acceptFormName">If set, indicates that the mapping should only receive values if the incoming form matches this name. If null, the mapping should receive data from any form in the mapping scope.</param>
     /// <param name="valueType">The <see cref="Type"/> of the value to map.</param>
     /// <param name="parameterName">The name of the parameter to map data to.</param>
-    public FormValueMappingContext(string mappingScopeName, string? restrictToFormName, Type valueType, string parameterName)
+    public FormValueMappingContext(string acceptMappingScopeName, string? acceptFormName, Type valueType, string parameterName)
     {
-        ArgumentNullException.ThrowIfNull(mappingScopeName, nameof(mappingScopeName));
+        ArgumentNullException.ThrowIfNull(acceptMappingScopeName, nameof(acceptMappingScopeName));
         ArgumentNullException.ThrowIfNull(valueType, nameof(valueType));
         ArgumentNullException.ThrowIfNull(parameterName, nameof(parameterName));
 
-        MappingScopeName = mappingScopeName;
-        RestrictToFormName = restrictToFormName;
+        AcceptMappingScopeName = acceptMappingScopeName;
+        AcceptFormName = acceptFormName;
         ParameterName = parameterName;
         ValueType = valueType;
     }
 
     /// <summary>
-    /// Gets the name of the current <see cref="FormMappingScope"/>.
+    /// Gets the name of <see cref="FormMappingScope"/> that is allowed to supply data in this context.
     /// </summary>
-    public string MappingScopeName { get; }
+    public string AcceptMappingScopeName { get; }
 
     /// <summary>
     /// If set, indicates that the mapping should only receive values if the incoming form matches this name. If null, the mapping should receive data from any form in the mapping scope.
     /// </summary>
-    public string? RestrictToFormName { get; }
+    public string? AcceptFormName { get; }
 
     /// <summary>
     /// Gets the name of the parameter to map data to.

--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -42,14 +42,14 @@ Microsoft.AspNetCore.Components.Forms.Mapping.FormMappingError.ErrorMessages.get
 Microsoft.AspNetCore.Components.Forms.Mapping.FormMappingError.Name.get -> string!
 Microsoft.AspNetCore.Components.Forms.Mapping.FormMappingError.Path.get -> string!
 Microsoft.AspNetCore.Components.Forms.Mapping.FormValueMappingContext
-Microsoft.AspNetCore.Components.Forms.Mapping.FormValueMappingContext.FormValueMappingContext(string! mappingScopeName, string? restrictToFormName, System.Type! valueType, string! parameterName) -> void
+Microsoft.AspNetCore.Components.Forms.Mapping.FormValueMappingContext.AcceptFormName.get -> string?
+Microsoft.AspNetCore.Components.Forms.Mapping.FormValueMappingContext.AcceptMappingScopeName.get -> string!
+Microsoft.AspNetCore.Components.Forms.Mapping.FormValueMappingContext.FormValueMappingContext(string! acceptMappingScopeName, string? acceptFormName, System.Type! valueType, string! parameterName) -> void
 Microsoft.AspNetCore.Components.Forms.Mapping.FormValueMappingContext.MapErrorToContainer.get -> System.Action<string!, object!>?
 Microsoft.AspNetCore.Components.Forms.Mapping.FormValueMappingContext.MapErrorToContainer.set -> void
-Microsoft.AspNetCore.Components.Forms.Mapping.FormValueMappingContext.MappingScopeName.get -> string!
 Microsoft.AspNetCore.Components.Forms.Mapping.FormValueMappingContext.OnError.get -> System.Action<string!, System.FormattableString!, string?>?
 Microsoft.AspNetCore.Components.Forms.Mapping.FormValueMappingContext.OnError.set -> void
 Microsoft.AspNetCore.Components.Forms.Mapping.FormValueMappingContext.ParameterName.get -> string!
-Microsoft.AspNetCore.Components.Forms.Mapping.FormValueMappingContext.RestrictToFormName.get -> string?
 Microsoft.AspNetCore.Components.Forms.Mapping.FormValueMappingContext.Result.get -> object?
 Microsoft.AspNetCore.Components.Forms.Mapping.FormValueMappingContext.SetResult(object? result) -> void
 Microsoft.AspNetCore.Components.Forms.Mapping.FormValueMappingContext.ValueType.get -> System.Type!

--- a/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
@@ -1058,6 +1058,36 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
         Assert.Contains("This is a deliberate form-event asynchronous error", errorBoundaryContent.Text);
     }
 
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void CanPostRedirectGet_Synchronous(bool suppressEnhancedNavigation, bool enableStreaming)
+    {
+        SuppressEnhancedNavigation(suppressEnhancedNavigation);
+        GoTo($"forms/post-redirect-get{(enableStreaming ? "-streaming" : "")}");
+
+        Browser.Exists(By.Id("sync-redirect")).Click();
+        Browser.Exists(By.Id("nav-home"));
+        Browser.True(() => Browser.Url.EndsWith("/nav", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void CanPostRedirectGet_Asynchronous(bool suppressEnhancedNavigation, bool enableStreaming)
+    {
+        SuppressEnhancedNavigation(suppressEnhancedNavigation);
+        GoTo($"forms/post-redirect-get{(enableStreaming ? "-streaming" : "")}");
+
+        Browser.Exists(By.Id("async-redirect")).Click();
+        Browser.Exists(By.Id("nav-home"));
+        Browser.True(() => Browser.Url.EndsWith("/nav", StringComparison.Ordinal));
+    }
+
     private void SuppressEnhancedNavigation(bool shouldSuppress)
     {
         if (shouldSuppress)

--- a/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
@@ -968,15 +968,127 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
         Browser.Exists(By.Id("pass"));
     }
 
-    private void DispatchToFormCore(DispatchToForm dispatch)
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void HandleErrorsOutsideErrorBoundary_OnInitialRender(bool suppressEnhancedNavigation, bool enableStreaming)
     {
-        if (dispatch.SuppressEnhancedNavigation)
+        SuppressEnhancedNavigation(suppressEnhancedNavigation);
+        GoTo($"forms/error-outside-error-boundary{( enableStreaming ? "-streaming" : "" )}");
+
+        Browser.Exists(By.LinkText("Throw during initial render")).Click();
+        AssertHasInternalServerError(suppressEnhancedNavigation);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void HandleErrorsOutsideErrorBoundary_SynchronouslyInSubmitEvent(bool suppressEnhancedNavigation, bool enableStreaming)
+    {
+        SuppressEnhancedNavigation(suppressEnhancedNavigation);
+        GoTo($"forms/error-outside-error-boundary{(enableStreaming ? "-streaming" : "")}");
+
+        Browser.Exists(By.Id("throw-sync")).Click();
+        AssertHasInternalServerError(suppressEnhancedNavigation, enableStreaming);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void HandleErrorsOutsideErrorBoundary_AsynchronouslyInSubmitEvent(bool suppressEnhancedNavigation, bool enableStreaming)
+    {
+        SuppressEnhancedNavigation(suppressEnhancedNavigation);
+        GoTo($"forms/error-outside-error-boundary{(enableStreaming ? "-streaming" : "")}");
+
+        Browser.Exists(By.Id("throw-async")).Click();
+        AssertHasInternalServerError(suppressEnhancedNavigation, enableStreaming);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void HandleErrorsInsideErrorBoundary_OnInitialRender(bool suppressEnhancedNavigation, bool enableStreaming)
+    {
+        SuppressEnhancedNavigation(suppressEnhancedNavigation);
+        GoTo($"forms/error-in-error-boundary{(enableStreaming ? "-streaming" : "")}");
+
+        Browser.Exists(By.LinkText("Throw during initial render")).Click();
+
+        var errorBoundaryContent = Browser.Exists(By.Id("error-content"));
+        Assert.Contains("This is a deliberate error during initial render", errorBoundaryContent.Text);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void HandleErrorsInsideErrorBoundary_SynchronouslyInSubmitEvent(bool suppressEnhancedNavigation, bool enableStreaming)
+    {
+        SuppressEnhancedNavigation(suppressEnhancedNavigation);
+        GoTo($"forms/error-in-error-boundary{(enableStreaming ? "-streaming" : "")}");
+
+        Browser.Exists(By.Id("throw-sync")).Click();
+
+        var errorBoundaryContent = Browser.Exists(By.Id("error-content"));
+        Assert.Contains("This is a deliberate form-event synchronous error", errorBoundaryContent.Text);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void HandleErrorsInsideErrorBoundary_AsynchronouslyInSubmitEvent(bool suppressEnhancedNavigation, bool enableStreaming)
+    {
+        SuppressEnhancedNavigation(suppressEnhancedNavigation);
+        GoTo($"forms/error-in-error-boundary{(enableStreaming ? "-streaming" : "")}");
+
+        Browser.Exists(By.Id("throw-async")).Click();
+
+        var errorBoundaryContent = Browser.Exists(By.Id("error-content"));
+        Assert.Contains("This is a deliberate form-event asynchronous error", errorBoundaryContent.Text);
+    }
+
+    private void SuppressEnhancedNavigation(bool shouldSuppress)
+    {
+        if (shouldSuppress)
         {
             GoTo("");
             Browser.Equal("Hello", () => Browser.Exists(By.TagName("h1")).Text);
             ((IJavaScriptExecutor)Browser).ExecuteScript("sessionStorage.setItem('suppress-enhanced-navigation', 'true')");
         }
+    }
 
+    private void AssertHasInternalServerError(bool suppressedEnhancedNavigation, bool streaming = false)
+    {
+        if (streaming)
+        {
+            Browser.True(() => Browser.FindElement(By.TagName("html")).Text.Contains("There was an unhandled exception on the current request"));
+        }
+        else if (suppressedEnhancedNavigation)
+        {
+            // Chrome's built-in error UI for a 500 response when there's no response content
+            Browser.Exists(By.Id("main-frame-error"));
+        }
+        else
+        {
+            // The UI generated by enhanced nav when there's no response content
+            Browser.Contains("Error: 500", () => Browser.Exists(By.TagName("html")).Text);
+        }
+    }
+
+    private void DispatchToFormCore(DispatchToForm dispatch)
+    {
+        SuppressEnhancedNavigation(dispatch.SuppressEnhancedNavigation);
         GoTo(dispatch.Url);
 
         if (!dispatch.DispatchEvent && dispatch.ShouldCauseInternalServerError)
@@ -1018,16 +1130,7 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
 
         if (dispatch.ShouldCauseInternalServerError)
         {
-            if (dispatch.SuppressEnhancedNavigation)
-            {
-                // Chrome's built-in error UI for a 500 response when there's no response content
-                Browser.Exists(By.Id("main-frame-error"));
-            }
-            else
-            {
-                // The UI generated by enhanced nav when there's no response content
-                Browser.Contains("Error: 500", () => Browser.Exists(By.TagName("html")).Text);
-            }
+            AssertHasInternalServerError(dispatch.SuppressEnhancedNavigation);
         }
         else if (dispatch.ShouldCauseBadRequest)
         {

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/EnhancedNav/Index.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/EnhancedNav/Index.razor
@@ -2,6 +2,6 @@
 
 <PageTitle>Home</PageTitle>
 
-<h1>Hello</h1>
+<h1 id="nav-home">Hello</h1>
 
 <p>This is a Razor Component endpoint.</p>

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/ComponentThatThrows.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/ComponentThatThrows.razor
@@ -1,0 +1,48 @@
+﻿@inject NavigationManager Nav
+@using Microsoft.AspNetCore.Components.Forms
+
+<p><a href="@(Nav.GetUriWithQueryParameter(nameof(ThrowDuringInitialRender), true))">Throw during initial render</a></p>
+
+<form method="post" @formname="trigger-error" @onsubmit="TriggerError">
+    <AntiforgeryToken />
+    <button id="throw-sync" type="submit" name="@(nameof(Scenario))" value="ThrowDuringEventSync">Throw during event synchronously</button>
+    <button id="throw-async" type="submit" name="@(nameof(Scenario))" value="ThrowDuringEventAsync">Throw during event asynchronously</button>
+</form>
+
+@if (loading)
+{
+    <p>Loading...</p>
+}
+
+@code {
+    [SupplyParameterFromQuery] public bool ThrowDuringInitialRender { get; set; }
+
+    [SupplyParameterFromForm] public string Scenario { get; set; }
+
+    bool loading;
+
+    protected override void OnInitialized()
+    {
+        if (ThrowDuringInitialRender)
+        {
+            throw new InvalidTimeZoneException("This is a deliberate error during initial render");
+        }
+    }
+
+    async Task TriggerError()
+    {
+        if (Scenario == "ThrowDuringEventSync")
+        {
+            throw new InvalidTimeZoneException("This is a deliberate form-event synchronous error");
+        }
+
+        loading = true;
+        await Task.Delay(500);
+        loading = false;
+
+        if (Scenario == "ThrowDuringEventAsync")
+        {
+            throw new InvalidTimeZoneException("This is a deliberate form-event asynchronous error");
+        }
+    }
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/ErrorInErrorBoundary.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/ErrorInErrorBoundary.razor
@@ -1,0 +1,15 @@
+﻿@page "/forms/error-in-error-boundary"
+@using Microsoft.AspNetCore.Components.Forms
+
+<h3>Error in error boundary</h3>
+
+<p>Demonstrates what happens with an unhandled exception during form post handling.</p>
+
+<ErrorBoundary>
+    <ChildContent>
+        <ComponentThatThrows />
+    </ChildContent>
+    <ErrorContent>
+        <p id="error-content">The error boundary caught an exception with message: @context.Message</p>
+    </ErrorContent>
+</ErrorBoundary>

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/ErrorInErrorBoundaryStreaming.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/ErrorInErrorBoundaryStreaming.razor
@@ -1,0 +1,16 @@
+﻿@page "/forms/error-in-error-boundary-streaming"
+@attribute [StreamRendering(true)]
+@using Microsoft.AspNetCore.Components.Forms
+
+<h3>Error in error boundary (streaming)</h3>
+
+<p>Demonstrates what happens with an unhandled exception during form post handling.</p>
+
+<ErrorBoundary>
+    <ChildContent>
+        <ComponentThatThrows />
+    </ChildContent>
+    <ErrorContent>
+        <p id="error-content">The error boundary caught an exception with message: @context.Message</p>
+    </ErrorContent>
+</ErrorBoundary>

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/ErrorOutsideErrorBoundary.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/ErrorOutsideErrorBoundary.razor
@@ -1,0 +1,8 @@
+﻿@page "/forms/error-outside-error-boundary"
+@using Microsoft.AspNetCore.Components.Forms
+
+<h3>Error outside error boundary</h3>
+
+<p>Demonstrates what happens with an unhandled exception during form post handling.</p>
+
+<ComponentThatThrows />

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/ErrorOutsideErrorBoundaryStreaming.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/ErrorOutsideErrorBoundaryStreaming.razor
@@ -1,0 +1,9 @@
+﻿@page "/forms/error-outside-error-boundary-streaming"
+@attribute [StreamRendering(true)]
+@using Microsoft.AspNetCore.Components.Forms
+
+<h3>Error outside error boundary (streaming)</h3>
+
+<p>Demonstrates what happens with an unhandled exception during form post handling.</p>
+
+<ComponentThatThrows />

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/PostRedirectGet.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/PostRedirectGet.razor
@@ -1,0 +1,28 @@
+﻿@page "/forms/post-redirect-get"
+@using Microsoft.AspNetCore.Components.Forms
+@inject NavigationManager Nav
+
+<h3>Post/Redirect/Get</h3>
+
+<form method="post" @formname="sync-form" @onsubmit="@DoRedirection">
+    <AntiforgeryToken />
+    <button id="sync-redirect" type="submit">Redirect synchronously</button>
+</form>
+
+<form method="post" @formname="async-form" @onsubmit="@DoAsyncRedirection">
+    <AntiforgeryToken />
+    <button id="async-redirect" type="submit">Redirect asynchronously</button>
+</form>
+
+@code {
+    void DoRedirection()
+    {
+        Nav.NavigateTo("nav");
+    }
+
+    async Task DoAsyncRedirection()
+    {
+        await Task.Delay(500);
+        Nav.NavigateTo("nav");
+    }
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/PostRedirectGetStreaming.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/PostRedirectGetStreaming.razor
@@ -1,0 +1,29 @@
+﻿@page "/forms/post-redirect-get-streaming"
+@using Microsoft.AspNetCore.Components.Forms
+@inject NavigationManager Nav
+@attribute [StreamRendering(true)]
+
+<h3>Post/Redirect/Get</h3>
+
+<form method="post" @formname="sync-form" @onsubmit="@DoRedirection">
+    <AntiforgeryToken />
+    <button id="sync-redirect" type="submit">Redirect synchronously</button>
+</form>
+
+<form method="post" @formname="async-form" @onsubmit="@DoAsyncRedirection">
+    <AntiforgeryToken />
+    <button id="async-redirect" type="submit">Redirect asynchronously</button>
+</form>
+
+@code {
+    void DoRedirection()
+    {
+        Nav.NavigateTo("nav");
+    }
+
+    async Task DoAsyncRedirection()
+    {
+        await Task.Delay(500);
+        Nav.NavigateTo("nav");
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/47903 and https://github.com/dotnet/aspnetcore/issues/49143

Mostly it's just tweaks to the flow in `RazorComponentEndpointInvoker`, plus a ton of E2E cases.

### Forms + streaming rendering

While doing this I realised the way we dispatch form events isn't as integrated into streaming SSR as I thought. What I thought would happen is:

 * Initial synchronous render
 * Streaming begins
   * Any series of further async renders until quiescence
   * Dispatch submit event
   * Any series of (possibly async) renders until quiescence

... but what actually happens is:

* Initial synchronous render
* Pause until quiescence, not doing any streaming during this time
* Dispatch submit event
* Streaming begins
   * Any series of (possibly async) renders until quiescence

So, it's not streaming until the submit event is dispatched. I tried fixing this but it involves more changes than I was ready to do just hours before the CC deadline. One particularly tricky bit is that the handling for returning 400 errors in the case of invalid/missing form names relies on the response not yet having started. If we are willing to do real streaming *before* we even get to the submit event dispatch, we also have to deal with the case where we then see it's an invalid submission but the response has already started.

We already handle "error after response already started" when it's an exception - we send a message over the SSR channel about it. Extending this to handle cases that aren't unhandled exceptions makes the flow more complex.

If we choose to do this in the future, the main aspects of the work are something like:

 * Move the call to `DispatchEventAsync` inside `BeginRenderingRootComponent`.
   * `BeginRenderingRootComponent` should continue waiting only until the non-streaming tasks have completed and then return an `HtmlRootComponent`, but now it should represent the *entire* rest of the process including event dispatch. That way the upstream code doesn't have to differentiate all these cases.
   * To achieve that, we probably need some new `protected` API on `StaticHtmlRenderer` that waits for a supplied task (for which we'll pass the original quiescence task) and then dispatches an event and return an `HtmlRootComponent` with a `QuiescenceTask` representing quiescence after that event
   * Then, `EndpointHtmlRenderer` would return that instead of the original `HtmlRootComponent`
   * The tricky bit with "invalid submission" remains. The best I can think of is throwing some kind of new "InvalidFormSubmitException" that we then catch at the same level we'd catch `NavigationException` and convert that into a 400 (if the response hasn't started) or a new streaming SSR message (if it has)

That's not going to happen for preview 7 but we can consider whether it's important for RC1.

**Update** Great point from @javiercn below about why the user experience is better if we don't change this: https://github.com/dotnet/aspnetcore/pull/49472#issuecomment-1638674411