### PR TITLE
Fix branch Wilson7 tests

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Startup.cs
@@ -5,6 +5,7 @@ using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.IO;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authentication.Negotiate;
 using Microsoft.AspNetCore.Authorization;
@@ -21,7 +22,7 @@ namespace Microsoft.AspNetCore.SignalR.Client.FunctionalTests;
 
 public class Startup
 {
-    private readonly SymmetricSecurityKey SecurityKey = new SymmetricSecurityKey(Guid.NewGuid().ToByteArray());
+    private readonly SymmetricSecurityKey SecurityKey = new SymmetricSecurityKey(SHA256.HashData(Guid.NewGuid().ToByteArray()));
     private readonly JwtSecurityTokenHandler JwtTokenHandler = new JwtSecurityTokenHandler();
 
     public void ConfigureServices(IServiceCollection services)

--- a/src/SignalR/clients/ts/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/ts/FunctionalTests/Startup.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Reflection;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http.Connections;
@@ -19,7 +20,7 @@ namespace FunctionalTests;
 
 public class Startup
 {
-    private readonly SymmetricSecurityKey SecurityKey = new SymmetricSecurityKey(Guid.NewGuid().ToByteArray());
+    private readonly SymmetricSecurityKey SecurityKey = new SymmetricSecurityKey(SHA256.HashData(Guid.NewGuid().ToByteArray()));
     private readonly JwtSecurityTokenHandler JwtTokenHandler = new JwtSecurityTokenHandler();
 
     private int _numRedirects;

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -10,6 +10,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.WebSockets;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Security.Principal;
 using System.Text;
 using Microsoft.AspNetCore.Authentication;
@@ -2988,7 +2989,7 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
     [InlineData(HttpTransportType.WebSockets)]
     public async Task AuthenticationExpirationSetOnAuthenticatedConnectionWithJWT(HttpTransportType transportType)
     {
-        SymmetricSecurityKey SecurityKey = new SymmetricSecurityKey(Guid.NewGuid().ToByteArray());
+        SymmetricSecurityKey SecurityKey = new SymmetricSecurityKey(SHA256.HashData(Guid.NewGuid().ToByteArray()));
         JwtSecurityTokenHandler JwtTokenHandler = new JwtSecurityTokenHandler();
 
         using var host = CreateHost(services =>
@@ -3150,7 +3151,7 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
     [InlineData(HttpTransportType.WebSockets)]
     public async Task AuthenticationExpirationUsesCorrectScheme(HttpTransportType transportType)
     {
-        var SecurityKey = new SymmetricSecurityKey(Guid.NewGuid().ToByteArray());
+        var SecurityKey = new SymmetricSecurityKey(SHA256.HashData(Guid.NewGuid().ToByteArray()));
         var JwtTokenHandler = new JwtSecurityTokenHandler();
 
         using var host = CreateHost(services =>

--- a/src/SignalR/samples/JwtSample/Startup.cs
+++ b/src/SignalR/samples/JwtSample/Startup.cs
@@ -11,7 +11,7 @@ namespace JwtSample;
 
 public class Startup
 {
-    private readonly SymmetricSecurityKey SecurityKey = new SymmetricSecurityKey(RandomNumberGenerator.GetBytes(16));
+    private readonly SymmetricSecurityKey SecurityKey = new SymmetricSecurityKey(RandomNumberGenerator.GetBytes(32));
     private readonly JwtSecurityTokenHandler JwtTokenHandler = new JwtSecurityTokenHandler();
 
     public void ConfigureServices(IServiceCollection services)


### PR DESCRIPTION
# Fix branch Wilson7 tests

## Fix Key Size of test SymmetricSecurityKeys

Newer versions of Identity Model libraries have more strict checks on minimum key sizes

See: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/2072