### PR TITLE
Remove array allocations routing in common cases

### DIFF
--- a/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Abstractions/src/PublicAPI.Unshipped.txt
@@ -35,3 +35,4 @@ static Microsoft.AspNetCore.Http.EndpointFilterInvocationContext.Create<T1, T2, 
 static Microsoft.AspNetCore.Http.EndpointFilterInvocationContext.Create<T1, T2>(Microsoft.AspNetCore.Http.HttpContext! httpContext, T1 arg1, T2 arg2) -> Microsoft.AspNetCore.Http.EndpointFilterInvocationContext!
 static Microsoft.AspNetCore.Http.EndpointFilterInvocationContext.Create<T>(Microsoft.AspNetCore.Http.HttpContext! httpContext, T arg) -> Microsoft.AspNetCore.Http.EndpointFilterInvocationContext!
 static Microsoft.AspNetCore.Http.HttpResults.EmptyHttpResult.Instance.get -> Microsoft.AspNetCore.Http.HttpResults.EmptyHttpResult!
+static Microsoft.AspNetCore.Routing.RouteValueDictionary.FromValues(System.Span<System.Collections.Generic.KeyValuePair<string!, object?>> items) -> Microsoft.AspNetCore.Routing.RouteValueDictionary!

--- a/src/Http/Http.Abstractions/src/Routing/DynamicArray.cs
+++ b/src/Http/Http.Abstractions/src/Routing/DynamicArray.cs
@@ -1,0 +1,144 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.AspNetCore.Routing;
+
+// Simple list wrapper that avoids allocations if the number of items is below a threshold.
+struct DynamicArray<T>
+{
+    // 4 is a good default capacity here because that leaves enough space for area/controller/action/id
+    private const int DefaultCapacity = 4;
+
+    private InlineArray<T> _inlineArray;
+    private T[]? _array;
+    private int _size;
+
+    public readonly int Length => _size;
+
+    public DynamicArray()
+    {
+    }
+
+    public DynamicArray(ReadOnlySpan<T> values)
+    {
+        _size = values.Length;
+
+        if (values.Length > DefaultCapacity)
+        {
+            _array = values.ToArray();
+        }
+        else
+        {
+            values.CopyTo(_inlineArray);
+        }
+    }
+
+    public DynamicArray(T[] array, int count)
+    {
+        _array = array;
+        _size = count;
+    }
+
+    public T this[int index]
+    {
+        get => (_array ?? (Span<T>)_inlineArray)[index];
+        set => (_array ?? (Span<T>)_inlineArray)[index] = value;
+    }
+
+    public readonly ReadOnlySpan<T> AsSpan()
+    {
+        if (_array is null)
+        {
+            return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<InlineArray<T>, T>(ref Unsafe.AsRef(in _inlineArray)), _size);
+        }
+        return _array.AsSpan(0, _size);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Add(T item)
+    {
+        Span<T> span = _array ?? (Span<T>)_inlineArray;
+        int size = _size;
+        if ((uint)size < (uint)span.Length)
+        {
+            _size = size + 1;
+            span[size] = item;
+        }
+        else
+        {
+            AddWithResize(item);
+        }
+    }
+
+    // Non-inline from List.Add to improve its code quality as uncommon path
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void AddWithResize(T item)
+    {
+        // Debug.Assert(_size == _items.Length);
+        Grow();
+        int size = _size;
+        _size = size + 1;
+        _array![size] = item;
+    }
+
+    private void Grow()
+    {
+        if (_array is null)
+        {
+            _array = new T[DefaultCapacity * 2];
+            ((Span<T>)_inlineArray).CopyTo(_array);
+        }
+        else
+        {
+            var newArray = new T[_array.Length * 2];
+            _array.AsSpan().CopyTo(newArray);
+            _array = newArray;
+        }
+    }
+
+    public void RemoveAt(int index)
+    {
+        if ((uint)index >= (uint)_size)
+        {
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, _size);
+        }
+
+        _size--;
+
+        Span<T> span = _array ?? (Span<T>)_inlineArray;
+
+        if (index < _size)
+        {
+            span.Slice(index + 1, _size - index).CopyTo(span.Slice(index));
+        }
+
+        if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+        {
+            span[_size] = default!;
+        }
+    }
+
+    public void Clear()
+    {
+        Span<T> span = _array ?? (Span<T>)_inlineArray;
+
+        span.Clear();
+        _size = 0;
+    }
+
+
+    [InlineArray(DefaultCapacity)]
+    struct InlineArray<TItem>
+    {
+#pragma warning disable CA1823 // Avoid unused private fields
+#pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0051 // Remove unused private members
+        private TItem _item0;
+#pragma warning restore IDE0051 // Remove unused private members
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning restore CA1823 // Avoid unused private fields
+    }
+}

--- a/src/Http/Http.Abstractions/src/Routing/DynamicArray.cs
+++ b/src/Http/Http.Abstractions/src/Routing/DynamicArray.cs
@@ -126,7 +126,9 @@ struct DynamicArray<T>
         Span<T> span = _array ?? (Span<T>)_inlineArray;
 
         span.Clear();
+
         _size = 0;
+        _array = null;
     }
 
     [InlineArray(DefaultCapacity)]

--- a/src/Http/Http.Abstractions/src/Routing/DynamicArray.cs
+++ b/src/Http/Http.Abstractions/src/Routing/DynamicArray.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.AspNetCore.Routing;
 
-// Simple list wrapper that avoids allocations if the number of items is below a threshold.
+// Simple list wrapper that avoids array allocations if the number of items is below a threshold.
 struct DynamicArray<T>
 {
     // 4 is a good default capacity here because that leaves enough space for area/controller/action/id

--- a/src/Http/Http.Abstractions/src/Routing/DynamicArray.cs
+++ b/src/Http/Http.Abstractions/src/Routing/DynamicArray.cs
@@ -129,7 +129,6 @@ struct DynamicArray<T>
         _size = 0;
     }
 
-
     [InlineArray(DefaultCapacity)]
     struct InlineArray<TItem>
     {

--- a/src/Http/Http.Abstractions/src/Routing/RouteValueDictionary.cs
+++ b/src/Http/Http.Abstractions/src/Routing/RouteValueDictionary.cs
@@ -67,7 +67,6 @@ public class RouteValueDictionary : IDictionary<string, object?>, IReadOnlyDicti
             }
         }
 
-
         return new RouteValueDictionary
         {
             _arrayStorage = new(items[..start]),
@@ -461,7 +460,6 @@ public class RouteValueDictionary : IDictionary<string, object?>, IReadOnlyDicti
         {
             return false;
         }
-
 
         EnsureCapacity();
 

--- a/src/Http/Http.Abstractions/src/Routing/RouteValueDictionary.cs
+++ b/src/Http/Http.Abstractions/src/Routing/RouteValueDictionary.cs
@@ -211,7 +211,6 @@ public class RouteValueDictionary : IDictionary<string, object?>, IReadOnlyDicti
         }
     }
 
-    [MemberNotNull(nameof(_arrayStorage))]
     private void Initialize(IEnumerable<KeyValuePair<string, string?>> stringValueEnumerable)
     {
         foreach (var kvp in stringValueEnumerable)
@@ -220,7 +219,6 @@ public class RouteValueDictionary : IDictionary<string, object?>, IReadOnlyDicti
         }
     }
 
-    [MemberNotNull(nameof(_arrayStorage))]
     private void Initialize(IEnumerable<KeyValuePair<string, object?>> keyValueEnumerable)
     {
         foreach (var kvp in keyValueEnumerable)
@@ -229,7 +227,6 @@ public class RouteValueDictionary : IDictionary<string, object?>, IReadOnlyDicti
         }
     }
 
-    [MemberNotNull(nameof(_arrayStorage))]
     private void Initialize(RouteValueDictionary dictionary)
     {
         if (dictionary._propertyStorage != null)
@@ -237,7 +234,6 @@ public class RouteValueDictionary : IDictionary<string, object?>, IReadOnlyDicti
             // PropertyStorage is immutable so we can just copy it.
             _propertyStorage = dictionary._propertyStorage;
             _count = dictionary._count;
-            _arrayStorage = default;
             return;
         }
 

--- a/src/Http/Http.Abstractions/test/RouteValueDictionaryTests.cs
+++ b/src/Http/Http.Abstractions/test/RouteValueDictionaryTests.cs
@@ -16,7 +16,7 @@ public class RouteValueDictionaryTests
 
         // Assert
         Assert.Empty(dict);
-        Assert.Empty(dict._arrayStorage);
+        Assert.Empty(dict._arrayStorage.AsSpan().ToArray());
         Assert.Null(dict._propertyStorage);
     }
 
@@ -29,7 +29,7 @@ public class RouteValueDictionaryTests
 
         // Assert
         Assert.Empty(dict);
-        Assert.Empty(dict._arrayStorage);
+        Assert.Empty(dict._arrayStorage.AsSpan().ToArray());
         Assert.Null(dict._propertyStorage);
     }
 
@@ -47,7 +47,7 @@ public class RouteValueDictionaryTests
 
         // Assert
         Assert.Equal(other, dict);
-        Assert.Single(dict._arrayStorage);
+        Assert.Single(dict._arrayStorage.AsSpan().ToArray());
         Assert.Null(dict._propertyStorage);
 
         var storage = Assert.IsType<KeyValuePair<string, object?>[]>(dict._arrayStorage);
@@ -859,7 +859,7 @@ public class RouteValueDictionaryTests
 
         // The upgrade from property -> array should make space for at least 4 entries
         Assert.Collection(
-            dict._arrayStorage,
+            dict._arrayStorage.AsSpan().ToArray(),
             kvp => Assert.Equal(new KeyValuePair<string, object?>("age", 30), kvp),
             kvp => Assert.Equal(new KeyValuePair<string, object?>("key", "value"), kvp),
             kvp => Assert.Equal(default, kvp),
@@ -988,7 +988,7 @@ public class RouteValueDictionaryTests
         // Assert
         Assert.Empty(dict);
         Assert.Null(dict._propertyStorage);
-        Assert.Empty(dict._arrayStorage);
+        Assert.Empty(dict._arrayStorage.AsSpan().ToArray());
     }
 
     [Fact]
@@ -1789,7 +1789,7 @@ public class RouteValueDictionaryTests
         Assert.True(result);
         Assert.Null(dict._propertyStorage);
         Assert.Collection(
-            dict._arrayStorage,
+            dict._arrayStorage.AsSpan().ToArray(),
             kvp => Assert.Equal(new KeyValuePair<string, object?>("key", "value"), kvp),
             kvp => Assert.Equal(new KeyValuePair<string, object?>("otherKey", "value"), kvp),
             kvp => Assert.Equal(default, kvp),
@@ -1826,7 +1826,7 @@ public class RouteValueDictionaryTests
         // Assert
         Assert.True(result);
         Assert.Collection(
-            dict._arrayStorage,
+            dict._arrayStorage.AsSpan().ToArray(),
             kvp => Assert.Equal(new KeyValuePair<string, object?>("key", "value"), kvp),
             kvp => Assert.Equal(default, kvp),
             kvp => Assert.Equal(default, kvp),
@@ -1848,7 +1848,7 @@ public class RouteValueDictionaryTests
         // Assert
         Assert.True(result);
         Assert.Collection(
-            dict._arrayStorage,
+            dict._arrayStorage.AsSpan().ToArray(),
             kvp => Assert.Equal(new KeyValuePair<string, object?>("key0", "value0"), kvp),
             kvp => Assert.Equal(new KeyValuePair<string, object?>("key1", "value1"), kvp),
             kvp => Assert.Equal(default, kvp),
@@ -1873,7 +1873,7 @@ public class RouteValueDictionaryTests
         // Assert
         Assert.True(result);
         Assert.Collection(
-            dict._arrayStorage,
+            dict._arrayStorage.AsSpan().ToArray(),
             kvp => Assert.Equal(new KeyValuePair<string, object?>("key0", "value0"), kvp),
             kvp => Assert.Equal(new KeyValuePair<string, object?>("key1", "value1"), kvp),
             kvp => Assert.Equal(new KeyValuePair<string, object?>("key2", "value2"), kvp),
@@ -1899,7 +1899,7 @@ public class RouteValueDictionaryTests
         // Assert
         Assert.False(result);
         Assert.Collection(
-            dict._arrayStorage,
+            dict._arrayStorage.AsSpan().ToArray(),
             kvp => Assert.Equal(new KeyValuePair<string, object?>("key0", "value0"), kvp),
             kvp => Assert.Equal(default, kvp),
             kvp => Assert.Equal(default, kvp),
@@ -2154,7 +2154,7 @@ public class RouteValueDictionaryTests
 
     private void AssertEmptyArrayStorage(RouteValueDictionary value)
     {
-        Assert.Same(Array.Empty<KeyValuePair<string, object?>>(), value._arrayStorage);
+        Assert.Empty(value._arrayStorage.AsSpan().ToArray());
     }
 
     private class RegularType

--- a/src/Http/Routing/src/Matching/DefaultEndpointSelector.cs
+++ b/src/Http/Routing/src/Matching/DefaultEndpointSelector.cs
@@ -19,7 +19,7 @@ internal sealed class DefaultEndpointSelector : EndpointSelector
         return Task.CompletedTask;
     }
 
-    internal static void Select(HttpContext httpContext, CandidateState[] candidateState)
+    internal static void Select(HttpContext httpContext, Span<CandidateState> candidateState)
     {
         // Fast path: We can specialize for trivial numbers of candidates since there can
         // be no ambiguities
@@ -55,7 +55,7 @@ internal sealed class DefaultEndpointSelector : EndpointSelector
 
     private static void ProcessFinalCandidates(
         HttpContext httpContext,
-        CandidateState[] candidateState)
+        Span<CandidateState> candidateState)
     {
         Endpoint? endpoint = null;
         RouteValueDictionary? values = null;
@@ -104,7 +104,7 @@ internal sealed class DefaultEndpointSelector : EndpointSelector
         }
     }
 
-    private static void ReportAmbiguity(CandidateState[] candidateState)
+    private static void ReportAmbiguity(Span<CandidateState> candidateState)
     {
         // If we get here it's the result of an ambiguity - we're OK with this
         // being a littler slower and more allocatey.

--- a/src/Http/Routing/src/Matching/DfaMatcher.cs
+++ b/src/Http/Routing/src/Matching/DfaMatcher.cs
@@ -119,7 +119,7 @@ internal sealed partial class DfaMatcher : Matcher
                 var prototype = candidate.Slots;
                 KeyValuePair<string, object?>[]? slotsArray = null;
 
-                // Use a stack allocated array for < 4 values
+                // Use a stack allocated array for < 5 values
                 // and a heap allocated array for anything more
                 var routeValues = new RouteValues();
 


### PR DESCRIPTION
While looking at some profiles these array allocations were showing up pretty high on the list once low hanging fruit was removed:
- The array of route values after matching
- The array of candidates matched for a route

Using C# 12's inline array feature, we can use stack allocated arrays in 2 cases:

1. When we have < 5 route values.
2. When we have < 5 route candidates (this is usually 1).

TODO: Check for throughput regressions. We have some BDN tests that I need to run.

Allocations:

Before

|Type|Allocations|Bytes|Average Size \(Bytes\)|
|-|-|-|-|
Microsoft.AspNetCore.Routing.Matching.CandidateState\[1\]|10,000|480,000|48|
System.Collections.Generic.KeyValuePair\<System.String, System.Object\>\[\]|10,000|400,000|40|
Microsoft.AspNetCore.Routing.RouteValueDictionary|10,000|400,000|40|

After

|Type|Allocations|Bytes|Average Size \(Bytes\)|
|-|-|-|-|
Microsoft.AspNetCore.Routing.RouteValueDictionary|10,000|1,119,400|111.94|

We've removed 2 heap allocations but increased the size of RVD (there are 4 extra KVP fields now). This was a request with a single route paramter.