### PR TITLE
[MVC] Support custom model binding limits within FromForm in MVC

### DIFF
--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/BindingInfo.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/BindingInfo.cs
@@ -90,6 +90,16 @@ public class BindingInfo
     public EmptyBodyBehavior EmptyBodyBehavior { get; set; }
 
     /// <summary>
+    /// Gets or sets the maximum number of elements to bind in collections.
+    /// </summary>
+    public int? MaxCollectionSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum depth of the model object graph that will be bound.
+    /// </summary>
+    public int? MaxRecursionDepth { get; set; }
+
+    /// <summary>
     /// Constructs a new instance of <see cref="BindingInfo"/> from the given <paramref name="attributes"/>.
     /// <para>
     /// This overload does not account for <see cref="BindingInfo"/> specified via <see cref="ModelMetadata"/>. Consider using
@@ -167,6 +177,13 @@ public class BindingInfo
             isBindingInfoPresent = true;
             bindingInfo.EmptyBodyBehavior = configureEmptyBodyBehavior.EmptyBodyBehavior;
             break;
+        }
+
+        foreach (var bindingLimits in attributes.OfType<IBindingLimitsMetadata>())
+        {
+            isBindingInfoPresent = true;
+            bindingInfo.MaxCollectionSize = bindingLimits.MaxModelBindingCollectionSize;
+            bindingInfo.MaxRecursionDepth = bindingLimits.MaxModelBindingRecursionDepth;
         }
 
         return isBindingInfoPresent ? bindingInfo : null;

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/IBindingLimitsMetadata.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/IBindingLimitsMetadata.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Mvc.ModelBinding;
+
+/// <summary>
+/// Metadata which specifies custom form limits for model binding..
+/// </summary>
+public interface IBindingLimitsMetadata
+{
+    /// <summary>
+    /// Gets the maximum number of collection items to allow during model binding.
+    /// </summary>
+    public int? MaxModelBindingCollectionSize { get; }
+
+    /// <summary>
+    /// Gets the maximum depth of the model object graph that will be bound.
+    /// </summary>
+    public int? MaxModelBindingRecursionDepth { get; }
+}

--- a/src/Mvc/Mvc.Abstractions/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Abstractions/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,10 @@
 #nullable enable
+Microsoft.AspNetCore.Mvc.ModelBinding.BindingInfo.MaxCollectionSize.get -> int?
+Microsoft.AspNetCore.Mvc.ModelBinding.BindingInfo.MaxCollectionSize.set -> void
+Microsoft.AspNetCore.Mvc.ModelBinding.BindingInfo.MaxRecursionDepth.get -> int?
+Microsoft.AspNetCore.Mvc.ModelBinding.BindingInfo.MaxRecursionDepth.set -> void
+Microsoft.AspNetCore.Mvc.ModelBinding.IBindingLimitsMetadata
+Microsoft.AspNetCore.Mvc.ModelBinding.IBindingLimitsMetadata.MaxModelBindingCollectionSize.get -> int?
+Microsoft.AspNetCore.Mvc.ModelBinding.IBindingLimitsMetadata.MaxModelBindingCollectionSize.set -> void
+Microsoft.AspNetCore.Mvc.ModelBinding.IBindingLimitsMetadata.MaxModelBindingRecursionDepth.get -> int?
+Microsoft.AspNetCore.Mvc.ModelBinding.IBindingLimitsMetadata.MaxModelBindingRecursionDepth.set -> void

--- a/src/Mvc/Mvc.Core/src/FromFormAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/FromFormAttribute.cs
@@ -10,11 +10,38 @@ namespace Microsoft.AspNetCore.Mvc;
 /// Specifies that a parameter or property should be bound using form-data in the request body.
 /// </summary>
 [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-public class FromFormAttribute : Attribute, IBindingSourceMetadata, IModelNameProvider, IFromFormMetadata
+public class FromFormAttribute : Attribute, IBindingSourceMetadata, IModelNameProvider, IFromFormMetadata, IBindingLimitsMetadata
 {
+    private int? _maxModelBindingCollectionSize;
+    private int? _maxModelBindingRecursionDepth;
+
     /// <inheritdoc />
     public BindingSource BindingSource => BindingSource.Form;
 
     /// <inheritdoc />
     public string? Name { get; set; }
+
+    /// <summary>
+    /// Gets the maximum number of collection items to allow during model binding.
+    /// </summary>
+    public int MaxModelBindingCollectionSize
+    {
+        get { return _maxModelBindingCollectionSize ?? 0; }
+        set { _maxModelBindingCollectionSize = value; }
+    }
+
+    /// <summary>
+    /// Gets the maximum depth of the model object graph that will be bound.
+    /// </summary>
+    public int MaxModelBindingRecursionDepth
+    {
+        get { return _maxModelBindingRecursionDepth ?? 0; }
+        set { _maxModelBindingRecursionDepth = value; }
+    }
+
+    /// <inheritdoc />
+    int? IBindingLimitsMetadata.MaxModelBindingCollectionSize => _maxModelBindingCollectionSize;
+
+    /// <inheritdoc />
+    int? IBindingLimitsMetadata.MaxModelBindingRecursionDepth => _maxModelBindingRecursionDepth;
 }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/CollectionModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/CollectionModelBinder.cs
@@ -330,10 +330,13 @@ public partial class CollectionModelBinder<TElement> : ICollectionModelBinder
         }
         else
         {
+            var collectionSize = bindingContext is DefaultModelBindingContext def && def.MaxModelBindingCollectionSize != null ?
+                def.MaxModelBindingCollectionSize : _maxModelBindingCollectionSize;
+
             indexNamesIsFinite = false;
-            var limit = _maxModelBindingCollectionSize == int.MaxValue ?
+            var limit = collectionSize == int.MaxValue ?
                 int.MaxValue :
-                _maxModelBindingCollectionSize + 1;
+                collectionSize.Value + 1;
             indexNames = Enumerable
                 .Range(0, limit)
                 .Select(i => i.ToString(CultureInfo.InvariantCulture));

--- a/src/Mvc/Mvc.Core/src/ModelBinding/DefaultModelBindingContext.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/DefaultModelBindingContext.cs
@@ -22,6 +22,7 @@ public class DefaultModelBindingContext : ModelBindingContext
     private ModelStateDictionary _modelState = default!;
     private ValidationStateDictionary _validationState = default!;
     private int? _maxModelBindingRecursionDepth;
+    private int? _maxModelBindingCollectionSize;
 
     private State _state;
     private readonly Stack<State> _stack = new Stack<State>();
@@ -183,6 +184,18 @@ public class DefaultModelBindingContext : ModelBindingContext
         }
     }
 
+    internal int? MaxModelBindingCollectionSize
+    {
+        get
+        {
+            return _maxModelBindingCollectionSize;
+        }
+        set
+        {
+            _maxModelBindingCollectionSize = value;
+        }
+    }
+
     /// <summary>
     /// Creates a new <see cref="DefaultModelBindingContext"/> for top-level model binding operation.
     /// </summary>
@@ -236,6 +249,14 @@ public class DefaultModelBindingContext : ModelBindingContext
         if (mvcOptions != null)
         {
             bindingContext.MaxModelBindingRecursionDepth = mvcOptions.Value.MaxModelBindingRecursionDepth;
+        }
+        if (bindingInfo?.MaxRecursionDepth != null)
+        {
+            bindingContext.MaxModelBindingRecursionDepth = bindingInfo.MaxRecursionDepth.Value;
+        }
+        if (bindingInfo?.MaxCollectionSize != null)
+        {
+            bindingContext.MaxModelBindingCollectionSize = bindingInfo.MaxCollectionSize.Value;
         }
 
         return bindingContext;

--- a/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
@@ -1,5 +1,9 @@
 #nullable enable
 *REMOVED*static Microsoft.AspNetCore.Routing.ControllerLinkGeneratorExtensions.GetUriByAction(this Microsoft.AspNetCore.Routing.LinkGenerator! generator, string! action, string! controller, object? values, string? scheme, Microsoft.AspNetCore.Http.HostString host, Microsoft.AspNetCore.Http.PathString pathBase = default(Microsoft.AspNetCore.Http.PathString), Microsoft.AspNetCore.Http.FragmentString fragment = default(Microsoft.AspNetCore.Http.FragmentString), Microsoft.AspNetCore.Routing.LinkOptions? options = null) -> string?
+Microsoft.AspNetCore.Mvc.FromFormAttribute.MaxModelBindingCollectionSize.get -> int
+Microsoft.AspNetCore.Mvc.FromFormAttribute.MaxModelBindingCollectionSize.set -> void
+Microsoft.AspNetCore.Mvc.FromFormAttribute.MaxModelBindingRecursionDepth.get -> int
+Microsoft.AspNetCore.Mvc.FromFormAttribute.MaxModelBindingRecursionDepth.set -> void
 Microsoft.AspNetCore.Mvc.MiddlewareFilterAttribute<T>
 Microsoft.AspNetCore.Mvc.MiddlewareFilterAttribute<T>.MiddlewareFilterAttribute() -> void
 Microsoft.AspNetCore.Mvc.ModelBinderAttribute<TBinder>

--- a/src/Mvc/Mvc.Core/test/ModelBinding/Binders/CollectionModelBinderTest.cs
+++ b/src/Mvc/Mvc.Core/test/ModelBinding/Binders/CollectionModelBinderTest.cs
@@ -60,6 +60,29 @@ public class CollectionModelBinderTest
         Assert.DoesNotContain(boundCollection, bindingContext.ValidationState.Keys);
     }
 
+    [Fact]
+    public async Task BindComplexCollectionFromIndexes_CollectionSize()
+    {
+        // Arrange
+        var valueProvider = new SimpleValueProvider
+            {
+                { "someName[0]", "42" },
+                { "someName[1]", "100" },
+                { "someName[2]", "400" }
+            };
+        var bindingContext = GetModelBindingContext(valueProvider, collectionSize: 1);
+        var binder = new CollectionModelBinder<int>(CreateIntBinder(), NullLoggerFactory.Instance);
+
+        // Act
+        var boundCollection = await binder.BindComplexCollectionFromIndexes(bindingContext, indexNames: null);
+
+        // Assert
+        Assert.Equal(new[] { 42, 100 }, boundCollection.Model.ToArray());
+
+        // This uses the default IValidationStrategy
+        Assert.DoesNotContain(boundCollection, bindingContext.ValidationState.Keys);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -475,7 +498,8 @@ public class CollectionModelBinderTest
 
     private static DefaultModelBindingContext GetModelBindingContext(
         IValueProvider valueProvider,
-        bool isReadOnly = false)
+        bool isReadOnly = false,
+        int? collectionSize = null)
     {
         var metadataProvider = new TestModelMetadataProvider();
         metadataProvider
@@ -490,7 +514,7 @@ public class CollectionModelBinderTest
         bindingContext.ModelName = "someName";
         bindingContext.ModelMetadata = metadata;
         bindingContext.ValueProvider = valueProvider;
-
+        bindingContext.MaxCollectionSize = collectionSize;
         return bindingContext;
     }
 

--- a/src/Mvc/samples/MvcSandbox/Controllers/HomeController.cs
+++ b/src/Mvc/samples/MvcSandbox/Controllers/HomeController.cs
@@ -14,4 +14,20 @@ public class HomeController : Controller
     {
         return View();
     }
+
+    [FromForm(MaxModelBindingCollectionSize = 1)][BindProperty] public TypeWithCollection Value { get; set; }
+
+    public IActionResult SendFormData()
+    {
+        if (Value.Collection.Count > 2)
+        {
+            return Content("You have failed me for the last time");
+        }
+        return Content("Yolo");
+    }
+
+    public class TypeWithCollection
+    {
+        public List<string> Collection { get; set; }
+    }
 }

--- a/src/Mvc/samples/MvcSandbox/Views/Home/Index.cshtml
+++ b/src/Mvc/samples/MvcSandbox/Views/Home/Index.cshtml
@@ -6,3 +6,10 @@
     <h1 class="display-4">Sandbox</h1>
     <p>This sandbox should give you a quick view of a basic MVC application.</p>
 </div>
+
+<form asp-action="SendFormData" method="post">
+    <input type="text" name="value.Collection[0]" value="0" />
+    <input type="text" name="value.Collection[1]" value="1" />
+    <input type="text" name="value.Collection[2]" value="2" />
+    <input type="submit" value="send" />
+</form>


### PR DESCRIPTION
This is so that we can have the limits in the attribute itself for Minimal APIs to work. MVC must respect the attribute during binding.

If values are present it accept those, otherwise defaults to MvcOptions