### PR TITLE
Use correct case in ILCompiler package name

### DIFF
--- a/eng/testing/linker/SupportFiles/Directory.Build.targets
+++ b/eng/testing/linker/SupportFiles/Directory.Build.targets
@@ -10,7 +10,7 @@
     <FrameworkReference Update="Microsoft.NETCore.App"
                         RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimeVersion)" />
 
-    <PackageReference Include="Microsoft.Dotnet.ILCompiler"
+    <PackageReference Include="Microsoft.DotNet.ILCompiler"
                       Version="$(MicrosoftNETCoreAppRuntimeVersion)" />
   </ItemGroup>
 

--- a/eng/tools/GenerateFiles/Directory.Build.targets.in
+++ b/eng/tools/GenerateFiles/Directory.Build.targets.in
@@ -37,7 +37,7 @@
       RuntimeFrameworkVersion="${MicrosoftNETCoreAppRuntimeVersion}"
       TargetingPackVersion="${MicrosoftNETCoreAppRefVersion}" />
 
-    <PackageReference Include="Microsoft.Dotnet.ILCompiler"
+    <PackageReference Include="Microsoft.DotNet.ILCompiler"
       Condition=" '$(PublishAot)' == 'true' "
       Version="${MicrosoftNETCoreAppRuntimeVersion}" />
   </ItemGroup>


### PR DESCRIPTION
There was a regression in nuget.client that revealed this, the regression has been resolved in https://github.com/NuGet/NuGet.Client/pull/5321 but this still bothered me

(the fix hasn't flowed into sdk yet either)