### PR TITLE
Reduce allocations from route matching

### DIFF
--- a/src/Http/Routing/src/Matching/DefaultEndpointSelector.cs
+++ b/src/Http/Routing/src/Matching/DefaultEndpointSelector.cs
@@ -19,7 +19,7 @@ internal sealed class DefaultEndpointSelector : EndpointSelector
         return Task.CompletedTask;
     }
 
-    internal static void Select(HttpContext httpContext, CandidateState[] candidateState)
+    internal static void Select(HttpContext httpContext, Span<CandidateState> candidateState)
     {
         // Fast path: We can specialize for trivial numbers of candidates since there can
         // be no ambiguities
@@ -55,7 +55,7 @@ internal sealed class DefaultEndpointSelector : EndpointSelector
 
     private static void ProcessFinalCandidates(
         HttpContext httpContext,
-        CandidateState[] candidateState)
+        Span<CandidateState> candidateState)
     {
         Endpoint? endpoint = null;
         RouteValueDictionary? values = null;
@@ -104,7 +104,7 @@ internal sealed class DefaultEndpointSelector : EndpointSelector
         }
     }
 
-    private static void ReportAmbiguity(CandidateState[] candidateState)
+    private static void ReportAmbiguity(Span<CandidateState> candidateState)
     {
         // If we get here it's the result of an ambiguity - we're OK with this
         // being a littler slower and more allocatey.


### PR DESCRIPTION
- Remove heap array allocations for candidate state for a small number of candidates

Allocations before (right) and after (left), 10K requests:


<img width="1055" alt="image" src="https://github.com/dotnet/aspnetcore/assets/95136/cadae24d-9bc5-4eb5-9a9b-779875d3de57">

CandidateState[1] is gone 😄 