### PR TITLE
Make authorization policy caching work

### DIFF
--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -2748,7 +2748,7 @@ public class WebApplicationTests
             m => Assert.Equal("Microsoft.AspNetCore.HostFiltering.HostFilteringMiddleware", m),
             m => Assert.Equal("Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware", m),
             m => Assert.Equal("Microsoft.AspNetCore.Authentication.AuthenticationMiddleware", m),
-            m => Assert.Equal("Microsoft.AspNetCore.Authorization.AuthorizationMiddleware", m),
+            m => Assert.Equal("Microsoft.AspNetCore.Authorization.AuthorizationMiddlewareInternal", m),
             m => Assert.Equal(typeof(MiddlewareWithInterface).FullName, m),
             m => Assert.Equal("Microsoft.AspNetCore.Routing.EndpointMiddleware", m));
     }

--- a/src/Security/Authorization/Policy/src/AuthorizationAppBuilderExtensions.cs
+++ b/src/Security/Authorization/Policy/src/AuthorizationAppBuilderExtensions.cs
@@ -30,7 +30,7 @@ public static class AuthorizationAppBuilderExtensions
         VerifyServicesRegistered(app);
 
         app.Properties[AuthorizationMiddlewareSetKey] = true;
-        return app.UseMiddleware<AuthorizationMiddleware>();
+        return app.UseMiddleware<AuthorizationMiddlewareInternal>();
     }
 
     private static void VerifyServicesRegistered(IApplicationBuilder app)

--- a/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs
+++ b/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs
@@ -10,6 +10,17 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Authorization;
 
+// This middleware exists to force the correct constructor overload to be called when the user calls UseAuthorization().
+// Since we already expose the AuthorizationMiddleware type, we can't change the constructor signature without breaking it.
+internal class AuthorizationMiddlewareInternal(
+    RequestDelegate next,
+    IServiceProvider services,
+    IAuthorizationPolicyProvider policyProvider,
+    ILogger<AuthorizationMiddleware> logger) : AuthorizationMiddleware(next, policyProvider, services, logger)
+{
+
+}
+
 /// <summary>
 /// A middleware that enables authorization capabilities.
 /// </summary>

--- a/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs
+++ b/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Authorization;
 
 // This middleware exists to force the correct constructor overload to be called when the user calls UseAuthorization().
 // Since we already expose the AuthorizationMiddleware type, we can't change the constructor signature without breaking it.
-internal class AuthorizationMiddlewareInternal(
+internal sealed class AuthorizationMiddlewareInternal(
     RequestDelegate next,
     IServiceProvider services,
     IAuthorizationPolicyProvider policyProvider,

--- a/src/Security/Authorization/test/AuthorizationAppBuilderExtensionsTests.cs
+++ b/src/Security/Authorization/test/AuthorizationAppBuilderExtensionsTests.cs
@@ -65,6 +65,7 @@ public class AuthorizationAppBuilderExtensionsTests
     {
         var services = new ServiceCollection();
 
+        services.AddRouting();
         services.AddAuthorization();
         services.AddLogging();
         services.AddSingleton(authenticationService);


### PR DESCRIPTION
- Today attempt to cache auth policies per endpoint but this cache was ineffective because the wrong constructor is selected when UseMiddleware is being used. Instead we introduce an internal type that is used in UseMiddleware<T> instead.
- Added a test that uses UseMiddleware and verifies the caching.

This was found while profiling a new service written by an internal team.
