### PR TITLE
Make DataProtectionKey props virtual

### DIFF
--- a/src/DataProtection/EntityFrameworkCore/src/DataProtectionKey.cs
+++ b/src/DataProtection/EntityFrameworkCore/src/DataProtectionKey.cs
@@ -11,15 +11,15 @@ public class DataProtectionKey
     /// <summary>
     /// The entity identifier of the <see cref="DataProtectionKey"/>.
     /// </summary>
-    public int Id { get; set; }
+    public virtual int Id { get; set; }
 
     /// <summary>
     /// The friendly name of the <see cref="DataProtectionKey"/>.
     /// </summary>
-    public string? FriendlyName { get; set; }
+    public virtual string? FriendlyName { get; set; }
 
     /// <summary>
     /// The XML representation of the <see cref="DataProtectionKey"/>.
     /// </summary>
-    public string? Xml { get; set; }
+    public virtual string? Xml { get; set; }
 }

--- a/src/DataProtection/EntityFrameworkCore/src/PublicAPI.Shipped.txt
+++ b/src/DataProtection/EntityFrameworkCore/src/PublicAPI.Shipped.txt
@@ -1,12 +1,6 @@
 #nullable enable
 Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey
 Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey.DataProtectionKey() -> void
-Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey.FriendlyName.get -> string?
-Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey.FriendlyName.set -> void
-Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey.Id.get -> int
-Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey.Id.set -> void
-Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey.Xml.get -> string?
-Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey.Xml.set -> void
 Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContext>
 Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContext>.EntityFrameworkCoreXmlRepository(System.IServiceProvider! services, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
 Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContext>.StoreElement(System.Xml.Linq.XElement! element, string! friendlyName) -> void

--- a/src/DataProtection/EntityFrameworkCore/src/PublicAPI.Unshipped.txt
+++ b/src/DataProtection/EntityFrameworkCore/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+virtual Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey.FriendlyName.get -> string?
+virtual Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey.FriendlyName.set -> void
+virtual Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey.Id.get -> int
+virtual Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey.Id.set -> void
+virtual Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey.Xml.get -> string?
+virtual Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey.Xml.set -> void


### PR DESCRIPTION
# Make DataProtectionKey props virtual

## Description

If you enable EFC's [change tracking proxies](https://learn.microsoft.com/en-us/ef/core/change-tracking/change-detection#change-tracking-proxies), then ALL `DbSet<T>`'s of the `DbContext` must have all virtual properties.
If one is using `DataProtection.EntityFrameworkCore`, you'll run into the roadblock, that you cannot enable ChangeTrackingProxies, because `DataProtectionKey`, which is outside of your control, has non virtual properties.
![image](https://github.com/dotnet/aspnetcore/assets/7110884/999e4d6f-756e-49e1-9876-9a05a808d199)
