### PR TITLE
Fix text field generator with explicit value.

### DIFF
--- a/src/Mvc/Mvc.ViewFeatures/src/DefaultHtmlGenerator.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/DefaultHtmlGenerator.cs
@@ -1248,7 +1248,7 @@ public class DefaultHtmlGenerator : IHtmlGenerator
 
                 var attributeValue = (string)GetModelStateValue(viewContext, fullName, typeof(string));
                 attributeValue ??= useViewData ? EvalString(viewContext, expression, format) : valueParameter;
-                tagBuilder.MergeAttribute("value", attributeValue, replaceExisting: isExplicitValue);
+                tagBuilder.MergeAttribute("value", valueParameter, replaceExisting: isExplicitValue);
 
                 break;
         }


### PR DESCRIPTION
# Fix text field generator with explicit value.

## Description

When calling GenerateInput for a text field with `isExplicitValue` = true, if the root model has a property with the same name, the `value` parameter is ignored and the context is used regardless.

{Detail}

Fixes #{bug number} (in this specific format)
