### PR TITLE
Only compare the defaultserveraddress once

### DIFF
--- a/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
+++ b/src/Servers/Kestrel/test/BindTests/AddressRegistrationTests.cs
@@ -519,9 +519,7 @@ public class AddressRegistrationTests : TestApplicationErrorLoggerLoggedTest
 
             Assert.Equal(5000, host.GetPort());
 
-            Assert.Single(LogMessages, log => log.LogLevel == LogLevel.Debug &&
-                (string.Equals(CoreStrings.FormatBindingToDefaultAddress(Constants.DefaultServerAddress), log.Message, StringComparison.Ordinal)
-                    || string.Equals(CoreStrings.FormatBindingToDefaultAddress(Constants.DefaultServerAddress), log.Message, StringComparison.Ordinal)));
+            Assert.Single(LogMessages, log => log.LogLevel == LogLevel.Debug && string.Equals(CoreStrings.FormatBindingToDefaultAddress(Constants.DefaultServerAddress), log.Message, StringComparison.Ordinal));
 
             foreach (var address in addresses)
             {


### PR DESCRIPTION

# Only compare the defaultserveraddress once in test

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Only compare the defaultserveraddress once in test

## Description

A previous commit made it so defaultserveraddress got checked twice for no reason. Before it got checked for https too but this got deleted by the following [commit](https://github.com/dotnet/aspnetcore/commit/86e28e7b267579e2999e06b63eeef27e4836384a#diff-5941cc1785b7940041bb2291919eff8cb327fb1535128e87197ac0f79817cb62L531). Which made the comparision the same.

Fixes #49645
