### PR TITLE
Remove duplicate checks on path in test

### DIFF
--- a/src/ProjectTemplates/test/Templates.Tests/BaselineTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/BaselineTest.cs
@@ -89,9 +89,6 @@ public class BaselineTest : LoggedTest
             if (relativePath.EndsWith(".csproj", StringComparison.Ordinal) ||
                 relativePath.EndsWith(".fsproj", StringComparison.Ordinal) ||
                 relativePath.EndsWith(".props", StringComparison.Ordinal) ||
-                relativePath.EndsWith(".targets", StringComparison.Ordinal) ||
-                relativePath.StartsWith("bin/", StringComparison.Ordinal) ||
-                relativePath.StartsWith("obj/", StringComparison.Ordinal) ||
                 relativePath.EndsWith(".sln", StringComparison.Ordinal) ||
                 relativePath.EndsWith(".targets", StringComparison.Ordinal) ||
                 relativePath.StartsWith("bin/", StringComparison.Ordinal) ||


### PR DESCRIPTION
# Remove duplicate checks on path in test

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

3 checks were duplicate in test.

## Description
```
            if (relativePath.EndsWith(".csproj", StringComparison.Ordinal) ||
                relativePath.EndsWith(".fsproj", StringComparison.Ordinal) ||
                relativePath.EndsWith(".props", StringComparison.Ordinal) ||
                relativePath.EndsWith(".targets", StringComparison.Ordinal) ||            // duplicate
                relativePath.StartsWith("bin/", StringComparison.Ordinal) ||                // duplicate
                relativePath.StartsWith("obj/", StringComparison.Ordinal) ||                // duplicate
                relativePath.EndsWith(".sln", StringComparison.Ordinal) ||
                relativePath.EndsWith(".targets", StringComparison.Ordinal) ||            // duplicate
                relativePath.StartsWith("bin/", StringComparison.Ordinal) ||                // duplicate
                relativePath.StartsWith("obj/", StringComparison.Ordinal) ||                // duplicate
                relativePath.Contains("/bin/", StringComparison.Ordinal) ||
                relativePath.Contains("/obj/", StringComparison.Ordinal))
            {
                continue;
            }
```

was 
Fixes #49647
