### PR TITLE
Update EndpointDataSource.cs

### DIFF
--- a/src/Http/Routing/src/EndpointDataSource.cs
+++ b/src/Http/Routing/src/EndpointDataSource.cs
@@ -88,7 +88,7 @@ public abstract class EndpointDataSource
     // We don't implement DebuggerDisplay directly on the EndpointDataSource base type because this could have side effects.
     internal static string GetDebuggerDisplayStringForEndpoints(IReadOnlyList<Endpoint>? endpoints)
     {
-        if (endpoints is null)
+        if (endpoints is null || endpoints.Count == 0)
         {
             return "No endpoints";
         }


### PR DESCRIPTION
I noticed that an endpoint data source doesn't output anything in the debug display when there is an empty collection:

![image](https://github.com/dotnet/aspnetcore/assets/303201/7b08c1c1-0e41-4322-acbb-00c234603381)
