### PR TITLE
Fix MinimalFormSample location in sln

### DIFF
--- a/AspNetCore.sln
+++ b/AspNetCore.sln
@@ -1768,7 +1768,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IdentitySample.ApiEndpoints
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Components.WasmMinimal", "src\Components\test\testassets\Components.WasmMinimal\Components.WasmMinimal.csproj", "{87D58D50-20D1-4091-88C5-8D88DCCC2DE3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MinimalFormSample", "src\Antiforgery\samples\MinimalFormSample\MinimalFormSample.csproj", "{F7BCD3AD-31E2-4223-B215-851C3D0AB78A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinimalFormSample", "src\Antiforgery\samples\MinimalFormSample\MinimalFormSample.csproj", "{F7BCD3AD-31E2-4223-B215-851C3D0AB78A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MvcFormSample", "src\Mvc\samples\MvcFormSample\MvcFormSample.csproj", "{055F86AA-FB37-40CC-B39E-C29CE7547BB7}"
 EndProject
@@ -11518,6 +11518,7 @@ Global
 		{66FA1041-5556-43A0-9CA3-F9937F085F6E} = {56291265-B7BF-4756-92AB-FC30F09381D1}
 		{37FC77EA-AC44-4D08-B002-8EFF415C424A} = {64B2A28F-6D82-4F2B-B0BB-88DE5216DD2C}
 		{87D58D50-20D1-4091-88C5-8D88DCCC2DE3} = {6126DCE4-9692-4EE2-B240-C65743572995}
+		{F7BCD3AD-31E2-4223-B215-851C3D0AB78A} = {B55A5DE1-5AF3-4B18-AF04-C1735B071DA6}
 		{055F86AA-FB37-40CC-B39E-C29CE7547BB7} = {B8825E86-B8EA-4666-B681-C443D027C95D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution


### PR DESCRIPTION
This moves MinimalFormSample from the root of the sln to the src/Antiforgery subdirectory.
