### PR TITLE
Improve ANCM file watcher thread management

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.cpp
@@ -57,6 +57,11 @@ void FILE_WATCHER::WaitForMonitor(DWORD dwRetryCounter)
             WaitForSingleObject(m_hChangeNotificationThread, 50);
         }
     }
+
+    if (!m_fThreadExit)
+    {
+        LOG_INFO(L"File watcher thread didn't seem to exit.");
+    }
 }
 
 HRESULT
@@ -247,7 +252,7 @@ HRESULT
     //
     // There could be a FCN overflow
     // Let assume the file got changed instead of checking files
-    // Othersie we have to cache the file info
+    // Otherwise we have to cache the file info
     //
     if (cbCompletion == 0)
     {

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.cpp
@@ -80,6 +80,7 @@ void FILE_WATCHER::WaitForWatcherThreadExit()
     else
     {
         // Wait for the thread to exit.
+        LOG_INFO(L"Waiting for file watcher thread to exit.");
         WaitForSingleObject(m_hChangeNotificationThread, INFINITE);
     }
 }

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.cpp
@@ -469,7 +469,7 @@ FILE_WATCHER::StopMonitor()
 
     // Signal the file watcher thread to exit
     SetEvent(m_pShutdownEvent);
-    WaitForWatcherThreadExit(10000);
+    WaitForWatcherThreadExit();
 
     if (m_fShadowCopyEnabled)
     {

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.h
@@ -61,7 +61,7 @@ private:
     HandleWrapper<NullHandleTraits>               _hDirectory;
     HandleWrapper<NullHandleTraits>               m_pDoneCopyEvent;
     HandleWrapper<NullHandleTraits>               m_pShutdownEvent;
-    std::atomic<bool>       m_fThreadExit;
+    std::atomic_bool        m_fThreadExit;
     STTIMER                 m_Timer;
     SRWLOCK                 m_copyLock{};
     BOOL                    m_copied;

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.h
@@ -59,8 +59,9 @@ private:
     HandleWrapper<NullHandleTraits>               m_hCompletionPort;
     HandleWrapper<NullHandleTraits>               m_hChangeNotificationThread;
     HandleWrapper<NullHandleTraits>               _hDirectory;
-    HandleWrapper<NullHandleTraits> m_pDoneCopyEvent;
-    volatile   BOOL      m_fThreadExit;
+    HandleWrapper<NullHandleTraits>               m_pDoneCopyEvent;
+    HandleWrapper<NullHandleTraits>               m_pShutdownEvent;
+    std::atomic<bool>       m_fThreadExit;
     STTIMER                 m_Timer;
     SRWLOCK                 m_copyLock{};
     BOOL                    m_copied;

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.h
@@ -24,7 +24,7 @@ public:
 
     ~FILE_WATCHER();
 
-    void WaitForMonitor(DWORD dwRetryCounter);
+    void WaitForWatcherThreadExit();
 
     HRESULT Create(
         _In_ PCWSTR                  pszDirectoryToMonitor,

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.h
@@ -76,4 +76,5 @@ private:
     DWORD                   m_shutdownTimeout;
     OVERLAPPED              _overlapped;
     std::unique_ptr<AppOfflineTrackingApplication, IAPPLICATION_DELETER> _pApplication;
+    bool                    m_fRudeThreadTermination;
 };


### PR DESCRIPTION
I'm trying to get rid of `TerminateThread` usage in ANCM and decided to tackle the file watcher thread first. This change includes various improvements to the file watcher thread management and shutdown mechanisms.

- Creation of a new shutdown event `m_pShutdownEvent` that provides a more explicit and straightforward way to signal the thread to exit.
- Refactoring of `FILE_WATCHER::ChangeNotificationThread` to use `WaitForMultipleObjects` to wait on either the completion port or the new shutdown event, removing the need for the `FILE_WATCHER_SHUTDOWN_KEY` mechanism.
- Simplification of `FILE_WATCHER::WaitForMonitor` by removing calls to `GetExitCodeThread` and `TerminateThread`, relying on `WaitForSingleObject` to handle thread state checking and waiting.
- Replacement of the volatile BOOL `m_fThreadExit` with a `std::atomic<bool>`
- Other minor improvements

Contributes towards https://github.com/dotnet/aspnetcore/issues/45066