### PR TITLE
Fix Microsoft.Bcl.AsyncInterfaces references

### DIFF
--- a/src/HealthChecks/HealthChecks/src/Microsoft.Extensions.Diagnostics.HealthChecks.csproj
+++ b/src/HealthChecks/HealthChecks/src/Microsoft.Extensions.Diagnostics.HealthChecks.csproj
@@ -35,7 +35,7 @@ Microsoft.Extensions.Diagnostics.HealthChecks.IHealthChecksBuilder
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
 
     <!-- See: https://github.com/dotnet/aspnetcore/issues/46683 -->
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces" Condition="'$(TargetFramework)' != '$(DefaultNetCoreTargetFramework)'" />
   </ItemGroup>
 
 </Project>

--- a/src/Servers/Connections.Abstractions/src/Microsoft.AspNetCore.Connections.Abstractions.csproj
+++ b/src/Servers/Connections.Abstractions/src/Microsoft.AspNetCore.Connections.Abstractions.csproj
@@ -11,6 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces" Condition="'$(TargetFramework)' != '$(DefaultNetCoreTargetFramework)'" />
+
     <Reference Include="Microsoft.Extensions.Features" />
     <Reference Include="System.IO.Pipelines" />
 
@@ -22,13 +24,6 @@
   <ItemGroup>
     <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Unshipped.txt" />
-  </ItemGroup>
-
-  <!-- Special case building from source because Microsoft.Bcl.AsyncInterfaces isn't available for source builds. -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR
-      '$(TargetFramework)' == '$(DefaultNetFxTargetFramework)' OR
-      ('$(MSBuildRestoreSessionId)' == '' AND '$(DotNetBuildFromSource)' != 'true') ">
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- HealthChecks was missing a reference for net462
- Connections.Abstractions was missing a reference for netstandard2.1
- The DotNetBuildFromSource check was redundant

I noticed these references were wrong in HealthChecks when merging https://github.com/dotnet/aspnetcore/pull/42646. Then when I tried to copy the correct usage from the only other place in our repo depending on Microsoft.Bcl.AsyncInterfaces, Connections.Abstractions, I noticed those references were wrong too.

https://github.com/dotnet/aspnetcore/issues/46683 tracks catching this type of issue automatically. @dotnet/runtime-infrastructure @dotnet/aspnet-build Should we move that issue into the runtime?