### PR TITLE
Re-run routing for implicit middlewares that require endpoints

### DIFF
--- a/src/Antiforgery/src/AntiforgeryApplicationBuilderExtensions.cs
+++ b/src/Antiforgery/src/AntiforgeryApplicationBuilderExtensions.cs
@@ -27,6 +27,9 @@ public static class AntiforgeryApplicationBuilderExtensions
 
         builder.Properties[AntiforgeryMiddlewareSetKey] = true;
 
+        // The anti-forgery middleware adds annotations to HttpContext.Items to indicate that it has run
+        // that will be validated by the EndpointsRoutingMiddleware later. To do this, we need to ensure
+        // that routing has run and set the endpoint feature on the HttpContext associated with the request.
         if (builder.Properties.TryGetValue(RerouteHelper.GlobalRouteBuilderKey, out var routeBuilder) && routeBuilder is not null)
         {
             return builder.Use(next =>

--- a/src/Antiforgery/src/Microsoft.AspNetCore.Antiforgery.csproj
+++ b/src/Antiforgery/src/Microsoft.AspNetCore.Antiforgery.csproj
@@ -26,5 +26,6 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)HttpMethodExtensions.cs" LinkBase="Shared"/>
+    <Compile Include="$(SharedSourceRoot)Reroute.cs" LinkBase="Shared"/>
   </ItemGroup>
 </Project>

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/WebApplicationTests.cs
@@ -5,10 +5,12 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Net;
+using System.Net.Http;
 using System.Reflection;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.HostFiltering;
@@ -2839,26 +2841,100 @@ public class WebApplicationTests
     }
 
     [Fact]
-    public async Task ImplicitMiddlewares_RunAfterExplicitRouting_MapGet()
+    public async Task ImplicitMiddlewares_RunAfterExplicitRouting_MapAction()
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
         builder.Services.AddAuthentication("testSchemeName")
             .AddScheme<AuthenticationSchemeOptions, UberHandler>("testSchemeName", "testDisplayName", _ => { });
         builder.Services.AddAuthorization();
+        builder.Services.AddAntiforgery();
         await using var app = builder.Build();
         app.UseRouting();
         app.MapGet("/", (HttpContext context, string username) =>
         {
             Assert.NotNull(context.Items["__AuthorizationMiddlewareWithEndpointInvoked"]);
-            return $"Hello {username}!";
-        }).RequireAuthorization();
+            return $"GET: {username}";
+        }).AllowAnonymous();
+
+        app.MapPost("/form", (HttpContext context, string username, [FromForm] WebApplicationOptions options) =>
+        {
+            Assert.NotNull(context.Items["__AuthorizationMiddlewareWithEndpointInvoked"]);
+            Assert.NotNull(context.Items["__AntiforgeryMiddlewareWithEndpointInvoked"]);
+            return $"POST: {username}";
+        }).AllowAnonymous();
 
         await app.StartAsync();
 
         var client = app.GetTestClient();
-        var exception = await Record.ExceptionAsync(async () => await client.GetAsync("/?username=test"));
-        Assert.Null(exception);
+        var getResponse = await client.GetAsync("/?username=test");
+        getResponse.EnsureSuccessStatusCode();
+        Assert.Equal("GET: test", await getResponse.Content.ReadAsStringAsync());
+
+        var antiforgery = app.Services.GetRequiredService<IAntiforgery>();
+        var antiforgeryOptions = app.Services.GetRequiredService<IOptions<AntiforgeryOptions>>();
+        var tokens = antiforgery.GetAndStoreTokens(new DefaultHttpContext());
+        var request = new HttpRequestMessage(HttpMethod.Post, "form?username=test-form");
+        request.Headers.Add("Cookie", antiforgeryOptions.Value.Cookie.Name + "=" + tokens.CookieToken);
+        var nameValueCollection = new List<KeyValuePair<string, string>>
+        {
+            new KeyValuePair<string, string>("__RequestVerificationToken", tokens.RequestToken),
+        };
+        request.Content = new FormUrlEncodedContent(nameValueCollection);
+        var postResponse = await client.SendAsync(request);
+        postResponse.EnsureSuccessStatusCode();
+        Assert.Equal("POST: test-form", await postResponse.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task ExplicitMiddlewares_RunAfterExplicitRouting_MapAction()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddAuthentication("testSchemeName")
+            .AddScheme<AuthenticationSchemeOptions, UberHandler>("testSchemeName", "testDisplayName", _ => { });
+        builder.Services.AddAuthorization();
+        builder.Services.AddAntiforgery();
+        await using var app = builder.Build();
+
+        app.UseRouting();
+        app.UseAuthentication();
+        app.UseAuthorization();
+        app.UseAntiforgery();
+
+        app.MapGet("/", (HttpContext context, string username) =>
+        {
+            Assert.NotNull(context.Items["__AuthorizationMiddlewareWithEndpointInvoked"]);
+            return $"GET: {username}";
+        }).AllowAnonymous();
+
+        app.MapPost("/form", (HttpContext context, string username, [FromForm] WebApplicationOptions options) =>
+        {
+            Assert.NotNull(context.Items["__AuthorizationMiddlewareWithEndpointInvoked"]);
+            Assert.NotNull(context.Items["__AntiforgeryMiddlewareWithEndpointInvoked"]);
+            return $"POST: {username}";
+        }).AllowAnonymous();
+
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var getResponse = await client.GetAsync("/?username=test");
+        getResponse.EnsureSuccessStatusCode();
+        Assert.Equal("GET: test", await getResponse.Content.ReadAsStringAsync());
+
+        var antiforgery = app.Services.GetRequiredService<IAntiforgery>();
+        var antiforgeryOptions = app.Services.GetRequiredService<IOptions<AntiforgeryOptions>>();
+        var tokens = antiforgery.GetAndStoreTokens(new DefaultHttpContext());
+        var request = new HttpRequestMessage(HttpMethod.Post, "form?username=test-form");
+        request.Headers.Add("Cookie", antiforgeryOptions.Value.Cookie.Name + "=" + tokens.CookieToken);
+        var nameValueCollection = new List<KeyValuePair<string, string>>
+        {
+            new KeyValuePair<string, string>("__RequestVerificationToken", tokens.RequestToken),
+        };
+        request.Content = new FormUrlEncodedContent(nameValueCollection);
+        var postResponse = await client.SendAsync(request);
+        postResponse.EnsureSuccessStatusCode();
+        Assert.Equal("POST: test-form", await postResponse.Content.ReadAsStringAsync());
     }
 
     [Fact]
@@ -2869,7 +2945,10 @@ public class WebApplicationTests
         builder.Services.AddAuthentication("testSchemeName")
             .AddScheme<AuthenticationSchemeOptions, UberHandler>("testSchemeName", "testDisplayName", _ => { });
         builder.Services.AddAuthorization();
+        builder.Services.AddAntiforgery();
+
         await using var app = builder.Build();
+
         app.Run((HttpContext context) =>
         {
             Assert.NotNull(context.Features.Get<IAuthenticationFeature>());
@@ -2882,6 +2961,93 @@ public class WebApplicationTests
         var response = await client.GetAsync("/?username=test");
         response.EnsureSuccessStatusCode();
         Assert.Equal("Hello test!", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task ImplicitMiddlewares_RunBeforeImplicitRouting_Antiforgery_MapRequestDelegate()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddAuthentication("testSchemeName")
+            .AddScheme<AuthenticationSchemeOptions, UberHandler>("testSchemeName", "testDisplayName", _ => { });
+        builder.Services.AddAuthorization();
+        builder.Services.AddAntiforgery();
+
+        await using var app = builder.Build();
+        var invoked = false;
+
+        app.MapPost("/", (HttpContext context) =>
+        {
+            Assert.NotNull(context.Features.Get<IAuthenticationFeature>());
+            Assert.NotNull(context.Features.Get<IAntiforgeryValidationFeature>());
+            var e = Assert.Throws<InvalidOperationException>(() => context.Request.Form);
+            Assert.Equal("This form is being accessed with an invalid anti-forgery token. Validate the `IAntiforgeryValidationFeature` on the request before reading from the form.", e.Message);
+            invoked = true;
+        }).WithMetadata(new RequireAntiforgeryTokenAttribute()).AllowAnonymous();
+
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var response = await client.PostAsync("/?username=test", new FormUrlEncodedContent(new Dictionary<string, string>()));
+        response.EnsureSuccessStatusCode();
+        Assert.True(invoked);
+    }
+
+    [Fact]
+    public async Task ExplicitMiddlewares_RunBeforeImplicitRouting_TerminalMiddleware()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddAuthentication("testSchemeName")
+            .AddScheme<AuthenticationSchemeOptions, UberHandler>("testSchemeName", "testDisplayName", _ => { });
+        builder.Services.AddAuthorization();
+        await using var app = builder.Build();
+        app.UseAuthentication();
+        app.UseAuthorization();
+        app.Run((HttpContext context) =>
+        {
+            Assert.NotNull(context.Features.Get<IAuthenticationFeature>());
+            return context.Response.WriteAsync($"Hello {context.Request.Query["username"]}!");
+        });
+
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var response = await client.GetAsync("/?username=test");
+        response.EnsureSuccessStatusCode();
+        Assert.Equal("Hello test!", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task ExplicitMiddlewares_RunBeforeImplicitRouting_Antiforgery_MapRequestDelegate()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddAuthentication("testSchemeName")
+            .AddScheme<AuthenticationSchemeOptions, UberHandler>("testSchemeName", "testDisplayName", _ => { });
+        builder.Services.AddAuthorization();
+        builder.Services.AddAntiforgery();
+
+        await using var app = builder.Build();
+        var invoked = false;
+
+        app.UseAntiforgery();
+
+        app.MapPost("/", (HttpContext context) =>
+        {
+            Assert.NotNull(context.Features.Get<IAuthenticationFeature>());
+            Assert.NotNull(context.Features.Get<IAntiforgeryValidationFeature>());
+            var e = Assert.Throws<InvalidOperationException>(() => context.Request.Form);
+            Assert.Equal("This form is being accessed with an invalid anti-forgery token. Validate the `IAntiforgeryValidationFeature` on the request before reading from the form.", e.Message);
+            invoked = true;
+        }).WithMetadata(new RequireAntiforgeryTokenAttribute()).AllowAnonymous();
+
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var response = await client.PostAsync("/?username=test", new FormUrlEncodedContent(new Dictionary<string, string>()));
+        response.EnsureSuccessStatusCode();
+        Assert.True(invoked);
     }
 
     [Fact]
@@ -2911,6 +3077,38 @@ public class WebApplicationTests
     }
 
     [Fact]
+    public async Task ImplicitMiddlewares_RunBeforeExplicitRouting_Antiforgery_MapRequestDelegate()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddAuthentication("testSchemeName")
+            .AddScheme<AuthenticationSchemeOptions, UberHandler>("testSchemeName", "testDisplayName", _ => { });
+        builder.Services.AddAuthorization();
+        builder.Services.AddAntiforgery();
+
+        await using var app = builder.Build();
+        var invoked = false;
+
+        app.UseRouting();
+
+        app.MapPost("/", (HttpContext context) =>
+        {
+            Assert.NotNull(context.Features.Get<IAuthenticationFeature>());
+            Assert.NotNull(context.Features.Get<IAntiforgeryValidationFeature>());
+            var e = Assert.Throws<InvalidOperationException>(() => context.Request.Form);
+            Assert.Equal("This form is being accessed with an invalid anti-forgery token. Validate the `IAntiforgeryValidationFeature` on the request before reading from the form.", e.Message);
+            invoked = true;
+        }).WithMetadata(new RequireAntiforgeryTokenAttribute()).AllowAnonymous();
+
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var response = await client.PostAsync("/?username=test", new FormUrlEncodedContent(new Dictionary<string, string>()));
+        response.EnsureSuccessStatusCode();
+        Assert.True(invoked);
+    }
+
+    [Fact]
     public async Task ImplicitMiddlewares_RunBeforeExplicitRouting_TerminalMiddleware_AfterUseRouting()
     {
         var builder = WebApplication.CreateBuilder();
@@ -2922,10 +3120,13 @@ public class WebApplicationTests
 
         app.UseRouting();
 
-        app.Run((HttpContext context) =>
+        var invoked = false;
+
+        app.Run(async (HttpContext context) =>
         {
             Assert.NotNull(context.Features.Get<IAuthenticationFeature>());
-            return context.Response.WriteAsync($"Hello {context.Request.Query["username"]}!");
+            invoked = true;
+            await context.Response.WriteAsync("From terminal middleware");
         });
 
         await app.StartAsync();
@@ -2933,32 +3134,46 @@ public class WebApplicationTests
         var client = app.GetTestClient();
         var response = await client.GetAsync("/?username=test");
         response.EnsureSuccessStatusCode();
-        Assert.Equal("Hello test!", await response.Content.ReadAsStringAsync());
+        Assert.True(invoked);
     }
 
     [Fact]
-    public async Task ImplicitMiddlewares_RunBetween_ExplicitRouting_TerminalMiddlewareMapGet()
+    public async Task ImplicitMiddlewares_RunBetween_ExplicitRouting_MiddlewareMapGet()
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
         builder.Services.AddAuthentication("testSchemeName")
             .AddScheme<AuthenticationSchemeOptions, UberHandler>("testSchemeName", "testDisplayName", _ => { });
         builder.Services.AddAuthorization();
+        builder.Services.AddAntiforgery();
         await using var app = builder.Build();
 
         app.UseRouting();
 
-        app.Run((HttpContext context) =>
+        app.Use((context, next) =>
         {
+            if (context.Request.Path.Value != "/")
+            {
+                return next(context);
+            }
             Assert.NotNull(context.Features.Get<IAuthenticationFeature>());
-            return context.Response.WriteAsync($"Hello {context.Request.Query["username"]}!");
+            return context.Response.WriteAsync($"From terminal middleware: {context.Request.Query["username"]}");
         });
 
         app.MapGet("/endpoint", (HttpContext context, string username) =>
         {
             Assert.NotNull(context.Items["__AuthorizationMiddlewareWithEndpointInvoked"]);
             Assert.NotNull(context.Features.Get<IAuthenticationFeature>());
-            return $"Hello {username}!";
+            return $"From endpoint: {username}";
+        }).AllowAnonymous();
+
+        app.MapPost("/form", (HttpContext context, string username, [FromForm] WebApplicationOptions options) =>
+        {
+            Assert.NotNull(context.Items["__AuthorizationMiddlewareWithEndpointInvoked"]);
+            Assert.NotNull(context.Features.Get<IAuthenticationFeature>());
+            Assert.NotNull(context.Items["__AntiforgeryMiddlewareWithEndpointInvoked"]);
+            Assert.NotNull(context.Features.Get<IAntiforgeryValidationFeature>());
+            return $"From form endpoint: {username}";
         }).AllowAnonymous();
 
         await app.StartAsync();
@@ -2966,46 +3181,31 @@ public class WebApplicationTests
         var client = app.GetTestClient();
         var response = await client.GetAsync("/?username=test");
         response.EnsureSuccessStatusCode();
-        Assert.Equal("Hello test!", await response.Content.ReadAsStringAsync());
+        Assert.Equal("From terminal middleware: test", await response.Content.ReadAsStringAsync());
 
-        var endpointResponse = await client.GetAsync("/endpoint?username=test");
+        var endpointResponse = await client.GetAsync("/endpoint?username=test-endpoint");
         endpointResponse.EnsureSuccessStatusCode();
-        Assert.Equal("Hello test!", await endpointResponse.Content.ReadAsStringAsync());
+        Assert.Equal("From endpoint: test-endpoint", await endpointResponse.Content.ReadAsStringAsync());
+
+        var antiforgery = app.Services.GetRequiredService<IAntiforgery>();
+        var antiforgeryOptions = app.Services.GetRequiredService<IOptions<AntiforgeryOptions>>();
+        var tokens = antiforgery.GetAndStoreTokens(new DefaultHttpContext());
+        var request = new HttpRequestMessage(HttpMethod.Post, "form?username=test-form");
+        request.Headers.Add("Cookie", antiforgeryOptions.Value.Cookie.Name + "=" + tokens.CookieToken);
+        var nameValueCollection = new List<KeyValuePair<string, string>>
+        {
+            new KeyValuePair<string, string>("__RequestVerificationToken", tokens.RequestToken),
+        };
+        request.Content = new FormUrlEncodedContent(nameValueCollection);
+        var formResponse = await client.SendAsync(request);
+        formResponse.EnsureSuccessStatusCode();
+        Assert.Equal("From form endpoint: test-form", await formResponse.Content.ReadAsStringAsync());
     }
 
-    [Fact]
-    public async Task ImplicitMiddlewares_RunBetween_TerminalMiddlewareMapGet()
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public class FromFormAttribute(string name = "") : Attribute, IFromFormMetadata
     {
-        var builder = WebApplication.CreateBuilder();
-        builder.WebHost.UseTestServer();
-        builder.Services.AddAuthentication("testSchemeName")
-            .AddScheme<AuthenticationSchemeOptions, UberHandler>("testSchemeName", "testDisplayName", _ => { });
-        builder.Services.AddAuthorization();
-        await using var app = builder.Build();
-
-        app.Run((HttpContext context) =>
-        {
-            Assert.NotNull(context.Features.Get<IAuthenticationFeature>());
-            return context.Response.WriteAsync($"Hello {context.Request.Query["username"]}!");
-        });
-
-        app.MapGet("/endpoint", (HttpContext context, string username) =>
-        {
-            Assert.NotNull(context.Items["__AuthorizationMiddlewareWithEndpointInvoked"]);
-            Assert.NotNull(context.Features.Get<IAuthenticationFeature>());
-            return $"Hello {username}!";
-        }).AllowAnonymous();
-
-        await app.StartAsync();
-
-        var client = app.GetTestClient();
-        var response = await client.GetAsync("/?username=test");
-        response.EnsureSuccessStatusCode();
-        Assert.Equal("Hello test!", await response.Content.ReadAsStringAsync());
-
-        var endpointResponse = await client.GetAsync("/endpoint?username=test");
-        endpointResponse.EnsureSuccessStatusCode();
-        Assert.Equal("Hello test!", await endpointResponse.Content.ReadAsStringAsync());
+        public string Name { get; } = name;
     }
 
     private class MiddlewareWithInterface : IMiddleware

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -2020,6 +2020,9 @@ public static partial class RequestDelegateFactory
             ArrayPoolSharedReturnMethod,
             formBuffer,
             Expression.Constant(false));
+        var conditionalReturnBufferExpr = Expression.IfThen(
+            Expression.NotEqual(formBuffer, Expression.Constant(null)),
+            returnBufferExpr);
 
         return Expression.Block(
             new[] { formArgument, formReader, formDict, formBuffer },
@@ -2028,7 +2031,7 @@ public static partial class RequestDelegateFactory
                     processFormExpr,
                     initializeReaderExpr,
                     Expression.Assign(formArgument, invokeMapMethodExpr)),
-                returnBufferExpr),
+                conditionalReturnBufferExpr),
             formArgument
         );
     }

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -2014,7 +2014,10 @@ public static partial class RequestDelegateFactory
             FormDataMapperMapMethod.MakeGenericMethod(parameter.ParameterType),
             formReader,
             Expression.Constant(FormDataMapperOptions));
-        // ArrayPool<char>.Shared.Return(form_buffer, false);
+        // if (form_buffer != null)
+        // {
+        //   ArrayPool<char>.Shared.Return(form_buffer, false);
+        // }
         var returnBufferExpr = Expression.Call(
             Expression.Property(null, typeof(ArrayPool<char>).GetProperty(nameof(ArrayPool<char>.Shared))!),
             ArrayPoolSharedReturnMethod,

--- a/src/Security/Authentication/Core/src/AuthAppBuilderExtensions.cs
+++ b/src/Security/Authentication/Core/src/AuthAppBuilderExtensions.cs
@@ -25,6 +25,9 @@ public static class AuthAppBuilderExtensions
 
         app.Properties[AuthenticationMiddlewareSetKey] = true;
 
+        // The authentication middleware adds annotation to HttpContext.Items to indicate that it has run
+        // that will be validated by the EndpointsRoutingMiddleware later. To do this, we need to ensure
+        // that routing has run and set the endpoint feature on the HttpContext associated with the request.
         if (app.Properties.TryGetValue(RerouteHelper.GlobalRouteBuilderKey, out var routeBuilder) && routeBuilder is not null)
         {
             return app.Use(next =>

--- a/src/Security/Authentication/Core/src/Microsoft.AspNetCore.Authentication.csproj
+++ b/src/Security/Authentication/Core/src/Microsoft.AspNetCore.Authentication.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)SecurityHelper\**\*.cs" />
+    <Compile Include="$(SharedSourceRoot)Reroute.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Security/Authorization/Policy/src/Microsoft.AspNetCore.Authorization.Policy.csproj
+++ b/src/Security/Authorization/Policy/src/Microsoft.AspNetCore.Authorization.Policy.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)SecurityHelper\**\*.cs" />
     <Compile Include="..\..\..\..\Http\Routing\src\DataSourceDependentCache.cs" Link="DataSourceDependentCache.cs" />
+    <Compile Include="$(SharedSourceRoot)Reroute.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/49654.

Auth-related middlewares set state on the HttpContext to indicate that they have run when an endpoint is available so that the endpoints middleware can warn if endpoints that should've been evaluated by the middleware have not been.

The WebApplicationBuilder registers a set of auth-related middlewares implicitly when their associated services are registered. When the user calls `UseRouting` explicitly in their application code, the middlewares are registered after and are not able to examine the endpoint set by the routing middleware.

A combination of these factors means that users receive erroneous warnings that auth-related middlewares have not run on endpoints when they have (as in the issue above).

To resolve this, we force routing to run in the middlewares that need to set state in reaction to it.