### PR TITLE
Update OAuthOptions.cs

### DIFF
--- a/src/Security/Authentication/OAuth/src/OAuthOptions.cs
+++ b/src/Security/Authentication/OAuth/src/OAuthOptions.cs
@@ -14,7 +14,7 @@ public class OAuthOptions : RemoteAuthenticationOptions
     /// <summary>
     /// Initializes a new instance of <see cref="OAuthOptions"/>.
     /// </summary>
-    public OAuthOptions()
+    public OAuthOptions() : base()
     {
         Events = new OAuthEvents();
     }


### PR DESCRIPTION
The constructor of the base class must be executed to instantiate the CookieBuilder in the base class.

# Fix  correlation failed.

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

The constructor of the base class must be executed to instantiate the CookieBuilder in the base class.
Otherwise, the default properties in the base class cannot be used in OAuthOptions.  code blew:

```
  private CookieBuilder _correlationCookieBuilder;

  /// <summary>
  /// Initializes a new <see cref="RemoteAuthenticationOptions"/>.
  /// </summary>
  public RemoteAuthenticationOptions()
  {
      _correlationCookieBuilder = new CorrelationCookieBuilder(this)
      {
          Name = CorrelationPrefix,
          HttpOnly = true,
          SameSite = SameSiteMode.None,
          SecurePolicy = CookieSecurePolicy.SameAsRequest,
          IsEssential = true,
      };
  }
```

Fixes #49741 (in this specific format)
