### PR TITLE
Rename Kestrel metrics to be consistent with OpenTelemetry

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1192,7 +1192,7 @@ internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHt
         }
 
         KestrelEventSource.Log.RequestQueuedStart(_currentHeadersStream, AspNetCore.Http.HttpProtocol.Http2);
-        _context.ServiceContext.Metrics.RequestQueuedStart(_metricsContext, AspNetCore.Http.HttpProtocol.Http2);
+        _context.ServiceContext.Metrics.RequestQueuedStart(_metricsContext, "2");
 
         // _scheduleInline is only true in tests
         if (!_scheduleInline)

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -1192,7 +1192,7 @@ internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHt
         }
 
         KestrelEventSource.Log.RequestQueuedStart(_currentHeadersStream, AspNetCore.Http.HttpProtocol.Http2);
-        _context.ServiceContext.Metrics.RequestQueuedStart(_metricsContext, "2");
+        _context.ServiceContext.Metrics.RequestQueuedStart(_metricsContext, KestrelMetrics.Http2);
 
         // _scheduleInline is only true in tests
         if (!_scheduleInline)

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
@@ -20,7 +20,7 @@ internal sealed class Http2Stream<TContext> : Http2Stream, IHostContextContainer
     public override void Execute()
     {
         KestrelEventSource.Log.RequestQueuedStop(this, AspNetCore.Http.HttpProtocol.Http2);
-        ServiceContext.Metrics.RequestQueuedStop(MetricsContext, AspNetCore.Http.HttpProtocol.Http2);
+        ServiceContext.Metrics.RequestQueuedStop(MetricsContext, "2");
 
         // REVIEW: Should we store this in a field for easy debugging?
         _ = ProcessRequestsAsync(_application);

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2StreamOfT.cs
@@ -20,7 +20,7 @@ internal sealed class Http2Stream<TContext> : Http2Stream, IHostContextContainer
     public override void Execute()
     {
         KestrelEventSource.Log.RequestQueuedStop(this, AspNetCore.Http.HttpProtocol.Http2);
-        ServiceContext.Metrics.RequestQueuedStop(MetricsContext, "2");
+        ServiceContext.Metrics.RequestQueuedStop(MetricsContext, KestrelMetrics.Http2);
 
         // REVIEW: Should we store this in a field for easy debugging?
         _ = ProcessRequestsAsync(_application);

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -595,7 +595,7 @@ internal sealed class Http3Connection : IHttp3StreamLifetimeHandler, IRequestPro
 
         _streamLifetimeHandler.OnStreamCreated(stream);
         KestrelEventSource.Log.RequestQueuedStart(stream, AspNetCore.Http.HttpProtocol.Http3);
-        _context.ServiceContext.Metrics.RequestQueuedStart(MetricsContext, AspNetCore.Http.HttpProtocol.Http3);
+        _context.ServiceContext.Metrics.RequestQueuedStart(MetricsContext, "3");
 
         ThreadPool.UnsafeQueueUserWorkItem(stream, preferLocal: false);
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Connection.cs
@@ -595,7 +595,7 @@ internal sealed class Http3Connection : IHttp3StreamLifetimeHandler, IRequestPro
 
         _streamLifetimeHandler.OnStreamCreated(stream);
         KestrelEventSource.Log.RequestQueuedStart(stream, AspNetCore.Http.HttpProtocol.Http3);
-        _context.ServiceContext.Metrics.RequestQueuedStart(MetricsContext, "3");
+        _context.ServiceContext.Metrics.RequestQueuedStart(MetricsContext, KestrelMetrics.Http3);
 
         ThreadPool.UnsafeQueueUserWorkItem(stream, preferLocal: false);
     }

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3StreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3StreamOfT.cs
@@ -20,7 +20,7 @@ internal sealed class Http3Stream<TContext> : Http3Stream, IHostContextContainer
     public override void Execute()
     {
         KestrelEventSource.Log.RequestQueuedStop(this, AspNetCore.Http.HttpProtocol.Http3);
-        ServiceContext.Metrics.RequestQueuedStop(MetricsContext, AspNetCore.Http.HttpProtocol.Http3);
+        ServiceContext.Metrics.RequestQueuedStop(MetricsContext, "3");
 
         if (_requestHeaderParsingState == RequestHeaderParsingState.Ready)
         {

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3StreamOfT.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3StreamOfT.cs
@@ -20,7 +20,7 @@ internal sealed class Http3Stream<TContext> : Http3Stream, IHostContextContainer
     public override void Execute()
     {
         KestrelEventSource.Log.RequestQueuedStop(this, AspNetCore.Http.HttpProtocol.Http3);
-        ServiceContext.Metrics.RequestQueuedStop(MetricsContext, "3");
+        ServiceContext.Metrics.RequestQueuedStop(MetricsContext, KestrelMetrics.Http3);
 
         if (_requestHeaderParsingState == RequestHeaderParsingState.Ready)
         {

--- a/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
@@ -60,7 +60,7 @@ internal sealed class HttpConnection : ITimeoutHandler
                     // _http1Connection must be initialized before adding the connection to the connection manager
                     requestProcessor = _http1Connection = new Http1Connection<TContext>((HttpConnectionContext)_context);
                     _protocolSelectionState = ProtocolSelectionState.Selected;
-                    AddMetricsHttpProtocolTag(HttpProtocol.Http11);
+                    AddMetricsHttpProtocolTag("1.1");
                     break;
                 case HttpProtocols.Http2:
                     // _http2Connection must be initialized before yielding control to the transport thread,
@@ -68,12 +68,12 @@ internal sealed class HttpConnection : ITimeoutHandler
                     // _http2Connection is about to be initialized.
                     requestProcessor = new Http2Connection((HttpConnectionContext)_context);
                     _protocolSelectionState = ProtocolSelectionState.Selected;
-                    AddMetricsHttpProtocolTag(HttpProtocol.Http2);
+                    AddMetricsHttpProtocolTag("2");
                     break;
                 case HttpProtocols.Http3:
                     requestProcessor = new Http3Connection((HttpMultiplexedConnectionContext)_context);
                     _protocolSelectionState = ProtocolSelectionState.Selected;
-                    AddMetricsHttpProtocolTag(HttpProtocol.Http3);
+                    AddMetricsHttpProtocolTag("3");
                     break;
                 case HttpProtocols.None:
                     // An error was already logged in SelectProtocol(), but we should close the connection.
@@ -116,11 +116,12 @@ internal sealed class HttpConnection : ITimeoutHandler
         }
     }
 
-    private void AddMetricsHttpProtocolTag(string httpProtocol)
+    private void AddMetricsHttpProtocolTag(string httpVersion)
     {
         if (_context.ConnectionContext.Features.Get<IConnectionMetricsTagsFeature>() is { } metricsTags)
         {
-            metricsTags.Tags.Add(new KeyValuePair<string, object?>("http-protocol", httpProtocol));
+            metricsTags.Tags.Add(new KeyValuePair<string, object?>("network.protocol.name", "http"));
+            metricsTags.Tags.Add(new KeyValuePair<string, object?>("network.protocol.version", httpVersion));
         }
     }
 

--- a/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.Extensions.Logging;
-using HttpProtocol = Microsoft.AspNetCore.Http.HttpProtocol;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 

--- a/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/HttpConnection.cs
@@ -59,7 +59,7 @@ internal sealed class HttpConnection : ITimeoutHandler
                     // _http1Connection must be initialized before adding the connection to the connection manager
                     requestProcessor = _http1Connection = new Http1Connection<TContext>((HttpConnectionContext)_context);
                     _protocolSelectionState = ProtocolSelectionState.Selected;
-                    AddMetricsHttpProtocolTag("1.1");
+                    AddMetricsHttpProtocolTag(KestrelMetrics.Http11);
                     break;
                 case HttpProtocols.Http2:
                     // _http2Connection must be initialized before yielding control to the transport thread,
@@ -67,12 +67,12 @@ internal sealed class HttpConnection : ITimeoutHandler
                     // _http2Connection is about to be initialized.
                     requestProcessor = new Http2Connection((HttpConnectionContext)_context);
                     _protocolSelectionState = ProtocolSelectionState.Selected;
-                    AddMetricsHttpProtocolTag("2");
+                    AddMetricsHttpProtocolTag(KestrelMetrics.Http2);
                     break;
                 case HttpProtocols.Http3:
                     requestProcessor = new Http3Connection((HttpMultiplexedConnectionContext)_context);
                     _protocolSelectionState = ProtocolSelectionState.Selected;
-                    AddMetricsHttpProtocolTag("3");
+                    AddMetricsHttpProtocolTag(KestrelMetrics.Http3);
                     break;
                 case HttpProtocols.None:
                     // An error was already logged in SelectProtocol(), but we should close the connection.

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelMetrics.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelMetrics.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Connections;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
 using System.Runtime.CompilerServices;
 using System.Security.Authentication;
@@ -306,7 +307,7 @@ internal sealed class KestrelMetrics
             _queuedRequestsCounter.Enabled, _currentUpgradedRequestsCounter.Enabled, _currentTlsHandshakesCounter.Enabled);
     }
 
-    private static bool TryGetHandshakeProtocol(SslProtocols? protocols, out string? name, out string? version)
+    private static bool TryGetHandshakeProtocol(SslProtocols? protocols, [NotNullWhen(true)] out string? name, [NotNullWhen(true)] out string? version)
     {
         if (protocols != null)
         {

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelMetrics.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelMetrics.cs
@@ -17,6 +17,10 @@ internal sealed class KestrelMetrics
     // Note: Dot separated instead of dash.
     public const string MeterName = "Microsoft.AspNetCore.Server.Kestrel";
 
+    public const string Http11 = "1.1";
+    public const string Http2 = "2";
+    public const string Http3 = "3";
+
     private readonly Meter _meter;
     private readonly UpDownCounter<long> _currentConnectionsCounter;
     private readonly Histogram<double> _connectionDuration;

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelMetrics.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelMetrics.cs
@@ -322,7 +322,7 @@ internal sealed class KestrelMetrics
         else if (localEndpoint != null)
         {
             tags.Add("server.socket.address", localEndpoint.ToString());
-            tags.Add("network.transport", localEndpoint.GetType().Name);
+            tags.Add("network.transport", localEndpoint.AddressFamily.ToString());
         }
     }
 

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpMultiplexedConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpMultiplexedConnectionMiddleware.cs
@@ -45,7 +45,8 @@ internal sealed class HttpMultiplexedConnectionMiddleware<TContext> where TConte
         if (connectionContext.Features.Get<IConnectionMetricsTagsFeature>() is { } metricsTags)
         {
             // HTTP/3 is always TLS 1.3. If multiple versions are support in the future then this value will need to be detected.
-            metricsTags.Tags.Add(new KeyValuePair<string, object?>("tls-protocol", SslProtocols.Tls13.ToString()));
+            metricsTags.Tags.Add(new KeyValuePair<string, object?>("tls.protocol.name", "tls"));
+            metricsTags.Tags.Add(new KeyValuePair<string, object?>("tls.protocol.version", "1.3"));
         }
 
         var connection = new HttpConnection(httpConnectionContext);

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpMultiplexedConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpMultiplexedConnectionMiddleware.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
-using System.Security.Authentication;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting.Server;

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpMultiplexedConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpMultiplexedConnectionMiddleware.cs
@@ -44,7 +44,6 @@ internal sealed class HttpMultiplexedConnectionMiddleware<TContext> where TConte
         if (connectionContext.Features.Get<IConnectionMetricsTagsFeature>() is { } metricsTags)
         {
             // HTTP/3 is always TLS 1.3. If multiple versions are support in the future then this value will need to be detected.
-            metricsTags.Tags.Add(new KeyValuePair<string, object?>("tls.protocol.name", "tls"));
             metricsTags.Tags.Add(new KeyValuePair<string, object?>("tls.protocol.version", "1.3"));
         }
 

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -206,7 +206,10 @@ internal sealed class HttpsConnectionMiddleware
         {
             if (KestrelMetrics.TryGetHandshakeProtocol(sslStream.SslProtocol, out var protocolName, out var protocolVersion))
             {
-                metricsTags.Tags.Add(new KeyValuePair<string, object?>("tls.protocol.name", protocolName));
+                if (protocolName != "tls")
+                {
+                    metricsTags.Tags.Add(new KeyValuePair<string, object?>("tls.protocol.name", protocolName));
+                }
                 metricsTags.Tags.Add(new KeyValuePair<string, object?>("tls.protocol.version", protocolVersion));
             }
         }

--- a/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
+++ b/src/Servers/Kestrel/Core/src/Middleware/HttpsConnectionMiddleware.cs
@@ -204,7 +204,11 @@ internal sealed class HttpsConnectionMiddleware
 
         if (context.Features.Get<IConnectionMetricsTagsFeature>() is { } metricsTags)
         {
-            metricsTags.Tags.Add(new KeyValuePair<string, object?>("tls-protocol", sslStream.SslProtocol.ToString()));
+            if (KestrelMetrics.TryGetHandshakeProtocol(sslStream.SslProtocol, out var protocolName, out var protocolVersion))
+            {
+                metricsTags.Tags.Add(new KeyValuePair<string, object?>("tls.protocol.name", protocolName));
+                metricsTags.Tags.Add(new KeyValuePair<string, object?>("tls.protocol.version", protocolVersion));
+            }
         }
 
         var originalTransport = context.Transport;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionLimitTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ConnectionLimitTests.cs
@@ -103,7 +103,7 @@ public class ConnectionLimitTests : LoggedTest
     public async Task RejectsConnectionsWhenLimitReached()
     {
         var testMeterFactory = new TestMeterFactory();
-        using var rejectedConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-rejected-connections");
+        using var rejectedConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.rejected_connections");
 
         const int max = 10;
         var requestTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
@@ -19,7 +19,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Diagnostics.Metrics;
-using Microsoft.Extensions.Telemetry.Latency;
 using Microsoft.Extensions.Telemetry.Testing.Metering;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
@@ -62,7 +62,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
             await sync.WaitForSyncPoint().DefaultTimeout();
 
             Assert.Empty(connectionDuration.GetMeasurementSnapshot());
-            Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"));
+            Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
 
             // Signal that connection can continue.
             sync.Continue();
@@ -79,11 +79,11 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
 
         Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m =>
         {
-            AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", KestrelMetrics.Http11);
+            AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", "ipv4", KestrelMetrics.Http11);
             Assert.Equal("value!", (string)m.Tags["custom"]);
         });
-        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
-        Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
+        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
+        Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
     }
 
     [Fact]
@@ -194,7 +194,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
             Assert.NotEqual(overridenFeature, currentConnectionContext.Features.Get<IConnectionMetricsTagsFeature>());
 
             Assert.Empty(connectionDuration.GetMeasurementSnapshot());
-            Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"));
+            Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
 
             // Signal that connection can continue.
             sync.Continue();
@@ -211,12 +211,12 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
 
         Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m =>
         {
-            AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", KestrelMetrics.Http11);
+            AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", "ipv4", KestrelMetrics.Http11);
             Assert.Equal("value!", (string)m.Tags["custom"]);
             Assert.False(m.Tags.ContainsKey("test"));
         });
-        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
-        Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
+        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
+        Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
     }
 
     private sealed class TestConnectionMetricsTagsFeature : IConnectionMetricsTagsFeature
@@ -260,7 +260,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
             await sync.WaitForSyncPoint();
 
             Assert.Empty(connectionDuration.GetMeasurementSnapshot());
-            Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"));
+            Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
 
             // Signal that connection can continue.
             sync.Continue();
@@ -272,11 +272,11 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
 
         Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m =>
         {
-            AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", httpVersion: null);
+            AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", "ipv4", httpVersion: null);
             Assert.Equal("System.InvalidOperationException", (string)m.Tags["exception.type"]);
         });
-        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
-        Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
+        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
+        Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
     }
 
     [Fact]
@@ -303,8 +303,8 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
                 "");
         }
 
-        Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m => AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", KestrelMetrics.Http11));
-        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
+        Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m => AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", "ipv4", KestrelMetrics.Http11));
+        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
         Assert.Collection(currentUpgradedRequests.GetMeasurementSnapshot(), m => Assert.Equal(1, m.Value), m => Assert.Equal(-1, m.Value));
 
         static async Task UpgradeApp(HttpContext context)
@@ -391,9 +391,9 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         Assert.NotNull(connectionId);
         Assert.Equal(2, requestsReceived);
 
-        Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m => AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", KestrelMetrics.Http2, "tls", "1.2"));
-        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
-        Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
+        Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m => AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", "ipv4", KestrelMetrics.Http2, "1.2"));
+        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
+        Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
 
         Assert.Collection(queuedRequests.GetMeasurementSnapshot(),
             m => AssertRequestCount(m, 1, KestrelMetrics.Http2),
@@ -404,7 +404,6 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         Assert.Collection(tlsHandshakeDuration.GetMeasurementSnapshot(), m =>
         {
             Assert.True(m.Value > 0);
-            Assert.Equal("tls", (string)m.Tags["tls.protocol.name"]);
             Assert.Equal("1.2", (string)m.Tags["tls.protocol.version"]);
         });
         Assert.Collection(currentTlsHandshakes.GetMeasurementSnapshot(), m => Assert.Equal(1, m.Value), m => Assert.Equal(-1, m.Value));
@@ -430,20 +429,27 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         }
     }
 
-    private static void AssertDuration(CollectedMeasurement<double> measurement, string localAddress, int? localPort, string networkTransport, string httpVersion, string tlsProtocolName = null, string tlsProtocolVersion = null)
+    private static void AssertDuration(CollectedMeasurement<double> measurement, string localAddress, int? localPort, string networkTransport, string networkType, string httpVersion, string tlsProtocolVersion = null)
     {
         Assert.True(measurement.Value > 0);
         Assert.Equal(networkTransport, (string)measurement.Tags["network.transport"]);
-        Assert.Equal(localAddress, (string)measurement.Tags["server.socket.address"]);
+        Assert.Equal(localAddress, (string)measurement.Tags["server.address"]);
         if (localPort is not null)
         {
-            Assert.Equal(localPort, (int)measurement.Tags["server.socket.port"]);
+            Assert.Equal(localPort, (int)measurement.Tags["server.port"]);
         }
         else
         {
-            Assert.False(measurement.Tags.ContainsKey("server.socket.port"));
+            Assert.False(measurement.Tags.ContainsKey("server.port"));
         }
-        Assert.Equal(localAddress, (string)measurement.Tags["server.socket.address"]);
+        if (networkType is not null)
+        {
+            Assert.Equal(networkType, (string)measurement.Tags["network.type"]);
+        }
+        else
+        {
+            Assert.False(measurement.Tags.ContainsKey("network.type"));
+        }
         if (httpVersion is not null)
         {
             Assert.Equal("http", (string)measurement.Tags["network.protocol.name"]);
@@ -453,14 +459,6 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         {
             Assert.False(measurement.Tags.ContainsKey("network.protocol.name"));
             Assert.False(measurement.Tags.ContainsKey("network.protocol.version"));
-        }
-        if (tlsProtocolName is not null)
-        {
-            Assert.Equal(tlsProtocolName, (string)measurement.Tags["tls.protocol.name"]);
-        }
-        else
-        {
-            Assert.False(measurement.Tags.ContainsKey("tls.protocol.name"));
         }
         if (tlsProtocolVersion is not null)
         {
@@ -472,19 +470,26 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         }
     }
 
-    private static void AssertCount(CollectedMeasurement<long> measurement, long expectedValue, string localAddress, int? localPort, string networkTransport)
+    private static void AssertCount(CollectedMeasurement<long> measurement, long expectedValue, string localAddress, int? localPort, string networkTransport, string networkType)
     {
         Assert.Equal(expectedValue, measurement.Value);
         Assert.Equal(networkTransport, (string)measurement.Tags["network.transport"]);
-        Assert.Equal(localAddress, (string)measurement.Tags["server.socket.address"]);
+        Assert.Equal(localAddress, (string)measurement.Tags["server.address"]);
         if (localPort is not null)
         {
-            Assert.Equal(localPort, (int)measurement.Tags["server.socket.port"]);
+            Assert.Equal(localPort, (int)measurement.Tags["server.port"]);
         }
         else
         {
-            Assert.False(measurement.Tags.ContainsKey("server.socket.port"));
+            Assert.False(measurement.Tags.ContainsKey("server.port"));
         }
-        Assert.Equal(localAddress, (string)measurement.Tags["server.socket.address"]);
+        if (networkType is not null)
+        {
+            Assert.Equal(networkType, (string)measurement.Tags["network.type"]);
+        }
+        else
+        {
+            Assert.False(measurement.Tags.ContainsKey("network.type"));
+        }
     }
 }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.Metrics;
 using System.Net;
 using System.Net.Http;
 using System.Net.Security;
@@ -14,11 +13,9 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests.TestTransport;
 using Microsoft.AspNetCore.Testing;
-using Microsoft.Extensions.Diagnostics.Metrics;
 using Microsoft.Extensions.Telemetry.Testing.Metering;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.InMemory.FunctionalTests;
@@ -65,7 +62,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
             await sync.WaitForSyncPoint().DefaultTimeout();
 
             Assert.Empty(connectionDuration.GetMeasurementSnapshot());
-            Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1:0"));
+            Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"));
 
             // Signal that connection can continue.
             sync.Continue();
@@ -82,11 +79,11 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
 
         Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m =>
         {
-            AssertDuration(m, "127.0.0.1:0", "1.1");
+            AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", "1.1");
             Assert.Equal("value!", (string)m.Tags["custom"]);
         });
-        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1:0"), m => AssertCount(m, -1, "127.0.0.1:0"));
-        Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1:0"), m => AssertCount(m, -1, "127.0.0.1:0"));
+        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
+        Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
     }
 
     [Fact]
@@ -197,7 +194,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
             Assert.NotEqual(overridenFeature, currentConnectionContext.Features.Get<IConnectionMetricsTagsFeature>());
 
             Assert.Empty(connectionDuration.GetMeasurementSnapshot());
-            Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1:0"));
+            Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"));
 
             // Signal that connection can continue.
             sync.Continue();
@@ -214,12 +211,12 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
 
         Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m =>
         {
-            AssertDuration(m, "127.0.0.1:0", "1.1");
+            AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", "1.1");
             Assert.Equal("value!", (string)m.Tags["custom"]);
             Assert.False(m.Tags.ContainsKey("test"));
         });
-        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1:0"), m => AssertCount(m, -1, "127.0.0.1:0"));
-        Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1:0"), m => AssertCount(m, -1, "127.0.0.1:0"));
+        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
+        Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
     }
 
     private sealed class TestConnectionMetricsTagsFeature : IConnectionMetricsTagsFeature
@@ -263,7 +260,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
             await sync.WaitForSyncPoint();
 
             Assert.Empty(connectionDuration.GetMeasurementSnapshot());
-            Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1:0"));
+            Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"));
 
             // Signal that connection can continue.
             sync.Continue();
@@ -275,11 +272,11 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
 
         Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m =>
         {
-            AssertDuration(m, "127.0.0.1:0", httpVersion: null);
+            AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", httpVersion: null);
             Assert.Equal("System.InvalidOperationException", (string)m.Tags["exception.type"]);
         });
-        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1:0"), m => AssertCount(m, -1, "127.0.0.1:0"));
-        Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1:0"), m => AssertCount(m, -1, "127.0.0.1:0"));
+        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
+        Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
     }
 
     [Fact]
@@ -306,8 +303,8 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
                 "");
         }
 
-        Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m => AssertDuration(m, "127.0.0.1:0", "1.1"));
-        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1:0"), m => AssertCount(m, -1, "127.0.0.1:0"));
+        Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m => AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", "1.1"));
+        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
         Assert.Collection(currentUpgradedRequests.GetMeasurementSnapshot(), m => Assert.Equal(1, m.Value), m => Assert.Equal(-1, m.Value));
 
         static async Task UpgradeApp(HttpContext context)
@@ -394,9 +391,9 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         Assert.NotNull(connectionId);
         Assert.Equal(2, requestsReceived);
 
-        Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m => AssertDuration(m, "127.0.0.1:0", "2"));
-        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1:0"), m => AssertCount(m, -1, "127.0.0.1:0"));
-        Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1:0"), m => AssertCount(m, -1, "127.0.0.1:0"));
+        Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m => AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", "2", "tls", "1.2"));
+        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
+        Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
 
         Assert.Collection(queuedRequests.GetMeasurementSnapshot(),
             m => AssertRequestCount(m, 1, "2"),
@@ -433,10 +430,20 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         }
     }
 
-    private static void AssertDuration(CollectedMeasurement<double> measurement, string localEndpoint, string httpVersion)
+    private static void AssertDuration(CollectedMeasurement<double> measurement, string localAddress, int? localPort, string networkTransport, string httpVersion, string tlsProtocolName = null, string tlsProtocolVersion = null)
     {
         Assert.True(measurement.Value > 0);
-        Assert.Equal(localEndpoint, (string)measurement.Tags["endpoint"]);
+        Assert.Equal(networkTransport, (string)measurement.Tags["network.transport"]);
+        Assert.Equal(localAddress, (string)measurement.Tags["server.socket.address"]);
+        if (localPort is not null)
+        {
+            Assert.Equal(localPort, (int)measurement.Tags["server.socket.port"]);
+        }
+        else
+        {
+            Assert.False(measurement.Tags.ContainsKey("server.socket.port"));
+        }
+        Assert.Equal(localAddress, (string)measurement.Tags["server.socket.address"]);
         if (httpVersion is not null)
         {
             Assert.Equal("http", (string)measurement.Tags["network.protocol.name"]);
@@ -447,11 +454,37 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
             Assert.False(measurement.Tags.ContainsKey("network.protocol.name"));
             Assert.False(measurement.Tags.ContainsKey("network.protocol.version"));
         }
+        if (tlsProtocolName is not null)
+        {
+            Assert.Equal(tlsProtocolName, (string)measurement.Tags["tls.protocol.name"]);
+        }
+        else
+        {
+            Assert.False(measurement.Tags.ContainsKey("tls.protocol.name"));
+        }
+        if (tlsProtocolVersion is not null)
+        {
+            Assert.Equal(tlsProtocolVersion, (string)measurement.Tags["tls.protocol.version"]);
+        }
+        else
+        {
+            Assert.False(measurement.Tags.ContainsKey("tls.protocol.version"));
+        }
     }
 
-    private static void AssertCount(CollectedMeasurement<long> measurement, long expectedValue, string localEndpoint)
+    private static void AssertCount(CollectedMeasurement<long> measurement, long expectedValue, string localAddress, int? localPort, string networkTransport)
     {
         Assert.Equal(expectedValue, measurement.Value);
-        Assert.Equal(localEndpoint, (string)measurement.Tags["endpoint"]);
+        Assert.Equal(networkTransport, (string)measurement.Tags["network.transport"]);
+        Assert.Equal(localAddress, (string)measurement.Tags["server.socket.address"]);
+        if (localPort is not null)
+        {
+            Assert.Equal(localPort, (int)measurement.Tags["server.socket.port"]);
+        }
+        else
+        {
+            Assert.False(measurement.Tags.ContainsKey("server.socket.port"));
+        }
+        Assert.Equal(localAddress, (string)measurement.Tags["server.socket.address"]);
     }
 }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
@@ -79,7 +79,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
 
         Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m =>
         {
-            AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", "1.1");
+            AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", KestrelMetrics.Http11);
             Assert.Equal("value!", (string)m.Tags["custom"]);
         });
         Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
@@ -211,7 +211,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
 
         Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m =>
         {
-            AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", "1.1");
+            AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", KestrelMetrics.Http11);
             Assert.Equal("value!", (string)m.Tags["custom"]);
             Assert.False(m.Tags.ContainsKey("test"));
         });
@@ -303,7 +303,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
                 "");
         }
 
-        Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m => AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", "1.1"));
+        Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m => AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", KestrelMetrics.Http11));
         Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
         Assert.Collection(currentUpgradedRequests.GetMeasurementSnapshot(), m => Assert.Equal(1, m.Value), m => Assert.Equal(-1, m.Value));
 
@@ -391,15 +391,15 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         Assert.NotNull(connectionId);
         Assert.Equal(2, requestsReceived);
 
-        Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m => AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", "2", "tls", "1.2"));
+        Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m => AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", KestrelMetrics.Http2, "tls", "1.2"));
         Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
         Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp"));
 
         Assert.Collection(queuedRequests.GetMeasurementSnapshot(),
-            m => AssertRequestCount(m, 1, "2"),
-            m => AssertRequestCount(m, -1, "2"),
-            m => AssertRequestCount(m, 1, "2"),
-            m => AssertRequestCount(m, -1, "2"));
+            m => AssertRequestCount(m, 1, KestrelMetrics.Http2),
+            m => AssertRequestCount(m, -1, KestrelMetrics.Http2),
+            m => AssertRequestCount(m, 1, KestrelMetrics.Http2),
+            m => AssertRequestCount(m, -1, KestrelMetrics.Http2));
 
         Assert.Collection(tlsHandshakeDuration.GetMeasurementSnapshot(), m =>
         {

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
@@ -45,7 +45,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
 
         var testMeterFactory = new TestMeterFactory();
         using var connectionDuration = new MetricCollector<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.connection.duration");
-        using var currentConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.active_connections");
+        using var activeConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.active_connections");
         using var queuedConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.queued_connections");
 
         var serviceContext = new TestServiceContext(LoggerFactory, metrics: new KestrelMetrics(testMeterFactory));
@@ -62,7 +62,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
             await sync.WaitForSyncPoint().DefaultTimeout();
 
             Assert.Empty(connectionDuration.GetMeasurementSnapshot());
-            Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
+            Assert.Collection(activeConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
 
             // Signal that connection can continue.
             sync.Continue();
@@ -82,7 +82,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
             AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", "ipv4", KestrelMetrics.Http11);
             Assert.Equal("value!", (string)m.Tags["custom"]);
         });
-        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
+        Assert.Collection(activeConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
         Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
     }
 
@@ -121,7 +121,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
             await sync.WaitForSyncPoint();
 
             using var connectionDuration = new MetricCollector<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.connection.duration");
-            using var currentConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.active_connections");
+            using var activeConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.active_connections");
             using var queuedConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.queued_connections");
 
             // Signal that connection can continue.
@@ -137,7 +137,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
             await connection.WaitForConnectionClose();
 
             Assert.Empty(connectionDuration.GetMeasurementSnapshot());
-            Assert.Empty(currentConnections.GetMeasurementSnapshot());
+            Assert.Empty(activeConnections.GetMeasurementSnapshot());
             Assert.Empty(queuedConnections.GetMeasurementSnapshot());
 
             Assert.False(hasConnectionMetricsTagsFeature);
@@ -168,7 +168,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
 
         var testMeterFactory = new TestMeterFactory();
         using var connectionDuration = new MetricCollector<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.connection.duration");
-        using var currentConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.active_connections");
+        using var activeConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.active_connections");
         using var queuedConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.queued_connections");
 
         var serviceContext = new TestServiceContext(LoggerFactory, metrics: new KestrelMetrics(testMeterFactory));
@@ -194,7 +194,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
             Assert.NotEqual(overridenFeature, currentConnectionContext.Features.Get<IConnectionMetricsTagsFeature>());
 
             Assert.Empty(connectionDuration.GetMeasurementSnapshot());
-            Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
+            Assert.Collection(activeConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
 
             // Signal that connection can continue.
             sync.Continue();
@@ -215,7 +215,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
             Assert.Equal("value!", (string)m.Tags["custom"]);
             Assert.False(m.Tags.ContainsKey("test"));
         });
-        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
+        Assert.Collection(activeConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
         Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
     }
 
@@ -243,7 +243,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
 
         var testMeterFactory = new TestMeterFactory();
         using var connectionDuration = new MetricCollector<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.connection.duration");
-        using var currentConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.active_connections");
+        using var activeConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.active_connections");
         using var queuedConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.queued_connections");
 
         var serviceContext = new TestServiceContext(LoggerFactory, metrics: new KestrelMetrics(testMeterFactory));
@@ -260,7 +260,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
             await sync.WaitForSyncPoint();
 
             Assert.Empty(connectionDuration.GetMeasurementSnapshot());
-            Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
+            Assert.Collection(activeConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
 
             // Signal that connection can continue.
             sync.Continue();
@@ -275,7 +275,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
             AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", "ipv4", httpVersion: null);
             Assert.Equal("System.InvalidOperationException", (string)m.Tags["exception.type"]);
         });
-        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
+        Assert.Collection(activeConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
         Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
     }
 
@@ -286,7 +286,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
 
         var testMeterFactory = new TestMeterFactory();
         using var connectionDuration = new MetricCollector<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.connection.duration");
-        using var currentConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.active_connections");
+        using var activeConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.active_connections");
         using var currentUpgradedRequests = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.upgraded_connections");
 
         var serviceContext = new TestServiceContext(LoggerFactory, metrics: new KestrelMetrics(testMeterFactory));
@@ -304,7 +304,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         }
 
         Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m => AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", "ipv4", KestrelMetrics.Http11));
-        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
+        Assert.Collection(activeConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
         Assert.Collection(currentUpgradedRequests.GetMeasurementSnapshot(), m => Assert.Equal(1, m.Value), m => Assert.Equal(-1, m.Value));
 
         static async Task UpgradeApp(HttpContext context)
@@ -330,11 +330,11 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
 
         var testMeterFactory = new TestMeterFactory();
         using var connectionDuration = new MetricCollector<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.connection.duration");
-        using var currentConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.active_connections");
+        using var activeConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.active_connections");
         using var queuedConnections = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.queued_connections");
         using var queuedRequests = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.queued_requests");
         using var tlsHandshakeDuration = new MetricCollector<double>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.tls_handshake.duration");
-        using var currentTlsHandshakes = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.active_tls_handshakes");
+        using var activeTlsHandshakes = new MetricCollector<long>(testMeterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.active_tls_handshakes");
 
         await using (var server = new TestServer(context =>
         {
@@ -392,7 +392,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         Assert.Equal(2, requestsReceived);
 
         Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m => AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", "ipv4", KestrelMetrics.Http2, "1.2"));
-        Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
+        Assert.Collection(activeConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
         Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
 
         Assert.Collection(queuedRequests.GetMeasurementSnapshot(),
@@ -406,7 +406,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
             Assert.True(m.Value > 0);
             Assert.Equal("1.2", (string)m.Tags["tls.protocol.version"]);
         });
-        Assert.Collection(currentTlsHandshakes.GetMeasurementSnapshot(), m => Assert.Equal(1, m.Value), m => Assert.Equal(-1, m.Value));
+        Assert.Collection(activeTlsHandshakes.GetMeasurementSnapshot(), m => Assert.Equal(1, m.Value), m => Assert.Equal(-1, m.Value));
 
         static void AssertRequestCount(CollectedMeasurement<long> measurement, long expectedValue, string httpVersion)
         {

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
@@ -38,7 +38,7 @@ public class Http2RequestTests : LoggedTest
         {
             var meterFactory = host.Services.GetRequiredService<IMeterFactory>();
 
-            using var connectionDuration = new MetricCollector<double>(meterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-connection-duration");
+            using var connectionDuration = new MetricCollector<double>(meterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.connection.duration");
 
             await host.StartAsync();
             var client = HttpHelpers.CreateClient();
@@ -63,9 +63,13 @@ public class Http2RequestTests : LoggedTest
                 m =>
                 {
                     Assert.True(m.Value > 0);
-                    Assert.Equal(protocol.ToString(), m.Tags["tls-protocol"]);
-                    Assert.Equal("HTTP/2", m.Tags["http-protocol"]);
-                    Assert.Equal($"127.0.0.1:{host.GetPort()}", m.Tags["endpoint"]);
+                    Assert.Equal("http", (string)m.Tags["network.protocol.name"]);
+                    Assert.Equal("2", (string)m.Tags["network.protocol.version"]);
+                    Assert.Equal("tcp", (string)m.Tags["network.transport"]);
+                    Assert.Equal("127.0.0.1", (string)m.Tags["server.socket.address"]);
+                    Assert.Equal(host.GetPort(), (int)m.Tags["server.socket.port"]);
+                    Assert.Equal("tls", (string)m.Tags["tls.protocol.name"]);
+                    Assert.Equal("1.3", (string)m.Tags["tls.protocol.version"]);
                 });
 
             await host.StopAsync();

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
@@ -36,7 +36,8 @@ public class Http2RequestTests : LoggedTest
             },
             configureKestrel: o =>
             {
-                o.Listen(IPAddress.Parse("127.0.0.1"), 0, listenOptions =>
+                // Test IPv6 endpoint with metrics.
+                o.Listen(IPAddress.IPv6Loopback, 0, listenOptions =>
                 {
                     listenOptions.Protocols = HttpProtocols.Http2;
                     listenOptions.UseHttps(TestResources.GetTestCertificate(), https =>
@@ -56,7 +57,7 @@ public class Http2RequestTests : LoggedTest
             var client = HttpHelpers.CreateClient();
 
             // Act
-            var request1 = new HttpRequestMessage(HttpMethod.Get, $"https://127.0.0.1:{host.GetPort()}/");
+            var request1 = new HttpRequestMessage(HttpMethod.Get, $"https://[::1]:{host.GetPort()}/");
             request1.Version = HttpVersion.Version20;
             request1.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
 
@@ -78,8 +79,8 @@ public class Http2RequestTests : LoggedTest
                     Assert.Equal("http", (string)m.Tags["network.protocol.name"]);
                     Assert.Equal("2", (string)m.Tags["network.protocol.version"]);
                     Assert.Equal("tcp", (string)m.Tags["network.transport"]);
-                    Assert.Equal("ipv4", (string)m.Tags["network.type"]);
-                    Assert.Equal("127.0.0.1", (string)m.Tags["server.address"]);
+                    Assert.Equal("ipv6", (string)m.Tags["network.type"]);
+                    Assert.Equal("::1", (string)m.Tags["server.address"]);
                     Assert.Equal(host.GetPort(), (int)m.Tags["server.port"]);
                     Assert.Equal("1.2", (string)m.Tags["tls.protocol.version"]);
                 });

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http2/Http2RequestTests.cs
@@ -78,9 +78,9 @@ public class Http2RequestTests : LoggedTest
                     Assert.Equal("http", (string)m.Tags["network.protocol.name"]);
                     Assert.Equal("2", (string)m.Tags["network.protocol.version"]);
                     Assert.Equal("tcp", (string)m.Tags["network.transport"]);
-                    Assert.Equal("127.0.0.1", (string)m.Tags["server.socket.address"]);
-                    Assert.Equal(host.GetPort(), (int)m.Tags["server.socket.port"]);
-                    Assert.Equal("tls", (string)m.Tags["tls.protocol.name"]);
+                    Assert.Equal("ipv4", (string)m.Tags["network.type"]);
+                    Assert.Equal("127.0.0.1", (string)m.Tags["server.address"]);
+                    Assert.Equal(host.GetPort(), (int)m.Tags["server.port"]);
                     Assert.Equal("1.2", (string)m.Tags["tls.protocol.version"]);
                 });
 

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -82,7 +82,7 @@ public class Http3RequestTests : LoggedTest
         {
             var meterFactory = host.Services.GetRequiredService<IMeterFactory>();
 
-            using var connectionDuration = new MetricCollector<double>(meterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel-connection-duration");
+            using var connectionDuration = new MetricCollector<double>(meterFactory, "Microsoft.AspNetCore.Server.Kestrel", "kestrel.connection.duration");
 
             await host.StartAsync();
             var client = HttpHelpers.CreateClient();
@@ -105,9 +105,13 @@ public class Http3RequestTests : LoggedTest
                 m =>
                 {
                     Assert.True(m.Value > 0);
-                    Assert.Equal("Tls13", m.Tags["tls-protocol"]);
-                    Assert.Equal("HTTP/3", m.Tags["http-protocol"]);
-                    Assert.Equal($"127.0.0.1:{host.GetPort()}", m.Tags["endpoint"]);
+                    Assert.Equal("http", (string)m.Tags["network.protocol.name"]);
+                    Assert.Equal("3", (string)m.Tags["network.protocol.version"]);
+                    Assert.Equal("udp", (string)m.Tags["network.transport"]);
+                    Assert.Equal("127.0.0.1", (string)m.Tags["server.socket.address"]);
+                    Assert.Equal(host.GetPort(), (int)m.Tags["server.socket.port"]);
+                    Assert.Equal("tls", (string)m.Tags["tls.protocol.name"]);
+                    Assert.Equal("1.3", (string)m.Tags["tls.protocol.version"]);
                 });
 
             await host.StopAsync();

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -105,12 +105,12 @@ public class Http3RequestTests : LoggedTest
                 m =>
                 {
                     Assert.True(m.Value > 0);
+                    Assert.Equal("ipv4", (string)m.Tags["network.type"]);
                     Assert.Equal("http", (string)m.Tags["network.protocol.name"]);
                     Assert.Equal("3", (string)m.Tags["network.protocol.version"]);
                     Assert.Equal("udp", (string)m.Tags["network.transport"]);
-                    Assert.Equal("127.0.0.1", (string)m.Tags["server.socket.address"]);
-                    Assert.Equal(host.GetPort(), (int)m.Tags["server.socket.port"]);
-                    Assert.Equal("tls", (string)m.Tags["tls.protocol.name"]);
+                    Assert.Equal("127.0.0.1", (string)m.Tags["server.address"]);
+                    Assert.Equal(host.GetPort(), (int)m.Tags["server.port"]);
                     Assert.Equal("1.3", (string)m.Tags["tls.protocol.version"]);
                 });
 


### PR DESCRIPTION
Applying changes from https://github.com/lmolkova/semantic-conventions/pull/1

@noahfalk @lmolkova