### PR TITLE
Rename rate limiting middleware metrics to be consistent with OpenTelemetry

### DIFF
--- a/src/Middleware/RateLimiting/src/RateLimitingMetrics.cs
+++ b/src/Middleware/RateLimiting/src/RateLimitingMetrics.cs
@@ -12,42 +12,42 @@ internal sealed class RateLimitingMetrics : IDisposable
     public const string MeterName = "Microsoft.AspNetCore.RateLimiting";
 
     private readonly Meter _meter;
-    private readonly UpDownCounter<long> _currentLeasedRequestsCounter;
-    private readonly Histogram<double> _leasedRequestDurationCounter;
-    private readonly UpDownCounter<long> _currentQueuedRequestsCounter;
+    private readonly UpDownCounter<long> _activeRequestLeasesCounter;
+    private readonly Histogram<double> _requestLeaseDurationCounter;
+    private readonly UpDownCounter<long> _queuedRequestsCounter;
     private readonly Histogram<double> _queuedRequestDurationCounter;
-    private readonly Counter<long> _leaseFailedRequestsCounter;
+    private readonly Counter<long> _requestsCounter;
 
     public RateLimitingMetrics(IMeterFactory meterFactory)
     {
         _meter = meterFactory.Create(MeterName);
 
-        _currentLeasedRequestsCounter = _meter.CreateUpDownCounter<long>(
-            "rate-limiting-current-leased-requests",
+        _activeRequestLeasesCounter = _meter.CreateUpDownCounter<long>(
+            "aspnet.rate_limiting.active_request_leases",
             description: "Number of HTTP requests that are currently active on the server that hold a rate limiting lease.");
 
-        _leasedRequestDurationCounter = _meter.CreateHistogram<double>(
-            "rate-limiting-leased-request-duration",
+        _requestLeaseDurationCounter = _meter.CreateHistogram<double>(
+            "aspnet.rate_limiting.request_lease.duration",
             unit: "s",
             description: "The duration of rate limiting leases held by HTTP requests on the server.");
 
-        _currentQueuedRequestsCounter = _meter.CreateUpDownCounter<long>(
-            "rate-limiting-current-queued-requests",
+        _queuedRequestsCounter = _meter.CreateUpDownCounter<long>(
+            "aspnet.rate_limiting.queued_requests",
             description: "Number of HTTP requests that are currently queued, waiting to acquire a rate limiting lease.");
 
         _queuedRequestDurationCounter = _meter.CreateHistogram<double>(
-            "rate-limiting-queued-request-duration",
+            "aspnet.rate_limiting.request.time_in_queue",
             unit: "s",
             description: "The duration of HTTP requests in a queue, waiting to acquire a rate limiting lease.");
 
-        _leaseFailedRequestsCounter = _meter.CreateCounter<long>(
-            "rate-limiting-lease-failed-requests",
-            description: "Number of HTTP requests that failed to acquire a rate limiting lease. Requests could be rejected by global or endpoint rate limiting policies. Or the request could be canceled while waiting for the lease.");
+        _requestsCounter = _meter.CreateCounter<long>(
+            "aspnet.rate_limiting.requests",
+            description: "Number of requests that tried to acquire a rate limiting lease. Requests could be rejected by global or endpoint rate limiting policies. Or the request could be canceled while waiting for the lease.");
     }
 
     public void LeaseFailed(in MetricsContext metricsContext, RequestRejectionReason reason)
     {
-        if (_leaseFailedRequestsCounter.Enabled)
+        if (_requestsCounter.Enabled)
         {
             LeaseFailedCore(metricsContext, reason);
         }
@@ -58,8 +58,8 @@ internal sealed class RateLimitingMetrics : IDisposable
     {
         var tags = new TagList();
         InitializeRateLimitingTags(ref tags, metricsContext);
-        tags.Add("reason", reason.ToString());
-        _leaseFailedRequestsCounter.Add(1, tags);
+        tags.Add("aspnet.rate_limiting.result", GetResult(reason));
+        _requestsCounter.Add(1, tags);
     }
 
     public void LeaseStart(in MetricsContext metricsContext)
@@ -75,12 +75,12 @@ internal sealed class RateLimitingMetrics : IDisposable
     {
         var tags = new TagList();
         InitializeRateLimitingTags(ref tags, metricsContext);
-        _currentLeasedRequestsCounter.Add(1, tags);
+        _activeRequestLeasesCounter.Add(1, tags);
     }
 
     public void LeaseEnd(in MetricsContext metricsContext, long startTimestamp, long currentTimestamp)
     {
-        if (metricsContext.CurrentLeasedRequestsCounterEnabled || _leasedRequestDurationCounter.Enabled)
+        if (metricsContext.CurrentLeasedRequestsCounterEnabled || _requestLeaseDurationCounter.Enabled || _requestsCounter.Enabled)
         {
             LeaseEndCore(metricsContext, startTimestamp, currentTimestamp);
         }
@@ -94,13 +94,20 @@ internal sealed class RateLimitingMetrics : IDisposable
 
         if (metricsContext.CurrentLeasedRequestsCounterEnabled)
         {
-            _currentLeasedRequestsCounter.Add(-1, tags);
+            _activeRequestLeasesCounter.Add(-1, tags);
         }
 
-        if (_leasedRequestDurationCounter.Enabled)
+        if (_requestLeaseDurationCounter.Enabled)
         {
             var duration = Stopwatch.GetElapsedTime(startTimestamp, currentTimestamp);
-            _leasedRequestDurationCounter.Record(duration.TotalSeconds, tags);
+            _requestLeaseDurationCounter.Record(duration.TotalSeconds, tags);
+        }
+
+        if (_requestsCounter.Enabled)
+        {
+            // This modifies the shared tags list so must be the last usage in the method.
+            tags.Add("aspnet.rate_limiting.result", "acquired");
+            _requestsCounter.Add(1, tags);
         }
     }
 
@@ -117,7 +124,7 @@ internal sealed class RateLimitingMetrics : IDisposable
     {
         var tags = new TagList();
         InitializeRateLimitingTags(ref tags, metricsContext);
-        _currentQueuedRequestsCounter.Add(1, tags);
+        _queuedRequestsCounter.Add(1, tags);
     }
 
     public void QueueEnd(in MetricsContext metricsContext, RequestRejectionReason? reason, long startTimestamp, long currentTimestamp)
@@ -136,15 +143,12 @@ internal sealed class RateLimitingMetrics : IDisposable
 
         if (metricsContext.CurrentQueuedRequestsCounterEnabled)
         {
-            _currentQueuedRequestsCounter.Add(-1, tags);
+            _queuedRequestsCounter.Add(-1, tags);
         }
 
         if (_queuedRequestDurationCounter.Enabled)
         {
-            if (reason != null)
-            {
-                tags.Add("reason", reason.Value.ToString());
-            }
+            tags.Add("aspnet.rate_limiting.result", reason != null ? GetResult(reason.Value) : "acquired");
             var duration = Stopwatch.GetElapsedTime(startTimestamp, currentTimestamp);
             _queuedRequestDurationCounter.Record(duration.TotalSeconds, tags);
         }
@@ -159,12 +163,23 @@ internal sealed class RateLimitingMetrics : IDisposable
     {
         if (metricsContext.PolicyName is not null)
         {
-            tags.Add("policy", metricsContext.PolicyName);
+            tags.Add("aspnet.rate_limiting.policy", metricsContext.PolicyName);
         }
+    }
+
+    private static string GetResult(RequestRejectionReason reason)
+    {
+        return reason switch
+        {
+            RequestRejectionReason.EndpointLimiter => "request_canceled",
+            RequestRejectionReason.GlobalLimiter => "global_limiter",
+            RequestRejectionReason.RequestCanceled => "endpoint_limiter",
+            _ => throw new InvalidOperationException("Unexpected value: " + reason)
+        };
     }
 
     public MetricsContext CreateContext(string? policyName)
     {
-        return new MetricsContext(policyName, _currentLeasedRequestsCounter.Enabled, _currentQueuedRequestsCounter.Enabled);
+        return new MetricsContext(policyName, _activeRequestLeasesCounter.Enabled, _queuedRequestsCounter.Enabled);
     }
 }

--- a/src/Middleware/RateLimiting/src/RateLimitingMetrics.cs
+++ b/src/Middleware/RateLimiting/src/RateLimitingMetrics.cs
@@ -171,9 +171,9 @@ internal sealed class RateLimitingMetrics : IDisposable
     {
         return reason switch
         {
-            RequestRejectionReason.EndpointLimiter => "request_canceled",
+            RequestRejectionReason.EndpointLimiter => "endpoint_limiter",
             RequestRejectionReason.GlobalLimiter => "global_limiter",
-            RequestRejectionReason.RequestCanceled => "endpoint_limiter",
+            RequestRejectionReason.RequestCanceled => "request_canceled",
             _ => throw new InvalidOperationException("Unexpected value: " + reason)
         };
     }

--- a/src/Middleware/RateLimiting/src/RateLimitingMetrics.cs
+++ b/src/Middleware/RateLimiting/src/RateLimitingMetrics.cs
@@ -24,6 +24,7 @@ internal sealed class RateLimitingMetrics : IDisposable
 
         _activeRequestLeasesCounter = _meter.CreateUpDownCounter<long>(
             "aspnetcore.rate_limiting.active_request_leases",
+            unit: "{request}",
             description: "Number of HTTP requests that are currently active on the server that hold a rate limiting lease.");
 
         _requestLeaseDurationCounter = _meter.CreateHistogram<double>(
@@ -33,6 +34,7 @@ internal sealed class RateLimitingMetrics : IDisposable
 
         _queuedRequestsCounter = _meter.CreateUpDownCounter<long>(
             "aspnetcore.rate_limiting.queued_requests",
+            unit: "{request}",
             description: "Number of HTTP requests that are currently queued, waiting to acquire a rate limiting lease.");
 
         _queuedRequestDurationCounter = _meter.CreateHistogram<double>(
@@ -42,6 +44,7 @@ internal sealed class RateLimitingMetrics : IDisposable
 
         _requestsCounter = _meter.CreateCounter<long>(
             "aspnetcore.rate_limiting.requests",
+            unit: "{request}",
             description: "Number of requests that tried to acquire a rate limiting lease. Requests could be rejected by global or endpoint rate limiting policies. Or the request could be canceled while waiting for the lease.");
     }
 

--- a/src/Middleware/RateLimiting/src/RateLimitingMetrics.cs
+++ b/src/Middleware/RateLimiting/src/RateLimitingMetrics.cs
@@ -23,25 +23,25 @@ internal sealed class RateLimitingMetrics : IDisposable
         _meter = meterFactory.Create(MeterName);
 
         _activeRequestLeasesCounter = _meter.CreateUpDownCounter<long>(
-            "aspnet.rate_limiting.active_request_leases",
+            "aspnetcore.rate_limiting.active_request_leases",
             description: "Number of HTTP requests that are currently active on the server that hold a rate limiting lease.");
 
         _requestLeaseDurationCounter = _meter.CreateHistogram<double>(
-            "aspnet.rate_limiting.request_lease.duration",
+            "aspnetcore.rate_limiting.request_lease.duration",
             unit: "s",
             description: "The duration of rate limiting leases held by HTTP requests on the server.");
 
         _queuedRequestsCounter = _meter.CreateUpDownCounter<long>(
-            "aspnet.rate_limiting.queued_requests",
+            "aspnetcore.rate_limiting.queued_requests",
             description: "Number of HTTP requests that are currently queued, waiting to acquire a rate limiting lease.");
 
         _queuedRequestDurationCounter = _meter.CreateHistogram<double>(
-            "aspnet.rate_limiting.request.time_in_queue",
+            "aspnetcore.rate_limiting.request.time_in_queue",
             unit: "s",
             description: "The duration of HTTP requests in a queue, waiting to acquire a rate limiting lease.");
 
         _requestsCounter = _meter.CreateCounter<long>(
-            "aspnet.rate_limiting.requests",
+            "aspnetcore.rate_limiting.requests",
             description: "Number of requests that tried to acquire a rate limiting lease. Requests could be rejected by global or endpoint rate limiting policies. Or the request could be canceled while waiting for the lease.");
     }
 
@@ -58,7 +58,7 @@ internal sealed class RateLimitingMetrics : IDisposable
     {
         var tags = new TagList();
         InitializeRateLimitingTags(ref tags, metricsContext);
-        tags.Add("aspnet.rate_limiting.result", GetResult(reason));
+        tags.Add("aspnetcore.rate_limiting.result", GetResult(reason));
         _requestsCounter.Add(1, tags);
     }
 
@@ -106,7 +106,7 @@ internal sealed class RateLimitingMetrics : IDisposable
         if (_requestsCounter.Enabled)
         {
             // This modifies the shared tags list so must be the last usage in the method.
-            tags.Add("aspnet.rate_limiting.result", "acquired");
+            tags.Add("aspnetcore.rate_limiting.result", "acquired");
             _requestsCounter.Add(1, tags);
         }
     }
@@ -148,7 +148,7 @@ internal sealed class RateLimitingMetrics : IDisposable
 
         if (_queuedRequestDurationCounter.Enabled)
         {
-            tags.Add("aspnet.rate_limiting.result", reason != null ? GetResult(reason.Value) : "acquired");
+            tags.Add("aspnetcore.rate_limiting.result", reason != null ? GetResult(reason.Value) : "acquired");
             var duration = Stopwatch.GetElapsedTime(startTimestamp, currentTimestamp);
             _queuedRequestDurationCounter.Record(duration.TotalSeconds, tags);
         }
@@ -163,7 +163,7 @@ internal sealed class RateLimitingMetrics : IDisposable
     {
         if (metricsContext.PolicyName is not null)
         {
-            tags.Add("aspnet.rate_limiting.policy", metricsContext.PolicyName);
+            tags.Add("aspnetcore.rate_limiting.policy", metricsContext.PolicyName);
         }
     }
 

--- a/src/Middleware/RateLimiting/test/RateLimitingMetricsTests.cs
+++ b/src/Middleware/RateLimiting/test/RateLimitingMetricsTests.cs
@@ -35,11 +35,11 @@ public class RateLimitingMetricsTests
 
         var context = new DefaultHttpContext();
 
-        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-leased-request-duration");
-        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-leased-requests");
-        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-queued-requests");
-        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-queued-request-duration");
-        using var leaseFailedRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-lease-failed-requests");
+        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request_lease.duration");
+        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.active_request_leases");
+        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.queued_requests");
+        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request.time_in_queue");
+        using var rateLimitingRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.requests");
 
         // Act
         await middleware.Invoke(context).DefaultTimeout();
@@ -51,11 +51,11 @@ public class RateLimitingMetricsTests
         Assert.Empty(leaseRequestDurationCollector.GetMeasurementSnapshot());
         Assert.Empty(currentRequestsQueuedCollector.GetMeasurementSnapshot());
         Assert.Empty(queuedRequestDurationCollector.GetMeasurementSnapshot());
-        Assert.Collection(leaseFailedRequestsCollector.GetMeasurementSnapshot(),
+        Assert.Collection(rateLimitingRequestsCollector.GetMeasurementSnapshot(),
             m =>
             {
                 Assert.Equal(1, m.Value);
-                Assert.Equal("GlobalLimiter", (string)m.Tags.ToArray().Single(t => t.Key == "reason").Value);
+                Assert.Equal("global_limiter", (string)m.Tags["aspnet.rate_limiting.result"]);
             });
     }
 
@@ -82,11 +82,11 @@ public class RateLimitingMetricsTests
         var context = new DefaultHttpContext();
         context.Request.Method = "GET";
 
-        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-leased-request-duration");
-        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-leased-requests");
-        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-queued-requests");
-        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-queued-request-duration");
-        using var leaseFailedRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-lease-failed-requests");
+        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request_lease.duration");
+        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.active_request_leases");
+        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.queued_requests");
+        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request.time_in_queue");
+        using var rateLimitingRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.requests");
 
         // Act
         var middlewareTask = middleware.Invoke(context);
@@ -111,7 +111,11 @@ public class RateLimitingMetricsTests
             m => AssertDuration(m, null));
         Assert.Empty(currentRequestsQueuedCollector.GetMeasurementSnapshot());
         Assert.Empty(queuedRequestDurationCollector.GetMeasurementSnapshot());
-        Assert.Empty(leaseFailedRequestsCollector.GetMeasurementSnapshot());
+        Assert.Collection(rateLimitingRequestsCollector.GetMeasurementSnapshot(),
+            m =>
+            {
+                Assert.Equal("acquired", (string)m.Tags["aspnet.rate_limiting.result"]);
+            });
     }
 
     [Fact]
@@ -142,11 +146,11 @@ public class RateLimitingMetricsTests
 
         await syncPoint.WaitForSyncPoint().DefaultTimeout();
 
-        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-leased-request-duration");
-        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-leased-requests");
-        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-queued-requests");
-        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-queued-request-duration");
-        using var leaseFailedRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-lease-failed-requests");
+        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request_lease.duration");
+        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.active_request_leases");
+        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.queued_requests");
+        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request.time_in_queue");
+        using var rateLimitingRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.requests");
 
         syncPoint.Continue();
 
@@ -193,11 +197,11 @@ public class RateLimitingMetricsTests
         routeEndpointBuilder.Metadata.Add(new EnableRateLimitingAttribute("concurrencyPolicy"));
         var endpoint = routeEndpointBuilder.Build();
 
-        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-leased-request-duration");
-        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-leased-requests");
-        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-queued-requests");
-        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-queued-request-duration");
-        using var leaseFailedRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-lease-failed-requests");
+        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request_lease.duration");
+        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.active_request_leases");
+        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.queued_requests");
+        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request.time_in_queue");
+        using var rateLimitingRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.requests");
 
         // Act
         var context1 = new DefaultHttpContext();
@@ -228,7 +232,11 @@ public class RateLimitingMetricsTests
             m => AssertCounter(m, 1, "concurrencyPolicy"),
             m => AssertCounter(m, -1, "concurrencyPolicy"));
         Assert.Collection(queuedRequestDurationCollector.GetMeasurementSnapshot(),
-            m => AssertDuration(m, "concurrencyPolicy"));
+            m =>
+            {
+                AssertDuration(m, "concurrencyPolicy");
+                Assert.Equal("acquired", (string)m.Tags["aspnet.rate_limiting.result"]);
+            });
     }
 
     [Fact]
@@ -280,11 +288,11 @@ public class RateLimitingMetricsTests
 
         // Start listening while the second request is queued.
 
-        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-leased-request-duration");
-        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-leased-requests");
-        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-current-queued-requests");
-        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-queued-request-duration");
-        using var leaseFailedRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "rate-limiting-lease-failed-requests");
+        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request_lease.duration");
+        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.active_request_leases");
+        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.queued_requests");
+        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request.time_in_queue");
+        using var rateLimitingRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.requests");
 
         Assert.Empty(currentRequestsQueuedCollector.GetMeasurementSnapshot());
         Assert.Empty(queuedRequestDurationCollector.GetMeasurementSnapshot());
@@ -303,24 +311,24 @@ public class RateLimitingMetricsTests
     private static void AssertCounter(CollectedMeasurement<long> measurement, long value, string policy)
     {
         Assert.Equal(value, measurement.Value);
-        AssertTag(measurement.Tags, "policy", policy);
+        AssertTag(measurement.Tags, "aspnet.rate_limiting.policy", policy);
     }
 
     private static void AssertDuration(CollectedMeasurement<double> measurement, string policy)
     {
         Assert.True(measurement.Value > 0);
-        AssertTag(measurement.Tags, "policy", policy);
+        AssertTag(measurement.Tags, "aspnet.rate_limiting.policy", policy);
     }
 
     private static void AssertTag<T>(IReadOnlyDictionary<string, object> tags, string tagName, T expected)
     {
         if (expected == null)
         {
-            Assert.DoesNotContain(tags.ToArray(), t => t.Key == tagName);
+            Assert.False(tags.ContainsKey(tagName));
         }
         else
         {
-            Assert.Equal(expected, (T)tags.ToArray().Single(t => t.Key == tagName).Value);
+            Assert.Equal(expected, (T)tags[tagName]);
         }
     }
 

--- a/src/Middleware/RateLimiting/test/RateLimitingMetricsTests.cs
+++ b/src/Middleware/RateLimiting/test/RateLimitingMetricsTests.cs
@@ -35,11 +35,11 @@ public class RateLimitingMetricsTests
 
         var context = new DefaultHttpContext();
 
-        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request_lease.duration");
-        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.active_request_leases");
-        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.queued_requests");
-        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request.time_in_queue");
-        using var rateLimitingRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.requests");
+        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.request_lease.duration");
+        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.active_request_leases");
+        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.queued_requests");
+        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.request.time_in_queue");
+        using var rateLimitingRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.requests");
 
         // Act
         await middleware.Invoke(context).DefaultTimeout();
@@ -55,7 +55,7 @@ public class RateLimitingMetricsTests
             m =>
             {
                 Assert.Equal(1, m.Value);
-                Assert.Equal("global_limiter", (string)m.Tags["aspnet.rate_limiting.result"]);
+                Assert.Equal("global_limiter", (string)m.Tags["aspnetcore.rate_limiting.result"]);
             });
     }
 
@@ -82,11 +82,11 @@ public class RateLimitingMetricsTests
         var context = new DefaultHttpContext();
         context.Request.Method = "GET";
 
-        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request_lease.duration");
-        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.active_request_leases");
-        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.queued_requests");
-        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request.time_in_queue");
-        using var rateLimitingRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.requests");
+        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.request_lease.duration");
+        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.active_request_leases");
+        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.queued_requests");
+        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.request.time_in_queue");
+        using var rateLimitingRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.requests");
 
         // Act
         var middlewareTask = middleware.Invoke(context);
@@ -114,7 +114,7 @@ public class RateLimitingMetricsTests
         Assert.Collection(rateLimitingRequestsCollector.GetMeasurementSnapshot(),
             m =>
             {
-                Assert.Equal("acquired", (string)m.Tags["aspnet.rate_limiting.result"]);
+                Assert.Equal("acquired", (string)m.Tags["aspnetcore.rate_limiting.result"]);
             });
     }
 
@@ -146,11 +146,11 @@ public class RateLimitingMetricsTests
 
         await syncPoint.WaitForSyncPoint().DefaultTimeout();
 
-        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request_lease.duration");
-        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.active_request_leases");
-        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.queued_requests");
-        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request.time_in_queue");
-        using var rateLimitingRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.requests");
+        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.request_lease.duration");
+        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.active_request_leases");
+        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.queued_requests");
+        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.request.time_in_queue");
+        using var rateLimitingRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.requests");
 
         syncPoint.Continue();
 
@@ -197,11 +197,11 @@ public class RateLimitingMetricsTests
         routeEndpointBuilder.Metadata.Add(new EnableRateLimitingAttribute("concurrencyPolicy"));
         var endpoint = routeEndpointBuilder.Build();
 
-        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request_lease.duration");
-        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.active_request_leases");
-        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.queued_requests");
-        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request.time_in_queue");
-        using var rateLimitingRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.requests");
+        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.request_lease.duration");
+        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.active_request_leases");
+        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.queued_requests");
+        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.request.time_in_queue");
+        using var rateLimitingRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.requests");
 
         // Act
         var context1 = new DefaultHttpContext();
@@ -235,7 +235,7 @@ public class RateLimitingMetricsTests
             m =>
             {
                 AssertDuration(m, "concurrencyPolicy");
-                Assert.Equal("acquired", (string)m.Tags["aspnet.rate_limiting.result"]);
+                Assert.Equal("acquired", (string)m.Tags["aspnetcore.rate_limiting.result"]);
             });
     }
 
@@ -288,11 +288,11 @@ public class RateLimitingMetricsTests
 
         // Start listening while the second request is queued.
 
-        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request_lease.duration");
-        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.active_request_leases");
-        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.queued_requests");
-        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.request.time_in_queue");
-        using var rateLimitingRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnet.rate_limiting.requests");
+        using var leaseRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.request_lease.duration");
+        using var currentLeaseRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.active_request_leases");
+        using var currentRequestsQueuedCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.queued_requests");
+        using var queuedRequestDurationCollector = new MetricCollector<double>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.request.time_in_queue");
+        using var rateLimitingRequestsCollector = new MetricCollector<long>(meterFactory, RateLimitingMetrics.MeterName, "aspnetcore.rate_limiting.requests");
 
         Assert.Empty(currentRequestsQueuedCollector.GetMeasurementSnapshot());
         Assert.Empty(queuedRequestDurationCollector.GetMeasurementSnapshot());
@@ -311,13 +311,13 @@ public class RateLimitingMetricsTests
     private static void AssertCounter(CollectedMeasurement<long> measurement, long value, string policy)
     {
         Assert.Equal(value, measurement.Value);
-        AssertTag(measurement.Tags, "aspnet.rate_limiting.policy", policy);
+        AssertTag(measurement.Tags, "aspnetcore.rate_limiting.policy", policy);
     }
 
     private static void AssertDuration(CollectedMeasurement<double> measurement, string policy)
     {
         Assert.True(measurement.Value > 0);
-        AssertTag(measurement.Tags, "aspnet.rate_limiting.policy", policy);
+        AssertTag(measurement.Tags, "aspnetcore.rate_limiting.policy", policy);
     }
 
     private static void AssertTag<T>(IReadOnlyDictionary<string, object> tags, string tagName, T expected)


### PR DESCRIPTION
Applying changes from https://github.com/lmolkova/semantic-conventions/pull/1

@noahfalk @lmolkova