### PR TITLE
Rename SignalR transport metrics to be consistent with OpenTelemetry

### DIFF
--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionsMetrics.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionsMetrics.cs
@@ -31,12 +31,12 @@ internal sealed class HttpConnectionsMetrics : IDisposable
         _meter = meterFactory.Create(MeterName);
 
         _connectionDuration = _meter.CreateHistogram<double>(
-            "signalr_http_transport.server.connection.duration",
+            "signalr.server.connection.duration",
             unit: "s",
             description: "The duration of connections on the server.");
 
         _currentConnectionsCounter = _meter.CreateUpDownCounter<long>(
-            "signalr_http_transport.server.active_connections",
+            "signalr.server.active_connections",
             description: "Number of connections that are currently active on the server.");
     }
 
@@ -46,8 +46,8 @@ internal sealed class HttpConnectionsMetrics : IDisposable
         {
             var duration = Stopwatch.GetElapsedTime(startTimestamp, currentTimestamp);
             _connectionDuration.Record(duration.TotalSeconds,
-                new KeyValuePair<string, object?>("signalr_http_transport.connection.status", ResolveStopStatus(status)),
-                new KeyValuePair<string, object?>("signalr_http_transport.type", ResolveTransportType(transportType)));
+                new KeyValuePair<string, object?>("signalr.connection.status", ResolveStopStatus(status)),
+                new KeyValuePair<string, object?>("signalr.transport", ResolveTransportType(transportType)));
         }
     }
 
@@ -58,7 +58,7 @@ internal sealed class HttpConnectionsMetrics : IDisposable
         // Tags must match transport end.
         if (metricsContext.CurrentConnectionsCounterEnabled)
         {
-            _currentConnectionsCounter.Add(1, new KeyValuePair<string, object?>("signalr_http_transport.type", ResolveTransportType(transportType)));
+            _currentConnectionsCounter.Add(1, new KeyValuePair<string, object?>("signalr.transport", ResolveTransportType(transportType)));
         }
     }
 
@@ -70,7 +70,7 @@ internal sealed class HttpConnectionsMetrics : IDisposable
             // If the transport type is none then the transport was never started for this connection.
             if (transportType != HttpTransportType.None)
             {
-                _currentConnectionsCounter.Add(-1, new KeyValuePair<string, object?>("signalr_http_transport.type", ResolveTransportType(transportType)));
+                _currentConnectionsCounter.Add(-1, new KeyValuePair<string, object?>("signalr.transport", ResolveTransportType(transportType)));
             }
         }
     }

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionsMetrics.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionsMetrics.cs
@@ -37,6 +37,7 @@ internal sealed class HttpConnectionsMetrics : IDisposable
 
         _currentConnectionsCounter = _meter.CreateUpDownCounter<long>(
             "signalr.server.active_connections",
+            unit: "{connection}",
             description: "Number of connections that are currently active on the server.");
     }
 

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionsMetrics.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionsMetrics.cs
@@ -31,12 +31,12 @@ internal sealed class HttpConnectionsMetrics : IDisposable
         _meter = meterFactory.Create(MeterName);
 
         _connectionDuration = _meter.CreateHistogram<double>(
-            "signalr-http-transport-connection-duration",
+            "signalr_http_transport.server.connection.duration",
             unit: "s",
             description: "The duration of connections on the server.");
 
         _currentConnectionsCounter = _meter.CreateUpDownCounter<long>(
-            "signalr-http-transport-current-connections",
+            "signalr_http_transport.server.active_connections",
             description: "Number of connections that are currently active on the server.");
     }
 
@@ -46,8 +46,8 @@ internal sealed class HttpConnectionsMetrics : IDisposable
         {
             var duration = Stopwatch.GetElapsedTime(startTimestamp, currentTimestamp);
             _connectionDuration.Record(duration.TotalSeconds,
-                new KeyValuePair<string, object?>("status", status.ToString()),
-                new KeyValuePair<string, object?>("transport", transportType.ToString()));
+                new KeyValuePair<string, object?>("signalr_http_transport.connection.status", ResolveStopStatus(status)),
+                new KeyValuePair<string, object?>("signalr_http_transport.type", ResolveTransportType(transportType)));
         }
     }
 
@@ -58,7 +58,7 @@ internal sealed class HttpConnectionsMetrics : IDisposable
         // Tags must match transport end.
         if (metricsContext.CurrentConnectionsCounterEnabled)
         {
-            _currentConnectionsCounter.Add(1, new KeyValuePair<string, object?>("transport", transportType.ToString()));
+            _currentConnectionsCounter.Add(1, new KeyValuePair<string, object?>("signalr_http_transport.type", ResolveTransportType(transportType)));
         }
     }
 
@@ -70,9 +70,31 @@ internal sealed class HttpConnectionsMetrics : IDisposable
             // If the transport type is none then the transport was never started for this connection.
             if (transportType != HttpTransportType.None)
             {
-                _currentConnectionsCounter.Add(-1, new KeyValuePair<string, object?>("transport", transportType.ToString()));
+                _currentConnectionsCounter.Add(-1, new KeyValuePair<string, object?>("signalr_http_transport.type", ResolveTransportType(transportType)));
             }
         }
+    }
+
+    private static string ResolveTransportType(HttpTransportType transportType)
+    {
+        return transportType switch
+        {
+            HttpTransportType.ServerSentEvents => "server_sent_events",
+            HttpTransportType.LongPolling => "long_polling",
+            HttpTransportType.WebSockets => "web_sockets",
+            _ => throw new InvalidOperationException("Unexpected value: " + transportType)
+        };
+    }
+
+    private static string ResolveStopStatus(HttpConnectionStopStatus connectionStopStatus)
+    {
+        return connectionStopStatus switch
+        {
+            HttpConnectionStopStatus.NormalClosure => "normal_closure",
+            HttpConnectionStopStatus.Timeout => "timeout",
+            HttpConnectionStopStatus.AppShutdown => "app_shutdown",
+            _ => throw new InvalidOperationException("Unexpected value: " + connectionStopStatus)
+        };
     }
 
     public void Dispose()

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -1094,8 +1094,8 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         using (StartVerifiableLog())
         {
             var testMeterFactory = new TestMeterFactory();
-            using var connectionDuration = new MetricCollector<double>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr_http_transport.server.connection.duration");
-            using var currentConnections = new MetricCollector<long>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr_http_transport.server.active_connections");
+            using var connectionDuration = new MetricCollector<double>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr.server.connection.duration");
+            using var currentConnections = new MetricCollector<long>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr.server.active_connections");
 
             var metrics = new HttpConnectionsMetrics(testMeterFactory);
             var manager = CreateConnectionManager(LoggerFactory, metrics);
@@ -1150,8 +1150,8 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             await dispatcher.ExecuteAsync(context, new HttpConnectionDispatcherOptions(), app);
             Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
 
-            using var connectionDuration = new MetricCollector<double>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr_http_transport.server.connection.duration");
-            using var currentConnections = new MetricCollector<long>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr_http_transport.server.active_connections");
+            using var connectionDuration = new MetricCollector<double>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr.server.connection.duration");
+            using var currentConnections = new MetricCollector<long>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr.server.active_connections");
 
             await dispatcher.ExecuteAsync(context, new HttpConnectionDispatcherOptions(), app);
 
@@ -1169,14 +1169,14 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
     private static void AssertTransport(CollectedMeasurement<long> measurement, long expected, string transportType)
     {
         Assert.Equal(expected, measurement.Value);
-        Assert.Equal(transportType.ToString(), (string)measurement.Tags["signalr_http_transport.type"]);
+        Assert.Equal(transportType.ToString(), (string)measurement.Tags["signalr.transport"]);
     }
 
     private static void AssertDuration(CollectedMeasurement<double> measurement, string status, string transportType)
     {
         Assert.True(measurement.Value > 0);
-        Assert.Equal(status.ToString(), (string)measurement.Tags["signalr_http_transport.connection.status"]);
-        Assert.Equal(transportType.ToString(), (string)measurement.Tags["signalr_http_transport.type"]);
+        Assert.Equal(status.ToString(), (string)measurement.Tags["signalr.connection.status"]);
+        Assert.Equal(transportType.ToString(), (string)measurement.Tags["signalr.transport"]);
     }
 
     [Fact]

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -1094,8 +1094,8 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         using (StartVerifiableLog())
         {
             var testMeterFactory = new TestMeterFactory();
-            using var connectionDuration = new MetricCollector<double>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr-http-transport-connection-duration");
-            using var currentConnections = new MetricCollector<long>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr-http-transport-current-connections");
+            using var connectionDuration = new MetricCollector<double>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr_http_transport.server.connection.duration");
+            using var currentConnections = new MetricCollector<long>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr_http_transport.server.active_connections");
 
             var metrics = new HttpConnectionsMetrics(testMeterFactory);
             var manager = CreateConnectionManager(LoggerFactory, metrics);
@@ -1122,8 +1122,8 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             var exists = manager.TryGetConnection(connection.ConnectionId, out _);
             Assert.False(exists);
 
-            Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m => AssertDuration(m, HttpConnectionStopStatus.NormalClosure, HttpTransportType.LongPolling));
-            Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertTransport(m, 1, HttpTransportType.LongPolling), m => AssertTransport(m, -1, HttpTransportType.LongPolling));
+            Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m => AssertDuration(m, "normal_closure", "long_polling"));
+            Assert.Collection(currentConnections.GetMeasurementSnapshot(), m => AssertTransport(m, 1, "long_polling"), m => AssertTransport(m, -1, "long_polling"));
         }
     }
 
@@ -1150,8 +1150,8 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             await dispatcher.ExecuteAsync(context, new HttpConnectionDispatcherOptions(), app);
             Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
 
-            using var connectionDuration = new MetricCollector<double>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr-http-transport-connection-duration");
-            using var currentConnections = new MetricCollector<long>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr-http-transport-current-connections");
+            using var connectionDuration = new MetricCollector<double>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr_http_transport.server.connection.duration");
+            using var currentConnections = new MetricCollector<long>(testMeterFactory, HttpConnectionsMetrics.MeterName, "signalr_http_transport.server.active_connections");
 
             await dispatcher.ExecuteAsync(context, new HttpConnectionDispatcherOptions(), app);
 
@@ -1166,17 +1166,17 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         }
     }
 
-    private static void AssertTransport(CollectedMeasurement<long> measurement, long expected, HttpTransportType transportType)
+    private static void AssertTransport(CollectedMeasurement<long> measurement, long expected, string transportType)
     {
         Assert.Equal(expected, measurement.Value);
-        Assert.Equal(transportType.ToString(), (string)measurement.Tags["transport"]);
+        Assert.Equal(transportType.ToString(), (string)measurement.Tags["signalr_http_transport.type"]);
     }
 
-    private static void AssertDuration(CollectedMeasurement<double> measurement, HttpConnectionStopStatus status, HttpTransportType transportType)
+    private static void AssertDuration(CollectedMeasurement<double> measurement, string status, string transportType)
     {
         Assert.True(measurement.Value > 0);
-        Assert.Equal(status.ToString(), (string)measurement.Tags["status"]);
-        Assert.Equal(transportType.ToString(), (string)measurement.Tags["transport"]);
+        Assert.Equal(status.ToString(), (string)measurement.Tags["signalr_http_transport.connection.status"]);
+        Assert.Equal(transportType.ToString(), (string)measurement.Tags["signalr_http_transport.type"]);
     }
 
     [Fact]


### PR DESCRIPTION
Applying changes from https://github.com/lmolkova/semantic-conventions/pull/1

@noahfalk @lmolkova