### PR TITLE
Fix IIS test build

### DIFF
--- a/src/Servers/IIS/build/testsite.props
+++ b/src/Servers/IIS/build/testsite.props
@@ -74,6 +74,6 @@
           Condition=" '$(InProcessTestSite)' == 'true' AND '$(UseIisNativeAssets)' == 'true' AND '$(TargetFrameworkIdentifier)' != '.NETFramework'"
           BeforeTargets="Publish"
           DependsOnTargets="GeneratePublishDependencyFile;CopyFilesToPublishDirectory;PrepareInjectionApp">
-    <Exec Command="$(InjectDepsApp) &quot;$(PublishDepsFilePath)&quot; $(RuntimeIdentifier) " />
+    <Exec Command="$(InjectDepsApp) &quot;$(PublishDir)$(ProjectDepsFileName)&quot; $(RuntimeIdentifier) " />
   </Target>
 </Project>

--- a/src/Servers/IIS/build/testsite.props
+++ b/src/Servers/IIS/build/testsite.props
@@ -74,6 +74,9 @@
           Condition=" '$(InProcessTestSite)' == 'true' AND '$(UseIisNativeAssets)' == 'true' AND '$(TargetFrameworkIdentifier)' != '.NETFramework'"
           BeforeTargets="Publish"
           DependsOnTargets="GeneratePublishDependencyFile;CopyFilesToPublishDirectory;PrepareInjectionApp">
+    <!-- Use $(PublishDir)$(ProjectDepsFileName) instead of $(PublishDepsFilePath) here until
+         https://github.com/dotnet/arcade/issues/13911 is fixed.
+    -->
     <Exec Command="$(InjectDepsApp) &quot;$(PublishDir)$(ProjectDepsFileName)&quot; $(RuntimeIdentifier) " />
   </Target>
 </Project>

--- a/src/Servers/IIS/build/testsite.props
+++ b/src/Servers/IIS/build/testsite.props
@@ -75,7 +75,8 @@
           BeforeTargets="Publish"
           DependsOnTargets="GeneratePublishDependencyFile;CopyFilesToPublishDirectory;PrepareInjectionApp">
     <!-- Use $(PublishDir)$(ProjectDepsFileName) instead of $(PublishDepsFilePath) here until
-         https://github.com/dotnet/arcade/issues/13911 is fixed.
+         https://github.com/dotnet/arcade/issues/13911 is fixed. This should be equivalent based on
+         https://github.com/dotnet/sdk/blob/b736f2e955a9167eda86cae79208a89a9e42bfe0/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets#L1059
     -->
     <Exec Command="$(InjectDepsApp) &quot;$(PublishDir)$(ProjectDepsFileName)&quot; $(RuntimeIdentifier) " />
   </Target>


### PR DESCRIPTION
A recent Arcade update broke local IIS builds. See https://github.com/dotnet/arcade/issues/13911 for more info.

While that's figured out, this change unblocks the build by just decomposing the missing property into the [parts that make it up](https://github.com/dotnet/sdk/blob/b736f2e955a9167eda86cae79208a89a9e42bfe0/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets#L1059).