### PR TITLE
Update template.json

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "author": "Microsoft",
   "classifications": [
     "Web",
-    "WebAPI"
+    "Web API"
   ],
   "name": "ASP.NET Core Web API",
   "generatorVersions": "[1.0.0.0-*)",


### PR DESCRIPTION
Fix WebAPI to Web API for consistency

Change tag `WebAPI` to `Web API` so that Web API is not duplicated in the new project dialog.

Fixes #49812 
