### PR TITLE
Don't pack Microsoft.Aspnetcore.Testing

### DIFF
--- a/src/Testing/src/Microsoft.AspNetCore.Testing.csproj
+++ b/src/Testing/src/Microsoft.AspNetCore.Testing.csproj
@@ -8,7 +8,6 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>
-    <IsPackable>true</IsPackable>
     <GenerateFrameworkReferenceAssembly>true</GenerateFrameworkReferenceAssembly>
     <!-- This package is internal, so we don't generate a package baseline. Always build against the latest dependencies. -->
     <UseLatestPackageReferences>true</UseLatestPackageReferences>

--- a/src/Testing/src/Microsoft.AspNetCore.Testing.csproj
+++ b/src/Testing/src/Microsoft.AspNetCore.Testing.csproj
@@ -8,6 +8,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>
+    <IsPackable>false</IsPackable>
     <GenerateFrameworkReferenceAssembly>true</GenerateFrameworkReferenceAssembly>
     <!-- This package is internal, so we don't generate a package baseline. Always build against the latest dependencies. -->
     <UseLatestPackageReferences>true</UseLatestPackageReferences>


### PR DESCRIPTION
This is an internal-only test library that nobody but us uses - it was a package for historical reasons (used to be built by dotnet/extensions & used by aspnetcore)