### PR TITLE
Support view buffer-based rendering in Blazor

### DIFF
--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -125,7 +125,6 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
         // response asynchronously. In the absence of this line, the buffer gets synchronously written to the
         // response as part of the Dispose which has a perf impact.
         await bufferWriter.FlushAsync();
-        await writer.FlushAsync();
     }
 
     private async Task<RequestValidationState> ValidateRequestAsync(HttpContext context, IAntiforgery? antiforgery)

--- a/src/Components/Endpoints/src/Rendering/ViewBufferTextWriter/MemoryPoolViewBuffer.cs
+++ b/src/Components/Endpoints/src/Rendering/ViewBufferTextWriter/MemoryPoolViewBuffer.cs
@@ -1,0 +1,386 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+/*
+ * The implementation here matches the one present at https://github.com/dotnet/aspnetcore/blob/9427854d4f10f62a5f7f89988ea367b278ea1703/src/Mvc/Mvc.ViewFeatures/src/Buffers/ViewBuffer.cs but avoids a dependency on the `IViewBufferScope` interface.
+ */
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Microsoft.AspNetCore.Components.Endpoints;
+
+/// <summary>
+/// An <see cref="IHtmlContentBuilder"/> that is backed by a buffer provided by <see cref="MemoryPoolViewBufferScope"/>.
+/// </summary>
+[DebuggerDisplay("{DebuggerToString()}")]
+internal sealed class MemoryPoolViewBuffer : IHtmlContentBuilder
+{
+    public const int PartialViewPageSize = 32;
+    public const int TagHelperPageSize = 32;
+    public const int ViewComponentPageSize = 32;
+    public const int ViewPageSize = 256;
+
+    private readonly MemoryPoolViewBufferScope _bufferScope;
+    private readonly string _name;
+    private readonly int _pageSize;
+    private ViewBufferPage? _currentPage;         // Limits allocation if the MemoryPoolViewBuffer has only one page (frequent case).
+    private List<ViewBufferPage>? _multiplePages; // Allocated only if necessary
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="MemoryPoolViewBuffer"/>.
+    /// </summary>
+    /// <param name="bufferScope">The <see cref="MemoryPoolViewBufferScope"/>.</param>
+    /// <param name="name">A name to identify this instance.</param>
+    /// <param name="pageSize">The size of buffer pages.</param>
+    public MemoryPoolViewBuffer(MemoryPoolViewBufferScope bufferScope, string name, int pageSize)
+    {
+        ArgumentNullException.ThrowIfNull(bufferScope);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pageSize);
+
+        _bufferScope = bufferScope;
+        _name = name;
+        _pageSize = pageSize;
+    }
+
+    /// <summary>
+    /// Get the <see cref="ViewBufferPage"/> count.
+    /// </summary>
+    public int Count
+    {
+        get
+        {
+            if (_multiplePages != null)
+            {
+                return _multiplePages.Count;
+            }
+            if (_currentPage != null)
+            {
+                return 1;
+            }
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// Gets a <see cref="ViewBufferPage"/>.
+    /// </summary>
+    public ViewBufferPage this[int index]
+    {
+        get
+        {
+            if (_multiplePages != null)
+            {
+                return _multiplePages[index];
+            }
+            if (index == 0 && _currentPage != null)
+            {
+                return _currentPage;
+            }
+            throw new ArgumentOutOfRangeException(nameof(index));
+        }
+    }
+
+    /// <inheritdoc />
+    // Very common trivial method; nudge it to inline https://github.com/aspnet/Mvc/pull/8339
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public IHtmlContentBuilder Append(string? unencoded)
+    {
+        if (unencoded != null)
+        {
+            // Text that needs encoding is the uncommon case in views, which is why it
+            // creates a wrapper and pre-encoded text does not.
+            AppendValue(new ViewBufferValue(new EncodingWrapper(unencoded)));
+        }
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    // Very common trivial method; nudge it to inline https://github.com/aspnet/Mvc/pull/8339
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public IHtmlContentBuilder AppendHtml(IHtmlContent? content)
+    {
+        if (content != null)
+        {
+            AppendValue(new ViewBufferValue(content));
+        }
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    // Very common trivial method; nudge it to inline https://github.com/aspnet/Mvc/pull/8339
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public IHtmlContentBuilder AppendHtml(string? encoded)
+    {
+        if (encoded != null)
+        {
+            AppendValue(new ViewBufferValue(encoded));
+        }
+
+        return this;
+    }
+
+    // Very common trivial method; nudge it to inline https://github.com/aspnet/Mvc/pull/8339
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void AppendValue(ViewBufferValue value)
+    {
+        var page = GetCurrentPage();
+        page?.Append(value);
+    }
+
+    // Very common trivial method; nudge it to inline https://github.com/aspnet/Mvc/pull/8339
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ViewBufferPage? GetCurrentPage()
+    {
+        var currentPage = _currentPage;
+        if (currentPage == null || currentPage.IsFull)
+        {
+            // Uncommon slow-path
+            return AppendNewPage();
+        }
+
+        return currentPage;
+    }
+
+    // Slow path for above, don't inline
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private ViewBufferPage? AppendNewPage()
+    {
+        AddPage(new ViewBufferPage(_bufferScope.GetPage(_pageSize)));
+        return _currentPage;
+    }
+
+    private void AddPage(ViewBufferPage page)
+    {
+        if (_multiplePages != null)
+        {
+            _multiplePages.Add(page);
+        }
+        else if (_currentPage != null)
+        {
+            _multiplePages = new List<ViewBufferPage>(2);
+            _multiplePages.Add(_currentPage);
+            _multiplePages.Add(page);
+        }
+
+        _currentPage = page;
+    }
+
+    /// <inheritdoc />
+    public IHtmlContentBuilder Clear()
+    {
+        _multiplePages = null;
+        _currentPage = null;
+        return this;
+    }
+
+    /// <inheritdoc />
+    public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(encoder);
+
+        for (var i = 0; i < Count; i++)
+        {
+            var page = this[i];
+            for (var j = 0; j < page.Count; j++)
+            {
+                var value = page.Buffer[j];
+
+                if (value.Value is string valueAsString)
+                {
+                    writer.Write(valueAsString);
+                    continue;
+                }
+
+                if (value.Value is IHtmlContent valueAsHtmlContent)
+                {
+                    valueAsHtmlContent.WriteTo(writer, encoder);
+                    continue;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Writes the buffered content to <paramref name="writer"/>.
+    /// </summary>
+    /// <param name="writer">The <see cref="TextWriter"/>.</param>
+    /// <param name="encoder">The <see cref="HtmlEncoder"/>.</param>
+    /// <returns>A <see cref="Task"/> which will complete once content has been written.</returns>
+    public async Task WriteToAsync(TextWriter writer, HtmlEncoder encoder)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(encoder);
+
+        for (var i = 0; i < Count; i++)
+        {
+            var page = this[i];
+            for (var j = 0; j < page.Count; j++)
+            {
+                var value = page.Buffer[j];
+
+                if (value.Value is string valueAsString)
+                {
+                    await writer.WriteAsync(valueAsString);
+                    continue;
+                }
+
+                if (value.Value is MemoryPoolViewBuffer valueAsViewBuffer)
+                {
+                    await valueAsViewBuffer.WriteToAsync(writer, encoder);
+                    continue;
+                }
+
+                if (value.Value is IHtmlAsyncContent valueAsHtmlAsyncContent)
+                {
+                    await valueAsHtmlAsyncContent.WriteToAsync(writer);
+                    await writer.FlushAsync();
+                    continue;
+                }
+
+                if (value.Value is IHtmlContent valueAsHtmlContent)
+                {
+                    valueAsHtmlContent.WriteTo(writer, encoder);
+                    await writer.FlushAsync();
+                    continue;
+                }
+            }
+        }
+    }
+
+    private string DebuggerToString() => _name;
+
+    public void CopyTo(IHtmlContentBuilder destination)
+    {
+        ArgumentNullException.ThrowIfNull(destination);
+
+        for (var i = 0; i < Count; i++)
+        {
+            var page = this[i];
+            for (var j = 0; j < page.Count; j++)
+            {
+                var value = page.Buffer[j];
+
+                string? valueAsString;
+                IHtmlContentContainer valueAsContainer;
+                if ((valueAsString = (string?)value.Value) != null)
+                {
+                    destination.AppendHtml(valueAsString);
+                }
+                else if ((valueAsContainer = (IHtmlContentContainer)value.Value) != null)
+                {
+                    valueAsContainer.CopyTo(destination);
+                }
+                else
+                {
+                    destination.AppendHtml((IHtmlContent)value.Value);
+                }
+            }
+        }
+    }
+
+    public void MoveTo(IHtmlContentBuilder destination)
+    {
+        ArgumentNullException.ThrowIfNull(destination);
+
+        // Perf: We have an efficient implementation when the destination is another view buffer,
+        // we can just insert our pages as-is.
+        if (destination is MemoryPoolViewBuffer other)
+        {
+            MoveTo(other);
+            return;
+        }
+
+        for (var i = 0; i < Count; i++)
+        {
+            var page = this[i];
+            for (var j = 0; j < page.Count; j++)
+            {
+                var value = page.Buffer[j];
+
+                string? valueAsString;
+                IHtmlContentContainer valueAsContainer;
+                if ((valueAsString = (string?)value.Value) != null)
+                {
+                    destination.AppendHtml(valueAsString);
+                }
+                else if ((valueAsContainer = (IHtmlContentContainer)value.Value) != null)
+                {
+                    valueAsContainer.MoveTo(destination!);
+                }
+                else
+                {
+                    destination.AppendHtml((IHtmlContent)value.Value);
+                }
+            }
+        }
+
+        for (var i = 0; i < Count; i++)
+        {
+            var page = this[i];
+            Array.Clear(page.Buffer, 0, page.Count);
+            _bufferScope.ReturnSegment(page.Buffer);
+        }
+
+        Clear();
+    }
+
+    private void MoveTo(MemoryPoolViewBuffer destination)
+    {
+        for (var i = 0; i < Count; i++)
+        {
+            var page = this[i];
+
+            var destinationPage = destination.Count == 0 ? null : destination[destination.Count - 1];
+
+            // If the source page is less or equal to than half full, let's copy it's content to the destination
+            // page if possible.
+            var isLessThanHalfFull = 2 * page.Count <= page.Capacity;
+            if (isLessThanHalfFull &&
+                destinationPage != null &&
+                destinationPage.Capacity - destinationPage.Count >= page.Count)
+            {
+                // We have room, let's copy the items.
+                Array.Copy(
+                    sourceArray: page.Buffer,
+                    sourceIndex: 0,
+                    destinationArray: destinationPage.Buffer,
+                    destinationIndex: destinationPage.Count,
+                    length: page.Count);
+
+                destinationPage.Count += page.Count;
+
+                // Now we can return the source page, and it can be reused in the scope of this request.
+                Array.Clear(page.Buffer, 0, page.Count);
+                _bufferScope.ReturnSegment(page.Buffer);
+            }
+            else
+            {
+                // Otherwise, let's just add the source page to the other buffer.
+                destination.AddPage(page);
+            }
+        }
+
+        Clear();
+    }
+
+    private sealed class EncodingWrapper : IHtmlContent
+    {
+        private readonly string _unencoded;
+
+        public EncodingWrapper(string unencoded)
+        {
+            _unencoded = unencoded;
+        }
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+        {
+            encoder.Encode(writer, _unencoded);
+        }
+    }
+}

--- a/src/Components/Endpoints/src/Rendering/ViewBufferTextWriter/MemoryPoolViewBufferScope.cs
+++ b/src/Components/Endpoints/src/Rendering/ViewBufferTextWriter/MemoryPoolViewBufferScope.cs
@@ -1,0 +1,105 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+/*
+ * The implementation here matches the one present at https://github.com/dotnet/aspnetcore/blob/88180f6f487a1222b3af8c111aa6b5f8aa278633/src/Mvc/Mvc.ViewFeatures/src/Buffers/MemoryPoolViewBufferScope.cs
+ * but avoids taking a depending on the IViewBufferScope interface to avoid circular dependencies between Mvc.Razor and Components.Endpoints.
+ */
+
+using System.Buffers;
+
+namespace Microsoft.AspNetCore.Components.Endpoints;
+
+/// <summary>
+/// A <see cref="MemoryPoolViewBufferScope"/> that uses pooled memory.
+/// </summary>
+internal sealed class MemoryPoolViewBufferScope : IDisposable
+{
+    public const int MinimumSize = 16;
+    private readonly ArrayPool<ViewBufferValue> _viewBufferPool;
+    private List<ViewBufferValue[]>? _available;
+    private List<ViewBufferValue[]>? _leased;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="MemoryPoolViewBufferScope"/>.
+    /// </summary>
+    /// <param name="viewBufferPool">
+    /// The <see cref="ArrayPool{ViewBufferValue}"/> for creating <see cref="ViewBufferValue"/> instances.
+    /// </param>
+    public MemoryPoolViewBufferScope(ArrayPool<ViewBufferValue> viewBufferPool)
+    {
+        _viewBufferPool = viewBufferPool;
+    }
+
+    /// <inheritdoc />
+    public ViewBufferValue[] GetPage(int pageSize)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pageSize);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (_leased == null)
+        {
+            _leased = new List<ViewBufferValue[]>(1);
+        }
+
+        ViewBufferValue[]? segment = null;
+
+        // Reuse pages that have been returned before going back to the memory pool.
+        if (_available != null && _available.Count > 0)
+        {
+            segment = _available[_available.Count - 1];
+            _available.RemoveAt(_available.Count - 1);
+            return segment;
+        }
+
+        try
+        {
+            segment = _viewBufferPool.Rent(Math.Max(pageSize, MinimumSize));
+            _leased.Add(segment);
+        }
+        catch when (segment != null)
+        {
+            _viewBufferPool.Return(segment);
+            throw;
+        }
+
+        return segment;
+    }
+
+    /// <inheritdoc />
+    public void ReturnSegment(ViewBufferValue[] segment)
+    {
+        ArgumentNullException.ThrowIfNull(segment);
+
+        Array.Clear(segment, 0, segment.Length);
+
+        if (_available == null)
+        {
+            _available = new List<ViewBufferValue[]>();
+        }
+
+        _available.Add(segment);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            _disposed = true;
+
+            if (_leased == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < _leased.Count; i++)
+            {
+                _viewBufferPool.Return(_leased[i], clearArray: true);
+            }
+
+            _leased.Clear();
+        }
+    }
+}

--- a/src/Components/Endpoints/src/Rendering/ViewBufferTextWriter/ViewBufferPage.cs
+++ b/src/Components/Endpoints/src/Rendering/ViewBufferTextWriter/ViewBufferPage.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Components.Endpoints;
+
+internal sealed class ViewBufferPage
+{
+    public ViewBufferPage(ViewBufferValue[] buffer)
+    {
+        Buffer = buffer;
+    }
+
+    public ViewBufferValue[] Buffer { get; }
+
+    public int Capacity => Buffer.Length;
+
+    public int Count { get; set; }
+
+    public bool IsFull => Count == Capacity;
+
+    // Very common trivial method; nudge it to inline https://github.com/aspnet/Mvc/pull/8339
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Append(ViewBufferValue value) => Buffer[Count++] = value;
+}

--- a/src/Components/Endpoints/src/Rendering/ViewBufferTextWriter/ViewBufferTextWriter.cs
+++ b/src/Components/Endpoints/src/Rendering/ViewBufferTextWriter/ViewBufferTextWriter.cs
@@ -1,0 +1,292 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+/*
+ * The implementation here matches the one present at https://github.com/dotnet/aspnetcore/blob/88180f6f487a1222b3af8c111aa6b5f8aa278633/src/Mvc/Mvc.ViewFeatures/src/Buffers/ViewBufferTextWriter.cs
+ * with the distinction that it implements a constructor that takes a concrete `MemoryPoolViewBuffer` type instead of
+ * the `ViewBuffer` abstract type. Source is copied here instead of shared to avoid circular dependency issues
+ * between Mvc.Razor and Components.Endpoints.
+ */
+
+using System.Text;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Microsoft.AspNetCore.Components.Endpoints;
+
+/// <summary>
+/// <para>
+/// A <see cref="TextWriter"/> that is backed by a unbuffered writer (over the Response stream) and/or a
+/// <see cref="MemoryPoolViewBuffer"/>
+/// </para>
+/// <para>
+/// When <c>Flush</c> or <c>FlushAsync</c> is invoked, the writer copies all content from the buffer to
+/// the writer and switches to writing to the unbuffered writer for all further write operations.
+/// </para>
+/// </summary>
+internal sealed class ViewBufferTextWriter : TextWriter
+{
+    private readonly TextWriter? _inner;
+    private readonly HtmlEncoder? _htmlEncoder;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="ViewBufferTextWriter"/>.
+    /// </summary>
+    /// <param name="buffer">The <see cref="MemoryPoolViewBuffer"/> for buffered output.</param>
+    /// <param name="encoding">The <see cref="System.Text.Encoding"/>.</param>
+    public ViewBufferTextWriter(MemoryPoolViewBuffer buffer, Encoding encoding)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        ArgumentNullException.ThrowIfNull(encoding);
+
+        Buffer = buffer;
+        Encoding = encoding;
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="ViewBufferTextWriter"/>.
+    /// </summary>
+    /// <param name="buffer">The <see cref="MemoryPoolViewBuffer"/> for buffered output.</param>
+    /// <param name="encoding">The <see cref="System.Text.Encoding"/>.</param>
+    /// <param name="htmlEncoder">The HTML encoder.</param>
+    /// <param name="inner">
+    /// The inner <see cref="TextWriter"/> to write output to when this instance is no longer buffering.
+    /// </param>
+    public ViewBufferTextWriter(MemoryPoolViewBuffer buffer, Encoding encoding, HtmlEncoder htmlEncoder, TextWriter inner)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        ArgumentNullException.ThrowIfNull(encoding);
+        ArgumentNullException.ThrowIfNull(htmlEncoder);
+        ArgumentNullException.ThrowIfNull(inner);
+
+        Buffer = buffer;
+        Encoding = encoding;
+        _htmlEncoder = htmlEncoder;
+        _inner = inner;
+    }
+
+    /// <inheritdoc />
+    public override Encoding Encoding { get; }
+
+    /// <summary>
+    /// Gets the <see cref="MemoryPoolViewBuffer"/>.
+    /// </summary>
+    public MemoryPoolViewBuffer Buffer { get; }
+
+    /// <summary>
+    /// Gets a value that indicates if <see cref="Flush"/> or <see cref="FlushAsync" /> was invoked.
+    /// </summary>
+    public bool Flushed { get; private set; }
+
+    /// <inheritdoc />
+    public override void Write(char value)
+    {
+        Buffer.AppendHtml(value.ToString());
+    }
+
+    /// <inheritdoc />
+    public override void Write(char[] buffer, int index, int count)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(count, buffer.Length - index);
+
+        Buffer.AppendHtml(new string(buffer, index, count));
+    }
+
+    /// <inheritdoc />
+    public override void Write(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return;
+        }
+
+        Buffer.AppendHtml(value);
+    }
+
+    /// <inheritdoc />
+    public override void Write(object? value)
+    {
+        if (value == null)
+        {
+            return;
+        }
+
+        if (value is IHtmlContentContainer container)
+        {
+            Write(container);
+        }
+        else if (value is IHtmlContent htmlContent)
+        {
+            Write(htmlContent);
+        }
+        else
+        {
+            Write(value.ToString());
+        }
+    }
+
+    /// <summary>
+    /// Writes an <see cref="IHtmlContent"/> value.
+    /// </summary>
+    /// <param name="value">The <see cref="IHtmlContent"/> value.</param>
+    public void Write(IHtmlContent? value)
+    {
+        if (value == null)
+        {
+            return;
+        }
+
+        Buffer.AppendHtml(value);
+    }
+
+    /// <summary>
+    /// Writes an <see cref="IHtmlContentContainer"/> value.
+    /// </summary>
+    /// <param name="value">The <see cref="IHtmlContentContainer"/> value.</param>
+    public void Write(IHtmlContentContainer? value)
+    {
+        if (value == null)
+        {
+            return;
+        }
+
+        value.MoveTo(Buffer);
+    }
+
+    /// <inheritdoc />
+    public override void WriteLine(object? value)
+    {
+        if (value == null)
+        {
+            return;
+        }
+
+        if (value is IHtmlContentContainer container)
+        {
+            Write(container);
+            Write(NewLine);
+        }
+        else if (value is IHtmlContent htmlContent)
+        {
+            Write(htmlContent);
+            Write(NewLine);
+        }
+        else
+        {
+            Write(value.ToString());
+            Write(NewLine);
+        }
+    }
+
+    /// <inheritdoc />
+    public override Task WriteAsync(char value)
+    {
+        Buffer.AppendHtml(value.ToString());
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public override Task WriteAsync(char[] buffer, int index, int count)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        if (count < 0 || (buffer.Length - index < count))
+        {
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
+
+        Buffer.AppendHtml(new string(buffer, index, count));
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public override Task WriteAsync(string? value)
+    {
+        Buffer.AppendHtml(value);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public override void WriteLine()
+    {
+        Buffer.AppendHtml(NewLine);
+    }
+
+    /// <inheritdoc />
+    public override void WriteLine(string? value)
+    {
+        Buffer.AppendHtml(value);
+        Buffer.AppendHtml(NewLine);
+    }
+
+    /// <inheritdoc />
+    public override Task WriteLineAsync(char value)
+    {
+        Buffer.AppendHtml(value.ToString());
+        Buffer.AppendHtml(NewLine);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public override Task WriteLineAsync(char[] value, int start, int offset)
+    {
+        Buffer.AppendHtml(new string(value, start, offset));
+        Buffer.AppendHtml(NewLine);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public override Task WriteLineAsync(string? value)
+    {
+        Buffer.AppendHtml(value);
+        Buffer.AppendHtml(NewLine);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public override Task WriteLineAsync()
+    {
+        Buffer.AppendHtml(NewLine);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Copies the buffered content to the unbuffered writer and invokes flush on it.
+    /// </summary>
+    public override void Flush()
+    {
+        if (_inner == null || _inner is ViewBufferTextWriter)
+        {
+            return;
+        }
+
+        Flushed = true;
+
+        Buffer.WriteTo(_inner, _htmlEncoder ?? HtmlEncoder.Default);
+        Buffer.Clear();
+
+        _inner.Flush();
+    }
+
+    /// <summary>
+    /// Copies the buffered content to the unbuffered writer and invokes flush on it.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous copy and flush operations.</returns>
+    public override async Task FlushAsync()
+    {
+        if (_inner == null || _inner is ViewBufferTextWriter)
+        {
+            return;
+        }
+
+        Flushed = true;
+
+        await Buffer.WriteToAsync(_inner, _htmlEncoder ?? HtmlEncoder.Default);
+        Buffer.Clear();
+
+        await _inner.FlushAsync();
+    }
+}

--- a/src/Components/Endpoints/src/Rendering/ViewBufferTextWriter/ViewBufferValue.cs
+++ b/src/Components/Endpoints/src/Rendering/ViewBufferTextWriter/ViewBufferValue.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+/*
+ * The implementation here matches the one present at https://github.com/dotnet/aspnetcore/blob/88180f6f487a1222b3af8c111aa6b5f8aa278633/src/Mvc/Mvc.ViewFeatures/src/Buffers/ViewBufferValue.cs
+ * but implements a struct with internal accessibility to avoid introducing public API and circular dependencies
+ * between Mvc.Razor and Components.Endpoints.
+ */
+
+using System.Diagnostics;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+namespace Microsoft.AspNetCore.Components.Endpoints;
+
+/// <summary>
+/// Encapsulates a string or <see cref="IHtmlContent"/> value.
+/// </summary>
+[DebuggerDisplay("{DebuggerToString()}")]
+internal readonly struct ViewBufferValue
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="ViewBufferValue"/> with a <c>string</c> value.
+    /// </summary>
+    /// <param name="value">The value.</param>
+    public ViewBufferValue(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ViewBufferValue"/> with a <see cref="IHtmlContent"/> value.
+    /// </summary>
+    /// <param name="content">The <see cref="IHtmlContent"/>.</param>
+    public ViewBufferValue(IHtmlContent content)
+    {
+        Value = content;
+    }
+
+    /// <summary>
+    /// Gets the value.
+    /// </summary>
+    public object Value { get; }
+
+    private string DebuggerToString()
+    {
+        using (var writer = new StringWriter())
+        {
+            if (Value is string valueAsString)
+            {
+                writer.Write(valueAsString);
+                return writer.ToString();
+            }
+
+            if (Value is IHtmlContent valueAsContent)
+            {
+                valueAsContent.WriteTo(writer, HtmlEncoder.Default);
+                return writer.ToString();
+            }
+
+            return "(null)";
+        }
+    }
+}

--- a/src/Components/test/E2ETest/ServerRenderingTests/RenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/RenderingTest.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Components.TestServer.RazorComponents;
+using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
+using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
+using Microsoft.AspNetCore.E2ETesting;
+using OpenQA.Selenium;
+using TestServer;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Components.E2ETests.ServerRenderingTests;
+
+public class RenderingTest : ServerTestBase<BasicTestAppServerSiteFixture<RazorComponentEndpointsStartup<App>>>
+{
+    public RenderingTest(
+        BrowserFixture browserFixture,
+        BasicTestAppServerSiteFixture<RazorComponentEndpointsStartup<App>> serverFixture,
+        ITestOutputHelper output)
+        : base(browserFixture, serverFixture, output)
+    {
+    }
+
+    public override Task InitializeAsync()
+        => InitializeAsync(BrowserFixture.StreamingContext);
+
+    [Fact]
+    public void CanRenderLargeComponentsWithServerRenderMode()
+    {
+        Navigate($"{ServerPathBase}/large-html-server");
+        var result = new string('*', 50000);
+
+        Assert.Equal(result, Browser.FindElement(By.Id("webassembly-prerender")).Text);
+        Assert.Equal(result, Browser.FindElement(By.Id("server-prerender")).Text);
+        Assert.Equal(result, Browser.FindElement(By.Id("server-prerender")).Text);
+    }
+}

--- a/src/Components/test/E2ETest/ServerRenderingTests/StreamingRenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/StreamingRenderingTest.cs
@@ -35,22 +35,26 @@ public class StreamingRenderingTest : ServerTestBase<BasicTestAppServerSiteFixtu
     }
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public void CanPerformStreamingRendering(bool duringEnhancedNavigation)
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void CanPerformStreamingRendering(bool useLargeItems, bool duringEnhancedNavigation)
     {
         IWebElement originalH1Elem;
+        var linkText = useLargeItems ? "Large Streaming" : "Streaming";
+        var url = useLargeItems ? "large-streaming" : "streaming";
 
         if (duringEnhancedNavigation)
         {
             Navigate($"{ServerPathBase}/nav");
             originalH1Elem = Browser.Exists(By.TagName("h1"));
             Browser.Equal("Hello", () => originalH1Elem.Text);
-            Browser.Exists(By.TagName("nav")).FindElement(By.LinkText("Streaming")).Click();
+            Browser.Exists(By.TagName("nav")).FindElement(By.LinkText(linkText)).Click();
         }
         else
         {
-            Navigate($"{ServerPathBase}/streaming");
+            Navigate($"{ServerPathBase}/{url}");
             originalH1Elem = Browser.Exists(By.TagName("h1"));
         }
 
@@ -68,7 +72,9 @@ public class StreamingRenderingTest : ServerTestBase<BasicTestAppServerSiteFixtu
             Browser.FindElement(By.Id("add-item-link")).Click();
             Browser.Collection(getDisplayedItems, Enumerable.Range(1, i).Select<int, Action<IWebElement>>(index =>
             {
-                return actualItem => Assert.Equal($"Item {index}", actualItem.Text);
+                return useLargeItems
+                    ? actualItem => Assert.StartsWith($"Large Item {index}", actualItem.Text)
+                    : actualItem => Assert.Equal($"Item {index}", actualItem.Text);
             }).ToArray());
             Assert.Equal("Waiting for more...", getStatusText().Text);
 
@@ -82,22 +88,26 @@ public class StreamingRenderingTest : ServerTestBase<BasicTestAppServerSiteFixtu
     }
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public void RetainsDomNodesDuringStreamingRenderingUpdates(bool duringEnhancedNavigation)
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void RetainsDomNodesDuringStreamingRenderingUpdates(bool useLargeItems, bool duringEnhancedNavigation)
     {
         IWebElement originalH1Elem;
+        var linkText = useLargeItems ? "Large Streaming" : "Streaming";
+        var url = useLargeItems ? "streaming" : "large-streaming";
 
         if (duringEnhancedNavigation)
         {
             Navigate($"{ServerPathBase}/nav");
             originalH1Elem = Browser.Exists(By.TagName("h1"));
             Browser.Equal("Hello", () => originalH1Elem.Text);
-            Browser.Exists(By.TagName("nav")).FindElement(By.LinkText("Streaming")).Click();
+            Browser.Exists(By.TagName("nav")).FindElement(By.LinkText(linkText)).Click();
         }
         else
         {
-            Navigate($"{ServerPathBase}/streaming");
+            Navigate($"{ServerPathBase}/{url}");
             originalH1Elem = Browser.Exists(By.TagName("h1"));
         }
 

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Components/NotEnabledStreamingRenderingComponent.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Components/NotEnabledStreamingRenderingComponent.razor
@@ -2,7 +2,7 @@
 @using System.Threading.Channels;
 
 <p>
-    Every time you make a request to <a id="add-item-link" href="@AddItemUrl" target="_blank">add item</a>, we'll
+    Every time you make a request to <a id="add-item-link" href="@(UseLargeItems ? AddLargeItemUrl : AddItemUrl)" target="_blank">add item</a>, we'll
     add an item to this streaming response.
 </p>
 <p>
@@ -28,12 +28,16 @@
 </p>
 
 @code {
+    [Parameter]
+    public bool UseLargeItems { get; set; } = false;
+
     // Caution: Don't use statics like this in real apps. This is only for an E2E test. If you did this
     // in production, different users/requests could interfere with each other.
     static Channel<string> StreamingDataChannel;
     static int StreamingDataChannelCount;
 
     const string AddItemUrl = "streaming/add-item";
+    const string AddLargeItemUrl = "streaming/add-large-item";
     const string EndResponseUrl = "streaming/end-response";
 
     bool finished;
@@ -59,6 +63,11 @@
         {
             StreamingDataChannel.Writer.TryWrite($"Item {++StreamingDataChannelCount}");
             return "Added item";
+        });
+        endpoints.MapGet(AddLargeItemUrl, () =>
+        {
+            StreamingDataChannel.Writer.TryWrite( $"Large Item {++StreamingDataChannelCount} {new string('*', 5000)}");
+            return "Added large item";
         });
 
         endpoints.MapGet(EndResponseUrl, () =>

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Rendering/LargeComponent.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Rendering/LargeComponent.razor
@@ -1,0 +1,9 @@
+﻿<h3>Large Component</h3>
+
+<p id="@Id">@content</p>
+
+@code {
+    [Parameter]
+    public string Id { get; set; }
+    private string content = new string('*', 50000);
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Rendering/LargeHtml.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Rendering/LargeHtml.razor
@@ -1,0 +1,10 @@
+﻿@page "/large-html-server"
+
+<h1>WebAssembly with pre-rendering</h1>
+<LargeComponent Id="webassembly-prerender" @rendermode="@(new WebAssemblyRenderMode(true))" />
+
+<h1>Server with pre-rendering</h1>
+<LargeComponent Id="server-no-prerender" @rendermode="@(new ServerRenderMode(false))" />
+
+<h1>Server without pre-rendering</h1>
+<LargeComponent Id="server-prerender" @rendermode="@(new ServerRenderMode(true))" />

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/StreamingRendering/LargeStreamRendering.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/StreamingRendering/LargeStreamRendering.razor
@@ -1,0 +1,7 @@
+﻿@page "/large-streaming"
+
+@attribute [StreamRendering(true)]
+
+<h1>Streaming Rendering</h1>
+
+<NotEnabledStreamingRenderingComponent UseLargeItems="true"/>

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Shared/EnhancedNavLayout.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Shared/EnhancedNavLayout.razor
@@ -2,6 +2,7 @@
 <nav>
     <NavLink href="nav">Home</NavLink> |
     <NavLink href="streaming">Streaming</NavLink> |
+    <NavLink href="large-streaming">Large Streaming</NavLink> |
     <NavLink href="streaming-interactivity">Streaming with interactivity</NavLink> |
     <NavLink href="nav/give-404-with-content">Error page with 404 content</NavLink> |
     <NavLink href="nav/nonexistent-page">Error page with no content</NavLink> |


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/49172.

Support larger HTML payloads by buffering and writing to the underlying `HttpResponseStreamWriter`, following a strategy similar to ViewBuffers in MVC. To avoid having to introduce new public API in the endpoints library and to avoid circular dependency chains between `M.A.Mvc.Razor` and `M.A.Components.Endpoints`, I opt-ed to copysource the relevant files from `M.A.ViewFeatures.Buffers` and make a few targeted modifications (relying on internal concrete implementations instead of public interfaces in method/constructor signatures), to make the code sharing a bit more sensible. In the future, we may consider moving the buffering logic to `M.A.Html.Abstractions` so that it can be used in both APIs, although the fact that `M.A.Mvc.Razor` has a transitive dependency on `M.A.Componnents.Endpoints` here.