### PR TITLE
Improve debugger display in Microsoft.AspNetCore.Http

### DIFF
--- a/src/Http/Http.Abstractions/src/HttpResponse.cs
+++ b/src/Http/Http.Abstractions/src/HttpResponse.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Pipelines;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.AspNetCore.Http;
@@ -165,6 +166,14 @@ public abstract class HttpResponse
 
         public int StatusCode => _response.StatusCode;
         public IHeaderDictionary Headers => _response.Headers;
+        public IHeaderDictionary? Trailers
+        {
+            get
+            {
+                var feature = response.HttpContext.Features.Get<IHttpResponseTrailersFeature>();
+                return feature?.Trailers;
+            }
+        }
         public long? ContentLength => _response.ContentLength;
         public string? ContentType => _response.ContentType;
         public bool HasStarted => _response.HasStarted;

--- a/src/Http/Http.Abstractions/src/HttpResponse.cs
+++ b/src/Http/Http.Abstractions/src/HttpResponse.cs
@@ -170,7 +170,7 @@ public abstract class HttpResponse
         {
             get
             {
-                var feature = response.HttpContext.Features.Get<IHttpResponseTrailersFeature>();
+                var feature = _response.HttpContext.Features.Get<IHttpResponseTrailersFeature>();
                 return feature?.Trailers;
             }
         }

--- a/src/Http/Http/src/HeaderDictionary.cs
+++ b/src/Http/Http/src/HeaderDictionary.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Http;
 /// Represents a wrapper for RequestHeaders and ResponseHeaders.
 /// </summary>
 [DebuggerTypeProxy(typeof(HeaderDictionaryDebugView))]
-[DebuggerDisplay("Count = {Count}")]
+[DebuggerDisplay("{DebuggerToString(),nq}")]
 public class HeaderDictionary : IHeaderDictionary
 {
     private static readonly string[] EmptyKeys = Array.Empty<string>();
@@ -378,6 +378,16 @@ public class HeaderDictionary : IHeaderDictionary
     private static void ThrowKeyNotFoundException()
     {
         throw new KeyNotFoundException();
+    }
+
+    internal string DebuggerToString()
+    {
+        var debugText = $"Count = {Count}";
+        if (IsReadOnly)
+        {
+            debugText += ", IsReadOnly = true";
+        }
+        return debugText;
     }
 
     /// <summary>

--- a/src/Http/Http/test/DefaultHttpContextTests.cs
+++ b/src/Http/Http/test/DefaultHttpContextTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Http;
@@ -270,6 +271,54 @@ public class DefaultHttpContextTests
         context.Uninitialize();
 
         Assert.False(context._active);
+    }
+
+    [Fact]
+    public void DebuggerToString_EmptyRequest()
+    {
+        var context = new DefaultHttpContext();
+
+        var debugText = HttpContextDebugFormatter.ContextToString(context, reasonPhrase: null);
+        Assert.Equal("(unspecified) 200", debugText);
+    }
+
+    [Fact]
+    public void DebuggerToString_HasReason()
+    {
+        var context = new DefaultHttpContext();
+
+        var debugText = HttpContextDebugFormatter.ContextToString(context, reasonPhrase: "OK");
+        Assert.Equal("(unspecified) 200 OK", debugText);
+    }
+
+    [Fact]
+    public void DebuggerToString_HasMethod()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Method = "GET";
+
+        var debugText = HttpContextDebugFormatter.ContextToString(context, reasonPhrase: null);
+        Assert.Equal("GET (unspecified) 200", debugText);
+    }
+
+    [Fact]
+    public void DebuggerToString_HasProtocol()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Protocol = "HTTP/2";
+
+        var debugText = HttpContextDebugFormatter.ContextToString(context, reasonPhrase: null);
+        Assert.Equal("(unspecified) HTTP/2 200", debugText);
+    }
+
+    [Fact]
+    public void DebuggerToString_HasContentType()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.ContentType = "application/json";
+
+        var debugText = HttpContextDebugFormatter.ContextToString(context, reasonPhrase: null);
+        Assert.Equal("(unspecified) application/json 200", debugText);
     }
 
     void TestAllCachedFeaturesAreNull(HttpContext context, IFeatureCollection features)

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
@@ -14,7 +14,7 @@ using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
-[DebuggerDisplay("Count = {Count}")]
+[DebuggerDisplay("{DebuggerToString(),nq}")]
 [DebuggerTypeProxy(typeof(HttpHeadersDebugView))]
 internal abstract partial class HttpHeaders : IHeaderDictionary
 {
@@ -261,6 +261,16 @@ internal abstract partial class HttpHeaders : IHeaderDictionary
     bool IDictionary<string, StringValues>.TryGetValue(string key, out StringValues value)
     {
         return TryGetValueFast(key, out value);
+    }
+
+    internal string DebuggerToString()
+    {
+        var debugText = $"Count = {Count}";
+        if (_isReadOnly)
+        {
+            debugText += ", IsReadOnly = true";
+        }
+        return debugText;
     }
 
     public static void ValidateHeaderValueCharacters(string headerName, StringValues headerValues, Func<string, Encoding?> encodingSelector)

--- a/src/Shared/Debugger/HttpContextDebugFormatter.cs
+++ b/src/Shared/Debugger/HttpContextDebugFormatter.cs
@@ -49,7 +49,20 @@ internal static class HttpContextDebugFormatter
 
     public static string ContextToString(HttpContext context, string? reasonPhrase)
     {
-        var text = $"{context.Request.Method} {GetRequestUrl(context.Request, includeQueryString: false)} {context.Response.StatusCode}";
+        var text = GetRequestUrl(context.Request, includeQueryString: false);
+        if (!string.IsNullOrEmpty(context.Request.Method))
+        {
+            text = $"{context.Request.Method} {text}";
+        }
+        if (!string.IsNullOrEmpty(context.Request.Protocol))
+        {
+            text += $" {context.Request.Protocol}";
+        }
+        if (!string.IsNullOrEmpty(context.Request.ContentType))
+        {
+            text += $" {context.Request.ContentType}";
+        }
+        text += $" {context.Response.StatusCode}";
         var resolvedReasonPhrase = ResolveReasonPhrase(context.Response, reasonPhrase);
         if (!string.IsNullOrEmpty(resolvedReasonPhrase))
         {

--- a/src/Shared/Debugger/HttpContextDebugFormatter.cs
+++ b/src/Shared/Debugger/HttpContextDebugFormatter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 
@@ -11,17 +12,73 @@ internal static class HttpContextDebugFormatter
 {
     public static string ResponseToString(HttpResponse response, string? reasonPhrase)
     {
-        var text = response.StatusCode.ToString(CultureInfo.InvariantCulture);
+        var sb = new StringBuilder();
+        sb.Append(response.StatusCode);
         var resolvedReasonPhrase = ResolveReasonPhrase(response, reasonPhrase);
         if (!string.IsNullOrEmpty(resolvedReasonPhrase))
         {
-            text += $" {resolvedReasonPhrase}";
+            sb.Append(' ');
+            sb.Append(resolvedReasonPhrase);
         }
         if (!string.IsNullOrEmpty(response.ContentType))
         {
-            text += $" {response.ContentType}";
+            sb.Append(' ');
+            sb.Append(response.ContentType);
         }
-        return text;
+        return sb.ToString();
+    }
+
+    public static string RequestToString(HttpRequest request)
+    {
+        var sb = new StringBuilder();
+        if (!string.IsNullOrEmpty(request.Method))
+        {
+            sb.Append(request.Method);
+            sb.Append(' ');
+        }
+        GetRequestUrl(sb, request, includeQueryString: true);
+        if (!string.IsNullOrEmpty(request.Protocol))
+        {
+            sb.Append(' ');
+            sb.Append(request.Protocol);
+        }
+        if (!string.IsNullOrEmpty(request.ContentType))
+        {
+            sb.Append(' ');
+            sb.Append(request.ContentType);
+        }
+        return sb.ToString();
+    }
+
+    public static string ContextToString(HttpContext context, string? reasonPhrase)
+    {
+        var sb = new StringBuilder();
+        if (!string.IsNullOrEmpty(context.Request.Method))
+        {
+            sb.Append(context.Request.Method);
+            sb.Append(' ');
+        }
+        GetRequestUrl(sb, context.Request, includeQueryString: false);
+        if (!string.IsNullOrEmpty(context.Request.Protocol))
+        {
+            sb.Append(' ');
+            sb.Append(context.Request.Protocol);
+        }
+        if (!string.IsNullOrEmpty(context.Request.ContentType))
+        {
+            sb.Append(' ');
+            sb.Append(context.Request.ContentType);
+        }
+        sb.Append(' ');
+        sb.Append(context.Response.StatusCode);
+        var resolvedReasonPhrase = ResolveReasonPhrase(context.Response, reasonPhrase);
+        if (!string.IsNullOrEmpty(resolvedReasonPhrase))
+        {
+            sb.Append(' ');
+            sb.Append(resolvedReasonPhrase);
+        }
+
+        return sb.ToString();
     }
 
     private static string? ResolveReasonPhrase(HttpResponse response, string? reasonPhrase)
@@ -29,50 +86,7 @@ internal static class HttpContextDebugFormatter
         return response.HttpContext.Features.Get<IHttpResponseFeature>()?.ReasonPhrase ?? reasonPhrase;
     }
 
-    public static string RequestToString(HttpRequest request)
-    {
-        var text = GetRequestUrl(request, includeQueryString: true);
-        if (!string.IsNullOrEmpty(request.Method))
-        {
-            text = $"{request.Method} {text}";
-        }
-        if (!string.IsNullOrEmpty(request.Protocol))
-        {
-            text += $" {request.Protocol}";
-        }
-        if (!string.IsNullOrEmpty(request.ContentType))
-        {
-            text += $" {request.ContentType}";
-        }
-        return text;
-    }
-
-    public static string ContextToString(HttpContext context, string? reasonPhrase)
-    {
-        var text = GetRequestUrl(context.Request, includeQueryString: false);
-        if (!string.IsNullOrEmpty(context.Request.Method))
-        {
-            text = $"{context.Request.Method} {text}";
-        }
-        if (!string.IsNullOrEmpty(context.Request.Protocol))
-        {
-            text += $" {context.Request.Protocol}";
-        }
-        if (!string.IsNullOrEmpty(context.Request.ContentType))
-        {
-            text += $" {context.Request.ContentType}";
-        }
-        text += $" {context.Response.StatusCode}";
-        var resolvedReasonPhrase = ResolveReasonPhrase(context.Response, reasonPhrase);
-        if (!string.IsNullOrEmpty(resolvedReasonPhrase))
-        {
-            text += $" {resolvedReasonPhrase}";
-        }
-
-        return text;
-    }
-
-    private static string GetRequestUrl(HttpRequest request, bool includeQueryString)
+    private static void GetRequestUrl(StringBuilder sb, HttpRequest request, bool includeQueryString)
     {
         // The URL might be missing because the context was manually created in a test, e.g. new DefaultHttpContext()
         if (string.IsNullOrEmpty(request.Scheme) &&
@@ -81,7 +95,8 @@ internal static class HttpContextDebugFormatter
             !request.Path.HasValue &&
             !request.QueryString.HasValue)
         {
-            return "(unspecified)";
+            sb.Append("(unspecified)");
+            return;
         }
 
         // If some parts of the URL are provided then default the significant parts to avoid a werid output.
@@ -96,6 +111,6 @@ internal static class HttpContextDebugFormatter
             host = "(unspecified)";
         }
 
-        return $"{scheme}://{host}{request.PathBase.Value}{request.Path.Value}{(includeQueryString ? request.QueryString.Value : string.Empty)}";
+        sb.Append(CultureInfo.InvariantCulture, $"{scheme}://{host}{request.PathBase.Value}{request.Path.Value}{(includeQueryString ? request.QueryString.Value : string.Empty)}");
     }
 }


### PR DESCRIPTION
* Include response trailers in HttpResponse type proxy
* Include more request details in HttpContext debugger display
* Add IsReadOnly = true to header collections when the collection is set to readonly (i.e. when the response is flushed and it can't be changed).

HttpContext with HTTP version:
![image](https://github.com/dotnet/aspnetcore/assets/303201/2ec96690-4aa9-4ab3-ab70-8e893d13753a)

HttpResponse with trailers and headers are readonly because they've been sent to the client:
![image](https://github.com/dotnet/aspnetcore/assets/303201/afeef513-d9e5-46d2-8a23-faf5184428d8)
