### PR TITLE
Fix some trim warnings in Components.Endpoints

### DIFF
--- a/src/Components/Endpoints/src/Builder/ComponentTypeMetadata.cs
+++ b/src/Components/Endpoints/src/Builder/ComponentTypeMetadata.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
+
 namespace Microsoft.AspNetCore.Components.Endpoints;
 
 /// <summary>
@@ -12,7 +15,7 @@ public class ComponentTypeMetadata
     /// Initializes a new instance of <see cref="ComponentTypeMetadata"/>.
     /// </summary>
     /// <param name="componentType">The component type.</param>
-    public ComponentTypeMetadata(Type componentType)
+    public ComponentTypeMetadata([DynamicallyAccessedMembers(Component)] Type componentType)
     {
         Type = componentType;
     }
@@ -20,5 +23,6 @@ public class ComponentTypeMetadata
     /// <summary>
     /// Gets the component type.
     /// </summary>
+    [DynamicallyAccessedMembers(Component)]
     public Type Type { get; }
 }

--- a/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSource.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSource.cs
@@ -2,16 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Components.Discovery;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Primitives;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
 
-internal class RazorComponentEndpointDataSource<TRootComponent> : EndpointDataSource
+internal class RazorComponentEndpointDataSource<[DynamicallyAccessedMembers(Component)] TRootComponent> : EndpointDataSource
 {
     private readonly object _lock = new();
     private readonly List<Action<EndpointBuilder>> _conventions = new();

--- a/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSourceFactory.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSourceFactory.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Components.Discovery;
 using Microsoft.AspNetCore.Components.Endpoints;
 using Microsoft.AspNetCore.Routing;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Components.Infrastructure;
 
@@ -20,7 +22,7 @@ internal class RazorComponentEndpointDataSourceFactory
         _providers = providers;
     }
 
-    public RazorComponentEndpointDataSource<TRootComponent> CreateDataSource<TRootComponent>(IEndpointRouteBuilder endpoints)
+    public RazorComponentEndpointDataSource<TRootComponent> CreateDataSource<[DynamicallyAccessedMembers(Component)] TRootComponent>(IEndpointRouteBuilder endpoints)
     {
         var builder = ComponentApplicationBuilder.GetBuilder<TRootComponent>() ??
             DefaultRazorComponentApplication<TRootComponent>.Instance.GetBuilder();

--- a/src/Components/Endpoints/src/Builder/RazorComponentEndpointFactory.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentEndpointFactory.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Components.Discovery;
@@ -8,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
 
@@ -19,7 +21,7 @@ internal class RazorComponentEndpointFactory
     internal void AddEndpoints(
 #pragma warning restore CA1822 // It's a singleton
         List<Endpoint> endpoints,
-        Type rootComponent,
+        [DynamicallyAccessedMembers(Component)] Type rootComponent,
         PageComponentInfo pageDefinition,
         IReadOnlyList<Action<EndpointBuilder>> conventions,
         IReadOnlyList<Action<EndpointBuilder>> finallyConventions)

--- a/src/Components/Endpoints/src/Builder/RazorComponentsEndpointRouteBuilderExtensions.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentsEndpointRouteBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.AspNetCore.Components.Endpoints;
 using Microsoft.AspNetCore.Components.Infrastructure;
@@ -9,20 +10,21 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Builder;
 
 /// <summary>
-/// 
+///
 /// </summary>
 public static class RazorComponentsEndpointRouteBuilderExtensions
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="endpoints"></param>
     /// <returns></returns>
-    public static RazorComponentEndpointConventionBuilder MapRazorComponents<TRootComponent>(this IEndpointRouteBuilder endpoints)
+    public static RazorComponentEndpointConventionBuilder MapRazorComponents<[DynamicallyAccessedMembers(Component)] TRootComponent>(this IEndpointRouteBuilder endpoints)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
 
@@ -63,7 +65,7 @@ public static class RazorComponentsEndpointRouteBuilderExtensions
 #endif
     }
 
-    private static RazorComponentEndpointDataSource<TRootComponent> GetOrCreateDataSource<TRootComponent>(IEndpointRouteBuilder endpoints)
+    private static RazorComponentEndpointDataSource<TRootComponent> GetOrCreateDataSource<[DynamicallyAccessedMembers(Component)] TRootComponent>(IEndpointRouteBuilder endpoints)
     {
         var dataSource = endpoints.DataSources.OfType<RazorComponentEndpointDataSource<TRootComponent>>().FirstOrDefault();
         if (dataSource == null)

--- a/src/Components/Endpoints/src/Builder/RenderModeEndpointProvider.cs
+++ b/src/Components/Endpoints/src/Builder/RenderModeEndpointProvider.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
 
@@ -31,7 +33,7 @@ public abstract class RenderModeEndpointProvider
 
     internal static void AddEndpoints(
         List<Endpoint> endpoints,
-        Type rootComponent,
+        [DynamicallyAccessedMembers(Component)] Type rootComponent,
         IEnumerable<RouteEndpointBuilder> renderModeEndpoints,
         IComponentRenderMode renderMode,
         List<Action<EndpointBuilder>> conventions,

--- a/src/Components/Endpoints/src/Builder/RootComponentMetadata.cs
+++ b/src/Components/Endpoints/src/Builder/RootComponentMetadata.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
+
 namespace Microsoft.AspNetCore.Components.Endpoints;
 
 /// <summary>
@@ -12,7 +15,7 @@ public class RootComponentMetadata
     /// Initializes a new instance of <see cref="RootComponentMetadata"/>.
     /// </summary>
     /// <param name="rootComponentType">The component type.</param>
-    public RootComponentMetadata(Type rootComponentType)
+    public RootComponentMetadata([DynamicallyAccessedMembers(Component)] Type rootComponentType)
     {
         Type = rootComponentType;
     }
@@ -20,5 +23,6 @@ public class RootComponentMetadata
     /// <summary>
     /// Gets the component type.
     /// </summary>
+    [DynamicallyAccessedMembers(Component)]
     public Type Type { get; }
 }

--- a/src/Components/Endpoints/src/DependencyInjection/IComponentPrerenderer.cs
+++ b/src/Components/Endpoints/src/DependencyInjection/IComponentPrerenderer.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Http;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
 
@@ -21,7 +23,7 @@ public interface IComponentPrerenderer
     /// <returns>A task that completes with the prerendered content.</returns>
     ValueTask<IHtmlAsyncContent> PrerenderComponentAsync(
         HttpContext httpContext,
-        Type componentType,
+        [DynamicallyAccessedMembers(Component)] Type componentType,
         IComponentRenderMode renderMode,
         ParameterView parameters);
 

--- a/src/Components/Endpoints/src/Discovery/PageComponentBuilder.cs
+++ b/src/Components/Endpoints/src/Discovery/PageComponentBuilder.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Components.Discovery;
 
@@ -35,6 +37,7 @@ public class PageComponentBuilder : IEquatable<PageComponentBuilder?>
     /// <summary>
     /// Gets or sets the page type.
     /// </summary>
+    [DynamicallyAccessedMembers(Component)]
     public required Type PageType { get; set; }
 
     /// <summary>

--- a/src/Components/Endpoints/src/Discovery/PageComponentInfo.cs
+++ b/src/Components/Endpoints/src/Discovery/PageComponentInfo.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Components.Discovery;
 
@@ -20,7 +22,7 @@ internal class PageComponentInfo
     /// <param name="metadata">The page metadata.</param>
     internal PageComponentInfo(
         string displayName,
-        Type type,
+        [DynamicallyAccessedMembers(Component)] Type type,
         string route,
         IReadOnlyList<object> metadata)
     {
@@ -38,6 +40,7 @@ internal class PageComponentInfo
     /// <summary>
     /// Gets the page type.
     /// </summary>
+    [DynamicallyAccessedMembers(Component)]
     public Type Type { get; }
 
     /// <summary>

--- a/src/Components/Endpoints/src/Microsoft.AspNetCore.Components.Endpoints.csproj
+++ b/src/Components/Endpoints/src/Microsoft.AspNetCore.Components.Endpoints.csproj
@@ -35,6 +35,7 @@
     <Compile Include="$(RepoRoot)src\Shared\ClosedGenericMatcher\ClosedGenericMatcher.cs" LinkBase="FormMapping" />
     <Compile Include="$(ComponentsSharedSourceRoot)src\CacheHeaderSettings.cs" Link="Shared\CacheHeaderSettings.cs" />
     <Compile Include="$(ComponentsSharedSourceRoot)src\DefaultAntiforgeryStateProvider.cs" LinkBase="Forms" />
+    <Compile Include="$(SharedSourceRoot)LinkerFlags.cs" LinkBase="Shared" />
 
     <Compile Include="$(SharedSourceRoot)PropertyHelper\**\*.cs" />
 

--- a/src/Components/Endpoints/src/RazorComponentEndpointHost.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointHost.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.AspNetCore.Components.Rendering;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
 
@@ -19,8 +21,12 @@ internal class RazorComponentEndpointHost : IComponent
 {
     private RenderHandle _renderHandle;
 
-    [Parameter] public Type ComponentType { get; set; } = default!;
-    [Parameter] public IReadOnlyDictionary<string, object?>? ComponentParameters { get; set; }
+    [Parameter]
+    [DynamicallyAccessedMembers(Component)]
+    public Type ComponentType { get; set; } = default!;
+
+    [Parameter]
+    public IReadOnlyDictionary<string, object?>? ComponentParameters { get; set; }
 
     public void Attach(RenderHandle renderHandle)
         => _renderHandle = renderHandle;

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Components.Web.HtmlRendering;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Http;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
 
@@ -12,7 +14,7 @@ internal partial class EndpointHtmlRenderer
 {
     private static readonly object ComponentSequenceKey = new object();
 
-    protected override IComponent ResolveComponentForRenderMode(Type componentType, int? parentComponentId, IComponentActivator componentActivator, IComponentRenderMode renderMode)
+    protected override IComponent ResolveComponentForRenderMode([DynamicallyAccessedMembers(Component)] Type componentType, int? parentComponentId, IComponentActivator componentActivator, IComponentRenderMode renderMode)
     {
         var closestRenderModeBoundary = parentComponentId.HasValue
             ? GetClosestRenderModeBoundary(parentComponentId.Value)
@@ -50,14 +52,14 @@ internal partial class EndpointHtmlRenderer
 
     public ValueTask<IHtmlAsyncContent> PrerenderComponentAsync(
         HttpContext httpContext,
-        Type componentType,
+        [DynamicallyAccessedMembers(Component)] Type componentType,
         IComponentRenderMode prerenderMode,
         ParameterView parameters)
         => PrerenderComponentAsync(httpContext, componentType, prerenderMode, parameters, waitForQuiescence: true);
 
     public async ValueTask<IHtmlAsyncContent> PrerenderComponentAsync(
         HttpContext httpContext,
-        Type componentType,
+        [DynamicallyAccessedMembers(Component)] Type componentType,
         IComponentRenderMode? prerenderMode,
         ParameterView parameters,
         bool waitForQuiescence)
@@ -98,7 +100,7 @@ internal partial class EndpointHtmlRenderer
 
     internal async ValueTask<PrerenderedComponentHtmlContent> RenderEndpointComponent(
         HttpContext httpContext,
-        Type rootComponentType,
+        [DynamicallyAccessedMembers(Component)] Type rootComponentType,
         ParameterView parameters,
         bool waitForQuiescence)
     {

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
 
@@ -65,7 +66,7 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
 
     internal static async Task InitializeStandardComponentServicesAsync(
         HttpContext httpContext,
-        Type? componentType = null,
+        [DynamicallyAccessedMembers(Component)] Type? componentType = null,
         string? handler = null,
         IFormCollection? form = null)
     {

--- a/src/Components/Endpoints/src/Rendering/SSRRenderModeBoundary.cs
+++ b/src/Components/Endpoints/src/Rendering/SSRRenderModeBoundary.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
@@ -10,6 +11,7 @@ using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
 
@@ -21,6 +23,7 @@ internal class SSRRenderModeBoundary : IComponent
 {
     private static readonly ConcurrentDictionary<Type, string> _componentTypeNameHashCache = new();
 
+    [DynamicallyAccessedMembers(Component)]
     private readonly Type _componentType;
     private readonly IComponentRenderMode _renderMode;
     private readonly bool _prerender;
@@ -28,7 +31,7 @@ internal class SSRRenderModeBoundary : IComponent
     private IReadOnlyDictionary<string, object?>? _latestParameters;
     private string? _markerKey;
 
-    public SSRRenderModeBoundary(Type componentType, IComponentRenderMode renderMode)
+    public SSRRenderModeBoundary([DynamicallyAccessedMembers(Component)] Type componentType, IComponentRenderMode renderMode)
     {
         _componentType = componentType;
         _renderMode = renderMode;

--- a/src/Components/Endpoints/src/Results/RazorComponentResult.cs
+++ b/src/Components/Endpoints/src/Results/RazorComponentResult.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Internal;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
 
@@ -19,7 +21,7 @@ public class RazorComponentResult : IResult
     /// Constructs an instance of <see cref="RazorComponentResult"/>.
     /// </summary>
     /// <param name="componentType">The type of the component to render. This must implement <see cref="IComponent"/>.</param>
-    public RazorComponentResult(Type componentType)
+    public RazorComponentResult([DynamicallyAccessedMembers(Component)] Type componentType)
         : this(componentType, null)
     {
     }
@@ -29,7 +31,7 @@ public class RazorComponentResult : IResult
     /// </summary>
     /// <param name="componentType">The type of the component to render. This must implement <see cref="IComponent"/>.</param>
     /// <param name="parameters">Parameters for the component.</param>
-    public RazorComponentResult(Type componentType, object? parameters)
+    public RazorComponentResult([DynamicallyAccessedMembers(Component)] Type componentType, object? parameters)
         : this(componentType, CoerceParametersObjectToDictionary(parameters))
     {
     }
@@ -39,7 +41,7 @@ public class RazorComponentResult : IResult
     /// </summary>
     /// <param name="componentType">The type of the component to render. This must implement <see cref="IComponent"/>.</param>
     /// <param name="parameters">Parameters for the component.</param>
-    public RazorComponentResult(Type componentType, IReadOnlyDictionary<string, object?>? parameters)
+    public RazorComponentResult([DynamicallyAccessedMembers(Component)] Type componentType, IReadOnlyDictionary<string, object?>? parameters)
     {
         // Note that the Blazor renderer will validate that componentType implements IComponent and throws a suitable
         // exception if not, so we don't need to duplicate that logic here.
@@ -57,6 +59,7 @@ public class RazorComponentResult : IResult
     /// <summary>
     /// Gets the component type.
     /// </summary>
+    [DynamicallyAccessedMembers(Component)]
     public Type ComponentType { get; }
 
     /// <summary>

--- a/src/Components/Endpoints/src/Results/RazorComponentResultExecutor.cs
+++ b/src/Components/Endpoints/src/Results/RazorComponentResultExecutor.cs
@@ -1,12 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Buffers;
 using System.Text;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
 
@@ -34,7 +36,7 @@ public class RazorComponentResultExecutor
         {
             response.StatusCode = result.StatusCode.Value;
         }
-        
+
         return RenderComponentToResponse(
             httpContext,
             result.ComponentType,
@@ -44,7 +46,7 @@ public class RazorComponentResultExecutor
 
     internal static Task RenderComponentToResponse(
         HttpContext httpContext,
-        Type componentType,
+        [DynamicallyAccessedMembers(Component)] Type componentType,
         IReadOnlyDictionary<string, object?>? componentParameters,
         bool preventStreamingRendering)
     {

--- a/src/Components/Endpoints/src/Results/RazorComponentResultOfT.cs
+++ b/src/Components/Endpoints/src/Results/RazorComponentResultOfT.cs
@@ -1,14 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Http;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
 
 /// <summary>
 /// An <see cref="IResult"/> that renders a Razor Component.
 /// </summary>
-public class RazorComponentResult<TComponent> : RazorComponentResult where TComponent: IComponent
+public class RazorComponentResult<[DynamicallyAccessedMembers(Component)] TComponent> : RazorComponentResult where TComponent: IComponent
 {
     /// <summary>
     /// Constructs an instance of <see cref="RazorComponentResult"/>.


### PR DESCRIPTION
- Add DynamicallyAccessedMembers attributes to places that flow Component Type around.

With this change I can `dotnet publish` with `PublishTrimmed=true` a very simple RazorComponents/RazorComponentResult application and it loads successfully.