### PR TITLE
Support NativeAOT in PropertySetter

### DIFF
--- a/src/Components/Components/src/Reflection/PropertySetter.cs
+++ b/src/Components/Components/src/Reflection/PropertySetter.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.AspNetCore.Components.Reflection;
 
@@ -26,14 +27,21 @@ internal sealed class PropertySetter
                 "has no setter.");
         }
 
-        var setMethod = property.SetMethod;
+        if (RuntimeFeature.IsDynamicCodeSupported)
+        {
+            var setMethod = property.SetMethod;
 
-        var propertySetterAsAction =
-            setMethod.CreateDelegate(typeof(Action<,>).MakeGenericType(targetType, property.PropertyType));
-        var callPropertySetterClosedGenericMethod =
-            CallPropertySetterOpenGenericMethod.MakeGenericMethod(targetType, property.PropertyType);
-        _setterDelegate = (Action<object, object>)
-            callPropertySetterClosedGenericMethod.CreateDelegate(typeof(Action<object, object>), propertySetterAsAction);
+            var propertySetterAsAction =
+                setMethod.CreateDelegate(typeof(Action<,>).MakeGenericType(targetType, property.PropertyType));
+            var callPropertySetterClosedGenericMethod =
+                CallPropertySetterOpenGenericMethod.MakeGenericMethod(targetType, property.PropertyType);
+            _setterDelegate = (Action<object, object>)
+                callPropertySetterClosedGenericMethod.CreateDelegate(typeof(Action<object, object>), propertySetterAsAction);
+        }
+        else
+        {
+            _setterDelegate = property.SetValue;
+        }
     }
 
     public bool AcceptsDirectParameters { get; init; }


### PR DESCRIPTION
MakeGenericType and MakeGenericMethod aren't guaranteed to work on NativeAOT when using value types.

When dynamic code isn't supported, just use normal reflection to set the property instead of creating generic delegates.