### PR TITLE
Make stdout/stderr redirection thread timeout configurable

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/StandardStreamRedirection.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/StandardStreamRedirection.h
@@ -9,9 +9,15 @@
 
 class StandardStreamRedirection : NonCopyable
 {
-    // Timeout to be used if a thread never exits
-    #define PIPE_OUTPUT_THREAD_TIMEOUT 2000
-    #define PIPE_READ_SIZE 4096
+    // Default timeout for the redirection thread to exit before it is forcefully terminated
+    // This can be overridden with ASPNETCORE_OUTPUT_REDIRECTION_TERMINATION_TIMEOUT_MS
+    static constexpr int PIPE_OUTPUT_THREAD_TIMEOUT_MS_DEFAULT = 2000;
+
+    // Maximum allowed timeout value
+    static constexpr int PIPE_OUTPUT_THREAD_TIMEOUT_MS_MAX = 1800000; // 30 minutes
+
+    // Size of the buffer used to read from the pipe
+    static constexpr int PIPE_READ_SIZE = 4096;
 
 public:
     StandardStreamRedirection(RedirectionOutput& output, bool commandLineLaunch);
@@ -63,4 +69,5 @@ private:
     std::unique_ptr<StdWrapper> stdoutWrapper;
     std::unique_ptr<StdWrapper> stderrWrapper;
     RedirectionOutput& m_output;
+    int m_terminationTimeoutMs = PIPE_OUTPUT_THREAD_TIMEOUT_MS_DEFAULT;
 };


### PR DESCRIPTION
Contributes to https://github.com/dotnet/aspnetcore/issues/45066

The StandardStreamRedirection logic in ANCM uses `CancelSynchronousIo` to kick the redirection thread out of its blocking `ReadFile` call and waits a hardcoded 2 seconds to allow the thread to exit before it calls `TerminateThread` on the thread. This works reasonably well in the vast majority of cases (most of the time, the 2 seconds is enough), but occasionally, we have to resort to the `TerminateThread` and in a small number of _those_ cases, the thread might be doing something dangerous like holding the OS loader lock.

I'd like to eventually rewrite this whole mechanism to eliminate `TerminateThread` entirely (as I did in the file watcher in https://github.com/dotnet/aspnetcore/pull/49696) but given where we are in the .NET 8 schedule, it's important to minimize the risk involved. This change just makes the timeout for thread termination configurable, so that people who are running into issues with this can give the thread more than 2 seconds to exit.

@BrennanConroy 