### PR TITLE
Synchronize KestrelTrace next-id comments

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.BadRequests.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.BadRequests.cs
@@ -53,6 +53,6 @@ internal sealed partial class KestrelTrace : ILogger
         [LoggerMessage(54, LogLevel.Debug, @"Connection id ""{ConnectionId}"": Invalid content received on connection. Possible incorrect HTTP version detected. Expected {ExpectedHttpVersion} but received {DetectedHttpVersion}.", EventName = "PossibleInvalidHttpVersionDetected", SkipEnabledCheck = true)]
         public static partial void PossibleInvalidHttpVersionDetected(ILogger logger, string connectionId, string expectedHttpVersion, string detectedHttpVersion);
 
-        // Highest shared ID is 63. New consecutive IDs start at 64
+        // Highest shared ID is 66. New consecutive IDs start at 67
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.BadRequests.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.BadRequests.cs
@@ -53,6 +53,6 @@ internal sealed partial class KestrelTrace : ILogger
         [LoggerMessage(54, LogLevel.Debug, @"Connection id ""{ConnectionId}"": Invalid content received on connection. Possible incorrect HTTP version detected. Expected {ExpectedHttpVersion} but received {DetectedHttpVersion}.", EventName = "PossibleInvalidHttpVersionDetected", SkipEnabledCheck = true)]
         public static partial void PossibleInvalidHttpVersionDetected(ILogger logger, string connectionId, string expectedHttpVersion, string detectedHttpVersion);
 
-        // Highest shared ID is 66. New consecutive IDs start at 67
+        // Highest shared ID is 66. New consecutive IDs start at 67. Please update this comment in every file in which it appears.
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.BadRequests.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.BadRequests.cs
@@ -53,6 +53,6 @@ internal sealed partial class KestrelTrace : ILogger
         [LoggerMessage(54, LogLevel.Debug, @"Connection id ""{ConnectionId}"": Invalid content received on connection. Possible incorrect HTTP version detected. Expected {ExpectedHttpVersion} but received {DetectedHttpVersion}.", EventName = "PossibleInvalidHttpVersionDetected", SkipEnabledCheck = true)]
         public static partial void PossibleInvalidHttpVersionDetected(ILogger logger, string connectionId, string expectedHttpVersion, string detectedHttpVersion);
 
-        // Highest shared ID is 66. New consecutive IDs start at 67. Please update this comment in every file in which it appears.
+        // IDs prior to 64 are reserved for back compat (the various KestrelTrace loggers used to share a single sequence)
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Connections.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Connections.cs
@@ -97,6 +97,6 @@ internal sealed partial class KestrelTrace : ILogger
         [LoggerMessage(39, LogLevel.Debug, @"Connection id ""{ConnectionId}"" accepted.", EventName = "ConnectionAccepted")]
         public static partial void ConnectionAccepted(ILogger logger, string connectionId);
 
-        // Highest shared ID is 66. New consecutive IDs start at 67
+        // Highest shared ID is 66. New consecutive IDs start at 67. Please update this comment in every file in which it appears.
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Connections.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Connections.cs
@@ -97,6 +97,6 @@ internal sealed partial class KestrelTrace : ILogger
         [LoggerMessage(39, LogLevel.Debug, @"Connection id ""{ConnectionId}"" accepted.", EventName = "ConnectionAccepted")]
         public static partial void ConnectionAccepted(ILogger logger, string connectionId);
 
-        // Highest shared ID is 63. New consecutive IDs start at 64
+        // Highest shared ID is 66. New consecutive IDs start at 67
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Connections.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Connections.cs
@@ -97,6 +97,6 @@ internal sealed partial class KestrelTrace : ILogger
         [LoggerMessage(39, LogLevel.Debug, @"Connection id ""{ConnectionId}"" accepted.", EventName = "ConnectionAccepted")]
         public static partial void ConnectionAccepted(ILogger logger, string connectionId);
 
-        // Highest shared ID is 66. New consecutive IDs start at 67. Please update this comment in every file in which it appears.
+        // IDs prior to 64 are reserved for back compat (the various KestrelTrace loggers used to share a single sequence)
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.General.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.General.cs
@@ -107,6 +107,6 @@ internal sealed partial class KestrelTrace : ILogger
         [LoggerMessage(66, LogLevel.Debug, @"Connection id ""{ConnectionId}"", Request id ""{TraceIdentifier}"": The request was aborted by the client.", EventName = "RequestAborted")]
         public static partial void RequestAbortedException(ILogger logger, string connectionId, string traceIdentifier);
 
-        // Highest shared ID is 66. New consecutive IDs start at 67. Please update this comment in every file in which it appears.
+        // IDs prior to 64 are reserved for back compat (the various KestrelTrace loggers used to share a single sequence)
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.General.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.General.cs
@@ -107,6 +107,6 @@ internal sealed partial class KestrelTrace : ILogger
         [LoggerMessage(66, LogLevel.Debug, @"Connection id ""{ConnectionId}"", Request id ""{TraceIdentifier}"": The request was aborted by the client.", EventName = "RequestAborted")]
         public static partial void RequestAbortedException(ILogger logger, string connectionId, string traceIdentifier);
 
-        // Highest shared ID is 66. New consecutive IDs start at 67
+        // Highest shared ID is 66. New consecutive IDs start at 67. Please update this comment in every file in which it appears.
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Http2.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Http2.cs
@@ -129,6 +129,6 @@ internal sealed partial class KestrelTrace : ILogger
         [LoggerMessage(63, LogLevel.Critical, @"The event loop in connection {ConnectionId} failed unexpectedly.", EventName = "Http2UnexpectedConnectionQueueError")]
         public static partial void Http2UnexpectedConnectionQueueError(ILogger logger, string connectionId, Exception ex);
 
-        // Highest shared ID is 66. New consecutive IDs start at 67. Please update this comment in every file in which it appears.
+        // IDs prior to 64 are reserved for back compat (the various KestrelTrace loggers used to share a single sequence)
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Http2.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Http2.cs
@@ -129,6 +129,6 @@ internal sealed partial class KestrelTrace : ILogger
         [LoggerMessage(63, LogLevel.Critical, @"The event loop in connection {ConnectionId} failed unexpectedly.", EventName = "Http2UnexpectedConnectionQueueError")]
         public static partial void Http2UnexpectedConnectionQueueError(ILogger logger, string connectionId, Exception ex);
 
-        // Highest shared ID is 66. New consecutive IDs start at 67
+        // Highest shared ID is 66. New consecutive IDs start at 67. Please update this comment in every file in which it appears.
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Http2.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Http2.cs
@@ -129,6 +129,6 @@ internal sealed partial class KestrelTrace : ILogger
         [LoggerMessage(63, LogLevel.Critical, @"The event loop in connection {ConnectionId} failed unexpectedly.", EventName = "Http2UnexpectedConnectionQueueError")]
         public static partial void Http2UnexpectedConnectionQueueError(ILogger logger, string connectionId, Exception ex);
 
-        // Highest shared ID is 63. New consecutive IDs start at 64
+        // Highest shared ID is 66. New consecutive IDs start at 67
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Http3.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Http3.cs
@@ -101,6 +101,6 @@ internal sealed partial class KestrelTrace : ILogger
         [LoggerMessage(53, LogLevel.Debug, @"Connection id ""{ConnectionId}"": GOAWAY stream ID {GoAwayStreamId}.", EventName = "Http3GoAwayHighestOpenedStreamId")]
         public static partial void Http3GoAwayStreamId(ILogger logger, string connectionId, long goAwayStreamId);
 
-        // Highest shared ID is 66. New consecutive IDs start at 67. Please update this comment in every file in which it appears.
+        // IDs prior to 64 are reserved for back compat (the various KestrelTrace loggers used to share a single sequence)
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Http3.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Http3.cs
@@ -101,6 +101,6 @@ internal sealed partial class KestrelTrace : ILogger
         [LoggerMessage(53, LogLevel.Debug, @"Connection id ""{ConnectionId}"": GOAWAY stream ID {GoAwayStreamId}.", EventName = "Http3GoAwayHighestOpenedStreamId")]
         public static partial void Http3GoAwayStreamId(ILogger logger, string connectionId, long goAwayStreamId);
 
-        // Highest shared ID is 66. New consecutive IDs start at 67
+        // Highest shared ID is 66. New consecutive IDs start at 67. Please update this comment in every file in which it appears.
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Http3.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelTrace.Http3.cs
@@ -101,6 +101,6 @@ internal sealed partial class KestrelTrace : ILogger
         [LoggerMessage(53, LogLevel.Debug, @"Connection id ""{ConnectionId}"": GOAWAY stream ID {GoAwayStreamId}.", EventName = "Http3GoAwayHighestOpenedStreamId")]
         public static partial void Http3GoAwayStreamId(ILogger logger, string connectionId, long goAwayStreamId);
 
-        // Highest shared ID is 63. New consecutive IDs start at 64
+        // Highest shared ID is 66. New consecutive IDs start at 67
     }
 }


### PR DESCRIPTION
`KestrelTrace` IDs have to be unique across the many files in which they appear, so we have comments indicating the start of the unused range in multiple places.  Make those comments consistent.