### PR TITLE
Add buffer limit option for SignalR Stateful Reconnect

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -56,6 +56,9 @@ public partial class HubConnection : IAsyncDisposable
     /// </summary>
     public static readonly TimeSpan DefaultKeepAliveInterval = TimeSpan.FromSeconds(15);
 
+    // Default amount of bytes we'll buffer when using Stateful Reconnect until applying backpressure to sends from the client.
+    internal const long DefaultStatefulReconnectBufferSize = 100_000;
+
     // The receive loop has a single reader and single writer at a time so optimize the channel for that
     private static readonly UnboundedChannelOptions _receiveLoopOptions = new UnboundedChannelOptions
     {
@@ -1900,7 +1903,8 @@ public partial class HubConnection : IAsyncDisposable
             if (Connection.Features.Get<IReconnectFeature>() is IReconnectFeature feature)
             {
                 _messageBuffer = new MessageBuffer(connection, hubConnection._protocol,
-                    _hubConnection._serviceProvider.GetService<IOptions<HubConnectionOptions>>()?.Value.MessageBufferSize ?? HubConnectionOptions.DefaultMessageBufferSize);
+                    _hubConnection._serviceProvider.GetService<IOptions<HubConnectionOptions>>()?.Value.StatefulReconnectBufferSize
+                    ?? DefaultStatefulReconnectBufferSize);
 
                 feature.NotifyOnReconnect = _messageBuffer.Resend;
             }

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -1899,7 +1899,8 @@ public partial class HubConnection : IAsyncDisposable
 
             if (Connection.Features.Get<IReconnectFeature>() is IReconnectFeature feature)
             {
-                _messageBuffer = new MessageBuffer(connection, hubConnection._protocol);
+                _messageBuffer = new MessageBuffer(connection, hubConnection._protocol,
+                    _hubConnection._serviceProvider.GetService<IOptions<HubConnectionOptions>>()?.Value.MessageBufferSize ?? HubConnectionOptions.DefaultMessageBufferSize);
 
                 feature.NotifyOnReconnect = _messageBuffer.Resend;
             }

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnectionBuilderExtensions.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnectionBuilderExtensions.cs
@@ -87,17 +87,4 @@ public static class HubConnectionBuilderExtensions
         hubConnectionBuilder.Services.Configure<HubConnectionOptions>(o => o.KeepAliveInterval = interval);
         return hubConnectionBuilder;
     }
-
-    /// <summary>
-    /// Configures the message buffer size in bytes for the <see cref="HubConnection" />.
-    /// Only applies when using stateful reconnect.
-    /// </summary>
-    /// <param name="hubConnectionBuilder">The <see cref="IHubConnectionBuilder" /> to configure.</param>
-    /// <param name="messageBufferSize">Number of bytes to buffer before before sending messages is blocked waiting for the server to ack.</param>
-    /// <returns></returns>
-    public static IHubConnectionBuilder WithMessageBufferSize(this IHubConnectionBuilder hubConnectionBuilder, long messageBufferSize)
-    {
-        hubConnectionBuilder.Services.Configure<HubConnectionOptions>(o => o.MessageBufferSize = messageBufferSize);
-        return hubConnectionBuilder;
-    }
 }

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnectionBuilderExtensions.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnectionBuilderExtensions.cs
@@ -87,4 +87,17 @@ public static class HubConnectionBuilderExtensions
         hubConnectionBuilder.Services.Configure<HubConnectionOptions>(o => o.KeepAliveInterval = interval);
         return hubConnectionBuilder;
     }
+
+    /// <summary>
+    /// Configures the message buffer size in bytes for the <see cref="HubConnection" />.
+    /// Only applies when using stateful reconnect.
+    /// </summary>
+    /// <param name="hubConnectionBuilder">The <see cref="IHubConnectionBuilder" /> to configure.</param>
+    /// <param name="messageBufferSize">Number of bytes to buffer before before sending messages is blocked waiting for the server to ack.</param>
+    /// <returns></returns>
+    public static IHubConnectionBuilder WithMessageBufferSize(this IHubConnectionBuilder hubConnectionBuilder, long messageBufferSize)
+    {
+        hubConnectionBuilder.Services.Configure<HubConnectionOptions>(o => o.MessageBufferSize = messageBufferSize);
+        return hubConnectionBuilder;
+    }
 }

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnectionOptions.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnectionOptions.cs
@@ -10,23 +10,24 @@ using System.Threading.Tasks;
 namespace Microsoft.AspNetCore.SignalR.Client;
 
 /// <summary>
-/// Configures timeouts for the <see cref="HubConnection" />.
+/// Configures options for the <see cref="HubConnection" />.
 /// </summary>
-internal sealed class HubConnectionOptions
+public sealed class HubConnectionOptions
 {
     /// <summary>
     /// Configures ServerTimeout for the <see cref="HubConnection" />.
     /// </summary>
-    public TimeSpan? ServerTimeout { get; set; }
+    public TimeSpan ServerTimeout { get; set; } = HubConnection.DefaultServerTimeout;
 
     /// <summary>
     /// Configures KeepAliveInterval for the <see cref="HubConnection" />.
     /// </summary>
-    public TimeSpan? KeepAliveInterval { get; set; }
+    public TimeSpan KeepAliveInterval { get; set; } = HubConnection.DefaultKeepAliveInterval;
 
-    public const int DefaultMessageBufferSize = 100_000;
-
-    // Used for Stateful reconnect feature.
-    public long MessageBufferSize { get; set; } = DefaultMessageBufferSize;
+    /// <summary>
+    /// Amount of serialized messages in bytes we'll buffer when using Stateful Reconnect until applying backpressure to sends from the client.
+    /// </summary>
+    /// <remarks>Defaults to 100,000 bytes.</remarks>
+    public long StatefulReconnectBufferSize { get; set; } = HubConnection.DefaultStatefulReconnectBufferSize;
 
 }

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnectionOptions.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnectionOptions.cs
@@ -23,4 +23,10 @@ internal sealed class HubConnectionOptions
     /// Configures KeepAliveInterval for the <see cref="HubConnection" />.
     /// </summary>
     public TimeSpan? KeepAliveInterval { get; set; }
+
+    public const int DefaultMessageBufferSize = 100_000;
+
+    // Used for Stateful reconnect feature.
+    public long MessageBufferSize { get; set; } = DefaultMessageBufferSize;
+
 }

--- a/src/SignalR/clients/csharp/Client.Core/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/clients/csharp/Client.Core/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
 static Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilderExtensions.WithKeepAliveInterval(this Microsoft.AspNetCore.SignalR.Client.IHubConnectionBuilder! hubConnectionBuilder, System.TimeSpan interval) -> Microsoft.AspNetCore.SignalR.Client.IHubConnectionBuilder!
+static Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilderExtensions.WithMessageBufferSize(this Microsoft.AspNetCore.SignalR.Client.IHubConnectionBuilder! hubConnectionBuilder, long messageBufferSize) -> Microsoft.AspNetCore.SignalR.Client.IHubConnectionBuilder!
 static Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilderExtensions.WithServerTimeout(this Microsoft.AspNetCore.SignalR.Client.IHubConnectionBuilder! hubConnectionBuilder, System.TimeSpan timeout) -> Microsoft.AspNetCore.SignalR.Client.IHubConnectionBuilder!

--- a/src/SignalR/clients/csharp/Client.Core/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/clients/csharp/Client.Core/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,11 @@
 #nullable enable
+Microsoft.AspNetCore.SignalR.Client.HubConnectionOptions
+Microsoft.AspNetCore.SignalR.Client.HubConnectionOptions.HubConnectionOptions() -> void
+Microsoft.AspNetCore.SignalR.Client.HubConnectionOptions.KeepAliveInterval.get -> System.TimeSpan
+Microsoft.AspNetCore.SignalR.Client.HubConnectionOptions.KeepAliveInterval.set -> void
+Microsoft.AspNetCore.SignalR.Client.HubConnectionOptions.ServerTimeout.get -> System.TimeSpan
+Microsoft.AspNetCore.SignalR.Client.HubConnectionOptions.ServerTimeout.set -> void
+Microsoft.AspNetCore.SignalR.Client.HubConnectionOptions.StatefulReconnectBufferSize.get -> long
+Microsoft.AspNetCore.SignalR.Client.HubConnectionOptions.StatefulReconnectBufferSize.set -> void
 static Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilderExtensions.WithKeepAliveInterval(this Microsoft.AspNetCore.SignalR.Client.IHubConnectionBuilder! hubConnectionBuilder, System.TimeSpan interval) -> Microsoft.AspNetCore.SignalR.Client.IHubConnectionBuilder!
-static Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilderExtensions.WithMessageBufferSize(this Microsoft.AspNetCore.SignalR.Client.IHubConnectionBuilder! hubConnectionBuilder, long messageBufferSize) -> Microsoft.AspNetCore.SignalR.Client.IHubConnectionBuilder!
 static Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilderExtensions.WithServerTimeout(this Microsoft.AspNetCore.SignalR.Client.IHubConnectionBuilder! hubConnectionBuilder, System.TimeSpan timeout) -> Microsoft.AspNetCore.SignalR.Client.IHubConnectionBuilder!

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -2718,6 +2718,50 @@ public class HubConnectionTests : FunctionalTestBase
         }
     }
 
+    [Fact]
+    public async Task CanSetMessageBufferSizeOnClient()
+    {
+        var protocol = HubProtocols["json"];
+        await using (var server = await StartServer<Startup>())
+        {
+            const string originalMessage = "SignalR";
+            var connectionBuilder = new HubConnectionBuilder()
+                .WithLoggerFactory(LoggerFactory)
+                .WithMessageBufferSize(500)
+                .WithUrl(server.Url + "/default", HttpTransportType.WebSockets, o =>
+                {
+                    o.UseAcks = true;
+                });
+            connectionBuilder.Services.AddSingleton(protocol);
+            var connection = connectionBuilder.Build();
+
+            try
+            {
+                await connection.StartAsync().DefaultTimeout();
+                var originalConnectionId = connection.ConnectionId;
+
+                var result = await connection.InvokeAsync<string>(nameof(TestHub.Echo), new string('x', 500)).DefaultTimeout();
+
+                var resultTask = connection.InvokeAsync<string>(nameof(TestHub.Echo), originalMessage).DefaultTimeout();
+                // Waiting for buffer to be unblocked by ack from server
+                Assert.False(resultTask.IsCompleted);
+
+                result = await resultTask;
+
+                Assert.Equal(originalMessage, result);
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                await connection.DisposeAsync().DefaultTimeout();
+            }
+        }
+    }
+
     private class OneAtATimeSynchronizationContext : SynchronizationContext, IAsyncDisposable
     {
         private readonly Channel<(SendOrPostCallback, object)> _taskQueue = Channel.CreateUnbounded<(SendOrPostCallback, object)>();

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -2727,11 +2727,11 @@ public class HubConnectionTests : FunctionalTestBase
             const string originalMessage = "SignalR";
             var connectionBuilder = new HubConnectionBuilder()
                 .WithLoggerFactory(LoggerFactory)
-                .WithMessageBufferSize(500)
                 .WithUrl(server.Url + "/default", HttpTransportType.WebSockets, o =>
                 {
                     o.UseAcks = true;
                 });
+            connectionBuilder.Services.Configure<HubConnectionOptions>(o => o.StatefulReconnectBufferSize = 500);
             connectionBuilder.Services.AddSingleton(protocol);
             var connection = connectionBuilder.Build();
 

--- a/src/SignalR/common/Http.Connections.Common/src/NegotiationResponse.cs
+++ b/src/SignalR/common/Http.Connections.Common/src/NegotiationResponse.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Connections.Abstractions;
 
 namespace Microsoft.AspNetCore.Http.Connections;
 
@@ -46,7 +48,9 @@ public class NegotiationResponse
     public string? Error { get; set; }
 
     /// <summary>
-    /// 
+    /// If set, the connection should attempt to reconnect with the same <see cref="BaseConnectionContext.ConnectionId"/> if it disconnects.
+    /// It should also set <see cref="IReconnectFeature"/> on the <see cref="BaseConnectionContext.Features"/> collection so other layers of the
+    /// application (like SignalR) can react.
     /// </summary>
     public bool UseAcking { get; set; }
 }

--- a/src/SignalR/common/SignalR.Common/src/Protocol/AckMessage.cs
+++ b/src/SignalR/common/SignalR.Common/src/Protocol/AckMessage.cs
@@ -1,50 +1,24 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Microsoft.AspNetCore.SignalR.Protocol;
 
 /// <summary>
-/// Represents the ID being acknowledged so we can stop buffering older messages.
+/// Represents the ID being acknowledged so older messages do not need to be buffered anymore.
 /// </summary>
 public sealed class AckMessage : HubMessage
 {
     /// <summary>
-    /// 
+    /// Initializes a new instance of the <see cref="AckMessage"/> class.
     /// </summary>
-    /// <param name="sequenceId"></param>
+    /// <param name="sequenceId">The ID of the last message that was received.</param>
     public AckMessage(long sequenceId)
     {
         SequenceId = sequenceId;
     }
 
     /// <summary>
-    /// 
-    /// </summary>
-    public long SequenceId { get; set; }
-}
-
-/// <summary>
-/// Represents the restart of the sequence of messages being sent. <see cref="SequenceId"/> is the starting ID of messages being sent, which might be duplicate messages.
-/// </summary>
-public sealed class SequenceMessage : HubMessage
-{
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="sequenceId"></param>
-    public SequenceMessage(long sequenceId)
-    {
-        SequenceId = sequenceId;
-    }
-
-    /// <summary>
-    /// 
+    /// The ID of the last message that was received.
     /// </summary>
     public long SequenceId { get; set; }
 }

--- a/src/SignalR/common/SignalR.Common/src/Protocol/SequenceMessage.cs
+++ b/src/SignalR/common/SignalR.Common/src/Protocol/SequenceMessage.cs
@@ -11,7 +11,7 @@ public sealed class SequenceMessage : HubMessage
     /// <summary>
     /// Initializes a new instance of the <see cref="SequenceMessage"/> class.
     /// </summary>
-    /// <param name="sequenceId">Specifies the ID messages being received from now on should start at.</param>
+    /// <param name="sequenceId">Specifies the starting ID for messages that will be received from this point onward.</param>
     public SequenceMessage(long sequenceId)
     {
         SequenceId = sequenceId;

--- a/src/SignalR/common/SignalR.Common/src/Protocol/SequenceMessage.cs
+++ b/src/SignalR/common/SignalR.Common/src/Protocol/SequenceMessage.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.SignalR.Protocol;
+
+/// <summary>
+/// Represents the restart of the sequence of messages being sent. <see cref="SequenceId"/> is the starting ID of messages being sent, which might be duplicate messages.
+/// </summary>
+public sealed class SequenceMessage : HubMessage
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SequenceMessage"/> class.
+    /// </summary>
+    /// <param name="sequenceId">Specifies the ID messages being received from now on should start at.</param>
+    public SequenceMessage(long sequenceId)
+    {
+        SequenceId = sequenceId;
+    }
+
+    /// <summary>
+    /// The new starting ID of incoming messages.
+    /// </summary>
+    public long SequenceId { get; set; }
+}

--- a/src/SignalR/common/testassets/Tests.Utils/TestClient.cs
+++ b/src/SignalR/common/testassets/Tests.Utils/TestClient.cs
@@ -167,6 +167,12 @@ internal
                 case PingMessage _:
                     // Pings are ignored
                     break;
+                case AckMessage _:
+                    // Ignored for now
+                    break;
+                case SequenceMessage _:
+                    // Ignored for now
+                    break;
                 default:
                     // Message implement ToString so this should be helpful.
                     throw new NotSupportedException($"TestClient recieved an unexpected message: {message}.");

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -46,6 +46,7 @@ public partial class HubConnectionContext
     private volatile bool _allowReconnect = true;
     private readonly int _streamBufferCapacity;
     private readonly long? _maxMessageSize;
+    private readonly long _messageBufferSize;
     private bool _receivedMessageTimeoutEnabled;
     private TimeSpan _receivedMessageElapsed;
     private long _receivedMessageTick;
@@ -68,6 +69,7 @@ public partial class HubConnectionContext
         _clientTimeoutInterval = contextOptions.ClientTimeoutInterval;
         _streamBufferCapacity = contextOptions.StreamBufferCapacity;
         _maxMessageSize = contextOptions.MaximumReceiveMessageSize;
+        _messageBufferSize = contextOptions.MessageBufferSize;
 
         _connectionContext = connectionContext;
         _logger = loggerFactory.CreateLogger<HubConnectionContext>();
@@ -577,7 +579,7 @@ public partial class HubConnectionContext
                                 if (_connectionContext.Features.Get<IReconnectFeature>() is IReconnectFeature feature)
                                 {
                                     _useAcks = true;
-                                    _messageBuffer = new MessageBuffer(_connectionContext, Protocol);
+                                    _messageBuffer = new MessageBuffer(_connectionContext, Protocol, _messageBufferSize);
                                     feature.NotifyOnReconnect = _messageBuffer.Resend;
                                 }
                                 return true;

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -46,7 +46,7 @@ public partial class HubConnectionContext
     private volatile bool _allowReconnect = true;
     private readonly int _streamBufferCapacity;
     private readonly long? _maxMessageSize;
-    private readonly long _messageBufferSize;
+    private readonly long _statefulReconnectBufferSize;
     private bool _receivedMessageTimeoutEnabled;
     private TimeSpan _receivedMessageElapsed;
     private long _receivedMessageTick;
@@ -69,7 +69,7 @@ public partial class HubConnectionContext
         _clientTimeoutInterval = contextOptions.ClientTimeoutInterval;
         _streamBufferCapacity = contextOptions.StreamBufferCapacity;
         _maxMessageSize = contextOptions.MaximumReceiveMessageSize;
-        _messageBufferSize = contextOptions.MessageBufferSize;
+        _statefulReconnectBufferSize = contextOptions.StatefulReconnectBufferSize;
 
         _connectionContext = connectionContext;
         _logger = loggerFactory.CreateLogger<HubConnectionContext>();
@@ -579,7 +579,7 @@ public partial class HubConnectionContext
                                 if (_connectionContext.Features.Get<IReconnectFeature>() is IReconnectFeature feature)
                                 {
                                     _useAcks = true;
-                                    _messageBuffer = new MessageBuffer(_connectionContext, Protocol, _messageBufferSize);
+                                    _messageBuffer = new MessageBuffer(_connectionContext, Protocol, _statefulReconnectBufferSize);
                                     feature.NotifyOnReconnect = _messageBuffer.Resend;
                                 }
                                 return true;

--- a/src/SignalR/server/Core/src/HubConnectionContextOptions.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContextOptions.cs
@@ -38,5 +38,5 @@ public class HubConnectionContextOptions
     /// <summary>
     /// Gets or sets the maximum bytes to buffer per connection when using stateful reconnect.
     /// </summary>
-    public long MessageBufferSize { get; set; } = 100_000;
+    internal long StatefulReconnectBufferSize { get; set; } = 100_000;
 }

--- a/src/SignalR/server/Core/src/HubConnectionContextOptions.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContextOptions.cs
@@ -34,4 +34,9 @@ public class HubConnectionContextOptions
     /// Gets or sets the maximum parallel hub method invocations.
     /// </summary>
     public int MaximumParallelInvocations { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets the maximum bytes to buffer per connection when using stateful reconnect.
+    /// </summary>
+    public long MessageBufferSize { get; set; } = 100_000;
 }

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -28,7 +28,7 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
     private readonly bool _enableDetailedErrors;
     private readonly long? _maximumMessageSize;
     private readonly int _maxParallelInvokes;
-    private readonly long _messageBufferSize;
+    private readonly long _statefulReconnectBufferSize;
 
     // Internal for testing
     internal TimeProvider TimeProvider { get; set; } = TimeProvider.System;
@@ -71,7 +71,7 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
             _enableDetailedErrors = _hubOptions.EnableDetailedErrors ?? _enableDetailedErrors;
             _maxParallelInvokes = _hubOptions.MaximumParallelInvocationsPerClient;
             disableImplicitFromServiceParameters = _hubOptions.DisableImplicitFromServicesParameters;
-            _messageBufferSize = _hubOptions.MessageBufferSize;
+            _statefulReconnectBufferSize = _hubOptions.StatefulReconnectBufferSize;
 
             if (_hubOptions.HubFilters != null)
             {
@@ -84,7 +84,7 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
             _enableDetailedErrors = _globalHubOptions.EnableDetailedErrors ?? _enableDetailedErrors;
             _maxParallelInvokes = _globalHubOptions.MaximumParallelInvocationsPerClient;
             disableImplicitFromServiceParameters = _globalHubOptions.DisableImplicitFromServicesParameters;
-            _messageBufferSize = _globalHubOptions.MessageBufferSize;
+            _statefulReconnectBufferSize = _globalHubOptions.StatefulReconnectBufferSize;
 
             if (_globalHubOptions.HubFilters != null)
             {
@@ -126,7 +126,7 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
             MaximumReceiveMessageSize = _maximumMessageSize,
             TimeProvider = TimeProvider,
             MaximumParallelInvocations = _maxParallelInvokes,
-            MessageBufferSize = _messageBufferSize,
+            StatefulReconnectBufferSize = _statefulReconnectBufferSize,
         };
 
         Log.ConnectedStarting(_logger);

--- a/src/SignalR/server/Core/src/HubConnectionHandler.cs
+++ b/src/SignalR/server/Core/src/HubConnectionHandler.cs
@@ -28,6 +28,7 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
     private readonly bool _enableDetailedErrors;
     private readonly long? _maximumMessageSize;
     private readonly int _maxParallelInvokes;
+    private readonly long _messageBufferSize;
 
     // Internal for testing
     internal TimeProvider TimeProvider { get; set; } = TimeProvider.System;
@@ -70,6 +71,7 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
             _enableDetailedErrors = _hubOptions.EnableDetailedErrors ?? _enableDetailedErrors;
             _maxParallelInvokes = _hubOptions.MaximumParallelInvocationsPerClient;
             disableImplicitFromServiceParameters = _hubOptions.DisableImplicitFromServicesParameters;
+            _messageBufferSize = _hubOptions.MessageBufferSize;
 
             if (_hubOptions.HubFilters != null)
             {
@@ -82,6 +84,7 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
             _enableDetailedErrors = _globalHubOptions.EnableDetailedErrors ?? _enableDetailedErrors;
             _maxParallelInvokes = _globalHubOptions.MaximumParallelInvocationsPerClient;
             disableImplicitFromServiceParameters = _globalHubOptions.DisableImplicitFromServicesParameters;
+            _messageBufferSize = _globalHubOptions.MessageBufferSize;
 
             if (_globalHubOptions.HubFilters != null)
             {
@@ -123,6 +126,7 @@ public class HubConnectionHandler<THub> : ConnectionHandler where THub : Hub
             MaximumReceiveMessageSize = _maximumMessageSize,
             TimeProvider = TimeProvider,
             MaximumParallelInvocations = _maxParallelInvokes,
+            MessageBufferSize = _messageBufferSize,
         };
 
         Log.ConnectedStarting(_logger);

--- a/src/SignalR/server/Core/src/HubOptions.cs
+++ b/src/SignalR/server/Core/src/HubOptions.cs
@@ -84,5 +84,5 @@ public class HubOptions
     /// Gets or sets the maximum bytes to buffer per connection when using stateful reconnect.
     /// </summary>
     /// <remarks>Defaults to 100,000 bytes.</remarks>
-    public long MessageBufferSize { get; set; } = 100_000;
+    public long StatefulReconnectBufferSize { get; set; } = 100_000;
 }

--- a/src/SignalR/server/Core/src/HubOptions.cs
+++ b/src/SignalR/server/Core/src/HubOptions.cs
@@ -79,4 +79,10 @@ public class HubOptions
     /// False by default. Hub method arguments will be resolved from a DI container if possible.
     /// </remarks>
     public bool DisableImplicitFromServicesParameters { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum bytes to buffer per connection when using stateful reconnect.
+    /// </summary>
+    /// <remarks>Defaults to 100,000 bytes.</remarks>
+    public long MessageBufferSize { get; set; } = 100_000;
 }

--- a/src/SignalR/server/Core/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/server/Core/src/PublicAPI.Unshipped.txt
@@ -1,5 +1,3 @@
 #nullable enable
-Microsoft.AspNetCore.SignalR.HubConnectionContextOptions.MessageBufferSize.get -> long
-Microsoft.AspNetCore.SignalR.HubConnectionContextOptions.MessageBufferSize.set -> void
-Microsoft.AspNetCore.SignalR.HubOptions.MessageBufferSize.get -> long
-Microsoft.AspNetCore.SignalR.HubOptions.MessageBufferSize.set -> void
+Microsoft.AspNetCore.SignalR.HubOptions.StatefulReconnectBufferSize.get -> long
+Microsoft.AspNetCore.SignalR.HubOptions.StatefulReconnectBufferSize.set -> void

--- a/src/SignalR/server/Core/src/PublicAPI.Unshipped.txt
+++ b/src/SignalR/server/Core/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+Microsoft.AspNetCore.SignalR.HubConnectionContextOptions.MessageBufferSize.get -> long
+Microsoft.AspNetCore.SignalR.HubConnectionContextOptions.MessageBufferSize.set -> void
+Microsoft.AspNetCore.SignalR.HubOptions.MessageBufferSize.get -> long
+Microsoft.AspNetCore.SignalR.HubOptions.MessageBufferSize.set -> void

--- a/src/SignalR/server/SignalR/test/AddSignalRTests.cs
+++ b/src/SignalR/server/SignalR/test/AddSignalRTests.cs
@@ -112,6 +112,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             Assert.Equal(globalHubOptions.ClientTimeoutInterval, hubOptions.ClientTimeoutInterval);
             Assert.Equal(globalHubOptions.MaximumParallelInvocationsPerClient, hubOptions.MaximumParallelInvocationsPerClient);
             Assert.Equal(globalHubOptions.DisableImplicitFromServicesParameters, hubOptions.DisableImplicitFromServicesParameters);
+            Assert.Equal(globalHubOptions.MessageBufferSize, hubOptions.MessageBufferSize);
             Assert.True(hubOptions.UserHasSetValues);
         }
 
@@ -147,6 +148,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 options.ClientTimeoutInterval = TimeSpan.FromSeconds(1);
                 options.MaximumParallelInvocationsPerClient = 3;
                 options.DisableImplicitFromServicesParameters = true;
+                options.MessageBufferSize = 23;
             });
 
             var serviceProvider = serviceCollection.BuildServiceProvider();
@@ -161,6 +163,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             Assert.Equal(3, globalOptions.MaximumParallelInvocationsPerClient);
             Assert.Equal(TimeSpan.FromSeconds(1), globalOptions.ClientTimeoutInterval);
             Assert.True(globalOptions.DisableImplicitFromServicesParameters);
+            Assert.Equal(23, globalOptions.MessageBufferSize);
         }
 
         [Fact]

--- a/src/SignalR/server/SignalR/test/AddSignalRTests.cs
+++ b/src/SignalR/server/SignalR/test/AddSignalRTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             Assert.Equal(globalHubOptions.ClientTimeoutInterval, hubOptions.ClientTimeoutInterval);
             Assert.Equal(globalHubOptions.MaximumParallelInvocationsPerClient, hubOptions.MaximumParallelInvocationsPerClient);
             Assert.Equal(globalHubOptions.DisableImplicitFromServicesParameters, hubOptions.DisableImplicitFromServicesParameters);
-            Assert.Equal(globalHubOptions.MessageBufferSize, hubOptions.MessageBufferSize);
+            Assert.Equal(globalHubOptions.StatefulReconnectBufferSize, hubOptions.StatefulReconnectBufferSize);
             Assert.True(hubOptions.UserHasSetValues);
         }
 
@@ -148,7 +148,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
                 options.ClientTimeoutInterval = TimeSpan.FromSeconds(1);
                 options.MaximumParallelInvocationsPerClient = 3;
                 options.DisableImplicitFromServicesParameters = true;
-                options.MessageBufferSize = 23;
+                options.StatefulReconnectBufferSize = 23;
             });
 
             var serviceProvider = serviceCollection.BuildServiceProvider();
@@ -163,7 +163,7 @@ namespace Microsoft.AspNetCore.SignalR.Tests
             Assert.Equal(3, globalOptions.MaximumParallelInvocationsPerClient);
             Assert.Equal(TimeSpan.FromSeconds(1), globalOptions.ClientTimeoutInterval);
             Assert.True(globalOptions.DisableImplicitFromServicesParameters);
-            Assert.Equal(23, globalOptions.MessageBufferSize);
+            Assert.Equal(23, globalOptions.StatefulReconnectBufferSize);
         }
 
         [Fact]

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -13,6 +13,7 @@ using MessagePack.Formatters;
 using MessagePack.Resolvers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Connections.Abstractions;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Connections.Features;
@@ -5168,6 +5169,46 @@ public partial class HubConnectionHandlerTests : VerifiableLoggedTest
 
             Assert.Equal("test", completionMessage.Result);
         }
+    }
+
+    [Fact]
+    public async Task CanSetMessageBufferSizeOnServer()
+    {
+        var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(provider =>
+        {
+            provider.AddSignalR(options =>
+            {
+                options.EnableDetailedErrors = true;
+                options.MessageBufferSize = 500;
+            });
+        });
+        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
+
+        using (var client = new TestClient())
+        {
+            client.Connection.Features.Set<IReconnectFeature>(new EmptyReconnectFeature());
+            var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+
+            await client.InvokeAsync(nameof(MethodHub.Echo), new object[] { new string('x', 500) }).DefaultTimeout();
+
+            // Previous message filled buffer, this message will not send to client until buffer is reduced via Ack
+            await client.SendInvocationAsync(nameof(MethodHub.Echo), new object[] { "t" }).DefaultTimeout();
+
+            var readTask = client.ReadAsync();
+            Assert.False(readTask.IsCompleted);
+
+            // Remove large message from buffer
+            await client.SendHubMessageAsync(new AckMessage(1)).DefaultTimeout();
+
+            var completionMessage = Assert.IsType<CompletionMessage>(await readTask);
+
+            Assert.Equal("t", completionMessage.Result);
+        }
+    }
+
+    private class EmptyReconnectFeature : IReconnectFeature
+    {
+        public Action NotifyOnReconnect { get; set; }
     }
 
     private class CustomHubActivator<THub> : IHubActivator<THub> where THub : Hub

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -5179,7 +5179,7 @@ public partial class HubConnectionHandlerTests : VerifiableLoggedTest
             provider.AddSignalR(options =>
             {
                 options.EnableDetailedErrors = true;
-                options.MessageBufferSize = 500;
+                options.StatefulReconnectBufferSize = 500;
             });
         });
         var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();

--- a/src/SignalR/server/SignalR/test/Internal/MessageBufferTests.cs
+++ b/src/SignalR/server/SignalR/test/Internal/MessageBufferTests.cs
@@ -19,7 +19,7 @@ public class MessageBufferTests
         var connection = new TestConnectionContext();
         var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions());
         connection.Transport = pipes.Transport;
-        using var messageBuffer = new MessageBuffer(connection, protocol);
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 1);
 
         for (var i = 0; i < 100; i++)
         {
@@ -47,7 +47,7 @@ public class MessageBufferTests
         var connection = new TestConnectionContext();
         var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions(pauseWriterThreshold: 200000, resumeWriterThreshold: 100000));
         connection.Transport = pipes.Transport;
-        using var messageBuffer = new MessageBuffer(connection, protocol);
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000);
 
         await messageBuffer.WriteAsync(new SerializedHubMessage(new InvocationMessage("t", new object[] { new byte[100000] })), default);
 
@@ -84,7 +84,7 @@ public class MessageBufferTests
         var connection = new TestConnectionContext();
         var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions());
         connection.Transport = pipes.Transport;
-        using var messageBuffer = new MessageBuffer(connection, protocol);
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 1000);
 
         await messageBuffer.WriteAsync(new SerializedHubMessage(new StreamItemMessage("id", null)), default);
 
@@ -134,7 +134,7 @@ public class MessageBufferTests
         var connection = new TestConnectionContext();
         var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions());
         connection.Transport = pipes.Transport;
-        using var messageBuffer = new MessageBuffer(connection, protocol);
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 1000);
 
         await messageBuffer.WriteAsync(new SerializedHubMessage(new StreamItemMessage("id", null)), default);
 
@@ -178,7 +178,7 @@ public class MessageBufferTests
         var connection = new TestConnectionContext();
         var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions());
         connection.Transport = pipes.Transport;
-        using var messageBuffer = new MessageBuffer(connection, protocol);
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 1000);
 
         DuplexPipe.UpdateConnectionPair(ref pipes, connection);
         messageBuffer.Resend();
@@ -202,11 +202,11 @@ public class MessageBufferTests
         var connection = new TestConnectionContext();
         var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions());
         connection.Transport = pipes.Transport;
-        using var messageBuffer = new MessageBuffer(connection, protocol);
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000);
 
         for (var i = 0; i < 1000; i++)
         {
-            await messageBuffer.WriteAsync(new SerializedHubMessage(new StreamItemMessage("1", null)), default);
+            await messageBuffer.WriteAsync(new SerializedHubMessage(new StreamItemMessage("1", null)), default).DefaultTimeout();
         }
 
         var ackNum = Random.Shared.Next(0, 1000);
@@ -234,6 +234,43 @@ public class MessageBufferTests
 
             pipes.Application.Input.AdvanceTo(buffer.Start);
         }
+    }
+
+    [Fact]
+    public async Task MessageBufferLimitCanBeModified()
+    {
+        var protocol = new JsonHubProtocol();
+        var connection = new TestConnectionContext();
+        var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions());
+        connection.Transport = pipes.Transport;
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 1);
+
+        await messageBuffer.WriteAsync(new SerializedHubMessage(new InvocationMessage("t", new object[] { 1 })), default);
+
+        var writeTask = messageBuffer.WriteAsync(new SerializedHubMessage(new StreamItemMessage("id", null)), default);
+        Assert.False(writeTask.IsCompleted);
+
+        var res = await pipes.Application.Input.ReadAsync();
+
+        var buffer = res.Buffer;
+        Assert.True(protocol.TryParseMessage(ref buffer, new TestBinder(), out var message));
+        Assert.IsType<InvocationMessage>(message);
+
+        pipes.Application.Input.AdvanceTo(buffer.Start);
+
+        // Write not unblocked by read, only unblocked after ack received
+        Assert.False(writeTask.IsCompleted);
+
+        messageBuffer.Ack(new AckMessage(1));
+        await writeTask.DefaultTimeout();
+
+        res = await pipes.Application.Input.ReadAsync().DefaultTimeout();
+
+        buffer = res.Buffer;
+        Assert.True(protocol.TryParseMessage(ref buffer, new TestBinder(), out message));
+        Assert.IsType<StreamItemMessage>(message);
+
+        pipes.Application.Input.AdvanceTo(buffer.Start);
     }
 }
 


### PR DESCRIPTION
Allows the user to configure buffer limits on server and client.