### PR TITLE
Watch file-based certificates for changes

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -21,6 +21,7 @@
     {"testName": {"contains": "InjectedStartup_DefaultApplicationNameIsEntryAssembly"}},
     {"testName": {"contains": "HEADERS_Received_SecondRequest_ConnectProtocolReset"}},
     {"testName": {"contains": "ClientUsingOldCallWithNewProtocol"}},
+    {"testName": {"contains": "CertificateChangedOnDisk"}},
     {"testAssembly": {"contains": "IIS"}},
     {"testAssembly": {"contains": "Template"}},
     {"failureMessage": {"contains":"(Site is started but no worker process found)"}},

--- a/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcher.cs
@@ -47,7 +47,7 @@ internal sealed partial class CertificatePathWatcher : IDisposable
     /// If a given <see cref="CertificateConfig"/> appears in both lists, it is first removed and then added.
     /// </summary>
     /// <remarks>
-    /// Does not look consider targets when watching files that are symlinks.
+    /// Does not consider targets when watching files that are symlinks.
     /// </remarks>
     public void UpdateWatches(List<CertificateConfig> certificateConfigsToRemove, List<CertificateConfig> certificateConfigsToAdd)
     {
@@ -70,12 +70,12 @@ internal sealed partial class CertificatePathWatcher : IDisposable
             // Since removeSet doesn't contain any of these configs, this won't change the semantics.
             foreach (var certificateConfig in addSet)
             {
-                AddWatch(certificateConfig);
+                AddWatchUnsynchronized(certificateConfig);
             }
 
             foreach (var certificateConfig in removeSet)
             {
-                RemoveWatch(certificateConfig);
+                RemoveWatchUnsynchronized(certificateConfig);
             }
         }
     }
@@ -87,7 +87,7 @@ internal sealed partial class CertificatePathWatcher : IDisposable
     /// <remarks>
     /// Internal for testing.
     /// </remarks>
-    internal void AddWatch(CertificateConfig certificateConfig)
+    internal void AddWatchUnsynchronized(CertificateConfig certificateConfig)
     {
         Debug.Assert(certificateConfig.IsFileCert, "AddWatch called on non-file cert");
 
@@ -216,13 +216,13 @@ internal sealed partial class CertificatePathWatcher : IDisposable
     }
 
     /// <summary>
-    /// Stop watching a certificate's file path for changes (previously started by <see cref="AddWatch"/>.
+    /// Stop watching a certificate's file path for changes (previously started by <see cref="AddWatchUnsynchronized"/>.
     /// <paramref name="certificateConfig"/> must have <see cref="CertificateConfig.IsFileCert"/> set to <code>true</code>.
     /// </summary>
     /// <remarks>
     /// Internal for testing.
     /// </remarks>
-    internal void RemoveWatch(CertificateConfig certificateConfig)
+    internal void RemoveWatchUnsynchronized(CertificateConfig certificateConfig)
     {
         Debug.Assert(certificateConfig.IsFileCert, "RemoveWatch called on non-file cert");
 
@@ -269,13 +269,13 @@ internal sealed partial class CertificatePathWatcher : IDisposable
     }
 
     /// <remarks>Test hook</remarks>
-    internal int TestGetDirectoryWatchCount() => _metadataForDirectory.Count;
+    internal int TestGetDirectoryWatchCountUnsynchronized() => _metadataForDirectory.Count;
 
     /// <remarks>Test hook</remarks>
-    internal int TestGetFileWatchCount(string dir) => _metadataForDirectory.TryGetValue(dir, out var metadata) ? metadata.FileWatchCount : 0;
+    internal int TestGetFileWatchCountUnsynchronized(string dir) => _metadataForDirectory.TryGetValue(dir, out var metadata) ? metadata.FileWatchCount : 0;
 
     /// <remarks>Test hook</remarks>
-    internal int TestGetObserverCount(string path) => _metadataForFile.TryGetValue(path, out var metadata) ? metadata.Configs.Count : 0;
+    internal int TestGetObserverCountUnsynchronized(string path) => _metadataForFile.TryGetValue(path, out var metadata) ? metadata.Configs.Count : 0;
 
     void IDisposable.Dispose()
     {

--- a/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcher.cs
@@ -245,6 +245,7 @@ internal sealed partial class CertificatePathWatcher : IDisposable
 
         _logger.RemovedObserver(path);
 
+        // If we found fileMetadata, there must be a containing/corresponding dirMetadata
         var dirMetadata = _metadataForDirectory[dir];
 
         if (configs.Count == 0)

--- a/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcher.cs
@@ -307,8 +307,6 @@ internal sealed partial class CertificatePathWatcher : IDisposable
         {
             fileMetadata.Dispose();
         }
-
-        GC.SuppressFinalize(this);
     }
 
     private sealed class DirectoryWatchMetadata(IFileProvider fileProvider) : IDisposable

--- a/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcher.cs
@@ -91,7 +91,7 @@ internal sealed partial class CertificatePathWatcher : IDisposable
     {
         Debug.Assert(certificateConfig.IsFileCert, "AddWatch called on non-file cert");
 
-        var path = Path.Combine(_contentRootDir, certificateConfig.Path!);
+        var path = Path.Combine(_contentRootDir, certificateConfig.Path);
         var dir = Path.GetDirectoryName(path)!;
 
         if (!_metadataForDirectory.TryGetValue(dir, out var dirMetadata))
@@ -226,7 +226,7 @@ internal sealed partial class CertificatePathWatcher : IDisposable
     {
         Debug.Assert(certificateConfig.IsFileCert, "RemoveWatch called on non-file cert");
 
-        var path = Path.Combine(_contentRootDir, certificateConfig.Path!);
+        var path = Path.Combine(_contentRootDir, certificateConfig.Path);
         var dir = Path.GetDirectoryName(path)!;
 
         if (!_metadataForFile.TryGetValue(path, out var fileMetadata))

--- a/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcher.cs
@@ -1,0 +1,317 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.FileProviders.Physical;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
+
+internal sealed partial class CertificatePathWatcher : IDisposable
+{
+    private readonly string _contentRootDir;
+    private readonly ILogger<CertificatePathWatcher> _logger;
+
+    private readonly object _metadataLock = new();
+
+    /// <remarks>Acquire <see cref="_metadataLock"/> before accessing.</remarks>
+    private readonly Dictionary<string, DirectoryWatchMetadata> _metadataForDirectory = new();
+    /// <remarks>Acquire <see cref="_metadataLock"/> before accessing.</remarks>
+    private readonly Dictionary<string, FileWatchMetadata> _metadataForFile = new();
+
+    private ConfigurationReloadToken _reloadToken = new();
+    private bool _disposed;
+
+    public CertificatePathWatcher(IHostEnvironment hostEnvironment, ILogger<CertificatePathWatcher> logger)
+    {
+        _contentRootDir = hostEnvironment.ContentRootPath;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns a token that will fire when any watched <see cref="CertificateConfig"/> is changed on disk.
+    /// The affected <see cref="CertificateConfig"/> will have <see cref="CertificateConfig.FileHasChanged"/>
+    /// set to <code>true</code>.
+    /// </summary>
+    public IChangeToken GetChangeToken()
+    {
+        return _reloadToken;
+    }
+
+    /// <summary>
+    /// Update the set of <see cref="CertificateConfig"/>s being watched for file changes.
+    /// If a given <see cref="CertificateConfig"/> appears in both lists, it is first removed and then added.
+    /// </summary>
+    /// <remarks>
+    /// Does not look consider targets when watching files that are symlinks.
+    /// </remarks>
+    public void UpdateWatches(List<CertificateConfig> certificateConfigsToRemove, List<CertificateConfig> certificateConfigsToAdd)
+    {
+        var addSet = new HashSet<CertificateConfig>(certificateConfigsToAdd, ReferenceEqualityComparer.Instance);
+        var removeSet = new HashSet<CertificateConfig>(certificateConfigsToRemove, ReferenceEqualityComparer.Instance);
+
+        // Don't remove anything we're going to re-add anyway.
+        // Don't remove such items from addSet to guard against the (hypothetical) possibility
+        // that a caller might remove a config that isn't already present.
+        removeSet.ExceptWith(certificateConfigsToAdd);
+
+        if (addSet.Count == 0 && removeSet.Count == 0)
+        {
+            return;
+        }
+
+        lock (_metadataLock)
+        {
+            // Adds before removes to increase the chances of watcher reuse.
+            // Since removeSet doesn't contain any of these configs, this won't change the semantics.
+            foreach (var certificateConfig in addSet)
+            {
+                AddWatch(certificateConfig);
+            }
+
+            foreach (var certificateConfig in removeSet)
+            {
+                RemoveWatch(certificateConfig);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Start watching a certificate's file path for changes.
+    /// <paramref name="certificateConfig"/> must have <see cref="CertificateConfig.IsFileCert"/> set to <code>true</code>.
+    /// </summary>
+    /// <remarks>
+    /// Internal for testing.
+    /// </remarks>
+    internal void AddWatch(CertificateConfig certificateConfig)
+    {
+        Debug.Assert(certificateConfig.IsFileCert, "AddWatch called on non-file cert");
+
+        var path = Path.Combine(_contentRootDir, certificateConfig.Path!);
+        var dir = Path.GetDirectoryName(path)!;
+
+        if (!_metadataForDirectory.TryGetValue(dir, out var dirMetadata))
+        {
+            if (!Directory.Exists(dir))
+            {
+                _logger.DirectoryDoesNotExist(dir, path);
+                return;
+            }
+
+            // If we wanted to detected deletions of this whole directory (which we don't since we ignore deletions),
+            // we'd probably need to watch the whole directory hierarchy
+
+            var fileProvider = new PhysicalFileProvider(dir, ExclusionFilters.None);
+            dirMetadata = new DirectoryWatchMetadata(fileProvider);
+            _metadataForDirectory.Add(dir, dirMetadata);
+
+            _logger.CreatedDirectoryWatcher(dir);
+        }
+
+        if (!_metadataForFile.TryGetValue(path, out var fileMetadata))
+        {
+            // PhysicalFileProvider appears to be able to tolerate non-existent files, as long as the directory exists
+
+            var disposable = ChangeToken.OnChange(
+                () => dirMetadata.FileProvider.Watch(Path.GetFileName(path)),
+                static tuple => tuple.Item1.OnChange(tuple.Item2),
+                ValueTuple.Create(this, path));
+
+            fileMetadata = new FileWatchMetadata(disposable);
+            _metadataForFile.Add(path, fileMetadata);
+            dirMetadata.FileWatchCount++;
+
+            // We actually don't care if the file doesn't exist - we'll watch in case it is created
+            fileMetadata.LastModifiedTime = GetLastModifiedTimeOrMinimum(path);
+
+            _logger.CreatedFileWatcher(path);
+        }
+
+        if (!fileMetadata.Configs.Add(certificateConfig))
+        {
+            _logger.ReusedObserver(path);
+            return;
+        }
+
+        _logger.AddedObserver(path);
+
+        _logger.ObserverCount(path, fileMetadata.Configs.Count);
+        _logger.FileCount(dir, dirMetadata.FileWatchCount);
+    }
+
+    private DateTime GetLastModifiedTimeOrMinimum(string path)
+    {
+        try
+        {
+            var fileInfo = new FileInfo(path);
+            if (fileInfo.Exists)
+            {
+                return fileInfo.LastWriteTimeUtc;
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LastModifiedTimeError(path, e);
+        }
+
+        return DateTime.MinValue;
+    }
+
+    private void OnChange(string path)
+    {
+        // Block until any in-progress updates are complete
+        lock (_metadataLock)
+        {
+            if (!_metadataForFile.TryGetValue(path, out var fileMetadata))
+            {
+                _logger.UntrackedFileEvent(path);
+                return;
+            }
+
+            // We ignore file changes that don't advance the last modified time.
+            // For example, if we lose access to the network share the file is
+            // stored on, we don't notify our listeners because no one wants
+            // their endpoint/server to shutdown when that happens.
+            // We also anticipate that a cert file might be renamed to cert.bak
+            // before a new cert is introduced with the old name.
+            // This also helps us in scenarios where the underlying file system
+            // reports more than one change for a single logical operation.
+            var lastModifiedTime = GetLastModifiedTimeOrMinimum(path);
+            if (lastModifiedTime > fileMetadata.LastModifiedTime)
+            {
+                fileMetadata.LastModifiedTime = lastModifiedTime;
+            }
+            else
+            {
+                if (lastModifiedTime == DateTime.MinValue)
+                {
+                    _logger.EventWithoutLastModifiedTime(path);
+                }
+                else if (lastModifiedTime == fileMetadata.LastModifiedTime)
+                {
+                    _logger.RedundantEvent(path);
+                }
+                else
+                {
+                    _logger.OutOfOrderEvent(path);
+                }
+                return;
+            }
+
+            var configs = fileMetadata.Configs;
+            foreach (var config in configs)
+            {
+                config.FileHasChanged = true;
+            }
+        }
+
+        // AddWatch and RemoveWatch don't affect the token, so this doesn't need to be under the semaphore.
+        // It does however need to be synchronized, since there could be multiple concurrent events.
+        var previousToken = Interlocked.Exchange(ref _reloadToken, new());
+        previousToken.OnReload();
+    }
+
+    /// <summary>
+    /// Stop watching a certificate's file path for changes (previously started by <see cref="AddWatch"/>.
+    /// <paramref name="certificateConfig"/> must have <see cref="CertificateConfig.IsFileCert"/> set to <code>true</code>.
+    /// </summary>
+    /// <remarks>
+    /// Internal for testing.
+    /// </remarks>
+    internal void RemoveWatch(CertificateConfig certificateConfig)
+    {
+        Debug.Assert(certificateConfig.IsFileCert, "RemoveWatch called on non-file cert");
+
+        var path = Path.Combine(_contentRootDir, certificateConfig.Path!);
+        var dir = Path.GetDirectoryName(path)!;
+
+        if (!_metadataForFile.TryGetValue(path, out var fileMetadata))
+        {
+            _logger.UnknownFile(path);
+            return;
+        }
+
+        var configs = fileMetadata.Configs;
+
+        if (!configs.Remove(certificateConfig))
+        {
+            _logger.UnknownObserver(path);
+            return;
+        }
+
+        _logger.RemovedObserver(path);
+
+        var dirMetadata = _metadataForDirectory[dir];
+
+        if (configs.Count == 0)
+        {
+            fileMetadata.Dispose();
+            _metadataForFile.Remove(path);
+            dirMetadata.FileWatchCount--;
+
+            _logger.RemovedFileWatcher(path);
+
+            if (dirMetadata.FileWatchCount == 0)
+            {
+                dirMetadata.Dispose();
+                _metadataForDirectory.Remove(dir);
+
+                _logger.RemovedDirectoryWatcher(dir);
+            }
+        }
+
+        _logger.ObserverCount(path, configs.Count);
+        _logger.FileCount(dir, dirMetadata.FileWatchCount);
+    }
+
+    /// <remarks>Test hook</remarks>
+    internal int TestGetDirectoryWatchCount() => _metadataForDirectory.Count;
+
+    /// <remarks>Test hook</remarks>
+    internal int TestGetFileWatchCount(string dir) => _metadataForDirectory.TryGetValue(dir, out var metadata) ? metadata.FileWatchCount : 0;
+
+    /// <remarks>Test hook</remarks>
+    internal int TestGetObserverCount(string path) => _metadataForFile.TryGetValue(path, out var metadata) ? metadata.Configs.Count : 0;
+
+    void IDisposable.Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        _disposed = true;
+
+        foreach (var dirMetadata in _metadataForDirectory.Values)
+        {
+            dirMetadata.Dispose();
+        }
+
+        foreach (var fileMetadata in _metadataForFile.Values)
+        {
+            fileMetadata.Dispose();
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private sealed class DirectoryWatchMetadata(PhysicalFileProvider fileProvider) : IDisposable
+    {
+        public readonly PhysicalFileProvider FileProvider = fileProvider;
+        public int FileWatchCount;
+
+        public void Dispose() => FileProvider.Dispose();
+    }
+
+    private sealed class FileWatchMetadata(IDisposable disposable) : IDisposable
+    {
+        public readonly IDisposable Disposable = disposable;
+        public readonly HashSet<CertificateConfig> Configs = new(ReferenceEqualityComparer.Instance);
+        public DateTime LastModifiedTime = DateTime.MinValue;
+
+        public void Dispose() => Disposable.Dispose();
+    }
+}

--- a/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcherLoggerExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcherLoggerExtensions.cs
@@ -7,57 +7,57 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 
 internal static partial class CertificatePathWatcherLoggerExtensions
 {
-    [LoggerMessage(1, LogLevel.Warning, @"Directory '{Directory}' does not exist so changes to the certificate '{Path}' will not be tracked.", EventName = "DirectoryDoesNotExist")]
+    [LoggerMessage(1, LogLevel.Warning, "Directory '{Directory}' does not exist so changes to the certificate '{Path}' will not be tracked.", EventName = "DirectoryDoesNotExist")]
     public static partial void DirectoryDoesNotExist(this ILogger<CertificatePathWatcher> logger, string directory, string path);
 
-    [LoggerMessage(2, LogLevel.Warning, @"Attempted to remove watch from unwatched path '{Path}'.", EventName = "UnknownFile")]
+    [LoggerMessage(2, LogLevel.Warning, "Attempted to remove watch from unwatched path '{Path}'.", EventName = "UnknownFile")]
     public static partial void UnknownFile(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(3, LogLevel.Warning, @"Attempted to remove unknown observer from path '{Path}'.", EventName = "UnknownObserver")]
+    [LoggerMessage(3, LogLevel.Warning, "Attempted to remove unknown observer from path '{Path}'.", EventName = "UnknownObserver")]
     public static partial void UnknownObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(4, LogLevel.Debug, @"Created directory watcher for '{Directory}'.", EventName = "CreatedDirectoryWatcher")]
+    [LoggerMessage(4, LogLevel.Debug, "Created directory watcher for '{Directory}'.", EventName = "CreatedDirectoryWatcher")]
     public static partial void CreatedDirectoryWatcher(this ILogger<CertificatePathWatcher> logger, string directory);
 
-    [LoggerMessage(5, LogLevel.Debug, @"Created file watcher for '{Path}'.", EventName = "CreatedFileWatcher")]
+    [LoggerMessage(5, LogLevel.Debug, "Created file watcher for '{Path}'.", EventName = "CreatedFileWatcher")]
     public static partial void CreatedFileWatcher(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(6, LogLevel.Debug, @"Removed directory watcher for '{Directory}'.", EventName = "RemovedDirectoryWatcher")]
+    [LoggerMessage(6, LogLevel.Debug, "Removed directory watcher for '{Directory}'.", EventName = "RemovedDirectoryWatcher")]
     public static partial void RemovedDirectoryWatcher(this ILogger<CertificatePathWatcher> logger, string directory);
 
-    [LoggerMessage(7, LogLevel.Debug, @"Removed file watcher for '{Path}'.", EventName = "RemovedFileWatcher")]
+    [LoggerMessage(7, LogLevel.Debug, "Removed file watcher for '{Path}'.", EventName = "RemovedFileWatcher")]
     public static partial void RemovedFileWatcher(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(8, LogLevel.Debug, @"Error retrieving last modified time for '{Path}'.", EventName = "LastModifiedTimeError")]
+    [LoggerMessage(8, LogLevel.Debug, "Error retrieving last modified time for '{Path}'.", EventName = "LastModifiedTimeError")]
     public static partial void LastModifiedTimeError(this ILogger<CertificatePathWatcher> logger, string path, Exception e);
 
-    [LoggerMessage(9, LogLevel.Debug, @"Ignored event for presently untracked file '{Path}'.", EventName = "UntrackedFileEvent")]
+    [LoggerMessage(9, LogLevel.Debug, "Ignored event for presently untracked file '{Path}'.", EventName = "UntrackedFileEvent")]
     public static partial void UntrackedFileEvent(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(10, LogLevel.Debug, @"Ignored out-of-order event for file '{Path}'.", EventName = "OutOfOrderEvent")]
+    [LoggerMessage(10, LogLevel.Debug, "Ignored out-of-order event for file '{Path}'.", EventName = "OutOfOrderEvent")]
     public static partial void OutOfOrderEvent(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(11, LogLevel.Trace, @"Reused existing observer on file watcher for '{Path}'.", EventName = "ReusedObserver")]
+    [LoggerMessage(11, LogLevel.Trace, "Reused existing observer on file watcher for '{Path}'.", EventName = "ReusedObserver")]
     public static partial void ReusedObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(12, LogLevel.Trace, @"Added observer to file watcher for '{Path}'.", EventName = "AddedObserver")]
+    [LoggerMessage(12, LogLevel.Trace, "Added observer to file watcher for '{Path}'.", EventName = "AddedObserver")]
     public static partial void AddedObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(13, LogLevel.Trace, @"Removed observer from file watcher for '{Path}'.", EventName = "RemovedObserver")]
+    [LoggerMessage(13, LogLevel.Trace, "Removed observer from file watcher for '{Path}'.", EventName = "RemovedObserver")]
     public static partial void RemovedObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(14, LogLevel.Trace, @"File '{Path}' now has {Count} observers.", EventName = "ObserverCount")]
+    [LoggerMessage(14, LogLevel.Trace, "File '{Path}' now has {Count} observers.", EventName = "ObserverCount")]
     public static partial void ObserverCount(this ILogger<CertificatePathWatcher> logger, string path, int count);
 
-    [LoggerMessage(15, LogLevel.Trace, @"Directory '{Directory}' now has watchers on {Count} files.", EventName = "FileCount")]
+    [LoggerMessage(15, LogLevel.Trace, "Directory '{Directory}' now has watchers on {Count} files.", EventName = "FileCount")]
     public static partial void FileCount(this ILogger<CertificatePathWatcher> logger, string directory, int count);
 
-    [LoggerMessage(16, LogLevel.Trace, @"Ignored event since last modified time for '{Path}' was unavailable.", EventName = "EventWithoutLastModifiedTime")]
+    [LoggerMessage(16, LogLevel.Trace, "Ignored event since last modified time for '{Path}' was unavailable.", EventName = "EventWithoutLastModifiedTime")]
     public static partial void EventWithoutLastModifiedTime(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(17, LogLevel.Trace, @"Ignored redundant event for '{Path}'.", EventName = "RedundantEvent")]
+    [LoggerMessage(17, LogLevel.Trace, "Ignored redundant event for '{Path}'.", EventName = "RedundantEvent")]
     public static partial void RedundantEvent(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(18, LogLevel.Trace, @"Flagged {Count} observers of '{Path}' as changed.", EventName = "FlaggedObservers")]
+    [LoggerMessage(18, LogLevel.Trace, "Flagged {Count} observers of '{Path}' as changed.", EventName = "FlaggedObservers")]
     public static partial void FlaggedObservers(this ILogger<CertificatePathWatcher> logger, string path, int count);
 }

--- a/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcherLoggerExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcherLoggerExtensions.cs
@@ -7,57 +7,57 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 
 internal static partial class CertificatePathWatcherLoggerExtensions
 {
-    [LoggerMessage(1, LogLevel.Warning, @"Directory ""{Dir}"" does not exist so changes to the certificate ""{Path}"" will not be tracked", EventName = "DirectoryDoesNotExist")]
-    public static partial void DirectoryDoesNotExist(this ILogger<CertificatePathWatcher> logger, string dir, string path);
+    [LoggerMessage(1, LogLevel.Warning, @"Directory '{Directory}' does not exist so changes to the certificate '{Path}' will not be tracked.", EventName = "DirectoryDoesNotExist")]
+    public static partial void DirectoryDoesNotExist(this ILogger<CertificatePathWatcher> logger, string directory, string path);
 
-    [LoggerMessage(2, LogLevel.Warning, @"Attempted to remove watch from unwatched path ""{Path}""", EventName = "UnknownFile")]
+    [LoggerMessage(2, LogLevel.Warning, @"Attempted to remove watch from unwatched path '{Path}'.", EventName = "UnknownFile")]
     public static partial void UnknownFile(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(3, LogLevel.Warning, @"Attempted to remove unknown observer from path ""{Path}""", EventName = "UnknownObserver")]
+    [LoggerMessage(3, LogLevel.Warning, @"Attempted to remove unknown observer from path '{Path}'.", EventName = "UnknownObserver")]
     public static partial void UnknownObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(4, LogLevel.Debug, @"Created directory watcher for ""{Dir}""", EventName = "CreatedDirectoryWatcher")]
-    public static partial void CreatedDirectoryWatcher(this ILogger<CertificatePathWatcher> logger, string dir);
+    [LoggerMessage(4, LogLevel.Debug, @"Created directory watcher for '{Directory}'.", EventName = "CreatedDirectoryWatcher")]
+    public static partial void CreatedDirectoryWatcher(this ILogger<CertificatePathWatcher> logger, string directory);
 
-    [LoggerMessage(5, LogLevel.Debug, @"Created file watcher for ""{Path}""", EventName = "CreatedFileWatcher")]
+    [LoggerMessage(5, LogLevel.Debug, @"Created file watcher for '{Path}'.", EventName = "CreatedFileWatcher")]
     public static partial void CreatedFileWatcher(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(6, LogLevel.Debug, @"Removed directory watcher for ""{Dir}""", EventName = "RemovedDirectoryWatcher")]
-    public static partial void RemovedDirectoryWatcher(this ILogger<CertificatePathWatcher> logger, string dir);
+    [LoggerMessage(6, LogLevel.Debug, @"Removed directory watcher for '{Directory}'.", EventName = "RemovedDirectoryWatcher")]
+    public static partial void RemovedDirectoryWatcher(this ILogger<CertificatePathWatcher> logger, string directory);
 
-    [LoggerMessage(7, LogLevel.Debug, @"Removed file watcher for ""{Path}""", EventName = "RemovedFileWatcher")]
+    [LoggerMessage(7, LogLevel.Debug, @"Removed file watcher for '{Path}'.", EventName = "RemovedFileWatcher")]
     public static partial void RemovedFileWatcher(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(8, LogLevel.Debug, @"Error retrieving last modified time for ""{Path}""", EventName = "LastModifiedTimeError")]
+    [LoggerMessage(8, LogLevel.Debug, @"Error retrieving last modified time for '{Path}'.", EventName = "LastModifiedTimeError")]
     public static partial void LastModifiedTimeError(this ILogger<CertificatePathWatcher> logger, string path, Exception e);
 
-    [LoggerMessage(9, LogLevel.Debug, @"Ignored event for presently untracked file ""{Path}""", EventName = "UntrackedFileEvent")]
+    [LoggerMessage(9, LogLevel.Debug, @"Ignored event for presently untracked file '{Path}'.", EventName = "UntrackedFileEvent")]
     public static partial void UntrackedFileEvent(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(10, LogLevel.Debug, @"Ignored out-of-order event for file ""{Path}""", EventName = "OutOfOrderEvent")]
+    [LoggerMessage(10, LogLevel.Debug, @"Ignored out-of-order event for file '{Path}'.", EventName = "OutOfOrderEvent")]
     public static partial void OutOfOrderEvent(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(11, LogLevel.Trace, @"Reused existing observer on file watcher for ""{Path}""", EventName = "ReusedObserver")]
+    [LoggerMessage(11, LogLevel.Trace, @"Reused existing observer on file watcher for '{Path}'.", EventName = "ReusedObserver")]
     public static partial void ReusedObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(12, LogLevel.Trace, @"Added observer to file watcher for ""{Path}""", EventName = "AddedObserver")]
+    [LoggerMessage(12, LogLevel.Trace, @"Added observer to file watcher for '{Path}'.", EventName = "AddedObserver")]
     public static partial void AddedObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(13, LogLevel.Trace, @"Removed observer from file watcher for ""{Path}""", EventName = "RemovedObserver")]
+    [LoggerMessage(13, LogLevel.Trace, @"Removed observer from file watcher for '{Path}'.", EventName = "RemovedObserver")]
     public static partial void RemovedObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(14, LogLevel.Trace, @"File ""{Path}"" now has {Count} observers", EventName = "ObserverCount")]
+    [LoggerMessage(14, LogLevel.Trace, @"File '{Path}' now has {Count} observers.", EventName = "ObserverCount")]
     public static partial void ObserverCount(this ILogger<CertificatePathWatcher> logger, string path, int count);
 
-    [LoggerMessage(15, LogLevel.Trace, @"Directory ""{Dir}"" now has watchers on {Count} files", EventName = "FileCount")]
-    public static partial void FileCount(this ILogger<CertificatePathWatcher> logger, string dir, int count);
+    [LoggerMessage(15, LogLevel.Trace, @"Directory '{Directory}' now has watchers on {Count} files.", EventName = "FileCount")]
+    public static partial void FileCount(this ILogger<CertificatePathWatcher> logger, string directory, int count);
 
-    [LoggerMessage(16, LogLevel.Trace, @"Ignored event since last modified time for ""{Path}"" was unavailable", EventName = "EventWithoutLastModifiedTime")]
+    [LoggerMessage(16, LogLevel.Trace, @"Ignored event since last modified time for '{Path}' was unavailable.", EventName = "EventWithoutLastModifiedTime")]
     public static partial void EventWithoutLastModifiedTime(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(17, LogLevel.Trace, @"Ignored redundant event for ""{Path}""", EventName = "RedundantEvent")]
+    [LoggerMessage(17, LogLevel.Trace, @"Ignored redundant event for '{Path}'.", EventName = "RedundantEvent")]
     public static partial void RedundantEvent(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(18, LogLevel.Trace, @"Flagged {Count} observers of ""{Path}"" as changed", EventName = "FlaggedObservers")]
+    [LoggerMessage(18, LogLevel.Trace, @"Flagged {Count} observers of '{Path}' as changed.", EventName = "FlaggedObservers")]
     public static partial void FlaggedObservers(this ILogger<CertificatePathWatcher> logger, string path, int count);
 }

--- a/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcherLoggerExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcherLoggerExtensions.cs
@@ -7,57 +7,57 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 
 internal static partial class CertificatePathWatcherLoggerExtensions
 {
-    [LoggerMessage(0, LogLevel.Warning, @"Directory ""{dir}"" does not exist so changes to the certificate ""{path}"" will not be tracked", EventName = "DirectoryDoesNotExist")]
+    [LoggerMessage(1, LogLevel.Warning, @"Directory ""{dir}"" does not exist so changes to the certificate ""{path}"" will not be tracked", EventName = "DirectoryDoesNotExist")]
     public static partial void DirectoryDoesNotExist(this ILogger<CertificatePathWatcher> logger, string dir, string path);
 
-    [LoggerMessage(1, LogLevel.Warning, @"Attempted to remove watch from unwatched path ""{path}""", EventName = "UnknownFile")]
+    [LoggerMessage(2, LogLevel.Warning, @"Attempted to remove watch from unwatched path ""{path}""", EventName = "UnknownFile")]
     public static partial void UnknownFile(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(2, LogLevel.Warning, @"Attempted to remove unknown observer from path ""{path}""", EventName = "UnknownObserver")]
+    [LoggerMessage(3, LogLevel.Warning, @"Attempted to remove unknown observer from path ""{path}""", EventName = "UnknownObserver")]
     public static partial void UnknownObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(3, LogLevel.Debug, @"Created directory watcher for ""{dir}""", EventName = "CreatedDirectoryWatcher")]
+    [LoggerMessage(4, LogLevel.Debug, @"Created directory watcher for ""{dir}""", EventName = "CreatedDirectoryWatcher")]
     public static partial void CreatedDirectoryWatcher(this ILogger<CertificatePathWatcher> logger, string dir);
 
-    [LoggerMessage(4, LogLevel.Debug, @"Created file watcher for ""{path}""", EventName = "CreatedFileWatcher")]
+    [LoggerMessage(5, LogLevel.Debug, @"Created file watcher for ""{path}""", EventName = "CreatedFileWatcher")]
     public static partial void CreatedFileWatcher(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(5, LogLevel.Debug, @"Removed directory watcher for ""{dir}""", EventName = "RemovedDirectoryWatcher")]
+    [LoggerMessage(6, LogLevel.Debug, @"Removed directory watcher for ""{dir}""", EventName = "RemovedDirectoryWatcher")]
     public static partial void RemovedDirectoryWatcher(this ILogger<CertificatePathWatcher> logger, string dir);
 
-    [LoggerMessage(6, LogLevel.Debug, @"Removed file watcher for ""{path}""", EventName = "RemovedFileWatcher")]
+    [LoggerMessage(7, LogLevel.Debug, @"Removed file watcher for ""{path}""", EventName = "RemovedFileWatcher")]
     public static partial void RemovedFileWatcher(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(7, LogLevel.Debug, @"Error retrieving last modified time for ""{path}""", EventName = "LastModifiedTimeError")]
+    [LoggerMessage(8, LogLevel.Debug, @"Error retrieving last modified time for ""{path}""", EventName = "LastModifiedTimeError")]
     public static partial void LastModifiedTimeError(this ILogger<CertificatePathWatcher> logger, string path, Exception e);
 
-    [LoggerMessage(8, LogLevel.Debug, @"Ignored event for presently untracked file ""{path}""", EventName = "UntrackedFileEvent")]
+    [LoggerMessage(9, LogLevel.Debug, @"Ignored event for presently untracked file ""{path}""", EventName = "UntrackedFileEvent")]
     public static partial void UntrackedFileEvent(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(9, LogLevel.Debug, @"Ignored out-of-order event for file ""{path}""", EventName = "OutOfOrderEvent")]
+    [LoggerMessage(10, LogLevel.Debug, @"Ignored out-of-order event for file ""{path}""", EventName = "OutOfOrderEvent")]
     public static partial void OutOfOrderEvent(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(10, LogLevel.Trace, @"Reused existing observer on file watcher for ""{path}""", EventName = "ReusedObserver")]
+    [LoggerMessage(11, LogLevel.Trace, @"Reused existing observer on file watcher for ""{path}""", EventName = "ReusedObserver")]
     public static partial void ReusedObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(11, LogLevel.Trace, @"Added observer to file watcher for ""{path}""", EventName = "AddedObserver")]
+    [LoggerMessage(12, LogLevel.Trace, @"Added observer to file watcher for ""{path}""", EventName = "AddedObserver")]
     public static partial void AddedObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(12, LogLevel.Trace, @"Removed observer from file watcher for ""{path}""", EventName = "RemovedObserver")]
+    [LoggerMessage(13, LogLevel.Trace, @"Removed observer from file watcher for ""{path}""", EventName = "RemovedObserver")]
     public static partial void RemovedObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(13, LogLevel.Trace, @"File ""{path}"" now has {count} observers", EventName = "ObserverCount")]
+    [LoggerMessage(14, LogLevel.Trace, @"File ""{path}"" now has {count} observers", EventName = "ObserverCount")]
     public static partial void ObserverCount(this ILogger<CertificatePathWatcher> logger, string path, int count);
 
-    [LoggerMessage(14, LogLevel.Trace, @"Directory ""{dir}"" now has watchers on {count} files", EventName = "FileCount")]
+    [LoggerMessage(15, LogLevel.Trace, @"Directory ""{dir}"" now has watchers on {count} files", EventName = "FileCount")]
     public static partial void FileCount(this ILogger<CertificatePathWatcher> logger, string dir, int count);
 
-    [LoggerMessage(15, LogLevel.Trace, @"Ignored event since last modified time for ""{path}"" was unavailable", EventName = "EventWithoutLastModifiedTime")]
+    [LoggerMessage(16, LogLevel.Trace, @"Ignored event since last modified time for ""{path}"" was unavailable", EventName = "EventWithoutLastModifiedTime")]
     public static partial void EventWithoutLastModifiedTime(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(16, LogLevel.Trace, @"Ignored redundant event for ""{path}""", EventName = "RedundantEvent")]
+    [LoggerMessage(17, LogLevel.Trace, @"Ignored redundant event for ""{path}""", EventName = "RedundantEvent")]
     public static partial void RedundantEvent(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(17, LogLevel.Trace, @"Flagged {count} observers of ""{path}"" as changed", EventName = "FlaggedObservers")]
+    [LoggerMessage(18, LogLevel.Trace, @"Flagged {count} observers of ""{path}"" as changed", EventName = "FlaggedObservers")]
     public static partial void FlaggedObservers(this ILogger<CertificatePathWatcher> logger, string path, int count);
 }

--- a/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcherLoggerExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcherLoggerExtensions.cs
@@ -7,57 +7,57 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 
 internal static partial class CertificatePathWatcherLoggerExtensions
 {
-    [LoggerMessage(1, LogLevel.Warning, @"Directory ""{dir}"" does not exist so changes to the certificate ""{path}"" will not be tracked", EventName = "DirectoryDoesNotExist")]
+    [LoggerMessage(1, LogLevel.Warning, @"Directory ""{Dir}"" does not exist so changes to the certificate ""{Path}"" will not be tracked", EventName = "DirectoryDoesNotExist")]
     public static partial void DirectoryDoesNotExist(this ILogger<CertificatePathWatcher> logger, string dir, string path);
 
-    [LoggerMessage(2, LogLevel.Warning, @"Attempted to remove watch from unwatched path ""{path}""", EventName = "UnknownFile")]
+    [LoggerMessage(2, LogLevel.Warning, @"Attempted to remove watch from unwatched path ""{Path}""", EventName = "UnknownFile")]
     public static partial void UnknownFile(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(3, LogLevel.Warning, @"Attempted to remove unknown observer from path ""{path}""", EventName = "UnknownObserver")]
+    [LoggerMessage(3, LogLevel.Warning, @"Attempted to remove unknown observer from path ""{Path}""", EventName = "UnknownObserver")]
     public static partial void UnknownObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(4, LogLevel.Debug, @"Created directory watcher for ""{dir}""", EventName = "CreatedDirectoryWatcher")]
+    [LoggerMessage(4, LogLevel.Debug, @"Created directory watcher for ""{Dir}""", EventName = "CreatedDirectoryWatcher")]
     public static partial void CreatedDirectoryWatcher(this ILogger<CertificatePathWatcher> logger, string dir);
 
-    [LoggerMessage(5, LogLevel.Debug, @"Created file watcher for ""{path}""", EventName = "CreatedFileWatcher")]
+    [LoggerMessage(5, LogLevel.Debug, @"Created file watcher for ""{Path}""", EventName = "CreatedFileWatcher")]
     public static partial void CreatedFileWatcher(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(6, LogLevel.Debug, @"Removed directory watcher for ""{dir}""", EventName = "RemovedDirectoryWatcher")]
+    [LoggerMessage(6, LogLevel.Debug, @"Removed directory watcher for ""{Dir}""", EventName = "RemovedDirectoryWatcher")]
     public static partial void RemovedDirectoryWatcher(this ILogger<CertificatePathWatcher> logger, string dir);
 
-    [LoggerMessage(7, LogLevel.Debug, @"Removed file watcher for ""{path}""", EventName = "RemovedFileWatcher")]
+    [LoggerMessage(7, LogLevel.Debug, @"Removed file watcher for ""{Path}""", EventName = "RemovedFileWatcher")]
     public static partial void RemovedFileWatcher(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(8, LogLevel.Debug, @"Error retrieving last modified time for ""{path}""", EventName = "LastModifiedTimeError")]
+    [LoggerMessage(8, LogLevel.Debug, @"Error retrieving last modified time for ""{Path}""", EventName = "LastModifiedTimeError")]
     public static partial void LastModifiedTimeError(this ILogger<CertificatePathWatcher> logger, string path, Exception e);
 
-    [LoggerMessage(9, LogLevel.Debug, @"Ignored event for presently untracked file ""{path}""", EventName = "UntrackedFileEvent")]
+    [LoggerMessage(9, LogLevel.Debug, @"Ignored event for presently untracked file ""{Path}""", EventName = "UntrackedFileEvent")]
     public static partial void UntrackedFileEvent(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(10, LogLevel.Debug, @"Ignored out-of-order event for file ""{path}""", EventName = "OutOfOrderEvent")]
+    [LoggerMessage(10, LogLevel.Debug, @"Ignored out-of-order event for file ""{Path}""", EventName = "OutOfOrderEvent")]
     public static partial void OutOfOrderEvent(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(11, LogLevel.Trace, @"Reused existing observer on file watcher for ""{path}""", EventName = "ReusedObserver")]
+    [LoggerMessage(11, LogLevel.Trace, @"Reused existing observer on file watcher for ""{Path}""", EventName = "ReusedObserver")]
     public static partial void ReusedObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(12, LogLevel.Trace, @"Added observer to file watcher for ""{path}""", EventName = "AddedObserver")]
+    [LoggerMessage(12, LogLevel.Trace, @"Added observer to file watcher for ""{Path}""", EventName = "AddedObserver")]
     public static partial void AddedObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(13, LogLevel.Trace, @"Removed observer from file watcher for ""{path}""", EventName = "RemovedObserver")]
+    [LoggerMessage(13, LogLevel.Trace, @"Removed observer from file watcher for ""{Path}""", EventName = "RemovedObserver")]
     public static partial void RemovedObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(14, LogLevel.Trace, @"File ""{path}"" now has {count} observers", EventName = "ObserverCount")]
+    [LoggerMessage(14, LogLevel.Trace, @"File ""{Path}"" now has {Count} observers", EventName = "ObserverCount")]
     public static partial void ObserverCount(this ILogger<CertificatePathWatcher> logger, string path, int count);
 
-    [LoggerMessage(15, LogLevel.Trace, @"Directory ""{dir}"" now has watchers on {count} files", EventName = "FileCount")]
+    [LoggerMessage(15, LogLevel.Trace, @"Directory ""{Dir}"" now has watchers on {Count} files", EventName = "FileCount")]
     public static partial void FileCount(this ILogger<CertificatePathWatcher> logger, string dir, int count);
 
-    [LoggerMessage(16, LogLevel.Trace, @"Ignored event since last modified time for ""{path}"" was unavailable", EventName = "EventWithoutLastModifiedTime")]
+    [LoggerMessage(16, LogLevel.Trace, @"Ignored event since last modified time for ""{Path}"" was unavailable", EventName = "EventWithoutLastModifiedTime")]
     public static partial void EventWithoutLastModifiedTime(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(17, LogLevel.Trace, @"Ignored redundant event for ""{path}""", EventName = "RedundantEvent")]
+    [LoggerMessage(17, LogLevel.Trace, @"Ignored redundant event for ""{Path}""", EventName = "RedundantEvent")]
     public static partial void RedundantEvent(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(18, LogLevel.Trace, @"Flagged {count} observers of ""{path}"" as changed", EventName = "FlaggedObservers")]
+    [LoggerMessage(18, LogLevel.Trace, @"Flagged {Count} observers of ""{Path}"" as changed", EventName = "FlaggedObservers")]
     public static partial void FlaggedObservers(this ILogger<CertificatePathWatcher> logger, string path, int count);
 }

--- a/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcherLoggerExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcherLoggerExtensions.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
+
+internal static partial class CertificatePathWatcherLoggerExtensions
+{
+    [LoggerMessage(0, LogLevel.Warning, @"Directory ""{dir}"" does not exist so changes to the certificate ""{path}"" will not be tracked", EventName = "DirectoryDoesNotExist")]
+    public static partial void DirectoryDoesNotExist(this ILogger<CertificatePathWatcher> logger, string dir, string path);
+
+    [LoggerMessage(1, LogLevel.Warning, @"Attempted to remove watch from unwatched path ""{path}""", EventName = "UnknownFile")]
+    public static partial void UnknownFile(this ILogger<CertificatePathWatcher> logger, string path);
+
+    [LoggerMessage(2, LogLevel.Warning, @"Attempted to remove unknown observer from path ""{path}""", EventName = "UnknownObserver")]
+    public static partial void UnknownObserver(this ILogger<CertificatePathWatcher> logger, string path);
+
+    [LoggerMessage(3, LogLevel.Debug, @"Created directory watcher for ""{dir}""", EventName = "CreatedDirectoryWatcher")]
+    public static partial void CreatedDirectoryWatcher(this ILogger<CertificatePathWatcher> logger, string dir);
+
+    [LoggerMessage(4, LogLevel.Debug, @"Created file watcher for ""{path}""", EventName = "CreatedFileWatcher")]
+    public static partial void CreatedFileWatcher(this ILogger<CertificatePathWatcher> logger, string path);
+
+    [LoggerMessage(5, LogLevel.Debug, @"Removed directory watcher for ""{dir}""", EventName = "RemovedDirectoryWatcher")]
+    public static partial void RemovedDirectoryWatcher(this ILogger<CertificatePathWatcher> logger, string dir);
+
+    [LoggerMessage(6, LogLevel.Debug, @"Removed file watcher for ""{path}""", EventName = "RemovedFileWatcher")]
+    public static partial void RemovedFileWatcher(this ILogger<CertificatePathWatcher> logger, string path);
+
+    [LoggerMessage(7, LogLevel.Debug, @"Error retrieving last modified time for ""{path}""", EventName = "LastModifiedTimeError")]
+    public static partial void LastModifiedTimeError(this ILogger<CertificatePathWatcher> logger, string path, Exception e);
+
+    [LoggerMessage(8, LogLevel.Debug, @"Ignored event for presently untracked file ""{path}""", EventName = "UntrackedFileEvent")]
+    public static partial void UntrackedFileEvent(this ILogger<CertificatePathWatcher> logger, string path);
+
+    [LoggerMessage(9, LogLevel.Debug, @"Ignored out-of-order event for file ""{path}""", EventName = "OutOfOrderEvent")]
+    public static partial void OutOfOrderEvent(this ILogger<CertificatePathWatcher> logger, string path);
+
+    [LoggerMessage(10, LogLevel.Trace, @"Reused existing observer on file watcher for ""{path}""", EventName = "ReusedObserver")]
+    public static partial void ReusedObserver(this ILogger<CertificatePathWatcher> logger, string path);
+
+    [LoggerMessage(11, LogLevel.Trace, @"Added observer to file watcher for ""{path}""", EventName = "AddedObserver")]
+    public static partial void AddedObserver(this ILogger<CertificatePathWatcher> logger, string path);
+
+    [LoggerMessage(12, LogLevel.Trace, @"Removed observer from file watcher for ""{path}""", EventName = "RemovedObserver")]
+    public static partial void RemovedObserver(this ILogger<CertificatePathWatcher> logger, string path);
+
+    [LoggerMessage(13, LogLevel.Trace, @"File ""{path}"" now has {count} observers", EventName = "ObserverCount")]
+    public static partial void ObserverCount(this ILogger<CertificatePathWatcher> logger, string path, int count);
+
+    [LoggerMessage(14, LogLevel.Trace, @"Directory ""{dir}"" now has watchers on {count} files", EventName = "FileCount")]
+    public static partial void FileCount(this ILogger<CertificatePathWatcher> logger, string dir, int count);
+
+    [LoggerMessage(15, LogLevel.Trace, @"Ignored event since last modified time for ""{path}"" was unavailable", EventName = "EventWithoutLastModifiedTime")]
+    public static partial void EventWithoutLastModifiedTime(this ILogger<CertificatePathWatcher> logger, string path);
+
+    [LoggerMessage(16, LogLevel.Trace, @"Ignored redundant event for ""{path}""", EventName = "RedundantEvent")]
+    public static partial void RedundantEvent(this ILogger<CertificatePathWatcher> logger, string path);
+
+    [LoggerMessage(17, LogLevel.Trace, @"Flagged {count} observers of ""{path}"" as changed", EventName = "FlaggedObservers")]
+    public static partial void FlaggedObservers(this ILogger<CertificatePathWatcher> logger, string path, int count);
+}

--- a/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
@@ -390,35 +390,41 @@ internal sealed class CertificateConfig
     // File
     public bool IsFileCert => !string.IsNullOrEmpty(Path);
 
-    public string? Path { get; set; }
+    public string? Path { get; init; }
 
-    public string? KeyPath { get; set; }
+    public string? KeyPath { get; init; }
 
-    public string? Password { get; set; }
+    public string? Password { get; init; }
+
+    /// <remarks>
+    /// Vacuously false if this isn't a file cert.
+    /// </remarks>
+    public bool FileHasChanged { get; internal set; }
 
     // Cert store
 
     public bool IsStoreCert => !string.IsNullOrEmpty(Subject);
 
-    public string? Subject { get; set; }
+    public string? Subject { get; init; }
 
-    public string? Store { get; set; }
+    public string? Store { get; init; }
 
-    public string? Location { get; set; }
+    public string? Location { get; init; }
 
-    public bool? AllowInvalid { get; set; }
+    public bool? AllowInvalid { get; init; }
 
     public override bool Equals(object? obj) =>
         obj is CertificateConfig other &&
         Path == other.Path &&
         KeyPath == other.KeyPath &&
         Password == other.Password &&
+        FileHasChanged == other.FileHasChanged &&
         Subject == other.Subject &&
         Store == other.Store &&
         Location == other.Location &&
         (AllowInvalid ?? false) == (other.AllowInvalid ?? false);
 
-    public override int GetHashCode() => HashCode.Combine(Path, KeyPath, Password, Subject, Store, Location, AllowInvalid ?? false);
+    public override int GetHashCode() => HashCode.Combine(Path, KeyPath, Password, FileHasChanged, Subject, Store, Location, AllowInvalid ?? false);
 
     public static bool operator ==(CertificateConfig? lhs, CertificateConfig? rhs) => lhs is null ? rhs is null : lhs.Equals(rhs);
     public static bool operator !=(CertificateConfig? lhs, CertificateConfig? rhs) => !(lhs == rhs);

--- a/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Security.Authentication;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
@@ -388,6 +389,8 @@ internal sealed class CertificateConfig
     public IConfigurationSection? ConfigSection { get; }
 
     // File
+
+    [MemberNotNullWhen(true, nameof(Path))]
     public bool IsFileCert => !string.IsNullOrEmpty(Path);
 
     public string? Path { get; init; }
@@ -403,6 +406,7 @@ internal sealed class CertificateConfig
 
     // Cert store
 
+    [MemberNotNullWhen(true, nameof(Subject))]
     public bool IsStoreCert => !string.IsNullOrEmpty(Subject);
 
     public string? Subject { get; init; }

--- a/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/ConfigurationReader.cs
@@ -401,6 +401,7 @@ internal sealed class CertificateConfig
 
     /// <remarks>
     /// Vacuously false if this isn't a file cert.
+    /// Used for change tracking - not actually part of configuring the certificate.
     /// </remarks>
     public bool FileHasChanged { get; internal set; }
 

--- a/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/KestrelServerImpl.cs
@@ -300,7 +300,7 @@ internal sealed class KestrelServerImpl : IServer
 
             if (Options.ConfigurationLoader?.ReloadOnChange == true && (!_serverAddresses.PreferHostingUrls || _serverAddresses.InternalCollection.Count == 0))
             {
-                reloadToken = Options.ConfigurationLoader.Configuration.GetReloadToken();
+                reloadToken = Options.ConfigurationLoader.GetReloadToken();
             }
 
             Options.ConfigurationLoader?.LoadInternal();
@@ -340,7 +340,7 @@ internal sealed class KestrelServerImpl : IServer
 
             Debug.Assert(Options.ConfigurationLoader != null, "Rebind can only happen when there is a ConfigurationLoader.");
 
-            reloadToken = Options.ConfigurationLoader.Configuration.GetReloadToken();
+            reloadToken = Options.ConfigurationLoader.GetReloadToken();
             var (endpointsToStop, endpointsToStart) = Options.ConfigurationLoader.Reload();
 
             Trace.LogDebug("Config reload token fired. Checking for changes...");

--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -20,15 +20,22 @@ public class KestrelConfigurationLoader
 {
     private readonly IHttpsConfigurationService _httpsConfigurationService;
 
+    /// <remarks>
+    /// Non-null only makes sense if <see cref="ReloadOnChange"/> is true.
+    /// </remarks>
+    private readonly CertificatePathWatcher? _certificatePathWatcher;
+
     private bool _loaded;
     private bool _endpointsToAddProcessed;
 
+    // This is not used to trigger reloads but to suppress redundant reloads triggered in other ways
     private IChangeToken? _reloadToken;
 
     internal KestrelConfigurationLoader(
         KestrelServerOptions options,
         IConfiguration configuration,
         IHttpsConfigurationService httpsConfigurationService,
+        CertificatePathWatcher? certificatePathWatcher,
         bool reloadOnChange)
     {
         Options = options;
@@ -39,6 +46,8 @@ public class KestrelConfigurationLoader
         ConfigurationReader = new ConfigurationReader(configuration);
 
         _httpsConfigurationService = httpsConfigurationService;
+        _certificatePathWatcher = certificatePathWatcher;
+        Debug.Assert(!!reloadOnChange || (certificatePathWatcher is null), "If reloadOnChange is false, then certificatePathWatcher should be null");
     }
 
     /// <summary>
@@ -49,7 +58,7 @@ public class KestrelConfigurationLoader
     /// <summary>
     /// Gets the application <see cref="IConfiguration"/>.
     /// </summary>
-    public IConfiguration Configuration { get; internal set; }
+    public IConfiguration Configuration { get; internal set; } // Setter internal for testing
 
     /// <summary>
     /// If <see langword="true" />, Kestrel will dynamically update endpoint bindings when configuration changes.
@@ -283,18 +292,35 @@ public class KestrelConfigurationLoader
         }
     }
 
+    internal IChangeToken? GetReloadToken()
+    {
+        Debug.Assert(ReloadOnChange);
+
+        var configToken = Configuration.GetReloadToken();
+
+        if (_certificatePathWatcher is null)
+        {
+            return configToken;
+        }
+
+        var watcherToken = _certificatePathWatcher.GetChangeToken();
+        return new CompositeChangeToken(new[] { configToken, watcherToken });
+    }
+
     // Adds endpoints from config to KestrelServerOptions.ConfigurationBackedListenOptions and configures some other options.
     // Any endpoints that were removed from the last time endpoints were loaded are returned.
     internal (List<ListenOptions>, List<ListenOptions>) Reload()
     {
         if (ReloadOnChange)
         {
-            _reloadToken = Configuration.GetReloadToken();
+            _reloadToken = GetReloadToken();
         }
 
         var endpointsToStop = Options.ConfigurationBackedListenOptions.ToList();
         var endpointsToStart = new List<ListenOptions>();
         var endpointsToReuse = new List<ListenOptions>();
+
+        var oldDefaultCertificateConfig = DefaultCertificateConfig;
 
         DefaultCertificateConfig = null;
         DefaultCertificate = null;
@@ -345,6 +371,7 @@ public class KestrelConfigurationLoader
             {
                 if (o.EndpointConfig == endpoint)
                 {
+                    Debug.Assert(o.EndpointConfig?.Certificate?.FileHasChanged != true, "Preserving an endpoint with file changes");
                     matchingBoundEndpoints.Add(o);
                 }
             }
@@ -383,6 +410,75 @@ public class KestrelConfigurationLoader
         Options.ConfigurationBackedListenOptions.Clear();
         Options.ConfigurationBackedListenOptions.AddRange(endpointsToReuse);
         Options.ConfigurationBackedListenOptions.AddRange(endpointsToStart);
+
+        if (ReloadOnChange && _certificatePathWatcher is not null)
+        {
+            var certificateConfigsToRemove = new List<CertificateConfig>();
+            var certificateConfigsToAdd = new List<CertificateConfig>();
+
+            if (DefaultCertificateConfig != oldDefaultCertificateConfig)
+            {
+                if (DefaultCertificateConfig?.IsFileCert == true)
+                {
+                    certificateConfigsToAdd.Add(DefaultCertificateConfig);
+                }
+
+                if (oldDefaultCertificateConfig is not null)
+                {
+                    certificateConfigsToRemove.Add(oldDefaultCertificateConfig);
+                }
+            }
+
+            foreach (var endpointToStart in endpointsToStart)
+            {
+                var endpointConfig = endpointToStart.EndpointConfig;
+                if (endpointConfig is null)
+                {
+                    continue;
+                }
+
+                var certConfig = endpointConfig.Certificate;
+                if (certConfig?.IsFileCert == true)
+                {
+                    certificateConfigsToAdd.Add(certConfig);
+                }
+
+                foreach (var sniConfig in endpointConfig.Sni.Values)
+                {
+                    var sniCertConfig = sniConfig.Certificate;
+                    if (sniCertConfig?.IsFileCert == true)
+                    {
+                        certificateConfigsToAdd.Add(sniCertConfig);
+                    }
+                }
+            }
+
+            foreach (var endpointToStop in endpointsToStop)
+            {
+                var endpointConfig = endpointToStop.EndpointConfig;
+                if (endpointConfig is null)
+                {
+                    continue;
+                }
+
+                var certConfig = endpointConfig.Certificate;
+                if (certConfig?.IsFileCert == true)
+                {
+                    certificateConfigsToRemove.Add(certConfig);
+                }
+
+                foreach (var sniConfig in endpointConfig.Sni.Values)
+                {
+                    var sniCertConfig = sniConfig.Certificate;
+                    if (sniCertConfig?.IsFileCert == true)
+                    {
+                        certificateConfigsToRemove.Add(sniCertConfig);
+                    }
+                }
+            }
+
+            _certificatePathWatcher.UpdateWatches(certificateConfigsToRemove, certificateConfigsToAdd);
+        }
 
         return (endpointsToStop, endpointsToStart);
     }

--- a/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelConfigurationLoader.cs
@@ -47,7 +47,7 @@ public class KestrelConfigurationLoader
 
         _httpsConfigurationService = httpsConfigurationService;
         _certificatePathWatcher = certificatePathWatcher;
-        Debug.Assert(!!reloadOnChange || (certificatePathWatcher is null), "If reloadOnChange is false, then certificatePathWatcher should be null");
+        Debug.Assert(reloadOnChange || (certificatePathWatcher is null), "If reloadOnChange is false, then certificatePathWatcher should be null");
     }
 
     /// <summary>

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -28,11 +28,14 @@ public class KestrelServerOptions
 {
     internal const string DisableHttp1LineFeedTerminatorsSwitchKey = "Microsoft.AspNetCore.Server.Kestrel.DisableHttp1LineFeedTerminators";
     private const string FinOnErrorSwitch = "Microsoft.AspNetCore.Server.Kestrel.FinOnError";
+    private const string CertificateFileWatchingSwitch = "Microsoft.AspNetCore.Server.Kestrel.DisableCertificateFileWatching";
     private static readonly bool _finOnError;
+    private static readonly bool _disableCertificateFileWatching;
 
     static KestrelServerOptions()
     {
         AppContext.TryGetSwitch(FinOnErrorSwitch, out _finOnError);
+        AppContext.TryGetSwitch(CertificateFileWatchingSwitch, out _disableCertificateFileWatching);
     }
 
     // internal to fast-path header decoding when RequestHeaderEncodingSelector is unchanged.
@@ -443,7 +446,12 @@ public class KestrelServerOptions
         }
 
         var httpsConfigurationService = ApplicationServices.GetRequiredService<IHttpsConfigurationService>();
-        var loader = new KestrelConfigurationLoader(this, config, httpsConfigurationService, reloadOnChange);
+        var certificatePathWatcher = reloadOnChange && !_disableCertificateFileWatching
+            ? new CertificatePathWatcher(
+                ApplicationServices.GetRequiredService<IHostEnvironment>(),
+                ApplicationServices.GetRequiredService<ILogger<CertificatePathWatcher>>())
+            : null;
+        var loader = new KestrelConfigurationLoader(this, config, httpsConfigurationService, certificatePathWatcher, reloadOnChange);
         ConfigurationLoader = loader;
         return loader;
     }

--- a/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerOptions.cs
@@ -28,7 +28,7 @@ public class KestrelServerOptions
 {
     internal const string DisableHttp1LineFeedTerminatorsSwitchKey = "Microsoft.AspNetCore.Server.Kestrel.DisableHttp1LineFeedTerminators";
     private const string FinOnErrorSwitch = "Microsoft.AspNetCore.Server.Kestrel.FinOnError";
-    private const string CertificateFileWatchingSwitch = "Microsoft.AspNetCore.Server.Kestrel.DisableCertificateFileWatching";
+    internal const string CertificateFileWatchingSwitch = "Microsoft.AspNetCore.Server.Kestrel.DisableCertificateFileWatching";
     private static readonly bool _finOnError;
     private static readonly bool _disableCertificateFileWatching;
 

--- a/src/Servers/Kestrel/Core/test/CertificatePathWatcherTests.cs
+++ b/src/Servers/Kestrel/Core/test/CertificatePathWatcherTests.cs
@@ -44,7 +44,7 @@ public class CertificatePathWatcherTests : LoggedTest
 
             if (fileExists)
             {
-                Touch(filePath);
+                ChangeFile(filePath);
             }
 
             Assert.Equal(fileExists, File.Exists(filePath));
@@ -155,10 +155,10 @@ public class CertificatePathWatcherTests : LoggedTest
         try
         {
             var dir = dirInfo.FullName;
-            var fileName = $"{nameof(FileChanged)}-{observerCount}.pfx";
+            var fileName = Path.GetRandomFileName();
             var filePath = Path.Combine(dir, fileName);
 
-            Touch(filePath);
+            ChangeFile(filePath);
 
             var hostEnvironment = new Mock<IHostEnvironment>();
             hostEnvironment.SetupGet(h => h.ContentRootPath).Returns(dir);
@@ -187,7 +187,7 @@ public class CertificatePathWatcherTests : LoggedTest
             Assert.Equal(1, watcher.TestGetFileWatchCountUnsynchronized(dir));
             Assert.Equal(observerCount, watcher.TestGetObserverCountUnsynchronized(filePath));
 
-            Touch(filePath);
+            ChangeFile(filePath);
 
             await signalTcs.Task.TimeoutAfter(FileChangeTimeout);
 
@@ -244,7 +244,7 @@ public class CertificatePathWatcherTests : LoggedTest
             var fileName = Path.GetRandomFileName();
             var filePath = Path.Combine(dir, fileName);
 
-            Touch(filePath);
+            ChangeFile(filePath);
 
             var hostEnvironment = new Mock<IHostEnvironment>();
             hostEnvironment.SetupGet(h => h.ContentRootPath).Returns(dir);
@@ -291,7 +291,7 @@ public class CertificatePathWatcherTests : LoggedTest
             var fileName = Path.GetRandomFileName();
             var filePath = Path.Combine(dir, fileName);
 
-            Touch(filePath);
+            ChangeFile(filePath);
 
             var hostEnvironment = new Mock<IHostEnvironment>();
             hostEnvironment.SetupGet(h => h.ContentRootPath).Returns(dir);
@@ -344,7 +344,7 @@ public class CertificatePathWatcherTests : LoggedTest
             var fileName = Path.GetRandomFileName();
             var filePath = Path.Combine(dir, fileName);
 
-            Touch(filePath);
+            ChangeFile(filePath);
 
             var hostEnvironment = new Mock<IHostEnvironment>();
             hostEnvironment.SetupGet(h => h.ContentRootPath).Returns(dir);
@@ -385,10 +385,10 @@ public class CertificatePathWatcherTests : LoggedTest
         try
         {
             var dir = dirInfo.FullName;
-            var fileName = $"{nameof(IgnoreDeletion)}-{deleteDirectory}.pfx";
+            var fileName = Path.GetRandomFileName();
             var filePath = Path.Combine(dir, fileName);
 
-            Touch(filePath);
+            ChangeFile(filePath);
 
             var hostEnvironment = new Mock<IHostEnvironment>();
             hostEnvironment.SetupGet(h => h.ContentRootPath).Returns(dir);
@@ -464,7 +464,7 @@ public class CertificatePathWatcherTests : LoggedTest
 
             Assert.True(File.Exists(filePath));
 
-            Touch(filePath); // In some scenarios, renaming the file back doesn't change the last modified time
+            ChangeFile(filePath); // In some scenarios, renaming the file back doesn't change the last modified time
 
             await changeTcs.Task.TimeoutAfter(FileChangeTimeout);
         }
@@ -557,9 +557,10 @@ public class CertificatePathWatcherTests : LoggedTest
         }
     }
 
-    private static void Touch(string filePath)
+    private static void ChangeFile(string filePath)
     {
-        File.WriteAllBytes(filePath, Array.Empty<byte>());
+        File.WriteAllText(filePath, DateTime.UtcNow.ToLongTimeString());
+        File.SetLastWriteTimeUtc(filePath, DateTime.UtcNow);
     }
 
     private static IDictionary<string, object> GetLogMessageProperties(ITestSink testSink, string eventName)

--- a/src/Servers/Kestrel/Core/test/CertificatePathWatcherTests.cs
+++ b/src/Servers/Kestrel/Core/test/CertificatePathWatcherTests.cs
@@ -54,7 +54,7 @@ public class CertificatePathWatcherTests : LoggedTest
             watcher.AddWatchUnsynchronized(certificateConfig);
 
             messageProps = GetLogMessageProperties(TestSink, "CreatedDirectoryWatcher");
-            Assert.Equal(dir, messageProps["Dir"]);
+            Assert.Equal(dir, messageProps["Directory"]);
 
             messageProps = GetLogMessageProperties(TestSink, "CreatedFileWatcher");
             Assert.Equal(filePath, messageProps["Path"]);
@@ -69,7 +69,7 @@ public class CertificatePathWatcherTests : LoggedTest
             Assert.Equal(filePath, messageProps["Path"]);
 
             messageProps = GetLogMessageProperties(TestSink, "RemovedDirectoryWatcher");
-            Assert.Equal(dir, messageProps["Dir"]);
+            Assert.Equal(dir, messageProps["Directory"]);
 
             Assert.Equal(0, watcher.TestGetDirectoryWatchCountUnsynchronized());
             Assert.Equal(0, watcher.TestGetFileWatchCountUnsynchronized(dir));
@@ -227,7 +227,7 @@ public class CertificatePathWatcherTests : LoggedTest
         watcher.AddWatchUnsynchronized(certificateConfig);
 
         var messageProps = GetLogMessageProperties(TestSink, "DirectoryDoesNotExist");
-        Assert.Equal(dir, messageProps["Dir"]);
+        Assert.Equal(dir, messageProps["Directory"]);
 
         Assert.Equal(0, watcher.TestGetDirectoryWatchCountUnsynchronized());
     }

--- a/src/Servers/Kestrel/Core/test/CertificatePathWatcherTests.cs
+++ b/src/Servers/Kestrel/Core/test/CertificatePathWatcherTests.cs
@@ -51,7 +51,7 @@ public class CertificatePathWatcherTests : LoggedTest
 
             IDictionary<string, object> messageProps;
 
-            watcher.AddWatch(certificateConfig);
+            watcher.AddWatchUnsynchronized(certificateConfig);
 
             messageProps = GetLogMessageProperties(TestSink, "CreatedDirectoryWatcher");
             Assert.Equal(dir, messageProps["dir"]);
@@ -59,11 +59,11 @@ public class CertificatePathWatcherTests : LoggedTest
             messageProps = GetLogMessageProperties(TestSink, "CreatedFileWatcher");
             Assert.Equal(filePath, messageProps["path"]);
 
-            Assert.Equal(1, watcher.TestGetDirectoryWatchCount());
-            Assert.Equal(1, watcher.TestGetFileWatchCount(dir));
-            Assert.Equal(1, watcher.TestGetObserverCount(filePath));
+            Assert.Equal(1, watcher.TestGetDirectoryWatchCountUnsynchronized());
+            Assert.Equal(1, watcher.TestGetFileWatchCountUnsynchronized(dir));
+            Assert.Equal(1, watcher.TestGetObserverCountUnsynchronized(filePath));
 
-            watcher.RemoveWatch(certificateConfig);
+            watcher.RemoveWatchUnsynchronized(certificateConfig);
 
             messageProps = GetLogMessageProperties(TestSink, "RemovedFileWatcher");
             Assert.Equal(filePath, messageProps["path"]);
@@ -71,9 +71,9 @@ public class CertificatePathWatcherTests : LoggedTest
             messageProps = GetLogMessageProperties(TestSink, "RemovedDirectoryWatcher");
             Assert.Equal(dir, messageProps["dir"]);
 
-            Assert.Equal(0, watcher.TestGetDirectoryWatchCount());
-            Assert.Equal(0, watcher.TestGetFileWatchCount(dir));
-            Assert.Equal(0, watcher.TestGetObserverCount(filePath));
+            Assert.Equal(0, watcher.TestGetDirectoryWatchCountUnsynchronized());
+            Assert.Equal(0, watcher.TestGetFileWatchCountUnsynchronized(dir));
+            Assert.Equal(0, watcher.TestGetObserverCountUnsynchronized(filePath));
 
             Assert.Same(changeToken, watcher.GetChangeToken());
             Assert.False(changeToken.HasChanged);
@@ -122,22 +122,22 @@ public class CertificatePathWatcherTests : LoggedTest
 
             foreach (var certificateConfig in certificateConfigs)
             {
-                watcher.AddWatch(certificateConfig);
+                watcher.AddWatchUnsynchronized(certificateConfig);
             }
 
-            Assert.Equal(Math.Min(dirCount, fileCount), watcher.TestGetDirectoryWatchCount());
+            Assert.Equal(Math.Min(dirCount, fileCount), watcher.TestGetDirectoryWatchCountUnsynchronized());
 
             for (int i = 0; i < dirCount; i++)
             {
-                Assert.Equal(filesInDir[i], watcher.TestGetFileWatchCount(dirs[i]));
+                Assert.Equal(filesInDir[i], watcher.TestGetFileWatchCountUnsynchronized(dirs[i]));
             }
 
             foreach (var certificateConfig in certificateConfigs)
             {
-                watcher.RemoveWatch(certificateConfig);
+                watcher.RemoveWatchUnsynchronized(certificateConfig);
             }
 
-            Assert.Equal(0, watcher.TestGetDirectoryWatchCount());
+            Assert.Equal(0, watcher.TestGetDirectoryWatchCountUnsynchronized());
         }
         finally
         {
@@ -179,12 +179,12 @@ public class CertificatePathWatcherTests : LoggedTest
                     Path = filePath,
                 };
 
-                watcher.AddWatch(certificateConfigs[i]);
+                watcher.AddWatchUnsynchronized(certificateConfigs[i]);
             }
 
-            Assert.Equal(1, watcher.TestGetDirectoryWatchCount());
-            Assert.Equal(1, watcher.TestGetFileWatchCount(dir));
-            Assert.Equal(observerCount, watcher.TestGetObserverCount(filePath));
+            Assert.Equal(1, watcher.TestGetDirectoryWatchCountUnsynchronized());
+            Assert.Equal(1, watcher.TestGetFileWatchCountUnsynchronized(dir));
+            Assert.Equal(observerCount, watcher.TestGetObserverCountUnsynchronized(filePath));
 
             Touch(filePath);
 
@@ -223,12 +223,12 @@ public class CertificatePathWatcherTests : LoggedTest
             Path = Path.Combine(dir, "test.pfx"),
         };
 
-        watcher.AddWatch(certificateConfig);
+        watcher.AddWatchUnsynchronized(certificateConfig);
 
         var messageProps = GetLogMessageProperties(TestSink, "DirectoryDoesNotExist");
         Assert.Equal(dir, messageProps["dir"]);
 
-        Assert.Equal(0, watcher.TestGetDirectoryWatchCount());
+        Assert.Equal(0, watcher.TestGetDirectoryWatchCountUnsynchronized());
     }
 
     [Theory]
@@ -259,18 +259,18 @@ public class CertificatePathWatcherTests : LoggedTest
 
             if (previouslyAdded)
             {
-                watcher.AddWatch(certificateConfig);
-                watcher.RemoveWatch(certificateConfig);
+                watcher.AddWatchUnsynchronized(certificateConfig);
+                watcher.RemoveWatchUnsynchronized(certificateConfig);
             }
 
-            Assert.Equal(0, watcher.TestGetObserverCount(filePath));
+            Assert.Equal(0, watcher.TestGetObserverCountUnsynchronized(filePath));
 
-            watcher.RemoveWatch(certificateConfig);
+            watcher.RemoveWatchUnsynchronized(certificateConfig);
 
             var messageProps = GetLogMessageProperties(TestSink, "UnknownFile");
             Assert.Equal(filePath, messageProps["path"]);
 
-            Assert.Equal(0, watcher.TestGetObserverCount(filePath));
+            Assert.Equal(0, watcher.TestGetObserverCountUnsynchronized(filePath));
         }
         finally
         {
@@ -309,22 +309,22 @@ public class CertificatePathWatcherTests : LoggedTest
                 Path = filePath,
             };
 
-            watcher.AddWatch(certificateConfig1);
+            watcher.AddWatchUnsynchronized(certificateConfig1);
 
             if (previouslyAdded)
             {
-                watcher.AddWatch(certificateConfig2);
-                watcher.RemoveWatch(certificateConfig2);
+                watcher.AddWatchUnsynchronized(certificateConfig2);
+                watcher.RemoveWatchUnsynchronized(certificateConfig2);
             }
 
-            Assert.Equal(1, watcher.TestGetObserverCount(filePath));
+            Assert.Equal(1, watcher.TestGetObserverCountUnsynchronized(filePath));
 
-            watcher.RemoveWatch(certificateConfig2);
+            watcher.RemoveWatchUnsynchronized(certificateConfig2);
 
             var messageProps = GetLogMessageProperties(TestSink, "UnknownObserver");
             Assert.Equal(filePath, messageProps["path"]);
 
-            Assert.Equal(1, watcher.TestGetObserverCount(filePath));
+            Assert.Equal(1, watcher.TestGetObserverCountUnsynchronized(filePath));
         }
         finally
         {
@@ -357,16 +357,16 @@ public class CertificatePathWatcherTests : LoggedTest
                 Path = filePath,
             };
 
-            watcher.AddWatch(certificateConfig);
+            watcher.AddWatchUnsynchronized(certificateConfig);
 
-            Assert.Equal(1, watcher.TestGetObserverCount(filePath));
+            Assert.Equal(1, watcher.TestGetObserverCountUnsynchronized(filePath));
 
-            watcher.AddWatch(certificateConfig);
+            watcher.AddWatchUnsynchronized(certificateConfig);
 
             var messageProps = GetLogMessageProperties(TestSink, "ReusedObserver");
             Assert.Equal(filePath, messageProps["path"]);
 
-            Assert.Equal(1, watcher.TestGetObserverCount(filePath));
+            Assert.Equal(1, watcher.TestGetObserverCountUnsynchronized(filePath));
         }
         finally
         {
@@ -401,11 +401,11 @@ public class CertificatePathWatcherTests : LoggedTest
                 Path = filePath,
             };
 
-            watcher.AddWatch(certificateConfig);
+            watcher.AddWatchUnsynchronized(certificateConfig);
 
-            Assert.Equal(1, watcher.TestGetDirectoryWatchCount());
-            Assert.Equal(1, watcher.TestGetFileWatchCount(dir));
-            Assert.Equal(1, watcher.TestGetObserverCount(filePath));
+            Assert.Equal(1, watcher.TestGetDirectoryWatchCountUnsynchronized());
+            Assert.Equal(1, watcher.TestGetFileWatchCountUnsynchronized(dir));
+            Assert.Equal(1, watcher.TestGetObserverCountUnsynchronized(filePath));
 
             var changeTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -445,9 +445,9 @@ public class CertificatePathWatcherTests : LoggedTest
                 Assert.True(deleteDirectory);
             }
 
-            Assert.Equal(1, watcher.TestGetDirectoryWatchCount());
-            Assert.Equal(1, watcher.TestGetFileWatchCount(dir));
-            Assert.Equal(1, watcher.TestGetObserverCount(filePath));
+            Assert.Equal(1, watcher.TestGetDirectoryWatchCountUnsynchronized());
+            Assert.Equal(1, watcher.TestGetFileWatchCountUnsynchronized(dir));
+            Assert.Equal(1, watcher.TestGetObserverCountUnsynchronized(filePath));
 
             Assert.False(changeTcs.Task.IsCompleted);
 
@@ -510,23 +510,23 @@ public class CertificatePathWatcherTests : LoggedTest
             // Add certificateConfig1
             watcher.UpdateWatches(new List<CertificateConfig> { }, new List<CertificateConfig> { certificateConfig1 });
 
-            Assert.Equal(1, watcher.TestGetDirectoryWatchCount());
-            Assert.Equal(1, watcher.TestGetFileWatchCount(dir));
-            Assert.Equal(1, watcher.TestGetObserverCount(filePath));
+            Assert.Equal(1, watcher.TestGetDirectoryWatchCountUnsynchronized());
+            Assert.Equal(1, watcher.TestGetFileWatchCountUnsynchronized(dir));
+            Assert.Equal(1, watcher.TestGetObserverCountUnsynchronized(filePath));
 
             // Remove certificateConfig1
             watcher.UpdateWatches(new List<CertificateConfig> { certificateConfig1 }, new List<CertificateConfig> { });
 
-            Assert.Equal(0, watcher.TestGetDirectoryWatchCount());
-            Assert.Equal(0, watcher.TestGetFileWatchCount(dir));
-            Assert.Equal(0, watcher.TestGetObserverCount(filePath));
+            Assert.Equal(0, watcher.TestGetDirectoryWatchCountUnsynchronized());
+            Assert.Equal(0, watcher.TestGetFileWatchCountUnsynchronized(dir));
+            Assert.Equal(0, watcher.TestGetObserverCountUnsynchronized(filePath));
 
             // Re-add certificateConfig1
             watcher.UpdateWatches(new List<CertificateConfig> { }, new List<CertificateConfig> { certificateConfig1 });
 
-            Assert.Equal(1, watcher.TestGetDirectoryWatchCount());
-            Assert.Equal(1, watcher.TestGetFileWatchCount(dir));
-            Assert.Equal(1, watcher.TestGetObserverCount(filePath));
+            Assert.Equal(1, watcher.TestGetDirectoryWatchCountUnsynchronized());
+            Assert.Equal(1, watcher.TestGetFileWatchCountUnsynchronized(dir));
+            Assert.Equal(1, watcher.TestGetObserverCountUnsynchronized(filePath));
 
             watcher.UpdateWatches(
                 new List<CertificateConfig>
@@ -546,9 +546,9 @@ public class CertificatePathWatcherTests : LoggedTest
                     certificateConfig3, // Add it again
                 });
 
-            Assert.Equal(1, watcher.TestGetDirectoryWatchCount());
-            Assert.Equal(1, watcher.TestGetFileWatchCount(dir));
-            Assert.Equal(3, watcher.TestGetObserverCount(filePath));
+            Assert.Equal(1, watcher.TestGetDirectoryWatchCountUnsynchronized());
+            Assert.Equal(1, watcher.TestGetFileWatchCountUnsynchronized(dir));
+            Assert.Equal(3, watcher.TestGetObserverCountUnsynchronized(filePath));
         }
         finally
         {

--- a/src/Servers/Kestrel/Core/test/CertificatePathWatcherTests.cs
+++ b/src/Servers/Kestrel/Core/test/CertificatePathWatcherTests.cs
@@ -54,10 +54,10 @@ public class CertificatePathWatcherTests : LoggedTest
             watcher.AddWatchUnsynchronized(certificateConfig);
 
             messageProps = GetLogMessageProperties(TestSink, "CreatedDirectoryWatcher");
-            Assert.Equal(dir, messageProps["dir"]);
+            Assert.Equal(dir, messageProps["Dir"]);
 
             messageProps = GetLogMessageProperties(TestSink, "CreatedFileWatcher");
-            Assert.Equal(filePath, messageProps["path"]);
+            Assert.Equal(filePath, messageProps["Path"]);
 
             Assert.Equal(1, watcher.TestGetDirectoryWatchCountUnsynchronized());
             Assert.Equal(1, watcher.TestGetFileWatchCountUnsynchronized(dir));
@@ -66,10 +66,10 @@ public class CertificatePathWatcherTests : LoggedTest
             watcher.RemoveWatchUnsynchronized(certificateConfig);
 
             messageProps = GetLogMessageProperties(TestSink, "RemovedFileWatcher");
-            Assert.Equal(filePath, messageProps["path"]);
+            Assert.Equal(filePath, messageProps["Path"]);
 
             messageProps = GetLogMessageProperties(TestSink, "RemovedDirectoryWatcher");
-            Assert.Equal(dir, messageProps["dir"]);
+            Assert.Equal(dir, messageProps["Dir"]);
 
             Assert.Equal(0, watcher.TestGetDirectoryWatchCountUnsynchronized());
             Assert.Equal(0, watcher.TestGetFileWatchCountUnsynchronized(dir));
@@ -226,7 +226,7 @@ public class CertificatePathWatcherTests : LoggedTest
         watcher.AddWatchUnsynchronized(certificateConfig);
 
         var messageProps = GetLogMessageProperties(TestSink, "DirectoryDoesNotExist");
-        Assert.Equal(dir, messageProps["dir"]);
+        Assert.Equal(dir, messageProps["Dir"]);
 
         Assert.Equal(0, watcher.TestGetDirectoryWatchCountUnsynchronized());
     }
@@ -268,7 +268,7 @@ public class CertificatePathWatcherTests : LoggedTest
             watcher.RemoveWatchUnsynchronized(certificateConfig);
 
             var messageProps = GetLogMessageProperties(TestSink, "UnknownFile");
-            Assert.Equal(filePath, messageProps["path"]);
+            Assert.Equal(filePath, messageProps["Path"]);
 
             Assert.Equal(0, watcher.TestGetObserverCountUnsynchronized(filePath));
         }
@@ -322,7 +322,7 @@ public class CertificatePathWatcherTests : LoggedTest
             watcher.RemoveWatchUnsynchronized(certificateConfig2);
 
             var messageProps = GetLogMessageProperties(TestSink, "UnknownObserver");
-            Assert.Equal(filePath, messageProps["path"]);
+            Assert.Equal(filePath, messageProps["Path"]);
 
             Assert.Equal(1, watcher.TestGetObserverCountUnsynchronized(filePath));
         }
@@ -364,7 +364,7 @@ public class CertificatePathWatcherTests : LoggedTest
             watcher.AddWatchUnsynchronized(certificateConfig);
 
             var messageProps = GetLogMessageProperties(TestSink, "ReusedObserver");
-            Assert.Equal(filePath, messageProps["path"]);
+            Assert.Equal(filePath, messageProps["Path"]);
 
             Assert.Equal(1, watcher.TestGetObserverCountUnsynchronized(filePath));
         }

--- a/src/Servers/Kestrel/Core/test/CertificatePathWatcherTests.cs
+++ b/src/Servers/Kestrel/Core/test/CertificatePathWatcherTests.cs
@@ -558,7 +558,7 @@ public class CertificatePathWatcherTests : LoggedTest
 
     private static void Touch(string filePath)
     {
-        File.Create(filePath).Dispose();
+        File.WriteAllBytes(filePath, Array.Empty<byte>());
     }
 
     private static IDictionary<string, object> GetLogMessageProperties(ITestSink testSink, string eventName)

--- a/src/Servers/Kestrel/Core/test/CertificatePathWatcherTests.cs
+++ b/src/Servers/Kestrel/Core/test/CertificatePathWatcherTests.cs
@@ -147,6 +147,7 @@ public class CertificatePathWatcherTests : LoggedTest
 
     [Theory]
     [InlineData(1)]
+    [InlineData(2)]
     [InlineData(4)]
     public async Task FileChanged(int observerCount)
     {
@@ -154,7 +155,7 @@ public class CertificatePathWatcherTests : LoggedTest
         try
         {
             var dir = dirInfo.FullName;
-            var fileName = Path.GetRandomFileName();
+            var fileName = $"{nameof(FileChanged)}-{observerCount}.pfx";
             var filePath = Path.Combine(dir, fileName);
 
             Touch(filePath);
@@ -384,7 +385,7 @@ public class CertificatePathWatcherTests : LoggedTest
         try
         {
             var dir = dirInfo.FullName;
-            var fileName = Path.GetRandomFileName();
+            var fileName = $"{nameof(IgnoreDeletion)}-{deleteDirectory}.pfx";
             var filePath = Path.Combine(dir, fileName);
 
             Touch(filePath);

--- a/src/Servers/Kestrel/Core/test/CertificatePathWatcherTests.cs
+++ b/src/Servers/Kestrel/Core/test/CertificatePathWatcherTests.cs
@@ -12,6 +12,8 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
 
 public class CertificatePathWatcherTests : LoggedTest
 {
+    private static readonly TimeSpan FileChangeTimeout = TimeSpan.FromSeconds(10);
+
     [Theory]
     [InlineData(true, true)]
     [InlineData(true, false)]
@@ -186,7 +188,7 @@ public class CertificatePathWatcherTests : LoggedTest
 
             Touch(filePath);
 
-            await signalTcs.Task.DefaultTimeout();
+            await signalTcs.Task.TimeoutAfter(FileChangeTimeout);
 
             var newChangeToken = watcher.GetChangeToken();
 
@@ -433,7 +435,7 @@ public class CertificatePathWatcherTests : LoggedTest
 
             try
             {
-                await logTcs.Task.DefaultTimeout();
+                await logTcs.Task.TimeoutAfter(FileChangeTimeout);
             }
             catch (TimeoutException)
             {
@@ -463,7 +465,7 @@ public class CertificatePathWatcherTests : LoggedTest
 
             Touch(filePath); // In some scenarios, renaming the file back doesn't change the last modified time
 
-            await changeTcs.Task.DefaultTimeout();
+            await changeTcs.Task.TimeoutAfter(FileChangeTimeout);
         }
         finally
         {

--- a/src/Servers/Kestrel/Core/test/CertificatePathWatcherTests.cs
+++ b/src/Servers/Kestrel/Core/test/CertificatePathWatcherTests.cs
@@ -1,0 +1,569 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
+using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+using Moq;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
+
+public class CertificatePathWatcherTests : LoggedTest
+{
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public void AddAndRemoveWatch(bool fileExists, bool absoluteFilePath)
+    {
+        var dirInfo = Directory.CreateTempSubdirectory();
+        try
+        {
+            var dir = dirInfo.FullName;
+            var fileName = Path.GetRandomFileName();
+            var filePath = Path.Combine(dir, fileName);
+
+            var hostEnvironment = new Mock<IHostEnvironment>();
+            hostEnvironment.SetupGet(h => h.ContentRootPath).Returns(dir);
+
+            var logger = LoggerFactory.CreateLogger<CertificatePathWatcher>();
+
+            using var watcher = new CertificatePathWatcher(hostEnvironment.Object, logger);
+
+            var changeToken = watcher.GetChangeToken();
+
+            var certificateConfig = new CertificateConfig
+            {
+                Path = absoluteFilePath ? filePath : fileName,
+            };
+
+            if (fileExists)
+            {
+                Touch(filePath);
+            }
+
+            Assert.Equal(fileExists, File.Exists(filePath));
+
+            IDictionary<string, object> messageProps;
+
+            watcher.AddWatch(certificateConfig);
+
+            messageProps = GetLogMessageProperties(TestSink, "CreatedDirectoryWatcher");
+            Assert.Equal(dir, messageProps["dir"]);
+
+            messageProps = GetLogMessageProperties(TestSink, "CreatedFileWatcher");
+            Assert.Equal(filePath, messageProps["path"]);
+
+            Assert.Equal(1, watcher.TestGetDirectoryWatchCount());
+            Assert.Equal(1, watcher.TestGetFileWatchCount(dir));
+            Assert.Equal(1, watcher.TestGetObserverCount(filePath));
+
+            watcher.RemoveWatch(certificateConfig);
+
+            messageProps = GetLogMessageProperties(TestSink, "RemovedFileWatcher");
+            Assert.Equal(filePath, messageProps["path"]);
+
+            messageProps = GetLogMessageProperties(TestSink, "RemovedDirectoryWatcher");
+            Assert.Equal(dir, messageProps["dir"]);
+
+            Assert.Equal(0, watcher.TestGetDirectoryWatchCount());
+            Assert.Equal(0, watcher.TestGetFileWatchCount(dir));
+            Assert.Equal(0, watcher.TestGetObserverCount(filePath));
+
+            Assert.Same(changeToken, watcher.GetChangeToken());
+            Assert.False(changeToken.HasChanged);
+        }
+        finally
+        {
+            dirInfo.Delete(recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(2, 4)]
+    [InlineData(5, 3)]
+    [InlineData(5, 13)]
+    public void WatchMultipleDirectories(int dirCount, int fileCount)
+    {
+        var rootDirInfo = Directory.CreateTempSubdirectory();
+        try
+        {
+            var rootDir = rootDirInfo.FullName;
+            var dirs = new string[dirCount];
+
+            var hostEnvironment = new Mock<IHostEnvironment>();
+            hostEnvironment.SetupGet(h => h.ContentRootPath).Returns(rootDir);
+
+            var logger = LoggerFactory.CreateLogger<CertificatePathWatcher>();
+
+            for (int i = 0; i < dirCount; i++)
+            {
+                dirs[i] = Path.Combine(rootDir, $"dir{i}");
+                Directory.CreateDirectory(dirs[i]);
+            }
+
+            using var watcher = new CertificatePathWatcher(hostEnvironment.Object, logger);
+
+            var certificateConfigs = new CertificateConfig[fileCount];
+            var filesInDir = new int[dirCount];
+            for (int i = 0; i < fileCount; i++)
+            {
+                certificateConfigs[i] = new CertificateConfig
+                {
+                    Path = $"dir{i % dirCount}/file{i % fileCount}",
+                };
+                filesInDir[i % dirCount]++;
+            }
+
+            foreach (var certificateConfig in certificateConfigs)
+            {
+                watcher.AddWatch(certificateConfig);
+            }
+
+            Assert.Equal(Math.Min(dirCount, fileCount), watcher.TestGetDirectoryWatchCount());
+
+            for (int i = 0; i < dirCount; i++)
+            {
+                Assert.Equal(filesInDir[i], watcher.TestGetFileWatchCount(dirs[i]));
+            }
+
+            foreach (var certificateConfig in certificateConfigs)
+            {
+                watcher.RemoveWatch(certificateConfig);
+            }
+
+            Assert.Equal(0, watcher.TestGetDirectoryWatchCount());
+        }
+        finally
+        {
+            rootDirInfo.Delete(recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(4)]
+    public async Task FileChanged(int observerCount)
+    {
+        var dirInfo = Directory.CreateTempSubdirectory();
+        try
+        {
+            var dir = dirInfo.FullName;
+            var fileName = Path.GetRandomFileName();
+            var filePath = Path.Combine(dir, fileName);
+
+            Touch(filePath);
+
+            var hostEnvironment = new Mock<IHostEnvironment>();
+            hostEnvironment.SetupGet(h => h.ContentRootPath).Returns(dir);
+
+            var logger = LoggerFactory.CreateLogger<CertificatePathWatcher>();
+
+            using var watcher = new CertificatePathWatcher(hostEnvironment.Object, logger);
+
+            var signalTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var oldChangeToken = watcher.GetChangeToken();
+            oldChangeToken.RegisterChangeCallback(_ => signalTcs.SetResult(), state: null);
+
+            var certificateConfigs = new CertificateConfig[observerCount];
+            for (int i = 0; i < observerCount; i++)
+            {
+                certificateConfigs[i] = new CertificateConfig
+                {
+                    Path = filePath,
+                };
+
+                watcher.AddWatch(certificateConfigs[i]);
+            }
+
+            Assert.Equal(1, watcher.TestGetDirectoryWatchCount());
+            Assert.Equal(1, watcher.TestGetFileWatchCount(dir));
+            Assert.Equal(observerCount, watcher.TestGetObserverCount(filePath));
+
+            Touch(filePath);
+
+            await signalTcs.Task.DefaultTimeout();
+
+            var newChangeToken = watcher.GetChangeToken();
+
+            Assert.NotSame(oldChangeToken, newChangeToken);
+            Assert.True(oldChangeToken.HasChanged);
+            Assert.False(newChangeToken.HasChanged);
+
+            Assert.All(certificateConfigs, cc => Assert.True(cc.FileHasChanged));
+        }
+        finally
+        {
+            dirInfo.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void DirectoryDoesNotExist()
+    {
+        var dir = Path.Combine(Directory.GetCurrentDirectory(), Path.GetRandomFileName());
+
+        Assert.False(Directory.Exists(dir));
+
+        var hostEnvironment = new Mock<IHostEnvironment>();
+        hostEnvironment.SetupGet(h => h.ContentRootPath).Returns(dir);
+
+        var logger = LoggerFactory.CreateLogger<CertificatePathWatcher>();
+
+        using var watcher = new CertificatePathWatcher(hostEnvironment.Object, logger);
+
+        var certificateConfig = new CertificateConfig
+        {
+            Path = Path.Combine(dir, "test.pfx"),
+        };
+
+        watcher.AddWatch(certificateConfig);
+
+        var messageProps = GetLogMessageProperties(TestSink, "DirectoryDoesNotExist");
+        Assert.Equal(dir, messageProps["dir"]);
+
+        Assert.Equal(0, watcher.TestGetDirectoryWatchCount());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void RemoveUnknownFileWatch(bool previouslyAdded)
+    {
+        var dirInfo = Directory.CreateTempSubdirectory();
+        try
+        {
+            var dir = dirInfo.FullName;
+            var fileName = Path.GetRandomFileName();
+            var filePath = Path.Combine(dir, fileName);
+
+            Touch(filePath);
+
+            var hostEnvironment = new Mock<IHostEnvironment>();
+            hostEnvironment.SetupGet(h => h.ContentRootPath).Returns(dir);
+
+            var logger = LoggerFactory.CreateLogger<CertificatePathWatcher>();
+
+            using var watcher = new CertificatePathWatcher(hostEnvironment.Object, logger);
+
+            var certificateConfig = new CertificateConfig
+            {
+                Path = filePath,
+            };
+
+            if (previouslyAdded)
+            {
+                watcher.AddWatch(certificateConfig);
+                watcher.RemoveWatch(certificateConfig);
+            }
+
+            Assert.Equal(0, watcher.TestGetObserverCount(filePath));
+
+            watcher.RemoveWatch(certificateConfig);
+
+            var messageProps = GetLogMessageProperties(TestSink, "UnknownFile");
+            Assert.Equal(filePath, messageProps["path"]);
+
+            Assert.Equal(0, watcher.TestGetObserverCount(filePath));
+        }
+        finally
+        {
+            dirInfo.Delete(recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void RemoveUnknownFileObserver(bool previouslyAdded)
+    {
+        var dirInfo = Directory.CreateTempSubdirectory();
+        try
+        {
+            var dir = dirInfo.FullName;
+            var fileName = Path.GetRandomFileName();
+            var filePath = Path.Combine(dir, fileName);
+
+            Touch(filePath);
+
+            var hostEnvironment = new Mock<IHostEnvironment>();
+            hostEnvironment.SetupGet(h => h.ContentRootPath).Returns(dir);
+
+            var logger = LoggerFactory.CreateLogger<CertificatePathWatcher>();
+
+            using var watcher = new CertificatePathWatcher(hostEnvironment.Object, logger);
+
+            var certificateConfig1 = new CertificateConfig
+            {
+                Path = filePath,
+            };
+
+            var certificateConfig2 = new CertificateConfig
+            {
+                Path = filePath,
+            };
+
+            watcher.AddWatch(certificateConfig1);
+
+            if (previouslyAdded)
+            {
+                watcher.AddWatch(certificateConfig2);
+                watcher.RemoveWatch(certificateConfig2);
+            }
+
+            Assert.Equal(1, watcher.TestGetObserverCount(filePath));
+
+            watcher.RemoveWatch(certificateConfig2);
+
+            var messageProps = GetLogMessageProperties(TestSink, "UnknownObserver");
+            Assert.Equal(filePath, messageProps["path"]);
+
+            Assert.Equal(1, watcher.TestGetObserverCount(filePath));
+        }
+        finally
+        {
+            dirInfo.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    [LogLevel(LogLevel.Trace)]
+    public void ReuseFileObserver()
+    {
+        var dirInfo = Directory.CreateTempSubdirectory();
+        try
+        {
+            var dir = dirInfo.FullName;
+            var fileName = Path.GetRandomFileName();
+            var filePath = Path.Combine(dir, fileName);
+
+            Touch(filePath);
+
+            var hostEnvironment = new Mock<IHostEnvironment>();
+            hostEnvironment.SetupGet(h => h.ContentRootPath).Returns(dir);
+
+            var logger = LoggerFactory.CreateLogger<CertificatePathWatcher>();
+
+            using var watcher = new CertificatePathWatcher(hostEnvironment.Object, logger);
+
+            var certificateConfig = new CertificateConfig
+            {
+                Path = filePath,
+            };
+
+            watcher.AddWatch(certificateConfig);
+
+            Assert.Equal(1, watcher.TestGetObserverCount(filePath));
+
+            watcher.AddWatch(certificateConfig);
+
+            var messageProps = GetLogMessageProperties(TestSink, "ReusedObserver");
+            Assert.Equal(filePath, messageProps["path"]);
+
+            Assert.Equal(1, watcher.TestGetObserverCount(filePath));
+        }
+        finally
+        {
+            dirInfo.Delete(recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    [LogLevel(LogLevel.Trace)]
+    public async Task IgnoreDeletion(bool deleteDirectory)
+    {
+        var dirInfo = Directory.CreateTempSubdirectory();
+        try
+        {
+            var dir = dirInfo.FullName;
+            var fileName = Path.GetRandomFileName();
+            var filePath = Path.Combine(dir, fileName);
+
+            Touch(filePath);
+
+            var hostEnvironment = new Mock<IHostEnvironment>();
+            hostEnvironment.SetupGet(h => h.ContentRootPath).Returns(dir);
+
+            var logger = LoggerFactory.CreateLogger<CertificatePathWatcher>();
+
+            using var watcher = new CertificatePathWatcher(hostEnvironment.Object, logger);
+
+            var certificateConfig = new CertificateConfig
+            {
+                Path = filePath,
+            };
+
+            watcher.AddWatch(certificateConfig);
+
+            Assert.Equal(1, watcher.TestGetDirectoryWatchCount());
+            Assert.Equal(1, watcher.TestGetFileWatchCount(dir));
+            Assert.Equal(1, watcher.TestGetObserverCount(filePath));
+
+            var changeTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            watcher.GetChangeToken().RegisterChangeCallback(_ => changeTcs.SetResult(), state: null);
+
+            var logTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            TestSink.MessageLogged += writeContext =>
+            {
+                if (writeContext.EventId.Name == "EventWithoutLastModifiedTime")
+                {
+                    logTcs.SetResult();
+                }
+            };
+
+            // "Delete" the file or directory
+            if (deleteDirectory)
+            {
+                dirInfo.MoveTo(dir + ".bak");
+            }
+            else
+            {
+                File.Move(filePath, filePath + ".bak");
+            }
+
+            Assert.False(File.Exists(filePath));
+
+            try
+            {
+                await logTcs.Task.DefaultTimeout();
+            }
+            catch (TimeoutException)
+            {
+                // In some scenarios, the directory deletion won't trigger an event.
+                // For example, a `FileSystemWatcher` on Windows won't fire one,
+                // whereas the polling watcher will.
+                Assert.True(deleteDirectory);
+            }
+
+            Assert.Equal(1, watcher.TestGetDirectoryWatchCount());
+            Assert.Equal(1, watcher.TestGetFileWatchCount(dir));
+            Assert.Equal(1, watcher.TestGetObserverCount(filePath));
+
+            Assert.False(changeTcs.Task.IsCompleted);
+
+            // Restore the file or directory
+            if (deleteDirectory)
+            {
+                dirInfo.MoveTo(dir);
+            }
+            else
+            {
+                File.Move(filePath + ".bak", filePath);
+            }
+
+            Assert.True(File.Exists(filePath));
+
+            Touch(filePath); // In some scenarios, renaming the file back doesn't change the last modified time
+
+            await changeTcs.Task.DefaultTimeout();
+        }
+        finally
+        {
+            dirInfo.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void UpdateWatches()
+    {
+        var dirInfo = Directory.CreateTempSubdirectory();
+        try
+        {
+            var dir = dirInfo.FullName;
+            var fileName = Path.GetRandomFileName();
+            var filePath = Path.Combine(dir, fileName);
+
+            var hostEnvironment = new Mock<IHostEnvironment>();
+            hostEnvironment.SetupGet(h => h.ContentRootPath).Returns(dir);
+
+            var logger = LoggerFactory.CreateLogger<CertificatePathWatcher>();
+
+            using var watcher = new CertificatePathWatcher(hostEnvironment.Object, logger);
+
+            var changeToken = watcher.GetChangeToken();
+
+            var certificateConfig1 = new CertificateConfig
+            {
+                Path = filePath,
+            };
+
+            var certificateConfig2 = new CertificateConfig
+            {
+                Path = filePath,
+            };
+
+            var certificateConfig3 = new CertificateConfig
+            {
+                Path = filePath,
+            };
+
+            // Add certificateConfig1
+            watcher.UpdateWatches(new List<CertificateConfig> { }, new List<CertificateConfig> { certificateConfig1 });
+
+            Assert.Equal(1, watcher.TestGetDirectoryWatchCount());
+            Assert.Equal(1, watcher.TestGetFileWatchCount(dir));
+            Assert.Equal(1, watcher.TestGetObserverCount(filePath));
+
+            // Remove certificateConfig1
+            watcher.UpdateWatches(new List<CertificateConfig> { certificateConfig1 }, new List<CertificateConfig> { });
+
+            Assert.Equal(0, watcher.TestGetDirectoryWatchCount());
+            Assert.Equal(0, watcher.TestGetFileWatchCount(dir));
+            Assert.Equal(0, watcher.TestGetObserverCount(filePath));
+
+            // Re-add certificateConfig1
+            watcher.UpdateWatches(new List<CertificateConfig> { }, new List<CertificateConfig> { certificateConfig1 });
+
+            Assert.Equal(1, watcher.TestGetDirectoryWatchCount());
+            Assert.Equal(1, watcher.TestGetFileWatchCount(dir));
+            Assert.Equal(1, watcher.TestGetObserverCount(filePath));
+
+            watcher.UpdateWatches(
+                new List<CertificateConfig>
+                {
+                    certificateConfig1, // Delete something present
+                    certificateConfig1, // Delete it again
+                    certificateConfig2, // Delete something never added
+                    certificateConfig2, // Delete it again
+                },
+                new List<CertificateConfig>
+                {
+                    certificateConfig1, // Re-add something removed above
+                    certificateConfig1, // Re-add it again
+                    certificateConfig2, // Add something vacuously removed above
+                    certificateConfig2, // Add it again
+                    certificateConfig3, // Add something new
+                    certificateConfig3, // Add it again
+                });
+
+            Assert.Equal(1, watcher.TestGetDirectoryWatchCount());
+            Assert.Equal(1, watcher.TestGetFileWatchCount(dir));
+            Assert.Equal(3, watcher.TestGetObserverCount(filePath));
+        }
+        finally
+        {
+            dirInfo.Delete(recursive: true);
+        }
+    }
+
+    private static void Touch(string filePath)
+    {
+        File.Create(filePath).Dispose();
+    }
+
+    private static IDictionary<string, object> GetLogMessageProperties(ITestSink testSink, string eventName)
+    {
+        var writeContext = Assert.Single(testSink.Writes.Where(wc => wc.EventId.Name == eventName));
+        var pairs = (IReadOnlyList<KeyValuePair<string, object>>)writeContext.State;
+        var dict = new Dictionary<string, object>(pairs);
+        return dict;
+    }
+}

--- a/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
+++ b/src/Servers/Kestrel/Core/test/KestrelServerTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Https.Internal;
@@ -760,6 +761,7 @@ public class KestrelServerTests
         TaskCompletionSource changeCallbackRegisteredTcs = null;
 
         var mockChangeToken = new Mock<IChangeToken>();
+        mockChangeToken.Setup(t => t.ActiveChangeCallbacks).Returns(true);
         mockChangeToken.Setup(t => t.RegisterChangeCallback(It.IsAny<Action<object>>(), It.IsAny<object>())).Returns<Action<object>, object>((callback, state) =>
         {
             changeCallbackRegisteredTcs?.SetResult();
@@ -786,6 +788,7 @@ public class KestrelServerTests
         serviceCollection.AddSingleton(Mock.Of<IHostEnvironment>());
         serviceCollection.AddSingleton(Mock.Of<ILogger<KestrelServer>>());
         serviceCollection.AddSingleton(Mock.Of<ILogger<HttpsConnectionMiddleware>>());
+        serviceCollection.AddSingleton(Mock.Of<ILogger<CertificatePathWatcher>>());
         serviceCollection.AddSingleton(Mock.Of<IHttpsConfigurationService>());
 
         var options = new KestrelServerOptions

--- a/src/Servers/Kestrel/Core/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
+++ b/src/Servers/Kestrel/Core/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj
@@ -28,6 +28,7 @@
     <Reference Include="Microsoft.AspNetCore.Http" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Core" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
     <Reference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 </Project>

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -841,8 +841,8 @@ public class KestrelConfigurationLoaderTests
     }
 
     [Theory]
-    [InlineData(true)] // This might be flaky
-    [InlineData(false)] // This will be slow (5 seconds)
+    [InlineData(true)] // This might be flaky, since it depends on file system events (or polling)
+    [InlineData(false)] // This will be slow (1 seconds)
     public async Task CertificateChangedOnDisk(bool reloadOnChange)
     {
         var certificatePath = GetCertificatePath();
@@ -899,7 +899,7 @@ public class KestrelConfigurationLoaderTests
             else
             {
                 // We can't just check immediately that the callback hasn't fired - we might preempt it
-                await Task.Delay(Testing.TaskExtensions.DefaultTimeoutDuration);
+                await Task.Delay(TimeSpan.FromSeconds(1));
                 Assert.False(fileTcs.Task.IsCompleted);
             }
 

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/HttpsConnectionMiddlewareTests.cs
@@ -79,7 +79,7 @@ public class HttpsConnectionMiddlewareTests : LoggedTest
 
         var options = CreateServerOptions();
 
-        var loader = new KestrelConfigurationLoader(options, configuration, options.ApplicationServices.GetRequiredService<IHttpsConfigurationService>(), reloadOnChange: false);
+        var loader = new KestrelConfigurationLoader(options, configuration, options.ApplicationServices.GetRequiredService<IHttpsConfigurationService>(), certificatePathWatcher: null, reloadOnChange: false);
         options.ConfigurationLoader = loader; // Since we're constructing it explicitly, we have to hook it up explicitly
         loader.Load();
 


### PR DESCRIPTION
When `IConfiguration` specifies certificates by path and `reloadOnChange` is true, monitor those paths for changes and trigger reloads.  The reload behavior is the same as if the path in the configuration file were changed, rather than the contents of the referenced file.

- Does not apply to code-based configuration, which never triggers reloads
- Does not trigger on deletion - that would just tear down the server
- Does not look through symlinks to determine whether the target has changed
- On by default (when `reloadOnChange` is true) but can be disabled with app context switch `Microsoft.AspNetCore.Server.Kestrel.DisableCertificateFileWatching`

Fixes #32351