### PR TITLE
Fix a typo in EndpointRoutingApplicationBuilderExtensions

### DIFF
--- a/src/Http/Routing/src/Builder/EndpointRoutingApplicationBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/EndpointRoutingApplicationBuilderExtensions.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Options;
 namespace Microsoft.AspNetCore.Builder;
 
 /// <summary>
-/// Constains extensions for configuring routing on an <see cref="IApplicationBuilder"/>.
+/// Contains extensions for configuring routing on an <see cref="IApplicationBuilder"/>.
 /// </summary>
 public static class EndpointRoutingApplicationBuilderExtensions
 {


### PR DESCRIPTION
# Fix a typo in EndpointRoutingApplicationBuilderExtensions

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

This PR fixes a typo in XML documentation
