### PR TITLE
Extend `PersistKeysToDbContext` (#49329)

### DIFF
--- a/src/DataProtection/EntityFrameworkCore/src/EntityFrameworkCoreDataProtectionExtensions.cs
+++ b/src/DataProtection/EntityFrameworkCore/src/EntityFrameworkCoreDataProtectionExtensions.cs
@@ -35,4 +35,25 @@ public static class EntityFrameworkCoreDataProtectionExtensions
 
         return builder;
     }
+
+    /// <summary>
+    /// Configures the data protection system to persist keys to an EntityFrameworkCore datastore
+    /// </summary>
+    /// <param name="builder">The <see cref="IDataProtectionBuilder"/> instance to modify.</param>
+    /// <returns>The value <paramref name="builder"/>.</returns>
+    public static IDataProtectionBuilder PersistKeysToDbContext<TContextService, TContextImplementation>(this IDataProtectionBuilder builder)
+        where TContextService : IDataProtectionKeyContext
+        where TContextImplementation : DbContext, TContextService
+    {
+        builder.Services.AddSingleton<IConfigureOptions<KeyManagementOptions>>(services =>
+        {
+            var loggerFactory = services.GetService<ILoggerFactory>() ?? NullLoggerFactory.Instance;
+            return new ConfigureOptions<KeyManagementOptions>(options =>
+            {
+                options.XmlRepository = new EntityFrameworkCoreXmlRepository<TContextService, TContextImplementation>(services, loggerFactory);
+            });
+        });
+
+        return builder;
+    }
 }

--- a/src/DataProtection/EntityFrameworkCore/src/EntityFrameworkCoreXmlRepository.cs
+++ b/src/DataProtection/EntityFrameworkCore/src/EntityFrameworkCoreXmlRepository.cs
@@ -92,7 +92,7 @@ public class EntityFrameworkCoreXmlRepository<TContextService, TContextImplement
     private readonly ILogger _logger;
 
     /// <summary>
-    /// Creates a new instance of the <see cref="EntityFrameworkCoreXmlRepository{TContext}"/>.
+    /// Creates a new instance of the <see cref="EntityFrameworkCoreXmlRepository{TContextService, TContextImplementation}"/>.
     /// </summary>
     /// <param name="services"></param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>

--- a/src/DataProtection/EntityFrameworkCore/src/EntityFrameworkCoreXmlRepository.cs
+++ b/src/DataProtection/EntityFrameworkCore/src/EntityFrameworkCoreXmlRepository.cs
@@ -80,3 +80,74 @@ public class EntityFrameworkCoreXmlRepository<TContext> : IXmlRepository
         }
     }
 }
+
+/// <summary>
+/// An <see cref="IXmlRepository"/> backed by an EntityFrameworkCore datastore.
+/// </summary>
+public class EntityFrameworkCoreXmlRepository<TContextService, TContextImplementation> : IXmlRepository
+    where TContextService : IDataProtectionKeyContext
+    where TContextImplementation : DbContext, TContextService
+{
+    private readonly IServiceProvider _services;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="EntityFrameworkCoreXmlRepository{TContext}"/>.
+    /// </summary>
+    /// <param name="services"></param>
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
+    // DataProtectionKey.Id is not used anywhere. Add DynamicDependency to prevent it from being trimmed.
+    // Note that in the future EF may annotate itself to include properties automatically, and the annotation here could be removed.
+    // Fixes https://github.com/dotnet/aspnetcore/issues/43187
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(DataProtectionKey))]
+    public EntityFrameworkCoreXmlRepository(IServiceProvider services, ILoggerFactory loggerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+
+        _logger = loggerFactory.CreateLogger<EntityFrameworkCoreXmlRepository<TContextService, TContextImplementation>>();
+        _services = services ?? throw new ArgumentNullException(nameof(services));
+    }
+
+    /// <inheritdoc />
+    public virtual IReadOnlyCollection<XElement> GetAllElements()
+    {
+        // forces complete enumeration
+        return GetAllElementsCore().ToList().AsReadOnly();
+
+        IEnumerable<XElement> GetAllElementsCore()
+        {
+            using (var scope = _services.CreateScope())
+            {
+                var context = scope.ServiceProvider.GetRequiredService<TContextService>();
+
+                foreach (var key in context.DataProtectionKeys.AsNoTracking())
+                {
+                    _logger.ReadingXmlFromKey(key.FriendlyName!, key.Xml);
+
+                    if (!string.IsNullOrEmpty(key.Xml))
+                    {
+                        yield return XElement.Parse(key.Xml);
+                    }
+                }
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void StoreElement(XElement element, string friendlyName)
+    {
+        using (var scope = _services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<TContextService>();
+            var newKey = new DataProtectionKey()
+            {
+                FriendlyName = friendlyName,
+                Xml = element.ToString(SaveOptions.DisableFormatting)
+            };
+
+            context.DataProtectionKeys.Add(newKey);
+            _logger.LogSavingKeyToDbContext(friendlyName, typeof(TContextImplementation).Name);
+            (context as TContextImplementation)!.SaveChanges();
+        }
+    }
+}

--- a/src/DataProtection/EntityFrameworkCore/src/PublicAPI.Shipped.txt
+++ b/src/DataProtection/EntityFrameworkCore/src/PublicAPI.Shipped.txt
@@ -10,8 +10,13 @@ Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey.Xml.se
 Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContext>
 Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContext>.EntityFrameworkCoreXmlRepository(System.IServiceProvider! services, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
 Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContext>.StoreElement(System.Xml.Linq.XElement! element, string! friendlyName) -> void
+Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContextService, TContextImplementation>
+Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContextService, TContextImplementation>.EntityFrameworkCoreXmlRepository(System.IServiceProvider! services, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
+Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContextService, TContextImplementation>.StoreElement(System.Xml.Linq.XElement! element, string! friendlyName) -> void
 Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.IDataProtectionKeyContext
 Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.IDataProtectionKeyContext.DataProtectionKeys.get -> Microsoft.EntityFrameworkCore.DbSet<Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey!>!
 Microsoft.AspNetCore.DataProtection.EntityFrameworkCoreDataProtectionExtensions
 static Microsoft.AspNetCore.DataProtection.EntityFrameworkCoreDataProtectionExtensions.PersistKeysToDbContext<TContext>(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder! builder) -> Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder!
 virtual Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContext>.GetAllElements() -> System.Collections.Generic.IReadOnlyCollection<System.Xml.Linq.XElement!>!
+static Microsoft.AspNetCore.DataProtection.EntityFrameworkCoreDataProtectionExtensions.PersistKeysToDbContext<TContextService, TContextImplementation>(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder! builder) -> Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder!
+virtual Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContextService, TContextImplementation>.GetAllElements() -> System.Collections.Generic.IReadOnlyCollection<System.Xml.Linq.XElement!>!

--- a/src/DataProtection/EntityFrameworkCore/src/PublicAPI.Shipped.txt
+++ b/src/DataProtection/EntityFrameworkCore/src/PublicAPI.Shipped.txt
@@ -10,13 +10,8 @@ Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey.Xml.se
 Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContext>
 Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContext>.EntityFrameworkCoreXmlRepository(System.IServiceProvider! services, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
 Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContext>.StoreElement(System.Xml.Linq.XElement! element, string! friendlyName) -> void
-Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContextService, TContextImplementation>
-Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContextService, TContextImplementation>.EntityFrameworkCoreXmlRepository(System.IServiceProvider! services, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
-Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContextService, TContextImplementation>.StoreElement(System.Xml.Linq.XElement! element, string! friendlyName) -> void
 Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.IDataProtectionKeyContext
 Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.IDataProtectionKeyContext.DataProtectionKeys.get -> Microsoft.EntityFrameworkCore.DbSet<Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey!>!
 Microsoft.AspNetCore.DataProtection.EntityFrameworkCoreDataProtectionExtensions
 static Microsoft.AspNetCore.DataProtection.EntityFrameworkCoreDataProtectionExtensions.PersistKeysToDbContext<TContext>(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder! builder) -> Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder!
 virtual Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContext>.GetAllElements() -> System.Collections.Generic.IReadOnlyCollection<System.Xml.Linq.XElement!>!
-static Microsoft.AspNetCore.DataProtection.EntityFrameworkCoreDataProtectionExtensions.PersistKeysToDbContext<TContextService, TContextImplementation>(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder! builder) -> Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder!
-virtual Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContextService, TContextImplementation>.GetAllElements() -> System.Collections.Generic.IReadOnlyCollection<System.Xml.Linq.XElement!>!

--- a/src/DataProtection/EntityFrameworkCore/src/PublicAPI.Unshipped.txt
+++ b/src/DataProtection/EntityFrameworkCore/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContextService, TContextImplementation>
+Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContextService, TContextImplementation>.EntityFrameworkCoreXmlRepository(System.IServiceProvider! services, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
+Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContextService, TContextImplementation>.StoreElement(System.Xml.Linq.XElement! element, string! friendlyName) -> void
+static Microsoft.AspNetCore.DataProtection.EntityFrameworkCoreDataProtectionExtensions.PersistKeysToDbContext<TContextService, TContextImplementation>(this Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder! builder) -> Microsoft.AspNetCore.DataProtection.IDataProtectionBuilder!
+virtual Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.EntityFrameworkCoreXmlRepository<TContextService, TContextImplementation>.GetAllElements() -> System.Collections.Generic.IReadOnlyCollection<System.Xml.Linq.XElement!>!

--- a/src/DataProtection/EntityFrameworkCore/test/DataProtectionEntityFrameworkTests.cs
+++ b/src/DataProtection/EntityFrameworkCore/test/DataProtectionEntityFrameworkTests.cs
@@ -21,7 +21,7 @@ public class DataProtectionEntityFrameworkTests
     [Fact]
     public void CreateRepository_ThrowsIf_ContextIsNull_WithContextService()
     {
-        Assert.Throws<ArgumentNullException>(() => new EntityFrameworkCoreXmlRepository<IDataProtectionKeyContext, DataProtectionKeyContext>(null, null));
+        Assert.Throws<ArgumentNullException>(() => new EntityFrameworkCoreXmlRepository<IDataProtectionKeyContextService, DataProtectionKeyContextImplementation>(null, null));
     }
 
     [Fact]
@@ -52,11 +52,11 @@ public class DataProtectionEntityFrameworkTests
         var key = new DataProtectionKey() { FriendlyName = friendlyName, Xml = element.ToString() };
 
         var services = GetServices_WithContextService(nameof(StoreElement_PersistsData_WithContextService));
-        var service = new EntityFrameworkCoreXmlRepository<IDataProtectionKeyContext, DataProtectionKeyContext>(services, NullLoggerFactory.Instance);
+        var service = new EntityFrameworkCoreXmlRepository<IDataProtectionKeyContextService, DataProtectionKeyContextImplementation>(services, NullLoggerFactory.Instance);
         service.StoreElement(element, friendlyName);
 
         // Use a separate instance of the context to verify correct data was saved to database
-        using (var context = services.CreateScope().ServiceProvider.GetRequiredService<IDataProtectionKeyContext>())
+        using (var context = services.CreateScope().ServiceProvider.GetRequiredService<IDataProtectionKeyContextService>())
         {
             Assert.Equal(1, context.DataProtectionKeys.Count());
             Assert.Equal(key.FriendlyName, context.DataProtectionKeys.Single()?.FriendlyName);
@@ -101,8 +101,8 @@ public class DataProtectionEntityFrameworkTests
     private EntityFrameworkCoreXmlRepository<DataProtectionKeyContext> CreateRepo(IServiceProvider services)
         => new EntityFrameworkCoreXmlRepository<DataProtectionKeyContext>(services, NullLoggerFactory.Instance);
 
-    private EntityFrameworkCoreXmlRepository<IDataProtectionKeyContext, DataProtectionKeyContext> CreateRepo_WithContextService(IServiceProvider services)
-        => new EntityFrameworkCoreXmlRepository<IDataProtectionKeyContext, DataProtectionKeyContext>(services, NullLoggerFactory.Instance);
+    private EntityFrameworkCoreXmlRepository<IDataProtectionKeyContextService, DataProtectionKeyContextImplementation> CreateRepo_WithContextService(IServiceProvider services)
+        => new EntityFrameworkCoreXmlRepository<IDataProtectionKeyContextService, DataProtectionKeyContextImplementation>(services, NullLoggerFactory.Instance);
 
     private IServiceProvider GetServices(string dbName)
         => new ServiceCollection()
@@ -111,6 +111,6 @@ public class DataProtectionEntityFrameworkTests
 
     private IServiceProvider GetServices_WithContextService(string dbName)
         => new ServiceCollection()
-            .AddDbContext<IDataProtectionKeyContext, DataProtectionKeyContext>(o => o.UseInMemoryDatabase(dbName))
+            .AddDbContext<IDataProtectionKeyContextService, DataProtectionKeyContextImplementation>(o => o.UseInMemoryDatabase(dbName))
             .BuildServiceProvider(validateScopes: true);
 }

--- a/src/DataProtection/EntityFrameworkCore/test/DataProtectionEntityFrameworkTests.cs
+++ b/src/DataProtection/EntityFrameworkCore/test/DataProtectionEntityFrameworkTests.cs
@@ -93,7 +93,7 @@ public class DataProtectionEntityFrameworkTests
         service1.StoreElement(element2, "element2");
 
         // Use a separate instance of the context to verify correct data was saved to database
-        var service2 = CreateRepo(services);
+        var service2 = CreateRepo_WithContextService(services);
         var elements = service2.GetAllElements();
         Assert.Equal(2, elements.Count);
     }

--- a/src/DataProtection/EntityFrameworkCore/test/DataProtectionKeyContextImplementation.cs
+++ b/src/DataProtection/EntityFrameworkCore/test/DataProtectionKeyContextImplementation.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.Test;
+
+class DataProtectionKeyContextImplementation : DbContext, IDataProtectionKeyContextService
+{
+    public DataProtectionKeyContextImplementation(DbContextOptions<DataProtectionKeyContextImplementation> options) : base(options) { }
+
+    public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
+}

--- a/src/DataProtection/EntityFrameworkCore/test/EntityFrameworkCoreDataProtectionBuilderExtensionsTests.cs
+++ b/src/DataProtection/EntityFrameworkCore/test/EntityFrameworkCoreDataProtectionBuilderExtensionsTests.cs
@@ -21,4 +21,17 @@ public class EntityFrameworkCoreDataProtectionBuilderExtensionsTests
         var keyManagementOptions = serviceProvider.GetRequiredService<IOptions<KeyManagementOptions>>();
         Assert.IsType<EntityFrameworkCoreXmlRepository<DataProtectionKeyContext>>(keyManagementOptions.Value.XmlRepository);
     }
+
+    [Fact]
+    public void PersistKeysToEntityFrameworkCore_UsesEntityFrameworkCoreXmlRepository_WithContextSerivce()
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection
+            .AddDbContext<DataProtectionKeyContext>()
+            .AddDataProtection()
+            .PersistKeysToDbContext<IDataProtectionKeyContextService, DataProtectionKeyContextImplementation>();
+        var serviceProvider = serviceCollection.BuildServiceProvider(validateScopes: true);
+        var keyManagementOptions = serviceProvider.GetRequiredService<IOptions<KeyManagementOptions>>();
+        Assert.IsType<EntityFrameworkCoreXmlRepository<IDataProtectionKeyContextService, DataProtectionKeyContextImplementation>>(keyManagementOptions.Value.XmlRepository);
+    }
 }

--- a/src/DataProtection/EntityFrameworkCore/test/IDataProtectionKeyContextService.cs
+++ b/src/DataProtection/EntityFrameworkCore/test/IDataProtectionKeyContextService.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.Test;
+
+interface IDataProtectionKeyContextService : IDataProtectionKeyContext, IDisposable
+{
+}


### PR DESCRIPTION
# Extend `PersistKeysToDbContext` (#49329)

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!--
- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
-->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes

`EntityFrameworkCoreXmlRepository` got a twin due to the reasons below.

## Description

With this pull request `EntityFrameworkCoreXmlRepository` class was extended with a twin, which accepts not only `TContext` as generic parameter, but both `TContextService` and `TContextImplementation`.

These changes are required because of the reasons described in the #49329.

Here is a brief excerpt:

> in case DbContext was configured in DI container with AddDbContext<TContextService, TContextImplementation>() it will retrieve an instance of DbContext, but DbContext.Dispose() method would be called twice. Which leads to ObjectDisposedException in case you have own implementation of Dispose method and working with DbContext.ChangeTracker there.

Fixes #49329
