### PR TITLE
GetDocumentInsider: use System.Diagnostics.DiagnosticSource from runtime (not OOB)

### DIFF
--- a/src/Tools/GetDocumentInsider/src/GetDocument.Insider.csproj
+++ b/src/Tools/GetDocumentInsider/src/GetDocument.Insider.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <RootNamespace>Microsoft.Extensions.ApiDescription.Tool</RootNamespace>
-    <TargetFrameworks>netcoreapp2.1;$(DefaultNetCoreTargetFramework);$(DefaultNetFxTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework);$(DefaultNetFxTargetFramework)</TargetFrameworks>
     <IsShippingPackage>false</IsShippingPackage>
     <NoWarn>$(NoWarn);nullable</NoWarn>
   </PropertyGroup>
@@ -20,9 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0">
-      <AllowExplicitReference>true</AllowExplicitReference>
-    </PackageReference>
+    <Reference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/GetDocumentInsider/src/GetDocument.Insider.csproj
+++ b/src/Tools/GetDocumentInsider/src/GetDocument.Insider.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <RootNamespace>Microsoft.Extensions.ApiDescription.Tool</RootNamespace>
-    <TargetFrameworks>$(DefaultNetCoreTargetFramework);$(DefaultNetFxTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;$(DefaultNetCoreTargetFramework);$(DefaultNetFxTargetFramework)</TargetFrameworks>
     <IsShippingPackage>false</IsShippingPackage>
     <NoWarn>$(NoWarn);nullable</NoWarn>
   </PropertyGroup>
@@ -19,7 +19,13 @@
     <Reference Include="Microsoft.Extensions.Hosting.Abstractions" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0">
+      <AllowExplicitReference>true</AllowExplicitReference>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
     <Reference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 


### PR DESCRIPTION
(via build-ops)

(probably ignore the actual code here for now; this is becoming more of a place-holder for investigation and discussion)

# GetDocumentInsider: use `System.Diagnostics.DiagnosticSource` from runtime

`GetDocumentInsider` has historically been using a very old version of the archived `System.Diagnostics.DiagnosticSource` from NuGet (OOB); however, `System.Diagnostics.DiagnosticSource` has recently been [transitively updated in runtime via a resurected `Microsoft.Extensions.Diagnostics.Abstractions`](https://github.com/dotnet/runtime/commit/786b9872ad306d5b0febdc2e6c820b69e0e232dc#diff-f185b4dcb4962b61cf5657a4b9b1d8a214ebc6479b7dded464a9a8b8b54d3684) by @Tratcher ; this is causing CI failures due to competition between two routes to the assembly, as illustrated by the [CI here](https://github.com/dotnet/aspnetcore/pull/50019):

- GetDocument.Insider -> Microsoft.Extensions.Hosting.Abstractions 8.0.0-rc.1.23410.15 -> Microsoft.Extensions.Diagnostics.Abstractions 8.0.0-rc.1.23410.15 -> System.Diagnostics.DiagnosticSource (>= 8.0.0-rc.1.23410.15)
- GetDocument.Insider -> System.Diagnostics.DiagnosticSource (>= 4.6.0)

To resolve this, I propose changing `GetDocumentInsider` to use the runtime version of `System.Diagnostics.DiagnosticSource` (since I can't reasonably remove `Microsoft.Extensions.Hosting.Abstractions`).

Notes:

- I do not know how to test this!
- the transitive use of `Unsafe` was unsupported on netcoreapp2.1; I propose dropping this TFM, but I do not know if this has any significance (edit: yes, it very much does have significance; we can't do this 😢 )

> C:\Users\marcg\.nuget\packages\system.runtime.compilerservices.unsafe\6.0.0\buildTransitive\netcoreapp2.0\System.Runtime.CompilerServices.Unsafe.targets(4,5): error : System.Runtime.CompilerServices.Unsafe doesn't support netcoreapp2.1. Consi
der updating your TargetFramework to netcoreapp3.1 or later. [C:\Code\aspnet\marc-diagnostics\src\Tools\GetDocumentInsider\src\GetDocument.Insider.csproj::TargetFramework=netcoreapp2.1]

~~I *could* have changed to netcoreapp3.1, but that too is end-of-life, so... :shrug:~~

I've done a quick scan of the repo and `GetDocumentInsider` *appears* to be the only likely conflict, which is also supported by the CI failure above only reporting this one package.