### PR TITLE
[DRAFT] Consider symlinks when watching certificate file paths

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcherLoggerExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcherLoggerExtensions.cs
@@ -28,6 +28,7 @@ internal static partial class CertificatePathWatcherLoggerExtensions
     [LoggerMessage(7, LogLevel.Debug, "Removed file watcher for '{Path}'.", EventName = "RemovedFileWatcher")]
     public static partial void RemovedFileWatcher(this ILogger<CertificatePathWatcher> logger, string path);
 
+    [Obsolete("This event will no longer be reported")]
     [LoggerMessage(8, LogLevel.Debug, "Error retrieving last modified time for '{Path}'.", EventName = "LastModifiedTimeError")]
     public static partial void LastModifiedTimeError(this ILogger<CertificatePathWatcher> logger, string path, Exception e);
 

--- a/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcherLoggerExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcherLoggerExtensions.cs
@@ -61,4 +61,7 @@ internal static partial class CertificatePathWatcherLoggerExtensions
 
     [LoggerMessage(18, LogLevel.Trace, "Flagged {Count} observers of '{Path}' as changed.", EventName = "FlaggedObservers")]
     public static partial void FlaggedObservers(this ILogger<CertificatePathWatcher> logger, string path, int count);
+
+    [LoggerMessage(19, LogLevel.Trace, "Saw change event for '{OriginalPath}' (as '{Path}').", EventName = "FileEventReceived")]
+    public static partial void FileEventReceived(this ILogger<CertificatePathWatcher> logger, string path, string originalPath);
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IFileInfoWithLinkInfo.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IFileInfoWithLinkInfo.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.FileProviders;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+
+/// <summary>
+/// Extends <see cref="IFileInfo"/> with the ability to resolve symlink targets.
+/// </summary>
+internal interface IFileInfoWithLinkInfo : IFileInfo
+{
+    /// <summary>
+    /// <see cref="IFileInfo"/> equivalent of <see cref="FileSystemInfo.ResolveLinkTarget"/>.
+    /// </summary>
+    IFileInfoWithLinkInfo? ResolveLinkTarget(bool returnFinalTarget);
+}

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IFileProviderWithLinkInfo.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IFileProviderWithLinkInfo.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.FileProviders;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+
+/// <summary>
+/// Extends <see cref="IFileProvider"/> with the ability to resolve symlink targets of the provided directory.
+/// </summary>
+internal interface IFileProviderWithLinkInfo : IFileProvider
+{
+    /// <summary>
+    /// Returns the link target of the <see cref="IFileProvider"/>'s root directory.
+    /// </summary>
+    /// <remarks>
+    /// Effectively <see cref="FileSystemInfo.ResolveLinkTarget"/>.
+    /// </remarks>
+    IFileInfoWithLinkInfo? ResolveLinkTarget(bool returnFinalTarget);
+
+    public new IFileInfoWithLinkInfo GetFileInfo(string subpath);
+}

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IFileProviderWithLinkInfo.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/IFileProviderWithLinkInfo.cs
@@ -10,13 +10,5 @@ namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 /// </summary>
 internal interface IFileProviderWithLinkInfo : IFileProvider
 {
-    /// <summary>
-    /// Returns the link target of the <see cref="IFileProvider"/>'s root directory.
-    /// </summary>
-    /// <remarks>
-    /// Effectively <see cref="FileSystemInfo.ResolveLinkTarget"/>.
-    /// </remarks>
-    IFileInfoWithLinkInfo? ResolveLinkTarget(bool returnFinalTarget);
-
     public new IFileInfoWithLinkInfo GetFileInfo(string subpath);
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/PhysicalFileProviderWithLinkInfo.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/PhysicalFileProviderWithLinkInfo.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.FileProviders.Physical;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+
+/// <summary>
+/// A <see cref="PhysicalFileProvider"/> that returns <see cref="IFileInfoWithLinkInfo"/>, rather than <see cref="IFileInfo"/>.
+/// </summary>
+internal sealed class PhysicalFileProviderWithLinkInfo : IFileProviderWithLinkInfo
+{
+    private readonly PhysicalFileProvider _inner;
+
+    public PhysicalFileProviderWithLinkInfo(string root, ExclusionFilters filters)
+    {
+        _inner = new PhysicalFileProvider(root, filters);
+    }
+
+    IDirectoryContents IFileProvider.GetDirectoryContents(string subpath) => _inner.GetDirectoryContents(subpath);
+    IChangeToken IFileProvider.Watch(string filter) => _inner.Watch(filter);
+
+    IFileInfo IFileProvider.GetFileInfo(string subpath)
+    {
+        return ((IFileProviderWithLinkInfo)this).GetFileInfo(subpath);
+    }
+
+    IFileInfoWithLinkInfo IFileProviderWithLinkInfo.GetFileInfo(string subpath)
+    {
+        return new FileInfoWithLinkInfo(_inner.GetFileInfo(subpath));
+    }
+
+    IFileInfoWithLinkInfo? IFileProviderWithLinkInfo.ResolveLinkTarget(bool returnFinalTarget)
+    {
+        IFileInfoWithLinkInfo dirInfo = new DirectoryInfoWithLinkInfo(new DirectoryInfo(_inner.Root));
+        return dirInfo.ResolveLinkTarget(returnFinalTarget);
+    }
+
+    private sealed class FileInfoWithLinkInfo : IFileInfoWithLinkInfo
+    {
+        private readonly IFileInfo _inner;
+
+        public FileInfoWithLinkInfo(IFileInfo inner)
+        {
+            _inner = inner;
+        }
+
+        bool IFileInfo.Exists => _inner.Exists;
+        bool IFileInfo.IsDirectory => _inner.IsDirectory;
+        DateTimeOffset IFileInfo.LastModified => _inner.LastModified;
+        long IFileInfo.Length => _inner.Length;
+        string IFileInfo.Name => _inner.Name;
+        string? IFileInfo.PhysicalPath => _inner.PhysicalPath;
+        Stream IFileInfo.CreateReadStream() => _inner.CreateReadStream();
+
+        IFileInfoWithLinkInfo? IFileInfoWithLinkInfo.ResolveLinkTarget(bool returnFinalTarget)
+        {
+            if (!_inner.Exists)
+            {
+                return null;
+            }
+
+            var path = _inner.PhysicalPath;
+
+            if (path is null)
+            {
+                return null;
+            }
+
+            var fileInfo = new FileInfo(path);
+
+            var linkFileSystemInfo = fileInfo.ResolveLinkTarget(returnFinalTarget);
+
+            if (linkFileSystemInfo is not FileInfo linkInfo)
+            {
+                return null;
+            }
+
+            return new FileInfoWithLinkInfo(new PhysicalFileInfo(linkInfo));
+        }
+    }
+    private sealed class DirectoryInfoWithLinkInfo : IFileInfoWithLinkInfo
+    {
+        private readonly DirectoryInfo _directoryInfo;
+
+        public DirectoryInfoWithLinkInfo(DirectoryInfo directoryInfo)
+        {
+            _directoryInfo = directoryInfo;
+        }
+
+        bool IFileInfo.IsDirectory => true;
+
+        bool IFileInfo.Exists => _directoryInfo.Exists;
+        DateTimeOffset IFileInfo.LastModified => _directoryInfo.LastWriteTimeUtc;
+        string IFileInfo.Name => _directoryInfo.Name;
+        string? IFileInfo.PhysicalPath => _directoryInfo.FullName;
+
+        long IFileInfo.Length => throw new NotSupportedException(); // We could probably just return 0, though that's not strictly accurate
+        Stream IFileInfo.CreateReadStream() => throw new NotSupportedException();
+
+        IFileInfoWithLinkInfo? IFileInfoWithLinkInfo.ResolveLinkTarget(bool returnFinalTarget)
+        {
+            if (!_directoryInfo.Exists)
+            {
+                return null;
+            }
+
+            var linkFileSystemInfo = _directoryInfo.ResolveLinkTarget(returnFinalTarget);
+
+            if (linkFileSystemInfo is not DirectoryInfo linkInfo)
+            {
+                return null;
+            }
+
+            return new DirectoryInfoWithLinkInfo(linkInfo);
+        }
+    }
+}


### PR DESCRIPTION
Also watch resolved targets of symlinks.

There are still some rough edges around directory symlinks, since non-polling watchers tend not to notify us when they change.  I think there might be something we can do, but I have yet to investigate.

This may or may not work for the k8s case, depending on what events are produced when the `..data` symlink is updated (and whether polling is enabled).