### PR TITLE
Fix IndexOutOfRangeException when an added/removed attribute spans a buffer size boundary

### DIFF
--- a/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
+++ b/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
@@ -18,6 +18,8 @@ internal static class RenderTreeDiffBuilder
     // hit the "old < new" code path during diffing so we only have to check for it in one place.
     public const int SystemAddedAttributeSequenceNumber = int.MinValue;
 
+    private static RenderTreeFrame NoSuchAttributeFrame = RenderTreeFrame.Attribute(int.MaxValue, null, null);
+
     public static RenderTreeDiff ComputeDiff(
         Renderer renderer,
         RenderBatchBuilder batchBuilder,
@@ -429,10 +431,10 @@ internal static class RenderTreeDiffBuilder
 
         while (hasMoreOld || hasMoreNew)
         {
-            var oldSeq = hasMoreOld ? oldTree[oldStartIndex].SequenceField : int.MaxValue;
-            var newSeq = hasMoreNew ? newTree[newStartIndex].SequenceField : int.MaxValue;
-            var oldAttributeName = oldTree[oldStartIndex].AttributeNameField;
-            var newAttributeName = newTree[newStartIndex].AttributeNameField;
+            ref var oldAttributeFrame = ref (hasMoreOld ? ref oldTree[oldStartIndex] : ref NoSuchAttributeFrame);
+            ref var newAttributeFrame = ref (hasMoreNew ? ref newTree[newStartIndex] : ref NoSuchAttributeFrame);
+            var (oldSeq, oldAttributeName) = (oldAttributeFrame.Sequence, oldAttributeFrame.AttributeName);
+            var (newSeq, newAttributeName) = (newAttributeFrame.Sequence, newAttributeFrame.AttributeName);
 
             if (oldSeq == newSeq &&
                 string.Equals(oldAttributeName, newAttributeName, StringComparison.Ordinal))

--- a/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
+++ b/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
@@ -18,8 +18,6 @@ internal static class RenderTreeDiffBuilder
     // hit the "old < new" code path during diffing so we only have to check for it in one place.
     public const int SystemAddedAttributeSequenceNumber = int.MinValue;
 
-    private static readonly RenderTreeFrame NoSuchAttributeFrame = RenderTreeFrame.Attribute(int.MaxValue, null, null);
-
     public static RenderTreeDiff ComputeDiff(
         Renderer renderer,
         RenderBatchBuilder batchBuilder,
@@ -431,10 +429,12 @@ internal static class RenderTreeDiffBuilder
 
         while (hasMoreOld || hasMoreNew)
         {
-            ref var oldAttributeFrame = ref (hasMoreOld ? ref oldTree[oldStartIndex] : ref NoSuchAttributeFrame);
-            ref var newAttributeFrame = ref (hasMoreNew ? ref newTree[newStartIndex] : ref NoSuchAttributeFrame);
-            var (oldSeq, oldAttributeName) = (oldAttributeFrame.Sequence, oldAttributeFrame.AttributeName);
-            var (newSeq, newAttributeName) = (newAttributeFrame.Sequence, newAttributeFrame.AttributeName);
+            var (oldSeq, oldAttributeName) = hasMoreOld
+                ? (oldTree[oldStartIndex].SequenceField, oldTree[oldStartIndex].AttributeNameField)
+                : (int.MaxValue, null);
+            var (newSeq, newAttributeName) = hasMoreNew
+                ? (newTree[newStartIndex].SequenceField, newTree[newStartIndex].AttributeNameField)
+                : (int.MaxValue, null);
 
             if (oldSeq == newSeq &&
                 string.Equals(oldAttributeName, newAttributeName, StringComparison.Ordinal))

--- a/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
+++ b/src/Components/Components/src/RenderTree/RenderTreeDiffBuilder.cs
@@ -18,7 +18,7 @@ internal static class RenderTreeDiffBuilder
     // hit the "old < new" code path during diffing so we only have to check for it in one place.
     public const int SystemAddedAttributeSequenceNumber = int.MinValue;
 
-    private static RenderTreeFrame NoSuchAttributeFrame = RenderTreeFrame.Attribute(int.MaxValue, null, null);
+    private static readonly RenderTreeFrame NoSuchAttributeFrame = RenderTreeFrame.Attribute(int.MaxValue, null, null);
 
     public static RenderTreeDiff ComputeDiff(
         Renderer renderer,


### PR DESCRIPTION
**NOTE: I'm not actually proposing this for servicing right now, because it doesn't look like there would be a major benefit from including it in RC1, and including it in RC2 would be perfectly sufficient. However I'm writing up the ask mode template anyway just in case people disagree.**

Extremely rarely, component rendering could cause IndexOutOfRangeException.

## Description

If a component rendered a very specific number of frames, and then updated to render exactly one more frame, and that new frame was an attribute, and it was the last frame in the component, the diffing system would throw `IndexOutOfRangeException`. This was due to a bug in checking whether there are more attributes to process.

Fixes #49192

## Customer Impact

Fairly low, because it's really hard to reproduce this, even if you're doing so on purpose. However, total correctness of the Blazor renderer is a high priority for us, and we do not want any edge cases where it can fail.

In the event that the issue does occur, it would behave like an unhandled exception from application code:

 * For Blazor WebAssembly, the yellow error bar would appear, but the app would continue running
 * For Blazor Server, the current user's circuit would be terminated, but other server activity would be unaffected
 * For Blazor WebView, the unhandled exception callback would run

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Low because the code change is small enough (4 lines) to reason clearly that it only makes a difference in the case where it would have failed before. The updated boundary condition is simple to understand.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
