### PR TITLE
Update Helix to Fedora 38

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -4,7 +4,7 @@
     <HelixQueueAlmaLinux8>(AlmaLinux.8.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-8-helix-amd64</HelixQueueAlmaLinux8>
     <HelixQueueAlpine316>(Alpine.316.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.16-helix-amd64</HelixQueueAlpine316>
     <HelixQueueDebian11>(Debian.11.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-amd64</HelixQueueDebian11>
-    <HelixQueueFedora34>(Fedora.34.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-34-helix</HelixQueueFedora34>
+    <HelixQueueFedora38>(Fedora.38.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-38-helix</HelixQueueFedora38>
     <HelixQueueMariner>(Mariner)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-1.0-helix</HelixQueueMariner>
     <HelixQueueArmDebian12>(Debian.12.Arm64.Open)ubuntu.2004.armarch.open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-arm64v8</HelixQueueArmDebian12>
 
@@ -44,7 +44,7 @@
         <!-- Containers -->
         <HelixAvailableTargetQueue Include="$(HelixQueueAlpine316)" Platform="Linux" />
         <HelixAvailableTargetQueue Include="$(HelixQueueDebian11)" Platform="Linux" />
-        <HelixAvailableTargetQueue Include="$(HelixQueueFedora34)" Platform="Linux" />
+        <HelixAvailableTargetQueue Include="$(HelixQueueFedora38)" Platform="Linux" />
         <HelixAvailableTargetQueue Include="$(HelixQueueMariner)" Platform="Linux" />
         <HelixAvailableTargetQueue Include="$(HelixQueueArmDebian12)" Platform="Linux" />
 

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -19,7 +19,7 @@
       $(HelixQueueAlmaLinux8);
       $(HelixQueueAlpine316);
       $(HelixQueueDebian11);
-      $(HelixQueueFedora34);
+      $(HelixQueueFedora38);
       $(HelixQueueMariner);
       Ubuntu.2004.Amd64.Open;
     </SkipHelixQueues>


### PR DESCRIPTION
Fedora 34 is EOL and we no longer update container images for it. We need an image with a newer MsQuic so we need to move to Fedora 38.

https://github.com/dotnet/dotnet-buildtools-prereqs-docker/tree/main/src/fedora

Runtime dependency update:
https://github.com/dotnet/runtime/commit/8986374ea73f1e5b1977dd0058fbdf591936408a Consume MsQuic release package on Win, MsQuic 2.1.7->2.2.2

Failing build:
https://dev.azure.com/dnceng-public/public/_build/results?buildId=374268&view=ms.vss-test-web.build-test-results-tab&runId=7955534&resultId=109015&paneView=debug