### PR TITLE
Make it clear in the bot comment that repros must be GitHub repos and not ZIPs

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -3401,7 +3401,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "Thank you for filing this issue. In order for us to investigate this issue, please provide [a minimalistic repro project](https://github.com/dotnet/aspnetcore/blob/main/docs/repro.md) that illustrates the problem. Please post the project as a public GitHub repo because we cannot open ZIP attachments."
+              "comment": "Thank you for filing this issue. In order for us to investigate this issue, please provide [a minimal repro project](https://github.com/dotnet/aspnetcore/blob/main/docs/repro.md) that illustrates the problem without unnecessary code. Please share with us in a public GitHub repo because we cannot open ZIP attachments, and don't include any confidential content."
             }
           },
           {

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -3401,7 +3401,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "Thank you for filing this issue. In order for us to investigate this issue, please provide [a minimalistic repro project](https://github.com/dotnet/aspnetcore/blob/main/docs/repro.md) that illustrates the problem."
+              "comment": "Thank you for filing this issue. In order for us to investigate this issue, please provide [a minimalistic repro project](https://github.com/dotnet/aspnetcore/blob/main/docs/repro.md) that illustrates the problem. Please post the project as a public GitHub repo because we cannot open ZIP attachments."
             }
           },
           {


### PR DESCRIPTION
The bot comment already links to the doc on how to submit a repro, but we often get ZIPs instead of GitHub repos. It might be helpful to have the bot comment mention the GitHub repo in case people don't follow the doc link.

(The idea for this came up in a Blazor triage meeting, so tagging @dotnet/aspnet-blazor-eng here.)