### PR TITLE
Call AddMetrics inside AddRouting

### DIFF
--- a/src/Http/Routing/src/DependencyInjection/RoutingServiceCollectionExtensions.cs
+++ b/src/Http/Routing/src/DependencyInjection/RoutingServiceCollectionExtensions.cs
@@ -43,6 +43,9 @@ public static class RoutingServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
+        // Required for IMeterFactory dependency.
+        services.AddMetrics();
+
         services.TryAddTransient<IInlineConstraintResolver, DefaultInlineConstraintResolver>();
         services.TryAddTransient<ObjectPoolProvider, DefaultObjectPoolProvider>();
         services.TryAddSingleton<ObjectPool<UriBuildingContext>>(s =>

--- a/src/Http/Routing/src/Microsoft.AspNetCore.Routing.csproj
+++ b/src/Http/Routing/src/Microsoft.AspNetCore.Routing.csproj
@@ -46,6 +46,7 @@
     <Reference Include="Microsoft.AspNetCore.Http.Features" />
     <Reference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <Reference Include="Microsoft.AspNetCore.Routing.Abstractions" />
+    <Reference Include="Microsoft.Extensions.Diagnostics" />
     <Reference Include="Microsoft.Extensions.Features" />
     <Reference Include="Microsoft.Extensions.ObjectPool" />
     <Reference Include="Microsoft.Extensions.Options" />

--- a/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
+++ b/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.AspNetCore.Routing.TestObjects;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
@@ -391,6 +392,36 @@ public class EndpointRoutingMiddlewareTest
 
         var actualRequestSizeLimit = maxRequestBodySizeFeature.MaxRequestBodySize;
         Assert.Equal(expectedRequestSizeLimit, actualRequestSizeLimit);
+    }
+
+    [Fact]
+    public async Task Create_WithoutHostBuilder_Success()
+    {
+        // Arrange
+        var httpContext = CreateHttpContext();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.AddSingleton<DiagnosticListener>(s => new DiagnosticListener("Test"));
+        services.AddRouting();
+
+        var applicationBuilder = new ApplicationBuilder(services.BuildServiceProvider());
+
+        applicationBuilder.UseRouting();
+        applicationBuilder.UseEndpoints(endpoints =>
+        {
+            endpoints.MapGet("/", (HttpContext c) => Task.CompletedTask);
+        });
+
+        var requestDelegate = applicationBuilder.Build();
+
+        // Act
+        await requestDelegate(httpContext);
+
+        // Assert
+        var endpointFeature = httpContext.Features.Get<IEndpointFeature>();
+        Assert.NotNull(endpointFeature);
     }
 
     private class RequestSizeLimitMetadata(long? maxRequestBodySize) : IRequestSizeLimitMetadata


### PR DESCRIPTION
Routing now uses metrics. The meter and counters are created using `IMeterFactory`. `IMeterFactory` is a new type and an implementation is registered by calling `AddMetrics()`. `AddMetrics()` is called by host builders.

However, this breaks if someone creates an app without using a host builder. They will get an error that `IMeterFactory` can't be resolved. Orchard Core doesn't use one of our built-in host builders and runs into this problem: https://github.com/OrchardCMS/OrchardCore/blob/fa03f92536de065c87f780ae27b277cce6d2d656/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs#L92. This is probably a rare situation.

Fix this issue by calling `AddMetrics()` inside `AddRouting()` so an `IMeterFactory` is always present. If the host already added metrics then the extra add inside routing doesn't have any impact.