### PR TITLE
Avoid some Logger instantiations per request

### DIFF
--- a/src/Mvc/Mvc.Core/src/ChallengeResult.cs
+++ b/src/Mvc/Mvc.Core/src/ChallengeResult.cs
@@ -94,7 +94,7 @@ public partial class ChallengeResult : ActionResult
 
         var httpContext = context.HttpContext;
         var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
-        var logger = loggerFactory.CreateLogger<ChallengeResult>();
+        var logger = loggerFactory.CreateLogger(typeof(ChallengeResult));
         Log.ChallengeResultExecuting(logger, AuthenticationSchemes);
 
         if (AuthenticationSchemes != null && AuthenticationSchemes.Count > 0)

--- a/src/Mvc/Mvc.Core/src/ForbidResult.cs
+++ b/src/Mvc/Mvc.Core/src/ForbidResult.cs
@@ -95,7 +95,7 @@ public partial class ForbidResult : ActionResult
         var httpContext = context.HttpContext;
 
         var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
-        var logger = loggerFactory.CreateLogger<ForbidResult>();
+        var logger = loggerFactory.CreateLogger(typeof(ForbidResult));
         Log.ForbidResultExecuting(logger, AuthenticationSchemes);
 
         if (AuthenticationSchemes != null && AuthenticationSchemes.Count > 0)

--- a/src/Mvc/Mvc.Core/src/SignInResult.cs
+++ b/src/Mvc/Mvc.Core/src/SignInResult.cs
@@ -81,7 +81,7 @@ public partial class SignInResult : ActionResult
 
         var httpContext = context.HttpContext;
         var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
-        var logger = loggerFactory.CreateLogger<SignInResult>();
+        var logger = loggerFactory.CreateLogger(typeof(SignInResult));
         Log.SignInResultExecuting(logger, AuthenticationScheme, Principal);
 
         return httpContext.SignInAsync(AuthenticationScheme, Principal, Properties);

--- a/src/Mvc/Mvc.Core/src/SignOutResult.cs
+++ b/src/Mvc/Mvc.Core/src/SignOutResult.cs
@@ -111,7 +111,7 @@ public partial class SignOutResult : ActionResult, IResult
         }
 
         var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
-        var logger = loggerFactory.CreateLogger<SignOutResult>();
+        var logger = loggerFactory.CreateLogger(typeof(SignOutResult));
         Log.SignOutResultExecuting(logger, AuthenticationSchemes);
 
         if (AuthenticationSchemes.Count == 0)

--- a/src/Mvc/Mvc.Core/src/StatusCodeResult.cs
+++ b/src/Mvc/Mvc.Core/src/StatusCodeResult.cs
@@ -37,7 +37,7 @@ public partial class StatusCodeResult : ActionResult, IClientErrorActionResult
 
         var httpContext = context.HttpContext;
         var factory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
-        var logger = factory.CreateLogger<StatusCodeResult>();
+        var logger = factory.CreateLogger(typeof(StatusCodeResult));
         Log.HttpStatusCodeResultExecuting(logger, StatusCode);
 
         httpContext.Response.StatusCode = StatusCode;

--- a/src/SignalR/clients/csharp/Client.Core/src/Internal/InvocationRequest.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/Internal/InvocationRequest.cs
@@ -70,7 +70,7 @@ internal abstract partial class InvocationRequest : IDisposable
         private readonly Channel<object?> _channel = Channel.CreateUnbounded<object?>();
 
         public Streaming(CancellationToken cancellationToken, Type resultType, string invocationId, ILoggerFactory loggerFactory, HubConnection hubConnection)
-            : base(cancellationToken, resultType, invocationId, loggerFactory.CreateLogger<Streaming>(), hubConnection)
+            : base(cancellationToken, resultType, invocationId, loggerFactory.CreateLogger(typeof(Streaming)), hubConnection)
         {
         }
 
@@ -130,7 +130,7 @@ internal abstract partial class InvocationRequest : IDisposable
         private readonly TaskCompletionSource<object?> _completionSource = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public NonStreaming(CancellationToken cancellationToken, Type resultType, string invocationId, ILoggerFactory loggerFactory, HubConnection hubConnection)
-            : base(cancellationToken, resultType, invocationId, loggerFactory.CreateLogger<NonStreaming>(), hubConnection)
+            : base(cancellationToken, resultType, invocationId, loggerFactory.CreateLogger(typeof(NonStreaming)), hubConnection)
         {
         }
 


### PR DESCRIPTION
`CreateLogger<T>` returns an `ILogger<T>` and always allocates a new `Logger<T>` instance. `CreateLogger(typeof(T))` returns a non-generic `ILogger` and delegates to the factory's `CreateLogger`, thus typically not allocating a new one.