### PR TITLE
Update NavMenu.razor to use project name

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/NavMenu.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/NavMenu.razor
@@ -1,6 +1,6 @@
 ﻿<div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
-        <a class="navbar-brand" href="">MyBlazorWeb</a>
+        <a class="navbar-brand" href="">BlazorWeb-CSharp</a>
     </div>
 </div>
 


### PR DESCRIPTION
Currently the Blazor Web App template always displays the app name "MyBlazorWeb" in the NavMenu. It should instead use the project name to be consistent with our other web templates.