### PR TITLE
Improve crawlability of links in default Blazor project templates

### DIFF
--- a/src/Components/Samples/BlazorServerApp/Shared/MainLayout.razor
+++ b/src/Components/Samples/BlazorServerApp/Shared/MainLayout.razor
@@ -16,6 +16,6 @@
 </div>
 <div id="blazor-error-ui">
     An unhandled error has occurred.
-    <a class="reload">Reload</a>
-    <a class="dismiss">X</a>
+    <a href="." class="reload">Reload</a>
+    <span class="dismiss">🗙</span>
 </div>

--- a/src/Components/WebAssembly/Samples/HostedBlazorWebassemblyApp/Client/wwwroot/index.html
+++ b/src/Components/WebAssembly/Samples/HostedBlazorWebassemblyApp/Client/wwwroot/index.html
@@ -17,8 +17,8 @@
 
     <div id="blazor-error-ui">
         An unhandled error has occurred.
-        <a href="" class="reload">Reload</a>
-        <a class="dismiss">🗙</a>
+        <a href="." class="reload">Reload</a>
+        <span class="dismiss">🗙</span>
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>

--- a/src/Components/WebView/Samples/PhotinoPlatform/testassets/PhotinoTestApp/wwwroot/webviewhost.html
+++ b/src/Components/WebView/Samples/PhotinoPlatform/testassets/PhotinoTestApp/wwwroot/webviewhost.html
@@ -22,8 +22,8 @@
     <!-- Explicit display:none required so StartupErrorNotificationTest can observe it change -->
     <div id="blazor-error-ui" style="display: none;">
         An unhandled error has occurred.
-        <a href class='reload'>Reload</a>
-        <a class='dismiss' style="cursor: pointer;">🗙</a>
+        <a href="." class="reload">Reload</a>
+        <span class="dismiss">🗙</span>
     </div>
 
     <!-- Used for specific test cases -->

--- a/src/Components/test/testassets/BasicTestApp/wwwroot/index.html
+++ b/src/Components/test/testassets/BasicTestApp/wwwroot/index.html
@@ -21,8 +21,8 @@
     <!-- Explicit display:none required so StartupErrorNotificationTest can observe it change -->
     <div id="blazor-error-ui" style="display: none;">
         An unhandled error has occurred.
-        <a href class='reload'>Reload</a>
-        <a class='dismiss' style="cursor: pointer;">🗙</a>
+        <a href="." class="reload">Reload</a>
+        <span class="dismiss">🗙</span>
     </div>
 
     <!-- Used for specific test cases -->

--- a/src/Components/test/testassets/Components.TestServer/Pages/_ServerHost.cshtml
+++ b/src/Components/test/testassets/Components.TestServer/Pages/_ServerHost.cshtml
@@ -26,8 +26,8 @@
 
     <div id="blazor-error-ui">
         An unhandled error has occurred.
-        <a href class='reload'>Reload</a>
-        <a class='dismiss' style="cursor: pointer;">🗙</a>
+        <a href="." class="reload">Reload</a>
+        <span class="dismiss">🗙</span>
     </div>
 
     <script>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/MainLayout.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/MainLayout.razor
@@ -24,7 +24,7 @@
 
 <div id="blazor-error-ui">
     An unhandled error has occurred.
-    <a href="" class="reload">Reload</a>
-    <a class="dismiss">🗙</a>
+    <a href="." class="reload">Reload</a>
+    <span class="dismiss">🗙</span>
 </div>
 ##endif*@

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/wwwroot/index.html
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/wwwroot/index.html
@@ -29,8 +29,8 @@
 
     <div id="blazor-error-ui">
         An unhandled error has occurred.
-        <a href="" class="reload">Reload</a>
-        <a class="dismiss">🗙</a>
+        <a href="." class="reload">Reload</a>
+        <span class="dismiss">🗙</span>
     </div>
 <!--#if (IndividualLocalAuth)  -->
     <script src="_content/Microsoft.AspNetCore.Components.WebAssembly.Authentication/AuthenticationService.js"></script>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/wwwroot/index.html
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/EmptyComponentsWebAssembly-CSharp/wwwroot/index.html
@@ -9,7 +9,7 @@
     <!--#if PWA -->
     <link href="manifest.webmanifest" rel="manifest" />
     <!--#endif -->
-    
+
     <!-- If you add any scoped CSS files, uncomment the following to load them
     <link href="EmptyComponentsWebAssembly_CSharp.styles.css" rel="stylesheet" /> -->
 </head>
@@ -19,8 +19,8 @@
 
     <div id="blazor-error-ui">
         An unhandled error has occurred.
-        <a href="" class="reload">Reload</a>
-        <a class="dismiss">🗙</a>
+        <a href="." class="reload">Reload</a>
+        <span class="dismiss">🗙</span>
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
     <!--#if PWA -->


### PR DESCRIPTION
https://developers.google.com/search/docs/crawling-indexing/links-crawlable

# Improve crawlability of links in default Blazor project templates

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

I made two links in the Blazor project templates more SEO friendly.

## Description
Two links in the starter templates are not SEO friendly/uncrawlable. I've made the links more semantically correct based on guidelines from [Google](https://developers.google.com/search/docs/crawling-indexing/links-crawlable), StackOverflow links advising how to [reload a page in a link](https://stackoverflow.com/a/12108553/3991315), and StackOverflow links avising that you probably [shouldn't use an `<a>` tag](https://stackoverflow.com/a/11145021/3991315) if you don't want it to be an anchor link.

Tested on my .NET 7 Blazor project:
|  Before  |  After | 
|---|---|
| ![image](https://github.com/dotnet/aspnetcore/assets/7528322/9f5f5162-aac8-450c-ab10-d5496b5a0f16) |  ![image](https://github.com/dotnet/aspnetcore/assets/7528322/969d2daf-69c6-4526-b2a4-b0ed339c2698) |

Fixes #50196 
