### PR TITLE
Remove Visual Studio Extension development workload requirement from `.vsconfig`

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -15,7 +15,6 @@
     "Microsoft.VisualStudio.Component.Windows10SDK.19041",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
     "Microsoft.VisualStudio.Workload.NativeDesktop",
-    "Microsoft.VisualStudio.Workload.NetWeb",
-    "Microsoft.VisualStudio.Workload.VisualStudioExtension"
+    "Microsoft.VisualStudio.Workload.NetWeb"
   ]
 }


### PR DESCRIPTION
We don't need the Visual Studio Extension development workload as we are building any extensions (at least to my knowledge) as part of `aspnetcore` repo. 

I just build my new clone without this option and the repo was built successfully.