### PR TITLE
added builder config - appsettings to BlazorWeb template

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Program.Main.cs
@@ -8,6 +8,9 @@ public class Program
     public static void Main(string[] args)
     {
         var builder = WebApplication.CreateBuilder(args);
+        // Add appsettings files to the configuration
+        builder.Configuration.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
+        builder.Configuration.AddJsonFile($"appsettings.Development.json", optional: true);
 
         // Add services to the container.
         #if (!UseServer && !UseWebAssembly)

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Program.cs
@@ -2,6 +2,10 @@ using BlazorWeb_CSharp.Components;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Add appsettings files to the configuration
+builder.Configuration.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
+builder.Configuration.AddJsonFile($"appsettings.Development.json", optional: true);
+
 // Add services to the container.
 #if (!UseServer && !UseWebAssembly)
 builder.Services.AddRazorComponents();


### PR DESCRIPTION
# added builder config - appsettings to BlazorWeb template

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Added the use of appsettings in builder.configuration in BlazorWeb template

## Description

Added the use of appsettings in builder.configuration in BlazorWeb template as I thought it wasn't helpful to supply the appsettings.json files without actually having them added to the builder.configuration.

As this is only a minor change in the template I believe it could be released to .NET 8 with no issues
