### PR TITLE
[SignalR] Error if multiple service attributes are on a single parameter

### DIFF
--- a/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
+++ b/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
@@ -119,7 +119,7 @@ internal sealed class HubMethodDescriptor
                         if (marked)
                         {
                             throw new InvalidOperationException(
-                                $"Multiple service attributes on parameter '{p.ParameterType}' of method '{methodExecutor.MethodInfo.DeclaringType?.Name}.{methodExecutor.MethodInfo.Name}' is not supported.");
+                                $"{methodExecutor.MethodInfo.DeclaringType?.Name}.{methodExecutor.MethodInfo.Name}: The {nameof(FromKeyedServicesAttribute)} is not supported on parameters that are also annotated with {nameof(IFromServiceMetadata)}.");
                         }
                     }
                 }

--- a/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
+++ b/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
@@ -81,22 +81,53 @@ internal sealed class HubMethodDescriptor
             }
             else if (p.CustomAttributes.Any())
             {
+                var markedParameter = false;
                 foreach (var attribute in p.GetCustomAttributes(true))
                 {
                     if (attribute is IFromServiceMetadata)
                     {
-                        return MarkServiceParameter(index);
+                        ThrowIfMarked(markedParameter);
+                        markedParameter = true;
+                        MarkServiceParameter(index);
                     }
                     else if (attribute is FromKeyedServicesAttribute keyedServicesAttribute)
                     {
-                        if (serviceProviderIsService is IServiceProviderIsKeyedService keyedServiceProvider &&
-                            keyedServiceProvider.IsKeyedService(GetServiceType(p.ParameterType), keyedServicesAttribute.Key))
+                        ThrowIfMarked(markedParameter);
+                        markedParameter = true;
+
+                        if (serviceProviderIsService is IServiceProviderIsKeyedService keyedServiceProvider)
                         {
-                            KeyedServiceKeys ??= new List<(int, object)>();
-                            KeyedServiceKeys.Add((index, keyedServicesAttribute.Key));
-                            return MarkServiceParameter(index);
+                            if (keyedServiceProvider.IsKeyedService(GetServiceType(p.ParameterType), keyedServicesAttribute.Key))
+                            {
+                                KeyedServiceKeys ??= new List<(int, object)>();
+                                KeyedServiceKeys.Add((index, keyedServicesAttribute.Key));
+                                MarkServiceParameter(index);
+                            }
+                            else
+                            {
+                                throw new InvalidOperationException($"'{p.ParameterType}' is not in DI as a keyed service.");
+                            }
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException($"This service provider doesn't support keyed services.");
                         }
                     }
+
+                    void ThrowIfMarked(bool marked)
+                    {
+                        if (marked)
+                        {
+                            throw new InvalidOperationException(
+                                $"Multiple service attributes on parameter '{p.ParameterType}' of method '{methodExecutor.MethodInfo.DeclaringType?.Name}.{methodExecutor.MethodInfo.Name}' is not supported.");
+                        }
+                    }
+                }
+
+                if (markedParameter)
+                {
+                    // If the parameter is marked because of being a service, we don't want to consider it for method parameters during deserialization
+                    return false;
                 }
             }
             else if (serviceProviderIsService?.IsService(GetServiceType(p.ParameterType)) == true)

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTestUtils/Hubs.cs
@@ -1363,12 +1363,6 @@ public class ServicesHub : TestHub
         return total + value;
     }
 
-    public int MultipleSameKeyedServices([FromKeyedServices("service1")] Service1 service, [FromKeyedServices("service1")] Service1 service2)
-    {
-        Assert.Same(service, service2);
-        return 445;
-    }
-
     public int ServiceWithoutAttribute(Service1 service)
     {
         return 1;
@@ -1391,6 +1385,15 @@ public class ServicesHub : TestHub
             await channelReader.ReadAsync();
         }
     }
+}
+
+public class KeyedServicesHub : TestHub
+{
+    public int MultipleSameKeyedServices([FromKeyedServices("service1")] Service1 service, [FromKeyedServices("service1")] Service1 service2)
+    {
+        Assert.Same(service, service2);
+        return 445;
+    }
 
     public int KeyedService([FromKeyedServices("service1")] Service1 service)
     {
@@ -1411,6 +1414,13 @@ public class ServicesHub : TestHub
     {
         Assert.NotEqual(service, service2);
         return 45;
+    }
+}
+
+public class BadServicesHub : Hub
+{
+    public void BadMethod([FromKeyedServices("service1")] [FromService] Service1 service)
+    {
     }
 }
 

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -4927,13 +4927,14 @@ public partial class HubConnectionHandlerTests : VerifiableLoggedTest
             });
 
             provider.AddKeyedScoped<Service1>("service1");
+            provider.AddKeyedScoped<Service1>("service2");
         });
-        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<ServicesHub>>();
+        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<KeyedServicesHub>>();
 
         using (var client = new TestClient())
         {
             var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
-            var res = await client.InvokeAsync(nameof(ServicesHub.KeyedService)).DefaultTimeout();
+            var res = await client.InvokeAsync(nameof(KeyedServicesHub.KeyedService)).DefaultTimeout();
             Assert.Equal(43L, res.Result);
         }
     }
@@ -4949,13 +4950,14 @@ public partial class HubConnectionHandlerTests : VerifiableLoggedTest
             });
 
             provider.AddKeyedScoped<Service1>("service1");
+            provider.AddKeyedScoped<Service1>("service2");
         });
-        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<ServicesHub>>();
+        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<KeyedServicesHub>>();
 
         using (var client = new TestClient())
         {
             var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
-            var res = await client.InvokeAsync(nameof(ServicesHub.KeyedServiceWithParam), 91).DefaultTimeout();
+            var res = await client.InvokeAsync(nameof(KeyedServicesHub.KeyedServiceWithParam), 91).DefaultTimeout();
             Assert.Equal(1183L, res.Result);
         }
     }
@@ -4971,14 +4973,15 @@ public partial class HubConnectionHandlerTests : VerifiableLoggedTest
             });
 
             provider.AddKeyedScoped<Service1>("service1");
+            provider.AddKeyedScoped<Service1>("service2");
             provider.AddScoped<Service2>();
         });
-        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<ServicesHub>>();
+        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<KeyedServicesHub>>();
 
         using (var client = new TestClient())
         {
             var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
-            var res = await client.InvokeAsync(nameof(ServicesHub.KeyedServiceNonKeyedService)).DefaultTimeout();
+            var res = await client.InvokeAsync(nameof(KeyedServicesHub.KeyedServiceNonKeyedService)).DefaultTimeout();
             Assert.Equal(11L, res.Result);
         }
     }
@@ -4996,12 +4999,12 @@ public partial class HubConnectionHandlerTests : VerifiableLoggedTest
             provider.AddKeyedScoped<Service1>("service1");
             provider.AddKeyedScoped<Service1>("service2");
         });
-        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<ServicesHub>>();
+        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<KeyedServicesHub>>();
 
         using (var client = new TestClient())
         {
             var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
-            var res = await client.InvokeAsync(nameof(ServicesHub.MultipleKeyedServices)).DefaultTimeout();
+            var res = await client.InvokeAsync(nameof(KeyedServicesHub.MultipleKeyedServices)).DefaultTimeout();
             Assert.Equal(45L, res.Result);
         }
     }
@@ -5017,19 +5020,20 @@ public partial class HubConnectionHandlerTests : VerifiableLoggedTest
             });
 
             provider.AddKeyedScoped<Service1>("service1");
+            provider.AddKeyedScoped<Service1>("service2");
         });
-        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<ServicesHub>>();
+        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<KeyedServicesHub>>();
 
         using (var client = new TestClient())
         {
             var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
-            var res = await client.InvokeAsync(nameof(ServicesHub.MultipleSameKeyedServices)).DefaultTimeout();
+            var res = await client.InvokeAsync(nameof(KeyedServicesHub.MultipleSameKeyedServices)).DefaultTimeout();
             Assert.Equal(445L, res.Result);
         }
     }
 
     [Fact]
-    public async Task KeyedServiceNotResolvedIfNotInDI()
+    public void KeyedServiceNotResolvedIfNotInDI()
     {
         var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(provider =>
         {
@@ -5038,14 +5042,24 @@ public partial class HubConnectionHandlerTests : VerifiableLoggedTest
                 options.EnableDetailedErrors = true;
             });
         });
-        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<ServicesHub>>();
+        var ex = Assert.Throws<InvalidOperationException>(() => serviceProvider.GetService<HubConnectionHandler<KeyedServicesHub>>());
+        Assert.Equal("'Microsoft.AspNetCore.SignalR.Tests.Service1' is not in DI as a keyed service.", ex.Message);
+    }
 
-        using (var client = new TestClient())
+    [Fact]
+    public void KeyedServiceAndFromServiceOnSameParameterInvalidWithKeyedServiceInDI()
+    {
+        var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(provider =>
         {
-            var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
-            var res = await client.InvokeAsync(nameof(ServicesHub.KeyedService)).DefaultTimeout();
-            Assert.Equal("Failed to invoke 'KeyedService' due to an error on the server. InvalidDataException: Invocation provides 0 argument(s) but target expects 1.", res.Error);
-        }
+            provider.AddSignalR(options =>
+            {
+                options.EnableDetailedErrors = true;
+            });
+
+            provider.AddKeyedScoped<Service1>("service1");
+        });
+        var ex = Assert.Throws<InvalidOperationException>(() => serviceProvider.GetService<HubConnectionHandler<BadServicesHub>>());
+        Assert.Equal("Multiple service attributes on parameter 'Microsoft.AspNetCore.SignalR.Tests.Service1' of method 'BadServicesHub.BadMethod' is not supported.", ex.Message);
     }
 
     [Fact]

--- a/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/HubConnectionHandlerTests.cs
@@ -5059,7 +5059,7 @@ public partial class HubConnectionHandlerTests : VerifiableLoggedTest
             provider.AddKeyedScoped<Service1>("service1");
         });
         var ex = Assert.Throws<InvalidOperationException>(() => serviceProvider.GetService<HubConnectionHandler<BadServicesHub>>());
-        Assert.Equal("Multiple service attributes on parameter 'Microsoft.AspNetCore.SignalR.Tests.Service1' of method 'BadServicesHub.BadMethod' is not supported.", ex.Message);
+        Assert.Equal("BadServicesHub.BadMethod: The FromKeyedServicesAttribute is not supported on parameters that are also annotated with IFromServiceMetadata.", ex.Message);
     }
 
     [Fact]


### PR DESCRIPTION
Also throw if the `ServiceProvider` doesn't support keyed services.

Recommend reviewing with whitespace hidden: https://github.com/dotnet/aspnetcore/pull/50248/files?diff=split&w=1