### PR TITLE
Use polling to watch certificate paths

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -22,6 +22,7 @@
     {"testName": {"contains": "HEADERS_Received_SecondRequest_ConnectProtocolReset"}},
     {"testName": {"contains": "ClientUsingOldCallWithNewProtocol"}},
     {"testName": {"contains": "CertificateChangedOnDisk"}},
+    {"testName": {"contains": "CertificateChangedOnDisk_Symlink"}},
     {"testAssembly": {"contains": "IIS"}},
     {"testAssembly": {"contains": "Template"}},
     {"failureMessage": {"contains":"(Site is started but no worker process found)"}},

--- a/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcher.cs
@@ -144,9 +144,6 @@ internal sealed partial class CertificatePathWatcher : IDisposable
             _metadataForFile.Add(path, fileMetadata);
             dirMetadata.FileWatchCount++;
 
-            // We actually don't care if the file doesn't exist - we'll watch in case it is created
-            fileMetadata.LastModifiedTime = GetLastModifiedTimeOrMinimum(path, dirMetadata.FileProvider);
-
             _logger.CreatedFileWatcher(path);
         }
 
@@ -160,20 +157,6 @@ internal sealed partial class CertificatePathWatcher : IDisposable
 
         _logger.ObserverCount(path, fileMetadata.Configs.Count);
         _logger.FileCount(dir, dirMetadata.FileWatchCount);
-    }
-
-    private DateTimeOffset GetLastModifiedTimeOrMinimum(string path, IFileProvider fileProvider)
-    {
-        try
-        {
-            return fileProvider.GetFileInfo(Path.GetFileName(path)).LastModified;
-        }
-        catch (Exception e)
-        {
-            _logger.LastModifiedTimeError(path, e);
-        }
-
-        return DateTimeOffset.MinValue;
     }
 
     private void OnChange(string path)
@@ -190,33 +173,17 @@ internal sealed partial class CertificatePathWatcher : IDisposable
             // Existence implied by the fact that we're tracking the file
             var dirMetadata = _metadataForDirectory[Path.GetDirectoryName(path)!];
 
-            // We ignore file changes that don't advance the last modified time.
+            // We ignore file changes that result in a file becoming unavailable.
             // For example, if we lose access to the network share the file is
             // stored on, we don't notify our listeners because no one wants
             // their endpoint/server to shutdown when that happens.
             // We also anticipate that a cert file might be renamed to cert.bak
             // before a new cert is introduced with the old name.
-            // This also helps us in scenarios where the underlying file system
-            // reports more than one change for a single logical operation.
-            var lastModifiedTime = GetLastModifiedTimeOrMinimum(path, dirMetadata.FileProvider);
-            if (lastModifiedTime > fileMetadata.LastModifiedTime)
+
+            var fileInfo = dirMetadata.FileProvider.GetFileInfo(Path.GetFileName(path));
+            if (!fileInfo.Exists)
             {
-                fileMetadata.LastModifiedTime = lastModifiedTime;
-            }
-            else
-            {
-                if (lastModifiedTime == DateTimeOffset.MinValue)
-                {
-                    _logger.EventWithoutLastModifiedTime(path);
-                }
-                else if (lastModifiedTime == fileMetadata.LastModifiedTime)
-                {
-                    _logger.RedundantEvent(path);
-                }
-                else
-                {
-                    _logger.OutOfOrderEvent(path);
-                }
+                _logger.EventWithoutFile(path);
                 return;
             }
 
@@ -225,6 +192,8 @@ internal sealed partial class CertificatePathWatcher : IDisposable
             {
                 config.FileHasChanged = true;
             }
+
+            _logger.FlaggedObservers(path, configs.Count);
         }
 
         // AddWatch and RemoveWatch don't affect the token, so this doesn't need to be under the semaphore.
@@ -327,7 +296,6 @@ internal sealed partial class CertificatePathWatcher : IDisposable
     {
         public readonly IDisposable Disposable = disposable;
         public readonly HashSet<CertificateConfig> Configs = new(ReferenceEqualityComparer.Instance);
-        public DateTimeOffset LastModifiedTime = DateTimeOffset.MinValue;
 
         public void Dispose() => Disposable.Dispose();
     }

--- a/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcher.cs
@@ -29,9 +29,15 @@ internal sealed partial class CertificatePathWatcher : IDisposable
 
     public CertificatePathWatcher(IHostEnvironment hostEnvironment, ILogger<CertificatePathWatcher> logger)
         : this(
-              hostEnvironment.ContentRootPath,
-              logger,
-              dir => Directory.Exists(dir) ? new PhysicalFileProvider(dir, ExclusionFilters.None) : null)
+            hostEnvironment.ContentRootPath,
+            logger,
+            dir => Directory.Exists(dir)
+                ? new PhysicalFileProvider(dir, ExclusionFilters.None)
+                {
+                    UseActivePolling = true,
+                    UsePollingFileWatcher = true,
+                }
+                : null)
     {
     }
 

--- a/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcher.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcher.cs
@@ -34,6 +34,8 @@ internal sealed partial class CertificatePathWatcher : IDisposable
             dir => Directory.Exists(dir)
                 ? new PhysicalFileProvider(dir, ExclusionFilters.None)
                 {
+                    // Force polling because it monitors both symlinks and their targets,
+                    // whereas the non-polling watcher only monitors the symlinks themselves
                     UseActivePolling = true,
                     UsePollingFileWatcher = true,
                 }

--- a/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcherLoggerExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcherLoggerExtensions.cs
@@ -34,6 +34,7 @@ internal static partial class CertificatePathWatcherLoggerExtensions
     [LoggerMessage(9, LogLevel.Debug, "Ignored event for presently untracked file '{Path}'.", EventName = "UntrackedFileEvent")]
     public static partial void UntrackedFileEvent(this ILogger<CertificatePathWatcher> logger, string path);
 
+    [Obsolete("No longer fired")]
     [LoggerMessage(10, LogLevel.Debug, "Ignored out-of-order event for file '{Path}'.", EventName = "OutOfOrderEvent")]
     public static partial void OutOfOrderEvent(this ILogger<CertificatePathWatcher> logger, string path);
 
@@ -52,12 +53,17 @@ internal static partial class CertificatePathWatcherLoggerExtensions
     [LoggerMessage(15, LogLevel.Trace, "Directory '{Directory}' now has watchers on {Count} files.", EventName = "FileCount")]
     public static partial void FileCount(this ILogger<CertificatePathWatcher> logger, string directory, int count);
 
+    [Obsolete("No longer fired")]
     [LoggerMessage(16, LogLevel.Trace, "Ignored event since last modified time for '{Path}' was unavailable.", EventName = "EventWithoutLastModifiedTime")]
     public static partial void EventWithoutLastModifiedTime(this ILogger<CertificatePathWatcher> logger, string path);
 
+    [Obsolete("No longer fired")]
     [LoggerMessage(17, LogLevel.Trace, "Ignored redundant event for '{Path}'.", EventName = "RedundantEvent")]
     public static partial void RedundantEvent(this ILogger<CertificatePathWatcher> logger, string path);
 
     [LoggerMessage(18, LogLevel.Trace, "Flagged {Count} observers of '{Path}' as changed.", EventName = "FlaggedObservers")]
     public static partial void FlaggedObservers(this ILogger<CertificatePathWatcher> logger, string path, int count);
+
+    [LoggerMessage(19, LogLevel.Trace, "Ignored event since '{Path}' was unavailable.", EventName = "EventWithoutFile")]
+    public static partial void EventWithoutFile(this ILogger<CertificatePathWatcher> logger, string path);
 }

--- a/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcherLoggerExtensions.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/CertificatePathWatcherLoggerExtensions.cs
@@ -34,36 +34,24 @@ internal static partial class CertificatePathWatcherLoggerExtensions
     [LoggerMessage(9, LogLevel.Debug, "Ignored event for presently untracked file '{Path}'.", EventName = "UntrackedFileEvent")]
     public static partial void UntrackedFileEvent(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [Obsolete("No longer fired")]
-    [LoggerMessage(10, LogLevel.Debug, "Ignored out-of-order event for file '{Path}'.", EventName = "OutOfOrderEvent")]
-    public static partial void OutOfOrderEvent(this ILogger<CertificatePathWatcher> logger, string path);
-
-    [LoggerMessage(11, LogLevel.Trace, "Reused existing observer on file watcher for '{Path}'.", EventName = "ReusedObserver")]
+    [LoggerMessage(10, LogLevel.Trace, "Reused existing observer on file watcher for '{Path}'.", EventName = "ReusedObserver")]
     public static partial void ReusedObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(12, LogLevel.Trace, "Added observer to file watcher for '{Path}'.", EventName = "AddedObserver")]
+    [LoggerMessage(11, LogLevel.Trace, "Added observer to file watcher for '{Path}'.", EventName = "AddedObserver")]
     public static partial void AddedObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(13, LogLevel.Trace, "Removed observer from file watcher for '{Path}'.", EventName = "RemovedObserver")]
+    [LoggerMessage(12, LogLevel.Trace, "Removed observer from file watcher for '{Path}'.", EventName = "RemovedObserver")]
     public static partial void RemovedObserver(this ILogger<CertificatePathWatcher> logger, string path);
 
-    [LoggerMessage(14, LogLevel.Trace, "File '{Path}' now has {Count} observers.", EventName = "ObserverCount")]
+    [LoggerMessage(13, LogLevel.Trace, "File '{Path}' now has {Count} observers.", EventName = "ObserverCount")]
     public static partial void ObserverCount(this ILogger<CertificatePathWatcher> logger, string path, int count);
 
-    [LoggerMessage(15, LogLevel.Trace, "Directory '{Directory}' now has watchers on {Count} files.", EventName = "FileCount")]
+    [LoggerMessage(14, LogLevel.Trace, "Directory '{Directory}' now has watchers on {Count} files.", EventName = "FileCount")]
     public static partial void FileCount(this ILogger<CertificatePathWatcher> logger, string directory, int count);
 
-    [Obsolete("No longer fired")]
-    [LoggerMessage(16, LogLevel.Trace, "Ignored event since last modified time for '{Path}' was unavailable.", EventName = "EventWithoutLastModifiedTime")]
-    public static partial void EventWithoutLastModifiedTime(this ILogger<CertificatePathWatcher> logger, string path);
-
-    [Obsolete("No longer fired")]
-    [LoggerMessage(17, LogLevel.Trace, "Ignored redundant event for '{Path}'.", EventName = "RedundantEvent")]
-    public static partial void RedundantEvent(this ILogger<CertificatePathWatcher> logger, string path);
-
-    [LoggerMessage(18, LogLevel.Trace, "Flagged {Count} observers of '{Path}' as changed.", EventName = "FlaggedObservers")]
+    [LoggerMessage(15, LogLevel.Trace, "Flagged {Count} observers of '{Path}' as changed.", EventName = "FlaggedObservers")]
     public static partial void FlaggedObservers(this ILogger<CertificatePathWatcher> logger, string path, int count);
 
-    [LoggerMessage(19, LogLevel.Trace, "Ignored event since '{Path}' was unavailable.", EventName = "EventWithoutFile")]
+    [LoggerMessage(16, LogLevel.Trace, "Ignored event since '{Path}' was unavailable.", EventName = "EventWithoutFile")]
     public static partial void EventWithoutFile(this ILogger<CertificatePathWatcher> logger, string path);
 }

--- a/src/Servers/Kestrel/Core/test/CertificatePathWatcherTests.cs
+++ b/src/Servers/Kestrel/Core/test/CertificatePathWatcherTests.cs
@@ -187,17 +187,10 @@ public class CertificatePathWatcherTests : LoggedTest
 
         watcher.AddWatchUnsynchronized(certificateConfig);
 
-        var logTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        TestSink.MessageLogged += writeContext =>
-        {
-            if (writeContext.EventId.Name == "OutOfOrderEvent")
-            {
-                logTcs.SetResult();
-            }
-        };
+        var signalTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var oldChangeToken = watcher.GetChangeToken();
+        oldChangeToken.RegisterChangeCallback(_ => signalTcs.SetResult(), state: null);
 
         Assert.Equal(1, watcher.TestGetDirectoryWatchCountUnsynchronized());
         Assert.Equal(1, watcher.TestGetFileWatchCountUnsynchronized(dir));
@@ -207,9 +200,9 @@ public class CertificatePathWatcherTests : LoggedTest
         fileProvider.SetLastModifiedTime(fileName, fileLastModifiedTime.AddSeconds(-1));
         fileProvider.FireChangeToken(fileName);
 
-        await logTcs.Task.DefaultTimeout();
+        await signalTcs.Task.DefaultTimeout();
 
-        Assert.False(oldChangeToken.HasChanged);
+        Assert.True(oldChangeToken.HasChanged);
     }
 
     [Fact]
@@ -342,12 +335,10 @@ public class CertificatePathWatcherTests : LoggedTest
     }
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
+    [InlineData(true)]
+    [InlineData(false)]
     [LogLevel(LogLevel.Trace)]
-    public async Task IgnoreDeletion(bool seeChangeForDeletion, bool restoredWithNewerLastModifiedTime)
+    public async Task IgnoreDeletion(bool restoredWithNewerLastModifiedTime)
     {
         var dir = Directory.GetCurrentDirectory();
         var fileName = Path.GetRandomFileName();
@@ -377,30 +368,21 @@ public class CertificatePathWatcherTests : LoggedTest
         watcher.GetChangeToken().RegisterChangeCallback(_ => changeTcs.SetResult(), state: null);
 
         var logNoLastModifiedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var logSameLastModifiedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         TestSink.MessageLogged += writeContext =>
         {
-            if (writeContext.EventId.Name == "EventWithoutLastModifiedTime")
+            if (writeContext.EventId.Name == "EventWithoutFile")
             {
                 logNoLastModifiedTcs.SetResult();
-            }
-            else if (writeContext.EventId.Name == "RedundantEvent")
-            {
-                logSameLastModifiedTcs.SetResult();
             }
         };
 
         // Simulate file deletion
         fileProvider.SetLastModifiedTime(fileName, null);
 
-        // In some file systems and watch modes, there's no event when (e.g.) the directory containing the watched file is deleted
-        if (seeChangeForDeletion)
-        {
-            fileProvider.FireChangeToken(fileName);
+        fileProvider.FireChangeToken(fileName);
 
-            await logNoLastModifiedTcs.Task.DefaultTimeout();
-        }
+        await logNoLastModifiedTcs.Task.DefaultTimeout();
 
         Assert.Equal(1, watcher.TestGetDirectoryWatchCountUnsynchronized());
         Assert.Equal(1, watcher.TestGetFileWatchCountUnsynchronized(dir));
@@ -412,16 +394,7 @@ public class CertificatePathWatcherTests : LoggedTest
         fileProvider.SetLastModifiedTime(fileName, restoredWithNewerLastModifiedTime ? fileLastModifiedTime.AddSeconds(1) : fileLastModifiedTime);
         fileProvider.FireChangeToken(fileName);
 
-        if (restoredWithNewerLastModifiedTime)
-        {
-            await changeTcs.Task.DefaultTimeout();
-            Assert.False(logSameLastModifiedTcs.Task.IsCompleted);
-        }
-        else
-        {
-            await logSameLastModifiedTcs.Task.DefaultTimeout();
-            Assert.False(changeTcs.Task.IsCompleted);
-        }
+        await changeTcs.Task.DefaultTimeout();
     }
 
     [Fact]

--- a/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
+++ b/src/Servers/Kestrel/Kestrel/test/KestrelConfigurationLoaderTests.cs
@@ -894,7 +894,7 @@ public class KestrelConfigurationLoaderTests
 
             if (reloadOnChange)
             {
-                await fileTcs.Task.DefaultTimeout();
+                await fileTcs.Task.TimeoutAfter(TimeSpan.FromSeconds(10)); // Needs to be meaningfully longer than the polling period - 4 seconds
             }
             else
             {


### PR DESCRIPTION
# Use polling to watch certificate paths

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->


## Description

It's common for certificates to be rotated using symlinks and `FileSystemWatcher` doesn't resolve symlinks.  Use polling, which does, but only for certificates since it has a CPU cost.

Polling checks the last-modified-time of the target path _after resolving symlinks_.  Since we don't know the resolved path, we can't check the last-modified-time accurately, so don't check it at all.

Fixes #32351
