### PR TITLE
Fix SSR redirection when coming from a non-root URL

### DIFF
--- a/src/Components/Endpoints/src/DependencyInjection/HttpNavigationManager.cs
+++ b/src/Components/Endpoints/src/DependencyInjection/HttpNavigationManager.cs
@@ -11,6 +11,7 @@ internal sealed class HttpNavigationManager : NavigationManager, IHostEnvironmen
 
     protected override void NavigateToCore(string uri, bool forceLoad)
     {
-        throw new NavigationException(uri);
+        var absoluteUriString = ToAbsoluteUri(uri).ToString();
+        throw new NavigationException(absoluteUriString);
     }
 }


### PR DESCRIPTION
Fixes #49670 trivially by making `HttpNavigationManager`'s redirection logic consistent with the other `NavigationManager` implementations.

You'll be wondering why there are no E2E tests with this PR. The reason is that, surprisingly, we *already* have E2E tests for these kinds of non-root redirections. However, they were falsely passing, which is tracked by https://github.com/dotnet/aspnetcore/issues/50260 and is outside the scope of this PR. I think we should address that other issue in .NET 9 as there should be no developer/API impact from leaving it as-is for .NET 8.
