### PR TITLE
Test updating SDK to 8.0.100-rc.1.23407.2

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -124,11 +124,11 @@ jobs:
       ${{ if eq(parameters.agentOs, 'Windows') }}:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals 1es-windows-2022-open
+          demands: ImageOverride -equals windows.vs2022preview.scout.amd64.open
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: $(DncEngInternalBuildPool)
           # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing
-          demands: ImageOverride -equals 1es-windows-2022
+          demands: ImageOverride -equals windows.vs2022preview.scout.amd64
     ${{ if ne(parameters.container, '') }}:
       container: ${{ parameters.container }}
     ${{ if ne(parameters.disableComponentGovernance, '') }}:

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,7 @@
 <Project>
   <PropertyGroup>
+    <!-- Disable IsTrimmable on non-DefaultNetCoreTargetFrameworks even if explicitly enabled or else we'll get NETSDK1195 and NETSDK1210 errors -->
+    <IsTrimmable Condition="'$(TargetFramework)' != '$(DefaultNetCoreTargetFramework)'"></IsTrimmable>
     <EnableAOTAnalyzer Condition=" '$(EnableAOTAnalyzer)' == '' ">$([MSBuild]::ValueOrDefault($(IsTrimmable),'false'))</EnableAOTAnalyzer>
     <!-- TODO: Remove when analyzer is enabled by default with AOT in SDK. See https://github.com/dotnet/sdk/issues/31284 -->
     <EnableSingleFileAnalyzer Condition=" '$(EnableSingleFileAnalyzer)' == '' ">$(EnableAOTAnalyzer)</EnableSingleFileAnalyzer>

--- a/eng/CodeGen.proj
+++ b/eng/CodeGen.proj
@@ -24,7 +24,9 @@
       <_RequiresDelayedBuild Include="@(_ProvidesReferenceOrRequiresDelay->WithMetadataValue('RequiresDelayedBuild','true')->Distinct())" />
       <_SharedFrameworkAndPackageRef Include="@(_ProjectReferenceProvider->WithMetadataValue('IsAspNetCoreApp','true')->WithMetadataValue('IsPackable', 'true'))" />
       <_SharedFrameworkRef Include="@(_ProjectReferenceProvider->WithMetadataValue('IsAspNetCoreApp','true')->WithMetadataValue('IsPackable', 'false'))" />
-      <_TrimmableProject Include="@(_ProjectReferenceProvider->WithMetadataValue('IsTrimmable', 'true'))" />
+      <!-- _ProjectReferenceProvider is already Distinct() and does not include metadata for each target framework. -->
+      <!-- If a project is trimmable for even just one of multiple target frameworks, include it in TrimmableProjects.props. -->
+      <_TrimmableProject Include="@(_ProvidesReferenceOrRequiresDelay->WithMetadataValue('IsTrimmable', 'true')->WithMetadataValue('IsProjectReferenceProvider','true')->Distinct())" />
       <_ShippingAssemblyWithDupes Include="@(_ProjectReferenceProvider->WithMetadataValue('IsAspNetCoreApp', 'true'))" />
       <_ShippingAssemblyWithDupes Include="@(_ProjectReferenceProvider->WithMetadataValue('IsShippingPackage', 'true'))" />
       <_ShippingAssembly Include="@(_ShippingAssemblyWithDupes->Distinct())" />

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -296,7 +296,7 @@ function InstallDotNet([string] $dotnetRoot,
     if ($runtime -eq "aspnetcore") { $runtimePath = $runtimePath + "\Microsoft.AspNetCore.App" }
     if ($runtime -eq "windowsdesktop") { $runtimePath = $runtimePath + "\Microsoft.WindowsDesktop.App" }
     $runtimePath = $runtimePath + "\" + $version
-  
+
     $dotnetVersionLabel = "runtime toolset '$runtime/$architecture v$version'"
 
     if (Test-Path $runtimePath) {
@@ -610,7 +610,7 @@ function InitializeBuildTool() {
       ExitWithExitCode 1
     }
 
-    $buildTool = @{ Path = $msbuildPath; Command = ""; Tool = "vs"; Framework = "net472"; ExcludePrereleaseVS = $excludePrereleaseVS }
+    $buildTool = @{ Path = $msbuildPath; Command = ""; Tool = "vs"; Framework = "net8.0"; ExcludePrereleaseVS = $excludePrereleaseVS }
   } else {
     Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Unexpected value of -msbuildEngine: '$msbuildEngine'."
     ExitWithExitCode 1

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.1.23381.2"
+    "version": "8.0.100-rc.1.23407.2"
   },
   "tools": {
-    "dotnet": "8.0.100-rc.1.23381.2",
+    "dotnet": "8.0.100-rc.1.23407.2",
     "runtimes": {
       "dotnet/x86": [
         "$(MicrosoftNETCoreBrowserDebugHostTransportVersion)"


### PR DESCRIPTION
I don't expect this to work, but I'm trying to get around the MissingMethodExceptions we're seeing in the InstallDotnetCore task in #49911. The only obvious difference is the target framework for Arcade.Sdk.dll.

![binlog](https://github.com/dotnet/aspnetcore/assets/54385/f8aac2a2-6a37-4b30-be47-4245774a1ff6)

That said, the supposedly missing method [ought to be there for the net472 target](https://apisof.net/catalog/63e8d5e1-3807-376c-67bf-341099078ad2), and the InstallDotNetCore task hasn't changed in a long time.