### PR TITLE
Unquarantine tests as part of blops.

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
@@ -27,7 +27,7 @@ public class WebHostTests : LoggedTest
     [SkipNonHelix]
     [SkipOnAlpine("https://github.com/dotnet/aspnetcore/issues/46537")]
     [SkipOnMariner("https://github.com/dotnet/aspnetcore/issues/46537")]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/46616;https://github.com/dotnet/aspnetcore/issues/47065", Queues = "Debian.12.Arm64.Open;Windows.Amd64.Server2022.Open")]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/46616;https://github.com/dotnet/aspnetcore/issues/47065", Queues = "Debian.12.Arm64.Open;")]
     [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "HTTP/3 isn't supported on MacOS.")]
     [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win11_21H2)]
     public void HelixPlatform_QuicListenerIsSupported()

--- a/src/SignalR/server/SignalR/test/EndToEndTests.cs
+++ b/src/SignalR/server/SignalR/test/EndToEndTests.cs
@@ -72,7 +72,6 @@ public class EndToEndTests : FunctionalTestBase
     [Theory]
     [MemberData(nameof(TransportTypes))]
     [LogLevel(LogLevel.Trace)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/49315")]
     public async Task CanStartAndStopConnectionUsingGivenTransport(HttpTransportType transportType)
     {
         await using (var server = await StartServer<Startup>())


### PR DESCRIPTION
Un quarantining some tests that are green. Includes one test that was being skipped on an AMD build queue but that issue with msquic should be resolved now (5 months later).

Related:
https://github.com/dotnet/aspnetcore/issues/47065
https://github.com/dotnet/aspnetcore/issues/49315