### PR TITLE
Start using the .NET 9 Planning milestone in issue response automation

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1633,7 +1633,7 @@
             {
               "name": "addedToMilestone",
               "parameters": {
-                "milestoneName": ".NET 8 Planning"
+                "milestoneName": ".NET 9 Planning"
               }
             },
             {
@@ -1649,12 +1649,12 @@
           "issues",
           "project_card"
         ],
-        "taskName": "Comment when an investigation issue moved to .NET 8 Planning",
+        "taskName": "Comment when an investigation issue moved to .NET 9 Planning",
         "actions": [
           {
             "name": "addReply",
             "parameters": {
-              "comment": "To learn more about what this message means, what to expect next, and how this issue will be handled you can read our [Triage Process document](https://github.com/dotnet/aspnetcore/blob/main/docs/TriageProcess.md).\nWe're moving this issue to the .NET 8 Planning milestone for future evaluation / consideration. Because it's not immediately obvious what is causing this behavior, we would like to keep this around to collect more feedback, which can later help us determine how to handle this. We will re-evaluate this issue, during our next planning meeting(s).\nIf we later determine, that the issue has no community involvement, or it's very rare and low-impact issue, we will close it - so that the team can focus on more important and high impact work."
+              "comment": "To learn more about what this message means, what to expect next, and how this issue will be handled you can read our [Triage Process document](https://github.com/dotnet/aspnetcore/blob/main/docs/TriageProcess.md).\nWe're moving this issue to the .NET 9 Planning milestone for future evaluation / consideration. Because it's not immediately obvious what is causing this behavior, we would like to keep this around to collect more feedback, which can later help us determine how to handle this. We will re-evaluate this issue, during our next planning meeting(s).\nIf we later determine, that the issue has no community involvement, or it's very rare and low-impact issue, we will close it - so that the team can focus on more important and high impact work."
             }
           }
         ]
@@ -2510,7 +2510,7 @@
             {
               "name": "addedToMilestone",
               "parameters": {
-                "milestoneName": ".NET 8 Planning"
+                "milestoneName": ".NET 9 Planning"
               }
             },
             {
@@ -2531,12 +2531,12 @@
           "issues",
           "project_card"
         ],
-        "taskName": "Comment when an issue is moved to `.NET 8 Planning` milestone",
+        "taskName": "Comment when an issue is moved to `.NET 9 Planning` milestone",
         "actions": [
           {
             "name": "addReply",
             "parameters": {
-              "comment": "Thanks for contacting us.\n\nWe're moving this issue to the `.NET 8 Planning` milestone for future evaluation / consideration. We would like to keep this around to collect more feedback, which can help us with prioritizing this work. We will re-evaluate this issue, during our next planning meeting(s). \nIf we later determine, that the issue has no community involvement, or it's very rare and low-impact issue, we will close it - so that the team can focus on more important and high impact issues.\nTo learn more about what to expect next and how this issue will be handled you can read more about our triage process [here](https://github.com/dotnet/aspnetcore/blob/main/docs/TriageProcess.md)."
+              "comment": "Thanks for contacting us.\n\nWe're moving this issue to the `.NET 9 Planning` milestone for future evaluation / consideration. We would like to keep this around to collect more feedback, which can help us with prioritizing this work. We will re-evaluate this issue, during our next planning meeting(s). \nIf we later determine, that the issue has no community involvement, or it's very rare and low-impact issue, we will close it - so that the team can focus on more important and high impact issues.\nTo learn more about what to expect next and how this issue will be handled you can read more about our triage process [here](https://github.com/dotnet/aspnetcore/blob/main/docs/TriageProcess.md)."
             }
           }
         ]


### PR DESCRIPTION
As we're wrapping up the .NET 8 work, we shouldn't utilize `.NET 8 Planning` milestone anymore. Hence, this updates the automation to comment when issues move to the `.NET 9 Planning` milestone instead.