### PR TITLE
Remove more setup overhead in RDG benchmarks

### DIFF
--- a/src/Http/Http/perf/Microbenchmarks/RequestDelegateGeneratorBenchmarks.cs
+++ b/src/Http/Http/perf/Microbenchmarks/RequestDelegateGeneratorBenchmarks.cs
@@ -1,7 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using System.Text;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Http.Generators.Tests;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.AspNetCore.Http.Microbenchmarks;
 

--- a/src/Http/Http/perf/Microbenchmarks/RequestDelegateGeneratorBenchmarks.cs
+++ b/src/Http/Http/perf/Microbenchmarks/RequestDelegateGeneratorBenchmarks.cs
@@ -43,4 +43,3 @@ public class RequestDelegateGeneratorBenchmarks : RequestDelegateCreationTestBas
         _driver.RunGeneratorsAndUpdateCompilation(_compilation, out var _, out var _);
     }
 }
-}


### PR DESCRIPTION
While leveraging the benchmark some more, I realized that it was measuring the setup for the compilation instance in its inner loop. Moving this to the global setup so we can measure just the portions associated with RDG itself.