### PR TITLE
Give a useful error if rendermode endpoints aren't mapped

### DIFF
--- a/src/Components/Endpoints/src/Builder/ConfiguredRenderModesMetadata.cs
+++ b/src/Components/Endpoints/src/Builder/ConfiguredRenderModesMetadata.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Endpoints;
+
+internal class ConfiguredRenderModesMetadata(IComponentRenderMode[] configuredRenderModes)
+{
+    public IComponentRenderMode[] ConfiguredRenderModes => configuredRenderModes;
+}

--- a/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSource.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentEndpointDataSource.cs
@@ -98,10 +98,12 @@ internal class RazorComponentEndpointDataSource<[DynamicallyAccessedMembers(Comp
         {
             var endpoints = new List<Endpoint>();
             var context = _builder.Build();
+            var configuredRenderModesMetadata = new ConfiguredRenderModesMetadata(
+                Options.ConfiguredRenderModes.ToArray());
 
             foreach (var definition in context.Pages)
             {
-                _factory.AddEndpoints(endpoints, typeof(TRootComponent), definition, _conventions, _finallyConventions);
+                _factory.AddEndpoints(endpoints, typeof(TRootComponent), definition, _conventions, _finallyConventions, configuredRenderModesMetadata);
             }
 
             ICollection<IComponentRenderMode> renderModes = Options.ConfiguredRenderModes;
@@ -127,8 +129,8 @@ internal class RazorComponentEndpointDataSource<[DynamicallyAccessedMembers(Comp
                 if (!found)
                 {
                     throw new InvalidOperationException($"Unable to find a provider for the render mode: {renderMode.GetType().FullName}. This generally " +
-                        $"means that a call to 'AddWebAssemblyComponents' or 'AddServerComponents' is missing. " +
-                        $"Alternatively call 'AddWebAssemblyRenderMode', 'AddServerRenderMode' might be missing if you have set UseDeclaredRenderModes = false.");
+                        "means that a call to 'AddWebAssemblyComponents' or 'AddServerComponents' is missing. " +
+                        "For example, change builder.Services.AddRazorComponents() to builder.Services.AddRazorComponents().AddServerComponents().");
                 }
             }
 

--- a/src/Components/Endpoints/src/Builder/RazorComponentEndpointFactory.cs
+++ b/src/Components/Endpoints/src/Builder/RazorComponentEndpointFactory.cs
@@ -24,7 +24,8 @@ internal class RazorComponentEndpointFactory
         [DynamicallyAccessedMembers(Component)] Type rootComponent,
         PageComponentInfo pageDefinition,
         IReadOnlyList<Action<EndpointBuilder>> conventions,
-        IReadOnlyList<Action<EndpointBuilder>> finallyConventions)
+        IReadOnlyList<Action<EndpointBuilder>> finallyConventions,
+        ConfiguredRenderModesMetadata configuredRenderModesMetadata)
     {
         // We do not provide a way to establish the order or the name for the page routes.
         // Order is not supported in our client router.
@@ -48,6 +49,7 @@ internal class RazorComponentEndpointFactory
         builder.Metadata.Add(HttpMethodsMetadata);
         builder.Metadata.Add(new ComponentTypeMetadata(pageDefinition.Type));
         builder.Metadata.Add(new RootComponentMetadata(rootComponent));
+        builder.Metadata.Add(configuredRenderModesMetadata);
 
         foreach (var convention in conventions)
         {

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
@@ -29,7 +29,7 @@ internal partial class EndpointHtmlRenderer
         else
         {
             // This component is the start of a subtree with a rendermode, so introduce a new rendermode boundary here
-            return new SSRRenderModeBoundary(componentType, renderMode);
+            return new SSRRenderModeBoundary(_httpContext, componentType, renderMode);
         }
     }
 
@@ -84,7 +84,7 @@ internal partial class EndpointHtmlRenderer
         {
             var rootComponent = prerenderMode is null
                 ? InstantiateComponent(componentType)
-                : new SSRRenderModeBoundary(componentType, prerenderMode);
+                : new SSRRenderModeBoundary(_httpContext, componentType, prerenderMode);
             var htmlRootComponent = await Dispatcher.InvokeAsync(() => BeginRenderingComponent(rootComponent, parameters));
             var result = new PrerenderedComponentHtmlContent(Dispatcher, htmlRootComponent);
 

--- a/src/Components/Endpoints/test/RazorComponentEndpointFactoryTest.cs
+++ b/src/Components/Endpoints/test/RazorComponentEndpointFactoryTest.cs
@@ -18,13 +18,16 @@ public class RazorComponentEndpointFactoryTest
         var factory = new RazorComponentEndpointFactory();
         var conventions = new List<Action<EndpointBuilder>>();
         var finallyConventions = new List<Action<EndpointBuilder>>();
+        var testRenderMode = new TestRenderMode();
+        var configuredRenderModes = new ConfiguredRenderModesMetadata(new[] { testRenderMode });
         factory.AddEndpoints(endpoints, typeof(App), new PageComponentInfo(
             "App",
             typeof(App),
             "/",
             new object[] { new AuthorizeAttribute() }),
             conventions,
-            finallyConventions);
+            finallyConventions,
+            configuredRenderModes);
 
         var endpoint = Assert.Single(endpoints);
         Assert.Equal("/ (App)", endpoint.DisplayName);
@@ -35,6 +38,8 @@ public class RazorComponentEndpointFactoryTest
         Assert.Contains(endpoint.Metadata, m => m is ComponentTypeMetadata);
         Assert.Contains(endpoint.Metadata, m => m is SuppressLinkGenerationMetadata);
         Assert.Contains(endpoint.Metadata, m => m is AuthorizeAttribute);
+        Assert.Contains(endpoint.Metadata, m => m is ConfiguredRenderModesMetadata c
+            && c.ConfiguredRenderModes.Single() == testRenderMode);
         Assert.NotNull(endpoint.RequestDelegate);
 
         var methods = Assert.Single(endpoint.Metadata.GetOrderedMetadata<HttpMethodMetadata>());
@@ -63,7 +68,8 @@ public class RazorComponentEndpointFactoryTest
                 "/",
                 Array.Empty<object>()),
             conventions,
-            finallyConventions);
+            finallyConventions,
+            new ConfiguredRenderModesMetadata(Array.Empty<IComponentRenderMode>()));
 
         var endpoint = Assert.Single(endpoints);
         Assert.Contains(endpoint.Metadata, m => m is AuthorizeAttribute);
@@ -90,7 +96,8 @@ public class RazorComponentEndpointFactoryTest
                 "/",
                 Array.Empty<object>()),
             conventions,
-            finallyConventions);
+            finallyConventions,
+            new ConfiguredRenderModesMetadata(Array.Empty<IComponentRenderMode>()));
 
         var endpoint = Assert.Single(endpoints);
         Assert.Contains(endpoint.Metadata, m => m is AuthorizeAttribute);
@@ -117,7 +124,8 @@ public class RazorComponentEndpointFactoryTest
                 "/",
                 Array.Empty<object>()),
             conventions,
-            finallyConventions);
+            finallyConventions,
+            new ConfiguredRenderModesMetadata(Array.Empty<IComponentRenderMode>()));
 
         var endpoint = Assert.Single(endpoints);
         var routeEndpoint = Assert.IsType<RouteEndpoint>(endpoint);
@@ -148,9 +156,12 @@ public class RazorComponentEndpointFactoryTest
                 "/",
                 Array.Empty<object>()),
             conventions,
-            finallyConventions);
+            finallyConventions,
+            new ConfiguredRenderModesMetadata(Array.Empty<IComponentRenderMode>()));
 
         var endpoint = Assert.Single(endpoints);
         Assert.DoesNotContain(endpoint.Metadata, m => m is AuthorizeAttribute);
     }
+
+    class TestRenderMode : IComponentRenderMode { }
 }

--- a/src/Components/Endpoints/test/SSRRenderModeBoundaryTest.cs
+++ b/src/Components/Endpoints/test/SSRRenderModeBoundaryTest.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Components.Endpoints;
+
+public class SSRRenderModeBoundaryTest
+{
+    // While most aspects of SSRRenderModeBoundary are only interesting to test E2E,
+    // the configuration validation aspect is better covered as unit tests because
+    // otherwise we would need many different E2E test app configurations.
+
+    [Fact]
+    public void DoesNotAssertAboutConfiguredRenderModesOnUnknownEndpoints()
+    {
+        // Arrange: an endpoint with no ConfiguredRenderModesMetadata
+        var httpContext = new DefaultHttpContext();
+        httpContext.SetEndpoint(new Endpoint(null, new EndpointMetadataCollection(), null));
+
+        // Act/Assert: no exception means we're OK
+        new SSRRenderModeBoundary(httpContext, typeof(TestComponent), new ServerRenderMode());
+        new SSRRenderModeBoundary(httpContext, typeof(TestComponent), new WebAssemblyRenderMode());
+        new SSRRenderModeBoundary(httpContext, typeof(TestComponent), new AutoRenderMode());
+    }
+
+    [Fact]
+    public void ThrowsIfServerRenderModeUsedAndNotConfigured()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        PrepareEndpoint(httpContext, new WebAssemblyRenderModeSubclass());
+
+        // Act/Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => new SSRRenderModeBoundary(
+            httpContext, typeof(TestComponent), new ServerRenderModeSubclass()));
+        Assert.Contains($"A component of type '{typeof(TestComponent)}' has render mode '{nameof(ServerRenderModeSubclass)}'", ex.Message);
+        Assert.Contains($"add a call to 'AddServerRenderMode'", ex.Message);
+    }
+
+    [Fact]
+    public void ThrowsIfWebAssemblyRenderModeUsedAndNotConfigured()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        PrepareEndpoint(httpContext, new ServerRenderModeSubclass());
+
+        // Act/Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => new SSRRenderModeBoundary(
+            httpContext, typeof(TestComponent), new WebAssemblyRenderModeSubclass()));
+        Assert.Contains($"A component of type '{typeof(TestComponent)}' has render mode '{nameof(WebAssemblyRenderModeSubclass)}'", ex.Message);
+        Assert.Contains($"add a call to 'AddWebAssemblyRenderMode'", ex.Message);
+    }
+
+    [Fact]
+    public void ThrowsIfAutoRenderModeUsedAndServerNotConfigured()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        PrepareEndpoint(httpContext, new WebAssemblyRenderModeSubclass());
+
+        // Act/Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => new SSRRenderModeBoundary(
+            httpContext, typeof(TestComponent), new AutoRenderModeSubclass()));
+        Assert.Contains($"A component of type '{typeof(TestComponent)}' has render mode '{nameof(AutoRenderModeSubclass)}'", ex.Message);
+        Assert.Contains($"add a call to 'AddServerRenderMode'", ex.Message);
+    }
+
+    [Fact]
+    public void ThrowsIfAutoRenderModeUsedAndWebAssemblyNotConfigured()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        PrepareEndpoint(httpContext, new ServerRenderModeSubclass());
+
+        // Act/Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => new SSRRenderModeBoundary(
+            httpContext, typeof(TestComponent), new AutoRenderModeSubclass()));
+        Assert.Contains($"A component of type '{typeof(TestComponent)}' has render mode '{nameof(AutoRenderModeSubclass)}'", ex.Message);
+        Assert.Contains($"add a call to 'AddWebAssemblyRenderMode'", ex.Message);
+    }
+
+    private static void PrepareEndpoint(HttpContext httpContext, params IComponentRenderMode[] configuredModes)
+    {
+        httpContext.SetEndpoint(new Endpoint(null, new EndpointMetadataCollection(
+            new ConfiguredRenderModesMetadata(configuredModes)), null));
+    }
+
+    class TestComponent : IComponent
+    {
+        public void Attach(RenderHandle renderHandle)
+            => throw new NotImplementedException();
+
+        public Task SetParametersAsync(ParameterView parameters)
+            => throw new NotImplementedException();
+    }
+
+    class ServerRenderModeSubclass : ServerRenderMode { }
+    class WebAssemblyRenderModeSubclass : WebAssemblyRenderMode { }
+    class AutoRenderModeSubclass : AutoRenderMode { }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/49312

It's easy to misconfigure render modes. For example, if you're trying to use Server render mode:

 * You might not have any call to `AddServerComponents()` in the DI config
 * Or even if you do, you might not have a call to `AddServerRenderMode` on the endpoint mapping

Since this is such a common mistake (I think all of us on the team have done it by now), we need this to be easy to diagnose and fix.

 * Before this PR, the page would render regardless, and then when client-side code tried to start a circuit/wasm-runtime, it would fail in an obscure way because of the server returning 404 for whatever rendermode-specific endpoint happens to be requested first. This made it really hard to understand what was wrong and how to fix it.
 * After this PR, the server immediately returns a 500 giving a clear message:

![image](https://github.com/dotnet/aspnetcore/assets/1101362/70c94d65-2fdf-44b7-b739-4513452b275d)
