### PR TITLE
SignalR MessageBuffer fixes

### DIFF
--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -17,6 +17,7 @@ and are generated based on the last package release.
     <LatestPackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" />
     <LatestPackageReference Include="Microsoft.Azure.SignalR" />
     <LatestPackageReference Include="Microsoft.Bcl.HashCode" />
+    <LatestPackageReference Include="Microsoft.Bcl.TimeProvider" />
     <LatestPackageReference Include="Microsoft.Css.Parser" />
     <LatestPackageReference Include="Microsoft.CodeAnalysis.Common" />
     <LatestPackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
@@ -63,6 +64,7 @@ and are generated based on the last package release.
     <LatestPackageReference Include="Microsoft.Extensions.Options" />
     <LatestPackageReference Include="Microsoft.Extensions.Primitives" />
     <LatestPackageReference Include="Microsoft.Extensions.Telemetry.Testing" />
+    <LatestPackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <LatestPackageReference Include="Microsoft.Win32.Registry" />
     <LatestPackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" />
     <LatestPackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -397,7 +397,7 @@
       <Uri>https://github.com/dotnet/extensions</Uri>
       <Sha>7c6fa3e84ea0b3d08998726c7cac30e3117ed318</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0-rc.2.23417.1">
+    <Dependency Name="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0-rc.2.23422.1">
       <Uri>https://github.com/dotnet/extensions</Uri>
       <Sha>6f38a71521d48c518445e39dc643a43d8599ce23</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -397,9 +397,9 @@
       <Uri>https://github.com/dotnet/extensions</Uri>
       <Sha>7c6fa3e84ea0b3d08998726c7cac30e3117ed318</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0-rc.2.23427.2">
+    <Dependency Name="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0-rc.2.23461.3">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>03d4f611bc8204d0e2f027f5c9c60a96aec3250b</Sha>
+      <Sha>7c6fa3e84ea0b3d08998726c7cac30e3117ed318</Sha>
     </Dependency>
     <Dependency Name="NuGet.Frameworks" Version="6.2.4">
       <Uri>https://github.com/nuget/nuget.client</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -397,6 +397,10 @@
       <Uri>https://github.com/dotnet/extensions</Uri>
       <Sha>7c6fa3e84ea0b3d08998726c7cac30e3117ed318</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0-rc.2.23417.1">
+      <Uri>https://github.com/dotnet/extensions</Uri>
+      <Sha>6f38a71521d48c518445e39dc643a43d8599ce23</Sha>
+    </Dependency>
     <Dependency Name="NuGet.Frameworks" Version="6.2.4">
       <Uri>https://github.com/nuget/nuget.client</Uri>
       <Sha>8fef55f5a55a3b4f2c96cd1a9b5ddc51d4b927f8</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -397,9 +397,9 @@
       <Uri>https://github.com/dotnet/extensions</Uri>
       <Sha>7c6fa3e84ea0b3d08998726c7cac30e3117ed318</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0-rc.2.23422.1">
+    <Dependency Name="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0-rc.2.23427.2">
       <Uri>https://github.com/dotnet/extensions</Uri>
-      <Sha>6f38a71521d48c518445e39dc643a43d8599ce23</Sha>
+      <Sha>03d4f611bc8204d0e2f027f5c9c60a96aec3250b</Sha>
     </Dependency>
     <Dependency Name="NuGet.Frameworks" Version="6.2.4">
       <Uri>https://github.com/nuget/nuget.client</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -138,6 +138,7 @@
     <SystemRuntimeCachingVersion>8.0.0-rc.2.23457.7</SystemRuntimeCachingVersion>
     <!-- Packages from dotnet/extensions -->
     <MicrosoftExtensionsTelemetryTestingVersion>8.0.0-rc.2.23461.3</MicrosoftExtensionsTelemetryTestingVersion>
+    <MicrosoftExtensionsTimeProviderTestingVersion>8.0.0-rc.2.23422.1</MicrosoftExtensionsTimeProviderTestingVersion>
     <!-- Packages from dotnet/efcore -->
     <dotnetefVersion>8.0.0-rc.2.23462.14</dotnetefVersion>
     <MicrosoftEntityFrameworkCoreInMemoryVersion>8.0.0-rc.2.23462.14</MicrosoftEntityFrameworkCoreInMemoryVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -138,7 +138,7 @@
     <SystemRuntimeCachingVersion>8.0.0-rc.2.23457.7</SystemRuntimeCachingVersion>
     <!-- Packages from dotnet/extensions -->
     <MicrosoftExtensionsTelemetryTestingVersion>8.0.0-rc.2.23461.3</MicrosoftExtensionsTelemetryTestingVersion>
-    <MicrosoftExtensionsTimeProviderTestingVersion>8.0.0-rc.2.23422.1</MicrosoftExtensionsTimeProviderTestingVersion>
+    <MicrosoftExtensionsTimeProviderTestingVersion>8.0.0-rc.2.23427.2</MicrosoftExtensionsTimeProviderTestingVersion>
     <!-- Packages from dotnet/efcore -->
     <dotnetefVersion>8.0.0-rc.2.23462.14</dotnetefVersion>
     <MicrosoftEntityFrameworkCoreInMemoryVersion>8.0.0-rc.2.23462.14</MicrosoftEntityFrameworkCoreInMemoryVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -138,7 +138,7 @@
     <SystemRuntimeCachingVersion>8.0.0-rc.2.23457.7</SystemRuntimeCachingVersion>
     <!-- Packages from dotnet/extensions -->
     <MicrosoftExtensionsTelemetryTestingVersion>8.0.0-rc.2.23461.3</MicrosoftExtensionsTelemetryTestingVersion>
-    <MicrosoftExtensionsTimeProviderTestingVersion>8.0.0-rc.2.23427.2</MicrosoftExtensionsTimeProviderTestingVersion>
+    <MicrosoftExtensionsTimeProviderTestingVersion>8.0.0-rc.2.23461.3</MicrosoftExtensionsTimeProviderTestingVersion>
     <!-- Packages from dotnet/efcore -->
     <dotnetefVersion>8.0.0-rc.2.23462.14</dotnetefVersion>
     <MicrosoftEntityFrameworkCoreInMemoryVersion>8.0.0-rc.2.23462.14</MicrosoftEntityFrameworkCoreInMemoryVersion>

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -1133,7 +1133,7 @@ public partial class HubConnection : IAsyncDisposable
                 break;
             case AckMessage ackMessage:
                 Log.ReceivedAckMessage(_logger, ackMessage.SequenceId);
-                await connectionState.Ack(ackMessage).ConfigureAwait(false);
+                await connectionState.AckAsync(ackMessage).ConfigureAwait(false);
                 break;
             case SequenceMessage sequenceMessage:
                 Log.ReceivedSequenceMessage(_logger, sequenceMessage.SequenceId);
@@ -1943,7 +1943,7 @@ public partial class HubConnection : IAsyncDisposable
             {
                 _messageBuffer = new MessageBuffer(connection, hubConnection._protocol,
                     _hubConnection._serviceProvider.GetService<IOptions<HubConnectionOptions>>()?.Value.StatefulReconnectBufferSize
-                        ?? DefaultStatefulReconnectBufferSize);
+                        ?? DefaultStatefulReconnectBufferSize, _logger);
 
                 feature.OnReconnected(_messageBuffer.ResendAsync);
             }
@@ -2090,7 +2090,7 @@ public partial class HubConnection : IAsyncDisposable
             return true;
         }
 
-        public Task Ack(AckMessage ackMessage)
+        public Task AckAsync(AckMessage ackMessage)
         {
             if (UsingAcks())
             {

--- a/src/SignalR/clients/csharp/Client.Core/src/Microsoft.AspNetCore.SignalR.Client.Core.csproj
+++ b/src/SignalR/clients/csharp/Client.Core/src/Microsoft.AspNetCore.SignalR.Client.Core.csproj
@@ -34,6 +34,10 @@
     <Reference Include="System.Threading.Channels" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' != '$(DefaultNetCoreTargetFramework)'">
+    <Reference Include="Microsoft.Bcl.TimeProvider" />
+  </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Client.FunctionalTests" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.SignalR.Client.Tests" />

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
@@ -616,7 +616,7 @@ internal sealed partial class WebSocketsTransport : ITransport, IStatefulReconne
 
             if (_gracefulClose || !_useStatefulReconnect)
             {
-                _application.Input.Complete(error);
+                _application.Input.Complete();
             }
             else
             {

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -297,7 +297,7 @@ internal sealed partial class HttpConnectionDispatcher
                     // We'll mark the connection as inactive and allow the connection to reconnect if that's the case.
                     if (await connection.TransportTask!
                         // If acks aren't enabled we can close the connection immediately (not LongPolling)
-                        || (!connection.UseStatefulReconnect && connection.TransportType != HttpTransportType.LongPolling))
+                        || !connection.ClientReconnectExpected())
                     {
                         await _manager.DisposeAndRemoveAsync(connection, closeGracefully: true, HttpConnectionStopStatus.NormalClosure);
                     }

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -295,8 +295,9 @@ internal sealed partial class HttpConnectionDispatcher
                 {
                     // If false then the transport was ungracefully closed, this can mean a temporary network disconnection
                     // We'll mark the connection as inactive and allow the connection to reconnect if that's the case.
-                    // TODO: If acks aren't enabled we can close the connection immediately (not LongPolling)
-                    if (await connection.TransportTask!)
+                    if (await connection.TransportTask!
+                        // If acks aren't enabled we can close the connection immediately (not LongPolling)
+                        || (!connection.UseStatefulReconnect && connection.TransportType != HttpTransportType.LongPolling))
                     {
                         await _manager.DisposeAndRemoveAsync(connection, closeGracefully: true, HttpConnectionStopStatus.NormalClosure);
                     }

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs
@@ -288,7 +288,7 @@ internal sealed partial class WebSocketsServerTransport : IHttpTransport
 
             if (_gracefulClose)
             {
-                _application.Input.Complete(error);
+                _application.Input.Complete();
             }
             else if (error is not null)
             {

--- a/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/Transports/WebSocketsServerTransport.cs
@@ -290,7 +290,8 @@ internal sealed partial class WebSocketsServerTransport : IHttpTransport
             {
                 _application.Input.Complete();
             }
-            else if (error is not null)
+
+            if (error is not null)
             {
                 Log.SendErrored(_logger, error);
             }

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -590,7 +590,7 @@ public partial class HubConnectionContext
                                     else
                                     {
                                         _useStatefulReconnect = true;
-                                        _messageBuffer = new MessageBuffer(_connectionContext, Protocol, _statefulReconnectBufferSize, _timeProvider);
+                                        _messageBuffer = new MessageBuffer(_connectionContext, Protocol, _statefulReconnectBufferSize, _logger, _timeProvider);
                                         feature.OnReconnected(_messageBuffer.ResendAsync);
                                     }
                                 }
@@ -784,7 +784,7 @@ public partial class HubConnectionContext
         _streamTracker?.CompleteAll(new OperationCanceledException("The underlying connection was closed."));
     }
 
-    internal Task Ack(AckMessage ackMessage)
+    internal Task AckAsync(AckMessage ackMessage)
     {
         if (UsingStatefulReconnect())
         {

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -266,7 +266,7 @@ public partial class HubConnectionContext
         {
             if (UsingStatefulReconnect())
             {
-                return _messageBuffer.WriteAsync(new SerializedHubMessage(message), cancellationToken);
+                return _messageBuffer.WriteAsync(message, cancellationToken);
             }
             else
             {
@@ -590,7 +590,7 @@ public partial class HubConnectionContext
                                     else
                                     {
                                         _useStatefulReconnect = true;
-                                        _messageBuffer = new MessageBuffer(_connectionContext, Protocol, _statefulReconnectBufferSize);
+                                        _messageBuffer = new MessageBuffer(_connectionContext, Protocol, _statefulReconnectBufferSize, _timeProvider);
                                         feature.OnReconnected(_messageBuffer.ResendAsync);
                                     }
                                 }
@@ -784,12 +784,14 @@ public partial class HubConnectionContext
         _streamTracker?.CompleteAll(new OperationCanceledException("The underlying connection was closed."));
     }
 
-    internal void Ack(AckMessage ackMessage)
+    internal Task Ack(AckMessage ackMessage)
     {
         if (UsingStatefulReconnect())
         {
-            _messageBuffer.Ack(ackMessage);
+            return _messageBuffer.AckAsync(ackMessage);
         }
+
+        return Task.CompletedTask;
     }
 
     internal bool ShouldProcessMessage(HubMessage message)

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -194,7 +194,7 @@ internal sealed partial class DefaultHubDispatcher<THub> : HubDispatcher<THub> w
 
             case AckMessage ackMessage:
                 Log.ReceivedAckMessage(_logger, ackMessage.SequenceId);
-                return connection.Ack(ackMessage);
+                return connection.AckAsync(ackMessage);
 
             case SequenceMessage sequenceMessage:
                 Log.ReceivedSequenceMessage(_logger, sequenceMessage.SequenceId);

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -195,7 +195,6 @@ internal sealed partial class DefaultHubDispatcher<THub> : HubDispatcher<THub> w
             case AckMessage ackMessage:
                 Log.ReceivedAckMessage(_logger, ackMessage.SequenceId);
                 return connection.Ack(ackMessage);
-                break;
 
             case SequenceMessage sequenceMessage:
                 Log.ReceivedSequenceMessage(_logger, sequenceMessage.SequenceId);

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -194,7 +194,7 @@ internal sealed partial class DefaultHubDispatcher<THub> : HubDispatcher<THub> w
 
             case AckMessage ackMessage:
                 Log.ReceivedAckMessage(_logger, ackMessage.SequenceId);
-                connection.Ack(ackMessage);
+                return connection.Ack(ackMessage);
                 break;
 
             case SequenceMessage sequenceMessage:

--- a/src/SignalR/server/SignalR/test/Internal/MessageBufferTests.cs
+++ b/src/SignalR/server/SignalR/test/Internal/MessageBufferTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 
 namespace Microsoft.AspNetCore.SignalR.Tests.Internal;
@@ -20,7 +21,7 @@ public class MessageBufferTests
         var connection = new TestConnectionContext();
         var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions());
         connection.Transport = pipes.Transport;
-        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 1);
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 1, NullLogger.Instance);
 
         for (var i = 0; i < 100; i++)
         {
@@ -48,7 +49,7 @@ public class MessageBufferTests
         var connection = new TestConnectionContext();
         var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions(pauseWriterThreshold: 200000, resumeWriterThreshold: 100000));
         connection.Transport = pipes.Transport;
-        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000);
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000, NullLogger.Instance);
 
         await messageBuffer.WriteAsync(new SerializedHubMessage(new InvocationMessage("t", new object[] { new byte[100000] })), default);
 
@@ -86,7 +87,7 @@ public class MessageBufferTests
         var pipeOptions = new PipeOptions(pauseWriterThreshold: 100, resumeWriterThreshold: 50);
         var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), pipeOptions);
         connection.Transport = pipes.Transport;
-        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_00);
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000, NullLogger.Instance);
 
         await messageBuffer.WriteAsync(new SerializedHubMessage(new InvocationMessage("t", new object[] { new byte[40] })), default);
 
@@ -126,7 +127,7 @@ public class MessageBufferTests
         var connection = new TestConnectionContext();
         var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions());
         connection.Transport = pipes.Transport;
-        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 1000);
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 1000, NullLogger.Instance);
 
         await messageBuffer.WriteAsync(new StreamItemMessage("id", null), default);
 
@@ -176,7 +177,7 @@ public class MessageBufferTests
         var connection = new TestConnectionContext();
         var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions());
         connection.Transport = pipes.Transport;
-        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 1000);
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 1000, NullLogger.Instance);
 
         await messageBuffer.WriteAsync(new StreamItemMessage("id", null), default);
 
@@ -220,7 +221,7 @@ public class MessageBufferTests
         var connection = new TestConnectionContext();
         var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions());
         connection.Transport = pipes.Transport;
-        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 1000);
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 1000, NullLogger.Instance);
 
         DuplexPipe.UpdateConnectionPair(ref pipes, connection);
         await messageBuffer.ResendAsync(pipes.Transport.Output);
@@ -244,7 +245,7 @@ public class MessageBufferTests
         var connection = new TestConnectionContext();
         var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions());
         connection.Transport = pipes.Transport;
-        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000);
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000, NullLogger.Instance);
 
         for (var i = 0; i < 1000; i++)
         {
@@ -287,7 +288,7 @@ public class MessageBufferTests
         var connection = new TestConnectionContext();
         var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions());
         connection.Transport = pipes.Transport;
-        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 1);
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 1, NullLogger.Instance);
 
         await messageBuffer.WriteAsync(new SerializedHubMessage(new InvocationMessage("t", new object[] { 1 })), default);
 
@@ -324,7 +325,7 @@ public class MessageBufferTests
         var connection = new TestConnectionContext();
         var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions());
         connection.Transport = pipes.Transport;
-        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000);
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000, NullLogger.Instance);
 
         await messageBuffer.WriteAsync(new StreamItemMessage("1", null), default);
 
@@ -367,7 +368,7 @@ public class MessageBufferTests
         var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions());
         connection.Transport = pipes.Transport;
         var timeProvider = new FakeTimeProvider();
-        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000, timeProvider);
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000, NullLogger.Instance, timeProvider);
 
         // Simulate receiving messages
         Assert.True(messageBuffer.ShouldProcessMessage(new StreamItemMessage("1", null)));
@@ -404,7 +405,7 @@ public class MessageBufferTests
         var pipeOptions = new PipeOptions(pauseWriterThreshold: 250, resumeWriterThreshold: 120);
         var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), pipeOptions);
         connection.Transport = pipes.Transport;
-        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000);
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000, NullLogger.Instance);
 
         await messageBuffer.WriteAsync(new SerializedHubMessage(new InvocationMessage("t", new object[] { new byte[10] })), default);
         await messageBuffer.WriteAsync(new SerializedHubMessage(new InvocationMessage("t", new object[] { new byte[100] })), default).DefaultTimeout();
@@ -447,7 +448,7 @@ public class MessageBufferTests
         var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), pipeOptions);
         connection.Transport = pipes.Transport;
         var timeProvider = new FakeTimeProvider();
-        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000, timeProvider);
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000, NullLogger.Instance, timeProvider);
 
         await messageBuffer.WriteAsync(new SerializedHubMessage(new InvocationMessage("t", new object[] { new byte[10] })), default);
         var writeTask = messageBuffer.WriteAsync(new SerializedHubMessage(new InvocationMessage("t", new object[] { new byte[100] })), default).DefaultTimeout();

--- a/src/SignalR/server/SignalR/test/Internal/MessageBufferTests.cs
+++ b/src/SignalR/server/SignalR/test/Internal/MessageBufferTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.SignalR.Internal;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Microsoft.AspNetCore.SignalR.Tests.Internal;
 
@@ -23,7 +24,7 @@ public class MessageBufferTests
 
         for (var i = 0; i < 100; i++)
         {
-            await messageBuffer.WriteAsync(new SerializedHubMessage(PingMessage.Instance), default).DefaultTimeout();
+            await messageBuffer.WriteAsync(PingMessage.Instance, default).DefaultTimeout();
         }
 
         var count = 0;
@@ -41,7 +42,7 @@ public class MessageBufferTests
     }
 
     [Fact]
-    public async Task WriteBlocksOnAckWhenBufferFull()
+    public async Task WriteBlocksOnAckWhenMessageBufferFull()
     {
         var protocol = new JsonHubProtocol();
         var connection = new TestConnectionContext();
@@ -65,7 +66,7 @@ public class MessageBufferTests
         // Write not unblocked by read, only unblocked after ack received
         Assert.False(writeTask.IsCompleted);
 
-        messageBuffer.Ack(new AckMessage(1));
+        await messageBuffer.AckAsync(new AckMessage(1));
         await writeTask.DefaultTimeout();
 
         res = await pipes.Application.Input.ReadAsync().DefaultTimeout();
@@ -78,6 +79,47 @@ public class MessageBufferTests
     }
 
     [Fact]
+    public async Task BackpressureWriteMessageSurvivesReconnect()
+    {
+        var protocol = new JsonHubProtocol();
+        var connection = new TestConnectionContext();
+        var pipeOptions = new PipeOptions(pauseWriterThreshold: 100, resumeWriterThreshold: 50);
+        var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), pipeOptions);
+        connection.Transport = pipes.Transport;
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_00);
+
+        await messageBuffer.WriteAsync(new SerializedHubMessage(new InvocationMessage("t", new object[] { new byte[40] })), default);
+
+        // Write will hit pipe backpressure
+        var writeTask = messageBuffer.WriteAsync(new SerializedHubMessage(new InvocationMessage("t", new object[] { new byte[40] })), default);
+        Assert.False(writeTask.IsCompleted);
+
+        DuplexPipe.UpdateConnectionPair(ref pipes, connection, pipeOptions);
+        var resendTask = messageBuffer.ResendAsync(pipes.Transport.Output);
+
+        var res = await pipes.Application.Input.ReadAsync();
+        var buffer = res.Buffer;
+        Assert.True(protocol.TryParseMessage(ref buffer, new TestBinder(), out var message));
+        Assert.IsType<SequenceMessage>(message);
+
+        pipes.Application.Input.AdvanceTo(buffer.Start);
+
+        for (var i = 0; i < 2; i++)
+        {
+            res = await pipes.Application.Input.ReadAsync();
+            buffer = res.Buffer;
+            Assert.True(protocol.TryParseMessage(ref buffer, new TestBinder(), out message));
+            Assert.IsType<InvocationMessage>(message);
+
+            pipes.Application.Input.AdvanceTo(buffer.Start);
+        }
+
+        Assert.False(pipes.Application.Input.TryRead(out res));
+
+        await resendTask;
+    }
+
+    [Fact]
     public async Task UnAckedMessageResentOnReconnect()
     {
         var protocol = new JsonHubProtocol();
@@ -86,7 +128,7 @@ public class MessageBufferTests
         connection.Transport = pipes.Transport;
         using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 1000);
 
-        await messageBuffer.WriteAsync(new SerializedHubMessage(new StreamItemMessage("id", null)), default);
+        await messageBuffer.WriteAsync(new StreamItemMessage("id", null), default);
 
         var res = await pipes.Application.Input.ReadAsync();
 
@@ -136,7 +178,7 @@ public class MessageBufferTests
         connection.Transport = pipes.Transport;
         using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 1000);
 
-        await messageBuffer.WriteAsync(new SerializedHubMessage(new StreamItemMessage("id", null)), default);
+        await messageBuffer.WriteAsync(new StreamItemMessage("id", null), default);
 
         var res = await pipes.Application.Input.ReadAsync();
 
@@ -146,7 +188,7 @@ public class MessageBufferTests
 
         pipes.Application.Input.AdvanceTo(buffer.Start);
 
-        messageBuffer.Ack(new AckMessage(1));
+        await messageBuffer.AckAsync(new AckMessage(1));
 
         DuplexPipe.UpdateConnectionPair(ref pipes, connection);
         await messageBuffer.ResendAsync(pipes.Transport.Output);
@@ -160,7 +202,7 @@ public class MessageBufferTests
 
         pipes.Application.Input.AdvanceTo(buffer.Start);
 
-        await messageBuffer.WriteAsync(new SerializedHubMessage(CompletionMessage.WithResult("1", null)), default);
+        await messageBuffer.WriteAsync(CompletionMessage.WithResult("1", null), default);
 
         res = await pipes.Application.Input.ReadAsync();
 
@@ -206,11 +248,11 @@ public class MessageBufferTests
 
         for (var i = 0; i < 1000; i++)
         {
-            await messageBuffer.WriteAsync(new SerializedHubMessage(new StreamItemMessage("1", null)), default).DefaultTimeout();
+            await messageBuffer.WriteAsync(new StreamItemMessage("1", null), default).DefaultTimeout();
         }
 
         var ackNum = Random.Shared.Next(0, 1000);
-        messageBuffer.Ack(new AckMessage(ackNum));
+        await messageBuffer.AckAsync(new AckMessage(ackNum));
 
         DuplexPipe.UpdateConnectionPair(ref pipes, connection);
         await messageBuffer.ResendAsync(pipes.Transport.Output);
@@ -234,6 +276,8 @@ public class MessageBufferTests
 
             pipes.Application.Input.AdvanceTo(buffer.Start);
         }
+
+        Assert.False(pipes.Application.Input.TryRead(out res));
     }
 
     [Fact]
@@ -261,7 +305,7 @@ public class MessageBufferTests
         // Write not unblocked by read, only unblocked after ack received
         Assert.False(writeTask.IsCompleted);
 
-        messageBuffer.Ack(new AckMessage(1));
+        await messageBuffer.AckAsync(new AckMessage(1));
         await writeTask.DefaultTimeout();
 
         res = await pipes.Application.Input.ReadAsync().DefaultTimeout();
@@ -271,6 +315,183 @@ public class MessageBufferTests
         Assert.IsType<StreamItemMessage>(message);
 
         pipes.Application.Input.AdvanceTo(buffer.Start);
+    }
+
+    [Fact]
+    public async Task CanSendMessagesWhilePipeClosed()
+    {
+        var protocol = new JsonHubProtocol();
+        var connection = new TestConnectionContext();
+        var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions());
+        connection.Transport = pipes.Transport;
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000);
+
+        await messageBuffer.WriteAsync(new StreamItemMessage("1", null), default);
+
+        // simulate connection closing
+        pipes.Application.Input.Complete();
+
+        // send while connection down
+        await messageBuffer.WriteAsync(new StreamItemMessage("1", null), default);
+        await messageBuffer.WriteAsync(new StreamItemMessage("1", null), default);
+
+        // simulate reconnect
+        DuplexPipe.UpdateConnectionPair(ref pipes, connection);
+        await messageBuffer.ResendAsync(pipes.Transport.Output);
+
+        var res = await pipes.Application.Input.ReadAsync();
+        var buffer = res.Buffer;
+        Assert.True(protocol.TryParseMessage(ref buffer, new TestBinder(), out var message));
+        Assert.IsType<SequenceMessage>(message);
+
+        pipes.Application.Input.AdvanceTo(buffer.Start);
+
+        for (var i = 0; i < 3; i++)
+        {
+            res = await pipes.Application.Input.ReadAsync();
+            buffer = res.Buffer;
+            Assert.True(protocol.TryParseMessage(ref buffer, new TestBinder(), out message));
+            Assert.IsType<StreamItemMessage>(message);
+
+            pipes.Application.Input.AdvanceTo(buffer.Start);
+        }
+
+        Assert.False(pipes.Application.Input.TryRead(out res));
+    }
+
+    [Fact]
+    public async Task AckMessagesSentAutomatically()
+    {
+        var protocol = new JsonHubProtocol();
+        var connection = new TestConnectionContext();
+        var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions());
+        connection.Transport = pipes.Transport;
+        var timeProvider = new FakeTimeProvider();
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000, timeProvider);
+
+        // Simulate receiving messages
+        Assert.True(messageBuffer.ShouldProcessMessage(new StreamItemMessage("1", null)));
+        Assert.True(messageBuffer.ShouldProcessMessage(new StreamItemMessage("1", null)));
+
+        timeProvider.Advance(MessageBuffer.AckRate);
+
+        var res = await pipes.Application.Input.ReadAsync();
+        var buffer = res.Buffer;
+        Assert.True(protocol.TryParseMessage(ref buffer, new TestBinder(), out var message));
+        var ackMessage = Assert.IsType<AckMessage>(message);
+        pipes.Application.Input.AdvanceTo(buffer.Start);
+
+        Assert.Equal(2, ackMessage.SequenceId);
+
+        Assert.True(messageBuffer.ShouldProcessMessage(new StreamItemMessage("1", null)));
+
+        timeProvider.Advance(MessageBuffer.AckRate);
+
+        res = await pipes.Application.Input.ReadAsync();
+        buffer = res.Buffer;
+        Assert.True(protocol.TryParseMessage(ref buffer, new TestBinder(), out message));
+        ackMessage = Assert.IsType<AckMessage>(message);
+        pipes.Application.Input.AdvanceTo(buffer.Start);
+
+        Assert.Equal(3, ackMessage.SequenceId);
+    }
+
+    [Fact]
+    public async Task ReceiveAckDuringResendStillSendsAllMessages()
+    {
+        var protocol = new JsonHubProtocol();
+        var connection = new TestConnectionContext();
+        var pipeOptions = new PipeOptions(pauseWriterThreshold: 250, resumeWriterThreshold: 120);
+        var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), pipeOptions);
+        connection.Transport = pipes.Transport;
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000);
+
+        await messageBuffer.WriteAsync(new SerializedHubMessage(new InvocationMessage("t", new object[] { new byte[10] })), default);
+        await messageBuffer.WriteAsync(new SerializedHubMessage(new InvocationMessage("t", new object[] { new byte[100] })), default).DefaultTimeout();
+        var writeTask = messageBuffer.WriteAsync(new SerializedHubMessage(new InvocationMessage("t", new object[] { new byte[100] })), default);
+
+        // simulate reconnect
+        // Smaller PipeOptions on reconnect to force the Resend loop to pause on sending the 2nd message
+        DuplexPipe.UpdateConnectionPair(ref pipes, connection, new PipeOptions(pauseWriterThreshold: 100, resumeWriterThreshold: 50));
+        var resendTask = messageBuffer.ResendAsync(pipes.Transport.Output);
+
+        Assert.True(messageBuffer.ShouldProcessMessage(new SequenceMessage(1)));
+        // Ack all 3 messages while the Resend loop is running, Resend should continue sending all messages
+        var ackTask = messageBuffer.AckAsync(new AckMessage(3));
+
+        var res = await pipes.Application.Input.ReadAsync();
+        var buffer = res.Buffer;
+        Assert.True(protocol.TryParseMessage(ref buffer, new TestBinder(), out var message));
+        Assert.IsType<SequenceMessage>(message);
+        pipes.Application.Input.AdvanceTo(buffer.Start);
+
+        for (var i = 0; i < 3; i++)
+        {
+            res = await pipes.Application.Input.ReadAsync();
+            buffer = res.Buffer;
+            Assert.True(protocol.TryParseMessage(ref buffer, new TestBinder(), out message));
+            Assert.IsType<InvocationMessage>(message);
+            pipes.Application.Input.AdvanceTo(buffer.Start);
+        }
+
+        await resendTask;
+        await ackTask;
+    }
+
+    [Fact]
+    public async Task SendingAckMessageDelayedDuringResend()
+    {
+        var protocol = new JsonHubProtocol();
+        var connection = new TestConnectionContext();
+        var pipeOptions = new PipeOptions(pauseWriterThreshold: 100, resumeWriterThreshold: 50);
+        var pipes = DuplexPipe.CreateConnectionPair(new PipeOptions(), pipeOptions);
+        connection.Transport = pipes.Transport;
+        var timeProvider = new FakeTimeProvider();
+        using var messageBuffer = new MessageBuffer(connection, protocol, bufferLimit: 100_000, timeProvider);
+
+        await messageBuffer.WriteAsync(new SerializedHubMessage(new InvocationMessage("t", new object[] { new byte[10] })), default);
+        var writeTask = messageBuffer.WriteAsync(new SerializedHubMessage(new InvocationMessage("t", new object[] { new byte[100] })), default).DefaultTimeout();
+
+        // simulate reconnect
+        DuplexPipe.UpdateConnectionPair(ref pipes, connection, pipeOptions);
+        var resendTask = messageBuffer.ResendAsync(pipes.Transport.Output);
+
+        // Simulate receiving messages
+        Assert.True(messageBuffer.ShouldProcessMessage(new SequenceMessage(1)));
+        Assert.True(messageBuffer.ShouldProcessMessage(new StreamItemMessage("1", null)));
+        Assert.True(messageBuffer.ShouldProcessMessage(new StreamItemMessage("1", null)));
+
+        Assert.False(resendTask.IsCompleted);
+
+        // Trigger sending an AckMessage while Resend is running
+        timeProvider.Advance(MessageBuffer.AckRate);
+
+        var res = await pipes.Application.Input.ReadAsync();
+        var buffer = res.Buffer;
+        Assert.True(protocol.TryParseMessage(ref buffer, new TestBinder(), out var message));
+        Assert.IsType<SequenceMessage>(message);
+        pipes.Application.Input.AdvanceTo(buffer.Start);
+
+        timeProvider.Advance(MessageBuffer.AckRate);
+
+        for (var i = 0; i < 2; i++)
+        {
+            res = await pipes.Application.Input.ReadAsync();
+            buffer = res.Buffer;
+            Assert.True(protocol.TryParseMessage(ref buffer, new TestBinder(), out message));
+            Assert.IsType<InvocationMessage>(message);
+            pipes.Application.Input.AdvanceTo(buffer.Start);
+        }
+
+        await resendTask;
+
+        res = await pipes.Application.Input.ReadAsync();
+        buffer = res.Buffer;
+        Assert.True(protocol.TryParseMessage(ref buffer, new TestBinder(), out message));
+        Assert.IsType<AckMessage>(message);
+        pipes.Application.Input.AdvanceTo(buffer.Start);
+
+        Assert.False(pipes.Application.Input.TryRead(out res));
     }
 }
 
@@ -318,9 +539,9 @@ internal sealed class DuplexPipe : IDuplexPipe
         }
     }
 
-    public static void UpdateConnectionPair(ref DuplexPipePair duplexPipePair, ConnectionContext connection)
+    public static void UpdateConnectionPair(ref DuplexPipePair duplexPipePair, ConnectionContext connection, PipeOptions pipeOptions = null)
     {
-        var input = new Pipe();
+        var input = new Pipe(pipeOptions ?? new PipeOptions());
 
         // Add new pipe for reading from and writing to transport from app code
         var transportToApplication = new DuplexPipe(duplexPipePair.Transport.Input, input.Writer);

--- a/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests.csproj
+++ b/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests.csproj
@@ -25,6 +25,7 @@
     <Reference Include="Microsoft.Extensions.Logging.Console" />
     <Reference Include="Microsoft.Extensions.Logging.Debug" />
     <Reference Include="Microsoft.Extensions.Logging" />
+    <Reference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <Reference Include="System.Reactive.Linq" />
   </ItemGroup>
 


### PR DESCRIPTION
* Fix backpressure on the Pipe during Write blocking the Resend loop if a reconnect occurs
* Fix Ack being received while Resend loop is running which could cause messages to not be resent
* Added `TimeProvider` and tests that use it for quick and deterministic timer testing
* Added `HubMessage` overload so all Write callsites don't need to allocate `SerializedHubMessage`
* Added per connection `LinkedBuffer` pool

### Customer Impact

Fixing a couple issues that would make the new Stateful Reconnect feature not reliable.
The two main ones:
* backpressure on the server-side writes would could block and not unblock until a timeout occurs, which would cause the connection to close. 
* During reconnect, if an ack was received the server could end up not sending some buffered messages which could result in missed messages and the server and client having mismatched message IDs.

Additional customer impact are a couple performance improvements in the new feature so we allocate less.

### Risk

Low. Changes are all in the new feature code and are well understood problems. Hit them while adding more extensive testing using the `FakeTimeProvider` from dotnet/extensions.