### PR TITLE
Fix error message in CodeCheck file

### DIFF
--- a/eng/scripts/CodeCheck.ps1
+++ b/eng/scripts/CodeCheck.ps1
@@ -264,7 +264,7 @@ try {
         if ($changedAPIBaselines.count -gt 0) {
             LogError ("Detected modification to baseline API files. PublicAPI.Shipped.txt files should only " +
                 "be updated after a major release, and PublicAPI.Unshipped.txt files should not " +
-                "be updated in release branches. If this is an rc branch and you've updated a PublicAPI.Unshipped.txt " +
+                "be updated in release branches. If this is a preview or rc branch and you've updated a PublicAPI.Unshipped.txt " +
                 "file, contact a repo admin to help you force-merge this PR. See /docs/APIBaselines.md for more information.")
             LogError "Modified API baseline files:"
             foreach ($file in $changedAPIBaselines) {

--- a/eng/scripts/CodeCheck.ps1
+++ b/eng/scripts/CodeCheck.ps1
@@ -263,7 +263,9 @@ try {
 
         if ($changedAPIBaselines.count -gt 0) {
             LogError ("Detected modification to baseline API files. PublicAPI.Shipped.txt files should only " +
-                "be updated after a major release. See /docs/APIBaselines.md for more information.")
+                "be updated after a major release, and PublicAPI.Unshipped.txt files should not " +
+                "be updated in release branches. If this is an rc branch and you've updated a PublicAPI.Unshipped.txt " +
+                "file, contact a repo admin to help you force-merge this PR. See /docs/APIBaselines.md for more information.")
             LogError "Modified API baseline files:"
             foreach ($file in $changedAPIBaselines) {
                 LogError $file

--- a/eng/scripts/CodeCheck.ps1
+++ b/eng/scripts/CodeCheck.ps1
@@ -253,7 +253,7 @@ try {
                     }
                 }
                 # Check for changes in Unshipped in servicing branches
-                if ($targetBranch -like 'release*' -and $targetBranch -notlike '*preview*' -and $file -like '*PublicAPI.Unshipped.txt') {
+                if ($targetBranch -like 'release*' -and $targetBranch -notlike '*preview*' -and $targetBranch -notlike '*rc1*' -and $targetBranch -notlike '*rc2*' -and $file -like '*PublicAPI.Unshipped.txt') {
                     $changedAPIBaselines.Add($file)
                 }
             }
@@ -264,8 +264,7 @@ try {
         if ($changedAPIBaselines.count -gt 0) {
             LogError ("Detected modification to baseline API files. PublicAPI.Shipped.txt files should only " +
                 "be updated after a major release, and PublicAPI.Unshipped.txt files should not " +
-                "be updated in release branches. If this is a preview or rc branch and you've updated a PublicAPI.Unshipped.txt " +
-                "file, contact a repo admin to help you force-merge this PR. See /docs/APIBaselines.md for more information.")
+                "be updated in release branches. See /docs/APIBaselines.md for more information.")
             LogError "Modified API baseline files:"
             foreach ($file in $changedAPIBaselines) {
                 LogError $file


### PR DESCRIPTION
This has been causing confusion lately. This PR improves the (previously incomplete) error message in the CodeCheck.ps1 script for PublicApi file changes.