### PR TITLE
Rename internal UseAck to UseStatefulReconnect

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/UnitTests/TestTransportFactory.cs
+++ b/src/SignalR/clients/csharp/Client/test/UnitTests/TestTransportFactory.cs
@@ -15,7 +15,7 @@ internal class TestTransportFactory : ITransportFactory
         _transport = transport;
     }
 
-    public ITransport CreateTransport(HttpTransportType availableServerTransports, bool useAck)
+    public ITransport CreateTransport(HttpTransportType availableServerTransports, bool useStatefulReconnect)
     {
         return _transport;
     }

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -313,7 +313,7 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
             if (_httpConnectionOptions.Transports == HttpTransportType.WebSockets)
             {
                 Log.StartingTransport(_logger, _httpConnectionOptions.Transports, uri);
-                await StartTransport(uri, _httpConnectionOptions.Transports, transferFormat, cancellationToken, useAck: false).ConfigureAwait(false);
+                await StartTransport(uri, _httpConnectionOptions.Transports, transferFormat, cancellationToken, useStatefulReconnect: false).ConfigureAwait(false);
             }
             else
             {
@@ -459,7 +459,7 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
 
             if (_httpConnectionOptions.UseStatefulReconnect)
             {
-                uri = Utils.AppendQueryString(uri, "useAck=true");
+                uri = Utils.AppendQueryString(uri, "useStatefulReconnect=true");
             }
 
             using (var request = new HttpRequestMessage(HttpMethod.Post, uri))
@@ -507,10 +507,11 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
         return Utils.AppendQueryString(url, $"id={connectionId}");
     }
 
-    private async Task StartTransport(Uri connectUrl, HttpTransportType transportType, TransferFormat transferFormat, CancellationToken cancellationToken, bool useAck)
+    private async Task StartTransport(Uri connectUrl, HttpTransportType transportType, TransferFormat transferFormat,
+        CancellationToken cancellationToken, bool useStatefulReconnect)
     {
         // Construct the transport
-        var transport = _transportFactory.CreateTransport(transportType, useAck);
+        var transport = _transportFactory.CreateTransport(transportType, useStatefulReconnect);
 
         // Start the transport, giving it one end of the pipe
         try
@@ -531,7 +532,7 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
         // We successfully started, set the transport properties (we don't want to set these until the transport is definitely running).
         _transport = transport;
 
-        if (useAck && _transport is IStatefulReconnectFeature reconnectFeature)
+        if (useStatefulReconnect && _transport is IStatefulReconnectFeature reconnectFeature)
         {
 #pragma warning disable CA2252 // This API requires opting into preview features
             Features.Set(reconnectFeature);

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/DefaultTransportFactory.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/DefaultTransportFactory.cs
@@ -31,13 +31,13 @@ internal sealed partial class DefaultTransportFactory : ITransportFactory
         _accessTokenProvider = accessTokenProvider;
     }
 
-    public ITransport CreateTransport(HttpTransportType availableServerTransports, bool useAck)
+    public ITransport CreateTransport(HttpTransportType availableServerTransports, bool useStatefulReconnect)
     {
         if (_websocketsSupported && (availableServerTransports & HttpTransportType.WebSockets & _requestedTransportType) == HttpTransportType.WebSockets)
         {
             try
             {
-                return new WebSocketsTransport(_httpConnectionOptions, _loggerFactory, _accessTokenProvider, _httpClient, useAck);
+                return new WebSocketsTransport(_httpConnectionOptions, _loggerFactory, _accessTokenProvider, _httpClient, useStatefulReconnect);
             }
             catch (PlatformNotSupportedException ex)
             {
@@ -49,13 +49,13 @@ internal sealed partial class DefaultTransportFactory : ITransportFactory
         if ((availableServerTransports & HttpTransportType.ServerSentEvents & _requestedTransportType) == HttpTransportType.ServerSentEvents)
         {
             // We don't need to give the transport the accessTokenProvider because the HttpClient has a message handler that does the work for us.
-            return new ServerSentEventsTransport(_httpClient!, _httpConnectionOptions, _loggerFactory, useAck);
+            return new ServerSentEventsTransport(_httpClient!, _httpConnectionOptions, _loggerFactory);
         }
 
         if ((availableServerTransports & HttpTransportType.LongPolling & _requestedTransportType) == HttpTransportType.LongPolling)
         {
             // We don't need to give the transport the accessTokenProvider because the HttpClient has a message handler that does the work for us.
-            return new LongPollingTransport(_httpClient!, _httpConnectionOptions, _loggerFactory, useAck);
+            return new LongPollingTransport(_httpClient!, _httpConnectionOptions, _loggerFactory);
         }
 
         throw new InvalidOperationException("No requested transports available on the server.");

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/ITransportFactory.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/ITransportFactory.cs
@@ -5,5 +5,5 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal;
 
 internal interface ITransportFactory
 {
-    ITransport CreateTransport(HttpTransportType availableServerTransports, bool useAck);
+    ITransport CreateTransport(HttpTransportType availableServerTransports, bool useStatefulReconnect);
 }

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/LongPollingTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/LongPollingTransport.cs
@@ -19,7 +19,6 @@ internal sealed partial class LongPollingTransport : ITransport
     private readonly HttpClient _httpClient;
     private readonly ILogger _logger;
     private readonly HttpConnectionOptions _httpConnectionOptions;
-    private readonly bool _useAck;
     private IDuplexPipe? _application;
     private IDuplexPipe? _transport;
     // Volatile so that the poll loop sees the updated value set from a different thread
@@ -33,12 +32,11 @@ internal sealed partial class LongPollingTransport : ITransport
 
     public PipeWriter Output => _transport!.Output;
 
-    public LongPollingTransport(HttpClient httpClient, HttpConnectionOptions? httpConnectionOptions = null, ILoggerFactory? loggerFactory = null, bool useAck = false)
+    public LongPollingTransport(HttpClient httpClient, HttpConnectionOptions? httpConnectionOptions = null, ILoggerFactory? loggerFactory = null)
     {
         _httpClient = httpClient;
         _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<LongPollingTransport>();
         _httpConnectionOptions = httpConnectionOptions ?? new();
-        _useAck = useAck;
     }
 
     public async Task StartAsync(Uri url, TransferFormat transferFormat, CancellationToken cancellationToken = default)

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/ServerSentEventsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/ServerSentEventsTransport.cs
@@ -26,7 +26,6 @@ internal sealed partial class ServerSentEventsTransport : ITransport
     private readonly CancellationTokenSource _transportCts = new CancellationTokenSource();
     private readonly CancellationTokenSource _inputCts = new CancellationTokenSource();
     private readonly ServerSentEventsMessageParser _parser = new ServerSentEventsMessageParser();
-    private readonly bool _useAck;
     private IDuplexPipe? _transport;
     private IDuplexPipe? _application;
 
@@ -36,11 +35,10 @@ internal sealed partial class ServerSentEventsTransport : ITransport
 
     public PipeWriter Output => _transport!.Output;
 
-    public ServerSentEventsTransport(HttpClient httpClient, HttpConnectionOptions? httpConnectionOptions = null, ILoggerFactory? loggerFactory = null, bool useAck = false)
+    public ServerSentEventsTransport(HttpClient httpClient, HttpConnectionOptions? httpConnectionOptions = null, ILoggerFactory? loggerFactory = null)
     {
         ArgumentNullThrowHelper.ThrowIfNull(httpClient);
 
-        _useAck = useAck;
         _httpClient = httpClient;
         _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<ServerSentEventsTransport>();
         _httpConnectionOptions = httpConnectionOptions ?? new();

--- a/src/SignalR/clients/ts/signalr/src/HttpConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HttpConnection.ts
@@ -31,7 +31,7 @@ export interface INegotiateResponse {
     url?: string;
     accessToken?: string;
     error?: string;
-    useAck?: boolean;
+    useStatefulReconnect?: boolean;
 }
 
 /** @private */
@@ -333,7 +333,7 @@ export class HttpConnection implements IConnection {
                 negotiateResponse.connectionToken = negotiateResponse.connectionId;
             }
 
-            if (negotiateResponse.useAck && this._options._useStatefulReconnect !== true) {
+            if (negotiateResponse.useStatefulReconnect && this._options._useStatefulReconnect !== true) {
                 return Promise.reject(new FailedToNegotiateWithServerError("Client didn't negotiate Stateful Reconnect but the server did."));
             }
 
@@ -374,7 +374,8 @@ export class HttpConnection implements IConnection {
         const transports = negotiateResponse.availableTransports || [];
         let negotiate: INegotiateResponse | undefined = negotiateResponse;
         for (const endpoint of transports) {
-            const transportOrError = this._resolveTransportOrError(endpoint, requestedTransport, requestedTransferFormat, negotiate?.useAck === true);
+            const transportOrError = this._resolveTransportOrError(endpoint, requestedTransport, requestedTransferFormat,
+                negotiate?.useStatefulReconnect === true);
             if (transportOrError instanceof Error) {
                 // Store the error and continue, we don't want to cause a re-negotiate in these cases
                 transportExceptions.push(`${endpoint.transport} failed:`);
@@ -438,7 +439,7 @@ export class HttpConnection implements IConnection {
         if (this.features.reconnect) {
             this.transport!.onclose = async (e) => {
                 let callStop = false;
-                if (this.features.resend) {
+                if (this.features.reconnect) {
                     try {
                         this.features.disconnected();
                         await this.transport!.connect(url, transferFormat);
@@ -462,7 +463,7 @@ export class HttpConnection implements IConnection {
     }
 
     private _resolveTransportOrError(endpoint: IAvailableTransport, requestedTransport: HttpTransportType | undefined,
-        requestedTransferFormat: TransferFormat, useAcks: boolean): ITransport | Error | unknown {
+        requestedTransferFormat: TransferFormat, useStatefulReconnect: boolean): ITransport | Error | unknown {
         const transport = HttpTransportType[endpoint.transport];
         if (transport === null || transport === undefined) {
             this._logger.log(LogLevel.Debug, `Skipping transport '${endpoint.transport}' because it is not supported by this client.`);
@@ -478,7 +479,7 @@ export class HttpConnection implements IConnection {
                     } else {
                         this._logger.log(LogLevel.Debug, `Selecting transport '${HttpTransportType[transport]}'.`);
                         try {
-                            this.features.reconnect = transport === HttpTransportType.WebSockets ? useAcks : undefined;
+                            this.features.reconnect = transport === HttpTransportType.WebSockets ? useStatefulReconnect : undefined;
                             return this._constructTransport(transport);
                         } catch (ex) {
                             return ex;
@@ -588,12 +589,12 @@ export class HttpConnection implements IConnection {
             searchParams.append("negotiateVersion", this._negotiateVersion.toString());
         }
 
-        if (searchParams.has("useAck")) {
-            if (searchParams.get("useAck") === "true") {
+        if (searchParams.has("useStatefulReconnect")) {
+            if (searchParams.get("useStatefulReconnect") === "true") {
                 this._options._useStatefulReconnect = true;
             }
         } else if (this._options._useStatefulReconnect === true) {
-            searchParams.append("useAck", "true");
+            searchParams.append("useStatefulReconnect", "true");
         }
 
         negotiateUrl.search = searchParams.toString();

--- a/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
@@ -1666,7 +1666,7 @@ describe("TransportSendQueue", () => {
                 _useStatefulReconnect: false,
                 WebSocket: TestWebSocket,
                 httpClient: new TestHttpClient()
-                    .on("POST", "http://tempuri.org/negotiate?negotiateVersion=1&useAck=true", () => { throw new Error(); })
+                    .on("POST", "http://tempuri.org/negotiate?negotiateVersion=1&useStatefulReconnect=true", () => { throw new Error(); })
                     .on("POST", "http://tempuri.org/negotiate?negotiateVersion=1", () => negotiateResponse)
                     .on("GET", () => ""),
                 logger,
@@ -1691,14 +1691,14 @@ describe("TransportSendQueue", () => {
     it("negotiate Stateful Reconnect sets query string", async () => {
         await VerifyLogger.run(async (logger) => {
             const negotiateResponse: INegotiateResponse = { ...defaultNegotiateResponse };
-            negotiateResponse.useAck = true;
+            negotiateResponse.useStatefulReconnect = true;
 
             const options: IHttpConnectionOptions = {
                 ...commonOptions,
                 _useStatefulReconnect: true,
                 WebSocket: TestWebSocket,
                 httpClient: new TestHttpClient()
-                    .on("POST", "http://tempuri.org/negotiate?negotiateVersion=1&useAck=true", () => negotiateResponse)
+                    .on("POST", "http://tempuri.org/negotiate?negotiateVersion=1&useStatefulReconnect=true", () => negotiateResponse)
                     .on("GET", () => ""),
                 logger,
             } as IHttpConnectionOptions;
@@ -1722,19 +1722,19 @@ describe("TransportSendQueue", () => {
     it("negotiate Stateful Reconnect with query string present", async () => {
         await VerifyLogger.run(async (logger) => {
             const negotiateResponse: INegotiateResponse = { ...defaultNegotiateResponse };
-            negotiateResponse.useAck = true;
+            negotiateResponse.useStatefulReconnect = true;
 
             const options: IHttpConnectionOptions = {
                 ...commonOptions,
                 _useStatefulReconnect: false,
                 WebSocket: TestWebSocket,
                 httpClient: new TestHttpClient()
-                    .on("POST", "http://tempuri.org/negotiate?useAck=true&negotiateVersion=1", () => negotiateResponse)
+                    .on("POST", "http://tempuri.org/negotiate?useStatefulReconnect=true&negotiateVersion=1", () => negotiateResponse)
                     .on("GET", () => ""),
                 logger,
             } as IHttpConnectionOptions;
 
-            const connection = new HttpConnection("http://tempuri.org?useAck=true", options);
+            const connection = new HttpConnection("http://tempuri.org?useStatefulReconnect=true", options);
 
             TestWebSocket.webSocketSet = new PromiseSource();
             const startPromise = connection.start(TransferFormat.Text);
@@ -1754,18 +1754,18 @@ describe("TransportSendQueue", () => {
         await VerifyLogger.run(async (logger) => {
             const negotiateResponse: INegotiateResponse = { ...defaultNegotiateResponse };
             // client didn't request the feature, we should error
-            negotiateResponse.useAck = true;
+            negotiateResponse.useStatefulReconnect = true;
 
             const options: IHttpConnectionOptions = {
                 ...commonOptions,
                 WebSocket: TestWebSocket,
                 httpClient: new TestHttpClient()
-                    .on("POST", "http://tempuri.org/negotiate?useAck=false&negotiateVersion=1", () => negotiateResponse)
+                    .on("POST", "http://tempuri.org/negotiate?useStatefulReconnect=false&negotiateVersion=1", () => negotiateResponse)
                     .on("GET", () => ""),
                 logger,
             } as IHttpConnectionOptions;
 
-            const connection = new HttpConnection("http://tempuri.org?useAck=false", options);
+            const connection = new HttpConnection("http://tempuri.org?useStatefulReconnect=false", options);
 
             await expect(connection.start(TransferFormat.Text))
                 .rejects
@@ -1779,7 +1779,7 @@ describe("TransportSendQueue", () => {
     it("negotiate Stateful Reconnect works with websockets", async () => {
         await VerifyLogger.run(async (logger) => {
             const negotiateResponse: INegotiateResponse = { ...defaultNegotiateResponse };
-            negotiateResponse.useAck = true;
+            negotiateResponse.useStatefulReconnect = true;
 
             const options: IHttpConnectionOptions = {
                 ...commonOptions,
@@ -1838,7 +1838,7 @@ describe("TransportSendQueue", () => {
     it("negotiate Stateful Reconnect does not work with long polling", async () => {
         await VerifyLogger.run(async (logger) => {
             const negotiateResponse: INegotiateResponse = { ...defaultNegotiateResponse };
-            negotiateResponse.useAck = true;
+            negotiateResponse.useStatefulReconnect = true;
 
             let firstPoll = true;
             const options: IHttpConnectionOptions = {
@@ -1874,7 +1874,7 @@ describe("TransportSendQueue", () => {
     it("using Stateful Reconnect restarts connection", async () => {
         await VerifyLogger.run(async (logger) => {
             const negotiateResponse: INegotiateResponse = { ...defaultNegotiateResponse };
-            negotiateResponse.useAck = true;
+            negotiateResponse.useStatefulReconnect = true;
 
             const options: IHttpConnectionOptions = {
                 ...commonOptions,
@@ -1937,7 +1937,7 @@ describe("TransportSendQueue", () => {
     it("using Stateful Reconnect restarts connection and closes on error", async () => {
         await VerifyLogger.run(async (logger) => {
             const negotiateResponse: INegotiateResponse = { ...defaultNegotiateResponse };
-            negotiateResponse.useAck = true;
+            negotiateResponse.useStatefulReconnect = true;
 
             const options: IHttpConnectionOptions = {
                 ...commonOptions,

--- a/src/SignalR/common/Http.Connections.Common/src/NegotiateProtocol.cs
+++ b/src/SignalR/common/Http.Connections.Common/src/NegotiateProtocol.cs
@@ -34,8 +34,8 @@ public static class NegotiateProtocol
     private static readonly JsonEncodedText ErrorPropertyNameBytes = JsonEncodedText.Encode(ErrorPropertyName);
     private const string NegotiateVersionPropertyName = "negotiateVersion";
     private static readonly JsonEncodedText NegotiateVersionPropertyNameBytes = JsonEncodedText.Encode(NegotiateVersionPropertyName);
-    private const string AckPropertyName = "useAck";
-    private static readonly JsonEncodedText AckPropertyNameBytes = JsonEncodedText.Encode(AckPropertyName);
+    private const string StatefulReconnectPropertyName = "useStatefulReconnect";
+    private static readonly JsonEncodedText StatefulReconnectPropertyNameBytes = JsonEncodedText.Encode(StatefulReconnectPropertyName);
 
     // Use C#7.3's ReadOnlySpan<byte> optimization for static data https://vcsjones.com/2019/02/01/csharp-readonly-span-bytes-static/
     // Used to detect ASP.NET SignalR Server connection attempt
@@ -68,7 +68,7 @@ public static class NegotiateProtocol
 
             if (response.UseStatefulReconnect)
             {
-                writer.WriteBoolean(AckPropertyNameBytes, true);
+                writer.WriteBoolean(StatefulReconnectPropertyNameBytes, true);
             }
 
             writer.WriteNumber(NegotiateVersionPropertyNameBytes, response.Version);
@@ -160,7 +160,7 @@ public static class NegotiateProtocol
             List<AvailableTransport>? availableTransports = null;
             string? error = null;
             int version = 0;
-            bool useAck = false;
+            bool useStatefulReconnect = false;
 
             var completed = false;
             while (!completed && reader.CheckRead())
@@ -214,9 +214,9 @@ public static class NegotiateProtocol
                         {
                             throw new InvalidOperationException("Detected a connection attempt to an ASP.NET SignalR Server. This client only supports connecting to an ASP.NET Core SignalR Server. See https://aka.ms/signalr-core-differences for details.");
                         }
-                        else if (reader.ValueTextEquals(AckPropertyNameBytes.EncodedUtf8Bytes))
+                        else if (reader.ValueTextEquals(StatefulReconnectPropertyNameBytes.EncodedUtf8Bytes))
                         {
-                            useAck = reader.ReadAsBoolean(AckPropertyName);
+                            useStatefulReconnect = reader.ReadAsBoolean(StatefulReconnectPropertyName);
                         }
                         else
                         {
@@ -262,7 +262,7 @@ public static class NegotiateProtocol
                 AvailableTransports = availableTransports,
                 Error = error,
                 Version = version,
-                UseStatefulReconnect = useAck,
+                UseStatefulReconnect = useStatefulReconnect,
             };
         }
         catch (Exception ex)

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionManager.cs
@@ -60,7 +60,7 @@ internal sealed partial class HttpConnectionManager
     /// Creates a connection without Pipes setup to allow saving allocations until Pipes are needed.
     /// </summary>
     /// <returns></returns>
-    internal HttpConnectionContext CreateConnection(HttpConnectionDispatcherOptions options, int negotiateVersion = 0, bool useAck = false)
+    internal HttpConnectionContext CreateConnection(HttpConnectionDispatcherOptions options, int negotiateVersion = 0, bool useStatefulReconnect = false)
     {
         string connectionToken;
         var id = MakeNewConnectionId();
@@ -78,7 +78,7 @@ internal sealed partial class HttpConnectionManager
         Log.CreatedNewConnection(_logger, id);
 
         var pair = CreateConnectionPair(options.TransportPipeOptions, options.AppPipeOptions);
-        var connection = new HttpConnectionContext(id, connectionToken, _connectionLogger, metricsContext, pair.Application, pair.Transport, options, useAck);
+        var connection = new HttpConnectionContext(id, connectionToken, _connectionLogger, metricsContext, pair.Application, pair.Transport, options, useStatefulReconnect);
 
         _connections.TryAdd(connectionToken, connection);
 

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -2263,7 +2263,7 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
     }
 
     [Fact]
-    public async Task NegotiateDoesNotReturnUseAckWhenNotEnabledOnServer()
+    public async Task NegotiateDoesNotReturnUseStatefulReconnectWhenNotEnabledOnServer()
     {
         using (StartVerifiableLog())
         {
@@ -2278,11 +2278,11 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             context.Request.Path = "/foo";
             context.Request.Method = "POST";
             context.Response.Body = ms;
-            context.Request.QueryString = new QueryString("?negotiateVersion=1&UseAck=true");
+            context.Request.QueryString = new QueryString("?negotiateVersion=1&UseStatefulReconnect=true");
             await dispatcher.ExecuteNegotiateAsync(context, new HttpConnectionDispatcherOptions { AllowStatefulReconnects = false });
 
             var negotiateResponse = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(ms.ToArray()));
-            Assert.False(negotiateResponse.TryGetValue("useAck", out _));
+            Assert.False(negotiateResponse.TryGetValue("useStatefulReconnect", out _));
 
             Assert.True(manager.TryGetConnection(negotiateResponse["connectionToken"].ToString(), out var connection));
 #pragma warning disable CA2252 // This API requires opting into preview features
@@ -2292,7 +2292,7 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
     }
 
     [Fact]
-    public async Task NegotiateDoesNotReturnUseAckWhenEnabledOnServerButNotRequestedByClient()
+    public async Task NegotiateDoesNotReturnUseStatefulReconnectWhenEnabledOnServerButNotRequestedByClient()
     {
         using (StartVerifiableLog())
         {
@@ -2311,7 +2311,7 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             await dispatcher.ExecuteNegotiateAsync(context, new HttpConnectionDispatcherOptions { AllowStatefulReconnects = true });
 
             var negotiateResponse = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(ms.ToArray()));
-            Assert.False(negotiateResponse.TryGetValue("useAck", out _));
+            Assert.False(negotiateResponse.TryGetValue("useStatefulReconnect", out _));
 
             Assert.True(manager.TryGetConnection(negotiateResponse["connectionToken"].ToString(), out var connection));
 #pragma warning disable CA2252 // This API requires opting into preview features
@@ -2321,7 +2321,7 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
     }
 
     [Fact]
-    public async Task NegotiateReturnsUseAckWhenEnabledOnServerAndRequestedByClient()
+    public async Task NegotiateReturnsUseStatefulReconnectWhenEnabledOnServerAndRequestedByClient()
     {
         using (StartVerifiableLog())
         {
@@ -2336,11 +2336,11 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             context.Request.Path = "/foo";
             context.Request.Method = "POST";
             context.Response.Body = ms;
-            context.Request.QueryString = new QueryString("?negotiateVersion=1&UseAck=true");
+            context.Request.QueryString = new QueryString("?negotiateVersion=1&UseStatefulReconnect=true");
             await dispatcher.ExecuteNegotiateAsync(context, new HttpConnectionDispatcherOptions { AllowStatefulReconnects = true });
 
             var negotiateResponse = JsonConvert.DeserializeObject<JObject>(Encoding.UTF8.GetString(ms.ToArray()));
-            Assert.True((bool)negotiateResponse["useAck"]);
+            Assert.True((bool)negotiateResponse["useStatefulReconnect"]);
 
             Assert.True(manager.TryGetConnection(negotiateResponse["connectionToken"].ToString(), out var connection));
 #pragma warning disable CA2252 // This API requires opting into preview features
@@ -2358,7 +2358,7 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             var options = new HttpConnectionDispatcherOptions() { AllowStatefulReconnects = true };
             options.WebSockets.CloseTimeout = TimeSpan.FromMilliseconds(1);
             // pretend negotiate occurred
-            var connection = manager.CreateConnection(options, negotiateVersion: 1, useAck: true);
+            var connection = manager.CreateConnection(options, negotiateVersion: 1, useStatefulReconnect: true);
             connection.TransportType = HttpTransportType.WebSockets;
 
             var dispatcher = CreateDispatcher(manager, LoggerFactory);
@@ -2433,7 +2433,7 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             var options = new HttpConnectionDispatcherOptions() { AllowStatefulReconnects = true };
             options.WebSockets.CloseTimeout = TimeSpan.FromMilliseconds(1);
             // pretend negotiate occurred
-            var connection = manager.CreateConnection(options, negotiateVersion: 1, useAck: true);
+            var connection = manager.CreateConnection(options, negotiateVersion: 1, useStatefulReconnect: true);
             connection.TransportType = HttpTransportType.WebSockets;
 
             var dispatcher = CreateDispatcher(manager, LoggerFactory);

--- a/src/SignalR/server/SignalR/test/DefaultTransportFactoryTests.cs
+++ b/src/SignalR/server/SignalR/test/DefaultTransportFactoryTests.cs
@@ -53,7 +53,7 @@ public class DefaultTransportFactoryTests
     {
         var transportFactory = new DefaultTransportFactory(requestedTransport, loggerFactory: null, httpClient: new HttpClient(), httpConnectionOptions: null, accessTokenProvider: null);
         Assert.IsType(expectedTransportType,
-            transportFactory.CreateTransport(AllTransportTypes, useAck: true));
+            transportFactory.CreateTransport(AllTransportTypes, useStatefulReconnect: true));
     }
 
     [Theory]
@@ -66,7 +66,7 @@ public class DefaultTransportFactoryTests
         var transportFactory =
             new DefaultTransportFactory(requestedTransport, loggerFactory: null, httpClient: new HttpClient(), httpConnectionOptions: null, accessTokenProvider: null);
         var ex = Assert.Throws<InvalidOperationException>(
-            () => transportFactory.CreateTransport(~requestedTransport, useAck: true));
+            () => transportFactory.CreateTransport(~requestedTransport, useStatefulReconnect: true));
 
         Assert.Equal("No requested transports available on the server.", ex.Message);
     }
@@ -77,7 +77,7 @@ public class DefaultTransportFactoryTests
     {
         Assert.IsType<WebSocketsTransport>(
             new DefaultTransportFactory(AllTransportTypes, loggerFactory: null, httpClient: new HttpClient(), httpConnectionOptions: null, accessTokenProvider: null)
-                .CreateTransport(AllTransportTypes, useAck: true));
+                .CreateTransport(AllTransportTypes, useStatefulReconnect: true));
     }
 
     [Theory]
@@ -90,7 +90,7 @@ public class DefaultTransportFactoryTests
         {
             var transportFactory = new DefaultTransportFactory(requestedTransport, loggerFactory: null, httpClient: new HttpClient(), httpConnectionOptions: null, accessTokenProvider: null);
             Assert.IsType(expectedTransportType,
-                transportFactory.CreateTransport(AllTransportTypes, useAck: true));
+                transportFactory.CreateTransport(AllTransportTypes, useStatefulReconnect: true));
         }
     }
 
@@ -103,7 +103,7 @@ public class DefaultTransportFactoryTests
             var transportFactory =
                 new DefaultTransportFactory(requestedTransport, loggerFactory: null, httpClient: new HttpClient(), httpConnectionOptions: null, accessTokenProvider: null);
             var ex = Assert.Throws<InvalidOperationException>(
-                () => transportFactory.CreateTransport(AllTransportTypes, useAck: true));
+                () => transportFactory.CreateTransport(AllTransportTypes, useStatefulReconnect: true));
 
             Assert.Equal("No requested transports available on the server.", ex.Message);
         }

--- a/src/SignalR/server/SignalR/test/EndToEndTests.cs
+++ b/src/SignalR/server/SignalR/test/EndToEndTests.cs
@@ -686,7 +686,7 @@ public class EndToEndTests : FunctionalTestBase
     {
         private ITransport _transport;
 
-        public ITransport CreateTransport(HttpTransportType availableServerTransports, bool useAck)
+        public ITransport CreateTransport(HttpTransportType availableServerTransports, bool useStatefulReconnect)
         {
             if (_transport == null)
             {


### PR DESCRIPTION
Also changes the query string from "useAck=true" -> "useStatefulReconnect=true"

### Customer Impact

Only visible when looking at the query string of the negotiate request.

Query strings aren't part of the traditional API review process so this was missed when we finalized on the `StatefulReconnect` naming for RC1.

### Risk

Low. This is a new feature in 8.0 so unlikely anyone has written their own support for the feature. Clients from previous previews (and RC1) will now fail to be able to use the stateful reconnect feature, but besides that they will continue working.