### PR TITLE
Fix dropping messages on reconnect

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -1114,7 +1114,6 @@ public partial class HubConnection : IAsyncDisposable
                 break;
             case SequenceMessage sequenceMessage:
                 Log.ReceivedSequenceMessage(_logger, sequenceMessage.SequenceId);
-                connectionState.ResetSequence(sequenceMessage);
                 break;
             default:
                 throw new InvalidOperationException($"Unexpected message type: {message.GetType().FullName}");
@@ -2072,14 +2071,6 @@ public partial class HubConnection : IAsyncDisposable
             if (UsingAcks())
             {
                 _messageBuffer.Ack(ackMessage);
-            }
-        }
-
-        public void ResetSequence(SequenceMessage sequenceMessage)
-        {
-            if (UsingAcks())
-            {
-                _messageBuffer.ResetSequence(sequenceMessage);
             }
         }
 

--- a/src/SignalR/common/Shared/MessageBuffer.cs
+++ b/src/SignalR/common/Shared/MessageBuffer.cs
@@ -204,8 +204,7 @@ internal sealed class MessageBuffer : IDisposable
         }
 
         var currentId = _currentReceivingSequenceId;
-        // Safe to modify outside a lock because the only other modifier is ResetSequence()
-        // which would be called on the same thread after this method completes
+        // ShouldProcessMessage is never called in parallel and is the only method referencing _currentReceivingSequenceId
         _currentReceivingSequenceId++;
         if (currentId <= _latestReceivedSequenceId)
         {

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -791,12 +791,4 @@ public partial class HubConnectionContext
         }
         return true;
     }
-
-    internal void ResetSequence(SequenceMessage sequenceMessage)
-    {
-        if (UsingStatefulReconnect())
-        {
-            _messageBuffer.ResetSequence(sequenceMessage);
-        }
-    }
 }

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -199,7 +199,6 @@ internal sealed partial class DefaultHubDispatcher<THub> : HubDispatcher<THub> w
 
             case SequenceMessage sequenceMessage:
                 Log.ReceivedSequenceMessage(_logger, sequenceMessage.SequenceId);
-                connection.ResetSequence(sequenceMessage);
                 break;
 
             case CloseMessage closeMessage:

--- a/src/SignalR/server/SignalR/test/Internal/MessageBufferTests.cs
+++ b/src/SignalR/server/SignalR/test/Internal/MessageBufferTests.cs
@@ -120,7 +120,7 @@ public class MessageBufferTests
 
         pipes.Application.Input.AdvanceTo(buffer.Start);
 
-        messageBuffer.ResetSequence(new SequenceMessage(1));
+        messageBuffer.ShouldProcessMessage(new SequenceMessage(1));
 
         Assert.True(messageBuffer.ShouldProcessMessage(PingMessage.Instance));
         Assert.False(messageBuffer.ShouldProcessMessage(CompletionMessage.WithResult("1", null)));
@@ -191,7 +191,7 @@ public class MessageBufferTests
 
         pipes.Application.Input.AdvanceTo(buffer.Start);
 
-        Assert.Throws<InvalidOperationException>(() => messageBuffer.ResetSequence(new SequenceMessage(2)));
+        Assert.Throws<InvalidOperationException>(() => messageBuffer.ShouldProcessMessage(new SequenceMessage(2)));
     }
 
     [Fact]

--- a/src/SignalR/server/SignalR/test/Internal/MessageBufferTests.cs
+++ b/src/SignalR/server/SignalR/test/Internal/MessageBufferTests.cs
@@ -99,9 +99,8 @@ public class MessageBufferTests
         DuplexPipe.UpdateConnectionPair(ref pipes, connection);
         await messageBuffer.ResendAsync(pipes.Transport.Output);
 
-        // Any message except SequenceMessage will be ignored until a SequenceMessage is received
-        Assert.False(messageBuffer.ShouldProcessMessage(PingMessage.Instance));
-        Assert.False(messageBuffer.ShouldProcessMessage(CompletionMessage.WithResult("1", null)));
+        Assert.True(messageBuffer.ShouldProcessMessage(PingMessage.Instance));
+        Assert.True(messageBuffer.ShouldProcessMessage(CompletionMessage.WithResult("1", null)));
         Assert.True(messageBuffer.ShouldProcessMessage(new SequenceMessage(1)));
 
         res = await pipes.Application.Input.ReadAsync();
@@ -124,7 +123,7 @@ public class MessageBufferTests
         messageBuffer.ResetSequence(new SequenceMessage(1));
 
         Assert.True(messageBuffer.ShouldProcessMessage(PingMessage.Instance));
-        Assert.True(messageBuffer.ShouldProcessMessage(CompletionMessage.WithResult("1", null)));
+        Assert.False(messageBuffer.ShouldProcessMessage(CompletionMessage.WithResult("1", null)));
     }
 
     [Fact]


### PR DESCRIPTION
There was a race where `ResendAsync` could run and set `_waitForSequenceMessage = true` **after** the `SequenceMessage` was received, which is what sets `_waitForSequenceMessage` to false.
This meant that you would drop all incoming messages on a successful reconnect if you hit this race.

There was already a TODO about potentially just processing messages even if we're expecting a SequenceMessage. Since we were already considering it, I just went that route to remove the race entirely.

Processing messages before the `SequenceMessage` is received will operate as if the connection never went away. Meaning the expected incoming ID will be incremented until it's reset/changed by the `SequenceMessage`. In theory that means if all sent messages have been acked we could avoid sending a `SequenceMessage` at all. But we're not going to change that at this time.

While our client implementations shouldn't send messages on reconnect before the `SequenceMessage`, it doesn't hurt to allow that.

@halter73 

### Customer Impact

There is a race where on reconnect the server (or client) could get into a state where it would ignore every message it received because of some incorrect state.

### Risk

Low. Change in new feature only. The change is removing some state management code that wasn't actually needed, so the race can't exist anymore.