### PR TITLE
Suppress nullability warning when resolving JSON body or service

### DIFF
--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
@@ -215,7 +215,6 @@ internal static class EndpointParameterEmitter
         var assigningCode = $"await {endpointParameter.SymbolName}_JsonBodyOrServiceResolver(httpContext, {(endpointParameter.IsOptional ? "true" : "false")})";
         var resolveJsonBodyOrServiceResult = $"{endpointParameter.SymbolName}_resolveJsonBodyOrServiceResult";
         codeWriter.WriteLine($"var {resolveJsonBodyOrServiceResult} = {assigningCode};");
-        codeWriter.WriteLine($"var {endpointParameter.EmitHandlerArgument()} = {resolveJsonBodyOrServiceResult}.Item2;");
 
         // If binding from the JSON body fails, ResolveJsonBodyOrService
         // will return `false` and we will need to exit early.
@@ -223,6 +222,14 @@ internal static class EndpointParameterEmitter
         codeWriter.StartBlock();
         codeWriter.WriteLine("return;");
         codeWriter.EndBlock();
+
+        // Required parameters are guranteed to be set by the time we reach this point
+        // because they are either associated with a service that existed in DI or
+        // the appropriate checks have already happened when binding from the JSON body.
+        codeWriter.WriteLine(!endpointParameter.IsOptional
+            ? $"var {endpointParameter.EmitHandlerArgument()} = {resolveJsonBodyOrServiceResult}.Item2!;"
+            : $"var {endpointParameter.EmitHandlerArgument()} = {resolveJsonBodyOrServiceResult}.Item2;");
+
     }
 
     internal static void EmitJsonBodyOrQueryParameterPreparationString(this EndpointParameter endpointParameter, CodeWriter codeWriter)

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_JsonBodyOrService_HandlesBothJsonAndService.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_JsonBodyOrService_HandlesBothJsonAndService.generated.txt
@@ -123,18 +123,18 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var wasParamCheckFailure = false;
                     // Endpoint Parameter: todo (Type = Microsoft.AspNetCore.Http.Generators.Tests.Todo, IsOptional = False, IsParsable = False, IsArray = False, Source = JsonBodyOrService)
                     var todo_resolveJsonBodyOrServiceResult = await todo_JsonBodyOrServiceResolver(httpContext, false);
-                    var todo_local = todo_resolveJsonBodyOrServiceResult.Item2;
                     if (!todo_resolveJsonBodyOrServiceResult.Item1)
                     {
                         return;
                     }
+                    var todo_local = todo_resolveJsonBodyOrServiceResult.Item2!;
                     // Endpoint Parameter: svc (Type = Microsoft.AspNetCore.Http.Generators.Tests.TestService, IsOptional = False, IsParsable = False, IsArray = False, Source = JsonBodyOrService)
                     var svc_resolveJsonBodyOrServiceResult = await svc_JsonBodyOrServiceResolver(httpContext, false);
-                    var svc_local = svc_resolveJsonBodyOrServiceResult.Item2;
                     if (!svc_resolveJsonBodyOrServiceResult.Item1)
                     {
                         return;
                     }
+                    var svc_local = svc_resolveJsonBodyOrServiceResult.Item2!;
 
                     if (wasParamCheckFailure)
                     {
@@ -158,18 +158,18 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var wasParamCheckFailure = false;
                     // Endpoint Parameter: todo (Type = Microsoft.AspNetCore.Http.Generators.Tests.Todo, IsOptional = False, IsParsable = False, IsArray = False, Source = JsonBodyOrService)
                     var todo_resolveJsonBodyOrServiceResult = await todo_JsonBodyOrServiceResolver(httpContext, false);
-                    var todo_local = todo_resolveJsonBodyOrServiceResult.Item2;
                     if (!todo_resolveJsonBodyOrServiceResult.Item1)
                     {
                         return;
                     }
+                    var todo_local = todo_resolveJsonBodyOrServiceResult.Item2!;
                     // Endpoint Parameter: svc (Type = Microsoft.AspNetCore.Http.Generators.Tests.TestService, IsOptional = False, IsParsable = False, IsArray = False, Source = JsonBodyOrService)
                     var svc_resolveJsonBodyOrServiceResult = await svc_JsonBodyOrServiceResolver(httpContext, false);
-                    var svc_local = svc_resolveJsonBodyOrServiceResult.Item2;
                     if (!svc_resolveJsonBodyOrServiceResult.Item1)
                     {
                         return;
                     }
+                    var svc_local = svc_resolveJsonBodyOrServiceResult.Item2!;
 
                     if (wasParamCheckFailure)
                     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_TakesCustomMetadataEmitter_Has_Metadata.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/MapAction_TakesCustomMetadataEmitter_Has_Metadata.generated.txt
@@ -125,11 +125,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var wasParamCheckFailure = false;
                     // Endpoint Parameter: x (Type = Microsoft.AspNetCore.Http.Generators.Tests.CustomMetadataEmitter, IsOptional = False, IsParsable = False, IsArray = False, Source = JsonBodyOrService)
                     var x_resolveJsonBodyOrServiceResult = await x_JsonBodyOrServiceResolver(httpContext, false);
-                    var x_local = x_resolveJsonBodyOrServiceResult.Item2;
                     if (!x_resolveJsonBodyOrServiceResult.Item1)
                     {
                         return;
                     }
+                    var x_local = x_resolveJsonBodyOrServiceResult.Item2!;
 
                     if (wasParamCheckFailure)
                     {
@@ -144,11 +144,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var wasParamCheckFailure = false;
                     // Endpoint Parameter: x (Type = Microsoft.AspNetCore.Http.Generators.Tests.CustomMetadataEmitter, IsOptional = False, IsParsable = False, IsArray = False, Source = JsonBodyOrService)
                     var x_resolveJsonBodyOrServiceResult = await x_JsonBodyOrServiceResolver(httpContext, false);
-                    var x_local = x_resolveJsonBodyOrServiceResult.Item2;
                     if (!x_resolveJsonBodyOrServiceResult.Item1)
                     {
                         return;
                     }
+                    var x_local = x_resolveJsonBodyOrServiceResult.Item2!;
 
                     if (wasParamCheckFailure)
                     {

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/VerifyAsParametersBaseline.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/VerifyAsParametersBaseline.generated.txt
@@ -473,11 +473,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var HttpContext_local = httpContext;
                     // Endpoint Parameter: Todo (Type = Microsoft.AspNetCore.Http.Generators.Tests.TodoStruct, IsOptional = False, IsParsable = False, IsArray = False, Source = JsonBodyOrService)
                     var Todo_resolveJsonBodyOrServiceResult = await Todo_JsonBodyOrServiceResolver(httpContext, false);
-                    var Todo_local = Todo_resolveJsonBodyOrServiceResult.Item2;
                     if (!Todo_resolveJsonBodyOrServiceResult.Item1)
                     {
                         return;
                     }
+                    var Todo_local = Todo_resolveJsonBodyOrServiceResult.Item2!;
 
                     var args_local = new global::Microsoft.AspNetCore.Http.Generators.Tests.ParametersListWithImplicitFromBody(HttpContext_local, Todo_local);
 
@@ -505,11 +505,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var HttpContext_local = httpContext;
                     // Endpoint Parameter: Todo (Type = Microsoft.AspNetCore.Http.Generators.Tests.TodoStruct, IsOptional = False, IsParsable = False, IsArray = False, Source = JsonBodyOrService)
                     var Todo_resolveJsonBodyOrServiceResult = await Todo_JsonBodyOrServiceResolver(httpContext, false);
-                    var Todo_local = Todo_resolveJsonBodyOrServiceResult.Item2;
                     if (!Todo_resolveJsonBodyOrServiceResult.Item1)
                     {
                         return;
                     }
+                    var Todo_local = Todo_resolveJsonBodyOrServiceResult.Item2!;
 
                     var args_local = new global::Microsoft.AspNetCore.Http.Generators.Tests.ParametersListWithImplicitFromBody(HttpContext_local, Todo_local);
 
@@ -594,11 +594,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var HttpContext_local = httpContext;
                     // Endpoint Parameter: Value (Type = Microsoft.AspNetCore.Http.Generators.Tests.AddsCustomParameterMetadataAsProperty, IsOptional = False, IsParsable = False, IsArray = False, Source = JsonBodyOrService)
                     var Value_resolveJsonBodyOrServiceResult = await Value_JsonBodyOrServiceResolver(httpContext, false);
-                    var Value_local = Value_resolveJsonBodyOrServiceResult.Item2;
                     if (!Value_resolveJsonBodyOrServiceResult.Item1)
                     {
                         return;
                     }
+                    var Value_local = Value_resolveJsonBodyOrServiceResult.Item2!;
 
                     var args_local = new global::Microsoft.AspNetCore.Http.Generators.Tests.ParametersListWithMetadataType(HttpContext_local, Value_local);
 
@@ -617,11 +617,11 @@ namespace Microsoft.AspNetCore.Http.Generated
                     var HttpContext_local = httpContext;
                     // Endpoint Parameter: Value (Type = Microsoft.AspNetCore.Http.Generators.Tests.AddsCustomParameterMetadataAsProperty, IsOptional = False, IsParsable = False, IsArray = False, Source = JsonBodyOrService)
                     var Value_resolveJsonBodyOrServiceResult = await Value_JsonBodyOrServiceResolver(httpContext, false);
-                    var Value_local = Value_resolveJsonBodyOrServiceResult.Item2;
                     if (!Value_resolveJsonBodyOrServiceResult.Item1)
                     {
                         return;
                     }
+                    var Value_local = Value_resolveJsonBodyOrServiceResult.Item2!;
 
                     var args_local = new global::Microsoft.AspNetCore.Http.Generators.Tests.ParametersListWithMetadataType(HttpContext_local, Value_local);
 
@@ -645,6 +645,136 @@ namespace Microsoft.AspNetCore.Http.Generated
                 pattern,
                 handler,
                 GetVerb,
+                populateMetadata,
+                createRequestDelegate);
+        }
+
+        [InterceptsLocation(@"TestMapActions.cs", 50, 5)]
+        internal static RouteHandlerBuilder MapPost5(
+            this IEndpointRouteBuilder endpoints,
+            [StringSyntax("Route")] string pattern,
+            Delegate handler)
+        {
+            MetadataPopulator populateMetadata = (methodInfo, options) =>
+            {
+                Debug.Assert(options != null, "RequestDelegateFactoryOptions not found.");
+                Debug.Assert(options.EndpointBuilder != null, "EndpointBuilder not found.");
+                options.EndpointBuilder.Metadata.Add(new System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.AspNetCore.Http.RequestDelegateGenerator, Version=42.42.42.42, Culture=neutral, PublicKeyToken=adb9793829ddae60", "42.42.42.42"));
+                options.EndpointBuilder.Metadata.Add(new AcceptsMetadata(contentTypes: GeneratedMetadataConstants.JsonContentType));
+                options.EndpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(statusCode: StatusCodes.Status200OK, contentTypes: GeneratedMetadataConstants.PlaintextContentType));
+                return new RequestDelegateMetadataResult { EndpointMetadata = options.EndpointBuilder.Metadata.AsReadOnly() };
+            };
+            RequestDelegateFactoryFunc createRequestDelegate = (del, options, inferredMetadataResult) =>
+            {
+                Debug.Assert(options != null, "RequestDelegateFactoryOptions not found.");
+                Debug.Assert(options.EndpointBuilder != null, "EndpointBuilder not found.");
+                Debug.Assert(options.EndpointBuilder.ApplicationServices != null, "ApplicationServices not found.");
+                Debug.Assert(options.EndpointBuilder.FilterFactories != null, "FilterFactories not found.");
+                var handler = Cast(del, global::System.String (global::Microsoft.AspNetCore.Http.Generators.Tests.ParameterRecordStructWithJsonBodyOrService arg0) => throw null!);
+                EndpointFilterDelegate? filteredInvocation = null;
+                var serviceProvider = options.ServiceProvider ?? options.EndpointBuilder.ApplicationServices;
+                var logOrThrowExceptionHelper = new LogOrThrowExceptionHelper(serviceProvider, options);
+                var jsonOptions = serviceProvider?.GetService<IOptions<JsonOptions>>()?.Value ?? FallbackJsonOptions;
+                var jsonSerializerOptions = jsonOptions.SerializerOptions;
+                jsonSerializerOptions.MakeReadOnly();
+                var objectJsonTypeInfo = (JsonTypeInfo<object?>)jsonSerializerOptions.GetTypeInfo(typeof(object));
+                var serviceProviderIsService = serviceProvider?.GetService<IServiceProviderIsService>();
+                var Todo_JsonBodyOrServiceResolver = ResolveJsonBodyOrService<global::Microsoft.AspNetCore.Http.Generators.Tests.TodoStruct>(logOrThrowExceptionHelper, "TodoStruct", "Todo", jsonSerializerOptions, serviceProviderIsService);
+                var Service_JsonBodyOrServiceResolver = ResolveJsonBodyOrService<global::Microsoft.AspNetCore.Http.Generators.Tests.TestService>(logOrThrowExceptionHelper, "TestService", "Service", jsonSerializerOptions, serviceProviderIsService);
+
+                if (options.EndpointBuilder.FilterFactories.Count > 0)
+                {
+                    filteredInvocation = GeneratedRouteBuilderExtensionsCore.BuildFilterDelegate(ic =>
+                    {
+                        if (ic.HttpContext.Response.StatusCode == 400)
+                        {
+                            return ValueTask.FromResult<object?>(Results.Empty);
+                        }
+                        return ValueTask.FromResult<object?>(handler(ic.GetArgument<global::Microsoft.AspNetCore.Http.Generators.Tests.ParameterRecordStructWithJsonBodyOrService>(0)!));
+                    },
+                    options.EndpointBuilder,
+                    handler.Method);
+                }
+
+                async Task RequestHandler(HttpContext httpContext)
+                {
+                    var wasParamCheckFailure = false;
+                    // Endpoint Parameter: args (Type = Microsoft.AspNetCore.Http.Generators.Tests.ParameterRecordStructWithJsonBodyOrService, IsOptional = False, IsParsable = False, IsArray = False, Source = AsParameters)
+                    // Endpoint Parameter: Todo (Type = Microsoft.AspNetCore.Http.Generators.Tests.TodoStruct, IsOptional = False, IsParsable = False, IsArray = False, Source = JsonBodyOrService)
+                    var Todo_resolveJsonBodyOrServiceResult = await Todo_JsonBodyOrServiceResolver(httpContext, false);
+                    if (!Todo_resolveJsonBodyOrServiceResult.Item1)
+                    {
+                        return;
+                    }
+                    var Todo_local = Todo_resolveJsonBodyOrServiceResult.Item2!;
+                    // Endpoint Parameter: Service (Type = Microsoft.AspNetCore.Http.Generators.Tests.TestService, IsOptional = False, IsParsable = False, IsArray = False, Source = JsonBodyOrService)
+                    var Service_resolveJsonBodyOrServiceResult = await Service_JsonBodyOrServiceResolver(httpContext, false);
+                    if (!Service_resolveJsonBodyOrServiceResult.Item1)
+                    {
+                        return;
+                    }
+                    var Service_local = Service_resolveJsonBodyOrServiceResult.Item2!;
+
+                    var args_local = new global::Microsoft.AspNetCore.Http.Generators.Tests.ParameterRecordStructWithJsonBodyOrService { Todo = Todo_local, Service = Service_local };
+
+                    if (wasParamCheckFailure)
+                    {
+                        httpContext.Response.StatusCode = 400;
+                        return;
+                    }
+                    var result = handler(args_local);
+                    if (result is string)
+                    {
+                        httpContext.Response.ContentType ??= "text/plain; charset=utf-8";
+                    }
+                    else
+                    {
+                        httpContext.Response.ContentType ??= "application/json; charset=utf-8";
+                    }
+                    await httpContext.Response.WriteAsync(result);
+                }
+
+                async Task RequestHandlerFiltered(HttpContext httpContext)
+                {
+                    var wasParamCheckFailure = false;
+                    // Endpoint Parameter: args (Type = Microsoft.AspNetCore.Http.Generators.Tests.ParameterRecordStructWithJsonBodyOrService, IsOptional = False, IsParsable = False, IsArray = False, Source = AsParameters)
+                    // Endpoint Parameter: Todo (Type = Microsoft.AspNetCore.Http.Generators.Tests.TodoStruct, IsOptional = False, IsParsable = False, IsArray = False, Source = JsonBodyOrService)
+                    var Todo_resolveJsonBodyOrServiceResult = await Todo_JsonBodyOrServiceResolver(httpContext, false);
+                    if (!Todo_resolveJsonBodyOrServiceResult.Item1)
+                    {
+                        return;
+                    }
+                    var Todo_local = Todo_resolveJsonBodyOrServiceResult.Item2!;
+                    // Endpoint Parameter: Service (Type = Microsoft.AspNetCore.Http.Generators.Tests.TestService, IsOptional = False, IsParsable = False, IsArray = False, Source = JsonBodyOrService)
+                    var Service_resolveJsonBodyOrServiceResult = await Service_JsonBodyOrServiceResolver(httpContext, false);
+                    if (!Service_resolveJsonBodyOrServiceResult.Item1)
+                    {
+                        return;
+                    }
+                    var Service_local = Service_resolveJsonBodyOrServiceResult.Item2!;
+
+                    var args_local = new global::Microsoft.AspNetCore.Http.Generators.Tests.ParameterRecordStructWithJsonBodyOrService { Todo = Todo_local, Service = Service_local };
+
+                    if (wasParamCheckFailure)
+                    {
+                        httpContext.Response.StatusCode = 400;
+                    }
+                    var result = await filteredInvocation(EndpointFilterInvocationContext.Create<global::Microsoft.AspNetCore.Http.Generators.Tests.ParameterRecordStructWithJsonBodyOrService>(httpContext, args_local));
+                    if (result is not null)
+                    {
+                        await GeneratedRouteBuilderExtensionsCore.ExecuteReturnAsync(result, httpContext, objectJsonTypeInfo);
+                    }
+                }
+
+                RequestDelegate targetDelegate = filteredInvocation is null ? RequestHandler : RequestHandlerFiltered;
+                var metadata = inferredMetadataResult?.EndpointMetadata ?? ReadOnlyCollection<object>.Empty;
+                return new RequestDelegateResult(targetDelegate, metadata);
+            };
+            return MapCore(
+                endpoints,
+                pattern,
+                handler,
+                PostVerb,
                 populateMetadata,
                 createRequestDelegate);
         }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.AsParameters.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.AsParameters.cs
@@ -241,6 +241,7 @@ app.MapPost("/parameterListRecordStruct/{value}", parameterListRecordStruct);
 app.MapPut("/parametersListWithHttpContext", parametersListWithHttpContext);
 app.MapPatch("/parametersListWithImplicitFromBody", ([AsParameters] ParametersListWithImplicitFromBody args) => args.Todo.Name ?? string.Empty);
 app.MapGet("/parametersListWithMetadataType", parametersListWithMetadataType);
+app.MapPost("/parameterRecordStructWithJsonBodyOrService", ([AsParameters] ParameterRecordStructWithJsonBodyOrService args) => args.Todo.Name ?? string.Empty);
 """);
 
         await VerifyAgainstBaselineUsingFile(compilation);

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.JsonBodyOrService.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.JsonBodyOrService.cs
@@ -86,7 +86,7 @@ app.MapPost("/", (Todo todo, TestService svc) => $"{svc.TestServiceMethod()}, {t
         await VerifyResponseBodyAsync(httpContext, expectedBody);
     }
 
-        public static IEnumerable<object[]> BodyParamOptionalityData
+    public static IEnumerable<object[]> BodyParamOptionalityData
     {
         get
         {
@@ -98,6 +98,11 @@ app.MapPost("/", (Todo todo, TestService svc) => $"{svc.TestServiceMethod()}, {t
                 new object[] { @"(Todo? todo = null) => $""Todo: {todo?.Name}"";", true, false, "Todo: Default Todo"},
                 new object[] { @"(Todo? todo) => $""Todo: {todo?.Name}"";", false, false, "Todo: " },
                 new object[] { @"(Todo? todo) => $""Todo: {todo?.Name}"";", true, false, "Todo: Default Todo" },
+                new object[] { @"(TodoStruct todo) => $""Todo: {todo.Name}"";", true, false, "Todo: Default Todo"},
+                new object[] { @"(TodoStruct? todo = null) => $""Todo: {todo?.Name}"";", false, false, "Todo: "},
+                new object[] { @"(TodoStruct? todo = null) => $""Todo: {todo?.Name}"";", true, false, "Todo: Default Todo"},
+                new object[] { @"(TodoStruct? todo) => $""Todo: {todo?.Name}"";", false, false, "Todo: " },
+                new object[] { @"(TodoStruct? todo) => $""Todo: {todo?.Name}"";", true, false, "Todo: Default Todo" },
             };
         }
     }

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
@@ -707,6 +707,7 @@ public record ParametersListWithHttpContext(
 public record struct ParameterListRecordStruct(HttpContext HttpContext, [FromRoute] int Value);
 
 public record ParameterListRecordClass(HttpContext HttpContext, [FromRoute] int Value);
+public record struct ParameterRecordStructWithJsonBodyOrService(TodoStruct Todo, TestService Service);
 
 #nullable enable
 public record ParameterListRecordWithoutPositionalParameters


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/49381.

We're resolving an unexpected nullability warning here by suppressing the incorrect warning. When a required parameter can be resolved from either the JSON body or the service, the value of bound type is guranteed to not be null.

Typically, we would use `NotNullWhen` to resolve this in a standard `TryX` API but since this is an async API, we're not able to leverage out parameters and the accompanying attribute.