### PR TITLE
Update Microsoft.IdentityModel to 7.0.0-preview4

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -189,9 +189,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4122c63a13cfe40e97ac1f9ef01d8110a66943f4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23429.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23430.1">
       <Uri>https://github.com/dotnet/source-build-externals</Uri>
-      <Sha>0603839a51f5e18b89c60a3690aff5e81fa666ca</Sha>
+      <Sha>5a51063272497101418a0bd272255f1b10e352c6</Sha>
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.symreader" Version="2.0.0-beta-23228-03">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -189,9 +189,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4122c63a13cfe40e97ac1f9ef01d8110a66943f4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23430.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23430.3">
       <Uri>https://github.com/dotnet/source-build-externals</Uri>
-      <Sha>5a51063272497101418a0bd272255f1b10e352c6</Sha>
+      <Sha>c88d8d75ed6b8d426b7fad50eadd7f6fec46a7e4</Sha>
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.symreader" Version="2.0.0-beta-23228-03">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
     <AspNetCorePatchVersion>0</AspNetCorePatchVersion>
     <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
     <ValidateBaseline>true</ValidateBaseline>
-    <IdentityModelVersion>7.0.0-preview3</IdentityModelVersion>
+    <IdentityModelVersion>7.0.0-preview4</IdentityModelVersion>
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -162,7 +162,7 @@
     <MicrosoftDotNetBuildTasksTemplatingVersion>8.0.0-beta.23419.1</MicrosoftDotNetBuildTasksTemplatingVersion>
     <MicrosoftDotNetRemoteExecutorVersion>8.0.0-beta.23419.1</MicrosoftDotNetRemoteExecutorVersion>
     <!-- Packages from dotnet/source-build-externals -->
-    <MicrosoftSourceBuildIntermediatesourcebuildexternalsVersion>8.0.0-alpha.1.23430.1</MicrosoftSourceBuildIntermediatesourcebuildexternalsVersion>
+    <MicrosoftSourceBuildIntermediatesourcebuildexternalsVersion>8.0.0-alpha.1.23430.3</MicrosoftSourceBuildIntermediatesourcebuildexternalsVersion>
     <!-- Packages from dotnet/source-build-reference-packages -->
     <MicrosoftSourceBuildIntermediatesourcebuildreferencepackagesVersion>8.0.0-alpha.1.23428.2</MicrosoftSourceBuildIntermediatesourcebuildreferencepackagesVersion>
     <!-- Packages from dotnet/symreader -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -162,7 +162,7 @@
     <MicrosoftDotNetBuildTasksTemplatingVersion>8.0.0-beta.23419.1</MicrosoftDotNetBuildTasksTemplatingVersion>
     <MicrosoftDotNetRemoteExecutorVersion>8.0.0-beta.23419.1</MicrosoftDotNetRemoteExecutorVersion>
     <!-- Packages from dotnet/source-build-externals -->
-    <MicrosoftSourceBuildIntermediatesourcebuildexternalsVersion>8.0.0-alpha.1.23429.1</MicrosoftSourceBuildIntermediatesourcebuildexternalsVersion>
+    <MicrosoftSourceBuildIntermediatesourcebuildexternalsVersion>8.0.0-alpha.1.23430.1</MicrosoftSourceBuildIntermediatesourcebuildexternalsVersion>
     <!-- Packages from dotnet/source-build-reference-packages -->
     <MicrosoftSourceBuildIntermediatesourcebuildreferencepackagesVersion>8.0.0-alpha.1.23428.2</MicrosoftSourceBuildIntermediatesourcebuildreferencepackagesVersion>
     <!-- Packages from dotnet/symreader -->

--- a/src/Security/Authentication/WsFederation/src/WsFederationHandler.cs
+++ b/src/Security/Authentication/WsFederation/src/WsFederationHandler.cs
@@ -98,7 +98,7 @@ public class WsFederationHandler : RemoteAuthenticationHandler<WsFederationOptio
         var wsFederationMessage = new WsFederationMessage()
         {
             IssuerAddress = _configuration.TokenEndpoint ?? string.Empty,
-            Wtrealm = Options.Wtrealm!, // TODO: https://github.com/dotnet/aspnetcore/issues/50242
+            Wtrealm = Options.Wtrealm,
             Wa = WsFederationConstants.WsFederationActions.SignIn,
         };
 
@@ -195,7 +195,7 @@ public class WsFederationHandler : RemoteAuthenticationHandler<WsFederationOptio
             {
                 // Extract the user state from properties and reset.
                 properties.Items.TryGetValue(WsFederationDefaults.UserstatePropertiesKey, out var userState);
-                wsFederationMessage.Wctx = userState!; // TODO: '!' can be removed with https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/2240
+                wsFederationMessage.Wctx = userState;
             }
 
             var messageReceivedContext = new MessageReceivedContext(Context, Scheme, Options, properties)
@@ -425,7 +425,7 @@ public class WsFederationHandler : RemoteAuthenticationHandler<WsFederationOptio
         var wsFederationMessage = new WsFederationMessage()
         {
             IssuerAddress = _configuration.TokenEndpoint ?? string.Empty,
-            Wtrealm = Options.Wtrealm!, // TODO: https://github.com/dotnet/aspnetcore/issues/50242
+            Wtrealm = Options.Wtrealm,
             Wa = WsFederationConstants.WsFederationActions.SignOut,
         };
 

--- a/src/Security/Authentication/test/JwtBearerTests_Handler.cs
+++ b/src/Security/Authentication/test/JwtBearerTests_Handler.cs
@@ -914,23 +914,21 @@ public class JwtBearerTests_Handler : SharedAuthenticationTests<JwtBearerOptions
     public async Task ExpirationAndIssuedWhenMinOrMaxValue()
     {
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(new string('a', 128)));
-        //var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
-        //var claims = new[]
-        //{
-        //    new Claim(ClaimTypes.NameIdentifier, "Bob")
-        //};
+        var claims = new[]
+        {
+           new Claim(ClaimTypes.NameIdentifier, "Bob")
+        };
 
-        //var token = new JwtSecurityToken(
-        //    issuer: "issuer.contoso.com",
-        //    audience: "audience.contoso.com",
-        //    claims: claims,
-        //    expires: DateTime.MaxValue,
-        //    signingCredentials: creds);
+        var token = new JwtSecurityToken(
+           issuer: "issuer.contoso.com",
+           audience: "audience.contoso.com",
+           claims: claims,
+           expires: DateTime.MaxValue,
+           signingCredentials: creds);
 
-        //var tokenText = new JwtSecurityTokenHandler().WriteToken(token);
-        // TODO: when https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/2261 is fixed, uncomment the above code and remove this hard-coded string
-        var tokenText = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9uYW1laWRlbnRpZmllciI6IkJvYiIsImV4cCI6MjUzNDAyMzAwODAwLCJpc3MiOiJpc3N1ZXIuY29udG9zby5jb20iLCJhdWQiOiJhdWRpZW5jZS5jb250b3NvLmNvbSJ9.0zvasyAh-GmjR_o46QSRCoQ9VaSXJjW5_YMcR6qy-jw";
+        var tokenText = new JwtSecurityTokenHandler().WriteToken(token);
 
         using var host = await CreateHost(o =>
         {


### PR DESCRIPTION
Updates our 8.0 dependencies on Microsoft.IdentityModel to 7.0.0-preview4 and undoes the workarounds added in #50218.

Note this will need https://github.com/dotnet/source-build-externals/pull/198 to be merged and updated here in order to pass source-build. (FYI - @mthalman @MichaelSimons)

Fix #50242