### PR TITLE
Fix typo in method name StopTrasnsportTracking -> StopTransportTracking

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/ConnectionManager.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/ConnectionManager.cs
@@ -79,7 +79,7 @@ internal sealed class ConnectionManager : IHeartbeatHandler
                 // It's safe to modify the ConcurrentDictionary in the foreach.
                 // The connection reference has become unrooted because the application never completed.
                 _trace.ApplicationNeverCompleted(reference.ConnectionId);
-                reference.StopTrasnsportTracking();
+                reference.StopTransportTracking();
             }
 
             // If both conditions are false, the connection was removed during the heartbeat.

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/ConnectionReference.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/ConnectionReference.cs
@@ -28,7 +28,7 @@ internal sealed class ConnectionReference
         return _weakReference.TryGetTarget(out connection);
     }
 
-    public void StopTrasnsportTracking()
+    public void StopTransportTracking()
     {
         _transportConnectionManager.StopTracking(_id);
     }


### PR DESCRIPTION
## Fix StopTrasnsportTracking method name typo

Simple change, didn't think making an issue would be necessary.
