### PR TITLE
Fix incoming connections with same ID sometimes failing incorrectly

### DIFF
--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
-using System.Diagnostics;
 using System.Security.Claims;
 using System.Security.Principal;
 using Microsoft.AspNetCore.Authentication;

--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -570,29 +570,29 @@ internal sealed partial class HttpConnectionDispatcher
             return false;
         }
 
+        switch (connection.TrySetTransport(transportType, _metrics))
+        {
+            case HttpConnectionContext.SetTransportState.Success:
+                break;
+
+            case HttpConnectionContext.SetTransportState.AlreadyActive:
+                Log.ConnectionAlreadyActive(_logger, connection.ConnectionId, context.TraceIdentifier);
+
+                // Reject the request with a 409 conflict
+                context.Response.StatusCode = StatusCodes.Status409Conflict;
+                context.Response.ContentType = "text/plain";
+                return false;
+
+            case HttpConnectionContext.SetTransportState.CannotChange:
+                context.Response.ContentType = "text/plain";
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                Log.CannotChangeTransport(_logger, connection.TransportType, transportType);
+                await context.Response.WriteAsync("Cannot change transports mid-connection");
+                return false;
+        }
+
         // Set the IHttpConnectionFeature now that we can access it.
         connection.Features.Set(context.Features.Get<IHttpConnectionFeature>());
-
-        if (connection.TransportType == HttpTransportType.None)
-        {
-            if (HttpConnectionsEventSource.Log.IsEnabled() || connection.MetricsContext.ConnectionDurationEnabled)
-            {
-                connection.StartTimestamp = Stopwatch.GetTimestamp();
-            }
-
-            connection.TransportType = transportType;
-
-            HttpConnectionsEventSource.Log.ConnectionStart(connection.ConnectionId);
-            _metrics.ConnectionTransportStart(connection.MetricsContext, transportType);
-        }
-        else if (connection.TransportType != transportType)
-        {
-            context.Response.ContentType = "text/plain";
-            context.Response.StatusCode = StatusCodes.Status400BadRequest;
-            Log.CannotChangeTransport(_logger, connection.TransportType, transportType);
-            await context.Response.WriteAsync("Cannot change transports mid-connection");
-            return false;
-        }
 
         // Configure transport-specific features.
         if (transportType == HttpTransportType.LongPolling)

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -450,7 +450,6 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             var manager = CreateConnectionManager(LoggerFactory);
             var dispatcher = CreateDispatcher(manager, LoggerFactory);
             var connection = manager.CreateConnection();
-            connection.TransportType = transportType;
 
             using (var strm = new MemoryStream())
             {
@@ -1001,7 +1000,6 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         {
             var manager = CreateConnectionManager(LoggerFactory);
             var connection = manager.CreateConnection();
-            connection.TransportType = HttpTransportType.ServerSentEvents;
 
             var dispatcher = CreateDispatcher(manager, LoggerFactory);
 
@@ -1036,7 +1034,6 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         {
             var manager = CreateConnectionManager(LoggerFactory);
             var connection = manager.CreateConnection();
-            connection.TransportType = HttpTransportType.ServerSentEvents;
 
             var dispatcher = CreateDispatcher(manager, LoggerFactory);
             var services = new ServiceCollection();
@@ -1315,12 +1312,11 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         {
             var manager = CreateConnectionManager(LoggerFactory);
             var connection = manager.CreateConnection();
-            connection.TransportType = HttpTransportType.ServerSentEvents;
             var dispatcher = CreateDispatcher(manager, LoggerFactory);
             var services = new ServiceCollection();
             services.AddSingleton<TestConnectionHandler>();
             var context = MakeRequest("/foo", connection, services);
-            SetTransport(context, connection.TransportType);
+            SetTransport(context, HttpTransportType.ServerSentEvents);
             var builder = new ConnectionBuilder(services.BuildServiceProvider());
             builder.UseConnectionHandler<TestConnectionHandler>();
             var app = builder.Build();
@@ -1352,13 +1348,12 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         {
             var manager = CreateConnectionManager(LoggerFactory);
             var connection = manager.CreateConnection();
-            connection.TransportType = HttpTransportType.WebSockets;
             var dispatcher = CreateDispatcher(manager, LoggerFactory);
             var sync = new SyncPoint();
             var services = new ServiceCollection();
             services.AddSingleton<TestConnectionHandler>();
             var context = MakeRequest("/foo", connection, services);
-            SetTransport(context, connection.TransportType, sync);
+            SetTransport(context, HttpTransportType.WebSockets, sync);
             var builder = new ConnectionBuilder(services.BuildServiceProvider());
             builder.UseConnectionHandler<TestConnectionHandler>();
             var app = builder.Build();
@@ -1414,7 +1409,6 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         {
             var manager = CreateConnectionManager(LoggerFactory);
             var connection = manager.CreateConnection();
-            connection.TransportType = transportType;
 
             var dispatcher = CreateDispatcher(manager, LoggerFactory);
 
@@ -1434,7 +1428,10 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
 
             await dispatcher.ExecuteAsync(context2, options, app).DefaultTimeout();
 
+            Assert.False(request1.IsCompleted);
+
             Assert.Equal(StatusCodes.Status409Conflict, context2.Response.StatusCode);
+            Assert.NotSame(connection.HttpContext, context2);
 
             var webSocketTask = Task.CompletedTask;
 
@@ -1586,7 +1583,6 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         {
             var manager = CreateConnectionManager(LoggerFactory);
             var connection = manager.CreateConnection();
-            connection.TransportType = transportType;
             connection.Status = HttpConnectionStatus.Disposed;
 
             var dispatcher = CreateDispatcher(manager, LoggerFactory);
@@ -1653,7 +1649,6 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         {
             var manager = CreateConnectionManager(LoggerFactory);
             var connection = manager.CreateConnection();
-            connection.TransportType = HttpTransportType.ServerSentEvents;
 
             var dispatcher = CreateDispatcher(manager, LoggerFactory);
 
@@ -1777,7 +1772,6 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         {
             var manager = CreateConnectionManager(LoggerFactory);
             var connection = manager.CreateConnection();
-            connection.TransportType = transportType;
 
             var dispatcher = CreateDispatcher(manager, LoggerFactory);
 
@@ -2434,7 +2428,6 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             options.WebSockets.CloseTimeout = TimeSpan.FromMilliseconds(1);
             // pretend negotiate occurred
             var connection = manager.CreateConnection(options, negotiateVersion: 1, useStatefulReconnect: true);
-            connection.TransportType = HttpTransportType.WebSockets;
 
             var dispatcher = CreateDispatcher(manager, LoggerFactory);
             var services = new ServiceCollection();
@@ -2800,12 +2793,11 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         {
             var manager = CreateConnectionManager(LoggerFactory);
             var connection = manager.CreateConnection();
-            connection.TransportType = HttpTransportType.ServerSentEvents;
             var dispatcher = CreateDispatcher(manager, LoggerFactory);
             var services = new ServiceCollection();
             services.AddSingleton<NeverEndingConnectionHandler>();
             var context = MakeRequest("/foo", connection, services);
-            SetTransport(context, connection.TransportType);
+            SetTransport(context, HttpTransportType.ServerSentEvents);
 
             var builder = new ConnectionBuilder(services.BuildServiceProvider());
             builder.UseConnectionHandler<NeverEndingConnectionHandler>();
@@ -2827,7 +2819,6 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         {
             var manager = CreateConnectionManager(LoggerFactory);
             var connection = manager.CreateConnection();
-            connection.TransportType = HttpTransportType.WebSockets;
 
             var dispatcher = CreateDispatcher(manager, LoggerFactory);
             var services = new ServiceCollection();
@@ -2875,14 +2866,13 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         {
             var manager = CreateConnectionManager(LoggerFactory);
             var connection = manager.CreateConnection();
-            connection.TransportType = HttpTransportType.ServerSentEvents;
             var dispatcher = CreateDispatcher(manager, LoggerFactory);
             var services = new ServiceCollection();
             services.AddSingleton<NeverEndingConnectionHandler>();
             var context = MakeRequest("/foo", connection, services);
             var lifetimeFeature = new CustomHttpRequestLifetimeFeature();
             context.Features.Set<IHttpRequestLifetimeFeature>(lifetimeFeature);
-            SetTransport(context, connection.TransportType);
+            SetTransport(context, HttpTransportType.ServerSentEvents);
 
             var builder = new ConnectionBuilder(services.BuildServiceProvider());
             builder.UseConnectionHandler<NeverEndingConnectionHandler>();
@@ -3062,7 +3052,6 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         {
             var manager = CreateConnectionManager(LoggerFactory);
             var connection = manager.CreateConnection();
-            connection.TransportType = HttpTransportType.ServerSentEvents;
 
             var dispatcher = CreateDispatcher(manager, LoggerFactory);
             var services = new ServiceCollection();
@@ -3313,56 +3302,56 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         var JwtTokenHandler = new JwtSecurityTokenHandler();
 
         using var host = CreateHost(services =>
+        {
+            // Set default to Cookie auth but use JWT auth for the endpoint
+            // This makes sure we take the scheme into account when grabbing the token expiration
+            services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+            .AddCookie()
+            .AddJwtBearer(options =>
             {
-                // Set default to Cookie auth but use JWT auth for the endpoint
-                // This makes sure we take the scheme into account when grabbing the token expiration
-                services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
-                .AddCookie()
-                .AddJwtBearer(options =>
-                {
-                    options.TokenValidationParameters =
-                        new TokenValidationParameters
-                        {
-                            LifetimeValidator = (before, expires, token, parameters) => expires > DateTime.UtcNow,
-                            ValidateAudience = false,
-                            ValidateIssuer = false,
-                            ValidateActor = false,
-                            ValidateLifetime = true,
-                            IssuerSigningKey = SecurityKey
-                        };
-
-                    options.Events = new JwtBearerEvents
+                options.TokenValidationParameters =
+                    new TokenValidationParameters
                     {
-                        OnMessageReceived = context =>
-                        {
-                            var accessToken = context.Request.Query["access_token"];
-
-                            if (!string.IsNullOrEmpty(accessToken) &&
-                                (context.HttpContext.WebSockets.IsWebSocketRequest || context.Request.Headers["Accept"] == "text/event-stream"))
-                            {
-                                context.Token = context.Request.Query["access_token"];
-                            }
-                            return Task.CompletedTask;
-                        }
+                        LifetimeValidator = (before, expires, token, parameters) => expires > DateTime.UtcNow,
+                        ValidateAudience = false,
+                        ValidateIssuer = false,
+                        ValidateActor = false,
+                        ValidateLifetime = true,
+                        IssuerSigningKey = SecurityKey
                     };
-                });
-            }, endpoints =>
+
+                options.Events = new JwtBearerEvents
+                {
+                    OnMessageReceived = context =>
+                    {
+                        var accessToken = context.Request.Query["access_token"];
+
+                        if (!string.IsNullOrEmpty(accessToken) &&
+                            (context.HttpContext.WebSockets.IsWebSocketRequest || context.Request.Headers["Accept"] == "text/event-stream"))
+                        {
+                            context.Token = context.Request.Query["access_token"];
+                        }
+                        return Task.CompletedTask;
+                    }
+                };
+            });
+        }, endpoints =>
+        {
+            endpoints.MapConnectionHandler<JwtConnectionHandler>("/foo", o => o.CloseOnAuthenticationExpiration = true);
+
+            endpoints.MapGet("/generatetoken", context =>
             {
-                endpoints.MapConnectionHandler<JwtConnectionHandler>("/foo", o => o.CloseOnAuthenticationExpiration = true);
+                return context.Response.WriteAsync(GenerateToken(context));
+            });
 
-                endpoints.MapGet("/generatetoken", context =>
-                {
-                    return context.Response.WriteAsync(GenerateToken(context));
-                });
-
-                string GenerateToken(HttpContext httpContext)
-                {
-                    var claims = new[] { new Claim(ClaimTypes.NameIdentifier, httpContext.Request.Query["user"]) };
-                    var credentials = new SigningCredentials(SecurityKey, SecurityAlgorithms.HmacSha256);
-                    var token = new JwtSecurityToken("SignalRTestServer", "SignalRTests", claims, expires: DateTime.UtcNow.AddMinutes(1), signingCredentials: credentials);
-                    return JwtTokenHandler.WriteToken(token);
-                }
-            }, LoggerFactory);
+            string GenerateToken(HttpContext httpContext)
+            {
+                var claims = new[] { new Claim(ClaimTypes.NameIdentifier, httpContext.Request.Query["user"]) };
+                var credentials = new SigningCredentials(SecurityKey, SecurityAlgorithms.HmacSha256);
+                var token = new JwtSecurityToken("SignalRTestServer", "SignalRTests", claims, expires: DateTime.UtcNow.AddMinutes(1), signingCredentials: credentials);
+                return JwtTokenHandler.WriteToken(token);
+            }
+        }, LoggerFactory);
 
         host.Start();
 
@@ -3639,7 +3628,6 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
     {
         var manager = CreateConnectionManager(loggerFactory);
         var connection = manager.CreateConnection();
-        connection.TransportType = transportType;
 
         var dispatcher = CreateDispatcher(manager, loggerFactory);
         using (var strm = new MemoryStream())


### PR DESCRIPTION
### Customer Impact

There was a race on the server where you could connect with the ID for a closing connection and it would start the connection again, when it should have either returned a 409 or 404.

This can break app developer assumptions since they may have used the connection ID for some state (Database, in memory dictionary, etc.) and when a new connection with the same ID connects again it can break their code.

This is fixed by checking if Stateful Reconnect is being used and adding a lock around updating the `TransportType` so it can only be changed once. i.e. Parallel connect requests can't compete and cause any issues.

### Risk

Low. The code is all the same except we added a lock around it so parallel requests can't compete. The lock should not be highly contended unless someone was maliciously trying to find issues by using parallel requests.