### PR TITLE
Fix Set size in HttpLoggingOptions

### DIFF
--- a/src/Middleware/HttpLogging/src/HttpLoggingOptions.cs
+++ b/src/Middleware/HttpLogging/src/HttpLoggingOptions.cs
@@ -68,7 +68,7 @@ public sealed class HttpLoggingOptions
     /// </summary>
     public ISet<string> ResponseHeaders => _internalResponseHeaders;
 
-    internal HashSet<string> _internalResponseHeaders = new HashSet<string>(20, StringComparer.OrdinalIgnoreCase)
+    internal HashSet<string> _internalResponseHeaders = new HashSet<string>(19, StringComparer.OrdinalIgnoreCase)
         {
             HeaderNames.AcceptRanges,
             HeaderNames.Age,


### PR DESCRIPTION
One of `ResponseHeaders` has been removed in this commit ([src/Middleware/HttpLogging/src/HttpLoggingOptions.cs)](https://github.com/Kahbazi/AspNetCore/commit/0240b1f62c8c1b6cf5875d5e3ef49759afe5ad8e#diff-4057675d06471b2325ba2bc536a606577aacbc36c2096e5743e5a9e8dfbefb6d)) so I'm just updating the HashSet size.