### PR TITLE
Increment HubProtocol version for Stateful Reconnect

### DIFF
--- a/src/Components/Server/src/BlazorPack/BlazorPackHubProtocol.cs
+++ b/src/Components/Server/src/BlazorPack/BlazorPackHubProtocol.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Components.Server.BlazorPack;
 internal sealed class BlazorPackHubProtocol : IHubProtocol
 {
     internal const string ProtocolName = "blazorpack";
-    private const int ProtocolVersion = 1;
+    private const int ProtocolVersion = 2;
 
     private readonly BlazorPackHubProtocolWorker _worker = new BlazorPackHubProtocolWorker();
 
@@ -32,7 +32,7 @@ internal sealed class BlazorPackHubProtocol : IHubProtocol
     /// <inheritdoc />
     public bool IsVersionSupported(int version)
     {
-        return version == Version;
+        return version <= Version;
     }
 
     /// <inheritdoc />

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.Log.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.Log.cs
@@ -334,5 +334,8 @@ public partial class HubConnection
 
         [LoggerMessage(92, LogLevel.Trace, "Received SequenceMessage with Sequence ID '{SequenceId}'.", EventName = "ReceivedSequenceMessage")]
         public static partial void ReceivedSequenceMessage(ILogger logger, long sequenceId);
+
+        [LoggerMessage(93, LogLevel.Debug, "HubProtocol '{Protocol} v{Version}' does not support Stateful Reconnect. Disabling the feature.", EventName = "DisablingReconnect")]
+        public static partial void DisablingReconnect(ILogger logger, string protocol, int version);
     }
 }

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -481,12 +481,31 @@ public partial class HubConnection : IAsyncDisposable
         var connection = await _connectionFactory.ConnectAsync(_endPoint, cancellationToken).ConfigureAwait(false);
         var startingConnectionState = new ConnectionState(connection, this);
 
+#pragma warning disable CA2252 // This API requires opting into preview features
+        var statefulReconnectFeature = connection.Features.Get<IStatefulReconnectFeature>();
+#pragma warning restore CA2252 // This API requires opting into preview features
+
         // From here on, if an error occurs we need to shut down the connection because
         // we still own it.
         try
         {
-            Log.HubProtocol(_logger, _protocol.Name, _protocol.Version);
-            await HandshakeAsync(startingConnectionState, cancellationToken).ConfigureAwait(false);
+            var usedProtocolVersion = _protocol.Version;
+            if (statefulReconnectFeature is null)
+            {
+                // Stateful Reconnect starts with HubProtocol version 2, newer clients connecting to older servers will fail to connect due to
+                // the handshake only supporting version 1, so we will try to send version 1 during the handshake to keep old servers working.
+                usedProtocolVersion = _protocol.IsVersionSupported(1) ? 1 : _protocol.Version;
+            }
+            else if (_protocol.Version < 2)
+            {
+                Log.DisablingReconnect(_logger, _protocol.Name, _protocol.Version);
+#pragma warning disable CA2252 // This API requires opting into preview features
+                statefulReconnectFeature.DisableReconnect();
+#pragma warning restore CA2252 // This API requires opting into preview features
+            }
+
+            Log.HubProtocol(_logger, _protocol.Name, usedProtocolVersion);
+            await HandshakeAsync(startingConnectionState, usedProtocolVersion, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -1240,12 +1259,12 @@ public partial class HubConnection : IAsyncDisposable
         ObjectDisposedThrowHelper.ThrowIf(_disposed, this);
     }
 
-    private async Task HandshakeAsync(ConnectionState startingConnectionState, CancellationToken cancellationToken)
+    private async Task HandshakeAsync(ConnectionState startingConnectionState, int protocolVersion, CancellationToken cancellationToken)
     {
         // Send the Handshake request
         Log.SendingHubHandshake(_logger);
 
-        var handshakeRequest = new HandshakeRequestMessage(_protocol.Name, _protocol.Version);
+        var handshakeRequest = new HandshakeRequestMessage(_protocol.Name, protocolVersion);
         HandshakeProtocol.WriteRequestMessage(handshakeRequest, startingConnectionState.Connection.Transport.Output);
 
         var sendHandshakeResult = await startingConnectionState.Connection.Transport.Output.FlushAsync(CancellationToken.None).ConfigureAwait(false);

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -2833,6 +2833,83 @@ public class HubConnectionTests : FunctionalTestBase
         }
     }
 
+    [Fact]
+    public async Task ServerWithOldProtocolVersionClientWithNewProtocolVersionWorksDoesNotAllowStatefulReconnect()
+    {
+        bool ExpectedErrors(WriteContext writeContext)
+        {
+            return writeContext.LoggerName == typeof(HubConnection).FullName &&
+                   (writeContext.EventId.Name == "ShutdownWithError" ||
+                   writeContext.EventId.Name == "ServerDisconnectedWithError");
+        }
+
+        var protocol = HubProtocols["json"];
+        await using (var server = await StartServer<Startup>(ExpectedErrors))
+        {
+            var websocket = new ClientWebSocket();
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            tcs.SetResult();
+
+            const string originalMessage = "SignalR";
+            var connectionBuilder = new HubConnectionBuilder()
+                .WithLoggerFactory(LoggerFactory)
+                .WithUrl(server.Url + "/default", HttpTransportType.WebSockets, o =>
+                {
+                    o.WebSocketFactory = async (context, token) =>
+                    {
+                        await tcs.Task;
+                        await websocket.ConnectAsync(context.Uri, token);
+                        tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                        return websocket;
+                    };
+                    o.UseStatefulReconnect = true;
+                });
+            // Force version 1 on the server so it turns off Stateful Reconnects
+            connectionBuilder.Services.AddSingleton<IHubProtocol>(new HubProtocolVersionTests.SingleVersionHubProtocol(HubProtocols["json"], 1));
+            var connection = connectionBuilder.Build();
+
+            var closedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            connection.Closed += (_) =>
+            {
+                closedTcs.SetResult();
+                return Task.CompletedTask;
+            };
+
+            try
+            {
+                await connection.StartAsync().DefaultTimeout();
+                var originalConnectionId = connection.ConnectionId;
+
+                var result = await connection.InvokeAsync<string>(nameof(TestHub.Echo), originalMessage).DefaultTimeout();
+
+                Assert.Equal(originalMessage, result);
+
+                var originalWebsocket = websocket;
+                websocket = new ClientWebSocket();
+                originalWebsocket.Dispose();
+
+                var resultTask = connection.InvokeAsync<string>(nameof(TestHub.Echo), originalMessage).DefaultTimeout();
+                tcs.SetResult();
+
+                // In-progress send canceled when connection closes
+                var ex = await Assert.ThrowsAnyAsync<Exception>(() => resultTask);
+                Assert.True(ex is TaskCanceledException or WebSocketException);
+                await closedTcs.Task;
+
+                Assert.Equal(HubConnectionState.Disconnected, connection.State);
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                await connection.DisposeAsync().DefaultTimeout();
+            }
+        }
+    }
+
     private class OneAtATimeSynchronizationContext : SynchronizationContext, IAsyncDisposable
     {
         private readonly Channel<(SendOrPostCallback, object)> _taskQueue = Channel.CreateUnbounded<(SendOrPostCallback, object)>();

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubProtocolVersionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubProtocolVersionTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Text;
 using System.Threading;
@@ -171,7 +172,7 @@ public class HubProtocolVersionTests : FunctionalTestBase
             var connectionBuilder = new HubConnectionBuilder()
                 .WithLoggerFactory(LoggerFactory)
                 .WithUrl(server.Url + "/version", transportType);
-            connectionBuilder.Services.AddSingleton<IHubProtocol>(new VersionedJsonHubProtocol(int.MaxValue));
+            connectionBuilder.Services.AddSingleton<IHubProtocol>(new SingleVersionHubProtocol(new VersionedJsonHubProtocol(int.MaxValue), int.MaxValue));
 
             var connection = connectionBuilder.Build();
 
@@ -190,6 +191,41 @@ public class HubProtocolVersionTests : FunctionalTestBase
             {
                 await connection.DisposeAsync().DefaultTimeout();
             }
+        }
+    }
+
+    public class SingleVersionHubProtocol : IHubProtocol
+    {
+        private readonly IHubProtocol _protocol;
+        private readonly int _version;
+
+        public SingleVersionHubProtocol(IHubProtocol inner, int version)
+        {
+            _protocol = inner;
+            _version = version;
+        }
+
+        public string Name => _protocol.Name;
+
+        public int Version => _version;
+
+        public TransferFormat TransferFormat => _protocol.TransferFormat;
+
+        public ReadOnlyMemory<byte> GetMessageBytes(HubMessage message) => _protocol.GetMessageBytes(message);
+
+        public bool IsVersionSupported(int version)
+        {
+            return version == _version;
+        }
+
+        public bool TryParseMessage(ref ReadOnlySequence<byte> input, IInvocationBinder binder, [NotNullWhen(true)] out HubMessage message)
+        {
+            return _protocol.TryParseMessage(ref input, binder, out message);
+        }
+
+        public void WriteMessage(HubMessage message, IBufferWriter<byte> output)
+        {
+            _protocol.WriteMessage(message, output);
         }
     }
 

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
@@ -402,22 +402,17 @@ internal sealed partial class WebSocketsTransport : ITransport, IStatefulReconne
         var cleanup = true;
         try
         {
-            if (_useStatefulReconnect && !_gracefulClose)
+            if (!_gracefulClose && UpdateConnectionPair())
             {
-                if (!UpdateConnectionPair())
-                {
-                    return;
-                }
-
                 try
                 {
                     await StartAsync(url, _webSocketMessageType == WebSocketMessageType.Binary ? TransferFormat.Binary : TransferFormat.Text,
                         cancellationToken: default).ConfigureAwait(false);
                     cleanup = false;
                 }
-                catch
+                catch (Exception ex)
                 {
-                    throw new InvalidOperationException("Reconnect attempt failed.");
+                    throw new InvalidOperationException("Reconnect attempt failed.", innerException: ex);
                 }
             }
         }

--- a/src/SignalR/clients/ts/signalr-protocol-msgpack/src/MessagePackHubProtocol.ts
+++ b/src/SignalR/clients/ts/signalr-protocol-msgpack/src/MessagePackHubProtocol.ts
@@ -26,7 +26,7 @@ export class MessagePackHubProtocol implements IHubProtocol {
     /** The name of the protocol. This is used by SignalR to resolve the protocol between the client and server. */
     public readonly name: string = "messagepack";
     /** The version of the protocol. */
-    public readonly version: number = 1;
+    public readonly version: number = 2;
     /** The TransferFormat of the protocol. */
     public readonly transferFormat: TransferFormat = TransferFormat.Binary;
 

--- a/src/SignalR/clients/ts/signalr/src/JsonHubProtocol.ts
+++ b/src/SignalR/clients/ts/signalr/src/JsonHubProtocol.ts
@@ -15,7 +15,7 @@ export class JsonHubProtocol implements IHubProtocol {
     /** @inheritDoc */
     public readonly name: string = JSON_HUB_PROTOCOL_NAME;
     /** @inheritDoc */
-    public readonly version: number = 1;
+    public readonly version: number = 2;
 
     /** @inheritDoc */
     public readonly transferFormat: TransferFormat = TransferFormat.Text;

--- a/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs
+++ b/src/SignalR/common/Protocols.Json/src/Protocol/JsonHubProtocol.cs
@@ -47,7 +47,7 @@ public sealed class JsonHubProtocol : IHubProtocol
     private static readonly JsonEncodedText SequenceIdPropertyNameBytes = JsonEncodedText.Encode(SequenceIdPropertyName);
 
     private const string ProtocolName = "json";
-    private const int ProtocolVersion = 1;
+    private const int ProtocolVersion = 2;
 
     /// <summary>
     /// Gets the serializer used to serialize invocation arguments and return values.
@@ -82,7 +82,7 @@ public sealed class JsonHubProtocol : IHubProtocol
     /// <inheritdoc />
     public bool IsVersionSupported(int version)
     {
-        return version == Version;
+        return version <= Version;
     }
 
     /// <inheritdoc />

--- a/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocol.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.SignalR.Protocol;
 public class MessagePackHubProtocol : IHubProtocol
 {
     private const string ProtocolName = "messagepack";
-    private const int ProtocolVersion = 1;
+    private const int ProtocolVersion = 2;
     private readonly DefaultMessagePackHubProtocolWorker _worker;
 
     /// <inheritdoc />
@@ -53,7 +53,7 @@ public class MessagePackHubProtocol : IHubProtocol
     /// <inheritdoc />
     public bool IsVersionSupported(int version)
     {
-        return version == Version;
+        return version <= Version;
     }
 
     /// <inheritdoc />

--- a/src/SignalR/common/Protocols.NewtonsoftJson/src/Protocol/NewtonsoftJsonHubProtocol.cs
+++ b/src/SignalR/common/Protocols.NewtonsoftJson/src/Protocol/NewtonsoftJsonHubProtocol.cs
@@ -37,7 +37,7 @@ public class NewtonsoftJsonHubProtocol : IHubProtocol
     private const string SequenceIdPropertyName = "sequenceId";
 
     private const string ProtocolName = "json";
-    private const int ProtocolVersion = 1;
+    private const int ProtocolVersion = 2;
 
     /// <summary>
     /// Gets the serializer used to serialize invocation arguments and return values.
@@ -72,7 +72,7 @@ public class NewtonsoftJsonHubProtocol : IHubProtocol
     /// <inheritdoc />
     public bool IsVersionSupported(int version)
     {
-        return version == Version;
+        return version <= Version;
     }
 
     /// <inheritdoc />

--- a/src/SignalR/server/Core/src/HubConnectionContext.Log.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.Log.cs
@@ -38,5 +38,8 @@ public partial class HubConnectionContext
 
         [LoggerMessage(10, LogLevel.Debug, "The maximum message size of {MaxMessageSize}B was exceeded while parsing the Handshake. The message size can be configured in AddHubOptions.", EventName = "HandshakeSizeLimitExceeded")]
         public static partial void HandshakeSizeLimitExceeded(ILogger logger, long maxMessageSize);
+
+        [LoggerMessage(11, LogLevel.Debug, "HubProtocol '{Protocol} v{Version}' does not support Stateful Reconnect. Disabling the feature.", EventName = "DisablingReconnect")]
+        public static partial void DisablingReconnect(ILogger logger, string protocol, int version);
     }
 }

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -132,7 +132,7 @@ internal sealed partial class DefaultHubDispatcher<THub> : HubDispatcher<THub> w
 
         if (!connection.ShouldProcessMessage(hubMessage))
         {
-            Log.DroppingMessage(_logger, ((HubInvocationMessage)hubMessage).GetType().Name, ((HubInvocationMessage)hubMessage).InvocationId);
+            Log.DroppingMessage(_logger, hubMessage.GetType().Name, (hubMessage as HubInvocationMessage)?.InvocationId ?? "(null)");
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
HubProtocol version 2 adds AckMessage and SequenceMessage as well as the back-and-forth protocol involving them.

* If a HubProtocol version 1 is used we disable stateful reconnect.
* If stateful reconnect isn't being used by the client we use HubProtocol version 1 so old servers with new clients will continue to work.

### Customer Impact

Customers using new clients with old servers, or custom `IHubProtocol` implementations ([example](https://github.com/Azure/azure-signalr/blob/dev/src/Microsoft.Azure.SignalR.Management/Serialization/JsonObjectSerializerHubProtocol.cs#L33)) could have the connection closed by the server when trying to use the new stateful reconnect feature. This is because we added new protocol messages that old `IHubProtocol` implementations don't understand which would result in an "unknown message" failure and the server would close the connection.

This PR fixes it so new clients can connect to old servers when using the feature. And we'll turn the feature off for them (with a log).

### Risk

Low. The fix mainly just tells the user that we disabled the stateful reconnect feature (before it's even used) for them when we detect either of the cases (old server, not supported `IHubProtocol`).