### PR TITLE
Fix exception handling for complex form mapping in minimal APIs

### DIFF
--- a/src/Components/Endpoints/src/FormMapping/FormDataResources.resx
+++ b/src/Components/Endpoints/src/FormMapping/FormDataResources.resx
@@ -124,7 +124,7 @@
     <value>The value '{0}' is not valid for '{1}'.</value>
   </data>
   <data name="MappingExceptionMessage" xml:space="preserve">
-    <value>An error occurred while trying to map a value from form data. For more details, see the 'Error' property and the `InnerException' property.</value>
+    <value>An error occurred while trying to map a value from form data. For more details, see the 'Error' property and the 'InnerException' property.</value>
   </data>
   <data name="MaxCollectionSizeReached" xml:space="preserve">
     <value>The number of elements in the {0} exceeded the maximum number of '{1}' elements allowed.</value>

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -81,6 +81,8 @@ public static partial class RequestDelegateFactory
         Log.RequiredParameterNotProvided(httpContext, parameterType, parameterName, source, shouldThrow));
     private static readonly MethodInfo LogImplicitBodyNotProvidedMethod = GetMethodInfo<Action<HttpContext, string, bool>>((httpContext, parameterName, shouldThrow) =>
         Log.ImplicitBodyNotProvided(httpContext, parameterName, shouldThrow));
+    private static readonly MethodInfo LogFormMappingFailedMethod = GetMethodInfo<Action<HttpContext, string, string, FormDataMappingException, bool>>((httpContext, parameterName, parameterType, exception, shouldThrow) =>
+        Log.FormDataMappingFailed(httpContext, parameterName, parameterType, exception, shouldThrow));
 
     private static readonly ParameterExpression TargetExpr = Expression.Parameter(typeof(object), "target");
     private static readonly ParameterExpression BodyValueExpr = Expression.Parameter(typeof(object), "bodyValue");
@@ -2026,7 +2028,7 @@ public static partial class RequestDelegateFactory
             var key = parameter.Name!;
             if (factoryContext.TrackedParameters.TryGetValue(key, out var trackedParameter) && trackedParameter == RequestDelegateFactoryConstants.FormBindingAttribute)
             {
-                factoryContext.ArgumentExpressions[i] = BindComplexParameterFromFormItem(parameter, key, factoryContext);
+                factoryContext.ArgumentExpressions[i] = BindComplexParameterFromFormItem(parameter, key, factoryContext, i);
             }
         }
     }
@@ -2034,7 +2036,8 @@ public static partial class RequestDelegateFactory
     private static Expression BindComplexParameterFromFormItem(
         ParameterInfo parameter,
         string key,
-        RequestDelegateFactoryContext factoryContext)
+        RequestDelegateFactoryContext factoryContext,
+        int? index = null)
     {
         factoryContext.FirstFormRequestBodyParameter ??= parameter;
         factoryContext.TrackedParameters.TryAdd(key, RequestDelegateFactoryConstants.FormBindingAttribute);
@@ -2056,6 +2059,7 @@ public static partial class RequestDelegateFactory
         var formReader = Expression.Variable(typeof(FormDataReader), $"{parameter.Name}_reader");
         var formDict = Expression.Variable(typeof(IReadOnlyDictionary<FormKey, StringValues>), "form_dict");
         var formBuffer = Expression.Variable(typeof(char[]), "form_buffer");
+        var formDataMappingException = Expression.Variable(typeof(FormDataMappingException), "form_exception");
 
         // ProcessForm(context.Request.Form, form_dict, form_buffer);
         var processFormExpr = Expression.Call(ProcessFormMethod, FormExpr, Expression.Constant(formDataMapperOptions.MaxKeyBufferSize), formDict, formBuffer);
@@ -2088,17 +2092,65 @@ public static partial class RequestDelegateFactory
             Expression.NotEqual(formBuffer, Expression.Constant(null)),
             returnBufferExpr);
 
-        return Expression.Block(
-            new[] { formArgument, formReader, formDict, formBuffer },
-            Expression.TryFinally(
+        var parameterTypeNameConstant = Expression.Constant(TypeNameHelper.GetTypeDisplayName(parameter.ParameterType, fullName: false));
+        var parameterNameConstant = Expression.Constant(parameter.Name);
+
+        // try
+        // {
+        //   ProcessForm(context.Request.Form, form_dict, form_buffer);
+        //   name_reader = new FormDataReader(form_dict, CultureInfo.InvariantCulture, form_buffer.AsMemory(0, FormDataMapperOptions.MaxKeyBufferSize));
+        //   name_reader.MaxRecursionDepth = formDataMapperOptions.MaxRecursionDepth;
+        //   name_local = FormDataMapper.Map<string>(name_reader, FormDataMapperOptions);
+        // }
+        // catch (FormDataMappingException e)
+        // {
+        //    wasParamCheckFailure = true;
+        // }
+        // finally
+        // {
+        //   if (form_buffer != null)
+        //   {
+        //     ArrayPool<char>.Shared.Return(form_buffer, false);
+        //   }
+        // }
+        var bindAndCheckForm = Expression.Block(
+            new[] { formReader, formDict, formBuffer, formDataMappingException },
+            Expression.TryCatchFinally(
                 Expression.Block(
+                    typeof(void),
                     processFormExpr,
                     initializeReaderExpr,
                     setMaxRecursionDepthExpr,
                     Expression.Assign(formArgument, invokeMapMethodExpr)),
-                conditionalReturnBufferExpr),
-            formArgument
+                conditionalReturnBufferExpr,
+                Expression.Catch(formDataMappingException, Expression.Block(
+                    typeof(void),
+                    Expression.Assign(WasParamCheckFailureExpr, Expression.Constant(true)),
+                    Expression.Call(
+                        LogFormMappingFailedMethod,
+                        HttpContextExpr,
+                        parameterTypeNameConstant,
+                        parameterNameConstant,
+                        formDataMappingException,
+                        Expression.Constant(factoryContext.ThrowOnBadRequest))
+                )))
         );
+
+        // Update the existing expressions if they already exist and we're
+        // recomputing the form binding expressions after reading endpoint
+        // metadata.
+        if (index is {} i)
+        {
+            factoryContext.ParamCheckExpressions[i] = bindAndCheckForm;
+            factoryContext.ExtraLocals[i] = formArgument;
+        }
+        else
+        {
+            factoryContext.ParamCheckExpressions.Add(bindAndCheckForm);
+            factoryContext.ExtraLocals.Add(formArgument);
+        }
+
+        return formArgument;
     }
 
     private static void ProcessForm(IFormCollection form, int maxKeyBufferSize, ref IReadOnlyDictionary<FormKey, StringValues> formDictionary, ref char[] buffer)
@@ -2641,6 +2693,20 @@ public static partial class RequestDelegateFactory
 
         [LoggerMessage(RequestDelegateCreationLogging.InvalidAntiforgeryTokenEventId, LogLevel.Debug, RequestDelegateCreationLogging.InvalidAntiforgeryTokenLogMessage, EventName = RequestDelegateCreationLogging.InvalidAntiforgeryTokenEventName)]
         private static partial void InvalidAntiforgeryToken(ILogger logger, string parameterType, string parameterName, Exception exception);
+
+        public static void FormDataMappingFailed(HttpContext httpContext, string parameterTypeName, string parameterName, FormDataMappingException exception, bool shouldThrow)
+        {
+            if (shouldThrow)
+            {
+                var message = string.Format(CultureInfo.InvariantCulture, exception.Error.Message.Format, exception.Error.Message.GetArguments());
+                throw new BadHttpRequestException(message, exception);
+            }
+
+            FormDataMappingFailed(GetLogger(httpContext), parameterTypeName, parameterName, exception);
+        }
+
+        [LoggerMessage(RequestDelegateCreationLogging.FormDataMappingFailedEventId, LogLevel.Debug, RequestDelegateCreationLogging.FormDataMappingFailedLogMessage, EventName = RequestDelegateCreationLogging.FormDataMappingFailedEventName)]
+        private static partial void FormDataMappingFailed(ILogger logger, string parameterType, string parameterName, Exception exception);
 
         private static ILogger GetLogger(HttpContext httpContext)
         {

--- a/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.FormMapping.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateFactoryTests.FormMapping.cs
@@ -23,6 +23,7 @@ public partial class RequestDelegateFactoryTests : LoggedTest
             {
                 new FormMappingOptionsMetadata(maxCollectionSize: 2)
             }),
+            ThrowOnBadRequest = true
         };
         var metadataResult = new RequestDelegateMetadataResult { EndpointMetadata = new List<object>() };
         var httpContext = CreateHttpContext();
@@ -52,10 +53,10 @@ public partial class RequestDelegateFactoryTests : LoggedTest
         var requestDelegate = factoryResult.RequestDelegate;
 
         // Act
-        var exception = await Assert.ThrowsAsync<FormDataMappingException>(async () => await requestDelegate(httpContext));
+        var exception = await Assert.ThrowsAsync<BadHttpRequestException>(async () => await requestDelegate(httpContext));
 
         // Assert
-        Assert.Equal("The number of elements in the dictionary exceeded the maximum number of '2' elements allowed.", exception.Error.Message.ToString(CultureInfo.InvariantCulture));
+        Assert.Equal("The number of elements in the dictionary exceeded the maximum number of '2' elements allowed.", exception.Message);
     }
 
     [Fact]
@@ -69,6 +70,7 @@ public partial class RequestDelegateFactoryTests : LoggedTest
             {
                 new FormMappingOptionsMetadata(maxCollectionSize: 2)
             }),
+            ThrowOnBadRequest = true
         };
         var metadataResult = new RequestDelegateMetadataResult { EndpointMetadata = new List<object>() };
         var httpContext = CreateHttpContext();
@@ -98,10 +100,10 @@ public partial class RequestDelegateFactoryTests : LoggedTest
         var requestDelegate = factoryResult.RequestDelegate;
 
         // Act
-        var exception = await Assert.ThrowsAsync<FormDataMappingException>(async () => await requestDelegate(httpContext));
+        var exception = await Assert.ThrowsAsync<BadHttpRequestException>(async () => await requestDelegate(httpContext));
 
         // Assert
-        Assert.Equal("The number of elements in the dictionary exceeded the maximum number of '2' elements allowed.", exception.Error.Message.ToString(CultureInfo.InvariantCulture));
+        Assert.Equal("The number of elements in the dictionary exceeded the maximum number of '2' elements allowed.", exception.Message);
     }
 
     [Fact]
@@ -116,6 +118,7 @@ public partial class RequestDelegateFactoryTests : LoggedTest
                 new FormMappingOptionsMetadata(maxCollectionSize: 2),
                 new FormMappingOptionsMetadata(maxKeySize: 23)
             }),
+            ThrowOnBadRequest = true
         };
         var metadataResult = new RequestDelegateMetadataResult { EndpointMetadata = new List<object>() };
         var httpContext = CreateHttpContext();
@@ -145,10 +148,10 @@ public partial class RequestDelegateFactoryTests : LoggedTest
         var requestDelegate = factoryResult.RequestDelegate;
 
         // Act
-        var exception = await Assert.ThrowsAsync<FormDataMappingException>(async () => await requestDelegate(httpContext));
+        var exception = await Assert.ThrowsAsync<BadHttpRequestException>(async () => await requestDelegate(httpContext));
 
         // Assert
-        Assert.Equal("The number of elements in the dictionary exceeded the maximum number of '2' elements allowed.", exception.Error.Message.ToString(CultureInfo.InvariantCulture));
+        Assert.Equal("The number of elements in the dictionary exceeded the maximum number of '2' elements allowed.", exception.Message);
 
         // Arrange - 2
         httpContext = CreateHttpContext();
@@ -239,6 +242,7 @@ public partial class RequestDelegateFactoryTests : LoggedTest
             {
                 new FormMappingOptionsMetadata(maxRecursionDepth: 3)
             }),
+            ThrowOnBadRequest = true
         };
         var metadataResult = new RequestDelegateMetadataResult { EndpointMetadata = new List<object>() };
         void TestAction([FromForm] Employee args) { capturedEmployee = args; };
@@ -271,10 +275,9 @@ public partial class RequestDelegateFactoryTests : LoggedTest
         var factoryResult = RequestDelegateFactory.Create(TestAction, options, metadataResult);
         var requestDelegate = factoryResult.RequestDelegate;
 
-        var exception = await Assert.ThrowsAsync<FormDataMappingException>(async () => await requestDelegate(httpContext));
+        var exception = await Assert.ThrowsAsync<BadHttpRequestException>(async () => await requestDelegate(httpContext));
 
-        Assert.Equal("Manager.Manager.Manager", exception.Error.Key);
-        Assert.Equal("The maximum recursion depth of '3' was exceeded for 'Manager.Manager.Manager.Name'.", exception.Error.Message.ToString(CultureInfo.InvariantCulture));
+        Assert.Equal("The maximum recursion depth of '3' was exceeded for 'Manager.Manager.Manager.Name'.", exception.Message);
 
     }
 

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RuntimeCreationTests.ComplexFormBinding.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RuntimeCreationTests.ComplexFormBinding.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Components.Endpoints.FormMapping;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Http.Generators.Tests;
 
@@ -172,7 +173,19 @@ app.MapPost("/", ([FromForm] Dictionary<string, bool> elements) => Results.Ok(el
         httpContext.Request.Headers["Content-Type"] = "multipart/form-data;boundary=some-boundary";
         httpContext.Features.Set<IHttpRequestBodyDetectionFeature>(new RequestBodyDetectionFeature(true));
 
-        await Assert.ThrowsAsync<FormDataMappingException>(async () => await endpoint.RequestDelegate(httpContext));
+        await endpoint.RequestDelegate(httpContext);
+        Assert.Equal(StatusCodes.Status400BadRequest, httpContext.Response.StatusCode);
+
+        var logs = TestSink.Writes.ToArray();
+
+        var log = Assert.Single(logs);
+
+        Assert.Equal(new EventId(10, "FormMappingFailed"), log.EventId);
+        Assert.Equal(LogLevel.Debug, logs[0].LogLevel);
+        Assert.Equal(@"Failed to bind parameter ""Dictionary<string, bool> elements"" from the request body as form.", log.Message);
+        var log1Values = Assert.IsAssignableFrom<IReadOnlyList<KeyValuePair<string, object>>>(log.State);
+        Assert.Equal("Dictionary<string, bool>", log1Values[0].Value);
+        Assert.Equal("elements", log1Values[1].Value);
     }
 
     [Fact]

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RuntimeCreationTests.ComplexFormBinding.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RuntimeCreationTests.ComplexFormBinding.cs
@@ -181,7 +181,7 @@ app.MapPost("/", ([FromForm] Dictionary<string, bool> elements) => Results.Ok(el
         var log = Assert.Single(logs);
 
         Assert.Equal(new EventId(10, "FormMappingFailed"), log.EventId);
-        Assert.Equal(LogLevel.Debug, logs[0].LogLevel);
+        Assert.Equal(LogLevel.Debug, log.LogLevel);
         Assert.Equal(@"Failed to bind parameter ""Dictionary<string, bool> elements"" from the request body as form.", log.Message);
         var log1Values = Assert.IsAssignableFrom<IReadOnlyList<KeyValuePair<string, object>>>(log.State);
         Assert.Equal("Dictionary<string, bool>", log1Values[0].Value);

--- a/src/Http/Routing/test/FunctionalTests/MinimalFormTests.cs
+++ b/src/Http/Routing/test/FunctionalTests/MinimalFormTests.cs
@@ -498,9 +498,8 @@ public class MinimalFormTests
         };
         request.Content = new FormUrlEncodedContent(nameValueCollection);
 
-        var exception = await Record.ExceptionAsync(async () => await client.SendAsync(request));
-        Assert.NotNull(exception);
-        Assert.Contains("An error occurred while trying to map a value from form data.", exception.Message);
+        var response = await client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]

--- a/src/Shared/RequestDelegateCreationMessages.cs
+++ b/src/Shared/RequestDelegateCreationMessages.cs
@@ -48,4 +48,9 @@ internal static class RequestDelegateCreationLogging
     public const string InvalidAntiforgeryTokenEventName = "InvalidAntiforgeryToken";
     public const string InvalidAntiforgeryTokenLogMessage = @"Invalid anti-forgery token found when reading parameter ""{ParameterType} {ParameterName}"" from the request body as form.";
     public const string InvalidAntiforgeryTokenExceptionMessage = @"Invalid anti-forgery token found when reading parameter ""{0} {1}"" from the request body as form.";
+
+    public const int FormDataMappingFailedEventId = 10;
+    public const string FormDataMappingFailedEventName = "FormDataMappingFailed";
+    public const string FormDataMappingFailedLogMessage = @"Failed to bind parameter ""{ParameterType} {ParameterName}"" from the request body as form.";
+    public const string FormDataMappingFailedExceptionMessage = @"Failed to bind parameter ""{0} {1}"" from the request body as form.";
 }


### PR DESCRIPTION
Captures exceptions thrown from the complex form mapping logic into either `BadHttpRequestException`s or log messages using the standard conventions in RDF.

Before:

<img width="1680" alt="Pasted Graphic 1" src="https://github.com/dotnet/aspnetcore/assets/1857993/cdf4695a-e17c-4351-965d-8b7b4aa8b65a">


After:

<img width="3003" alt="Pasted Graphic 2" src="https://github.com/dotnet/aspnetcore/assets/1857993/d1f485f3-583a-45f8-a321-550049f8e244">
