### PR TITLE
Fix pRequestInfo INVALID_POINTER_READ caused by GCs (v6 backport)

### DIFF
--- a/src/Shared/HttpSys/RequestProcessing/NativeRequestContext.cs
+++ b/src/Shared/HttpSys/RequestProcessing/NativeRequestContext.cs
@@ -553,9 +553,12 @@ namespace Microsoft.AspNetCore.HttpSys.Internal
 
             var info = new Dictionary<int, ReadOnlyMemory<byte>>(count);
 
+            long fixup = (byte*)nativeRequest - (byte*)baseAddress;
+            var pRequestInfo = (HttpApiTypes.HTTP_REQUEST_INFO*)((byte*)nativeRequest->pRequestInfo + fixup);
+
             for (var i = 0; i < count; i++)
             {
-                var requestInfo = nativeRequest->pRequestInfo[i];
+                var requestInfo = pRequestInfo[i];
                 var offset = (long)requestInfo.pInfo - (long)baseAddress;
                 info.Add(
                     (int)requestInfo.InfoType,


### PR DESCRIPTION
# Fix pRequestInfo INVALID_POINTER_READ caused by GCs

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Backports #50446 to v6.

## Description

When using the IHttpSysRequestInfoFeature it's possible to hit invalid pointer read errors which causes a process crash. It's also possible to hit other issue caused by the invalid pointer. The error occurs when a GC moves to memory of the request's _backingBuffer before trying to access the RequestInfo property of IHttpSysRequestInfoFeature. 

The fix is to adjust the pRequestInfo pointer similar to how other pointers in this class are adjusted.

Fixes #50445

## Customer Impact

It's not possible to use the IHttpSysRequestInfoFeature without eventually crashing the process due to the INVALID_POINTER_READ.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The change is very small an in-line with how pointers are used/updated within NativeRequestContext.

## Verification

- [x] Manual (required)
- [x] Automated

I haven't been able to reproduce the crash locally, but I was able to confirm this is the root caused from a crash dump. I did verify this change did not regress this feature.

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props
