### PR TITLE
Fix outputcache bug when using IOutputCacheBufferStore

### DIFF
--- a/src/Middleware/OutputCaching/src/OutputCacheEntryFormatter.cs
+++ b/src/Middleware/OutputCaching/src/OutputCacheEntryFormatter.cs
@@ -50,7 +50,7 @@ internal static class OutputCacheEntryFormatter
         {
             if (store is IOutputCacheBufferStore bufferStore)
             {
-                await bufferStore.SetAsync(key, new(buffer.GetMemory()), CopyToLeasedMemory(tags, out var lease), duration, cancellationToken);
+                await bufferStore.SetAsync(key, new(buffer.GetCommittedMemory()), CopyToLeasedMemory(tags, out var lease), duration, cancellationToken);
                 if (lease is not null)
                 {
                     ArrayPool<string>.Shared.Return(lease);

--- a/src/Middleware/OutputCaching/src/RecyclableArrayBufferWriter.cs
+++ b/src/Middleware/OutputCaching/src/RecyclableArrayBufferWriter.cs
@@ -58,6 +58,9 @@ internal sealed class RecyclableArrayBufferWriter<T> : IBufferWriter<T>, IDispos
             => throw new ArgumentOutOfRangeException(nameof(count));
     }
 
+    public ReadOnlyMemory<T> GetCommittedMemory() => new ReadOnlyMemory<T>(_buffer, 0, _index);
+    public ReadOnlySpan<T> GetCommittedSpan() => new ReadOnlySpan<T>(_buffer, 0, _index);
+
     public Memory<T> GetMemory(int sizeHint = 0)
     {
         CheckAndResizeBuffer(sizeHint);

--- a/src/Middleware/OutputCaching/src/RecyclableArrayBufferWriter.cs
+++ b/src/Middleware/OutputCaching/src/RecyclableArrayBufferWriter.cs
@@ -58,8 +58,7 @@ internal sealed class RecyclableArrayBufferWriter<T> : IBufferWriter<T>, IDispos
             => throw new ArgumentOutOfRangeException(nameof(count));
     }
 
-    public ReadOnlyMemory<T> GetCommittedMemory() => new ReadOnlyMemory<T>(_buffer, 0, _index);
-    public ReadOnlySpan<T> GetCommittedSpan() => new ReadOnlySpan<T>(_buffer, 0, _index);
+    public ReadOnlyMemory<T> GetCommittedMemory() => new ReadOnlyMemory<T>(_buffer, 0, _index); // could also directly expose a ReadOnlySpan<byte> if useful
 
     public Memory<T> GetMemory(int sizeHint = 0)
     {

--- a/src/Middleware/OutputCaching/test/OutputCacheEntryFormatterTests.cs
+++ b/src/Middleware/OutputCaching/test/OutputCacheEntryFormatterTests.cs
@@ -5,18 +5,31 @@ using System.Buffers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Net.Http.Headers;
+using static Microsoft.AspNetCore.OutputCaching.Tests.OutputCacheMiddlewareTests;
 
 namespace Microsoft.AspNetCore.OutputCaching.Tests;
 
-public class OutputCacheEntryFormatterTests
+public class OutputCacheEntryFormatterTests_SimpleStore : OutputCacheEntryFormatterTests
 {
+    public override ITestOutputCacheStore GetStore() => new SimpleTestOutputCache();
+}
+
+public class OutputCacheEntryFormatterTests_BufferStore : OutputCacheEntryFormatterTests
+{
+    public override ITestOutputCacheStore GetStore() => new BufferTestOutputCache();
+}
+
+public abstract class OutputCacheEntryFormatterTests
+{
+    public abstract ITestOutputCacheStore GetStore();
+
     // arbitrarily some time 17 May 2023 - so we can predict payloads
     static readonly DateTimeOffset KnownTime = DateTimeOffset.FromUnixTimeMilliseconds(1684322693875);
 
     [Fact]
     public async Task StoreAndGet_StoresEmptyValues()
     {
-        var store = new TestOutputCache();
+        var store = GetStore();
         var key = "abc";
         using var entry = new OutputCacheEntry(KnownTime, StatusCodes.Status200OK);
 
@@ -33,7 +46,7 @@ public class OutputCacheEntryFormatterTests
         var bodySegment1 = "lorem"u8.ToArray();
         var bodySegment2 = "こんにちは"u8.ToArray();
 
-        var store = new TestOutputCache();
+        var store = GetStore();
         var key = "abc";
         using (var entry = new OutputCacheEntry(KnownTime, StatusCodes.Status201Created)
             .CopyHeadersFrom(new HeaderDictionary { [HeaderNames.Accept] = new[] { "text/plain", "text/html" }, [HeaderNames.AcceptCharset] = "utf8" })
@@ -50,7 +63,7 @@ public class OutputCacheEntryFormatterTests
 
     public async Task StoreAndGet_StoresNullHeaders()
     {
-        var store = new TestOutputCache();
+        var store = GetStore();
         var key = "abc";
 
         using (var entry = new OutputCacheEntry(KnownTime, StatusCodes.Status201Created))

--- a/src/Middleware/OutputCaching/test/OutputCacheEntryFormatterTests.cs
+++ b/src/Middleware/OutputCaching/test/OutputCacheEntryFormatterTests.cs
@@ -5,7 +5,6 @@ using System.Buffers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Net.Http.Headers;
-using static Microsoft.AspNetCore.OutputCaching.Tests.OutputCacheMiddlewareTests;
 
 namespace Microsoft.AspNetCore.OutputCaching.Tests;
 

--- a/src/Middleware/OutputCaching/test/OutputCacheMiddlewareTests.cs
+++ b/src/Middleware/OutputCaching/test/OutputCacheMiddlewareTests.cs
@@ -18,10 +18,12 @@ public class OutputCacheMiddlewareTests_SimpleStore : OutputCacheMiddlewareTests
 {
     public override ITestOutputCacheStore GetStore() => new SimpleTestOutputCache();
 }
+
 public class OutputCacheMiddlewareTests_BufferStore : OutputCacheMiddlewareTests
 {
     public override ITestOutputCacheStore GetStore() => new BufferTestOutputCache();
 }
+
 public abstract class OutputCacheMiddlewareTests
 {
     public interface ITestOutputCacheStore : IOutputCacheStore

--- a/src/Middleware/OutputCaching/test/OutputCacheMiddlewareTests.cs
+++ b/src/Middleware/OutputCaching/test/OutputCacheMiddlewareTests.cs
@@ -26,12 +26,6 @@ public class OutputCacheMiddlewareTests_BufferStore : OutputCacheMiddlewareTests
 
 public abstract class OutputCacheMiddlewareTests
 {
-    public interface ITestOutputCacheStore : IOutputCacheStore
-    {
-        int GetCount { get; }
-        int SetCount { get; }
-    }
-
     public abstract ITestOutputCacheStore GetStore();
 
     [Fact]

--- a/src/Middleware/OutputCaching/test/TestUtils.cs
+++ b/src/Middleware/OutputCaching/test/TestUtils.cs
@@ -6,7 +6,6 @@ using System.Buffers;
 using System.IO.Pipelines;
 using System.Net.Http;
 using System.Text;
-using System.Threading;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -20,7 +19,6 @@ using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.Options;
 using Moq;
-using static Microsoft.AspNetCore.OutputCaching.Tests.OutputCacheMiddlewareTests;
 
 namespace Microsoft.AspNetCore.OutputCaching.Tests;
 
@@ -401,4 +399,10 @@ internal class AllowTestPolicy : IOutputCachePolicy
     {
         return ValueTask.CompletedTask;
     }
+}
+
+public interface ITestOutputCacheStore : IOutputCacheStore
+{
+    int GetCount { get; }
+    int SetCount { get; }
 }

--- a/src/Middleware/OutputCaching/test/TestUtils.cs
+++ b/src/Middleware/OutputCaching/test/TestUtils.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable enable
+using System.Buffers;
+using System.IO.Pipelines;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -17,6 +20,7 @@ using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.Options;
 using Moq;
+using static Microsoft.AspNetCore.OutputCaching.Tests.OutputCacheMiddlewareTests;
 
 namespace Microsoft.AspNetCore.OutputCaching.Tests;
 
@@ -197,7 +201,7 @@ internal class TestUtils
         }
         if (cache == null)
         {
-            cache = new TestOutputCache();
+            cache = new SimpleTestOutputCache();
         }
         if (options == null)
         {
@@ -219,7 +223,7 @@ internal class TestUtils
     internal static OutputCacheContext CreateTestContext(HttpContext? httpContext = null, IOutputCacheStore? cache = null, OutputCacheOptions? options = null, ITestSink? testSink = null)
     {
         var serviceProvider = new Mock<IServiceProvider>();
-        serviceProvider.Setup(x => x.GetService(typeof(IOutputCacheStore))).Returns(cache ?? new TestOutputCache());
+        serviceProvider.Setup(x => x.GetService(typeof(IOutputCacheStore))).Returns(cache ?? new SimpleTestOutputCache());
         serviceProvider.Setup(x => x.GetService(typeof(IOptions<OutputCacheOptions>))).Returns(Options.Create(options ?? new OutputCacheOptions()));
         serviceProvider.Setup(x => x.GetService(typeof(ILogger<OutputCacheMiddleware>))).Returns(testSink == null ? NullLogger.Instance : new TestLogger("OutputCachingTests", testSink, true));
 
@@ -239,7 +243,7 @@ internal class TestUtils
     internal static OutputCacheContext CreateUninitializedContext(HttpContext? httpContext = null, IOutputCacheStore? cache = null, OutputCacheOptions? options = null, ITestSink? testSink = null)
     {
         var serviceProvider = new Mock<IServiceProvider>();
-        serviceProvider.Setup(x => x.GetService(typeof(IOutputCacheStore))).Returns(cache ?? new TestOutputCache());
+        serviceProvider.Setup(x => x.GetService(typeof(IOutputCacheStore))).Returns(cache ?? new SimpleTestOutputCache());
         serviceProvider.Setup(x => x.GetService(typeof(IOptions<OutputCacheOptions>))).Returns(Options.Create(options ?? new OutputCacheOptions()));
         serviceProvider.Setup(x => x.GetService(typeof(ILogger<OutputCacheMiddleware>))).Returns(testSink == null ? NullLogger.Instance : new TestLogger("OutputCachingTests", testSink, true));
 
@@ -320,7 +324,7 @@ internal class TestResponseCachingKeyProvider : IOutputCacheKeyProvider
     }
 }
 
-internal class TestOutputCache : IOutputCacheStore
+internal class SimpleTestOutputCache : ITestOutputCacheStore
 {
     private readonly Dictionary<string, byte[]?> _storage = new();
     public int GetCount { get; private set; }
@@ -359,6 +363,23 @@ internal class TestOutputCache : IOutputCacheStore
 
             return ValueTask.CompletedTask;
         }
+    }
+}
+
+internal class BufferTestOutputCache : SimpleTestOutputCache, IOutputCacheBufferStore
+{
+    ValueTask IOutputCacheBufferStore.SetAsync(string key, ReadOnlySequence<byte> value, ReadOnlyMemory<string> tags, TimeSpan validFor, CancellationToken cancellationToken)
+        => SetAsync(key, value.ToArray(), tags.ToArray(), validFor, cancellationToken);
+
+    async ValueTask<bool> IOutputCacheBufferStore.TryGetAsync(string key, PipeWriter destination, CancellationToken cancellationToken)
+    {
+        var data = await GetAsync(key, cancellationToken); // in reality we expect this to be sync, but: meh
+        if (data is null)
+        {
+            return false;
+        }
+        await destination.WriteAsync(data, cancellationToken);
+        return true;
     }
 }
 


### PR DESCRIPTION
- when using `IOutputCacheBufferStore`, write the *committed* bytes (not an incorrect new buffer)
- doubles all store tests to independently check stores with/without buffer support (shows repro, pre fix)

Fixes #50452

(duplicate of https://github.com/dotnet/aspnetcore/pull/50454, but starting from release/8.0, cherry-picking the commit; rebase was *not* happy)