### PR TITLE
Split redis output-cache pieces from Microsoft.Extensions.Caching.StackExchange.Redis into Microsoft.AspNetCore.OutputCaching.StackExchangeRedis

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -189,9 +189,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4122c63a13cfe40e97ac1f9ef01d8110a66943f4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23429.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23430.3">
       <Uri>https://github.com/dotnet/source-build-externals</Uri>
-      <Sha>0603839a51f5e18b89c60a3690aff5e81fa666ca</Sha>
+      <Sha>c88d8d75ed6b8d426b7fad50eadd7f6fec46a7e4</Sha>
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.symreader" Version="2.0.0-beta-23228-03">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,37 +9,37 @@
 -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="dotnet-ef" Version="8.0.0-rc.2.23429.1">
+    <Dependency Name="dotnet-ef" Version="8.0.0-rc.2.23429.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>6af71610366277d36698b69998cadfe6981c26b0</Sha>
+      <Sha>59389e5b86b5cd49a919939d3192e5df1e08d502</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-rc.2.23429.1">
+    <Dependency Name="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-rc.2.23429.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>6af71610366277d36698b69998cadfe6981c26b0</Sha>
+      <Sha>59389e5b86b5cd49a919939d3192e5df1e08d502</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0-rc.2.23429.1">
+    <Dependency Name="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0-rc.2.23429.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>6af71610366277d36698b69998cadfe6981c26b0</Sha>
+      <Sha>59389e5b86b5cd49a919939d3192e5df1e08d502</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0-rc.2.23429.1">
+    <Dependency Name="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0-rc.2.23429.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>6af71610366277d36698b69998cadfe6981c26b0</Sha>
+      <Sha>59389e5b86b5cd49a919939d3192e5df1e08d502</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0-rc.2.23429.1">
+    <Dependency Name="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0-rc.2.23429.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>6af71610366277d36698b69998cadfe6981c26b0</Sha>
+      <Sha>59389e5b86b5cd49a919939d3192e5df1e08d502</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0-rc.2.23429.1">
+    <Dependency Name="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0-rc.2.23429.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>6af71610366277d36698b69998cadfe6981c26b0</Sha>
+      <Sha>59389e5b86b5cd49a919939d3192e5df1e08d502</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore" Version="8.0.0-rc.2.23429.1">
+    <Dependency Name="Microsoft.EntityFrameworkCore" Version="8.0.0-rc.2.23429.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>6af71610366277d36698b69998cadfe6981c26b0</Sha>
+      <Sha>59389e5b86b5cd49a919939d3192e5df1e08d502</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.EntityFrameworkCore.Design" Version="8.0.0-rc.2.23429.1">
+    <Dependency Name="Microsoft.EntityFrameworkCore.Design" Version="8.0.0-rc.2.23429.3">
       <Uri>https://github.com/dotnet/efcore</Uri>
-      <Sha>6af71610366277d36698b69998cadfe6981c26b0</Sha>
+      <Sha>59389e5b86b5cd49a919939d3192e5df1e08d502</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0-rc.2.23426.4">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -139,14 +139,14 @@
     <!-- Packages from dotnet/extensions -->
     <MicrosoftExtensionsTelemetryTestingVersion>8.0.0-rc.2.23428.2</MicrosoftExtensionsTelemetryTestingVersion>
     <!-- Packages from dotnet/efcore -->
-    <dotnetefVersion>8.0.0-rc.2.23429.1</dotnetefVersion>
-    <MicrosoftEntityFrameworkCoreInMemoryVersion>8.0.0-rc.2.23429.1</MicrosoftEntityFrameworkCoreInMemoryVersion>
-    <MicrosoftEntityFrameworkCoreRelationalVersion>8.0.0-rc.2.23429.1</MicrosoftEntityFrameworkCoreRelationalVersion>
-    <MicrosoftEntityFrameworkCoreSqliteVersion>8.0.0-rc.2.23429.1</MicrosoftEntityFrameworkCoreSqliteVersion>
-    <MicrosoftEntityFrameworkCoreSqlServerVersion>8.0.0-rc.2.23429.1</MicrosoftEntityFrameworkCoreSqlServerVersion>
-    <MicrosoftEntityFrameworkCoreToolsVersion>8.0.0-rc.2.23429.1</MicrosoftEntityFrameworkCoreToolsVersion>
-    <MicrosoftEntityFrameworkCoreVersion>8.0.0-rc.2.23429.1</MicrosoftEntityFrameworkCoreVersion>
-    <MicrosoftEntityFrameworkCoreDesignVersion>8.0.0-rc.2.23429.1</MicrosoftEntityFrameworkCoreDesignVersion>
+    <dotnetefVersion>8.0.0-rc.2.23429.3</dotnetefVersion>
+    <MicrosoftEntityFrameworkCoreInMemoryVersion>8.0.0-rc.2.23429.3</MicrosoftEntityFrameworkCoreInMemoryVersion>
+    <MicrosoftEntityFrameworkCoreRelationalVersion>8.0.0-rc.2.23429.3</MicrosoftEntityFrameworkCoreRelationalVersion>
+    <MicrosoftEntityFrameworkCoreSqliteVersion>8.0.0-rc.2.23429.3</MicrosoftEntityFrameworkCoreSqliteVersion>
+    <MicrosoftEntityFrameworkCoreSqlServerVersion>8.0.0-rc.2.23429.3</MicrosoftEntityFrameworkCoreSqlServerVersion>
+    <MicrosoftEntityFrameworkCoreToolsVersion>8.0.0-rc.2.23429.3</MicrosoftEntityFrameworkCoreToolsVersion>
+    <MicrosoftEntityFrameworkCoreVersion>8.0.0-rc.2.23429.3</MicrosoftEntityFrameworkCoreVersion>
+    <MicrosoftEntityFrameworkCoreDesignVersion>8.0.0-rc.2.23429.3</MicrosoftEntityFrameworkCoreDesignVersion>
     <!-- Packages from dotnet/roslyn -->
     <MicrosoftCodeAnalysisCommonVersion>4.7.0-3.23314.3</MicrosoftCodeAnalysisCommonVersion>
     <MicrosoftCodeAnalysisExternalAccessAspNetCoreVersion>4.7.0-3.23314.3</MicrosoftCodeAnalysisExternalAccessAspNetCoreVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
     <AspNetCorePatchVersion>0</AspNetCorePatchVersion>
     <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
     <ValidateBaseline>true</ValidateBaseline>
-    <IdentityModelVersion>7.0.0-preview3</IdentityModelVersion>
+    <IdentityModelVersion>7.0.0-preview4</IdentityModelVersion>
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->
@@ -162,7 +162,7 @@
     <MicrosoftDotNetBuildTasksTemplatingVersion>8.0.0-beta.23419.1</MicrosoftDotNetBuildTasksTemplatingVersion>
     <MicrosoftDotNetRemoteExecutorVersion>8.0.0-beta.23419.1</MicrosoftDotNetRemoteExecutorVersion>
     <!-- Packages from dotnet/source-build-externals -->
-    <MicrosoftSourceBuildIntermediatesourcebuildexternalsVersion>8.0.0-alpha.1.23429.1</MicrosoftSourceBuildIntermediatesourcebuildexternalsVersion>
+    <MicrosoftSourceBuildIntermediatesourcebuildexternalsVersion>8.0.0-alpha.1.23430.3</MicrosoftSourceBuildIntermediatesourcebuildexternalsVersion>
     <!-- Packages from dotnet/source-build-reference-packages -->
     <MicrosoftSourceBuildIntermediatesourcebuildreferencepackagesVersion>8.0.0-alpha.1.23428.2</MicrosoftSourceBuildIntermediatesourcebuildreferencepackagesVersion>
     <!-- Packages from dotnet/symreader -->

--- a/src/Http/Routing/src/DependencyInjection/RoutingServiceCollectionExtensions.cs
+++ b/src/Http/Routing/src/DependencyInjection/RoutingServiceCollectionExtensions.cs
@@ -43,6 +43,9 @@ public static class RoutingServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
+        // Required for IMeterFactory dependency.
+        services.AddMetrics();
+
         services.TryAddTransient<IInlineConstraintResolver, DefaultInlineConstraintResolver>();
         services.TryAddTransient<ObjectPoolProvider, DefaultObjectPoolProvider>();
         services.TryAddSingleton<ObjectPool<UriBuildingContext>>(s =>

--- a/src/Http/Routing/src/Microsoft.AspNetCore.Routing.csproj
+++ b/src/Http/Routing/src/Microsoft.AspNetCore.Routing.csproj
@@ -46,6 +46,7 @@
     <Reference Include="Microsoft.AspNetCore.Http.Features" />
     <Reference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <Reference Include="Microsoft.AspNetCore.Routing.Abstractions" />
+    <Reference Include="Microsoft.Extensions.Diagnostics" />
     <Reference Include="Microsoft.Extensions.Features" />
     <Reference Include="Microsoft.Extensions.ObjectPool" />
     <Reference Include="Microsoft.Extensions.Options" />

--- a/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
+++ b/src/Http/Routing/test/UnitTests/EndpointRoutingMiddlewareTest.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.AspNetCore.Routing.TestObjects;
 using Microsoft.AspNetCore.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
@@ -391,6 +392,36 @@ public class EndpointRoutingMiddlewareTest
 
         var actualRequestSizeLimit = maxRequestBodySizeFeature.MaxRequestBodySize;
         Assert.Equal(expectedRequestSizeLimit, actualRequestSizeLimit);
+    }
+
+    [Fact]
+    public async Task Create_WithoutHostBuilder_Success()
+    {
+        // Arrange
+        var httpContext = CreateHttpContext();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.AddSingleton<DiagnosticListener>(s => new DiagnosticListener("Test"));
+        services.AddRouting();
+
+        var applicationBuilder = new ApplicationBuilder(services.BuildServiceProvider());
+
+        applicationBuilder.UseRouting();
+        applicationBuilder.UseEndpoints(endpoints =>
+        {
+            endpoints.MapGet("/", (HttpContext c) => Task.CompletedTask);
+        });
+
+        var requestDelegate = applicationBuilder.Build();
+
+        // Act
+        await requestDelegate(httpContext);
+
+        // Assert
+        var endpointFeature = httpContext.Features.Get<IEndpointFeature>();
+        Assert.NotNull(endpointFeature);
     }
 
     private class RequestSizeLimitMetadata(long? maxRequestBodySize) : IRequestSizeLimitMetadata

--- a/src/Security/Authentication/WsFederation/src/WsFederationHandler.cs
+++ b/src/Security/Authentication/WsFederation/src/WsFederationHandler.cs
@@ -98,7 +98,7 @@ public class WsFederationHandler : RemoteAuthenticationHandler<WsFederationOptio
         var wsFederationMessage = new WsFederationMessage()
         {
             IssuerAddress = _configuration.TokenEndpoint ?? string.Empty,
-            Wtrealm = Options.Wtrealm!, // TODO: https://github.com/dotnet/aspnetcore/issues/50242
+            Wtrealm = Options.Wtrealm,
             Wa = WsFederationConstants.WsFederationActions.SignIn,
         };
 
@@ -195,7 +195,7 @@ public class WsFederationHandler : RemoteAuthenticationHandler<WsFederationOptio
             {
                 // Extract the user state from properties and reset.
                 properties.Items.TryGetValue(WsFederationDefaults.UserstatePropertiesKey, out var userState);
-                wsFederationMessage.Wctx = userState!; // TODO: '!' can be removed with https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/2240
+                wsFederationMessage.Wctx = userState;
             }
 
             var messageReceivedContext = new MessageReceivedContext(Context, Scheme, Options, properties)
@@ -425,7 +425,7 @@ public class WsFederationHandler : RemoteAuthenticationHandler<WsFederationOptio
         var wsFederationMessage = new WsFederationMessage()
         {
             IssuerAddress = _configuration.TokenEndpoint ?? string.Empty,
-            Wtrealm = Options.Wtrealm!, // TODO: https://github.com/dotnet/aspnetcore/issues/50242
+            Wtrealm = Options.Wtrealm,
             Wa = WsFederationConstants.WsFederationActions.SignOut,
         };
 

--- a/src/Security/Authentication/test/JwtBearerTests_Handler.cs
+++ b/src/Security/Authentication/test/JwtBearerTests_Handler.cs
@@ -914,23 +914,21 @@ public class JwtBearerTests_Handler : SharedAuthenticationTests<JwtBearerOptions
     public async Task ExpirationAndIssuedWhenMinOrMaxValue()
     {
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(new string('a', 128)));
-        //var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
-        //var claims = new[]
-        //{
-        //    new Claim(ClaimTypes.NameIdentifier, "Bob")
-        //};
+        var claims = new[]
+        {
+           new Claim(ClaimTypes.NameIdentifier, "Bob")
+        };
 
-        //var token = new JwtSecurityToken(
-        //    issuer: "issuer.contoso.com",
-        //    audience: "audience.contoso.com",
-        //    claims: claims,
-        //    expires: DateTime.MaxValue,
-        //    signingCredentials: creds);
+        var token = new JwtSecurityToken(
+           issuer: "issuer.contoso.com",
+           audience: "audience.contoso.com",
+           claims: claims,
+           expires: DateTime.MaxValue,
+           signingCredentials: creds);
 
-        //var tokenText = new JwtSecurityTokenHandler().WriteToken(token);
-        // TODO: when https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/2261 is fixed, uncomment the above code and remove this hard-coded string
-        var tokenText = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9uYW1laWRlbnRpZmllciI6IkJvYiIsImV4cCI6MjUzNDAyMzAwODAwLCJpc3MiOiJpc3N1ZXIuY29udG9zby5jb20iLCJhdWQiOiJhdWRpZW5jZS5jb250b3NvLmNvbSJ9.0zvasyAh-GmjR_o46QSRCoQ9VaSXJjW5_YMcR6qy-jw";
+        var tokenText = new JwtSecurityTokenHandler().WriteToken(token);
 
         using var host = await CreateHost(o =>
         {


### PR DESCRIPTION
# Split redis output-cache pieces from Microsoft.Extensions.Caching.StackExchange.Redis into Microsoft.AspNetCore.OutputCaching.StackExchangeRedis

## Description

Split SE.Redis OutputCache implementation into new package, Microsoft.AspNetCore.OutputCaching.StackExchangeRedis (it was causing an undesirable framework ref)
    
- remove the output cache functionality and ref from Microsoft.Extensions.Caching.StackExchange.Redis
  - (simplified API [un]shipped.txt back to single; no change except no more unshipped)
- moved functionality to new package (and update eng files accordingly)
- new namespace etc; will need API review
- in particular, RedisCacheOptions was shared between both APIs; now RedisOutputCacheOptions

Related: https://github.com/dotnet/aspnetcore/issues/50402
