### PR TITLE
Merge property attributes with parameter attributes for AsParameters

### DIFF
--- a/src/Http/Http.Extensions/gen/RequestDelegateGeneratorSources.cs
+++ b/src/Http/Http.Extensions/gen/RequestDelegateGeneratorSources.cs
@@ -388,14 +388,20 @@ internal static class RequestDelegateGeneratorSources
 
         public override object[] GetCustomAttributes(Type attributeType, bool inherit)
         {
-            var attributes = _constructionParameterInfo?.GetCustomAttributes(attributeType, inherit);
+            var constructorAttributes = _constructionParameterInfo?.GetCustomAttributes(attributeType, inherit);
 
-            if (attributes == null || attributes is { Length: 0 })
+            if (constructorAttributes == null || constructorAttributes is { Length: 0 })
             {
-                attributes = _underlyingProperty.GetCustomAttributes(attributeType, inherit);
+                return _underlyingProperty.GetCustomAttributes(attributeType, inherit);
             }
 
-            return attributes;
+            var propertyAttributes = _underlyingProperty.GetCustomAttributes(inherit);
+
+            var mergedAttributes = new Attribute[constructorAttributes.Length + propertyAttributes.Length];
+            Array.Copy(constructorAttributes, mergedAttributes, constructorAttributes.Length);
+            Array.Copy(propertyAttributes, 0, mergedAttributes, constructorAttributes.Length, propertyAttributes.Length);
+
+            return mergedAttributes;
         }
 
         public override object[] GetCustomAttributes(bool inherit)

--- a/src/Http/Http.Extensions/gen/RequestDelegateGeneratorSources.cs
+++ b/src/Http/Http.Extensions/gen/RequestDelegateGeneratorSources.cs
@@ -395,7 +395,7 @@ internal static class RequestDelegateGeneratorSources
                 return _underlyingProperty.GetCustomAttributes(attributeType, inherit);
             }
 
-            var propertyAttributes = _underlyingProperty.GetCustomAttributes(inherit);
+            var propertyAttributes = _underlyingProperty.GetCustomAttributes(attributeType, inherit);
 
             var mergedAttributes = new Attribute[constructorAttributes.Length + propertyAttributes.Length];
             Array.Copy(constructorAttributes, mergedAttributes, constructorAttributes.Length);

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/VerifyAsParametersBaseline.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/VerifyAsParametersBaseline.generated.txt
@@ -857,14 +857,20 @@ namespace Microsoft.AspNetCore.Http.Generated
 
         public override object[] GetCustomAttributes(Type attributeType, bool inherit)
         {
-            var attributes = _constructionParameterInfo?.GetCustomAttributes(attributeType, inherit);
+            var constructorAttributes = _constructionParameterInfo?.GetCustomAttributes(attributeType, inherit);
 
-            if (attributes == null || attributes is { Length: 0 })
+            if (constructorAttributes == null || constructorAttributes is { Length: 0 })
             {
-                attributes = _underlyingProperty.GetCustomAttributes(attributeType, inherit);
+                return _underlyingProperty.GetCustomAttributes(attributeType, inherit);
             }
 
-            return attributes;
+            var propertyAttributes = _underlyingProperty.GetCustomAttributes(inherit);
+
+            var mergedAttributes = new Attribute[constructorAttributes.Length + propertyAttributes.Length];
+            Array.Copy(constructorAttributes, mergedAttributes, constructorAttributes.Length);
+            Array.Copy(propertyAttributes, 0, mergedAttributes, constructorAttributes.Length, propertyAttributes.Length);
+
+            return mergedAttributes;
         }
 
         public override object[] GetCustomAttributes(bool inherit)

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/VerifyAsParametersBaseline.generated.txt
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/Baselines/VerifyAsParametersBaseline.generated.txt
@@ -864,7 +864,7 @@ namespace Microsoft.AspNetCore.Http.Generated
                 return _underlyingProperty.GetCustomAttributes(attributeType, inherit);
             }
 
-            var propertyAttributes = _underlyingProperty.GetCustomAttributes(inherit);
+            var propertyAttributes = _underlyingProperty.GetCustomAttributes(attributeType, inherit);
 
             var mergedAttributes = new Attribute[constructorAttributes.Length + propertyAttributes.Length];
             Array.Copy(constructorAttributes, mergedAttributes, constructorAttributes.Length);

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.AsParameters.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.AsParameters.cs
@@ -40,11 +40,17 @@ app.MapGet("/{Value}", TestAction);
         // we should match the case here
         const string paramName = "Value";
         const int originalQueryParam = 42;
+        const string customParamName = "customQuery";
+        const int originalCustomQueryParam = 43;
+        const string anotherCustomParamName = "anotherCustomQuery";
+        const int originalAnotherCustomQueryParam = 44;
 
         var source = """
 static void TestAction([AsParameters] ParameterListFromQuery args)
 {
     args.HttpContext.Items.Add("input", args.Value);
+    args.HttpContext.Items.Add("customInput", args.CustomValue);
+    args.HttpContext.Items.Add("anotherCustomInput", args.AnotherCustomValue);
 }
 app.MapGet("/", TestAction);
 """;
@@ -53,7 +59,9 @@ app.MapGet("/", TestAction);
 
         var query = new QueryCollection(new Dictionary<string, StringValues>()
         {
-            [paramName] = originalQueryParam.ToString(NumberFormatInfo.InvariantInfo)
+            [paramName] = originalQueryParam.ToString(NumberFormatInfo.InvariantInfo),
+            [customParamName] = originalCustomQueryParam.ToString(NumberFormatInfo.InvariantInfo),
+            [anotherCustomParamName] = originalAnotherCustomQueryParam.ToString(NumberFormatInfo.InvariantInfo)
         });
 
         var httpContext = CreateHttpContext();
@@ -62,6 +70,8 @@ app.MapGet("/", TestAction);
         await endpoint.RequestDelegate(httpContext);
 
         Assert.Equal(originalQueryParam, httpContext.Items["input"]);
+        Assert.Equal(originalCustomQueryParam, httpContext.Items["customInput"]);
+        Assert.Equal(originalAnotherCustomQueryParam, httpContext.Items["anotherCustomInput"]);
     }
 
     [Fact]

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/SharedTypes.cs
@@ -692,7 +692,10 @@ public class AccessesServicesMetadataBinder : IEndpointMetadataProvider
 }
 
 public record MetadataService;
-public record ParameterListFromQuery(HttpContext HttpContext, [FromQuery] int Value);
+public record ParameterListFromQuery(HttpContext HttpContext,
+    [FromQuery] int Value,
+    [FromQuery(Name = "customQuery")] int CustomValue,
+    [property: FromQuery(Name = "anotherCustomQuery")] int? AnotherCustomValue = null);
 public record ParameterListFromRoute(HttpContext HttpContext, int Value);
 public record ParameterListFromHeader(HttpContext HttpContext, [FromHeader(Name = "X-Custom-Header")] int Value);
 public record ParametersListWithImplicitFromBody(HttpContext HttpContext, TodoStruct Todo);

--- a/src/Shared/PropertyAsParameterInfo.cs
+++ b/src/Shared/PropertyAsParameterInfo.cs
@@ -146,7 +146,7 @@ internal sealed class PropertyAsParameterInfo : ParameterInfo
             return _underlyingProperty.GetCustomAttributes(attributeType, inherit);
         }
 
-        var propertyAttributes = _underlyingProperty.GetCustomAttributes(inherit);
+        var propertyAttributes = _underlyingProperty.GetCustomAttributes(attributeType, inherit);
 
         var mergedAttributes = new Attribute[constructorAttributes.Length + propertyAttributes.Length];
         Array.Copy(constructorAttributes, mergedAttributes, constructorAttributes.Length);

--- a/src/Shared/PropertyAsParameterInfo.cs
+++ b/src/Shared/PropertyAsParameterInfo.cs
@@ -139,14 +139,20 @@ internal sealed class PropertyAsParameterInfo : ParameterInfo
 
     public override object[] GetCustomAttributes(Type attributeType, bool inherit)
     {
-        var attributes = _constructionParameterInfo?.GetCustomAttributes(attributeType, inherit);
+        var constructorAttributes = _constructionParameterInfo?.GetCustomAttributes(attributeType, inherit);
 
-        if (attributes == null || attributes is { Length: 0 })
+        if (constructorAttributes == null || constructorAttributes is { Length: 0 })
         {
-            attributes = _underlyingProperty.GetCustomAttributes(attributeType, inherit);
+            return _underlyingProperty.GetCustomAttributes(attributeType, inherit);
         }
 
-        return attributes;
+        var propertyAttributes = _underlyingProperty.GetCustomAttributes(inherit);
+
+        var mergedAttributes = new Attribute[constructorAttributes.Length + propertyAttributes.Length];
+        Array.Copy(constructorAttributes, mergedAttributes, constructorAttributes.Length);
+        Array.Copy(propertyAttributes, 0, mergedAttributes, constructorAttributes.Length, propertyAttributes.Length);
+
+        return mergedAttributes;
     }
 
     public override object[] GetCustomAttributes(bool inherit)


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/50408.

This `GetCustomAttributes` implementation gets called for nullable types but doesn't combine property-level attributes in the `AsParameters` command with parameter-level attributes in the `AsParameters` type.