### PR TITLE
Document the coupling between KestrelServerLimits and *TransportOptions

### DIFF
--- a/src/Servers/Kestrel/Core/src/KestrelServerLimits.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerLimits.cs
@@ -42,7 +42,6 @@ public class KestrelServerLimits
     private long? _maxConcurrentConnections;
     private long? _maxConcurrentUpgradedConnections;
 
-#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
     /// <summary>
     /// Gets or sets the maximum size of the response buffer before write
     /// calls begin to block or return tasks that don't complete until the
@@ -61,7 +60,6 @@ public class KestrelServerLimits
     /// don't complete until the entire response buffer is flushed.
     /// </remarks>
     public long? MaxResponseBufferSize
-#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
     {
         get => _maxResponseBufferSize;
         set

--- a/src/Servers/Kestrel/Core/src/KestrelServerLimits.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerLimits.cs
@@ -52,6 +52,8 @@ public class KestrelServerLimits
     /// <code>MaxWriteBufferSize</code> in the transport options
     /// (e.g. <see cref="P:Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.MaxWriteBufferSize"/>
     /// and/or <see cref="P:Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportOptions.MaxWriteBufferSize"/>).
+    /// If this limit is smaller, the response might be truncated.  If this limit is larger, rate limit
+    /// might be too generous.
     /// </para>
     /// </summary>
     /// <remarks>

--- a/src/Servers/Kestrel/Core/src/KestrelServerLimits.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerLimits.cs
@@ -42,11 +42,19 @@ public class KestrelServerLimits
     private long? _maxConcurrentConnections;
     private long? _maxConcurrentUpgradedConnections;
 
+
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
     /// <summary>
     /// Gets or sets the maximum size of the response buffer before write
     /// calls begin to block or return tasks that don't complete until the
     /// buffer size drops below the configured limit.
     /// Defaults to 65,536 bytes (64 KB).
+    /// <para>
+    /// For limits to work correctly, this needs to be consistent with
+    /// <code>MaxWriteBufferSize</code> in the transport options
+    /// (e.g. <see cref="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.MaxWriteBufferSize"/>
+    /// and/or <see cref="Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportOptions.MaxWriteBufferSize"/>).
+    /// </para>
     /// </summary>
     /// <remarks>
     /// When set to null, the size of the response buffer is unlimited.
@@ -54,6 +62,7 @@ public class KestrelServerLimits
     /// don't complete until the entire response buffer is flushed.
     /// </remarks>
     public long? MaxResponseBufferSize
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
     {
         get => _maxResponseBufferSize;
         set

--- a/src/Servers/Kestrel/Core/src/KestrelServerLimits.cs
+++ b/src/Servers/Kestrel/Core/src/KestrelServerLimits.cs
@@ -42,7 +42,6 @@ public class KestrelServerLimits
     private long? _maxConcurrentConnections;
     private long? _maxConcurrentUpgradedConnections;
 
-
 #pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
     /// <summary>
     /// Gets or sets the maximum size of the response buffer before write
@@ -52,8 +51,8 @@ public class KestrelServerLimits
     /// <para>
     /// For limits to work correctly, this needs to be consistent with
     /// <code>MaxWriteBufferSize</code> in the transport options
-    /// (e.g. <see cref="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.MaxWriteBufferSize"/>
-    /// and/or <see cref="Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportOptions.MaxWriteBufferSize"/>).
+    /// (e.g. <see cref="P:Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportOptions.MaxWriteBufferSize"/>
+    /// and/or <see cref="P:Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.QuicTransportOptions.MaxWriteBufferSize"/>).
     /// </para>
     /// </summary>
     /// <remarks>

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
@@ -31,7 +31,6 @@ public sealed class NamedPipeTransportOptions
     /// </remarks>
     public long? MaxReadBufferSize { get; set; } = 1024 * 1024;
 
-#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
     /// <summary>
     /// Gets or sets the maximum outgoing bytes the transport will buffer before applying write backpressure.
     /// <para>
@@ -47,7 +46,6 @@ public sealed class NamedPipeTransportOptions
     /// Defaults to 64 KiB.
     /// </remarks>
     public long? MaxWriteBufferSize { get; set; } = 64 * 1024;
-#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
 
     /// <summary>
     /// Gets or sets a value that indicates that the pipe can only be connected to by a client created by

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
@@ -40,6 +40,8 @@ public sealed class NamedPipeTransportOptions
     /// <para>
     /// For server limits to work correctly, this needs to be consistent with
     /// <see cref="P:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxResponseBufferSize"/>.
+    /// If this limit is larger, the response might be truncated.  If this limit is smaller, rate limit
+    /// might be too generous.
     /// </para>
     /// </summary>
     /// <remarks>

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
@@ -31,7 +31,6 @@ public sealed class NamedPipeTransportOptions
     /// </remarks>
     public long? MaxReadBufferSize { get; set; } = 1024 * 1024;
 
-
 #pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
     /// <summary>
     /// Gets or sets the maximum outgoing bytes the transport will buffer before applying write backpressure.
@@ -41,7 +40,7 @@ public sealed class NamedPipeTransportOptions
     /// </para>
     /// <para>
     /// For server limits to work correctly, this needs to be consistent with
-    /// <see cref="Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxResponseBufferSize"/>.
+    /// <see cref="P:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxResponseBufferSize"/>.
     /// </para>
     /// </summary>
     /// <remarks>

--- a/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.NamedPipes/src/NamedPipeTransportOptions.cs
@@ -31,17 +31,24 @@ public sealed class NamedPipeTransportOptions
     /// </remarks>
     public long? MaxReadBufferSize { get; set; } = 1024 * 1024;
 
+
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
     /// <summary>
     /// Gets or sets the maximum outgoing bytes the transport will buffer before applying write backpressure.
     /// <para>
     /// A value of <see langword="null"/> or 0 disables backpressure entirely allowing unlimited buffering.
     /// Unlimited server buffering is a security risk given untrusted clients.
     /// </para>
+    /// <para>
+    /// For server limits to work correctly, this needs to be consistent with
+    /// <see cref="Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxResponseBufferSize"/>.
+    /// </para>
     /// </summary>
     /// <remarks>
     /// Defaults to 64 KiB.
     /// </remarks>
     public long? MaxWriteBufferSize { get; set; } = 64 * 1024;
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
 
     /// <summary>
     /// Gets or sets a value that indicates that the pipe can only be connected to by a client created by

--- a/src/Servers/Kestrel/Transport.Quic/src/QuicTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/QuicTransportOptions.cs
@@ -36,6 +36,8 @@ public sealed class QuicTransportOptions
     /// <para>
     /// For server limits to work correctly, this needs to be consistent with
     /// <see cref="P:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxResponseBufferSize"/>.
+    /// If this limit is larger, the response might be truncated.  If this limit is smaller, rate limit
+    /// might be too generous.
     /// </para>
     /// </summary>
     [RequiresPreviewFeatures]

--- a/src/Servers/Kestrel/Transport.Quic/src/QuicTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/QuicTransportOptions.cs
@@ -31,7 +31,6 @@ public sealed class QuicTransportOptions
     [RequiresPreviewFeatures]
     public long? MaxReadBufferSize { get; set; } = 1024 * 1024;
 
-#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
     /// <summary>
     /// The maximum write size.
     /// <para>
@@ -40,7 +39,6 @@ public sealed class QuicTransportOptions
     /// </para>
     /// </summary>
     [RequiresPreviewFeatures]
-#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
     public long? MaxWriteBufferSize { get; set; } = 64 * 1024;
 
     /// <summary>

--- a/src/Servers/Kestrel/Transport.Quic/src/QuicTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/QuicTransportOptions.cs
@@ -31,10 +31,17 @@ public sealed class QuicTransportOptions
     [RequiresPreviewFeatures]
     public long? MaxReadBufferSize { get; set; } = 1024 * 1024;
 
+
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
     /// <summary>
     /// The maximum write size.
+    /// <para>
+    /// For server limits to work correctly, this needs to be consistent with
+    /// <see cref="Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxResponseBufferSize"/>.
+    /// </para>
     /// </summary>
     [RequiresPreviewFeatures]
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
     public long? MaxWriteBufferSize { get; set; } = 64 * 1024;
 
     /// <summary>

--- a/src/Servers/Kestrel/Transport.Quic/src/QuicTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Quic/src/QuicTransportOptions.cs
@@ -31,13 +31,12 @@ public sealed class QuicTransportOptions
     [RequiresPreviewFeatures]
     public long? MaxReadBufferSize { get; set; } = 1024 * 1024;
 
-
 #pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
     /// <summary>
     /// The maximum write size.
     /// <para>
     /// For server limits to work correctly, this needs to be consistent with
-    /// <see cref="Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxResponseBufferSize"/>.
+    /// <see cref="P:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxResponseBufferSize"/>.
     /// </para>
     /// </summary>
     [RequiresPreviewFeatures]

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
@@ -55,6 +55,8 @@ public class SocketConnectionFactoryOptions
     /// <para>
     /// For server limits to work correctly, this needs to be consistent with
     /// <see cref="P:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxResponseBufferSize"/>.
+    /// If this limit is larger, the response might be truncated.  If this limit is smaller, rate limit
+    /// might be too generous.
     /// </para>
     /// </summary>
     public long? MaxWriteBufferSize { get; set; } = 64 * 1024;

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
@@ -50,7 +50,6 @@ public class SocketConnectionFactoryOptions
     /// </summary>
     public long? MaxReadBufferSize { get; set; } = 1024 * 1024;
 
-#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
     /// <summary>
     /// Gets or sets the maximum outgoing bytes the transport will buffer before applying write backpressure.
     /// <para>
@@ -59,7 +58,6 @@ public class SocketConnectionFactoryOptions
     /// </para>
     /// </summary>
     public long? MaxWriteBufferSize { get; set; } = 64 * 1024;
-#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
 
     /// <summary>
     /// Inline application and transport continuations instead of dispatching to the threadpool.

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
@@ -50,13 +50,12 @@ public class SocketConnectionFactoryOptions
     /// </summary>
     public long? MaxReadBufferSize { get; set; } = 1024 * 1024;
 
-
 #pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
     /// <summary>
     /// Gets or sets the maximum outgoing bytes the transport will buffer before applying write backpressure.
     /// <para>
     /// For server limits to work correctly, this needs to be consistent with
-    /// <see cref="Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxResponseBufferSize"/>.
+    /// <see cref="P:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxResponseBufferSize"/>.
     /// </para>
     /// </summary>
     public long? MaxWriteBufferSize { get; set; } = 64 * 1024;

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
@@ -50,10 +50,17 @@ public class SocketConnectionFactoryOptions
     /// </summary>
     public long? MaxReadBufferSize { get; set; } = 1024 * 1024;
 
+
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
     /// <summary>
     /// Gets or sets the maximum outgoing bytes the transport will buffer before applying write backpressure.
+    /// <para>
+    /// For server limits to work correctly, this needs to be consistent with
+    /// <see cref="Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxResponseBufferSize"/>.
+    /// </para>
     /// </summary>
     public long? MaxWriteBufferSize { get; set; } = 64 * 1024;
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
 
     /// <summary>
     /// Inline application and transport continuations instead of dispatching to the threadpool.

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -65,6 +65,8 @@ public class SocketTransportOptions
     /// <para>
     /// For server limits to work correctly, this needs to be consistent with
     /// <see cref="P:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxResponseBufferSize"/>.
+    /// If this limit is larger, the response might be truncated.  If this limit is smaller, rate limit
+    /// might be too generous.
     /// </para>
     /// </summary>
     /// <remarks>

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -56,7 +56,6 @@ public class SocketTransportOptions
     /// </remarks>
     public int Backlog { get; set; } = 512;
 
-#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
     /// <summary>
     /// Gets or sets the maximum unconsumed incoming bytes the transport will buffer.
     /// <para>
@@ -72,7 +71,6 @@ public class SocketTransportOptions
     /// Defaults to 1 MiB.
     /// </remarks>
     public long? MaxReadBufferSize { get; set; } = 1024 * 1024;
-#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
 
     /// <summary>
     /// Gets or sets the maximum outgoing bytes the transport will buffer before applying write backpressure.

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -65,7 +65,7 @@ public class SocketTransportOptions
     /// </para>
     /// <para>
     /// For server limits to work correctly, this needs to be consistent with
-    /// <see cref="Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxResponseBufferSize"/>.
+    /// <see cref="P:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxResponseBufferSize"/>.
     /// </para>
     /// </summary>
     /// <remarks>

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -56,17 +56,23 @@ public class SocketTransportOptions
     /// </remarks>
     public int Backlog { get; set; } = 512;
 
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
     /// <summary>
     /// Gets or sets the maximum unconsumed incoming bytes the transport will buffer.
     /// <para>
     /// A value of <see langword="null"/> or 0 disables backpressure entirely allowing unlimited buffering.
     /// Unlimited server buffering is a security risk given untrusted clients.
     /// </para>
+    /// <para>
+    /// For server limits to work correctly, this needs to be consistent with
+    /// <see cref="Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxResponseBufferSize"/>.
+    /// </para>
     /// </summary>
     /// <remarks>
     /// Defaults to 1 MiB.
     /// </remarks>
     public long? MaxReadBufferSize { get; set; } = 1024 * 1024;
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
 
     /// <summary>
     /// Gets or sets the maximum outgoing bytes the transport will buffer before applying write backpressure.


### PR DESCRIPTION
`KestrelServerLimits.MaxReponseBufferSize` needs to match `*TransportOptions.MaxWriteBufferSize` for things to work properly.

Fixes #12785