### PR TITLE
Update CertificateLoader.cs

### DIFF
--- a/src/Servers/Kestrel/Core/src/CertificateLoader.cs
+++ b/src/Servers/Kestrel/Core/src/CertificateLoader.cs
@@ -48,7 +48,7 @@ public static class CertificateLoader
                     // Pick the first one if there's no exact match as a fallback to substring default.
                     foundCertificate ??= certificate;
 
-                    if (certificate.GetNameInfo(X509NameType.SimpleName, true).Equals(subject, StringComparison.InvariantCultureIgnoreCase))
+                    if (certificate.GetNameInfo(X509NameType.SimpleName, forIssuer: false).Equals(subject, StringComparison.InvariantCultureIgnoreCase))
                     {
                         foundCertificate = certificate;
                         break;


### PR DESCRIPTION
# CertificateLoader loading wrong certificate

Fixes certificate selection by subject name

## Description

The check for exact match to certificate subject fails as the `forIssuer` flag is set to true. This returns the `issuer` and not the `subject` this means that if two certificates have a partial match, it will just select the first one that has the search value in the name.

Fixes #49062 (in this specific format)
