### PR TITLE
Add SetBrowserRequestStreamingEnabled extension method

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Http/WebAssemblyHttpRequestMessageExtensions.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Http/WebAssemblyHttpRequestMessageExtensions.cs
@@ -11,6 +11,7 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Http;
 public static class WebAssemblyHttpRequestMessageExtensions
 {
     private static readonly HttpRequestOptionsKey<IDictionary<string, object>> FetchRequestOptionsKey = new HttpRequestOptionsKey<IDictionary<string, object>>("WebAssemblyFetchOptions");
+    private static readonly HttpRequestOptionsKey<bool> WebAssemblyEnableStreamingRequestKey = new HttpRequestOptionsKey<bool>("WebAssemblyEnableStreamingRequest");
     private static readonly HttpRequestOptionsKey<bool> WebAssemblyEnableStreamingResponseKey = new HttpRequestOptionsKey<bool>("WebAssemblyEnableStreamingResponse");
 
     /// <summary>
@@ -132,14 +133,34 @@ public static class WebAssemblyHttpRequestMessageExtensions
     }
 
     /// <summary>
+    /// Configures streaming request for the HTTP request.
+    /// </summary>
+    /// <param name="requestMessage">The <see cref="HttpRequestMessage"/>.</param>
+    /// <param name="streamingEnabled"><see langword="true"/> if streaming is enabled; otherwise <see langword="false"/>.</param>
+    /// <returns>The <see cref="HttpRequestMessage"/>.</returns>
+    /// <remarks>
+    /// This API is only effective when the browser HTTP Fetch supports request streaming.
+    /// Requires HTTP/2 or higher server support.
+    /// See <see href="https://developer.mozilla.org/en-US/docs/Web/API/Request"/>.
+    /// </remarks>
+    public static HttpRequestMessage SetBrowserRequestStreamingEnabled(this HttpRequestMessage requestMessage, bool streamingEnabled)
+    {
+        ArgumentNullException.ThrowIfNull(requestMessage);
+
+        requestMessage.Options.Set(WebAssemblyEnableStreamingRequestKey, streamingEnabled);
+
+        return requestMessage;
+    }
+
+    /// <summary>
     /// Configures streaming response for the HTTP request.
     /// </summary>
     /// <param name="requestMessage">The <see cref="HttpRequestMessage"/>.</param>
-    /// <param name="streamingEnabled"><see langword="true"/> if streaming is enabled; otherwise false.</param>
+    /// <param name="streamingEnabled"><see langword="true"/> if streaming is enabled; otherwise <see langword="false"/>.</param>
     /// <returns>The <see cref="HttpRequestMessage"/>.</returns>
     /// <remarks>
-    /// This API is only effective when the browser HTTP Fetch supports streaming.
-    /// See <see href="https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream"/>.
+    /// This API is only effective when the browser HTTP Fetch supports response streaming.
+    /// See <see href="https://developer.mozilla.org/en-US/docs/Web/API/Response"/>.
     /// </remarks>
     public static HttpRequestMessage SetBrowserResponseStreamingEnabled(this HttpRequestMessage requestMessage, bool streamingEnabled)
     {

--- a/src/Components/WebAssembly/WebAssembly/src/PublicAPI.Unshipped.txt
+++ b/src/Components/WebAssembly/WebAssembly/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Microsoft.AspNetCore.Components.WebAssembly.Http.WebAssemblyHttpRequestMessageExtensions.SetBrowserRequestStreamingEnabled(this System.Net.Http.HttpRequestMessage! requestMessage, bool streamingEnabled) -> System.Net.Http.HttpRequestMessage!


### PR DESCRIPTION
# Add SetBrowserRequestStreamingEnabled extension method

Browser request streaming was implemented in https://github.com/dotnet/runtime/pull/91295. This adds the corresponding extension method for it.

## Description

Browser request streaming requires HTTP/2 or higher server support and is currently only supported in Chromium (Chrome / Edge / ...) e.g. it does not work in Firefox or Safari.
See also https://developer.chrome.com/articles/fetch-streaming-requests/


CC @pavelsavara