### PR TITLE
Update selenium

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -310,9 +310,9 @@
     <MicrosoftPlaywrightVersion>1.28.0</MicrosoftPlaywrightVersion>
     <PollyExtensionsHttpVersion>3.0.0</PollyExtensionsHttpVersion>
     <PollyVersion>7.2.4</PollyVersion>
-    <SeleniumSupportVersion>4.10.0</SeleniumSupportVersion>
-    <SeleniumWebDriverChromeDriverVersion>114.0.5735.9000</SeleniumWebDriverChromeDriverVersion>
-    <SeleniumWebDriverVersion>4.10.0</SeleniumWebDriverVersion>
+    <SeleniumSupportVersion>4.12.2</SeleniumSupportVersion>
+    <SeleniumWebDriverChromeDriverVersion>116.0.5845.9600</SeleniumWebDriverChromeDriverVersion>
+    <SeleniumWebDriverVersion>4.12.2</SeleniumWebDriverVersion>
     <SerilogExtensionsLoggingVersion>1.4.0</SerilogExtensionsLoggingVersion>
     <SerilogSinksFileVersion>4.0.0</SerilogSinksFileVersion>
     <StackExchangeRedisVersion>2.6.122</StackExchangeRedisVersion>

--- a/src/Components/benchmarkapps/Wasm.Performance/dockerfile
+++ b/src/Components/benchmarkapps/Wasm.Performance/dockerfile
@@ -28,7 +28,7 @@ RUN .dotnet/dotnet publish -c Release --no-restore -o /app ./src/Components/benc
 RUN chmod +x /app/Wasm.Performance.Driver
 
 WORKDIR /app
-FROM selenium/standalone-chrome:114.0 as final
+FROM selenium/standalone-chrome:115.0 as final
 COPY --from=build ./app ./
 COPY ./exec.sh ./
 


### PR DESCRIPTION
Updates selenium to the lastest version alongside the driver.


@wtgodbe (and others) - I wasn't able to find a new version for 

 - [ ] [Chrome driver in `selenium-config.json`](https://github.com/dotnet/aspnetcore/blob/39b54a3785bc69acb521cb0e96421074b19ea9e5/src/Shared/E2ETesting/selenium-config.json#L4) from [Chromium](https://chromedriver.chromium.org/downloads)

It looks like something changed starting with 115, but I don't know anything about Chromium. Can you help here?