### PR TITLE
Fix IIS OutOfProc sometimes creating multiple app instances after recycle

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp
@@ -188,7 +188,7 @@ APPLICATION_MANAGER::RecycleApplicationFromManager(
             while (itr != m_pApplicationInfoHash.end())
             {
                 if (itr->second != nullptr && itr->second->ConfigurationPathApplies(configurationPath)
-                    && applicationsToRecycle.contains(itr->second);)
+                    && std::find(applicationsToRecycle.begin(), applicationsToRecycle.end(), itr->second) != applicationsToRecycle.end())
                 {
                     itr = m_pApplicationInfoHash.erase(itr);
                     break;

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp
@@ -177,7 +177,7 @@ APPLICATION_MANAGER::RecycleApplicationFromManager(
         }
 
         // Remove apps after calling shutdown on each of them
-        // This is exclusive to in-process, as the shutdown of an inprocess app recycles
+        // This is exclusive to in-process, as the shutdown of an in-process app recycles
         // the entire worker process.
         if (m_handlerResolver.GetHostingModel() == APP_HOSTING_MODEL::HOSTING_IN_PROCESS)
         {
@@ -187,21 +187,18 @@ APPLICATION_MANAGER::RecycleApplicationFromManager(
             auto itr = m_pApplicationInfoHash.begin();
             while (itr != m_pApplicationInfoHash.end())
             {
-                for (auto& application : applicationsToRecycle)
+                if (itr->second != nullptr && itr->second->ConfigurationPathApplies(configurationPath)
+                    && applicationsToRecycle.contains(itr->second);)
                 {
-                    if (itr->second != nullptr && itr->second->ConfigurationPathApplies(configurationPath)
-                        && itr->second.get() == application.get())
-                    {
-                        itr = m_pApplicationInfoHash.erase(itr);
-                        break;
-                    }
-                    else
-                    {
-                        ++itr;
-                    }
+                    itr = m_pApplicationInfoHash.erase(itr);
+                    break;
                 }
-            } // Release Exclusive m_srwLock
-        }
+                else
+                {
+                    ++itr;
+                }
+            }
+        } // Release Exclusive m_srwLock
     }
     CATCH_RETURN()
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp
@@ -191,7 +191,6 @@ APPLICATION_MANAGER::RecycleApplicationFromManager(
                     && std::find(applicationsToRecycle.begin(), applicationsToRecycle.end(), itr->second) != applicationsToRecycle.end())
                 {
                     itr = m_pApplicationInfoHash.erase(itr);
-                    break;
                 }
                 else
                 {


### PR DESCRIPTION
Regression introduced by https://github.com/dotnet/aspnetcore/pull/28357/files#diff-8c4d15bd46e3322793578888d1de698026e0ef548f78bc1c7498fd4ce9d26d6bR182

What would happen is that we would start recycling the app(s) and if there were incoming requests at the same time they would call `APPLICATION_MANAGER::GetOrCreateApplicationInfo()`

Which would look for any active apps
https://github.com/dotnet/aspnetcore/blob/f510d8655230143a3bbc20e756baa12a5333a0d9/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp#L41-L45
and if none were found it would create one
https://github.com/dotnet/aspnetcore/blob/f510d8655230143a3bbc20e756baa12a5333a0d9/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp#L62-L70

The problem is that an in progress recycle (calling `APPLICATION_MANAGER::RecycleApplicationFromManager`) would be removing the application
https://github.com/dotnet/aspnetcore/blob/f510d8655230143a3bbc20e756baa12a5333a0d9/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp#L107-L120
Which is normally fine, but then it releases the lock to call `ShutdownApplication` on all the apps added to `applicationsToRecycle` and after that it would reacquire the lock and erase the applications again
https://github.com/dotnet/aspnetcore/blob/f510d8655230143a3bbc20e756baa12a5333a0d9/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp#L179-L190
As the comment in that last snippet suggests, this should have only run for in-process hosting as we'll be getting a new worker process and don't care about this one anymore. But as written it will run for out-of-process which results in a race where we can delete a just added application. This results in 2 web apps running, but only 1 actually receiving traffic. And on shutdown only the 1 tracked application will be shutdown, the other one is not being tracked by IIS anymore.