### PR TITLE
[Blazor] Obsolete Router.PreferExactMatches

### DIFF
--- a/src/Components/Components/src/Routing/Router.cs
+++ b/src/Components/Components/src/Routing/Router.cs
@@ -92,6 +92,7 @@ public partial class Router : IComponent, IHandleAfterRender, IDisposable
     /// over wildcards.
     /// <para>This property is obsolete and configuring it does nothing.</para>
     /// </summary>
+    [Obsolete("This property is obsolete and configuring it has not effect.")]
     [Parameter] public bool PreferExactMatches { get; set; }
 
     private RouteTable Routes { get; set; }


### PR DESCRIPTION
The property has had no effect for 3 years, but it was not flagged as obsoleted.