### PR TITLE
[release/8.0] [Blazor] Support injecting keyed services with `[Inject]`

### DIFF
--- a/src/Components/Components/src/ComponentFactory.cs
+++ b/src/Components/Components/src/ComponentFactory.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.AspNetCore.Components.Reflection;
 using Microsoft.AspNetCore.Components.RenderTree;
+using Microsoft.Extensions.DependencyInjection;
 using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
 namespace Microsoft.AspNetCore.Components;
@@ -95,16 +96,17 @@ internal sealed class ComponentFactory
     private static Action<IServiceProvider, IComponent> CreatePropertyInjector([DynamicallyAccessedMembers(Component)] Type type)
     {
         // Do all the reflection up front
-        List<(string name, Type propertyType, PropertySetter setter)>? injectables = null;
+        List<(string name, Type propertyType, PropertySetter setter, object? serviceKey)>? injectables = null;
         foreach (var property in MemberAssignment.GetPropertiesIncludingInherited(type, _injectablePropertyBindingFlags))
         {
-            if (!property.IsDefined(typeof(InjectAttribute)))
+            var injectAttribute = property.GetCustomAttribute<InjectAttribute>();
+            if (injectAttribute is null)
             {
                 continue;
             }
 
             injectables ??= new();
-            injectables.Add((property.Name, property.PropertyType, new PropertySetter(type, property)));
+            injectables.Add((property.Name, property.PropertyType, new PropertySetter(type, property), injectAttribute.Key));
         }
 
         if (injectables is null)
@@ -118,12 +120,29 @@ internal sealed class ComponentFactory
         // without any further reflection calls (just typecasts)
         void Initialize(IServiceProvider serviceProvider, IComponent component)
         {
-            foreach (var (propertyName, propertyType, setter) in injectables)
+            foreach (var (propertyName, propertyType, setter, serviceKey) in injectables)
             {
-                var serviceInstance = serviceProvider.GetService(propertyType);
-                if (serviceInstance == null)
+                object? serviceInstance;
+
+                if (serviceKey is not null)
                 {
-                    throw new InvalidOperationException($"Cannot provide a value for property " +
+                    if (serviceProvider is not IKeyedServiceProvider keyedServiceProvider)
+                    {
+                        throw new InvalidOperationException($"Cannot provide a value for property " +
+                            $"'{propertyName}' on type '{type.FullName}'. The service provider " +
+                            $"does not implement '{nameof(IKeyedServiceProvider)}' and therefore " +
+                            $"cannot provide keyed services.");
+                    }
+
+                    serviceInstance = keyedServiceProvider.GetKeyedService(propertyType, serviceKey)
+                        ?? throw new InvalidOperationException($"Cannot provide a value for property " +
+                        $"'{propertyName}' on type '{type.FullName}'. There is no " +
+                        $"registered keyed service of type '{propertyType}' with key '{serviceKey}'.");
+                }
+                else
+                {
+                    serviceInstance = serviceProvider.GetService(propertyType)
+                        ?? throw new InvalidOperationException($"Cannot provide a value for property " +
                         $"'{propertyName}' on type '{type.FullName}'. There is no " +
                         $"registered service of type '{propertyType}'.");
                 }

--- a/src/Components/Components/src/InjectAttribute.cs
+++ b/src/Components/Components/src/InjectAttribute.cs
@@ -10,4 +10,8 @@ namespace Microsoft.AspNetCore.Components;
 [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
 public sealed class InjectAttribute : Attribute
 {
+    /// <summary>
+    /// Gets or sets the object that specifies the key of the service to inject.
+    /// </summary>
+    public object? Key { get; init; }
 }

--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -17,6 +17,8 @@ Microsoft.AspNetCore.Components.CascadingValueSource<TValue>.NotifyChangedAsync(
 Microsoft.AspNetCore.Components.ComponentBase.DispatchExceptionAsync(System.Exception! exception) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.IComponentRenderMode
 Microsoft.AspNetCore.Components.Infrastructure.ComponentStatePersistenceManager.PersistStateAsync(Microsoft.AspNetCore.Components.IPersistentComponentStateStore! store, Microsoft.AspNetCore.Components.Dispatcher! dispatcher) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.InjectAttribute.Key.get -> object?
+Microsoft.AspNetCore.Components.InjectAttribute.Key.init -> void
 Microsoft.AspNetCore.Components.ParameterView.ToDictionary() -> System.Collections.Generic.IReadOnlyDictionary<string!, object?>!
 *REMOVED*Microsoft.AspNetCore.Components.ParameterView.ToDictionary() -> System.Collections.Generic.IReadOnlyDictionary<string!, object!>!
 Microsoft.AspNetCore.Components.RenderHandle.DispatchExceptionAsync(System.Exception! exception) -> System.Threading.Tasks.Task!

--- a/src/Components/Components/test/ComponentFactoryTest.cs
+++ b/src/Components/Components/test/ComponentFactoryTest.cs
@@ -86,6 +86,7 @@ public class ComponentFactoryTest
         Assert.NotNull(component.Property1);
         Assert.NotNull(component.GetProperty2());
         Assert.NotNull(component.Property3);
+        Assert.NotNull(component.KeyedProperty);
 
         // Property on derived type without [Inject] should not be assigned
         Assert.Null(component.Property4);
@@ -219,11 +220,14 @@ public class ComponentFactoryTest
         Assert.Equal($"The component type '{componentType}' has a fixed rendermode of '{typeof(TestRenderMode)}', so it is not valid to specify any rendermode when using this component.", ex.Message);
     }
 
+    private const string KeyedServiceKey = "my-keyed-service";
+
     private static IServiceProvider GetServiceProvider()
     {
         return new ServiceCollection()
             .AddTransient<TestService1>()
             .AddTransient<TestService2>()
+            .AddKeyedTransient<TestService3>(KeyedServiceKey)
             .BuildServiceProvider();
     }
 
@@ -253,6 +257,9 @@ public class ComponentFactoryTest
 
         [Inject]
         public TestService1 Property4 { get; set; }
+
+        [Inject(Key = KeyedServiceKey)]
+        public TestService3 KeyedProperty { get; set; }
 
         public TestService2 GetProperty2() => Property2;
 
@@ -295,6 +302,7 @@ public class ComponentFactoryTest
 
     public class TestService1 { }
     public class TestService2 { }
+    public class TestService3 { }
 
     private class CustomComponentActivator<TResult> : IComponentActivator where TResult : IComponent, new()
     {

--- a/src/Components/Components/test/DependencyInjectionTest.cs
+++ b/src/Components/Components/test/DependencyInjectionTest.cs
@@ -65,6 +65,22 @@ public class DependencyInjectionTest
     }
 
     [Fact]
+    public void ThrowsIfNoSuchKeyedServiceIsRegistered()
+    {
+        var serviceInstance = new MyServiceImplementation();
+        _serviceProvider.AddKeyedService<IMyService>(serviceInstance, "mismatched-key");
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+        {
+            InstantiateComponent<HasKeyedInjectableProperty>();
+        });
+
+        Assert.Equal($"Cannot provide a value for property '{nameof(HasKeyedInjectableProperty.MyService)}' " +
+            $"on type '{typeof(HasKeyedInjectableProperty).FullName}'. There is no registered keyed service " +
+            $"of type '{typeof(IMyService).FullName}' with key '{HasKeyedInjectableProperty.ServiceKey}'.", ex.Message);
+    }
+
+    [Fact]
     public void SetsInjectablePropertyValueIfServiceIsRegistered()
     {
         // Arrange
@@ -73,6 +89,20 @@ public class DependencyInjectionTest
 
         // Act
         var instance = InstantiateComponent<HasInjectableProperty>();
+
+        // Assert
+        Assert.Same(serviceInstance, instance.MyService);
+    }
+
+    [Fact]
+    public void SetsKeyedInjectablePropertyValueIfKeyedServiceIsRegistered()
+    {
+        // Arrange
+        var serviceInstance = new MyServiceImplementation();
+        _serviceProvider.AddKeyedService<IMyService>(serviceInstance, HasKeyedInjectableProperty.ServiceKey);
+
+        // Act
+        var instance = InstantiateComponent<HasKeyedInjectableProperty>();
 
         // Assert
         Assert.Same(serviceInstance, instance.MyService);
@@ -88,6 +118,7 @@ public class DependencyInjectionTest
         _serviceProvider.AddService<IMyService>(serviceInstance);
         _serviceProvider.AddService<IMyOtherService>(otherServiceInstance);
         _serviceProvider.AddService(concreteServiceInstance);
+        _serviceProvider.AddKeyedService<IMyService>(serviceInstance, HasManyInjectableProperties.ServiceKey);
 
         // Act
         var instance = InstantiateComponent<HasManyInjectableProperties>();
@@ -98,6 +129,7 @@ public class DependencyInjectionTest
         Assert.Same(serviceInstance, instance.PrivateValue);
         Assert.Same(otherServiceInstance, instance.DifferentServiceType);
         Assert.Same(concreteServiceInstance, instance.ConcreteServiceType);
+        Assert.Same(serviceInstance, instance.KeyedService);
     }
 
     [Fact]
@@ -154,6 +186,13 @@ public class DependencyInjectionTest
         [Inject] public IMyService MyService { get; set; }
     }
 
+    class HasKeyedInjectableProperty : TestComponent
+    {
+        public const string ServiceKey = "my-service";
+
+        [Inject(Key = ServiceKey)] public IMyService MyService { get; set; }
+    }
+
     class HasPrivateInjectableProperty : TestComponent
     {
         [Inject] private IMyService MyService { get; set; }
@@ -165,11 +204,14 @@ public class DependencyInjectionTest
 
     class HasManyInjectableProperties : TestComponent
     {
+        public const string ServiceKey = "my-service";
+
         [Inject] public IMyService PublicReadWrite { get; set; }
         [Inject] public IMyService PublicReadOnly { get; private set; }
         [Inject] private IMyService Private { get; set; }
         [Inject] public IMyOtherService DifferentServiceType { get; set; }
         [Inject] public MyConcreteService ConcreteServiceType { get; set; }
+        [Inject(Key = ServiceKey)] public IMyService KeyedService { get; set; }
 
         public IMyService PrivateValue => Private;
     }

--- a/src/Components/Shared/test/TestServiceProvider.cs
+++ b/src/Components/Shared/test/TestServiceProvider.cs
@@ -1,18 +1,43 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Components.Test.Helpers;
 
-public class TestServiceProvider : IServiceProvider
+public class TestServiceProvider : IServiceProvider, IKeyedServiceProvider
 {
-    private readonly Dictionary<Type, Func<object>> _factories
-        = new Dictionary<Type, Func<object>>();
+    private readonly Dictionary<Type, Func<object?>> _factories = new();
 
-    public object GetService(Type serviceType)
+    private Dictionary<(Type, object?), Func<object?>>? _keyedFactories;
+
+    private Dictionary<(Type, object?), Func<object?>> KeyedFactories
+    {
+        get
+        {
+            _keyedFactories ??= new();
+            return _keyedFactories;
+        }
+    }
+
+    public object? GetService(Type serviceType)
         => _factories.TryGetValue(serviceType, out var factory)
+            ? factory()
+            : null;
+
+    public object? GetKeyedService(Type serviceType, object? serviceKey)
+        => KeyedFactories.TryGetValue((serviceType, serviceKey), out var factory)
             ? factory()
             : null;
 
     internal void AddService<T>(T value)
         => _factories.Add(typeof(T), () => value);
+
+    internal void AddKeyedService<T>(T value, object serviceKey)
+        => KeyedFactories.Add((typeof(T), serviceKey), () => value);
+
+    public object GetRequiredKeyedService(Type serviceType, object? serviceKey)
+        => throw new NotImplementedException();
 }

--- a/src/Components/test/E2ETest/Tests/PropertyInjectionTest.cs
+++ b/src/Components/test/E2ETest/Tests/PropertyInjectionTest.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using BasicTestApp;
+using BasicTestApp.PropertyInjection;
+using Microsoft.AspNetCore.Components.E2ETest;
+using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
+using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
+using Microsoft.AspNetCore.E2ETesting;
+using OpenQA.Selenium;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Components.E2ETests.Tests;
+
+public class PropertyInjectionTest : ServerTestBase<ToggleExecutionModeServerFixture<Program>>
+{
+    public PropertyInjectionTest(
+        BrowserFixture browserFixture,
+        ToggleExecutionModeServerFixture<Program> serverFixture,
+        ITestOutputHelper output)
+        : base(browserFixture, serverFixture, output)
+    {
+    }
+
+    protected override void InitializeAsyncCore()
+    {
+        Navigate(ServerPathBase, noReload: false);
+        Browser.MountTestComponent<PropertyInjectionComponent>();
+    }
+
+    [Fact]
+    public void PropertyInjection_Works_ForKeyedServices()
+    {
+        Browser.Equal("value-1", () => Browser.FindElement(By.Id("keyed-service-value-1")).Text);
+        Browser.Equal("value-2", () => Browser.FindElement(By.Id("keyed-service-value-2")).Text);
+    }
+
+    [Fact]
+    public void PropertyInjection_Throws_WhenServiceKeyIsInvalid()
+    {
+        Browser.Equal("value-1", () => Browser.FindElement(By.Id("keyed-service-value-1")).Text);
+        Browser.Equal("value-2", () => Browser.FindElement(By.Id("keyed-service-value-2")).Text);
+
+        Browser.Click(By.Id("invalid-service-key"));
+
+        Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: block;']"), TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public void PropertyInjection_Throws_WhenKeyedServiceTypeDoesNotMatch()
+    {
+        Browser.Equal("value-1", () => Browser.FindElement(By.Id("keyed-service-value-1")).Text);
+        Browser.Equal("value-2", () => Browser.FindElement(By.Id("keyed-service-value-2")).Text);
+
+        Browser.Click(By.Id("invalid-keyed-service-type"));
+
+        Browser.Exists(By.CssSelector("#blazor-error-ui[style='display: block;']"), TimeSpan.FromSeconds(10));
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/Index.razor
+++ b/src/Components/test/testassets/BasicTestApp/Index.razor
@@ -80,6 +80,7 @@
         <option value="BasicTestApp.NavigationFailureComponent">Navigation failure</option>
         <option value="BasicTestApp.ParentChildComponent">Parent component with child</option>
         <option value="BasicTestApp.PropertiesChangedHandlerParent">Parent component that changes parameters on child</option>
+        <option value="BasicTestApp.PropertyInjection.PropertyInjectionComponent">Property injection</option>
         <option value="@GetTestServerProjectComponent("Components.TestServer.ProtectedBrowserStorageUsageComponent")">Protected browser storage usage</option>
         <option value="@GetTestServerProjectComponent("Components.TestServer.ProtectedBrowserStorageInjectionComponent")">Protected browser storage injection</option>
         <option value="BasicTestApp.QuickGridTest.SampleQuickGridComponent">QuickGrid Example</option>

--- a/src/Components/test/testassets/BasicTestApp/Program.cs
+++ b/src/Components/test/testassets/BasicTestApp/Program.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Net.Http;
 using System.Web;
 using BasicTestApp.AuthTest;
+using BasicTestApp.PropertyInjection;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Web;
@@ -40,6 +41,9 @@ public class Program
 
         builder.Services.AddScoped<PreserveStateService>();
         builder.Services.AddTransient<FormsTest.ValidationComponentDI.SaladChef>();
+
+        builder.Services.AddKeyedSingleton("keyed-service-1", TestKeyedService.Create("value-1"));
+        builder.Services.AddKeyedSingleton(TestServiceKey.ServiceB, TestKeyedService.Create("value-2"));
 
         builder.Logging.AddConfiguration(builder.Configuration.GetSection("Logging"));
 

--- a/src/Components/test/testassets/BasicTestApp/PropertyInjection/InvalidKeyedServiceType.razor
+++ b/src/Components/test/testassets/BasicTestApp/PropertyInjection/InvalidKeyedServiceType.razor
@@ -1,0 +1,7 @@
+﻿<h3>InvalidKeyedServiceType</h3>
+
+@code {
+    // The keyed service exists, but it has a different type than the property.
+    [Inject(Key = "keyed-service-1")]
+    public NavigationManager NavigationManager { get; set; }
+}

--- a/src/Components/test/testassets/BasicTestApp/PropertyInjection/InvalidServiceKey.razor
+++ b/src/Components/test/testassets/BasicTestApp/PropertyInjection/InvalidServiceKey.razor
@@ -1,0 +1,9 @@
+﻿<p>
+    Rendered component with invalid service key
+</p>
+
+@code {
+    // A service with a matching type exists, but it has a different key than the one specified here.
+    [Inject(Key = "invalid-key")]
+    public TestKeyedService InvalidKeyedService { get; set; }
+}

--- a/src/Components/test/testassets/BasicTestApp/PropertyInjection/PropertyInjectionComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/PropertyInjection/PropertyInjectionComponent.razor
@@ -1,0 +1,33 @@
+﻿<h3>Property injection</h3>
+
+<p>
+    Value of keyed service 1: <span id="keyed-service-value-1">@KeyedService1.Value</span>
+</p>
+
+<p>
+    Value of keyed service 2: <span id="keyed-service-value-2">@KeyedService2.Value</span>
+</p>
+
+<button id="invalid-service-key" type="button" @onclick="@(() => _renderInvalidServiceKeyComponent = true)">Render component with invalid service key</button>
+<button id="invalid-keyed-service-type" type="button" @onclick="@(() => _renderInvalidKeyedServiceTypeComponent = true)">Render component with invalid keyed service type</button>
+
+@if (_renderInvalidServiceKeyComponent)
+{
+    <InvalidServiceKey />
+}
+
+@if (_renderInvalidKeyedServiceTypeComponent)
+{
+    <InvalidKeyedServiceType />
+}
+
+@code {
+    private bool _renderInvalidServiceKeyComponent;
+    private bool _renderInvalidKeyedServiceTypeComponent;
+
+    [Inject(Key = "keyed-service-1")]
+    public TestKeyedService KeyedService1 { get; set; }
+
+    [Inject(Key = TestServiceKey.ServiceB)]
+    public TestKeyedService KeyedService2 { get; init; }
+}

--- a/src/Components/test/testassets/BasicTestApp/PropertyInjection/TestKeyedService.cs
+++ b/src/Components/test/testassets/BasicTestApp/PropertyInjection/TestKeyedService.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace BasicTestApp.PropertyInjection;
+
+public sealed class TestKeyedService
+{
+    public object Value { get; private init; }
+
+    public static TestKeyedService Create(object value)
+    {
+        return new()
+        {
+            Value = value,
+        };
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/PropertyInjection/TestServiceKey.cs
+++ b/src/Components/test/testassets/BasicTestApp/PropertyInjection/TestServiceKey.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace BasicTestApp.PropertyInjection;
+
+public enum TestServiceKey
+{
+    ServiceA,
+    ServiceB,
+}

--- a/src/Components/test/testassets/Components.TestServer/ServerStartup.cs
+++ b/src/Components/test/testassets/Components.TestServer/ServerStartup.cs
@@ -36,6 +36,13 @@ public class ServerStartup
         services.AddSingleton<CircuitHandler>(circuitContextAccessor);
         services.AddSingleton(circuitContextAccessor);
 
+        services.AddKeyedSingleton(
+            "keyed-service-1",
+            BasicTestApp.PropertyInjection.TestKeyedService.Create("value-1"));
+        services.AddKeyedSingleton(
+            BasicTestApp.PropertyInjection.TestServiceKey.ServiceB,
+            BasicTestApp.PropertyInjection.TestKeyedService.Create("value-2"));
+
         // Since tests run in parallel, we use an ephemeral key provider to avoid filesystem
         // contention issues.
         services.AddSingleton<IDataProtectionProvider, EphemeralDataProtectionProvider>();

--- a/src/Mvc/Mvc.Razor/src/Internal/RazorInjectAttribute.cs
+++ b/src/Mvc/Mvc.Razor/src/Internal/RazorInjectAttribute.cs
@@ -13,4 +13,8 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Internal;
 [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
 public class RazorInjectAttribute : Attribute
 {
+    /// <summary>
+    /// Gets or sets the object that specifies the key of the service to inject.
+    /// </summary>
+    public object? Key { get; init; }
 }

--- a/src/Mvc/Mvc.Razor/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Razor/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute.Key.get -> object?
+Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute.Key.init -> void

--- a/src/Mvc/Mvc.Razor/test/RazorPageActivatorTest.cs
+++ b/src/Mvc/Mvc.Razor/test/RazorPageActivatorTest.cs
@@ -72,8 +72,11 @@ public class RazorPageActivatorTest
         Assert.IsAssignableFrom<IHtmlHelper<object>>(instance.Html);
 
         var service = instance.MyService;
+        var keyedService = instance.MyKeyedService;
         Assert.NotNull(service);
+        Assert.NotNull(keyedService);
         Assert.Same(viewContext, service.ViewContext);
+        Assert.Same(viewContext, keyedService.ViewContext);
     }
 
     [Fact]
@@ -141,8 +144,11 @@ public class RazorPageActivatorTest
         Assert.IsAssignableFrom<IHtmlHelper<object>>(instance.Html);
 
         var service = instance.MyService;
+        var keyedService = instance.MyKeyedService;
         Assert.NotNull(service);
+        Assert.NotNull(keyedService);
         Assert.Same(viewContext, service.ViewContext);
+        Assert.Same(viewContext, keyedService.ViewContext);
     }
 
     [Fact]
@@ -228,6 +234,8 @@ public class RazorPageActivatorTest
         return new RazorPageActivator(MetadataProvider, UrlHelperFactory, JsonHelper, DiagnosticListener, HtmlEncoder, ModelExpressionProvider);
     }
 
+    private const string KeyedServiceKey = "my-keyed-service";
+
     private ViewContext CreateViewContext(ViewDataDictionary viewData = null)
     {
         if (viewData == null)
@@ -241,6 +249,7 @@ public class RazorPageActivatorTest
         var serviceProvider = new ServiceCollection()
             .AddSingleton(myService)
             .AddSingleton(htmlHelper)
+            .AddKeyedSingleton(KeyedServiceKey, myService)
             .BuildServiceProvider();
 
         var httpContext = new DefaultHttpContext
@@ -269,6 +278,9 @@ public class RazorPageActivatorTest
 
         [RazorInject]
         public IUrlHelper Url { get; set; }
+
+        [RazorInject(Key = KeyedServiceKey)]
+        public MyService MyKeyedService { get; set; }
     }
 
     private class TestRazorPage : TestPageBase<MyModel>


### PR DESCRIPTION
# Support injecting keyed services with `[Inject]`

This PR adds support for injecting keyed services into Blazor components using the `[Inject]` attribute.

## Description

API diff:

```diff
namespace Microsoft.AspNetCore.Components;

[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
public sealed class InjectAttribute : Attribute
{
+    /// <summary>
+    /// Gets or sets the object that specifies the key of the service to inject.
+    /// </summary>
+    public object? Key { get; init; }
}
```

Fixes #50374
