### PR TITLE
Fix FileLoggerProcessorTests output path

### DIFF
--- a/src/Middleware/HttpLogging/test/FileLoggerProcessorTests.cs
+++ b/src/Middleware/HttpLogging/test/FileLoggerProcessorTests.cs
@@ -19,7 +19,7 @@ public class FileLoggerProcessorTests
 
     public FileLoggerProcessorTests()
     {
-        TempPath = Environment.CurrentDirectory + "_";
+        TempPath = Path.Combine(Environment.CurrentDirectory, "_");
     }
 
     public string TempPath { get; }


### PR DESCRIPTION
Causes failures on some Helix queues (mainly docker containers where paths are restricted).
e.g. this was trying to access `/e_` where `/e/` is where the code lives. The intention was to use `/e/_` for the path.