### PR TITLE
Fix blocking call in FindByEmailAsync

### DIFF
--- a/src/Identity/EntityFrameworkCore/src/UserOnlyStore.cs
+++ b/src/Identity/EntityFrameworkCore/src/UserOnlyStore.cs
@@ -452,7 +452,7 @@ public class UserOnlyStore<TUser, TContext, TKey, TUserClaim, TUserLogin, TUserT
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfDisposed();
 
-        return Task.FromResult(Users.Where(u => u.NormalizedEmail == normalizedEmail).SingleOrDefault());
+        return Users.SingleOrDefaultAsync(u => u.NormalizedEmail == normalizedEmail, cancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
Make `FindByEmailAsync` actually an async method.

## Description

Seems like it was initially changed to a sync call as a workaround in #10660 by @ajcvickers. A part of the workaround was later removed in #11336 (again by @ajcvickers), but it stayed a sync call. Even later `UserStore.FindByEmailAsync` was made async again in #24116 (for #24113) by @HaoK, but the `UserOnlyStore` was not fixed.

Fixes #43973
