### PR TITLE
Update HttpHeaders Keys

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
@@ -115,7 +115,7 @@ internal abstract partial class HttpHeaders : IHeaderDictionary
 
     bool ICollection<KeyValuePair<string, StringValues>>.IsReadOnly => _isReadOnly;
 
-    ICollection<string> IDictionary<string, StringValues>.Keys => ((IDictionary<string, StringValues>)this).Select(pair => pair.Key).ToList();
+    ICollection<string> IDictionary<string, StringValues>.Keys => ((IDictionary<string, StringValues>)this).Select(pair => pair.Key).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
     ICollection<StringValues> IDictionary<string, StringValues>.Values => ((IDictionary<string, StringValues>)this).Select(pair => pair.Value).ToList();
 

--- a/src/Servers/Kestrel/Core/test/HttpHeadersTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpHeadersTests.cs
@@ -298,4 +298,12 @@ public class HttpHeadersTests
         Assert.Null(httpHeaders.ContentLength);
         Assert.False(httpHeaders.ContentLength.HasValue);
     }
+
+    [Fact]
+    public void KeysCompareShouldBeCaseInsensitive()
+    {
+        var httpHeaders = new HttpHeaders();
+        httpHeaders["Cache-Control"] = "no-cache";
+        Assert.True(httpHeaders.Keys.Contains("cache-control"));
+    }
 }

--- a/src/Servers/Kestrel/Core/test/HttpHeadersTests.cs
+++ b/src/Servers/Kestrel/Core/test/HttpHeadersTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
@@ -302,7 +303,7 @@ public class HttpHeadersTests
     [Fact]
     public void KeysCompareShouldBeCaseInsensitive()
     {
-        var httpHeaders = new HttpHeaders();
+        var httpHeaders = (IHeaderDictionary)new HttpRequestHeaders();
         httpHeaders["Cache-Control"] = "no-cache";
         Assert.True(httpHeaders.Keys.Contains("cache-control"));
     }


### PR DESCRIPTION
# Update HttpHeaders Keys to use a case-insensitive comparer

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Use `.ToHashSet(StringComparer.OrdinalIgnoreCase)` to implement case-insensitive comparer

Fixes #50553
