### PR TITLE
Fix AwaitableSocketAsyncEventArgs reorderings on weaker memory models

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketAwaitableEventArgs.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketAwaitableEventArgs.cs
@@ -18,7 +18,7 @@ internal class SocketAwaitableEventArgs : SocketAsyncEventArgs, IValueTaskSource
 
     private readonly PipeScheduler _ioScheduler;
 
-    private Action<object?>? _continuation;
+    private volatile Action<object?>? _continuation;
 
     public SocketAwaitableEventArgs(PipeScheduler ioScheduler)
         : base(unsafeSuppressExecutionContextFlow: true)

--- a/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketAwaitableEventArgs.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketAwaitableEventArgs.cs
@@ -18,6 +18,10 @@ internal class SocketAwaitableEventArgs : SocketAsyncEventArgs, IValueTaskSource
 
     private readonly PipeScheduler _ioScheduler;
 
+    // There are places where we read the _continuation field and then read some other state which we assume to be consistent
+    // with the value we read in _continuation. Without a fence, those secondary reads could be reordered with respect to the first.
+    // https://github.com/dotnet/runtime/pull/84432
+    // https://github.com/dotnet/aspnetcore/issues/50623
     private volatile Action<object?>? _continuation;
 
     public SocketAwaitableEventArgs(PipeScheduler ioScheduler)


### PR DESCRIPTION
# Fix AwaitableSocketAsyncEventArgs reorderings on weaker memory models

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

This is an equivalent of https://github.com/dotnet/runtime/pull/84432:

> There are a couple of places where we read the _continuation field and then read some other state which we assume to be consistent with the value we read in _continuation. But without a fence, those secondary reads could be reordered with respect to the first.

Just like with the runtime issue, we don't have a test or repro, but we have a customer validation of the fix, see https://github.com/dotnet/aspnetcore/issues/50623#issuecomment-1713700454.

In long term, you may want to adapt https://github.com/dotnet/runtime/pull/82147 (if possible), but the fix in the current PR is trivial to backport.

Fixes #50623
