### PR TITLE
Clean up route tooling for components

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/RoutePatternOptions.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/Infrastructure/RoutePattern/RoutePatternOptions.cs
@@ -7,30 +7,12 @@ internal sealed class RoutePatternOptions
 {
     private RoutePatternOptions() { }
     public bool SupportTokenReplacement { get; private set; }
-    public bool SupportComplexSegments { get; private set; }
-    public bool SupportDefaultValues { get; private set; }
-    public bool SupportTwoAsteriskCatchAll { get; private set; }
-    public char[]? AdditionalInvalidParameterCharacters { get; private set; }
 
-    public static readonly RoutePatternOptions DefaultRoute = new RoutePatternOptions
-    {
-        SupportComplexSegments = true,
-        SupportDefaultValues = true,
-        SupportTwoAsteriskCatchAll = true,
-    };
+    public static readonly RoutePatternOptions DefaultRoute = new RoutePatternOptions();
+    public static readonly RoutePatternOptions ComponentsRoute = new RoutePatternOptions();
 
     public static readonly RoutePatternOptions MvcAttributeRoute = new RoutePatternOptions
     {
-        SupportComplexSegments = true,
-        SupportDefaultValues = true,
-        SupportTwoAsteriskCatchAll = true,
         SupportTokenReplacement = true,
-    };
-
-    public static readonly RoutePatternOptions ComponentsRoute = new RoutePatternOptions
-    {
-        SupportComplexSegments = true,
-        SupportDefaultValues = true,
-        SupportTwoAsteriskCatchAll = true,
     };
 }


### PR DESCRIPTION
Blazor routing was unified with ASP.NET Core routing in https://github.com/dotnet/aspnetcore/pull/49622

That change eliminated the differences between routing. This PR removes the code that handled those differences because it's no longer needed.