### PR TITLE
Hard-code CSharp version to 12.0

### DIFF
--- a/eng/targets/CSharp.Common.props
+++ b/eng/targets/CSharp.Common.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>12.0</LangVersion>
 
     <!-- Enables Strict mode for Roslyn compiler -->
     <Features>strict</Features>


### PR DESCRIPTION
Hard-code to 12.0 in `release/8.0` so it doesn't continue incrementing