### PR TITLE
Use ArgumentException.ThrowIfNullOrEmpty

### DIFF
--- a/src/Components/Server/src/ProtectedBrowserStorage/ProtectedBrowserStorage.cs
+++ b/src/Components/Server/src/ProtectedBrowserStorage/ProtectedBrowserStorage.cs
@@ -33,10 +33,7 @@ public abstract class ProtectedBrowserStorage
             throw new PlatformNotSupportedException($"{GetType()} cannot be used when running in a browser.");
         }
 
-        if (string.IsNullOrEmpty(storeName))
-        {
-            throw new ArgumentException("The value cannot be null or empty", nameof(storeName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(storeName);
 
         _storeName = storeName;
         _jsRuntime = jsRuntime ?? throw new ArgumentNullException(nameof(jsRuntime));
@@ -71,15 +68,9 @@ public abstract class ProtectedBrowserStorage
     /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
     public ValueTask SetAsync(string purpose, string key, object value)
     {
-        if (string.IsNullOrEmpty(purpose))
-        {
-            throw new ArgumentException("Cannot be null or empty", nameof(purpose));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(purpose);
 
-        if (string.IsNullOrEmpty(key))
-        {
-            throw new ArgumentException("Cannot be null or empty", nameof(key));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(key);
 
         return SetProtectedJsonAsync(key, Protect(purpose, value));
     }

--- a/src/Components/Web/src/JSComponents/JSComponentConfigurationStore.cs
+++ b/src/Components/Web/src/JSComponents/JSComponentConfigurationStore.cs
@@ -56,10 +56,7 @@ public sealed class JSComponentConfigurationStore
     {
         Add(componentType, identifier);
 
-        if (string.IsNullOrEmpty(javaScriptInitializer))
-        {
-            throw new ArgumentException($"'{nameof(javaScriptInitializer)}' cannot be null or empty.", nameof(javaScriptInitializer));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(javaScriptInitializer);
 
         // Since it has a JS initializer, prepare the metadata we'll supply to JS code
         if (!JSComponentIdentifiersByInitializer.TryGetValue(javaScriptInitializer, out var identifiersForInitializer))

--- a/src/Hosting/Server.IntegrationTesting/src/Common/DeploymentParameters.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/DeploymentParameters.cs
@@ -52,10 +52,7 @@ public class DeploymentParameters
         RuntimeFlavor runtimeFlavor,
         RuntimeArchitecture runtimeArchitecture)
     {
-        if (string.IsNullOrEmpty(applicationPath))
-        {
-            throw new ArgumentException("Value cannot be null.", nameof(applicationPath));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(applicationPath);
 
         if (!Directory.Exists(applicationPath))
         {

--- a/src/Http/Http.Results/src/TypedResults.cs
+++ b/src/Http/Http.Results/src/TypedResults.cs
@@ -511,10 +511,7 @@ public static class TypedResults
         EntityTagHeaderValue? entityTag = null,
         bool enableRangeProcessing = false)
     {
-        if (string.IsNullOrEmpty(path))
-        {
-            throw new ArgumentException("Argument cannot be null or empty", nameof(path));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(path);
 
         return new(path, contentType)
         {
@@ -547,10 +544,7 @@ public static class TypedResults
         EntityTagHeaderValue? entityTag = null,
         bool enableRangeProcessing = false)
     {
-        if (string.IsNullOrEmpty(path))
-        {
-            throw new ArgumentException("Argument cannot be null or empty", nameof(path));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(path);
 
         return new(path, contentType)
         {
@@ -576,10 +570,7 @@ public static class TypedResults
     /// <returns>The created <see cref="RedirectHttpResult"/> for the response.</returns>
     public static RedirectHttpResult Redirect([StringSyntax(StringSyntaxAttribute.Uri)] string url, bool permanent = false, bool preserveMethod = false)
     {
-        if (string.IsNullOrEmpty(url))
-        {
-            throw new ArgumentException("Argument cannot be null or empty", nameof(url));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(url);
 
         return new(url, permanent, preserveMethod);
     }
@@ -599,10 +590,7 @@ public static class TypedResults
     /// <returns>The created <see cref="RedirectHttpResult"/> for the response.</returns>
     public static RedirectHttpResult LocalRedirect([StringSyntax(StringSyntaxAttribute.Uri, UriKind.Relative)] string localUrl, bool permanent = false, bool preserveMethod = false)
     {
-        if (string.IsNullOrEmpty(localUrl))
-        {
-            throw new ArgumentException("Argument cannot be null or empty", nameof(localUrl));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(localUrl);
 
         return new(localUrl, acceptLocalUrlOnly: true, permanent, preserveMethod);
     }

--- a/src/Http/Routing/src/Patterns/RoutePatternFactory.cs
+++ b/src/Http/Routing/src/Patterns/RoutePatternFactory.cs
@@ -727,10 +727,7 @@ internal static class RoutePatternFactory
     /// <returns>The <see cref="RoutePatternLiteralPart"/>.</returns>
     public static RoutePatternLiteralPart LiteralPart(string content)
     {
-        if (string.IsNullOrEmpty(content))
-        {
-            throw new ArgumentException(Resources.Argument_NullOrEmpty, nameof(content));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(content);
 
         if (content.Contains('?'))
         {
@@ -753,10 +750,7 @@ internal static class RoutePatternFactory
     /// <returns>The <see cref="RoutePatternSeparatorPart"/>.</returns>
     public static RoutePatternSeparatorPart SeparatorPart(string content)
     {
-        if (string.IsNullOrEmpty(content))
-        {
-            throw new ArgumentException(Resources.Argument_NullOrEmpty, nameof(content));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(content);
 
         return SeparatorPartCore(content);
     }
@@ -774,10 +768,7 @@ internal static class RoutePatternFactory
     /// <returns>The <see cref="RoutePatternParameterPart"/>.</returns>
     public static RoutePatternParameterPart ParameterPart(string parameterName)
     {
-        if (string.IsNullOrEmpty(parameterName))
-        {
-            throw new ArgumentException(Resources.Argument_NullOrEmpty, nameof(parameterName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(parameterName);
 
         if (parameterName.AsSpan().IndexOfAny(RoutePatternParser.InvalidParameterNameChars) >= 0)
         {
@@ -800,10 +791,7 @@ internal static class RoutePatternFactory
     /// <returns>The <see cref="RoutePatternParameterPart"/>.</returns>
     public static RoutePatternParameterPart ParameterPart(string parameterName, object @default)
     {
-        if (string.IsNullOrEmpty(parameterName))
-        {
-            throw new ArgumentException(Resources.Argument_NullOrEmpty, nameof(parameterName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(parameterName);
 
         if (parameterName.AsSpan().IndexOfAny(RoutePatternParser.InvalidParameterNameChars) >= 0)
         {
@@ -830,10 +818,7 @@ internal static class RoutePatternFactory
         object? @default,
         RoutePatternParameterKind parameterKind)
     {
-        if (string.IsNullOrEmpty(parameterName))
-        {
-            throw new ArgumentException(Resources.Argument_NullOrEmpty, nameof(parameterName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(parameterName);
 
         if (parameterName.AsSpan().IndexOfAny(RoutePatternParser.InvalidParameterNameChars) >= 0)
         {
@@ -867,10 +852,7 @@ internal static class RoutePatternFactory
         RoutePatternParameterKind parameterKind,
         IEnumerable<RoutePatternParameterPolicyReference> parameterPolicies)
     {
-        if (string.IsNullOrEmpty(parameterName))
-        {
-            throw new ArgumentException(Resources.Argument_NullOrEmpty, nameof(parameterName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(parameterName);
 
         if (parameterName.AsSpan().IndexOfAny(RoutePatternParser.InvalidParameterNameChars) >= 0)
         {
@@ -906,10 +888,7 @@ internal static class RoutePatternFactory
         RoutePatternParameterKind parameterKind,
         params RoutePatternParameterPolicyReference[] parameterPolicies)
     {
-        if (string.IsNullOrEmpty(parameterName))
-        {
-            throw new ArgumentException(Resources.Argument_NullOrEmpty, nameof(parameterName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(parameterName);
 
         if (parameterName.AsSpan().IndexOfAny(RoutePatternParser.InvalidParameterNameChars) >= 0)
         {
@@ -1008,10 +987,7 @@ internal static class RoutePatternFactory
 #endif
     public static RoutePatternParameterPolicyReference Constraint(string constraint)
     {
-        if (string.IsNullOrEmpty(constraint))
-        {
-            throw new ArgumentException(Resources.Argument_NullOrEmpty, nameof(constraint));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(constraint);
 
         return ParameterPolicyCore(constraint);
     }
@@ -1041,10 +1017,7 @@ internal static class RoutePatternFactory
 #endif
     public static RoutePatternParameterPolicyReference ParameterPolicy(string parameterPolicy)
     {
-        if (string.IsNullOrEmpty(parameterPolicy))
-        {
-            throw new ArgumentException(Resources.Argument_NullOrEmpty, nameof(parameterPolicy));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(parameterPolicy);
 
         return ParameterPolicyCore(parameterPolicy);
     }

--- a/src/JSInterop/Microsoft.JSInterop/src/JSInvokableAttribute.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSInvokableAttribute.cs
@@ -35,10 +35,7 @@ public sealed class JSInvokableAttribute : Attribute
     /// <param name="identifier">An identifier for the method, which must be unique within the scope of the assembly.</param>
     public JSInvokableAttribute(string identifier)
     {
-        if (string.IsNullOrEmpty(identifier))
-        {
-            throw new ArgumentException("Cannot be null or empty", nameof(identifier));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(identifier);
 
         Identifier = identifier;
     }

--- a/src/Middleware/Rewrite/src/ApacheModRewrite/FlagParser.cs
+++ b/src/Middleware/Rewrite/src/ApacheModRewrite/FlagParser.cs
@@ -54,10 +54,7 @@ internal static class FlagParser
 
     public static Flags Parse(string flagString)
     {
-        if (string.IsNullOrEmpty(flagString))
-        {
-            throw new ArgumentException("Argument cannot be null or empty string.", nameof(flagString));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(flagString);
 
         // Check that flags are contained within []
         // Guaranteed to have a length of at least 1 here, so this will never throw for indexing.

--- a/src/Middleware/Session/src/DistributedSession.cs
+++ b/src/Middleware/Session/src/DistributedSession.cs
@@ -65,10 +65,7 @@ public class DistributedSession : ISession
     {
         ArgumentNullException.ThrowIfNull(cache);
 
-        if (string.IsNullOrEmpty(sessionKey))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(sessionKey));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(sessionKey);
 
         ArgumentNullException.ThrowIfNull(tryEstablishSession);
         ArgumentNullException.ThrowIfNull(loggerFactory);

--- a/src/Middleware/Session/src/DistributedSessionStore.cs
+++ b/src/Middleware/Session/src/DistributedSessionStore.cs
@@ -32,10 +32,7 @@ public class DistributedSessionStore : ISessionStore
     /// <inheritdoc />
     public ISession Create(string sessionKey, TimeSpan idleTimeout, TimeSpan ioTimeout, Func<bool> tryEstablishSession, bool isNewSessionKey)
     {
-        if (string.IsNullOrEmpty(sessionKey))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(sessionKey));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(sessionKey);
 
         ArgumentNullException.ThrowIfNull(tryEstablishSession);
 

--- a/src/Middleware/Spa/SpaServices.Extensions/src/AngularCli/AngularCliBuilder.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/AngularCli/AngularCliBuilder.cs
@@ -30,10 +30,7 @@ public class AngularCliBuilder : ISpaPrerendererBuilder
     /// <param name="npmScript">The name of the script in your package.json file that builds the server-side bundle for your Angular application.</param>
     public AngularCliBuilder(string npmScript)
     {
-        if (string.IsNullOrEmpty(npmScript))
-        {
-            throw new ArgumentException("Cannot be null or empty.", nameof(npmScript));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(npmScript);
 
         _scriptName = npmScript;
     }

--- a/src/Middleware/Spa/SpaServices.Extensions/src/AngularCli/AngularCliMiddleware.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/AngularCli/AngularCliMiddleware.cs
@@ -27,15 +27,9 @@ internal static class AngularCliMiddleware
         var pkgManagerCommand = spaBuilder.Options.PackageManagerCommand;
         var sourcePath = spaBuilder.Options.SourcePath;
         var devServerPort = spaBuilder.Options.DevServerPort;
-        if (string.IsNullOrEmpty(sourcePath))
-        {
-            throw new ArgumentException("Property 'SourcePath' cannot be null or empty", nameof(spaBuilder));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(sourcePath);
 
-        if (string.IsNullOrEmpty(scriptName))
-        {
-            throw new ArgumentException("Cannot be null or empty", nameof(scriptName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(scriptName);
 
         // Start Angular CLI and attach to middleware pipeline
         var appBuilder = spaBuilder.ApplicationBuilder;

--- a/src/Middleware/Spa/SpaServices.Extensions/src/Npm/NodeScriptRunner.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/Npm/NodeScriptRunner.cs
@@ -24,20 +24,9 @@ internal sealed class NodeScriptRunner : IDisposable
 
     public NodeScriptRunner(string workingDirectory, string scriptName, string? arguments, IDictionary<string, string>? envVars, string pkgManagerCommand, DiagnosticSource diagnosticSource, CancellationToken applicationStoppingToken)
     {
-        if (string.IsNullOrEmpty(workingDirectory))
-        {
-            throw new ArgumentException("Cannot be null or empty.", nameof(workingDirectory));
-        }
-
-        if (string.IsNullOrEmpty(scriptName))
-        {
-            throw new ArgumentException("Cannot be null or empty.", nameof(scriptName));
-        }
-
-        if (string.IsNullOrEmpty(pkgManagerCommand))
-        {
-            throw new ArgumentException("Cannot be null or empty.", nameof(pkgManagerCommand));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(workingDirectory);
+        ArgumentException.ThrowIfNullOrEmpty(scriptName);
+        ArgumentException.ThrowIfNullOrEmpty(pkgManagerCommand);
 
         var exeToRun = pkgManagerCommand;
         var completeArguments = $"run {scriptName} -- {arguments ?? string.Empty}";

--- a/src/Middleware/Spa/SpaServices.Extensions/src/ReactDevelopmentServer/ReactDevelopmentServerMiddleware.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/ReactDevelopmentServer/ReactDevelopmentServerMiddleware.cs
@@ -27,15 +27,8 @@ internal static class ReactDevelopmentServerMiddleware
         var pkgManagerCommand = spaBuilder.Options.PackageManagerCommand;
         var sourcePath = spaBuilder.Options.SourcePath;
         var devServerPort = spaBuilder.Options.DevServerPort;
-        if (string.IsNullOrEmpty(sourcePath))
-        {
-            throw new ArgumentException("Property 'SourcePath' cannot be null or empty", nameof(spaBuilder));
-        }
-
-        if (string.IsNullOrEmpty(scriptName))
-        {
-            throw new ArgumentException("Cannot be null or empty", nameof(scriptName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(sourcePath);
+        ArgumentException.ThrowIfNullOrEmpty(scriptName);
 
         // Start create-react-app and attach to middleware pipeline
         var appBuilder = spaBuilder.ApplicationBuilder;

--- a/src/Middleware/Spa/SpaServices.Extensions/src/SpaOptions.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/SpaOptions.cs
@@ -44,10 +44,7 @@ public class SpaOptions
         get => _defaultPage;
         set
         {
-            if (string.IsNullOrEmpty(value.Value))
-            {
-                throw new ArgumentException($"The value for {nameof(DefaultPage)} cannot be null or empty.");
-            }
+            ArgumentException.ThrowIfNullOrEmpty(value, nameof(DefaultPage));
 
             _defaultPage = value;
         }
@@ -86,10 +83,7 @@ public class SpaOptions
         get => _packageManagerCommand;
         set
         {
-            if (string.IsNullOrEmpty(value))
-            {
-                throw new ArgumentException($"The value for {nameof(PackageManagerCommand)} cannot be null or empty.");
-            }
+            ArgumentException.ThrowIfNullOrEmpty(value, nameof(PackageManagerCommand));
 
             _packageManagerCommand = value;
         }

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/Metadata/ModelMetadataIdentity.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/Metadata/ModelMetadataIdentity.cs
@@ -53,10 +53,7 @@ public readonly struct ModelMetadataIdentity : IEquatable<ModelMetadataIdentity>
         ArgumentNullException.ThrowIfNull(modelType);
         ArgumentNullException.ThrowIfNull(containerType);
 
-        if (string.IsNullOrEmpty(name))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(name));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(name);
 
         return new ModelMetadataIdentity(modelType, name, containerType);
     }

--- a/src/Mvc/Mvc.Core/src/ActionConstraints/HttpMethodActionConstraint.cs
+++ b/src/Mvc/Mvc.Core/src/ActionConstraints/HttpMethodActionConstraint.cs
@@ -36,10 +36,7 @@ public class HttpMethodActionConstraint : IActionConstraint
 
         foreach (var method in httpMethods)
         {
-            if (string.IsNullOrEmpty(method))
-            {
-                throw new ArgumentException("httpMethod cannot be null or empty");
-            }
+            ArgumentException.ThrowIfNullOrEmpty(method);
 
             methods.Add(method);
         }

--- a/src/Mvc/Mvc.Core/src/ApiConventionMethodAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ApiConventionMethodAttribute.cs
@@ -39,10 +39,7 @@ public sealed class ApiConventionMethodAttribute : Attribute
         ConventionType = conventionType ?? throw new ArgumentNullException(nameof(conventionType));
         ApiConventionTypeAttribute.EnsureValid(conventionType);
 
-        if (string.IsNullOrEmpty(methodName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(methodName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(methodName);
 
         Method = GetConventionMethod(conventionType, methodName);
     }

--- a/src/Mvc/Mvc.Core/src/ApplicationParts/ProvideApplicationPartFactoryAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationParts/ProvideApplicationPartFactoryAttribute.cs
@@ -29,10 +29,7 @@ public sealed class ProvideApplicationPartFactoryAttribute : Attribute
     /// <param name="factoryTypeName">The assembly qualified type name.</param>
     public ProvideApplicationPartFactoryAttribute(string factoryTypeName)
     {
-        if (string.IsNullOrEmpty(factoryTypeName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(factoryTypeName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(factoryTypeName);
 
         _applicationPartFactoryTypeName = factoryTypeName;
     }

--- a/src/Mvc/Mvc.Core/src/ApplicationParts/RelatedAssemblyAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ApplicationParts/RelatedAssemblyAttribute.cs
@@ -20,10 +20,7 @@ public sealed class RelatedAssemblyAttribute : Attribute
     /// <param name="assemblyFileName">The file name, without extension, of the related assembly.</param>
     public RelatedAssemblyAttribute(string assemblyFileName)
     {
-        if (string.IsNullOrEmpty(assemblyFileName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(assemblyFileName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(assemblyFileName);
 
         AssemblyFileName = assemblyFileName;
     }

--- a/src/Mvc/Mvc.Core/src/AreaAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/AreaAttribute.cs
@@ -19,9 +19,6 @@ public class AreaAttribute : RouteValueAttribute
     public AreaAttribute(string areaName)
         : base("area", areaName)
     {
-        if (string.IsNullOrEmpty(areaName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(areaName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(areaName);
     }
 }

--- a/src/Mvc/Mvc.Core/src/Builder/ControllerEndpointRouteBuilderExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/Builder/ControllerEndpointRouteBuilderExtensions.cs
@@ -133,10 +133,7 @@ public static class ControllerEndpointRouteBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(endpoints);
 
-        if (string.IsNullOrEmpty(areaName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(areaName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(areaName);
 
         var defaultsDictionary = new RouteValueDictionary(defaults);
         defaultsDictionary["area"] = defaultsDictionary["area"] ?? areaName;

--- a/src/Mvc/Mvc.Core/src/Builder/MvcAreaRouteBuilderExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/Builder/MvcAreaRouteBuilderExtensions.cs
@@ -120,10 +120,7 @@ public static class MvcAreaRouteBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(routeBuilder);
 
-        if (string.IsNullOrEmpty(areaName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(areaName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(areaName);
 
         var defaultsDictionary = new RouteValueDictionary(defaults);
         defaultsDictionary["area"] = defaultsDictionary["area"] ?? areaName;

--- a/src/Mvc/Mvc.Core/src/ControllerBase.cs
+++ b/src/Mvc/Mvc.Core/src/ControllerBase.cs
@@ -328,10 +328,7 @@ public abstract class ControllerBase
     [NonAction]
     public virtual RedirectResult Redirect([StringSyntax(StringSyntaxAttribute.Uri)] string url)
     {
-        if (string.IsNullOrEmpty(url))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(url));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(url);
 
         return new RedirectResult(url);
     }
@@ -345,10 +342,7 @@ public abstract class ControllerBase
     [NonAction]
     public virtual RedirectResult RedirectPermanent([StringSyntax(StringSyntaxAttribute.Uri)] string url)
     {
-        if (string.IsNullOrEmpty(url))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(url));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(url);
 
         return new RedirectResult(url, permanent: true);
     }
@@ -363,10 +357,7 @@ public abstract class ControllerBase
     [NonAction]
     public virtual RedirectResult RedirectPreserveMethod([StringSyntax(StringSyntaxAttribute.Uri)] string url)
     {
-        if (string.IsNullOrEmpty(url))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(url));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(url);
 
         return new RedirectResult(url: url, permanent: false, preserveMethod: true);
     }
@@ -381,10 +372,7 @@ public abstract class ControllerBase
     [NonAction]
     public virtual RedirectResult RedirectPermanentPreserveMethod([StringSyntax(StringSyntaxAttribute.Uri)] string url)
     {
-        if (string.IsNullOrEmpty(url))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(url));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(url);
 
         return new RedirectResult(url: url, permanent: true, preserveMethod: true);
     }
@@ -398,10 +386,7 @@ public abstract class ControllerBase
     [NonAction]
     public virtual LocalRedirectResult LocalRedirect([StringSyntax(StringSyntaxAttribute.Uri, UriKind.Relative)] string localUrl)
     {
-        if (string.IsNullOrEmpty(localUrl))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(localUrl));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(localUrl);
 
         return new LocalRedirectResult(localUrl);
     }
@@ -415,10 +400,7 @@ public abstract class ControllerBase
     [NonAction]
     public virtual LocalRedirectResult LocalRedirectPermanent([StringSyntax(StringSyntaxAttribute.Uri, UriKind.Relative)] string localUrl)
     {
-        if (string.IsNullOrEmpty(localUrl))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(localUrl));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(localUrl);
 
         return new LocalRedirectResult(localUrl, permanent: true);
     }
@@ -433,10 +415,7 @@ public abstract class ControllerBase
     [NonAction]
     public virtual LocalRedirectResult LocalRedirectPreserveMethod([StringSyntax(StringSyntaxAttribute.Uri, UriKind.Relative)] string localUrl)
     {
-        if (string.IsNullOrEmpty(localUrl))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(localUrl));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(localUrl);
 
         return new LocalRedirectResult(localUrl: localUrl, permanent: false, preserveMethod: true);
     }
@@ -451,10 +430,7 @@ public abstract class ControllerBase
     [NonAction]
     public virtual LocalRedirectResult LocalRedirectPermanentPreserveMethod([StringSyntax(StringSyntaxAttribute.Uri, UriKind.Relative)] string localUrl)
     {
-        if (string.IsNullOrEmpty(localUrl))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(localUrl));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(localUrl);
 
         return new LocalRedirectResult(localUrl: localUrl, permanent: true, preserveMethod: true);
     }

--- a/src/Mvc/Mvc.Core/src/Formatters/FormatterMappings.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/FormatterMappings.cs
@@ -92,10 +92,7 @@ public class FormatterMappings
 
     private static string RemovePeriodIfPresent(string format)
     {
-        if (string.IsNullOrEmpty(format))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(format));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(format);
 
         if (format.StartsWith('.'))
         {

--- a/src/Mvc/Mvc.Core/src/LocalRedirectResult.cs
+++ b/src/Mvc/Mvc.Core/src/LocalRedirectResult.cs
@@ -46,10 +46,7 @@ public class LocalRedirectResult : ActionResult
     /// <param name="preserveMethod">If set to true, make the temporary redirect (307) or permanent redirect (308) preserve the initial request's method.</param>
     public LocalRedirectResult([StringSyntax(StringSyntaxAttribute.Uri, UriKind.Relative)] string localUrl, bool permanent, bool preserveMethod)
     {
-        if (string.IsNullOrEmpty(localUrl))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(localUrl));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(localUrl);
 
         Permanent = permanent;
         PreserveMethod = preserveMethod;
@@ -76,10 +73,7 @@ public class LocalRedirectResult : ActionResult
         [MemberNotNull(nameof(_localUrl))]
         set
         {
-            if (string.IsNullOrEmpty(value))
-            {
-                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(value));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(value);
 
             _localUrl = value;
         }

--- a/src/Mvc/Mvc.Core/src/RedirectResult.cs
+++ b/src/Mvc/Mvc.Core/src/RedirectResult.cs
@@ -48,12 +48,7 @@ public class RedirectResult : ActionResult, IKeepTempDataResult
     /// <param name="preserveMethod">If set to true, make the temporary redirect (307) or permanent redirect (308) preserve the initial request method.</param>
     public RedirectResult([StringSyntax(StringSyntaxAttribute.Uri)] string url, bool permanent, bool preserveMethod)
     {
-        ArgumentNullException.ThrowIfNull(url);
-
-        if (string.IsNullOrEmpty(url))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(url));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(url);
 
         Permanent = permanent;
         PreserveMethod = preserveMethod;
@@ -79,10 +74,7 @@ public class RedirectResult : ActionResult, IKeepTempDataResult
         [MemberNotNull(nameof(_url))]
         set
         {
-            if (string.IsNullOrEmpty(value))
-            {
-                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(value));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(value);
 
             _url = value;
         }

--- a/src/Mvc/Mvc.DataAnnotations/src/DataTypeAttributeAdapter.cs
+++ b/src/Mvc/Mvc.DataAnnotations/src/DataTypeAttributeAdapter.cs
@@ -16,10 +16,7 @@ internal sealed class DataTypeAttributeAdapter : AttributeAdapterBase<DataTypeAt
     public DataTypeAttributeAdapter(DataTypeAttribute attribute, string ruleName, IStringLocalizer? stringLocalizer)
         : base(attribute, stringLocalizer)
     {
-        if (string.IsNullOrEmpty(ruleName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(ruleName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(ruleName);
 
         RuleName = ruleName;
     }

--- a/src/Mvc/Mvc.Razor/src/RazorFileHierarchy.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorFileHierarchy.cs
@@ -11,10 +11,7 @@ internal static class RazorFileHierarchy
 
     public static IEnumerable<string> GetViewStartPaths(string path)
     {
-        if (string.IsNullOrEmpty(path))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(path));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(path);
 
         if (path[0] != '/')
         {

--- a/src/Mvc/Mvc.Razor/src/RazorViewEngine.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorViewEngine.cs
@@ -108,10 +108,7 @@ public partial class RazorViewEngine : IRazorViewEngine
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        if (string.IsNullOrEmpty(pageName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(pageName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(pageName);
 
         if (IsApplicationRelativePath(pageName) || IsRelativePath(pageName))
         {
@@ -134,10 +131,7 @@ public partial class RazorViewEngine : IRazorViewEngine
     /// <inheritdoc />
     public RazorPageResult GetPage(string executingFilePath, string pagePath)
     {
-        if (string.IsNullOrEmpty(pagePath))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(pagePath));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(pagePath);
 
         if (!(IsApplicationRelativePath(pagePath) || IsRelativePath(pagePath)))
         {
@@ -162,10 +156,7 @@ public partial class RazorViewEngine : IRazorViewEngine
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        if (string.IsNullOrEmpty(viewName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(viewName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(viewName);
 
         if (IsApplicationRelativePath(viewName) || IsRelativePath(viewName))
         {
@@ -180,10 +171,7 @@ public partial class RazorViewEngine : IRazorViewEngine
     /// <inheritdoc />
     public ViewEngineResult GetView(string? executingFilePath, string viewPath, bool isMainPage)
     {
-        if (string.IsNullOrEmpty(viewPath))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(viewPath));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(viewPath);
 
         if (!(IsApplicationRelativePath(viewPath) || IsRelativePath(viewPath)))
         {

--- a/src/Mvc/Mvc.RazorPages/src/DependencyInjection/MvcRazorPagesMvcBuilderExtensions.cs
+++ b/src/Mvc/Mvc.RazorPages/src/DependencyInjection/MvcRazorPagesMvcBuilderExtensions.cs
@@ -39,10 +39,7 @@ public static class MvcRazorPagesMvcBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        if (string.IsNullOrEmpty(rootDirectory))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(rootDirectory));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(rootDirectory);
 
         if (rootDirectory[0] != '/')
         {

--- a/src/Mvc/Mvc.RazorPages/src/DependencyInjection/MvcRazorPagesMvcCoreBuilderExtensions.cs
+++ b/src/Mvc/Mvc.RazorPages/src/DependencyInjection/MvcRazorPagesMvcCoreBuilderExtensions.cs
@@ -71,10 +71,7 @@ public static class MvcRazorPagesMvcCoreBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        if (string.IsNullOrEmpty(rootDirectory))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(rootDirectory));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(rootDirectory);
 
         builder.Services.Configure<RazorPagesOptions>(options => options.RootDirectory = rootDirectory);
         return builder;

--- a/src/Mvc/Mvc.RazorPages/src/DependencyInjection/PageConventionCollectionExtensions.cs
+++ b/src/Mvc/Mvc.RazorPages/src/DependencyInjection/PageConventionCollectionExtensions.cs
@@ -73,10 +73,7 @@ public static class PageConventionCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(conventions);
 
-        if (string.IsNullOrEmpty(pageName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(pageName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(pageName);
 
         conventions.AddPageApplicationModelConvention(pageName, model =>
         {
@@ -112,15 +109,9 @@ public static class PageConventionCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(conventions);
 
-        if (string.IsNullOrEmpty(areaName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(areaName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(areaName);
 
-        if (string.IsNullOrEmpty(pageName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(pageName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(pageName);
 
         conventions.AddAreaPageApplicationModelConvention(areaName, pageName, model =>
         {
@@ -146,10 +137,7 @@ public static class PageConventionCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(conventions);
 
-        if (string.IsNullOrEmpty(folderPath))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(folderPath));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(folderPath);
 
         conventions.AddFolderApplicationModelConvention(folderPath, model =>
         {
@@ -185,15 +173,9 @@ public static class PageConventionCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(conventions);
 
-        if (string.IsNullOrEmpty(areaName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(areaName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(areaName);
 
-        if (string.IsNullOrEmpty(folderPath))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(folderPath));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(folderPath);
 
         conventions.AddAreaFolderApplicationModelConvention(areaName, folderPath, model =>
         {
@@ -220,10 +202,7 @@ public static class PageConventionCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(conventions);
 
-        if (string.IsNullOrEmpty(pageName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(pageName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(pageName);
 
         conventions.AddPageApplicationModelConvention(pageName, model =>
         {
@@ -286,15 +265,9 @@ public static class PageConventionCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(conventions);
 
-        if (string.IsNullOrEmpty(areaName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(areaName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(areaName);
 
-        if (string.IsNullOrEmpty(pageName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(pageName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(pageName);
 
         conventions.AddAreaPageApplicationModelConvention(areaName, pageName, model =>
         {
@@ -321,10 +294,7 @@ public static class PageConventionCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(conventions);
 
-        if (string.IsNullOrEmpty(folderPath))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(folderPath));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(folderPath);
 
         conventions.AddFolderApplicationModelConvention(folderPath, model =>
         {
@@ -387,15 +357,9 @@ public static class PageConventionCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(conventions);
 
-        if (string.IsNullOrEmpty(areaName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(areaName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(areaName);
 
-        if (string.IsNullOrEmpty(folderPath))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(folderPath));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(folderPath);
 
         conventions.AddAreaFolderApplicationModelConvention(areaName, folderPath, model =>
         {
@@ -426,10 +390,7 @@ public static class PageConventionCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(conventions);
 
-        if (string.IsNullOrEmpty(pageName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(pageName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(pageName);
 
         ArgumentNullException.ThrowIfNull(route);
 
@@ -465,15 +426,9 @@ public static class PageConventionCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(conventions);
 
-        if (string.IsNullOrEmpty(areaName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(areaName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(areaName);
 
-        if (string.IsNullOrEmpty(pageName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(pageName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(pageName);
 
         ArgumentNullException.ThrowIfNull(route);
 

--- a/src/Mvc/Mvc.RazorPages/src/PageModel.cs
+++ b/src/Mvc/Mvc.RazorPages/src/PageModel.cs
@@ -717,10 +717,7 @@ public abstract class PageModel : IAsyncPageFilter, IPageFilter
     /// <returns>The created <see cref="LocalRedirectResult"/> for the response.</returns>
     public virtual LocalRedirectResult LocalRedirect([StringSyntax(StringSyntaxAttribute.Uri, UriKind.Relative)] string localUrl)
     {
-        if (string.IsNullOrEmpty(localUrl))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(localUrl));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(localUrl);
 
         return new LocalRedirectResult(localUrl);
     }
@@ -733,10 +730,7 @@ public abstract class PageModel : IAsyncPageFilter, IPageFilter
     /// <returns>The created <see cref="LocalRedirectResult"/> for the response.</returns>
     public virtual LocalRedirectResult LocalRedirectPermanent([StringSyntax(StringSyntaxAttribute.Uri, UriKind.Relative)] string localUrl)
     {
-        if (string.IsNullOrEmpty(localUrl))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(localUrl));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(localUrl);
 
         return new LocalRedirectResult(localUrl, permanent: true);
     }
@@ -750,10 +744,7 @@ public abstract class PageModel : IAsyncPageFilter, IPageFilter
     /// <returns>The created <see cref="LocalRedirectResult"/> for the response.</returns>
     public virtual LocalRedirectResult LocalRedirectPreserveMethod([StringSyntax(StringSyntaxAttribute.Uri, UriKind.Relative)] string localUrl)
     {
-        if (string.IsNullOrEmpty(localUrl))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(localUrl));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(localUrl);
 
         return new LocalRedirectResult(localUrl: localUrl, permanent: false, preserveMethod: true);
     }
@@ -767,10 +758,7 @@ public abstract class PageModel : IAsyncPageFilter, IPageFilter
     /// <returns>The created <see cref="LocalRedirectResult"/> for the response.</returns>
     public virtual LocalRedirectResult LocalRedirectPermanentPreserveMethod([StringSyntax(StringSyntaxAttribute.Uri, UriKind.Relative)] string localUrl)
     {
-        if (string.IsNullOrEmpty(localUrl))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(localUrl));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(localUrl);
 
         return new LocalRedirectResult(localUrl: localUrl, permanent: true, preserveMethod: true);
     }
@@ -828,10 +816,7 @@ public abstract class PageModel : IAsyncPageFilter, IPageFilter
     /// <returns>The created <see cref="RedirectResult"/> for the response.</returns>
     protected internal RedirectResult Redirect([StringSyntax(StringSyntaxAttribute.Uri)] string url)
     {
-        if (string.IsNullOrEmpty(url))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(url));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(url);
 
         return new RedirectResult(url);
     }
@@ -844,10 +829,7 @@ public abstract class PageModel : IAsyncPageFilter, IPageFilter
     /// <returns>The created <see cref="RedirectResult"/> for the response.</returns>
     public virtual RedirectResult RedirectPermanent([StringSyntax(StringSyntaxAttribute.Uri)] string url)
     {
-        if (string.IsNullOrEmpty(url))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(url));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(url);
 
         return new RedirectResult(url, permanent: true);
     }
@@ -861,10 +843,7 @@ public abstract class PageModel : IAsyncPageFilter, IPageFilter
     /// <returns>The created <see cref="RedirectResult"/> for the response.</returns>
     public virtual RedirectResult RedirectPreserveMethod([StringSyntax(StringSyntaxAttribute.Uri)] string url)
     {
-        if (string.IsNullOrEmpty(url))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(url));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(url);
 
         return new RedirectResult(url: url, permanent: false, preserveMethod: true);
     }
@@ -878,10 +857,7 @@ public abstract class PageModel : IAsyncPageFilter, IPageFilter
     /// <returns>The created <see cref="RedirectResult"/> for the response.</returns>
     public virtual RedirectResult RedirectPermanentPreserveMethod([StringSyntax(StringSyntaxAttribute.Uri)] string url)
     {
-        if (string.IsNullOrEmpty(url))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(url));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(url);
 
         return new RedirectResult(url: url, permanent: true, preserveMethod: true);
     }

--- a/src/Mvc/Mvc.RazorPages/src/RazorPagesOptions.cs
+++ b/src/Mvc/Mvc.RazorPages/src/RazorPagesOptions.cs
@@ -30,10 +30,7 @@ public class RazorPagesOptions : IEnumerable<ICompatibilitySwitch>
         get => _root;
         set
         {
-            if (string.IsNullOrEmpty(value))
-            {
-                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(value));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(value);
 
             if (value[0] != '/')
             {

--- a/src/Mvc/Mvc.ViewFeatures/src/RemoteAttributeBase.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/RemoteAttributeBase.cs
@@ -80,10 +80,7 @@ public abstract class RemoteAttributeBase : ValidationAttribute, IClientModelVal
     /// </remarks>
     public string FormatAdditionalFieldsForClientValidation(string property)
     {
-        if (string.IsNullOrEmpty(property))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(property));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(property);
 
         var delimitedAdditionalFields = string.Join(",", _additionalFieldsSplit);
         if (!string.IsNullOrEmpty(delimitedAdditionalFields))
@@ -104,10 +101,7 @@ public abstract class RemoteAttributeBase : ValidationAttribute, IClientModelVal
     /// <remarks>Returns <paramref name="property"/> with a <c>"*."</c> prefix.</remarks>
     public static string FormatPropertyForClientValidation(string property)
     {
-        if (string.IsNullOrEmpty(property))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(property));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(property);
 
         return "*." + property;
     }

--- a/src/Mvc/Mvc.ViewFeatures/src/Rendering/TagBuilder.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Rendering/TagBuilder.cs
@@ -28,10 +28,7 @@ public class TagBuilder : IHtmlContent
     /// <param name="tagName">An HTML tag name.</param>
     public TagBuilder(string tagName)
     {
-        if (string.IsNullOrEmpty(tagName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(tagName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(tagName);
 
         TagName = tagName;
     }
@@ -42,10 +39,7 @@ public class TagBuilder : IHtmlContent
     /// <param name="tagBuilder">Tag to copy.</param>
     public TagBuilder(TagBuilder tagBuilder)
     {
-        if (tagBuilder == null)
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(tagBuilder));
-        }
+        ArgumentException.ThrowIfNull(tagBuilder);
 
         if (tagBuilder._attributes != null)
         {

--- a/src/Mvc/Mvc.ViewFeatures/src/ViewEngines/CompositeViewEngine.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/ViewEngines/CompositeViewEngine.cs
@@ -29,10 +29,7 @@ public class CompositeViewEngine : ICompositeViewEngine
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        if (string.IsNullOrEmpty(viewName))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(viewName));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(viewName);
 
         if (ViewEngines.Count == 0)
         {
@@ -81,10 +78,7 @@ public class CompositeViewEngine : ICompositeViewEngine
     /// <inheritdoc />
     public ViewEngineResult GetView(string? executingFilePath, string viewPath, bool isMainPage)
     {
-        if (string.IsNullOrEmpty(viewPath))
-        {
-            throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(viewPath));
-        }
+        ArgumentException.ThrowIfNullOrEmpty(viewPath);
 
         if (ViewEngines.Count == 0)
         {

--- a/src/Security/CookiePolicy/src/CookiePolicyOptions.cs
+++ b/src/Security/CookiePolicy/src/CookiePolicyOptions.cs
@@ -59,10 +59,7 @@ public class CookiePolicyOptions
         get => _consentCookieValue;
         set
         {
-            if (string.IsNullOrEmpty(value))
-            {
-                throw new ArgumentException("Value cannot be null or empty string.", nameof(value));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(value);
             _consentCookieValue = value;
         }
     }

--- a/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
+++ b/src/Servers/IIS/IIS/src/Core/IISHttpContext.FeatureCollection.cs
@@ -285,10 +285,7 @@ internal partial class IISHttpContext : IFeatureCollection,
     {
         get
         {
-            if (string.IsNullOrEmpty(variableName))
-            {
-                throw new ArgumentException($"{nameof(variableName)} should be non-empty string");
-            }
+            ArgumentException.ThrowIfNullOrEmpty(variableName);
 
             // Synchronize access to native methods that might run in parallel with IO loops
             lock (_contextLock)
@@ -298,10 +295,7 @@ internal partial class IISHttpContext : IFeatureCollection,
         }
         set
         {
-            if (string.IsNullOrEmpty(variableName))
-            {
-                throw new ArgumentException($"{nameof(variableName)} should be non-empty string");
-            }
+            ArgumentException.ThrowIfNullOrEmpty(variableName);
 
             ArgumentNullException.ThrowIfNull(value);
 

--- a/src/Tools/Shared/CommandLine/Ensure.cs
+++ b/src/Tools/Shared/CommandLine/Ensure.cs
@@ -10,13 +10,16 @@ internal static class Ensure
     public static T NotNull<T>(T obj, string paramName)
         where T : class
     {
-        ArgumentNullThrowHelper.ThrowIfNull(paramName)
+		if (obj == null)
+        {
+            throw new ArgumentNullException(paramName);
+        }
         return obj;
     }
 
     public static string NotNullOrEmpty(string obj, string paramName)
     {
-        ArgumentThrowHelper.ThrowIfNullOrEmpty(paramName);
+        ArgumentThrowHelper.ThrowIfNullOrEmpty(obj, paramName);
         return obj;
     }
 }

--- a/src/Tools/Shared/CommandLine/Ensure.cs
+++ b/src/Tools/Shared/CommandLine/Ensure.cs
@@ -10,19 +10,13 @@ internal static class Ensure
     public static T NotNull<T>(T obj, string paramName)
         where T : class
     {
-        if (obj == null)
-        {
-            throw new ArgumentNullException(paramName);
-        }
+        ArgumentNullThrowHelper.ThrowIfNull(paramName)
         return obj;
     }
 
     public static string NotNullOrEmpty(string obj, string paramName)
     {
-        if (string.IsNullOrEmpty(obj))
-        {
-            throw new ArgumentException("Value cannot be null or an empty string.", paramName);
-        }
+        ArgumentThrowHelper.ThrowIfNullOrEmpty(paramName);
         return obj;
     }
 }

--- a/src/Tools/dotnet-sql-cache/src/SqlQueries.cs
+++ b/src/Tools/dotnet-sql-cache/src/SqlQueries.cs
@@ -30,14 +30,8 @@ internal sealed class SqlQueries
 
     public SqlQueries(string schemaName, string tableName)
     {
-        if (string.IsNullOrEmpty(schemaName))
-        {
-            throw new ArgumentException("Schema name cannot be empty or null");
-        }
-        if (string.IsNullOrEmpty(tableName))
-        {
-            throw new ArgumentException("Table name cannot be empty or null");
-        }
+        ArgumentException.ThrowIfNullOrEmpty(schemaName);
+        ArgumentException.ThrowIfNullOrEmpty(tableName);
 
         var tableNameWithSchema = string.Format(
             CultureInfo.InvariantCulture, "{0}.{1}", DelimitIdentifier(schemaName), DelimitIdentifier(tableName));


### PR DESCRIPTION
# Use `ArgumentException.ThrowIfNullOrEmpty` where applicable

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

As suggested here https://github.com/dotnet/aspnetcore/pull/48414#issuecomment-1615204944 , I have splitted up the changes specific to ArgumentException.ThrowIfNullOrEmpty and have already addressed the feedback in this PR. 

Also, I have made changes to `Resources.ArgumentCannotBeNullOrEmpty` in the separate commit (just easier to filter on commit and review)

Fixes #50665 
