### PR TITLE
Avoid excessive WellKnownType cache misses in RDG

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteEmbeddedLanguage/FrameworkParametersCompletionProvider.cs
@@ -131,7 +131,7 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
 
         // Don't offer route parameter names when the parameter type can't be bound to route parameters.
         // e.g. special types like HttpContext, non-primitive types that don't have a static TryParse method.
-        if (!IsCurrentParameterBindable(token, semanticModel, wellKnownTypes, context.CancellationToken))
+        if (!IsCurrentParameterBindable(token, semanticModel, context.CancellationToken))
         {
             return;
         }
@@ -383,7 +383,7 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
         return false;
     }
 
-    private static bool IsCurrentParameterBindable(SyntaxToken token, SemanticModel semanticModel, WellKnownTypes wellKnownTypes, CancellationToken cancellationToken)
+    private static bool IsCurrentParameterBindable(SyntaxToken token, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
         if (token.Parent.IsKind(SyntaxKind.PredefinedType))
         {
@@ -393,7 +393,7 @@ public sealed class FrameworkParametersCompletionProvider : CompletionProvider
         var parameterTypeSymbol = semanticModel.GetSymbolInfo(token.Parent!, cancellationToken).GetAnySymbol();
         if (parameterTypeSymbol is INamedTypeSymbol typeSymbol)
         {
-            return ParsabilityHelper.GetParsability(typeSymbol, wellKnownTypes) == Parsability.Parsable;
+            return ParsabilityHelper.GetParsability(typeSymbol) == Parsability.Parsable;
 
         }
         else if (parameterTypeSymbol is IMethodSymbol)

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DisallowNonParsableComplexTypesOnParameters.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DisallowNonParsableComplexTypesOnParameters.cs
@@ -67,7 +67,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
 
             if (IsRouteParameter(routeUsage, handlerDelegateParameter))
             {
-                var parsability = ParsabilityHelper.GetParsability(parameterTypeSymbol, wellKnownTypes);
+                var parsability = ParsabilityHelper.GetParsability(parameterTypeSymbol);
 
                 if (parsability != Parsability.Parsable)
                 {
@@ -97,7 +97,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
         static bool ReportFromAttributeDiagnostic(OperationAnalysisContext context, WellKnownType fromMetadataInterfaceType, WellKnownTypes wellKnownTypes, IParameterSymbol parameter, INamedTypeSymbol parameterTypeSymbol, Location location)
         {
             var fromMetadataInterfaceTypeSymbol = wellKnownTypes.Get(fromMetadataInterfaceType);
-            var parsability = ParsabilityHelper.GetParsability(parameterTypeSymbol, wellKnownTypes);
+            var parsability = ParsabilityHelper.GetParsability(parameterTypeSymbol);
             if (parameter.HasAttributeImplementingInterface(fromMetadataInterfaceTypeSymbol) && parsability != Parsability.Parsable)
             {
                 context.ReportDiagnostic(Diagnostic.Create(

--- a/src/Http/Http.Extensions/gen/RequestDelegateGenerator.cs
+++ b/src/Http/Http.Extensions/gen/RequestDelegateGenerator.cs
@@ -5,14 +5,11 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Microsoft.AspNetCore.Analyzers.Infrastructure;
-using Microsoft.AspNetCore.App.Analyzers.Infrastructure;
 using Microsoft.AspNetCore.Http.RequestDelegateGenerator.StaticRouteHandlerModel;
 using Microsoft.AspNetCore.Http.RequestDelegateGenerator.StaticRouteHandlerModel.Emitters;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.AspNetCore.Http.RequestDelegateGenerator;
 
@@ -26,10 +23,9 @@ public sealed class RequestDelegateGenerator : IIncrementalGenerator
             transform: static (context, token) =>
             {
                 var operation = context.SemanticModel.GetOperation(context.Node, token);
-                var wellKnownTypes = WellKnownTypes.GetOrCreate(context.SemanticModel.Compilation);
-                if (operation.IsValidOperation(wellKnownTypes, out var invocationOperation))
+                if (operation.IsValidOperation(out var invocationOperation))
                 {
-                    return new Endpoint(invocationOperation, wellKnownTypes, context.SemanticModel);
+                    return new Endpoint(invocationOperation, context.SemanticModel);
                 }
                 return null;
             })

--- a/src/Http/Http.Extensions/gen/RequestDelegateGeneratorSuppressor.cs
+++ b/src/Http/Http.Extensions/gen/RequestDelegateGeneratorSuppressor.cs
@@ -56,10 +56,9 @@ public sealed class RequestDelegateGeneratorSuppressor : DiagnosticSuppressor
 
             var semanticModel = context.GetSemanticModel(sourceTree);
             var operation = semanticModel.GetOperation(node, context.CancellationToken);
-            var wellKnownTypes = WellKnownTypes.GetOrCreate(semanticModel.Compilation);
-            if (operation.IsValidOperation(wellKnownTypes, out var invocationOperation))
+            if (operation.IsValidOperation(out var invocationOperation))
             {
-                var endpoint = new Endpoint(invocationOperation, wellKnownTypes, semanticModel);
+                var endpoint = new Endpoint(invocationOperation, semanticModel);
                 if (endpoint.Diagnostics.Count == 0)
                 {
                     var targetSuppression = diagnostic.Id == SuppressRUCDiagnostic.SuppressedDiagnosticId

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Endpoint.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Endpoint.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Http.RequestDelegateGenerator.StaticRouteHandlerM
 
 internal class Endpoint
 {
-    public Endpoint(IInvocationOperation operation, WellKnownTypes wellKnownTypes, SemanticModel semanticModel)
+    public Endpoint(IInvocationOperation operation, SemanticModel semanticModel)
     {
         Operation = operation;
         Location = GetLocation(operation);
@@ -28,7 +28,7 @@ internal class Endpoint
             return;
         }
 
-        Response = new EndpointResponse(method, wellKnownTypes);
+        Response = new EndpointResponse(method);
         Response.EmitRequiredDiagnostics(Diagnostics, Operation.Syntax.GetLocation());
         IsAwaitable = Response?.IsAwaitable == true;
 
@@ -56,7 +56,7 @@ internal class Endpoint
             {
                 continue;
             }
-            var parameter = new EndpointParameter(this, parameterSymbol, wellKnownTypes);
+            var parameter = new EndpointParameter(this, parameterSymbol);
 
             switch (parameter.Source)
             {

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointParameter.cs
@@ -345,7 +345,7 @@ internal class EndpointParameter
         {
             preferredTryParseInvocation = (string inputArgument, string outputArgument) => $$"""{{parameterType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}}.TryParse({{inputArgument}}!, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AllowWhiteSpaces, out var {{outputArgument}})""";
         }
-        else if (parameterType.EqualsByName(["DateOnly", "System"]))
+        else if (parameterType.EqualsByName(["System", "DateOnly"]))
         {
             preferredTryParseInvocation = (string inputArgument, string outputArgument) => $$"""{{parameterType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}}.TryParse({{inputArgument}}!, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out var {{outputArgument}})""";
         }

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointResponse.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/EndpointResponse.cs
@@ -77,7 +77,7 @@ internal class EndpointResponse
             return null;
         }
 
-        return ResponseType?.SpecialType is SpecialType.System_String ? "text/plain; charset=utf-8" : "application/json";
+        return ResponseType!.SpecialType is SpecialType.System_String ? "text/plain; charset=utf-8" : "application/json";
     }
 
     public override bool Equals(object obj)

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/InvocationOperationExtensions.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/InvocationOperationExtensions.cs
@@ -84,12 +84,12 @@ internal static class InvocationOperationExtensions
         IArgumentOperation argument => ResolveMethodFromOperation(argument.Value, semanticModel),
         IConversionOperation conv => ResolveMethodFromOperation(conv.Operand, semanticModel),
         IDelegateCreationOperation del => ResolveMethodFromOperation(del.Target, semanticModel),
-        IFieldReferenceOperation { Field.IsReadOnly: true } f when ResolveDeclarationOperation(f.Field, semanticModel) is IOperation op =>
-            ResolveMethodFromOperation(op, semanticModel),
         IAnonymousFunctionOperation anon => anon.Symbol,
         ILocalFunctionOperation local => local.Symbol,
         IMethodReferenceOperation method => method.Method,
         IParenthesizedOperation parenthesized => ResolveMethodFromOperation(parenthesized.Operand, semanticModel),
+        IFieldReferenceOperation { Field.IsReadOnly: true } f when ResolveDeclarationOperation(f.Field, semanticModel) is IOperation op =>
+            ResolveMethodFromOperation(op, semanticModel),
         _ => null
     };
 

--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/InvocationOperationExtensions.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/InvocationOperationExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
 using Microsoft.AspNetCore.App.Analyzers.Infrastructure;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -23,13 +24,13 @@ internal static class InvocationOperationExtensions
         "MapFallback"
     };
 
-    public static bool IsValidOperation(this IOperation? operation, WellKnownTypes wellKnownTypes, [NotNullWhen(true)] out IInvocationOperation? invocationOperation)
+    public static bool IsValidOperation(this IOperation? operation, [NotNullWhen(true)] out IInvocationOperation? invocationOperation)
     {
         invocationOperation = null;
         if (operation is IInvocationOperation targetOperation &&
             targetOperation.TryGetRouteHandlerArgument(out var routeHandlerParameter) &&
             routeHandlerParameter is { Parameter.Type: {} delegateType } &&
-            SymbolEqualityComparer.Default.Equals(delegateType, wellKnownTypes.Get(WellKnownTypeData.WellKnownType.System_Delegate)))
+            delegateType.EqualsByName(["System", "Delegate"]))
         {
             invocationOperation = targetOperation;
             return true;

--- a/src/Shared/RoslynUtils/ParsabilityHelper.cs
+++ b/src/Shared/RoslynUtils/ParsabilityHelper.cs
@@ -2,25 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis;
-using System.Threading;
 using System.Linq;
-using Microsoft.AspNetCore.App.Analyzers.Infrastructure;
 using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Analyzers.Infrastructure;
-
-using WellKnownType = WellKnownTypeData.WellKnownType;
 
 internal static class ParsabilityHelper
 {
     private static readonly BoundedCacheWithFactory<ITypeSymbol, (BindabilityMethod?, IMethodSymbol?)> BindabilityCache = new();
     private static readonly BoundedCacheWithFactory<ITypeSymbol, (Parsability, ParsabilityMethod?)> ParsabilityCache = new();
 
-    private static bool IsTypeAlwaysParsable(ITypeSymbol typeSymbol, WellKnownTypes wellKnownTypes, [NotNullWhen(true)] out ParsabilityMethod? parsabilityMethod)
+    private static bool IsTypeAlwaysParsable(ITypeSymbol typeSymbol, [NotNullWhen(true)] out ParsabilityMethod? parsabilityMethod)
     {
         // Any enum is valid.
         if (typeSymbol.TypeKind == TypeKind.Enum)
@@ -30,7 +24,7 @@ internal static class ParsabilityHelper
         }
 
         // Uri is valid.
-        if (SymbolEqualityComparer.Default.Equals(typeSymbol, wellKnownTypes.Get(WellKnownType.System_Uri)))
+        if (typeSymbol.EqualsByName(["System", "Uri"]))
         {
             parsabilityMethod = ParsabilityMethod.Uri;
             return true;
@@ -47,25 +41,25 @@ internal static class ParsabilityHelper
         return false;
     }
 
-    internal static Parsability GetParsability(ITypeSymbol typeSymbol, WellKnownTypes wellKnownTypes)
+    internal static Parsability GetParsability(ITypeSymbol typeSymbol)
     {
-        return GetParsability(typeSymbol, wellKnownTypes, out var _);
+        return GetParsability(typeSymbol, out var _);
     }
 
-    internal static Parsability GetParsability(ITypeSymbol typeSymbol, WellKnownTypes wellKnownTypes, [NotNullWhen(false)] out ParsabilityMethod? parsabilityMethod)
+    internal static Parsability GetParsability(ITypeSymbol typeSymbol, [NotNullWhen(false)] out ParsabilityMethod? parsabilityMethod)
     {
         var parsability = Parsability.NotParsable;
         parsabilityMethod = null;
 
         (parsability, parsabilityMethod) = ParsabilityCache.GetOrCreateValue(typeSymbol, (typeSymbol) =>
         {
-            if (IsTypeAlwaysParsable(typeSymbol, wellKnownTypes, out var parsabilityMethod))
+            if (IsTypeAlwaysParsable(typeSymbol, out var parsabilityMethod))
             {
                 return (Parsability.Parsable, parsabilityMethod);
             }
 
             // MyType : IParsable<MyType>()
-            if (IsParsableViaIParsable(typeSymbol, wellKnownTypes))
+            if (IsParsableViaIParsable(typeSymbol))
             {
                 return (Parsability.Parsable, ParsabilityMethod.IParsable);
             }
@@ -75,7 +69,7 @@ internal static class ParsabilityHelper
                 .SelectMany(t => t.GetMembers("TryParse"))
                 .OfType<IMethodSymbol>();
 
-            if (tryParseMethods.Any(m => IsTryParseWithFormat(m, wellKnownTypes)))
+            if (tryParseMethods.Any(m => IsTryParseWithFormat(m)))
             {
                 return (Parsability.Parsable, ParsabilityMethod.TryParseWithFormatProvider);
             }
@@ -101,65 +95,59 @@ internal static class ParsabilityHelper
             methodSymbol.Parameters[1].RefKind == RefKind.Out;
     }
 
-    private static bool IsTryParseWithFormat(IMethodSymbol methodSymbol, WellKnownTypes wellKnownTypes)
+    private static bool IsTryParseWithFormat(IMethodSymbol methodSymbol)
     {
         return methodSymbol.DeclaredAccessibility == Accessibility.Public &&
             methodSymbol.IsStatic &&
             methodSymbol.ReturnType.SpecialType == SpecialType.System_Boolean &&
             methodSymbol.Parameters.Length == 3 &&
             methodSymbol.Parameters[0].Type.SpecialType == SpecialType.System_String &&
-            SymbolEqualityComparer.Default.Equals(methodSymbol.Parameters[1].Type, wellKnownTypes.Get(WellKnownType.System_IFormatProvider)) &&
+            methodSymbol.Parameters[1].Type.EqualsByName(["System", "IFormatProvider"]) &&
             methodSymbol.Parameters[2].RefKind == RefKind.Out;
     }
 
-    internal static bool IsParsableViaIParsable(ITypeSymbol typeSymbol, WellKnownTypes wellKnownTypes)
-    {
-        var iParsableTypeSymbol = wellKnownTypes.Get(WellKnownType.System_IParsable_T);
-        var implementsIParsable = typeSymbol.AllInterfaces.Any(
-            i => SymbolEqualityComparer.Default.Equals(i.ConstructedFrom, iParsableTypeSymbol)
-            );
-        return implementsIParsable;
-    }
+    internal static bool IsParsableViaIParsable(ITypeSymbol typeSymbol) =>
+        typeSymbol.AllInterfaces.Any(i => i.ConstructedFrom.EqualsByName(["System", "IParsable"]));
 
-    private static bool IsBindableViaIBindableFromHttpContext(ITypeSymbol typeSymbol, WellKnownTypes wellKnownTypes)
+    private static bool IsBindableViaIBindableFromHttpContext(ITypeSymbol typeSymbol)
     {
-        var iBindableFromHttpContextTypeSymbol = wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Http_IBindableFromHttpContext_T);
         var constructedTypeSymbol = typeSymbol.AllInterfaces.FirstOrDefault(
-            i => SymbolEqualityComparer.Default.Equals(i.ConstructedFrom, iBindableFromHttpContextTypeSymbol)
+            i => i.ConstructedFrom.EqualsByName(["Microsoft", "AspNetCore", "Http", "IBindableFromHttpContext"])
             );
         return constructedTypeSymbol != null &&
             SymbolEqualityComparer.Default.Equals(constructedTypeSymbol.TypeArguments[0].UnwrapTypeSymbol(unwrapNullable: true), typeSymbol);
     }
 
-    private static bool IsBindAsync(IMethodSymbol methodSymbol, ITypeSymbol typeSymbol, WellKnownTypes wellKnownTypes)
+    private static bool IsBindAsync(IMethodSymbol methodSymbol, ITypeSymbol typeSymbol)
     {
         return methodSymbol.DeclaredAccessibility == Accessibility.Public &&
             methodSymbol.IsStatic &&
             methodSymbol.Parameters.Length == 1 &&
-            SymbolEqualityComparer.Default.Equals(methodSymbol.Parameters[0].Type, wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Http_HttpContext)) &&
+            methodSymbol.Parameters[0].Type.EqualsByName(["Microsoft", "AspNetCore", "Http", "HttpContext"]) &&
             methodSymbol.ReturnType is INamedTypeSymbol returnType &&
-            SymbolEqualityComparer.Default.Equals(returnType.ConstructedFrom, wellKnownTypes.Get(WellKnownType.System_Threading_Tasks_ValueTask_T)) &&
+            returnType.IsGenericType &&
+            returnType.ConstructedFrom.EqualsByName(["System", "Threading", "Tasks", "ValueTask"]) &&
             SymbolEqualityComparer.Default.Equals(returnType.TypeArguments[0], typeSymbol);
     }
 
-    private static bool IsBindAsyncWithParameter(IMethodSymbol methodSymbol, ITypeSymbol typeSymbol, WellKnownTypes wellKnownTypes)
+    private static bool IsBindAsyncWithParameter(IMethodSymbol methodSymbol, ITypeSymbol typeSymbol)
     {
         return methodSymbol.DeclaredAccessibility == Accessibility.Public &&
             methodSymbol.IsStatic &&
             methodSymbol.Parameters.Length == 2 &&
-            SymbolEqualityComparer.Default.Equals(methodSymbol.Parameters[0].Type, wellKnownTypes.Get(WellKnownType.Microsoft_AspNetCore_Http_HttpContext)) &&
-            SymbolEqualityComparer.Default.Equals(methodSymbol.Parameters[1].Type, wellKnownTypes.Get(WellKnownType.System_Reflection_ParameterInfo)) &&
+            methodSymbol.Parameters[0].Type.EqualsByName(["Microsoft", "AspNetCore", "Http", "HttpContext"]) &&
+            methodSymbol.Parameters[1].Type.EqualsByName(["System", "Reflection", "ParameterInfo"]) &&
             methodSymbol.ReturnType is INamedTypeSymbol returnType &&
-            IsReturningValueTaskOfTOrNullableT(returnType, typeSymbol, wellKnownTypes);
+            IsReturningValueTaskOfTOrNullableT(returnType, typeSymbol);
     }
 
-    private static bool IsReturningValueTaskOfTOrNullableT(INamedTypeSymbol returnType, ITypeSymbol containingType, WellKnownTypes wellKnownTypes)
+    private static bool IsReturningValueTaskOfTOrNullableT(INamedTypeSymbol returnType, ITypeSymbol containingType)
     {
-        return SymbolEqualityComparer.Default.Equals(returnType.ConstructedFrom, wellKnownTypes.Get(WellKnownType.System_Threading_Tasks_ValueTask_T)) &&
+        return returnType.IsGenericType && returnType.ConstructedFrom.EqualsByName(["System", "Threading", "Tasks", "ValueTask"]) &&
             SymbolEqualityComparer.Default.Equals(returnType.TypeArguments[0].UnwrapTypeSymbol(unwrapNullable: true), containingType);
     }
 
-    internal static Bindability GetBindability(ITypeSymbol typeSymbol, WellKnownTypes wellKnownTypes, out BindabilityMethod? bindabilityMethod, out IMethodSymbol? bindMethodSymbol)
+    internal static Bindability GetBindability(ITypeSymbol typeSymbol, out BindabilityMethod? bindabilityMethod, out IMethodSymbol? bindMethodSymbol)
     {
         bindabilityMethod = null;
         bindMethodSymbol = null;
@@ -169,7 +157,7 @@ internal static class ParsabilityHelper
         {
             BindabilityMethod? bindabilityMethod = null;
             IMethodSymbol? bindMethodSymbol = null;
-            if (IsBindableViaIBindableFromHttpContext(typeSymbol, wellKnownTypes))
+            if (IsBindableViaIBindableFromHttpContext(typeSymbol))
             {
                 return (BindabilityMethod.IBindableFromHttpContext, null);
             }
@@ -185,13 +173,13 @@ internal static class ParsabilityHelper
                     if (methodSymbolCandidate is IMethodSymbol methodSymbol)
                     {
                         bindAsyncMethod ??= methodSymbol;
-                        if (IsBindAsyncWithParameter(methodSymbol, typeSymbol, wellKnownTypes))
+                        if (IsBindAsyncWithParameter(methodSymbol, typeSymbol))
                         {
                             bindabilityMethod = BindabilityMethod.BindAsyncWithParameter;
                             bindMethodSymbol = methodSymbol;
                             break;
                         }
-                        if (IsBindAsync(methodSymbol, typeSymbol, wellKnownTypes))
+                        if (IsBindAsync(methodSymbol, typeSymbol))
                         {
                             bindabilityMethod = BindabilityMethod.BindAsync;
                             bindMethodSymbol = methodSymbol;
@@ -211,7 +199,7 @@ internal static class ParsabilityHelper
         // See if we can give better guidance on why the BindAsync method is no good.
         if (bindAsyncMethod is not null)
         {
-            if (bindAsyncMethod.ReturnType is INamedTypeSymbol returnType && !IsReturningValueTaskOfTOrNullableT(returnType, typeSymbol, wellKnownTypes))
+            if (bindAsyncMethod.ReturnType is INamedTypeSymbol returnType && !IsReturningValueTaskOfTOrNullableT(returnType, typeSymbol))
             {
                 return Bindability.InvalidReturnType;
             }


### PR DESCRIPTION
RDG currently relies on a WellKnownType cache to resolve type symbols for framework types that we want to compare against. The WellKnownType cache is keyed by compilation. VS invokes generators on each key press with a new compilation, which means that the cache is invalidated and we end up having to do expensive metadata look ups on the type with each keypress. To avoid this, we replace the type symbol comparisons with fuzzier checks that compare the fully-qualified names of the target types.