### PR TITLE
Blazor wasm template accessebility

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Components/Layout/MainLayout.razor.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Components/Layout/MainLayout.razor.css
@@ -37,11 +37,7 @@ main {
     }
 
 @media (max-width: 640.98px) {
-    .top-row:not(.auth) {
-        display: none;
-    }
-
-    .top-row.auth {
+    .top-row {
         justify-content: space-between;
     }
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Components/Layout/NavMenu.razor.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Components/Layout/NavMenu.razor.css
@@ -56,7 +56,7 @@
     }
 
 .nav-item ::deep a.active {
-    background-color: rgba(255,255,255,0.25);
+    background-color: rgba(255,255,255,0.4);
     color: white;
 }
 


### PR DESCRIPTION
# Blazor wasm template accessebility

Selected tab's color is opaque on top of the gradient. The average contrast is around 3.5:1 now.
![accessibily1](https://github.com/dotnet/aspnetcore/assets/114938397/4687b770-d151-4533-ae37-d2849182366c)

About link when window is shrinked (moves to the left side):
![2](https://github.com/dotnet/aspnetcore/assets/114938397/57b3be28-6397-407a-9346-818fd1928bab)

About link when zoomed 500%:
![4](https://github.com/dotnet/aspnetcore/assets/114938397/636ad8c9-70e3-49d5-a7d2-791742193513)


Fixes #49790
Fixes #49702
Fixes #49703
