### PR TITLE
Resolve CVE-2021-43877

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -31,8 +31,6 @@
     <UsagePattern IdentityGlob="System.Composition/*7.0.0*" />
     <UsagePattern IdentityGlob="System.Threading.Tasks.Extensions/*4.5.3*" />
 
-    <!-- Added to unblock dependency flow, needs review. -->
-    <UsagePattern IdentityGlob="System.Security.Cryptography.Xml/*6.0.0*" />
 
     <!-- These are coming in via runtime but the source-build infra isn't able to automatically pick up the right intermediate. -->
     <UsagePattern IdentityGlob="Microsoft.NET.ILLink.Tasks/*8.0.*" />

--- a/eng/tools/RepoTasks/RepoTasks.csproj
+++ b/eng/tools/RepoTasks/RepoTasks.csproj
@@ -26,6 +26,8 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
+    <!-- Manually updated version from 6.0.0 to address CVE-2021-43877 -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(RepoTasksSystemSecurityCryptographyXmlVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">


### PR DESCRIPTION
As per https://github.com/dotnet/aspnetcore-internal/issues/4372#issuecomment-1719506100

Revert "Remove hardcoded System.Security.Cryptography.Xml version (#48029)"

This reverts commit 42d14c4bab2afb8cddc1f9683aa8ff2e20a46edb.

