### PR TITLE
Port Blazor Hybrid Photino test to release/net8

### DIFF
--- a/AspNetCore.sln
+++ b/AspNetCore.sln
@@ -1774,6 +1774,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MvcFormSample", "src\Mvc\sa
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.OutputCaching.Microbenchmarks", "src\Middleware\OutputCaching\perf\Microbenchmarks\Microsoft.AspNetCore.OutputCaching.Microbenchmarks.csproj", "{137AD17B-066F-4ED4-80FA-8D21C7B76CA6}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Components.WebViewE2E.Test", "src\Components\WebView\test\E2ETest\Microsoft.AspNetCore.Components.WebViewE2E.Test.csproj", "{CAEB7F57-28A8-451C-95D0-45FCAA3C726C}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.OutputCaching.StackExchangeRedis.Tests", "src\Middleware\Microsoft.AspNetCore.OutputCaching.StackExchangeRedis\test\Microsoft.AspNetCore.OutputCaching.StackExchangeRedis.Tests.csproj", "{A939893A-B3CD-48F6-80D3-340C8A6E275B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.OutputCaching.StackExchangeRedis", "src\Middleware\Microsoft.AspNetCore.OutputCaching.StackExchangeRedis\src\Microsoft.AspNetCore.OutputCaching.StackExchangeRedis.csproj", "{F232B503-D412-45EE-8B31-EFD46B9FA302}"
@@ -10667,6 +10669,22 @@ Global
 		{137AD17B-066F-4ED4-80FA-8D21C7B76CA6}.Release|x64.Build.0 = Release|Any CPU
 		{137AD17B-066F-4ED4-80FA-8D21C7B76CA6}.Release|x86.ActiveCfg = Release|Any CPU
 		{137AD17B-066F-4ED4-80FA-8D21C7B76CA6}.Release|x86.Build.0 = Release|Any CPU
+		{CAEB7F57-28A8-451C-95D0-45FCAA3C726C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CAEB7F57-28A8-451C-95D0-45FCAA3C726C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CAEB7F57-28A8-451C-95D0-45FCAA3C726C}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{CAEB7F57-28A8-451C-95D0-45FCAA3C726C}.Debug|arm64.Build.0 = Debug|Any CPU
+		{CAEB7F57-28A8-451C-95D0-45FCAA3C726C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CAEB7F57-28A8-451C-95D0-45FCAA3C726C}.Debug|x64.Build.0 = Debug|Any CPU
+		{CAEB7F57-28A8-451C-95D0-45FCAA3C726C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CAEB7F57-28A8-451C-95D0-45FCAA3C726C}.Debug|x86.Build.0 = Debug|Any CPU
+		{CAEB7F57-28A8-451C-95D0-45FCAA3C726C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CAEB7F57-28A8-451C-95D0-45FCAA3C726C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CAEB7F57-28A8-451C-95D0-45FCAA3C726C}.Release|arm64.ActiveCfg = Release|Any CPU
+		{CAEB7F57-28A8-451C-95D0-45FCAA3C726C}.Release|arm64.Build.0 = Release|Any CPU
+		{CAEB7F57-28A8-451C-95D0-45FCAA3C726C}.Release|x64.ActiveCfg = Release|Any CPU
+		{CAEB7F57-28A8-451C-95D0-45FCAA3C726C}.Release|x64.Build.0 = Release|Any CPU
+		{CAEB7F57-28A8-451C-95D0-45FCAA3C726C}.Release|x86.ActiveCfg = Release|Any CPU
+		{CAEB7F57-28A8-451C-95D0-45FCAA3C726C}.Release|x86.Build.0 = Release|Any CPU
 		{A939893A-B3CD-48F6-80D3-340C8A6E275B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A939893A-B3CD-48F6-80D3-340C8A6E275B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A939893A-B3CD-48F6-80D3-340C8A6E275B}.Debug|arm64.ActiveCfg = Debug|Any CPU
@@ -11575,6 +11593,7 @@ Global
 		{F7BCD3AD-31E2-4223-B215-851C3D0AB78A} = {B55A5DE1-5AF3-4B18-AF04-C1735B071DA6}
 		{055F86AA-FB37-40CC-B39E-C29CE7547BB7} = {B8825E86-B8EA-4666-B681-C443D027C95D}
 		{137AD17B-066F-4ED4-80FA-8D21C7B76CA6} = {AA5ABFBC-177C-421E-B743-005E0FD1248B}
+		{CAEB7F57-28A8-451C-95D0-45FCAA3C726C} = {C445B129-0A4D-41F5-8347-6534B6B12303}
 		{A939893A-B3CD-48F6-80D3-340C8A6E275B} = {AA5ABFBC-177C-421E-B743-005E0FD1248B}
 		{F232B503-D412-45EE-8B31-EFD46B9FA302} = {AA5ABFBC-177C-421E-B743-005E0FD1248B}
 	EndGlobalSection

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -307,7 +307,7 @@
     <NewtonsoftJsonBsonVersion>1.0.2</NewtonsoftJsonBsonVersion>
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <NSwagApiDescriptionClientVersion>13.0.4</NSwagApiDescriptionClientVersion>
-    <PhotinoNETVersion>1.1.6</PhotinoNETVersion>
+    <PhotinoNETVersion>2.4.0</PhotinoNETVersion>
     <MicrosoftPlaywrightVersion>1.28.0</MicrosoftPlaywrightVersion>
     <PollyExtensionsHttpVersion>3.0.0</PollyExtensionsHttpVersion>
     <PollyVersion>7.2.4</PollyVersion>

--- a/src/Components/Components.slnf
+++ b/src/Components/Components.slnf
@@ -42,6 +42,7 @@
       "src\\Components\\WebView\\Samples\\PhotinoPlatform\\testassets\\PhotinoTestApp\\PhotinoTestApp.csproj",
       "src\\Components\\WebView\\WebView\\src\\Microsoft.AspNetCore.Components.WebView.csproj",
       "src\\Components\\WebView\\WebView\\test\\Microsoft.AspNetCore.Components.WebView.Test.csproj",
+      "src\\Components\\WebView\\test\\E2ETest\\Microsoft.AspNetCore.Components.WebViewE2E.Test.csproj",
       "src\\Components\\Web\\src\\Microsoft.AspNetCore.Components.Web.csproj",
       "src\\Components\\Web\\test\\Microsoft.AspNetCore.Components.Web.Tests.csproj",
       "src\\Components\\benchmarkapps\\BlazingPizza.Server\\BlazingPizza.Server.csproj",

--- a/src/Components/WebView/Samples/PhotinoPlatform/src/BlazorWindow.cs
+++ b/src/Components/WebView/Samples/PhotinoPlatform/src/BlazorWindow.cs
@@ -12,7 +12,6 @@ namespace Microsoft.AspNetCore.Components.WebView.Photino;
 /// </summary>
 public class BlazorWindow
 {
-    private readonly PhotinoWindow _window;
     private readonly PhotinoWebViewManager _manager;
     private readonly string _pathBase;
 
@@ -28,14 +27,20 @@ public class BlazorWindow
         string title,
         string hostPage,
         IServiceProvider services,
-        Action<PhotinoWindowOptions>? configureWindow = null,
+        Action<PhotinoWindow>? configureWindow = null,
         string? pathBase = null)
     {
-        _window = new PhotinoWindow(title, options =>
+        PhotinoWindow = new PhotinoWindow
         {
-            options.CustomSchemeHandlers.Add(PhotinoWebViewManager.BlazorAppScheme, HandleWebRequest);
-            configureWindow?.Invoke(options);
-        }, width: 1600, height: 1200, left: 300, top: 300);
+            Title = title,
+            Width = 1600,
+            Height = 1200,
+            Left = 300,
+            Top = 300,
+        };
+        PhotinoWindow.RegisterCustomSchemeHandler(PhotinoWebViewManager.BlazorAppScheme, HandleWebRequest);
+
+        configureWindow?.Invoke(PhotinoWindow);
 
         // We assume the host page is always in the root of the content directory, because it's
         // unclear there's any other use case. We can add more options later if so.
@@ -43,7 +48,7 @@ public class BlazorWindow
         var hostPageRelativePath = Path.GetRelativePath(contentRootDir, hostPage);
         var fileProvider = new PhysicalFileProvider(contentRootDir);
 
-        var dispatcher = new PhotinoDispatcher(_window);
+        var dispatcher = new PhotinoDispatcher(PhotinoWindow);
         var jsComponents = new JSComponentConfigurationStore();
 
         _pathBase = (pathBase ?? string.Empty);
@@ -53,14 +58,14 @@ public class BlazorWindow
         }
         var appBaseUri = new Uri(new Uri(PhotinoWebViewManager.AppBaseOrigin), _pathBase);
 
-        _manager = new PhotinoWebViewManager(_window, services, dispatcher, appBaseUri, fileProvider, jsComponents, hostPageRelativePath);
+        _manager = new PhotinoWebViewManager(PhotinoWindow, services, dispatcher, appBaseUri, fileProvider, jsComponents, hostPageRelativePath);
         RootComponents = new BlazorWindowRootComponents(_manager, jsComponents);
     }
 
     /// <summary>
-    /// Gets the underlying <see cref="PhotinoWindow"/>.
+    /// Gets the underlying <see cref="PhotinoNET.PhotinoWindow"/>.
     /// </summary>
-    public PhotinoWindow Photino => _window;
+    public PhotinoWindow PhotinoWindow { get; }
 
     /// <summary>
     /// Gets configuration for the root components in the window.
@@ -73,9 +78,12 @@ public class BlazorWindow
     public void Run()
     {
         _manager.Navigate(_pathBase);
-        _window.WaitForClose();
+
+        // This line actually starts Photino and makes the window appear
+        Console.WriteLine($"Starting Photino window...");
+        PhotinoWindow.WaitForClose();
     }
 
-    private Stream HandleWebRequest(string url, out string contentType)
+    private Stream HandleWebRequest(object sender, string scheme, string url, out string contentType)
         => _manager.HandleWebRequest(url, out contentType!)!;
 }

--- a/src/Components/WebView/Samples/PhotinoPlatform/testassets/PhotinoTestApp/PhotinoTestApp.csproj
+++ b/src/Components/WebView/Samples/PhotinoPlatform/testassets/PhotinoTestApp/PhotinoTestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <IsShippingPackage>false</IsShippingPackage>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>

--- a/src/Components/WebView/Samples/PhotinoPlatform/testassets/PhotinoTestApp/Program.cs
+++ b/src/Components/WebView/Samples/PhotinoPlatform/testassets/PhotinoTestApp/Program.cs
@@ -25,7 +25,9 @@ class Program
 
         AppDomain.CurrentDomain.UnhandledException += (sender, error) =>
         {
-            mainWindow.Photino.OpenAlertWindow("Fatal exception", error.ExceptionObject.ToString());
+            Console.Write(
+                "Fatal exception" + Environment.NewLine +
+                error.ExceptionObject.ToString() + Environment.NewLine);
         };
 
         mainWindow.RootComponents.Add<BasicTestApp.Index>("root");

--- a/src/Components/WebView/Samples/PhotinoPlatform/testassets/PhotinoTestApp/_Imports.razor
+++ b/src/Components/WebView/Samples/PhotinoPlatform/testassets/PhotinoTestApp/_Imports.razor
@@ -1,0 +1,7 @@
+﻿@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.JSInterop

--- a/src/Components/WebView/WebView/test/Microsoft.AspNetCore.Components.WebView.Test.csproj
+++ b/src/Components/WebView/WebView/test/Microsoft.AspNetCore.Components.WebView.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>

--- a/src/Components/WebView/test/E2ETest/BasicBlazorHybridTest.cs
+++ b/src/Components/WebView/test/E2ETest/BasicBlazorHybridTest.cs
@@ -1,0 +1,191 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using Microsoft.AspNetCore.Components.WebView.Photino;
+using Microsoft.Extensions.DependencyInjection;
+using PhotinoNET;
+
+namespace Microsoft.AspNetCore.Components.WebViewE2E.Test;
+
+public class BasicBlazorHybridTest
+{
+    private string _latestControlDivValue;
+
+    public void Run()
+    {
+        // Note: This test produces *a lot* of debug output to aid when debugging failures. The only output
+        // that is necessary for the functioning of this test is the "Test passed" at the end of this method.
+
+        Console.WriteLine($"Current directory: {Environment.CurrentDirectory}");
+        Console.WriteLine($"Current assembly: {typeof(Program).Assembly.Location}");
+        var thisProgramDir = Path.GetDirectoryName(typeof(Program).Assembly.Location);
+
+        // Add correct runtime sub-folder to PATH to ensure native files are discovered (this is supposed to happen automatically, but somehow it doesn't...)
+        var newNativePath = Path.Combine(thisProgramDir, "runtimes", RuntimeInformation.RuntimeIdentifier, "native");
+        Console.WriteLine($"Adding new native path: {newNativePath}");
+        Environment.SetEnvironmentVariable("PATH", newNativePath + ";" + Environment.GetEnvironmentVariable("PATH"));
+        Console.WriteLine($"New PATH env var: {Environment.GetEnvironmentVariable("PATH")}");
+
+        var thisAppFiles = Directory.GetFiles(thisProgramDir, "*", SearchOption.AllDirectories).ToArray();
+        Console.WriteLine($"Found {thisAppFiles.Length} files in this app:");
+        foreach (var file in thisAppFiles)
+        {
+            Console.WriteLine($"\t{file}");
+        }
+
+        var hostPage = "wwwroot/webviewtesthost.html";
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddBlazorWebView();
+        serviceCollection.AddSingleton<HttpClient>();
+
+        Console.WriteLine($"Creating BlazorWindow...");
+        BlazorWindow mainWindow = null;
+        try
+        {
+            mainWindow = new BlazorWindow(
+                title: "Hello, world!",
+                hostPage: hostPage,
+                services: serviceCollection.BuildServiceProvider(),
+                pathBase: "/subdir"); // The content in BasicTestApp assumes this
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Exception {ex.GetType().FullName} while creating window: {ex.Message}");
+            Console.WriteLine(ex.StackTrace);
+        }
+
+        Console.WriteLine($"Hooking exception handler...");
+        AppDomain.CurrentDomain.UnhandledException += (sender, error) =>
+        {
+            Console.Write(
+                "Fatal exception" + Environment.NewLine +
+                error.ExceptionObject.ToString() + Environment.NewLine);
+        };
+
+        Console.WriteLine($"Setting up root components...");
+        mainWindow.RootComponents.Add<Pages.TestPage>("root");
+
+        Console.WriteLine($"Running window...");
+
+        const string NewControlDivValueMessage = "wvt:NewControlDivValue";
+        var isWebViewReady = false;
+
+        Console.WriteLine($"RegisterWebMessageReceivedHandler...");
+        mainWindow.PhotinoWindow.RegisterWebMessageReceivedHandler((s, msg) =>
+        {
+            if (!msg.StartsWith("__bwv:", StringComparison.Ordinal))
+            {
+                if (msg == "wvt:Started")
+                {
+                    isWebViewReady = true;
+                }
+                else if (msg.StartsWith(NewControlDivValueMessage, StringComparison.Ordinal))
+                {
+                    _latestControlDivValue = msg.Substring(NewControlDivValueMessage.Length + 1);
+                }
+            }
+        });
+        var testPassed = false;
+
+        mainWindow.PhotinoWindow.WindowCreated += (s, e) =>
+        {
+            Task.Run(async () =>
+            {
+                try
+                {
+                    // This is the actual test logic here (wait for WebView, click button, verify updates, etc.)
+
+                    // 1. Wait for WebView ready
+                    Console.WriteLine($"Waiting for WebView ready...");
+                    var isWebViewReadyRetriesLeft = 20;
+                    while (!isWebViewReady)
+                    {
+                        Console.WriteLine($"WebView not ready yet, waiting 1sec...");
+                        await Task.Delay(1000);
+                        isWebViewReadyRetriesLeft--;
+                        if (isWebViewReadyRetriesLeft == 0)
+                        {
+                            Console.WriteLine($"WebView never became ready, failing the test...");
+                            return;
+                        }
+                    }
+                    Console.WriteLine($"WebView is ready!");
+
+                    // 2. Check TestPage starting state
+                    if (!await WaitForControlDiv(mainWindow.PhotinoWindow, controlValueToWaitFor: "0"))
+                    {
+                        return;
+                    }
+
+                    // 3. Click a button
+                    mainWindow.PhotinoWindow.SendWebMessage($"wvt:ClickButton:incrementButton");
+
+                    // 4. Check TestPage is updated after button click
+                    if (!await WaitForControlDiv(mainWindow.PhotinoWindow, controlValueToWaitFor: "1"))
+                    {
+                        return;
+                    }
+
+                    // 5. If we get here, it all worked!
+                    Console.WriteLine($"All tests passed!");
+                    testPassed = true;
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine("EXCEPTION DURING TEST: " + ex.Message);
+                    Console.WriteLine(ex.StackTrace);
+                    throw;
+                }
+                finally
+                {
+                    // No matter what happens, close the Photino Window
+                    mainWindow.PhotinoWindow.Close();
+                }
+            });
+        };
+
+        try
+        {
+            mainWindow.Run();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Exception while running window: {ex}");
+        }
+
+        // This line is what's required for the test to be considered as passed. The xUnit test in WebViewManagerE2ETests checks
+        // that this reports success and that decides if the test is pass/fail.
+        Console.WriteLine($"Test passed? {testPassed}");
+    }
+
+    const int MaxWaitTimes = 30;
+    const int WaitTimeInMS = 250;
+
+    public async Task<bool> WaitForControlDiv(PhotinoWindow photinoWindow, string controlValueToWaitFor)
+    {
+
+        for (var i = 0; i < MaxWaitTimes; i++)
+        {
+            // Tell WebView to report the current controlDiv value (this is inside the loop because
+            // it's possible for this to execute before the WebView has finished processing previous
+            // C#-generated events, such as WebView button clicks).
+            Console.WriteLine($"Asking WebView for current controlDiv value...");
+            photinoWindow.SendWebMessage($"wvt:GetControlDivValue");
+
+            // And wait for the value to appear
+            if (_latestControlDivValue == controlValueToWaitFor)
+            {
+                Console.WriteLine($"WebView reported the expected controlDiv value of {controlValueToWaitFor}!");
+                return true;
+            }
+            Console.WriteLine($"Waiting for controlDiv to have value '{controlValueToWaitFor}', but it's still '{_latestControlDivValue}', so waiting {WaitTimeInMS}ms.");
+            await Task.Delay(WaitTimeInMS);
+        }
+
+        Console.WriteLine($"Waited {MaxWaitTimes * WaitTimeInMS}ms but couldn't get controlDiv to have value '{controlValueToWaitFor}' (last value is '{_latestControlDivValue}').");
+        return false;
+    }
+}

--- a/src/Components/WebView/test/E2ETest/Microsoft.AspNetCore.Components.WebViewE2E.Test.csproj
+++ b/src/Components/WebView/test/E2ETest/Microsoft.AspNetCore.Components.WebViewE2E.Test.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <!-- Suppress CS8002 because Photino assemblies are not signed -->
+    <NoWarn>@(NoWarn);CS8002</NoWarn>
+    <!-- See code comment in Program.cs/Main in this project regarding this -->
+    <StartupObject>Microsoft.AspNetCore.Components.WebViewE2E.Test.Program</StartupObject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Samples\PhotinoPlatform\src\Microsoft.AspNetCore.Components.WebView.Photino.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Update="wwwroot\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/src/Components/WebView/test/E2ETest/Pages/TestPage.razor
+++ b/src/Components/WebView/test/E2ETest/Pages/TestPage.razor
@@ -1,0 +1,21 @@
+﻿@page "/"
+
+<div class="my-component">
+    The count is <span id="counterValue">@counter</span>. <button @onclick="DoClick" id="incrementButton">Increment</button>
+</div>
+
+<div id="controlDiv">@controlValue</div>
+
+@code
+{
+    int controlValue; // used to control test flow
+
+    int counter;
+
+    void DoClick()
+    {
+        counter++;
+
+        controlValue = counter;
+    }
+}

--- a/src/Components/WebView/test/E2ETest/Program.cs
+++ b/src/Components/WebView/test/E2ETest/Program.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.WebViewE2E.Test;
+
+class Program
+{
+    // Yes, this is a Program.Main() inside of a test project! This project is a regular xUnit.net test project, but
+    // some tests also launch this project as a regular executable to launch UI tests. To achieve this, the CSPROJ
+    // has the <StartupObject> property set to indicate that _this_ is the Program.Main() to use when launching as
+    // an executable.
+    [STAThread]
+    static void Main(string[] args)
+    {
+        try
+        {
+            // Future idea: To support multiple tests, the 'args' could specify which test to run, and this code could run
+            // different types/methods/args to control variations of that. Then in WebViewManagerE2ETests the arg could
+            // be specified for each variation when launching this executable. But, for now, we have only 1 test, so no need
+            // for extra complexity.
+
+            var basicBlazorHybridTest = new BasicBlazorHybridTest();
+            basicBlazorHybridTest.Run();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Exception while running {typeof(BasicBlazorHybridTest).FullName}: {ex}");
+        }
+    }
+}

--- a/src/Components/WebView/test/E2ETest/WebViewManagerE2ETests.cs
+++ b/src/Components/WebView/test/E2ETest/WebViewManagerE2ETests.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.AspNetCore.Testing;
+
+namespace Microsoft.AspNetCore.Components.WebViewE2E.Test;
+
+public class WebViewManagerE2ETests
+{
+    // Skips:
+    // - Ubuntu is skipped due to this error:
+    //       "Unable to load shared library 'Photino.Native' or one of its dependencies. In order to help diagnose
+    //       loading problems, consider using a tool like strace."
+    //   There's probably some way to make it work, but it's not currently a supported Blazor Hybrid scenario anyway
+    // - macOS is skipped due to the test not being able to detect when the WebView is ready. There's probably an issue
+    //   with the JS code sending a WebMessage to C# and not being sent properly or detected properly.
+    [ConditionalFact]
+    [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX,
+        SkipReason = "On Helix/Ubuntu the native Photino assemblies can't be found, and on macOS it can't detect when the WebView is ready")]
+    public async Task CanLaunchPhotinoWebViewAndClickButton()
+    {
+        var photinoTestProgramExePath = typeof(WebViewManagerE2ETests).Assembly.Location;
+
+        // This test launches this very test assembly as an executable so that the Photino UI window
+        // can launch and be automated. See the comment in Program.Main() for more info.
+        var photinoProcess = new Process()
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                WorkingDirectory = Path.GetDirectoryName(photinoTestProgramExePath),
+                FileName = "dotnet",
+                Arguments = $"\"{photinoTestProgramExePath}\"",
+                RedirectStandardOutput = true,
+            },
+        };
+
+        photinoProcess.Start();
+
+        var testProgramOutput = photinoProcess.StandardOutput.ReadToEnd();
+
+        await photinoProcess.WaitForExitAsync().TimeoutAfter(TimeSpan.FromSeconds(30));
+
+        // The test app reports its own results by calling Console.WriteLine(), so here we only need to verify that
+        // the test internally believes it passed (and we trust it!).
+        Assert.Contains($"Test passed? {true}", testProgramOutput);
+    }
+}

--- a/src/Components/WebView/test/E2ETest/_Imports.razor
+++ b/src/Components/WebView/test/E2ETest/_Imports.razor
@@ -1,0 +1,7 @@
+﻿@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.JSInterop

--- a/src/Components/WebView/test/E2ETest/wwwroot/css/app.css
+++ b/src/Components/WebView/test/E2ETest/wwwroot/css/app.css
@@ -1,0 +1,22 @@
+#blazor-error-ui {
+    background: lightyellow;
+    bottom: 0;
+    box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    display: none;
+    left: 0;
+    padding: 0.6rem 1.25rem 0.7rem 1.25rem;
+    position: fixed;
+    width: 100%;
+    z-index: 1000;
+}
+
+#blazor-error-ui .dismiss {
+    cursor: pointer;
+    position: absolute;
+    right: 0.75rem;
+    top: 0.5rem;
+}
+
+html {
+    font-family: Arial, Helvetica, sans-serif;
+}

--- a/src/Components/WebView/test/E2ETest/wwwroot/webviewtesthost.html
+++ b/src/Components/WebView/test/E2ETest/wwwroot/webviewtesthost.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <title>PhotinoTestApp</title>
+    <base href="/subdir/" />
+    <link href="css/app.css" rel="stylesheet" />
+</head>
+
+<body>
+    <root>Loading...</root>
+
+    <!-- Explicit display:none required so StartupErrorNotificationTest can observe it change -->
+    <div id="blazor-error-ui" style="display: none;">
+        An unhandled error has occurred.
+        <a href class='reload'>Reload</a>
+        <a class='dismiss' style="cursor: pointer;">🗙</a>
+    </div>
+
+    <script src="_framework/blazor.webview.js"></script>
+
+    <script>
+        // These methods are used to communicate with the test infrastructure. The test can
+        // send messages to this JS code to invoke things or to check the status of things.
+
+        function PostMessageToDotNet(message) {
+            if (window.chrome && window.chrome.webview) {
+                // Windows WebView2
+                window.chrome.webview.postMessage(message);
+            }
+            else if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.webwindowinterop) {
+                // iOS and MacCatalyst WKWebView
+                window.webkit.messageHandlers.webwindowinterop.postMessage(message);
+            }
+            else {
+                // Android WebView
+                // TODO: Not yet supported
+            }
+        }
+
+        window.chrome.webview.addEventListener('message', event => {
+            // console.log("ALL: Received message: " + event.data);
+            if (!event.data.startsWith('__bwv')) {
+                console.log("FILTER: Received message: " + event.data);
+
+                if (event.data === "wvt:GetControlDivValue") {
+                    var controlDivValue = document.getElementById('controlDiv').innerText;
+                    PostMessageToDotNet('wvt:NewControlDivValue:' + controlDivValue);
+                }
+                else if (event.data.startsWith("wvt:ClickButton:")) {
+                    var buttonToClick = event.data.substring(16);
+                    document.getElementById(buttonToClick).click();
+                }
+            }
+        });
+
+        PostMessageToDotNet('wvt:Started');
+
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
Note: This is a port of https://github.com/dotnet/aspnetcore/pull/50347 from main into release/8.0 so that we have additional test coverage for .NET 8 releases.

Original commit: Adds a test that launches a Photino-based app and clicks a Blazor counter button and verifies that the HTML is in fact updated.
