### PR TITLE
Retry stateful reconnect attempts

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -2082,7 +2082,7 @@ public partial class HubConnection : IAsyncDisposable
             {
                 if (!_messageBuffer.ShouldProcessMessage(message))
                 {
-                    Log.DroppingMessage(_logger, ((HubInvocationMessage)message).GetType().Name, ((HubInvocationMessage)message).InvocationId);
+                    Log.DroppingMessage(_logger, message.GetType().Name, (message as HubInvocationMessage)?.InvocationId ?? "(null}");
                     return false;
                 }
             }
@@ -2168,7 +2168,6 @@ public partial class HubConnection : IAsyncDisposable
         {
             if (!TryGetInvocation(invocationId, out var irq))
             {
-                Log.ReceivedUnexpectedResponse(_logger, invocationId);
                 throw new KeyNotFoundException($"No invocation with id '{invocationId}' could be found.");
             }
             return irq.ResultType;
@@ -2180,7 +2179,6 @@ public partial class HubConnection : IAsyncDisposable
             // literally the same code as the above method
             if (!TryGetInvocation(invocationId, out var irq))
             {
-                Log.ReceivedUnexpectedResponse(_logger, invocationId);
                 throw new KeyNotFoundException($"No invocation with id '{invocationId}' could be found.");
             }
             return irq.ResultType;

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -2543,7 +2543,7 @@ public class HubConnectionTests : FunctionalTestBase
     public async Task CanReconnectAndSendMessageWhileDisconnected()
     {
         var protocol = HubProtocols["json"];
-        await using (var server = await StartServer<Startup>(w => w.EventId.Name == "ReceivedUnexpectedResponse"))
+        await using (var server = await StartServer<Startup>())
         {
             var websocket = new ClientWebSocket();
             var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -2602,7 +2602,7 @@ public class HubConnectionTests : FunctionalTestBase
     public async Task CanReconnectAndSendMessageOnceConnected()
     {
         var protocol = HubProtocols["json"];
-        await using (var server = await StartServer<Startup>(w => w.EventId.Name == "ReceivedUnexpectedResponse"))
+        await using (var server = await StartServer<Startup>())
         {
             var websocket = new ClientWebSocket();
             var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -2897,6 +2897,143 @@ public class HubConnectionTests : FunctionalTestBase
                 await closedTcs.Task;
 
                 Assert.Equal(HubConnectionState.Disconnected, connection.State);
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                await connection.DisposeAsync().DefaultTimeout();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task MultipleReconnectAttemptsWhenUsingStatefulReconnectFailure()
+    {
+        bool ExpectedErrors(WriteContext writeContext)
+        {
+            return writeContext.LoggerName == typeof(HubConnection).FullName &&
+                   (writeContext.EventId.Name == "ShutdownWithError" ||
+                   writeContext.EventId.Name == "ServerDisconnectedWithError");
+        }
+
+        var protocol = HubProtocols["json"];
+        await using (var server = await StartServer<Startup>(ExpectedErrors))
+        {
+            var websocketConnectAttempts = 0;
+            var websocket = new ClientWebSocket();
+
+            const string originalMessage = "SignalR";
+            var connectionBuilder = new HubConnectionBuilder()
+                .WithLoggerFactory(LoggerFactory)
+                .WithUrl(server.Url + "/default", HttpTransportType.WebSockets, o =>
+                {
+                    o.WebSocketFactory = async (context, token) =>
+                    {
+                        websocketConnectAttempts++;
+                        if (websocketConnectAttempts > 1)
+                        {
+                            throw new Exception("from websocket connect");
+                        }
+                        await websocket.ConnectAsync(context.Uri, token);
+                        return websocket;
+                    };
+                    o.UseStatefulReconnect = true;
+                });
+            connectionBuilder.Services.AddSingleton(protocol);
+            var connection = connectionBuilder.Build();
+
+            try
+            {
+                await connection.StartAsync().DefaultTimeout();
+                Assert.Equal(1, websocketConnectAttempts);
+
+                var originalConnectionId = connection.ConnectionId;
+
+                var result = await connection.InvokeAsync<string>(nameof(TestHub.Echo), originalMessage).DefaultTimeout();
+
+                Assert.Equal(originalMessage, result);
+
+                var originalWebsocket = websocket;
+                websocket = new ClientWebSocket();
+                originalWebsocket.Dispose();
+
+                var resultTask = connection.InvokeAsync<string>(nameof(TestHub.Echo), originalMessage).DefaultTimeout();
+
+                await Assert.ThrowsAsync<TaskCanceledException>(() => resultTask);
+
+                // Initial connection + 3 failed reconnect attempts
+                Assert.Equal(4, websocketConnectAttempts);
+            }
+            catch (Exception ex)
+            {
+                LoggerFactory.CreateLogger<HubConnectionTests>().LogError(ex, "{ExceptionType} from test", ex.GetType().FullName);
+                throw;
+            }
+            finally
+            {
+                await connection.DisposeAsync().DefaultTimeout();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task MultipleReconnectAttemptsWhenUsingStatefulReconnectSuccessful()
+    {
+        var protocol = HubProtocols["json"];
+        await using (var server = await StartServer<Startup>())
+        {
+            var websocketConnectAttempts = 0;
+            var websocket = new ClientWebSocket();
+
+            const string originalMessage = "SignalR";
+            var connectionBuilder = new HubConnectionBuilder()
+                .WithLoggerFactory(LoggerFactory)
+                .WithUrl(server.Url + "/default", HttpTransportType.WebSockets, o =>
+                {
+                    o.WebSocketFactory = async (context, token) =>
+                    {
+                        websocketConnectAttempts++;
+                        if (websocketConnectAttempts is > 1 and < 4)
+                        {
+                            throw new Exception("from websocket connect");
+                        }
+                        await websocket.ConnectAsync(context.Uri, token);
+                        return websocket;
+                    };
+                    o.UseStatefulReconnect = true;
+                });
+            connectionBuilder.Services.AddSingleton(protocol);
+            var connection = connectionBuilder.Build();
+
+            try
+            {
+                await connection.StartAsync().DefaultTimeout();
+                Assert.Equal(1, websocketConnectAttempts);
+
+                var originalConnectionId = connection.ConnectionId;
+
+                var result = await connection.InvokeAsync<string>(nameof(TestHub.Echo), originalMessage).DefaultTimeout();
+
+                Assert.Equal(originalMessage, result);
+
+                var originalWebsocket = websocket;
+                websocket = new ClientWebSocket();
+                originalWebsocket.Dispose();
+
+                var resultTask = connection.InvokeAsync<string>(nameof(TestHub.Echo), originalMessage).DefaultTimeout();
+
+                result = await resultTask;
+                Assert.Equal(originalMessage, result);
+
+                // Initial connection + 2 failed reconnect attempts + 1 successful attempt
+                Assert.Equal(4, websocketConnectAttempts);
+
+                result = await connection.InvokeAsync<string>(nameof(TestHub.Echo), originalMessage).DefaultTimeout();
+                Assert.Equal(originalMessage, result);
             }
             catch (Exception ex)
             {

--- a/src/SignalR/clients/ts/signalr/src/HttpConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HttpConnection.ts
@@ -442,8 +442,22 @@ export class HttpConnection implements IConnection {
                 if (this.features.reconnect) {
                     try {
                         this.features.disconnected();
-                        await this.transport!.connect(url, transferFormat);
-                        await this.features.resend();
+                        let error;
+                        for (let i = 0; i < 3; i++) {
+                            try {
+                                await this.transport!.connect(url, transferFormat);
+                                error = undefined;
+                                break;
+                            } catch (ex) {
+                                error = ex;
+                            }
+                        }
+
+                        if (error) {
+                            callStop = true;
+                        } else {
+                            await this.features.resend();
+                        }
                     } catch {
                         callStop = true;
                     }

--- a/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HttpConnection.test.ts
@@ -1981,13 +1981,18 @@ describe("TransportSendQueue", () => {
             TestWebSocket.webSocketSet = new PromiseSource();
             TestWebSocket.webSocket.close();
 
-            // transport should be trying to connect again
-            await TestWebSocket.webSocketSet;
-            await TestWebSocket.webSocket.openSet;
-            expect(disconnectedCalled).toBe(true);
-            expect(resendCalled).toBe(false);
-            // fail to connect
-            TestWebSocket.webSocket.onclose(new TestEvent());
+            for (let i = 0; i < 3; i++) {
+                // transport should be trying to connect again
+                await TestWebSocket.webSocketSet;
+                await TestWebSocket.webSocket.openSet;
+                expect(resendCalled).toBe(false);
+                expect(disconnectedCalled).toBe(true);
+
+                TestWebSocket.webSocketSet = new PromiseSource();
+
+                // fail to connect
+                TestWebSocket.webSocket.onclose(new TestEvent());
+            }
 
             await onclosePromise;
             expect(resendCalled).toBe(false);


### PR DESCRIPTION
Add a few retires when attempting to reconnect during stateful reconnect.
Increases the likelihood of reconnecting successfully during a short network break.

Could consider adding a `Task.Delay(1000)` between each iteration.