### PR TITLE
[release/8.0] Add explicit dependency for Microsoft.SourceBuild.Intermediate.runtime.linux-x64

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -319,6 +319,10 @@
     <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="8.0.0-rc.2.23464.16">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>9cdbc87dadbf358206f20f17fed005cdcb253452</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.runtime.linux-x64" Version="8.0.0-rc.2.23464.16">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>9cdbc87dadbf358206f20f17fed005cdcb253452</Sha>
       <SourceBuild RepoName="runtime" ManagedOnly="false" />
     </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.browser-wasm" Version="8.0.0-rc.2.23464.16">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -127,6 +127,7 @@
     <SystemThreadingAccessControlVersion>8.0.0-rc.2.23464.16</SystemThreadingAccessControlVersion>
     <SystemThreadingChannelsVersion>8.0.0-rc.2.23464.16</SystemThreadingChannelsVersion>
     <SystemThreadingRateLimitingVersion>8.0.0-rc.2.23464.16</SystemThreadingRateLimitingVersion>
+    <MicrosoftSourceBuildIntermediateruntimelinuxx64Version>8.0.0-rc.2.23464.16</MicrosoftSourceBuildIntermediateruntimelinuxx64Version>
     <!-- Only listed explicitly to workaround https://github.com/dotnet/cli/issues/10528 -->
     <MicrosoftNETCorePlatformsVersion>8.0.0-rc.2.23464.16</MicrosoftNETCorePlatformsVersion>
     <MicrosoftBclAsyncInterfacesVersion>8.0.0-rc.2.23464.16</MicrosoftBclAsyncInterfacesVersion>


### PR DESCRIPTION
Fixes: https://dev.azure.com/dnceng/internal/_build/results?buildId=2265045&view=logs&j=2f0d093c-1064-5c86-fc5b-b7b1eca8e66a&t=d2b639a6-cb19-5f1f-66fd-8047f66b3026 which was discovered during the .NET 8 Test build