### PR TITLE
Handle obsolete InterceptorsPreview with .NET 8 RC2 SDK

### DIFF
--- a/src/Identity/Core/src/Microsoft.AspNetCore.Identity.csproj
+++ b/src/Identity/Core/src/Microsoft.AspNetCore.Identity.csproj
@@ -9,7 +9,9 @@
     <IsPackable>false</IsPackable>
     <IsTrimmable>true</IsTrimmable>
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
+    <!-- TODO: Remove InterceptorsPreview feature after 8.0 RC2 SDK is used for build -->
     <Features>$(Features);InterceptorsPreview</Features>
+    <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.AspNetCore.Http.Generated</InterceptorsPreviewNamespaces>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Handle obsolete InterceptorsPreview with .NET 8 RC2 SDK

## Description

When building the runtime repo using the latest build of .NET 8 RC2 SDK, it produces the following error:

`
##[error]/vmr/src/aspnetcore/artifacts/source-build/self/src/src/Identity/Core/src/Microsoft.AspNetCore.Http.RequestDelegateGenerator/Microsoft.AspNetCore.Http.RequestDelegateGenerator.RequestDelegateGenerator/GeneratedRouteBuilderExtensions.g.cs(62,10): error CS9137: (NETCORE_ENGINEERING_TELEMETRY=Build) The 'interceptors' experimental feature is not enabled in this namespace. Add '<InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.AspNetCore.Http.Generated</InterceptorsPreviewNamespaces>' to your project.
`

This is due to a new change from Roslyn: https://github.com/dotnet/roslyn/pull/69848. It replaces the usage of the `InterceptorsPreview` feature with an `InterceptorsPreviewNamespaces` property that needs to specify the applicable namespace.

The use of `InterceptorsPreview` in the project is still needed in order to work with the RC1 SDK. Both need to be specified as support for both versions of the SDK is required to support source-build scenarios. A separate issue will be logged as follow-up to remove the obsolete `InterceptorsPreview` feature usage.

This change is needed for RC2 release.
