### PR TITLE
Avoid allocating FormFeature in HttpRequest.HasFormContentType

### DIFF
--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -20,6 +20,7 @@ public class FormFeature : IFormFeature
     private FormOptions _options;
     private Task<IFormCollection>? _parsedFormTask;
     private IFormCollection? _form;
+    private MediaTypeHeaderValue? _mediaTypeHeaderValue;
 
     /// <summary>
     /// Initializes a new instance of <see cref="FormFeature"/>.
@@ -70,8 +71,12 @@ public class FormFeature : IFormFeature
     {
         get
         {
-            _ = MediaTypeHeaderValue.TryParse(_request.ContentType, out var mt);
-            return mt;
+            if (_mediaTypeHeaderValue != null)
+            {
+                return _mediaTypeHeaderValue;
+            }
+            _ = MediaTypeHeaderValue.TryParse(_request.ContentType, out _mediaTypeHeaderValue);
+            return _mediaTypeHeaderValue;
         }
     }
 
@@ -86,7 +91,7 @@ public class FormFeature : IFormFeature
                 return true;
             }
 
-            return HttpExtensions.HasApplicationFormContentType(_request.ContentType) || HttpExtensions.HasMultipartFormContentType(_request.ContentType);
+            return HttpExtensions.HasAnyFormContentType(_request.ContentType);
         }
     }
 

--- a/src/Http/Http/src/Internal/DefaultHttpRequest.cs
+++ b/src/Http/Http/src/Internal/DefaultHttpRequest.cs
@@ -147,7 +147,8 @@ internal sealed class DefaultHttpRequest : HttpRequest
         set { Headers.ContentType = value; }
     }
 
-    public override bool HasFormContentType => HttpExtensions.HasApplicationFormContentType(ContentType) || HttpExtensions.HasMultipartFormContentType(ContentType);
+    public override bool HasFormContentType => HttpExtensions.HasAnyFormContentType(ContentType)
+        || _features.Fetch(ref _features.Cache.Form, _features.Collection, collection => collection.Get<IFormFeature>()) != null;
 
     public override IFormCollection Form
     {

--- a/src/Http/Http/src/Internal/DefaultHttpRequest.cs
+++ b/src/Http/Http/src/Internal/DefaultHttpRequest.cs
@@ -147,10 +147,7 @@ internal sealed class DefaultHttpRequest : HttpRequest
         set { Headers.ContentType = value; }
     }
 
-    public override bool HasFormContentType
-    {
-        get { return FormFeature.HasFormContentType; }
-    }
+    public override bool HasFormContentType => HttpExtensions.HasApplicationFormContentType(ContentType) || HttpExtensions.HasMultipartFormContentType(ContentType);
 
     public override IFormCollection Form
     {

--- a/src/Http/Http/src/Microsoft.AspNetCore.Http.csproj
+++ b/src/Http/Http/src/Microsoft.AspNetCore.Http.csproj
@@ -22,6 +22,7 @@
     <Compile Include="$(SharedSourceRoot)Debugger\HttpContextDebugFormatter.cs" LinkBase="Shared" />
     <Compile Include="..\..\WebUtilities\src\AspNetCoreTempDirectory.cs" LinkBase="Internal" />
     <Compile Include="..\..\..\Shared\Dictionary\AdaptiveCapacityDictionary.cs" LinkBase="Internal" />
+    <Compile Include="$(SharedSourceRoot)HttpExtensions.cs" LinkBase="Shared"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Shared/HttpExtensions.cs
+++ b/src/Shared/HttpExtensions.cs
@@ -1,30 +1,25 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Http;
 
 internal static class HttpExtensions
 {
-    internal const string UrlEncodedFormContentType = "application/x-www-form-urlencoded";
-    internal const string MultipartFormContentType = "multipart/form-data";
+    private const string UrlEncodedFormContentType = "application/x-www-form-urlencoded";
+    private const string MultipartFormContentType = "multipart/form-data";
 
     internal static bool IsValidHttpMethodForForm(string method) =>
         HttpMethods.IsPost(method) || HttpMethods.IsPut(method) || HttpMethods.IsPatch(method);
 
-    internal static bool IsValidContentTypeForForm(string? contentType)
+    internal static bool HasApplicationFormContentType([NotNullWhen(true)] string? contentType)
     {
-        if (contentType == null)
-        {
-            return false;
-        }
+        // Content-Type: application/x-www-form-urlencoded; charset=utf-8
+        return contentType != null && contentType.Contains(UrlEncodedFormContentType, StringComparison.OrdinalIgnoreCase);
+    }
 
-        // Abort early if this doesn't look like it could be a form-related content-type
-
-        if (contentType.Length < MultipartFormContentType.Length)
-        {
-            return false;
-        }
-
-        return contentType.Equals(UrlEncodedFormContentType, StringComparison.OrdinalIgnoreCase) ||
-            contentType.StartsWith(MultipartFormContentType, StringComparison.OrdinalIgnoreCase);
+    internal static bool HasMultipartFormContentType([NotNullWhen(true)] string? contentType)
+    {
+        // Content-Type: multipart/form-data; boundary=----WebKitFormBoundarymx2fSWqWSd0OxQqq
+        return contentType != null && contentType.Contains(MultipartFormContentType, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Shared/HttpExtensions.cs
+++ b/src/Shared/HttpExtensions.cs
@@ -11,6 +11,9 @@ internal static class HttpExtensions
     internal static bool IsValidHttpMethodForForm(string method) =>
         HttpMethods.IsPost(method) || HttpMethods.IsPut(method) || HttpMethods.IsPatch(method);
 
+    internal static bool HasAnyFormContentType([NotNullWhen(true)] string? contentType)
+        => HasApplicationFormContentType(contentType) || HasMultipartFormContentType(contentType);
+
     internal static bool HasApplicationFormContentType([NotNullWhen(true)] string? contentType)
     {
         // Content-Type: application/x-www-form-urlencoded; charset=utf-8


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/50153.

```csharp
public class FormFeatureBenchmark
{
    private HttpRequest _request;

    [IterationSetup]
    public void Setup()
    {
        _request = new DefaultHttpRequest(new DefaultHttpContext());
    }

    [Benchmark]
    public void Get_HttpRequestHasFormContentType()
    {
        _ = _request.HasFormContentType;
    }
}
```

**Baseline**

|                            Method |     Mean |    Error |   StdDev |   Median |     Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------------------- |---------:|---------:|---------:|---------:|---------:|------:|------:|------:|----------:|
| Get_HttpRequestHasFormContentType | 10.69 us | 1.879 us | 5.390 us | 9.208 us | 93,577.6 |     - |     - |     - |     776 B |

**With Changeset**

|                            Method |     Mean |    Error |   StdDev |      Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------------------- |---------:|---------:|---------:|----------:|------:|------:|------:|----------:|
| Get_HttpRequestHasFormContentType | 8.959 us | 2.259 us | 6.445 us | 111,616.9 |     - |     - |     - |     672 B |