### PR TITLE
Fix streaming into nonstreaming outlet

### DIFF
--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs
@@ -127,6 +127,17 @@ internal partial class EndpointHtmlRenderer
                     continue;
                 }
 
+                // Of the components that updated, we want to emit the roots of all the streaming subtrees, and not
+                // any non-streaming ancestors. There's no point emitting non-streaming ancestor content since there
+                // are no markers in the document to receive it. Also we don't want to call WriteComponentHtml for
+                // nonstreaming ancestors, as that would make us skip over their descendants who may in fact be the
+                // roots of streaming subtrees.
+                var componentState = (EndpointComponentState)GetComponentState(componentId);
+                if (!componentState.StreamRendering)
+                {
+                    continue;
+                }
+
                 // This format relies on the component producing well-formed markup (i.e., it can't have a
                 // </template> at the top level without a preceding matching <template>). Alternatively we
                 // could look at using a custom TextWriter that does some extra encoding of all the content

--- a/src/Components/test/E2ETest/ServerRenderingTests/StreamingRenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/StreamingRenderingTest.cs
@@ -268,4 +268,11 @@ public class StreamingRenderingTest : ServerTestBase<BasicTestAppServerSiteFixtu
         // Tidy up
         await new HttpClient().GetAsync(endResponseUrl);
     }
+
+    [Fact]
+    public void CanStreamDirectlyIntoSectionContentConnectedToNonStreamingOutlet()
+    {
+        Navigate($"{ServerPathBase}/streaming-with-sections");
+        Browser.Equal("This is some streaming content", () => Browser.Exists(By.Id("streaming-message")).Text);
+    }
 }

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/StreamingRendering/StreamingWithSections.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/StreamingRendering/StreamingWithSections.razor
@@ -1,0 +1,20 @@
+﻿@page "/streaming-with-sections"
+@using Microsoft.AspNetCore.Components.Sections
+
+<h1>Streaming with sections</h1>
+
+<p>
+    If a section outlet is rendered from a nonstreaming component, but the section content comes from a streaming component,
+    then we should still see streaming updates arriving in the section outlet.
+</p>
+
+<p>
+    This component is not streaming, but it has a child that does stream, and supplies content back here to the parent.
+</p>
+
+<fieldset>
+    <legend>Section outlet in nonstreaming component</legend>
+    <SectionOutlet SectionName="streaming-outlet" />
+</fieldset>
+
+<StreamingWithSectionsContentSupplier />

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/StreamingRendering/StreamingWithSectionsContentSupplier.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/StreamingRendering/StreamingWithSectionsContentSupplier.razor
@@ -1,0 +1,24 @@
+﻿@using Microsoft.AspNetCore.Components.Sections
+@attribute [StreamRendering]
+
+@*
+    For the test to be relevant, it's important that the streaming output comes from *this component* and not some descendant.
+    This is to ensure we correctly represent issue https://github.com/dotnet/aspnetcore/issues/50804
+    If it's a descendant that streams, the descendant simply lives within the SectionOutlet and encapsulates its own streaming,
+    and sections aren't really involved. But if the streaming output goes *directly* into SectionContent, then we're in a more
+    challenging situation because we need the SectionOutletContentRenderer to become streaming.
+*@
+
+<SectionContent SectionName="streaming-outlet">
+    <span id="streaming-message">@message</span>
+</SectionContent>
+
+@code {
+    string message = "Starting...";
+
+    protected override async Task OnInitializedAsync()
+    {
+        await Task.Delay(1000);
+        message = "This is some streaming content";
+    }
+}


### PR DESCRIPTION
# Fix streaming into nonstreaming outlet

Makes an edge case with streaming SSR and SectionOutlet work correctly

## Description

A bug was discovered when combining streaming SSR and `<SectionOutlet>` in a particular way (i.e., streaming *directly* into the `<SectionContent>`, not via any child component, when connected to a `<SectionOutlet>` that itself is nonstreaming). In this case the streamed content would not appear in the UI.

This PR makes this situation behave the same as other uses of streaming/sections, including the existing case of streaming via a child component to a nonstreaming outlet which is what our E2E tests already covered and already worked correctly.

Fixes #50804

## Customer Impact

Without this fix, developers wanting to use sections with streaming SSR would find in some cases that it doesn't work. A workaround exists (move the streaming content to a child component) but with this fix, it simply works as intended in the first place.

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

It's only a change to how we decide which streamed components to emit content for, so it can only affect this one functional area. The code change is just to account for a case we hadn't considered before.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
