### PR TITLE
 Fix Blazor error UI CSS, making the dismiss button visible

### DIFF
--- a/src/Components/Samples/BlazorServerApp/wwwroot/css/site.css
+++ b/src/Components/Samples/BlazorServerApp/wwwroot/css/site.css
@@ -120,6 +120,7 @@ app {
     background: lightyellow;
     bottom: 0;
     box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    box-sizing: border-box;
     display: none;
     left: 0;
     padding: 0.6rem 1.25rem 0.7rem 1.25rem;

--- a/src/Components/Samples/BlazorUnitedApp/wwwroot/css/site.css
+++ b/src/Components/Samples/BlazorUnitedApp/wwwroot/css/site.css
@@ -40,6 +40,7 @@ a, .btn-link {
     background: lightyellow;
     bottom: 0;
     box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    box-sizing: border-box;
     display: none;
     left: 0;
     padding: 0.6rem 1.25rem 0.7rem 1.25rem;

--- a/src/Components/WebAssembly/Samples/HostedBlazorWebassemblyApp/Client/wwwroot/css/app.css
+++ b/src/Components/WebAssembly/Samples/HostedBlazorWebassemblyApp/Client/wwwroot/css/app.css
@@ -32,6 +32,7 @@ a, .btn-link {
     background: lightyellow;
     bottom: 0;
     box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    box-sizing: border-box;
     display: none;
     left: 0;
     padding: 0.6rem 1.25rem 0.7rem 1.25rem;

--- a/src/Components/WebAssembly/testassets/StandaloneApp/wwwroot/css/app.css
+++ b/src/Components/WebAssembly/testassets/StandaloneApp/wwwroot/css/app.css
@@ -119,6 +119,7 @@ app {
     background: lightyellow;
     bottom: 0;
     box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    box-sizing: border-box;
     display: none;
     left: 0;
     padding: 0.6rem 1.25rem 0.7rem 1.25rem;

--- a/src/Components/WebView/Samples/PhotinoPlatform/testassets/PhotinoTestApp/wwwroot/css/app.css
+++ b/src/Components/WebView/Samples/PhotinoPlatform/testassets/PhotinoTestApp/wwwroot/css/app.css
@@ -2,6 +2,7 @@
     background: lightyellow;
     bottom: 0;
     box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    box-sizing: border-box;
     display: none;
     left: 0;
     padding: 0.6rem 1.25rem 0.7rem 1.25rem;

--- a/src/Components/WebView/test/E2ETest/wwwroot/css/app.css
+++ b/src/Components/WebView/test/E2ETest/wwwroot/css/app.css
@@ -2,6 +2,7 @@
     background: lightyellow;
     bottom: 0;
     box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    box-sizing: border-box;
     display: none;
     left: 0;
     padding: 0.6rem 1.25rem 0.7rem 1.25rem;

--- a/src/Components/test/testassets/BasicTestApp/wwwroot/style.css
+++ b/src/Components/test/testassets/BasicTestApp/wwwroot/style.css
@@ -10,13 +10,13 @@
     background: lightyellow;
     bottom: 0;
     box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    box-sizing: border-box;
     display: none;
     left: 0;
     padding: 0.6rem 1.25rem 0.7rem 1.25rem;
     position: fixed;
     width: 100%;
     z-index: 1000;
-    box-sizing: border-box;
 }
 
     #blazor-error-ui .dismiss {

--- a/src/Components/test/testassets/ComponentsApp.Server/wwwroot/css/app.css
+++ b/src/Components/test/testassets/ComponentsApp.Server/wwwroot/css/app.css
@@ -119,6 +119,7 @@ app {
     background: lightyellow;
     bottom: 0;
     box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    box-sizing: border-box;
     display: none;
     left: 0;
     padding: 0.6rem 1.25rem 0.7rem 1.25rem;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/MainLayout.razor.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/MainLayout.razor.css
@@ -82,6 +82,7 @@ main {
     background: lightyellow;
     bottom: 0;
     box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    box-sizing: border-box;
     display: none;
     left: 0;
     padding: 0.6rem 1.25rem 0.7rem 1.25rem;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/wwwroot/css/app.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/wwwroot/css/app.css
@@ -42,6 +42,7 @@ a, .btn-link {
     background: lightyellow;
     bottom: 0;
     box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    box-sizing: border-box;
     display: none;
     left: 0;
     padding: 0.6rem 1.25rem 0.7rem 1.25rem;


### PR DESCRIPTION
This change makes it so that the bounds of the error UI are calculated as intended and the dismiss button is positioned as intended.

## Details

Because of the interaction between padding and `width: 100%`, the bounds of the error UI extended to the right outside the viewport by the sum of the left and right padding.
That in turn caused the dismiss button (positioned relative to the right end of the error UI) to end up entirely outside the viewport, making it impossible to press it.

Before:
![before](https://github.com/dotnet/aspnetcore/assets/2699122/e4e152ce-325c-4a14-b312-7d800fb5c3ae)

After:
![after](https://github.com/dotnet/aspnetcore/assets/2699122/90d38d59-e959-4990-8256-23feedff2a00)
