### PR TITLE
Fix Http/3 tests

### DIFF
--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -395,7 +395,7 @@ public class Http3RequestTests : LoggedTest
 
     [ConditionalFact]
     [MsQuicSupported]
-    [SkipOnCI("https://github.com/dotnet/aspnetcore/issues/50833")]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/50833")]
     public async Task POST_ServerCompletesWithoutReadingRequestBody_ClientGetsResponse()
     {
         // Arrange
@@ -431,6 +431,8 @@ public class Http3RequestTests : LoggedTest
             await requestStream.WriteAsync(TestData).DefaultTimeout();
 
             var response = await responseTask.DefaultTimeout();
+
+            requestContent.CompleteStream();
 
             // Assert
             response.EnsureSuccessStatusCode();
@@ -700,7 +702,7 @@ public class Http3RequestTests : LoggedTest
 
     [ConditionalFact]
     [MsQuicSupported]
-    [SkipOnCI("https://github.com/dotnet/aspnetcore/issues/50833")]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/50833")]
     public async Task POST_Expect100Continue_Get100Continue()
     {
         // Arrange
@@ -728,7 +730,7 @@ public class Http3RequestTests : LoggedTest
 
             // Act
             using var cts = new CancellationTokenSource();
-            cts.CancelAfter(TimeSpan.FromSeconds(1));
+            cts.CancelAfter(TimeSpan.FromSeconds(30));
             var responseTask = client.SendAsync(request, cts.Token);
 
             var response = await responseTask.DefaultTimeout();
@@ -960,7 +962,7 @@ public class Http3RequestTests : LoggedTest
     [ConditionalTheory]
     [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/38008")]
     [MsQuicSupported]
-    //[InlineData(HttpProtocols.Http3)] Skip: see https://github.com/dotnet/aspnetcore/issues/50833
+    [InlineData(HttpProtocols.Http3)]
     [InlineData(HttpProtocols.Http2)]
     public async Task POST_ClientCancellationBidirectional_RequestAbortRaised(HttpProtocols protocol)
     {
@@ -1033,6 +1035,8 @@ public class Http3RequestTests : LoggedTest
             Logger.LogInformation("Client reading response.");
             var data = await responseStream.ReadAtLeastLengthAsync(TestData.Length).DefaultTimeout();
 
+            requestContent.CompleteStream();
+
             Logger.LogInformation("Client canceled request.");
             response.Dispose();
 
@@ -1061,7 +1065,8 @@ public class Http3RequestTests : LoggedTest
     // Verify HTTP/2 and HTTP/3 match behavior
     [ConditionalTheory]
     [MsQuicSupported]
-    //[InlineData(HttpProtocols.Http3)] Skip: see https://github.com/dotnet/aspnetcore/issues/50833
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/50833")]
+    [InlineData(HttpProtocols.Http3)]
     [InlineData(HttpProtocols.Http2)]
     public async Task POST_Bidirectional_LargeData_Cancellation_Error(HttpProtocols protocol)
     {
@@ -1129,6 +1134,8 @@ public class Http3RequestTests : LoggedTest
             await requestStream.FlushAsync().DefaultTimeout();
 
             await tcs.Task;
+
+            requestContent.CompleteStream();
 
             Logger.LogInformation("Client canceled request.");
             response.Dispose();

--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/Http3/Http3RequestTests.cs
@@ -1035,8 +1035,6 @@ public class Http3RequestTests : LoggedTest
             Logger.LogInformation("Client reading response.");
             var data = await responseStream.ReadAtLeastLengthAsync(TestData.Length).DefaultTimeout();
 
-            requestContent.CompleteStream();
-
             Logger.LogInformation("Client canceled request.");
             response.Dispose();
 
@@ -1134,8 +1132,6 @@ public class Http3RequestTests : LoggedTest
             await requestStream.FlushAsync().DefaultTimeout();
 
             await tcs.Task;
-
-            requestContent.CompleteStream();
 
             Logger.LogInformation("Client canceled request.");
             response.Dispose();


### PR DESCRIPTION
Fixes the tests in https://github.com/dotnet/aspnetcore/issues/50833 that started failing (3 of them hanging) when we ingested runtime updates, specifically this change https://github.com/dotnet/runtime/pull/90253

We were blocking the send task, by blocking the request content, which is now being waited on in dispose. You could argue that dispose should timeout the send/receive tasks so that hanging `HttpContent` types can at least observe cancellation to try and unblock. See https://github.com/dotnet/runtime/issues/92390 where that is brought up.