### PR TITLE
Fix http2cat sample

### DIFF
--- a/src/Servers/Kestrel/samples/http2cat/Program.cs
+++ b/src/Servers/Kestrel/samples/http2cat/Program.cs
@@ -18,8 +18,6 @@ public class Program
         using var host = new HostBuilder()
             .ConfigureLogging(loggingBuilder =>
             {
-                loggingBuilder.AddFilter((category, level) =>
-                    level >= LogLevel.Information || category.StartsWith("Microsoft.AspNetCore.Http2Cat", StringComparison.Ordinal));
                 loggingBuilder.AddConsole();
             })
             .UseHttp2Cat("https://localhost:5001", RunTestCase)
@@ -30,6 +28,7 @@ public class Program
 
     internal static async Task RunTestCase(Http2Utilities h2Connection)
     {
+        // Kestrel sends a fourth setting, SETTINGS_ENABLE_CONNECT_PROTOCOL
         await h2Connection.InitializeConnectionAsync(expectedSettingsCount: 4);
 
         h2Connection.Logger.LogInformation("Initialized http2 connection. Starting stream 1.");

--- a/src/Servers/Kestrel/samples/http2cat/Program.cs
+++ b/src/Servers/Kestrel/samples/http2cat/Program.cs
@@ -19,7 +19,7 @@ public class Program
             .ConfigureLogging(loggingBuilder =>
             {
                 loggingBuilder.AddFilter((category, level) =>
-                    category.StartsWith("Microsoft.AspNetCore.Http2Cat", StringComparison.Ordinal) || level >= LogLevel.Debug);
+                    level >= LogLevel.Information || category.StartsWith("Microsoft.AspNetCore.Http2Cat", StringComparison.Ordinal));
                 loggingBuilder.AddConsole();
             })
             .UseHttp2Cat("https://localhost:5001", RunTestCase)

--- a/src/Servers/Kestrel/samples/http2cat/Program.cs
+++ b/src/Servers/Kestrel/samples/http2cat/Program.cs
@@ -18,6 +18,8 @@ public class Program
         using var host = new HostBuilder()
             .ConfigureLogging(loggingBuilder =>
             {
+                loggingBuilder.AddFilter((category, level) =>
+                    category.StartsWith("Microsoft.AspNetCore.Http2Cat", StringComparison.Ordinal) || level >= LogLevel.Debug);
                 loggingBuilder.AddConsole();
             })
             .UseHttp2Cat("https://localhost:5001", RunTestCase)
@@ -28,7 +30,7 @@ public class Program
 
     internal static async Task RunTestCase(Http2Utilities h2Connection)
     {
-        await h2Connection.InitializeConnectionAsync();
+        await h2Connection.InitializeConnectionAsync(expectedSettingsCount: 4);
 
         h2Connection.Logger.LogInformation("Initialized http2 connection. Starting stream 1.");
 


### PR DESCRIPTION
As of #41558, four settings are expected, not three.

~Bonus: Actually show the http2cat logging~