### PR TITLE
Delete eng/BeforeTargetFrameworkInference.targets

### DIFF
--- a/eng/BeforeTargetFrameworkInference.targets
+++ b/eng/BeforeTargetFrameworkInference.targets
@@ -1,6 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <!-- Workaround while there is no SDK available that understands the TFM; suppress unsupported version errors. -->
-    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
This file wasn't actually being used, which shows it's unnecessary.