### PR TITLE
Support multiple claims with same type in the /manage/info response

### DIFF
--- a/src/Identity/Core/src/Data/InfoResponse.cs
+++ b/src/Identity/Core/src/Data/InfoResponse.cs
@@ -25,5 +25,5 @@ public sealed class InfoResponse
     /// <summary>
     /// The <see cref="ClaimsPrincipal.Claims"/> from the authenticated <see cref="HttpContext.User"/>.
     /// </summary>
-    public required IDictionary<string, string> Claims { get; init; }
+    public required IDictionary<string, string[]> Claims { get; init; }
 }

--- a/src/Identity/Core/src/IdentityApiEndpointRouteBuilderExtensions.cs
+++ b/src/Identity/Core/src/IdentityApiEndpointRouteBuilderExtensions.cs
@@ -429,26 +429,7 @@ public static class IdentityApiEndpointRouteBuilderExtensions
         // We expect a single error code and description in the normal case.
         // This could be golfed with GroupBy and ToDictionary, but perf! :P
         Debug.Assert(!result.Succeeded);
-        var errorDictionary = new Dictionary<string, string[]>(1);
-
-        foreach (var error in result.Errors)
-        {
-            string[] newDescriptions;
-
-            if (errorDictionary.TryGetValue(error.Code, out var descriptions))
-            {
-                newDescriptions = new string[descriptions.Length + 1];
-                Array.Copy(descriptions, newDescriptions, descriptions.Length);
-                newDescriptions[descriptions.Length] = error.Description;
-            }
-            else
-            {
-                newDescriptions = [error.Description];
-            }
-
-            errorDictionary[error.Code] = newDescriptions;
-        }
-
+        var errorDictionary = AggregateDictionary(result.Errors.Select(error => (error.Code, error.Description)));
         return TypedResults.ValidationProblem(errorDictionary);
     }
 
@@ -459,8 +440,32 @@ public static class IdentityApiEndpointRouteBuilderExtensions
         {
             Email = await userManager.GetEmailAsync(user) ?? throw new NotSupportedException("Users must have an email."),
             IsEmailConfirmed = await userManager.IsEmailConfirmedAsync(user),
-            Claims = claimsPrincipal.Claims.ToDictionary(c => c.Type, c => c.Value),
+            Claims = AggregateDictionary(claimsPrincipal.Claims.Select(claim => (claim.Type, claim.Value))),
         };
+    }
+
+    private static Dictionary<TKey, TValue[]> AggregateDictionary<TKey, TValue>(IEnumerable<(TKey, TValue)> pairs) where TKey : notnull
+    {
+        var dictionary = new Dictionary<TKey, TValue[]>(1);
+        foreach (var (key, value) in pairs)
+        {
+            TValue[] newDescriptions;
+
+            if (dictionary.TryGetValue(key, out var descriptions))
+            {
+                newDescriptions = new TValue[descriptions.Length + 1];
+                Array.Copy(descriptions, newDescriptions, descriptions.Length);
+                newDescriptions[descriptions.Length] = value;
+            }
+            else
+            {
+                newDescriptions = [value];
+            }
+
+            dictionary[key] = newDescriptions;
+        }
+
+        return dictionary;
     }
 
     // Wrap RouteGroupBuilder with a non-public type to avoid a potential future behavioral breaking change.

--- a/src/Identity/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Identity/Core/src/PublicAPI.Unshipped.txt
@@ -12,7 +12,7 @@ Microsoft.AspNetCore.Identity.Data.InfoRequest.NewPassword.init -> void
 Microsoft.AspNetCore.Identity.Data.InfoRequest.OldPassword.get -> string?
 Microsoft.AspNetCore.Identity.Data.InfoRequest.OldPassword.init -> void
 Microsoft.AspNetCore.Identity.Data.InfoResponse
-Microsoft.AspNetCore.Identity.Data.InfoResponse.Claims.get -> System.Collections.Generic.IDictionary<string!, string!>!
+Microsoft.AspNetCore.Identity.Data.InfoResponse.Claims.get -> System.Collections.Generic.IDictionary<string!, string![]!>!
 Microsoft.AspNetCore.Identity.Data.InfoResponse.Claims.init -> void
 Microsoft.AspNetCore.Identity.Data.InfoResponse.Email.get -> string!
 Microsoft.AspNetCore.Identity.Data.InfoResponse.Email.init -> void


### PR DESCRIPTION
# Support multiple claims with same type in the /manage/info response

Prior to this change, the `/manage/info` endpoint added by the new `MapIdentityApi<TUser>()` method introduced in .NET 8, would return an empty 500 response when the user making the request had a `ClaimsPrincipal` with multiple claims of the same type. This is very common when a user is in multiple roles and was [reported by a customer](https://github.com/dotnet/aspnetcore/issues/50037) shortly after the `/manage/info` endpoint was added in preview 7.

To support multiple claims of the same type, the `InfoResponse` type that was made public in RC2 (#50247, [API Review Notes](https://github.com/dotnet/aspnetcore/issues/49424#issuecomment-1686799123)) has been updated so the `Claims` property is now an `IDictionary<string, string[]>` rather than a `IDictionary<string, string>` similar to [ValidationProblemDetails.Errors](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.validationproblemdetails.errors?view=aspnetcore-7.0#microsoft-aspnetcore-mvc-validationproblemdetails-errors) which we already respond with from multiple `MapIdentityApi` endpoints.

This is pending API approval.

Fixes #50037
