### PR TITLE
fix: cancellationTokenSource memory leak

### DIFF
--- a/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
+++ b/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
@@ -95,7 +95,7 @@ internal static class DebugProxyLauncher
         }
         finally
         {
-            ctr?.Dispose();
+            ctr.Dispose();
         }
     }
 

--- a/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
+++ b/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
@@ -71,6 +71,8 @@ internal static class DebugProxyLauncher
         };
         RemoveUnwantedEnvironmentVariables(processStartInfo.Environment);
 
+        using var cts = new CancellationTokenSource(DebugProxyLaunchTimeout);
+        var ctr = default(CancellationTokenRegistration);
         var debugProxyProcess = Process.Start(processStartInfo);
         if (debugProxyProcess is null)
         {
@@ -81,13 +83,20 @@ internal static class DebugProxyLauncher
             PassThroughConsoleOutput(debugProxyProcess);
             CompleteTaskWhenServerIsReady(debugProxyProcess, isFirefox, tcs);
 
-            new CancellationTokenSource(DebugProxyLaunchTimeout).Token.Register(() =>
+            ctr = cts.Token.Register(() =>
             {
                 tcs.TrySetException(new TimeoutException($"Failed to start the debug proxy within the timeout period of {DebugProxyLaunchTimeout.TotalSeconds} seconds."));
             });
         }
 
-        return await tcs.Task;
+        try
+        {
+            return await tcs.Task;
+        }
+        finally
+        {
+            ctr?.Dispose();
+        }
     }
 
     private static void RemoveUnwantedEnvironmentVariables(IDictionary<string, string?> environment)


### PR DESCRIPTION
I've added 2 fixes to prevent memory leak:
- using statement to CancellationToken Source
- dispose to CancellationTokenRegistration

Found by Linux Verification Center (linuxtesting.org) with SVACE.