### PR TITLE
[2.1] Fix IPNetwork.Contains for prefixes which are not at start of subnet range.

### DIFF
--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -139,6 +139,7 @@ Later on, this will be checked using this condition:
       Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv;
       Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
       Microsoft.AspNetCore.SignalR.Redis;
+      Microsoft.AspNetCore.HttpOverrides;
     </PackagesInPatch>
   </PropertyGroup>
 </Project>

--- a/src/Middleware/HttpOverrides/src/IPNetwork.cs
+++ b/src/Middleware/HttpOverrides/src/IPNetwork.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net;
+using System.Net.Sockets;
 
 namespace Microsoft.AspNetCore.HttpOverrides
 {
@@ -9,6 +10,7 @@ namespace Microsoft.AspNetCore.HttpOverrides
     {
         public IPNetwork(IPAddress prefix, int prefixLength)
         {
+            CheckPrefixLengthRange(prefix, prefixLength);
             Prefix = prefix;
             PrefixLength = prefixLength;
             PrefixBytes = Prefix.GetAddressBytes();
@@ -20,7 +22,7 @@ namespace Microsoft.AspNetCore.HttpOverrides
         private byte[] PrefixBytes { get; }
 
         /// <summary>
-        /// The CIDR notation of the subnet mask 
+        /// The CIDR notation of the subnet mask
         /// </summary>
         public int PrefixLength { get; }
 
@@ -36,7 +38,7 @@ namespace Microsoft.AspNetCore.HttpOverrides
             var addressBytes = address.GetAddressBytes();
             for (int i = 0; i < PrefixBytes.Length && Mask[i] != 0; i++)
             {
-                if (PrefixBytes[i] != (addressBytes[i] & Mask[i]))
+                if ((PrefixBytes[i] & Mask[i]) != (addressBytes[i] & Mask[i]))
                 {
                     return false;
                 }
@@ -62,6 +64,24 @@ namespace Microsoft.AspNetCore.HttpOverrides
             }
 
             return mask;
+        }
+
+        private static void CheckPrefixLengthRange(IPAddress prefix, int prefixLength)
+        {
+            if (prefixLength < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(prefixLength));
+            }
+
+            if (prefix.AddressFamily == AddressFamily.InterNetwork && prefixLength > 32)
+            {
+                throw new ArgumentOutOfRangeException(nameof(prefixLength));
+            }
+
+            if (prefix.AddressFamily == AddressFamily.InterNetworkV6 && prefixLength > 128)
+            {
+                throw new ArgumentOutOfRangeException(nameof(prefixLength));
+            }
         }
     }
 }

--- a/src/Middleware/HttpOverrides/src/IPNetwork.cs
+++ b/src/Middleware/HttpOverrides/src/IPNetwork.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Net;
 using System.Net.Sockets;
 

--- a/src/Middleware/HttpOverrides/test/IPNetworkTest.cs
+++ b/src/Middleware/HttpOverrides/test/IPNetworkTest.cs
@@ -12,6 +12,15 @@ namespace Microsoft.AspNetCore.HttpOverrides
         [InlineData("174.0.0.0", 7, "175.1.1.10")]
         [InlineData("10.174.0.0", 15, "10.175.1.10")]
         [InlineData("10.168.0.0", 14, "10.171.1.10")]
+        [InlineData("192.168.0.1", 31, "192.168.0.0")]
+        [InlineData("192.168.0.1", 31, "192.168.0.1")]
+        [InlineData("192.168.0.1", 32, "192.168.0.1")]
+        [InlineData("192.168.1.1", 0, "0.0.0.0")]
+        [InlineData("192.168.1.1", 0, "255.255.255.255")]
+        [InlineData("2001:db8:3c4d::", 127, "2001:db8:3c4d::1")]
+        [InlineData("2001:db8:3c4d::1", 128, "2001:db8:3c4d::1")]
+        [InlineData("2001:db8:3c4d::1", 0, "::")]
+        [InlineData("2001:db8:3c4d::1", 0, "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")]
         public void Contains_Positive(string prefixText, int length, string addressText)
         {
             var network = new IPNetwork(IPAddress.Parse(prefixText), length);
@@ -23,6 +32,9 @@ namespace Microsoft.AspNetCore.HttpOverrides
         [InlineData("174.0.0.0", 7, "173.1.1.10")]
         [InlineData("10.174.0.0", 15, "10.173.1.10")]
         [InlineData("10.168.0.0", 14, "10.172.1.10")]
+        [InlineData("192.168.0.1", 31, "192.168.0.2")]
+        [InlineData("192.168.0.1", 32, "192.168.0.0")]
+        [InlineData("2001:db8:3c4d::", 127, "2001:db8:3c4d::2")]
         public void Contains_Negative(string prefixText, int length, string addressText)
         {
             var network = new IPNetwork(IPAddress.Parse(prefixText), length);


### PR DESCRIPTION

# [2.1] Fix IPNetwork.Contains for prefixes which are not at start of subnet range

## Description

The code in IPNetwork.Contains was incorrectly handling certain cases because the way subnet membership comparison code was incorrect.

This is a backport of 3d009158 to 2.1.

6.0 PR: https://github.com/dotnet/aspnetcore/pull/31573

Fixes #6674 in 2.1

## Customer Impact

The result of the `Contains` method could be incorrect.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Simple correctness change.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [x] Make necessary changes in eng/PatchConfig.props