### PR TITLE
[Form data mapping] Support for mapping URIs from form data

### DIFF
--- a/src/Components/Endpoints/src/FormMapping/Converters/UriFormDataConverter.cs
+++ b/src/Components/Endpoints/src/FormMapping/Converters/UriFormDataConverter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.AspNetCore.Components.Endpoints.FormMapping;
@@ -26,6 +27,8 @@ internal class UriFormDataConverter : FormDataConverter<Uri>, ISingleValueConver
         }
     }
 
+    [RequiresDynamicCode(FormMappingHelpers.RequiresDynamicCodeMessage)]
+    [RequiresUnreferencedCode(FormMappingHelpers.RequiresUnreferencedCodeMessage)]
     internal override bool TryRead(ref FormDataReader context, Type type, FormDataMapperOptions options, out Uri? result, out bool found)
     {
         found = context.TryGetValue(out var value);

--- a/src/Components/Endpoints/src/FormMapping/Converters/UriFormDataConverter.cs
+++ b/src/Components/Endpoints/src/FormMapping/Converters/UriFormDataConverter.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Components.Endpoints.FormMapping;
+
+internal class UriFormDataConverter : FormDataConverter<Uri>, ISingleValueConverter<Uri>
+{
+    public bool CanConvertSingleValue() => true;
+
+    public bool TryConvertValue(ref FormDataReader reader, string value, out Uri result)
+    {
+        if (Uri.TryCreate(value, UriKind.RelativeOrAbsolute, out result!))
+        {
+            return true;
+        }
+        else
+        {
+            // Using ParsableMappingError as ParsableConverter<T> will subsume this
+            // converter in a future version.
+            var segment = reader.GetLastPrefixSegment();
+            reader.AddMappingError(FormattableStringFactory.Create(FormDataResources.ParsableMappingError, value, segment), value);
+            result = default!;
+            return false;
+        }
+    }
+
+    internal override bool TryRead(ref FormDataReader context, Type type, FormDataMapperOptions options, out Uri? result, out bool found)
+    {
+        found = context.TryGetValue(out var value);
+        if (!found)
+        {
+            result = default;
+            return true;
+        }
+        else
+        {
+            return TryConvertValue(ref context, value!, out result!);
+        }
+    }
+}

--- a/src/Components/Endpoints/src/FormMapping/Metadata/FormDataMetadataFactory.cs
+++ b/src/Components/Endpoints/src/FormMapping/Metadata/FormDataMetadataFactory.cs
@@ -93,6 +93,12 @@ internal partial class FormDataMetadataFactory(List<IFormDataConverterFactory> f
                     return result;
                 }
 
+                if (WellKnownConverters.Converters.TryGetValue(type, out var converter))
+                {
+                    result.Kind = FormDataTypeKind.Primitive;
+                    return result;
+                }
+
                 if (_dictionaryFactory.CanConvert(type, options))
                 {
                     Log.DictionaryType(_logger, type);

--- a/src/Components/Endpoints/src/FormMapping/WellKnownConverters.cs
+++ b/src/Components/Endpoints/src/FormMapping/WellKnownConverters.cs
@@ -46,6 +46,7 @@ internal static class WellKnownConverters
             { typeof(IFormFileCollection), new FileConverter<IFormFileCollection>() },
             { typeof(IFormFile), new FileConverter<IFormFile>() },
             { typeof(IReadOnlyList<IFormFile>), new FileConverter<IReadOnlyList<IFormFile>>() },
+            { typeof(Uri), new UriFormDataConverter() },
 #if COMPONENTS
             { typeof(IBrowserFile), new FileConverter<IBrowserFile>() },
             { typeof(IReadOnlyList<IBrowserFile>), new FileConverter<IReadOnlyList<IBrowserFile>>() }

--- a/src/Components/Endpoints/test/Binding/FormDataMapperTests.cs
+++ b/src/Components/Endpoints/test/Binding/FormDataMapperTests.cs
@@ -188,6 +188,49 @@ public class FormDataMapperTests
         Assert.Null(result);
     }
 
+    [Theory]
+    [MemberData(nameof(UriTestData))]
+    public void CanDeserialize_Uri(string value, Uri expected)
+    {
+        // Arrange
+        var collection = new Dictionary<string, StringValues>() { ["value"] = new StringValues(value) };
+        var reader = CreateFormDataReader(collection, CultureInfo.InvariantCulture);
+        reader.PushPrefix("value");
+        var options = new FormDataMapperOptions();
+
+        // Act
+        var result = FormDataMapper.Map<Uri>(reader, options);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [MemberData(nameof(UriTestData))]
+    public void CanDeserialize_ComplexTypes_WithUriProperties(string value, Uri expected)
+    {
+        // Arrange
+        var collection = new Dictionary<string, StringValues>() { ["value.Slug"] = new StringValues(value) };
+        var reader = CreateFormDataReader(collection, CultureInfo.InvariantCulture);
+        reader.PushPrefix("value");
+        var options = new FormDataMapperOptions();
+
+        // Act
+        var result = FormDataMapper.Map<TypeWithUri>(reader, options);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expected, result.Slug);
+    }
+
+    public static TheoryData<string, Uri> UriTestData => new TheoryData<string, Uri>
+    {
+        { "http://www.example.com", new Uri("http://www.example.com") },
+        { "http://www.example.com/path", new Uri("http://www.example.com/path") },
+        { "http://www.example.com/path/", new Uri("http://www.example.com/path/") },
+        { "/path", new Uri("/path", UriKind.Relative) },
+    };
+
     [Fact]
     public void CanDeserialize_CustomParsableTypes()
     {
@@ -2185,6 +2228,11 @@ public class FormDataMapperTests
 
         return method.MakeGenericMethod(type).Invoke(null, new object[] { reader, options })!;
     }
+}
+
+internal class TypeWithUri
+{
+    public Uri Slug { get; set; }
 }
 
 internal class Point : IParsable<Point>, IEquatable<Point>


### PR DESCRIPTION
Adds a special case to handle URIs when maping form data from the request.

## Description

We don't special case URI for deserializing form data to objects on the server and URI values are treated as a complex type instead of primitive type and when the system tries to deserialize them it can't.

Fixes #51072

## Customer Impact

If a model is a URI or a type that contains a URI property, the request will fail to deserialize the form data into an object.

## Regression?

- [ ] Yes
- [X] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [X] Low

URIs don't implement `IParsable<Uri>` and need to be handled specifically in the form mapping pipeline.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props