### PR TITLE
Add SERVER_NAME variable to IISUrlRewrite

### DIFF
--- a/src/Middleware/Rewrite/src/IISUrlRewrite/ServerVariables.cs
+++ b/src/Middleware/Rewrite/src/IISUrlRewrite/ServerVariables.cs
@@ -87,6 +87,9 @@ internal static class ServerVariables
             case "REQUEST_URI":
                 managedVariableThunk = () => new UrlSegment(uriMatchPart);
                 break;
+            case "SERVER_NAME":
+                managedVariableThunk = () => new ServerNameSegment();
+                break;
             default:
                 throw new FormatException(Resources.FormatError_InputParserUnrecognizedParameter(serverVariable, context.Index));
         }

--- a/src/Middleware/Rewrite/src/PatternSegments/ServerNameSegment.cs
+++ b/src/Middleware/Rewrite/src/PatternSegments/ServerNameSegment.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+
+namespace Microsoft.AspNetCore.Rewrite.PatternSegments;
+
+internal sealed class ServerNameSegment : PatternSegment
+{
+    public override string? Evaluate(RewriteContext context, BackReferenceCollection? ruleBackReferences, BackReferenceCollection? conditionBackReferences)
+    {
+        return context.HttpContext.Request.Host.Host.ToString(CultureInfo.InvariantCulture);
+    }
+}

--- a/src/Middleware/Rewrite/test/IISUrlRewrite/ServerVariableTests.cs
+++ b/src/Middleware/Rewrite/test/IISUrlRewrite/ServerVariableTests.cs
@@ -26,6 +26,7 @@ public class ServerVariableTests
     [InlineData("REQUEST_URI", "/foo", (int)UriMatchPart.Path)]
     [InlineData("REQUEST_URI", "http://example.com/foo?bar=1", (int)UriMatchPart.Full)]
     [InlineData("REQUEST_METHOD", "GET", (int)UriMatchPart.Full)]
+    [InlineData("SERVER_NAME", "example.com", (int)UriMatchPart.Full)]
     public void CheckServerVariableParsingAndApplication(string variable, string expected, int uriMatchPart)
     {
         // Arrange and Act
@@ -52,6 +53,7 @@ public class ServerVariableTests
     [InlineData("REQUEST_URI", "/other-foo", (int)UriMatchPart.Path)]
     [InlineData("REQUEST_URI", "/other-foo", (int)UriMatchPart.Full)]
     [InlineData("REQUEST_METHOD", "POST", (int)UriMatchPart.Full)]
+    [InlineData("SERVER_NAME", "otherexample.com", (int)UriMatchPart.Full)]
     public void CheckServerVariableFeatureHasPrecedenceWhenEnabled(string variable, string expected, int uriMatchPart)
     {
         // Arrange and Act
@@ -72,7 +74,8 @@ public class ServerVariableTests
             ["QUERY_STRING"] = "bar=2",
             ["REQUEST_FILENAME"] = "/other-foo",
             ["REQUEST_URI"] = "/other-foo",
-            ["REQUEST_METHOD"] = "POST"
+            ["REQUEST_METHOD"] = "POST",
+            ["SERVER_NAME"] = "otherexample.com",
         }));
 
         var rewriteContext = CreateTestRewriteContext(httpContext);
@@ -98,6 +101,7 @@ public class ServerVariableTests
     [InlineData("REQUEST_URI", "/foo", (int)UriMatchPart.Path)]
     [InlineData("REQUEST_URI", "http://example.com/foo?bar=1", (int)UriMatchPart.Full)]
     [InlineData("REQUEST_METHOD", "GET", (int)UriMatchPart.Full)]
+    [InlineData("SERVER_NAME", "example.com", (int)UriMatchPart.Full)]
     public void CheckServerVariableFeatureIsntUsedWhenDisabled(string variable, string expected, int uriMatchPart)
     {
         // Arrange and Act

--- a/src/Middleware/Rewrite/test/PatternSegments/ServerNameSegmentTests.cs
+++ b/src/Middleware/Rewrite/test/PatternSegments/ServerNameSegmentTests.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Rewrite.PatternSegments;
+
+namespace Microsoft.AspNetCore.Rewrite.Tests.PatternSegments;
+
+public class ServerNameSegmentTests
+{
+    [Theory]
+    [InlineData("foobar", 80, "foobar")]
+    [InlineData("foobar", 443, "foobar")]
+    [InlineData("foobar", 8080, "foobar")]
+    [InlineData("2001:0db8:85a3:0000:0000:8a2e:0370:7334", 8080, "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]")]
+    [InlineData("127.0.0.1", 8080, "127.0.0.1")]
+    public void AssertServerNameIsCorrect(string host, int port, string expectedResult)
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Host = new HostString(host, port);
+        httpContext.Request.Path = new PathString("/foo/bar");
+
+        var context = new RewriteContext { HttpContext = httpContext };
+        context.HttpContext = httpContext;
+
+        // Act
+        var segment = new ServerNameSegment();
+        var results = segment.Evaluate(context, null, null);
+
+        // Assert
+        Assert.Equal(expectedResult, results);
+    }
+}


### PR DESCRIPTION
# Add SERVER_NAME variable to IISUrlRewrite

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [X] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Adds the missing `SERVER_NAME` variable to the `IISUrlRewrite` middleware

## Description

The current implementation of the `IISUrlRewrite` is missing the `SERVER_NAME` variable which can cause issues when migrating from an older version of .NET or IIS to newer versions. This PR adds the missing `SERVER_NAME` variable which extends the existing server variable parser.

Note: We currently support the `HTTP_HOST` variable, but it doesn't only contain the host but also the port (e.g. `microsoft.com:8443`), but `SERVER_NAME` must only contain the `HTTP_HOST` without the port number (if it's included) according to https://learn.microsoft.com/en-us/iis/web-dev-reference/server-variables.

Fixes #9713
