### PR TITLE
[release/8.0] [Blazor] Fix Blazor WebAssembly PWA empty template

### DIFF
--- a/src/Components/Web/src/Forms/InputDate.cs
+++ b/src/Components/Web/src/Forms/InputDate.cs
@@ -10,7 +10,13 @@ namespace Microsoft.AspNetCore.Components.Forms;
 
 /// <summary>
 /// An input component for editing date values.
-/// Supported types are <see cref="DateTime"/> and <see cref="DateTimeOffset"/>.
+/// The supported types for the date value are:
+/// <list type="bullet">
+/// <item><see cref="DateTime"/></item>
+/// <item><see cref="DateTimeOffset"/></item>
+/// <item><see cref="DateOnly"/></item>
+/// <item><see cref="TimeOnly"/></item>
+/// </list>
 /// </summary>
 public class InputDate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TValue> : InputBase<TValue>
 {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/.template.config/template.json
@@ -127,7 +127,6 @@
             "wwwroot/css/bootstrap/**",
             "wwwroot/css/bootstrap-icons/**",
             "wwwroot/favicon.png",
-            "wwwroot/icon*.png",
             "wwwroot/sample-data/weather.json"
           ]
         }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/wwwroot/index.html
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/wwwroot/index.html
@@ -12,8 +12,11 @@
     <link rel="stylesheet" href="css/app.css" />
     <!--#if SampleContent -->
     <link rel="icon" type="image/png" href="favicon.png" />
-    <!--#endif -->
     <link href="ComponentsWebAssembly-CSharp.styles.css" rel="stylesheet" />
+    <!--#else -->
+    <!-- If you add any scoped CSS files, uncomment the following to load them
+    <link href="ComponentsWebAssembly-CSharp.styles.css" rel="stylesheet" /> -->
+    <!--#endif -->
     <!--#if PWA -->
     <link href="manifest.webmanifest" rel="manifest" />
     <link rel="apple-touch-icon" sizes="512x512" href="icon-512.png" />

--- a/src/ProjectTemplates/test/Templates.Tests/template-baselines.json
+++ b/src/ProjectTemplates/test/Templates.Tests/template-baselines.json
@@ -2209,6 +2209,7 @@
         "Components/Pages/Home.razor",
         "Components/Layout/MainLayout.razor",
         "Properties/launchSettings.json",
+        "wwwroot/icon-192.png",
         "wwwroot/index.html",
         "wwwroot/css/app.css"
       ]
@@ -2257,6 +2258,7 @@
         "Properties/launchSettings.json",
         "wwwroot/appsettings.Development.json",
         "wwwroot/appsettings.json",
+        "wwwroot/icon-192.png",
         "wwwroot/index.html",
         "wwwroot/css/app.css"
       ]
@@ -2303,6 +2305,7 @@
         "Components/Login/RedirectToLogin.razor",
         "Properties/launchSettings.json",
         "wwwroot/appsettings.json",
+        "wwwroot/icon-192.png",
         "wwwroot/index.html",
         "wwwroot/css/app.css"
       ]
@@ -2349,6 +2352,7 @@
         "Components/Login/RedirectToLogin.razor",
         "Properties/launchSettings.json",
         "wwwroot/appsettings.json",
+        "wwwroot/icon-192.png",
         "wwwroot/index.html",
         "wwwroot/css/app.css"
       ]
@@ -2391,6 +2395,8 @@
         "Components/Pages/Home.razor",
         "Components/Layout/MainLayout.razor",
         "Properties/launchSettings.json",
+        "wwwroot/icon-192.png",
+        "wwwroot/icon-512.png",
         "wwwroot/index.html",
         "wwwroot/manifest.webmanifest",
         "wwwroot/service-worker.js",
@@ -2430,6 +2436,7 @@
         "Components/_Imports.razor",
         "Components/Pages/Home.razor",
         "Components/Layout/MainLayout.razor",
+        "wwwroot/icon-192.png",
         "wwwroot/index.html",
         "wwwroot/css/app.css"
       ]


### PR DESCRIPTION
# Fix Blazor WebAssembly PWA empty template

Fixes runtime errors that occur when running a Blazor WebAssembly app created via `dotnet new blazorwasm --pwa --empty`.

## Description

This PR makes two changes:
* Includes icon assets in the Blazor WebAssembly template even when the `--empty` option is specified
* Doesn't attempt to load scoped CSS files if the `--empty` option is specified

This prevents errors from appearing in the browser console and fixes an issue where the "install" button was not appearing in the browser.

Fixes https://github.com/aspnet/AspNetCore-ManualTests/issues/2384

## Customer Impact

Customers who create an empty Blazor WebAssembly app **with PWA capabilities** will experience errors at runtime out-of-the-box. They will be forced to correct these changes by adding icon assets manually and removing the `<link>` element in `index.html` that loads scoped CSS files.

## Regression?

- [X] Yes
- [ ] No

Regressed from the .NET 7.0 Blazor WebAssembly Empty template.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

This is a very small change to the template, and it's unlikely to regress functionality in other templates.

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A