### PR TITLE
[8.0] Critical fix to output cache; remove OutputCacheEntry recycling

### DIFF
--- a/src/Middleware/OutputCaching/src/OutputCacheEntry.cs
+++ b/src/Middleware/OutputCaching/src/OutputCacheEntry.cs
@@ -17,8 +17,6 @@ internal sealed class OutputCacheEntry : IDisposable
         StatusCode = statusCode;
     }
 
-    private bool _recycleBuffers; // does this instance own the memory behind the segments?
-
     public StringValues FindHeader(string key)
     {
         TryFindHeader(key, out var value);
@@ -68,7 +66,8 @@ internal sealed class OutputCacheEntry : IDisposable
     internal void SetBody(ReadOnlySequence<byte> value, bool recycleBuffers)
     {
         Body = value;
-        _recycleBuffers = recycleBuffers;
+        // note that recycleBuffers is not stored currently, until OutputCacheEntry buffer recycling is re-implemented;
+        // it indicates whether this instance "owns" the memory behind the segments, such that they can be recycled later if desired
     }
 
     internal OutputCacheEntry CreateBodyFrom(IList<byte[]> segments) // mainly used from tests

--- a/src/Middleware/OutputCaching/src/OutputCacheEntry.cs
+++ b/src/Middleware/OutputCaching/src/OutputCacheEntry.cs
@@ -66,6 +66,7 @@ internal sealed class OutputCacheEntry : IDisposable
     internal void SetBody(ReadOnlySequence<byte> value, bool recycleBuffers)
     {
         Body = value;
+        _ = recycleBuffers; // satisfy IDE0060
         // note that recycleBuffers is not stored currently, until OutputCacheEntry buffer recycling is re-implemented;
         // it indicates whether this instance "owns" the memory behind the segments, such that they can be recycled later if desired
     }

--- a/src/Middleware/OutputCaching/src/OutputCacheMiddleware.cs
+++ b/src/Middleware/OutputCaching/src/OutputCacheMiddleware.cs
@@ -200,6 +200,7 @@ internal sealed class OutputCacheMiddleware
         {
             // avoid recycling in unknown outcomes, especially re concurrent buffer access thru cancellation
             hasException = true;
+            throw;
         }
         finally
         {

--- a/src/Middleware/OutputCaching/test/OutputCacheTests.cs
+++ b/src/Middleware/OutputCaching/test/OutputCacheTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.Net.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
@@ -932,6 +933,71 @@ public class OutputCacheTests
             var subsequentResponse = await client.SendAsync(TestUtils.CreateRequest("HEAD", "?contentLength=10"));
 
             await AssertCachedResponseAsync(initialResponse, subsequentResponse);
+        }
+    }
+
+    [Fact]
+    public async Task ServesCorrectlyUnderConcurrentLoad()
+    {
+        var builders = TestUtils.CreateBuildersWithOutputCaching();
+
+        foreach (var builder in builders)
+        {
+            using var host = builder.Build();
+
+            await host.StartAsync();
+
+            using var server = host.GetTestServer();
+
+            var guid = await RunClient(server, -1);
+
+            var clients = new Task<Guid>[1024];
+            for (int i = 0; i < clients.Length; i++)
+            {
+                clients[i] = Task.Run(() => RunClient(server, i));
+            }
+            await Task.WhenAll(clients);
+
+            // note already completed
+            for (int i = 0; i < clients.Length; i++)
+            {
+                Assert.Equal(guid, await clients[i]);
+            }
+        }
+
+        static async Task<Guid> RunClient(TestServer server, int id)
+        {
+            string s = null;
+            try
+            {
+                var client = server.CreateClient();
+                var resp = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, ""));
+                var len = resp.Content.Headers.ContentLength;
+                s = await resp.Content.ReadAsStringAsync();
+
+                Assert.NotNull(len);
+                Guid value;
+                switch (len.Value)
+                {
+                    case 36:
+                        // usually we just write a guid
+                        Assert.True(Guid.TryParse(s, out value));
+                        break;
+                    case 98:
+                        // the file-based builder prepends extra data
+                        Assert.True(Guid.TryParse(s.Substring(s.Length - 36), out value));
+                        break;
+                    default:
+                        Assert.Fail($"Unexpected length: {len.Value}");
+                        value = Guid.NewGuid(); // not reached
+                        break;
+                }
+                return value;
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Client {id} failed; payload '{s}', failure: {ex.Message}", ex);
+            }
         }
     }
 


### PR DESCRIPTION
# Critical fix to output cache

Output cache shared buffer in the "multiple people requesting same page" path released prematurely, leading to empty responses.

## Description

Part of net8 work in the output-cache middleware was to reduce allocations; one aspect of this was buffer recycling in the `OutputCacheEntry`, however a late discovery is that this recycling can impact separate requests, due to the `Task` reuse between requests when using "locking" mode (see `_requestDispatcher.ScheduleAsync`). This means that some requests (as a race condition) can get empty responses if the `OutputCacheEntry` was already recycled.

There is no risk of buffer bleed between responses (so: no infosec issue), but: empty responses is a critical failure and must be addressed.

Given the late stage of net8, it is proposed to simply drop the buffer recycling aspect; this puts `OutputCacheEntry` back *exactly where it is in net7*, so this choice is not a regression: we just lose something we wanted to add. We can revisit this when we have time to do this safely, in net9 and possibly back-ported to net8 as a service release. A brief investigation using counting was attempted, but this was not immediately successful, and I'd rather have minimum risk.

A new test shows the failure, and now passes.

Fixes #51009 (note that despite the title, this issue is not specific to any particular output-cache provider)

## Customer Impact

Without the fix, empty responses are possible

## Regression?

- [x] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

net7.0, net8 preview 6

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Resolution chosen with minimal risk rather than perfect solution in mind, that sacrifices some potential buffer reuse; we plan to
implement full buffer reuse by restructuring the shared result cache, allowing us to correctly track active usage, but this is
beyond what we will do "now". This work will be in net9 and optionally backported to a net8 servicing release (tbd).

## Verification

- [ ] Manual (required)
- [x] Automated - new test

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props
