### PR TITLE
Test-fixed reactions

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -19,8 +19,6 @@
     {"testName": {"contains": "POST_ServerAbortAfterWrite_ClientReceivesAbort"}},
     {"testName": {"contains": "ServerReset_BeforeRequestBody_ClientBodyThrows"}},
     {"testName": {"contains": "InjectedStartup_DefaultApplicationNameIsEntryAssembly"}},
-    {"testName": {"contains": "HEADERS_Received_SecondRequest_ConnectProtocolReset"}},
-    {"testName": {"contains": "ClientUsingOldCallWithNewProtocol"}},
     {"testName": {"contains": "CertificateChangedOnDisk"}},
     {"testName": {"contains": "CertificateChangedOnDisk_Symlink"}},
     {"testAssembly": {"contains": "IIS"}},

--- a/src/Components/test/E2ETest/Tests/ErrorNotificationTest.cs
+++ b/src/Components/test/E2ETest/Tests/ErrorNotificationTest.cs
@@ -32,7 +32,6 @@ public class ErrorNotificationTest : ServerTestBase<ToggleExecutionModeServerFix
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/50377")]
     public void ShowsErrorNotification_OnError_Dismiss()
     {
         var errorUi = Browser.Exists(By.Id("blazor-error-ui"));
@@ -50,7 +49,6 @@ public class ErrorNotificationTest : ServerTestBase<ToggleExecutionModeServerFix
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/50377")]
     public void ShowsErrorNotification_OnError_Reload()
     {
         var causeErrorButton = Browser.Exists(By.Id("throw-simple-exception"));

--- a/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
@@ -27,7 +27,7 @@ public class WebHostTests : LoggedTest
     [SkipNonHelix]
     [SkipOnAlpine("https://github.com/dotnet/aspnetcore/issues/46537")]
     [SkipOnMariner("https://github.com/dotnet/aspnetcore/issues/46537")]
-    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/46616;https://github.com/dotnet/aspnetcore/issues/47065", Queues = "Debian.12.Arm64.Open;")]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/46616", Queues = "Debian.12.Arm64.Open;")]
     [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "HTTP/3 isn't supported on MacOS.")]
     [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win11_21H2)]
     public void HelixPlatform_QuicListenerIsSupported()


### PR DESCRIPTION
`HelixPlatform_QuicListenerIsSupported` was referencing an issue that's already resolved via https://github.com/dotnet/aspnetcore/pull/50279.

The 2 blazor tests have been passing and are marked test-fixed in https://github.com/dotnet/aspnetcore/issues/50377

`HEADERS_Received_SecondRequest_ConnectProtocolReset` wasn't removed from the retry list when https://github.com/dotnet/aspnetcore/issues/48737 was closed.

`ClientUsingOldCallWithNewProtocol` has been passing and is marked test-fixed in https://github.com/dotnet/aspnetcore/issues/48733