### PR TITLE
Rename metrics tag exception.type to error.type

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
@@ -71,10 +71,10 @@ internal sealed class HostingMetrics : IDisposable
                 tags.Add("http.route", route);
             }
             // This exception is only present if there is an unhandled exception.
-            // An exception caught by ExceptionHandlerMiddleware and DeveloperExceptionMiddleware isn't thrown to here. Instead, those middleware add exception.type to custom tags.
+            // An exception caught by ExceptionHandlerMiddleware and DeveloperExceptionMiddleware isn't thrown to here. Instead, those middleware add error.type to custom tags.
             if (exception != null)
             {
-                tags.Add("exception.type", exception.GetType().FullName);
+                tags.Add("error.type", exception.GetType().FullName);
             }
             if (customTags != null)
             {

--- a/src/Hosting/Hosting/test/HostingMetricsTests.cs
+++ b/src/Hosting/Hosting/test/HostingMetricsTests.cs
@@ -97,11 +97,11 @@ public class HostingMetricsTests
             Assert.Equal(statusCode, (int)measurement.Tags["http.response.status_code"]);
             if (exceptionName == null)
             {
-                Assert.False(measurement.Tags.ContainsKey("exception.type"));
+                Assert.False(measurement.Tags.ContainsKey("error.type"));
             }
             else
             {
-                Assert.Equal(exceptionName, (string)measurement.Tags["exception.type"]);
+                Assert.Equal(exceptionName, (string)measurement.Tags["error.type"]);
             }
             if (unhandledRequest ?? false)
             {

--- a/src/Middleware/Diagnostics/src/DiagnosticsMetrics.cs
+++ b/src/Middleware/Diagnostics/src/DiagnosticsMetrics.cs
@@ -39,7 +39,7 @@ internal sealed class DiagnosticsMetrics
     private void RequestExceptionCore(string exceptionName, ExceptionResult result, string? handler)
     {
         var tags = new TagList();
-        tags.Add("exception.type", exceptionName);
+        tags.Add("error.type", exceptionName);
         tags.Add("aspnetcore.diagnostics.exception.result", GetExceptionResult(result));
         if (handler != null)
         {

--- a/src/Middleware/Diagnostics/src/DiagnosticsTelemetry.cs
+++ b/src/Middleware/Diagnostics/src/DiagnosticsTelemetry.cs
@@ -15,7 +15,7 @@ internal static class DiagnosticsTelemetry
 
         if (context.Features.Get<IHttpMetricsTagsFeature>() is { } tagsFeature)
         {
-            tagsFeature.Tags.Add(new KeyValuePair<string, object?>("exception.type", ex.GetType().FullName));
+            tagsFeature.Tags.Add(new KeyValuePair<string, object?>("error.type", ex.GetType().FullName));
         }
     }
 }

--- a/src/Middleware/Diagnostics/test/UnitTests/DeveloperExceptionPageMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/DeveloperExceptionPageMiddlewareTest.cs
@@ -579,7 +579,7 @@ public class DeveloperExceptionPageMiddlewareTest : LoggedTest
             {
                 Assert.True(m.Value > 0);
                 Assert.Equal(500, (int)m.Tags["http.response.status_code"]);
-                Assert.Equal("System.Exception", (string)m.Tags["exception.type"]);
+                Assert.Equal("System.Exception", (string)m.Tags["error.type"]);
             });
         Assert.Collection(requestExceptionCollector.GetMeasurementSnapshot(),
             m => AssertRequestException(m, "System.Exception", "unhandled"));
@@ -588,7 +588,7 @@ public class DeveloperExceptionPageMiddlewareTest : LoggedTest
     private static void AssertRequestException(CollectedMeasurement<long> measurement, string exceptionName, string result, string handler = null)
     {
         Assert.Equal(1, measurement.Value);
-        Assert.Equal(exceptionName, (string)measurement.Tags["exception.type"]);
+        Assert.Equal(exceptionName, (string)measurement.Tags["error.type"]);
         Assert.Equal(result, measurement.Tags["aspnetcore.diagnostics.exception.result"].ToString());
         if (handler == null)
         {

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerMiddlewareTest.cs
@@ -318,7 +318,7 @@ public class ExceptionHandlerMiddlewareTest
     private static void AssertRequestException(CollectedMeasurement<long> measurement, string exceptionName, string result, string handler = null)
     {
         Assert.Equal(1, measurement.Value);
-        Assert.Equal(exceptionName, (string)measurement.Tags["exception.type"]);
+        Assert.Equal(exceptionName, (string)measurement.Tags["error.type"]);
         Assert.Equal(result, measurement.Tags["aspnetcore.diagnostics.exception.result"].ToString());
         if (handler == null)
         {

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerTest.cs
@@ -962,7 +962,7 @@ public class ExceptionHandlerTest
             {
                 Assert.True(m.Value > 0);
                 Assert.Equal(404, (int)m.Tags["http.response.status_code"]);
-                Assert.Equal("System.Exception", (string)m.Tags["exception.type"]);
+                Assert.Equal("System.Exception", (string)m.Tags["error.type"]);
             });
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelMetrics.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelMetrics.cs
@@ -116,7 +116,7 @@ internal sealed class KestrelMetrics
         {
             if (exception != null)
             {
-                tags.Add("exception.type", exception.GetType().FullName);
+                tags.Add("error.type", exception.GetType().FullName);
             }
 
             // Add custom tags for duration.
@@ -298,7 +298,7 @@ internal sealed class KestrelMetrics
         }
         if (exception != null)
         {
-            tags.Add("exception.type", exception.GetType().FullName);
+            tags.Add("error.type", exception.GetType().FullName);
         }
 
         var duration = Stopwatch.GetElapsedTime(startTimestamp, currentTimestamp);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/KestrelMetricsTests.cs
@@ -273,7 +273,7 @@ public class KestrelMetricsTests : TestApplicationErrorLoggerLoggedTest
         Assert.Collection(connectionDuration.GetMeasurementSnapshot(), m =>
         {
             AssertDuration(m, "127.0.0.1", localPort: 0, "tcp", "ipv4", httpVersion: null);
-            Assert.Equal("System.InvalidOperationException", (string)m.Tags["exception.type"]);
+            Assert.Equal("System.InvalidOperationException", (string)m.Tags["error.type"]);
         });
         Assert.Collection(activeConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));
         Assert.Collection(queuedConnections.GetMeasurementSnapshot(), m => AssertCount(m, 1, "127.0.0.1", localPort: 0, "tcp", "ipv4"), m => AssertCount(m, -1, "127.0.0.1", localPort: 0, "tcp", "ipv4"));


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/51029

# Rename metrics tag exception.type to error.type

There has been a late change to OpenTelemetry conventions to rename the `exception.type` attribute to `error.type`. Because we are doing our best to follow the OTEL conventions, we want ASP.NET Core to use the right name.

This change should be done now before the metrics are in a GA release.

## Description

Rename the `exception.type` attribute to `error.type`.

Fixes https://github.com/dotnet/aspnetcore/issues/51029

## Customer Impact

The HTTP metrics in ASP.NET Core follow the OTEL convention.

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The PR changes a name. Nothing in .NET or ASP.NET Core depends on the name.

## Verification

- [x] Manual (required)
- [x] Automated

Correct tag name was manually verified by running `dotnet-counters monitor`:

![image](https://github.com/dotnet/aspnetcore/assets/303201/4798c701-a65c-4a16-9ae5-85e22ed39318)

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props
