### PR TITLE
Use token expiration value from options as fallback

### DIFF
--- a/src/Security/Authentication/BearerToken/src/BearerTokenHandler.cs
+++ b/src/Security/Authentication/BearerToken/src/BearerTokenHandler.cs
@@ -66,7 +66,7 @@ internal sealed class BearerTokenHandler(IOptionsMonitor<BearerTokenOptions> opt
         var utcNow = TimeProvider.GetUtcNow();
 
         properties ??= new();
-        properties.ExpiresUtc = utcNow + Options.BearerTokenExpiration;
+        properties.ExpiresUtc ??= utcNow + Options.BearerTokenExpiration;
 
         var response = new AccessTokenResponse
         {

--- a/src/Security/Authentication/BearerToken/src/BearerTokenHandler.cs
+++ b/src/Security/Authentication/BearerToken/src/BearerTokenHandler.cs
@@ -67,11 +67,12 @@ internal sealed class BearerTokenHandler(IOptionsMonitor<BearerTokenOptions> opt
 
         properties ??= new();
         properties.ExpiresUtc ??= utcNow + Options.BearerTokenExpiration;
+        var expiresIn = (long)(properties.ExpiresUtc.Value - utcNow).TotalSeconds;
 
         var response = new AccessTokenResponse
         {
             AccessToken = Options.BearerTokenProtector.Protect(CreateBearerTicket(user, properties)),
-            ExpiresIn = (long)Options.BearerTokenExpiration.TotalSeconds,
+            ExpiresIn = expiresIn,
             RefreshToken = Options.RefreshTokenProtector.Protect(CreateRefreshTicket(user, utcNow)),
         };
 

--- a/src/Security/Authentication/test/BearerTokenTests.cs
+++ b/src/Security/Authentication/test/BearerTokenTests.cs
@@ -1,7 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.AspNetCore.Authentication.BearerToken;
 
@@ -22,5 +31,87 @@ public class BearerTokenTests : SharedAuthenticationTests<BearerTokenOptions>
     protected override void RegisterAuth(AuthenticationBuilder services, Action<BearerTokenOptions> configure)
     {
         services.AddBearerToken(configure);
+    }
+
+    [Fact]
+    public async void ShouldUseExpirationDateFromAuthenticationPropertiesInsteadOfTokenOptions_WhenItIsSpecified()
+    {
+        // Arrange
+        var expiresUtc = DateTime.UtcNow + TimeSpan.FromHours(8);
+        using var host = await CreateHost(
+            options => options.BearerTokenExpiration = TimeSpan.FromDays(-1),
+            new AuthenticationProperties { ExpiresUtc = expiresUtc }
+        );
+        using var server = host.GetTestServer();
+
+        // Act
+        var signInTransaction = await SendAsync(server, "http://example.com/signIn");
+        var accessTokenResponse = JsonSerializer.Deserialize<AccessTokenResponse>(signInTransaction.ResponseText,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        var oauthTransaction = await SendAsync(server, "http://example.com/oauth", $"Bearer {accessTokenResponse.AccessToken}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, signInTransaction.Response.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, oauthTransaction.Response.StatusCode);
+        Assert.Equal("true", oauthTransaction.ResponseText);
+        Assert.True(accessTokenResponse.ExpiresIn > 0);
+    }
+
+    private static async Task<IHost> CreateHost(Action<BearerTokenOptions> configure, AuthenticationProperties props = null)
+    {
+        var host = new HostBuilder()
+            .ConfigureWebHost(builder =>
+            {
+                builder
+                    .UseTestServer()
+                    .Configure(builder =>
+                    {
+                        builder.UseAuthentication();
+                        builder.Use(async (HttpContext context, RequestDelegate next) =>
+                        {
+                            if (context.Request.Path == new PathString("/signIn"))
+                            {
+                                await context.SignInAsync(
+                                    BearerTokenDefaults.AuthenticationScheme,
+                                    new ClaimsPrincipal(new ClaimsIdentity("mock")),
+                                    props);
+                                return;
+                            }
+                            if (context.Request.Path == new PathString("/oauth"))
+                            {
+                                var authenticationResult = await context.AuthenticateAsync(BearerTokenDefaults.AuthenticationScheme);
+                                await context.Response.WriteAsJsonAsync(authenticationResult.Succeeded);
+                                return;
+                            }
+                        });
+                    })
+                    .ConfigureServices(services =>
+                    {
+                        services
+                            .AddAuthentication(BearerTokenDefaults.AuthenticationScheme)
+                            .AddBearerToken(BearerTokenDefaults.AuthenticationScheme, configure)
+                            ;
+                    });
+            })
+            .Build();
+
+        await host.StartAsync();
+        return host;
+    }
+
+    private static async Task<Transaction> SendAsync(TestServer server, string uri, string authorizationHeader = null)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, uri);
+        if (!string.IsNullOrEmpty(authorizationHeader))
+        {
+            request.Headers.Add("Authorization", authorizationHeader);
+        }
+        var transaction = new Transaction
+        {
+            Request = request,
+            Response = await server.CreateClient().SendAsync(request),
+        };
+        transaction.ResponseText = await transaction.Response.Content.ReadAsStringAsync();
+        return transaction;
     }
 }

--- a/src/Security/Authentication/test/BearerTokenTests.cs
+++ b/src/Security/Authentication/test/BearerTokenTests.cs
@@ -66,7 +66,6 @@ public class BearerTokenTests : SharedAuthenticationTests<BearerTokenOptions>
                     .UseTestServer()
                     .Configure(builder =>
                     {
-                        builder.UseAuthentication();
                         builder.Use(async (HttpContext context, RequestDelegate next) =>
                         {
                             if (context.Request.Path == new PathString("/signIn"))


### PR DESCRIPTION
Perhaps using the token expiration value from the options makes sense only if the user does not explicitly specify the ExpiresUtc property.

Example to reproduce

```csharp
builder.Services
    .AddAuthentication(BearerTokenDefaults.AuthenticationScheme)
    .AddBearerToken(BearerTokenDefaults.AuthenticationScheme, options =>
    {
        options.BearerTokenExpiration = TimeSpan.FromDays(1);
    });


var props = new AuthenticationProperties { ExpiresUtc = DateTime.UtcNow.Add(TimeSpan.FromHours(4));
await context.SignInAsync(principal, props);
```
