### PR TITLE
Refactor problem details exception handler

### DIFF
--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerServiceCollectionExtensions.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ public static class ExceptionHandlerServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configureOptions);
 
+        services.AddProblemDetailsExceptionHandler();
         return services.Configure(configureOptions);
     }
 
@@ -37,6 +38,7 @@ public static class ExceptionHandlerServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configureOptions);
 
+        services.AddProblemDetailsExceptionHandler();
         services.AddOptions<ExceptionHandlerOptions>().Configure(configureOptions);
         return services;
     }
@@ -51,5 +53,15 @@ public static class ExceptionHandlerServiceCollectionExtensions
     public static IServiceCollection AddExceptionHandler<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(this IServiceCollection services) where T : class, IExceptionHandler
     {
         return services.AddSingleton<IExceptionHandler, T>();
+    }
+
+    /// <summary>
+    /// Adds an `IExceptionHandler` implementation to services that uses the `IProblemDetails` service to produce responses.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> for adding services.</param>
+    /// <returns>The modified <see cref="IServiceCollection"/>.</returns>
+    public static IServiceCollection AddProblemDetailsExceptionHandler(this IServiceCollection services)
+    {
+        return services.AddExceptionHandler<ProblemDetailsExceptionHandler>();
     }
 }

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ProblemDetailsExceptionHandler.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ProblemDetailsExceptionHandler.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Diagnostics;
+
+internal class ProblemDetailsExceptionHandler(IProblemDetailsService? problemDetailsService = null) : IExceptionHandler
+{
+    private readonly IProblemDetailsService? _problemDetailsService = problemDetailsService;
+
+    public ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
+    {
+        if (_problemDetailsService == null)
+        {
+            return default;
+        }
+
+        return _problemDetailsService.TryWriteAsync(new()
+        {
+            HttpContext = httpContext,
+            AdditionalMetadata = httpContext.GetEndpoint()?.Metadata,
+            ProblemDetails = { Status = StatusCodes.Status500InternalServerError },
+            Exception = exception,
+        });
+    }
+}

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ProblemDetailsExceptionHandler.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ProblemDetailsExceptionHandler.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Diagnostics;
 
-internal class ProblemDetailsExceptionHandler(IProblemDetailsService? problemDetailsService = null) : IExceptionHandler
+internal sealed class ProblemDetailsExceptionHandler(IProblemDetailsService? problemDetailsService = null) : IExceptionHandler
 {
     private readonly IProblemDetailsService? _problemDetailsService = problemDetailsService;
 

--- a/src/Middleware/Diagnostics/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/Diagnostics/src/PublicAPI.Unshipped.txt
@@ -6,3 +6,4 @@ Microsoft.AspNetCore.Diagnostics.IExceptionHandler.TryHandleAsync(Microsoft.AspN
 Microsoft.AspNetCore.Diagnostics.StatusCodeReExecuteFeature.OriginalStatusCode.get -> int
 static Microsoft.AspNetCore.Builder.ExceptionHandlerExtensions.UseExceptionHandler(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, string! errorHandlingPath, bool createScopeForErrors) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
 static Microsoft.Extensions.DependencyInjection.ExceptionHandlerServiceCollectionExtensions.AddExceptionHandler<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Microsoft.Extensions.DependencyInjection.ExceptionHandlerServiceCollectionExtensions.AddProblemDetailsExceptionHandler(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerMiddlewareTest.cs
@@ -43,6 +43,7 @@ public class ExceptionHandlerMiddlewareTest
                         }
                     };
                 });
+                services.AddProblemDetailsExceptionHandler();
             })
             .ConfigureWebHost(webHostBuilder =>
             {

--- a/src/Middleware/Diagnostics/test/testassets/ExceptionHandlerSample/StartupWithProblemDetails.cs
+++ b/src/Middleware/Diagnostics/test/testassets/ExceptionHandlerSample/StartupWithProblemDetails.cs
@@ -12,6 +12,7 @@ public class StartupWithProblemDetails
     public void ConfigureServices(IServiceCollection services)
     {
         services.AddProblemDetails();
+        services.AddProblemDetailsExceptionHandler();
     }
 
     public void Configure(IApplicationBuilder app)


### PR DESCRIPTION
Follow up to https://github.com/dotnet/aspnetcore/pull/47923#issuecomment-1527852737 that introduced the IExceptionHandler abstraction. This now refactors problem details to implement the new abstraction.

The awkward bit is that `services.AddExceptionHandler(...)` is optional, so there's no guarantee this new implementation gets registered. I've added `services.AddProblemDetailsExceptionHandler()` to make that more obvious.

