### PR TITLE
Change HealthCheckPublisherHostedService exception log from debug to error

### DIFF
--- a/src/HealthChecks/HealthChecks/src/HealthCheckPublisherHostedService.cs
+++ b/src/HealthChecks/HealthChecks/src/HealthCheckPublisherHostedService.cs
@@ -167,7 +167,7 @@ internal sealed partial class HealthCheckPublisherHostedService : IHostedService
         catch (Exception ex)
         {
             // This is an error, publishing failed.
-            Logger.HealthCheckPublisherProcessingEnd(_logger, duration.GetElapsedTime(), ex);
+            Logger.HealthCheckPublisherError(_logger, duration.GetElapsedTime(), ex);
         }
         finally
         {


### PR DESCRIPTION
# Change HealthCheckPublisherHostedService exception log from debug to error

## Description

When an exception is thrown, the log should be on the error level, not debug, for visibility
