### PR TITLE
OutputCache - use ref-counting on OutputCacheEntry to ensure that buffers are fully recycled

### DIFF
--- a/src/Middleware/OutputCaching/src/OutputCacheContext.cs
+++ b/src/Middleware/OutputCaching/src/OutputCacheContext.cs
@@ -69,13 +69,6 @@ public sealed class OutputCacheContext
 
     internal OutputCacheEntry? CachedResponse { get; set; }
 
-    internal void ReleaseCachedResponse()
-    {
-        var tmp = CachedResponse;
-        CachedResponse = null;
-        tmp?.Dispose();
-    }
-
     internal bool ResponseStarted { get; set; }
 
     internal Stream OriginalResponseStream { get; set; } = default!;

--- a/src/Middleware/OutputCaching/src/OutputCacheEntry.cs
+++ b/src/Middleware/OutputCaching/src/OutputCacheEntry.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Diagnostics;
 using System.IO.Pipelines;
+using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
@@ -15,7 +17,15 @@ internal sealed class OutputCacheEntry : IDisposable
     {
         Created = created;
         StatusCode = statusCode;
+        _usageCounter = 1; // creator has a hook automatically
     }
+
+    private bool _recycleBuffers; // does this instance own the memory behind the segments?
+    private int _usageCounter;
+
+    [Conditional("DEBUG")]
+    private void DebugAssertNotRecycled()
+        => Debug.Assert(Volatile.Read(ref _usageCounter) > 0, nameof(OutputCacheEntry) + " recycled");
 
     public StringValues FindHeader(string key)
     {
@@ -47,39 +57,79 @@ internal sealed class OutputCacheEntry : IDisposable
     /// </summary>
     public int StatusCode { get; }
 
+    private ReadOnlyMemory<(string Name, StringValues Value)> _headers;
+
     /// <summary>
     /// Gets the headers of the cache entry.
     /// </summary>
-    public ReadOnlyMemory<(string Name, StringValues Value)> Headers { get; private set; }
+    public ReadOnlyMemory<(string Name, StringValues Value)> Headers
+    {
+        get
+        {
+            DebugAssertNotRecycled();
+            return _headers;
+        }
+    }
 
     // this is intentionally not an internal setter to make it clear that this should not be
     // used from most scenarios; this should consider buffer reuse - you *probably* want CopyFrom
-    internal void SetHeaders(ReadOnlyMemory<(string Name, StringValues Value)> value) => Headers = value;
+    internal void SetHeaders(ReadOnlyMemory<(string Name, StringValues Value)> value)
+    {
+        DebugAssertNotRecycled();
+        _headers = value;
+    }
 
+    private ReadOnlySequence<byte> _body;
     /// <summary>
     /// Gets the body of the cache entry.
     /// </summary>
-    public ReadOnlySequence<byte> Body { get; private set; }
+    public ReadOnlySequence<byte> Body
+    {
+        get
+        {
+            DebugAssertNotRecycled();
+            return _body;
+        }
+    }
 
     // this is intentionally not an internal setter to make it clear that this should not be
     // used from most scenarios; this should consider buffer reuse - you *probably* want CopyFrom
     internal void SetBody(ReadOnlySequence<byte> value, bool recycleBuffers)
     {
-        Body = value;
-        _ = recycleBuffers; // satisfy IDE0060
-        // note that recycleBuffers is not stored currently, until OutputCacheEntry buffer recycling is re-implemented;
-        // it indicates whether this instance "owns" the memory behind the segments, such that they can be recycled later if desired
+        DebugAssertNotRecycled();
+        _body = value;
+        _recycleBuffers = recycleBuffers;
+    }
+
+    private void Recycle()
+    {
+        var headers = _headers;
+        var body = _body;
+        _headers = default;
+        _body = default;
+        Recycle(headers);
+        RecyclableReadOnlySequenceSegment.RecycleChain(body, _recycleBuffers);
+    }
+
+    private static void Recycle<T>(ReadOnlyMemory<T> value)
+    {
+        if (MemoryMarshal.TryGetArray<T>(value, out var segment) && segment.Array is { Length: > 0 })
+        {
+            ArrayPool<T>.Shared.Return(segment.Array);
+        }
     }
 
     internal OutputCacheEntry CreateBodyFrom(IList<byte[]> segments) // mainly used from tests
     {
         // only expected in create path; don't reset/recycle existing
-        Body = RecyclableReadOnlySequenceSegment.CreateSequence(segments);
+        DebugAssertNotRecycled();
+        _body = RecyclableReadOnlySequenceSegment.CreateSequence(segments);
         return this;
     }
 
     internal OutputCacheEntry CopyHeadersFrom(IHeaderDictionary headers)
     {
+        DebugAssertNotRecycled();
         // only expected in create path; don't reset/recycle existing
         if (headers is not null)
         {
@@ -98,11 +148,11 @@ internal sealed class OutputCacheEntry : IDisposable
                 if (index == 0) // only ignored headers
                 {
                     ArrayPool<(string, StringValues)>.Shared.Return(arr);
-                    Headers = default;
+                    _headers = default;
                 }
                 else
                 {
-                    Headers = new(arr, 0, index);
+                    _headers = new(arr, 0, index);
                 }
             }
         }
@@ -124,5 +174,69 @@ internal sealed class OutputCacheEntry : IDisposable
     public ValueTask CopyToAsync(PipeWriter destination, CancellationToken cancellationToken)
         => RecyclableReadOnlySequenceSegment.CopyToAsync(Body, destination, cancellationToken);
 
-    public void Dispose() { } // intention here is to add recycling; this was removed late in NET8, but is retained as a callback
+    public void Dispose() => Release();
+
+    /// <summary>
+    /// Increment the usage counter *if we haven't already recycled* 
+    /// </summary>
+    /// <returns>true if the counter was successfully incremented, and this value can be safely used until <see cref="Release"/> is called</returns>
+    public bool TryPreserve()
+    {
+        int oldCount, newCount;
+        do // CEX retry loop
+        {
+            oldCount = Volatile.Read(ref _usageCounter);
+            newCount = oldCount + 1;
+            if (oldCount <= 0 || newCount <= 0)
+            {
+                // either already released, or we overflowed
+                return false;
+            }
+        }
+        while (Interlocked.CompareExchange(ref _usageCounter, newCount, oldCount) != oldCount);
+        return true;
+    }
+
+    /// <summary>
+    /// Decrement the usage counter by one; if we hit zero, recycle
+    /// </summary>
+    /// <returns>True if this operation caused it to become recycled (monitoring/logging only)</returns>
+    public bool Release()
+    {
+        int oldCount;
+        do // CEX retry loop
+        {
+            oldCount = Volatile.Read(ref _usageCounter);
+            if (oldCount <= 0)
+            {
+                // already released; nothing to do
+                // (note we can't underflow when subtracting 1 from a +ve number)
+                return false;
+            }
+        }
+        while (Interlocked.CompareExchange(ref _usageCounter, oldCount - 1, oldCount) != oldCount);
+        if (oldCount == 1)
+        {
+            // then this was the final hook
+            Recycle();
+            return true;
+        }
+        return false;
+    }
+
+    internal async Task DelayedReleaseAsync(int millisecondsDelay)
+    {
+        try
+        {
+            await Task.Delay(millisecondsDelay);
+            Release();
+        }
+        catch (Exception ex)
+        {
+            // we expect this to be in the background; we do *not* want
+            // to have an orphan exception (although we also never
+            // expect this to fail!)
+            Debug.WriteLine(ex.Message);
+        }
+    }
 }


### PR DESCRIPTION
for discussion as part of #51067

PR feedback there touched on dropping `ArrayPool<>` buffers causing strain; to avoid that, we can:

1. reinstate the buffer recycling, or
2. use non-pool buffers

Here we propose a solution for "1" using ref-counting so that the buffers are never prematurely recycled; there is a slight nuance in that without reworking the scheduler, we don't know *when* folks with a shared task will get their hook, so: on the "I actually did the thing" request, we add a slight background delay to their counter decrement

as a future item we could follow this up with reworking the scheduler so that incrementing the counter is achieved *as part of* fetching a shared item, but that's a bigger bit of work