### PR TITLE
[release/7.0] Fix `DragDrop_CanTrigger()` flakiness

### DIFF
--- a/src/Components/test/E2ETest/Tests/EventTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventTest.cs
@@ -215,8 +215,8 @@ public class EventTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
         var actions = new Actions(Browser).DragAndDrop(input, target);
 
         actions.Perform();
-        // drop doesn't seem to trigger in Selenium. But it's sufficient to determine "any" drag event works
-        Browser.Equal("dragstart,", () => output.Text);
+        // drop doesn't reliably trigger in Selenium. But it's sufficient to determine "any" drag event works
+        Browser.True(() => output.Text.StartsWith("dragstart,", StringComparison.Ordinal));
     }
 
     // Skipped because it will never pass because Selenium doesn't support this kind of event


### PR DESCRIPTION
# Fix `DragDrop_CanTrigger()` flakiness

Applies [this change](https://github.com/dotnet/aspnetcore/commit/79b23f42e3cd2363f2e99575003e9e88a716bd51#diff-2b897a93cfbc61223c85aff766a2353e81617bc78252e403745aaa6cbb93dd15R249) to the `release/7.0` branch to fix a flaky test.