### PR TITLE
Rename "ASP.NET Core Web App" to "ASP.NET Core Web App (Razor Pages)"

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/localize/templatestrings.en.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/localize/templatestrings.en.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": "ASP.NET Core Web App",
+  "name": "ASP.NET Core Web App (Razor Pages)",
   "description": "A project template for creating an ASP.NET Core application with example ASP.NET Core Razor Pages content",
   "symbols/auth/choices/None/description": "No authentication",
   "symbols/auth/choices/Individual/description": "Individual authentication",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
@@ -6,7 +6,7 @@
     "MVC",
     "Razor Pages"
   ],
-  "name": "ASP.NET Core Web App",
+  "name": "ASP.NET Core Web App (Razor Pages)",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating an ASP.NET Core application with example ASP.NET Core Razor Pages content",
   "groupIdentity": "Microsoft.Web.RazorPages",


### PR DESCRIPTION
# Rename "ASP.NET Core Web App" to "ASP.NET Core Web App (Razor Pages)"


![web-app-razor-pages](https://github.com/dotnet/aspnetcore/assets/114938397/3700cd64-cc7d-4817-87b3-17e38a83eb5e)
 

## Description

Renamed "ASP.NET Core Web App" template to "ASP.NET Core Web App (Razor Pages)"

Fixes #50999

## Customer Impact

The name for this template would be "ASP.NET Core Web App (Razor Pages)" in Visual Studio instead of "ASP.NET Core Web App".

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

[Justify the selection above]

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props
