### PR TITLE
Fix handling of default values in RDG

### DIFF
--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.SpecialTypes.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.SpecialTypes.cs
@@ -13,6 +13,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.RequestDelegateGenerator.StaticRouteHandlerModel;
+using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
 
@@ -247,9 +248,9 @@ app.MapPost("/", TestAction);
     }
 
     [Fact]
+    [UseCulture("fr-FR")]
     public async Task RequestDelegatePopulatesDecimalWithDefaultValuesAndCultureSet()
     {
-        CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("fr-FR");
         var source = $$"""
   const decimal defaultConst = 3.15m;
   static void TestAction(

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.SpecialTypes.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.SpecialTypes.cs
@@ -211,7 +211,10 @@ app.MapGet("/", TestAction);
     [MemberData(nameof(DefaultValues))]
     public async Task RequestDelegatePopulatesParametersWithDefaultValues(string type, string defaultValue, object expectedValue, bool declareConst)
     {
-        var source = declareConst ? $$"""
+        var source = string.Empty;
+        if (declareConst)
+        {
+            source = $$"""
 const {{type}} defaultConst = {{defaultValue}};
 static void TestAction(
     HttpContext context,
@@ -222,15 +225,20 @@ static void TestAction(
     context.Items.Add("parameterWithConst", parameterWithConst);
 }
 app.MapPost("/", TestAction);
-""" :$$"""
+""";
+        }
+        else
+        {
+            source = $$"""
 static void TestAction(
-   HttpContext context,
-   {{type}} parameterWithDefault = {{defaultValue}})
+HttpContext context,
+{{type}} parameterWithDefault = {{defaultValue}})
 {
-   context.Items.Add("parameterWithDefault", parameterWithDefault);
+context.Items.Add("parameterWithDefault", parameterWithDefault);
 }
 app.MapPost("/", TestAction);
 """;
+        }
 
         var (_, compilation) = await RunGeneratorAsync(source);
         var endpoint = GetEndpointFromCompilation(compilation);

--- a/src/Shared/RoslynUtils/SymbolExtensions.cs
+++ b/src/Shared/RoslynUtils/SymbolExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Reflection.PortableExecutable;
 using Microsoft.CodeAnalysis;
@@ -184,9 +185,9 @@ internal static class SymbolExtensions
         return defaultValue switch
         {
             string s => SymbolDisplay.FormatLiteral(s, true),
-            bool b => SymbolDisplay.FormatLiteral(b.ToString().ToLowerInvariant(), false),
+            char c => SymbolDisplay.FormatLiteral(c, true),
             null => "default",
-            _ => SymbolDisplay.FormatLiteral(defaultValue.ToString(), false)
+            _ => SymbolDisplay.FormatPrimitive(defaultValue, false, false)
         };
     }
 

--- a/src/Shared/RoslynUtils/SymbolExtensions.cs
+++ b/src/Shared/RoslynUtils/SymbolExtensions.cs
@@ -176,7 +176,18 @@ internal static class SymbolExtensions
     {
         return !parameterSymbol.HasExplicitDefaultValue
             ? "null"
-            : SymbolDisplay.FormatLiteral((parameterSymbol.ExplicitDefaultValue ?? "null").ToString(), parameterSymbol.ExplicitDefaultValue is string);
+            : InnerGetDefaultValueString(parameterSymbol.ExplicitDefaultValue);
+    }
+
+    private static string InnerGetDefaultValueString(object? defaultValue)
+    {
+        return defaultValue switch
+        {
+            string s => SymbolDisplay.FormatLiteral(s, true),
+            bool b => SymbolDisplay.FormatLiteral(b.ToString().ToLowerInvariant(), false),
+            null => "default",
+            _ => SymbolDisplay.FormatLiteral(defaultValue.ToString(), false)
+        };
     }
 
     public static bool TryGetNamedArgumentValue<T>(this AttributeData attribute, string argumentName, out T? argumentValue)

--- a/src/Shared/RoslynUtils/SymbolExtensions.cs
+++ b/src/Shared/RoslynUtils/SymbolExtensions.cs
@@ -186,8 +186,17 @@ internal static class SymbolExtensions
         {
             string s => SymbolDisplay.FormatLiteral(s, true),
             char c => SymbolDisplay.FormatLiteral(c, true),
+            bool b => b ? "true" : "false",
             null => "default",
-            _ => SymbolDisplay.FormatPrimitive(defaultValue, false, false)
+            float f when f is float.NegativeInfinity => "float.NegativeInfinity",
+            float f when f is float.PositiveInfinity => "float.PositiveInfinity",
+            float f when f is float.NaN => "float.NaN",
+            float f => $"{SymbolDisplay.FormatPrimitive(f, false, false)}F",
+            double d when d is double.NegativeInfinity => "double.NegativeInfinity",
+            double d when d is double.PositiveInfinity => "double.PositiveInfinity",
+            double d when d is double.NaN => "double.NaN",
+            decimal d => $"{SymbolDisplay.FormatPrimitive(d, false, false)}M",
+            _ => SymbolDisplay.FormatPrimitive(defaultValue, false, false),
         };
     }
 

--- a/src/Testing/src/UseCultureAttribute.cs
+++ b/src/Testing/src/UseCultureAttribute.cs
@@ -4,6 +4,7 @@ using System;
 using System.Globalization;
 using System.Reflection;
 using Xunit.Sdk;
+
 namespace Microsoft.AspNetCore.Testing;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
@@ -15,13 +16,16 @@ public sealed class UseCultureAttribute : BeforeAfterTestAttribute
         : this(culture, culture)
     {
     }
+
     public UseCultureAttribute(string culture, string uiCulture)
     {
         Culture = new CultureInfo(culture);
         UiCulture = new CultureInfo(uiCulture);
     }
+
     public CultureInfo Culture { get; }
     public CultureInfo UiCulture { get; }
+
     public override void Before(MethodInfo methodUnderTest)
     {
         _originalCulture = CultureInfo.CurrentCulture;
@@ -29,6 +33,7 @@ public sealed class UseCultureAttribute : BeforeAfterTestAttribute
         CultureInfo.CurrentCulture = Culture;
         CultureInfo.CurrentUICulture = UiCulture;
     }
+
     public override void After(MethodInfo methodUnderTest)
     {
         CultureInfo.CurrentCulture = _originalCulture;

--- a/src/Testing/src/UseCultureAttribute.cs
+++ b/src/Testing/src/UseCultureAttribute.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.Globalization;
+using System.Reflection;
+using Xunit.Sdk;
+namespace Microsoft.AspNetCore.Testing;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public sealed class UseCultureAttribute : BeforeAfterTestAttribute
+{
+    private CultureInfo _originalCulture;
+    private CultureInfo _originalUiCulture;
+    public UseCultureAttribute(string culture)
+        : this(culture, culture)
+    {
+    }
+    public UseCultureAttribute(string culture, string uiCulture)
+    {
+        Culture = new CultureInfo(culture);
+        UiCulture = new CultureInfo(uiCulture);
+    }
+    public CultureInfo Culture { get; }
+    public CultureInfo UiCulture { get; }
+    public override void Before(MethodInfo methodUnderTest)
+    {
+        _originalCulture = CultureInfo.CurrentCulture;
+        _originalUiCulture = CultureInfo.CurrentUICulture;
+        CultureInfo.CurrentCulture = Culture;
+        CultureInfo.CurrentUICulture = UiCulture;
+    }
+    public override void After(MethodInfo methodUnderTest)
+    {
+        CultureInfo.CurrentCulture = _originalCulture;
+        CultureInfo.CurrentUICulture = _originalUiCulture;
+    }
+}


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/51183.

`IParameterSymbol.ExplicitDefaultValue` returns null when the type is a struct type and th default value of the parameter is the default value of the struct type ([ref](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.iparametersymbol.explicitdefaultvalue?view=roslyn-dotnet-4.6.0)). Update the code generation to handle `IParameterSymbol.HasExplicitDefaultValue = true` and `IParameterSymbol.ExplicitDefaultValue = null`. Also fixes formating of stringified boolean default.