### PR TITLE
Fix pluralization of 'scheme' in doc comments

### DIFF
--- a/src/Mvc/Mvc.Core/src/ChallengeResult.cs
+++ b/src/Mvc/Mvc.Core/src/ChallengeResult.cs
@@ -56,7 +56,7 @@ public partial class ChallengeResult : ActionResult
     /// Initializes a new instance of <see cref="ChallengeResult"/> with the
     /// specified authentication scheme and <paramref name="properties"/>.
     /// </summary>
-    /// <param name="authenticationScheme">The authentication schemes to challenge.</param>
+    /// <param name="authenticationScheme">The authentication scheme to challenge.</param>
     /// <param name="properties"><see cref="AuthenticationProperties"/> used to perform the authentication
     /// challenge.</param>
     public ChallengeResult(string authenticationScheme, AuthenticationProperties? properties)
@@ -68,7 +68,7 @@ public partial class ChallengeResult : ActionResult
     /// Initializes a new instance of <see cref="ChallengeResult"/> with the
     /// specified authentication schemes and <paramref name="properties"/>.
     /// </summary>
-    /// <param name="authenticationSchemes">The authentication scheme to challenge.</param>
+    /// <param name="authenticationSchemes">The authentication schemes to challenge.</param>
     /// <param name="properties"><see cref="AuthenticationProperties"/> used to perform the authentication
     /// challenge.</param>
     public ChallengeResult(IList<string> authenticationSchemes, AuthenticationProperties? properties)

--- a/src/Mvc/Mvc.Core/src/ForbidResult.cs
+++ b/src/Mvc/Mvc.Core/src/ForbidResult.cs
@@ -56,7 +56,7 @@ public partial class ForbidResult : ActionResult
     /// Initializes a new instance of <see cref="ForbidResult"/> with the
     /// specified authentication scheme and <paramref name="properties"/>.
     /// </summary>
-    /// <param name="authenticationScheme">The authentication schemes to challenge.</param>
+    /// <param name="authenticationScheme">The authentication scheme to challenge.</param>
     /// <param name="properties"><see cref="AuthenticationProperties"/> used to perform the authentication
     /// challenge.</param>
     public ForbidResult(string authenticationScheme, AuthenticationProperties? properties)
@@ -68,7 +68,7 @@ public partial class ForbidResult : ActionResult
     /// Initializes a new instance of <see cref="ForbidResult"/> with the
     /// specified authentication schemes and <paramref name="properties"/>.
     /// </summary>
-    /// <param name="authenticationSchemes">The authentication scheme to challenge.</param>
+    /// <param name="authenticationSchemes">The authentication schemes to challenge.</param>
     /// <param name="properties"><see cref="AuthenticationProperties"/> used to perform the authentication
     /// challenge.</param>
     public ForbidResult(IList<string> authenticationSchemes, AuthenticationProperties? properties)

--- a/src/Mvc/Mvc.Core/src/SignOutResult.cs
+++ b/src/Mvc/Mvc.Core/src/SignOutResult.cs
@@ -57,7 +57,7 @@ public partial class SignOutResult : ActionResult, IResult
     /// Initializes a new instance of <see cref="SignOutResult"/> with the
     /// specified authentication scheme and <paramref name="properties"/>.
     /// </summary>
-    /// <param name="authenticationScheme">The authentication schemes to use when signing out the user.</param>
+    /// <param name="authenticationScheme">The authentication scheme to use when signing out the user.</param>
     /// <param name="properties"><see cref="AuthenticationProperties"/> used to perform the sign-out operation.</param>
     public SignOutResult(string authenticationScheme, AuthenticationProperties? properties)
         : this(new[] { authenticationScheme }, properties)
@@ -68,7 +68,7 @@ public partial class SignOutResult : ActionResult, IResult
     /// Initializes a new instance of <see cref="SignOutResult"/> with the
     /// specified authentication schemes and <paramref name="properties"/>.
     /// </summary>
-    /// <param name="authenticationSchemes">The authentication scheme to use when signing out the user.</param>
+    /// <param name="authenticationSchemes">The authentication schemes to use when signing out the user.</param>
     /// <param name="properties"><see cref="AuthenticationProperties"/> used to perform the sign-out operation.</param>
     public SignOutResult(IList<string> authenticationSchemes, AuthenticationProperties? properties)
     {


### PR DESCRIPTION
# Fix pluralization of 'scheme' in doc comments

I was looking at the doc comments of `ChallengeResult` and noticed that 'scheme' was used where 'schemes' was needed, and vice versa. I noticed the same mistake in `ForbidResult` and `SignOutResult` too (all three of these have the same set of constructors).