### PR TITLE
QuickGrid static pagination

### DIFF
--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Pagination/Paginator.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Pagination/Paginator.razor
@@ -15,14 +15,14 @@
             }
         </div>
         <nav role="navigation">
-            <button class="go-first" type="button" @onclick="GoFirstAsync" disabled="@(!CanGoBack)" title="Go to first page" aria-title="Go to first page"></button>
-            <button class="go-previous" type="button" @onclick="GoPreviousAsync" disabled="@(!CanGoBack)" title="Go to previous page" aria-title="Go to previous page"></button>
+            <a class="go-first" type="button" href="@(CanGoBack ? GetPageUrl(0) : null)" @onclick="GoFirstAsync" disabled="@(!CanGoBack)" title="Go to first page" aria-label="Go to first page"></a>
+            <a class="go-previous" type="button" href="@(CanGoBack ? GetPageUrl(State.CurrentPageIndex - 1) : null)" @onclick="GoPreviousAsync" disabled="@(!CanGoBack)" title="Go to previous page" aria-label="Go to previous page"></a>
             <div class="pagination-text">
                 Page <strong>@(State.CurrentPageIndex + 1)</strong>
                 of <strong>@(State.LastPageIndex + 1)</strong>
             </div>
-            <button class="go-next" type="button" @onclick="GoNextAsync" disabled="@(!CanGoForwards)" title="Go to next page" aria-title="Go to next page"></button>
-            <button class="go-last" type="button" @onclick="GoLastAsync" disabled="@(!CanGoForwards)" title="Go to last page" aria-title="Go to last page"></button>
+            <a class="go-next" type="button" href="@(CanGoForwards ? GetPageUrl(State.CurrentPageIndex + 1) : null)" @onclick="GoNextAsync" disabled="@(!CanGoForwards)" title="Go to next page" aria-label="Go to next page"></a>
+            <a class="go-last" type="button" href="@(CanGoForwards ? GetPageUrl(State.LastPageIndex) : null)" @onclick="GoLastAsync" disabled="@(!CanGoForwards)" title="Go to last page" aria-label="Go to last page"></a>
         </nav>
     }
 </div>

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Pagination/Paginator.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Pagination/Paginator.razor.cs
@@ -22,6 +22,8 @@ public partial class Paginator : IDisposable
     /// </summary>
     [Parameter] public RenderFragment? SummaryTemplate { get; set; }
 
+    [Parameter] public Func<int, string>? PageUrl { get; set; }
+
     /// <summary>
     /// Constructs an instance of <see cref="Paginator" />.
     /// </summary>
@@ -39,8 +41,11 @@ public partial class Paginator : IDisposable
     private bool CanGoBack => State.CurrentPageIndex > 0;
     private bool CanGoForwards => State.CurrentPageIndex < State.LastPageIndex;
 
+    private string? GetPageUrl(int? pageIndex)
+        => PageUrl is null || !pageIndex.HasValue ? null : PageUrl(pageIndex.Value);
+
     private Task GoToPageAsync(int pageIndex)
-        => State.SetCurrentPageIndexAsync(pageIndex);
+        => PageUrl is null ? State.SetCurrentPageIndexAsync(pageIndex) : Task.CompletedTask;
 
     /// <inheritdoc />
     protected override void OnParametersSet()

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Pagination/Paginator.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Pagination/Paginator.razor.cs
@@ -22,6 +22,10 @@ public partial class Paginator : IDisposable
     /// </summary>
     [Parameter] public RenderFragment? SummaryTemplate { get; set; }
 
+    /// <summary>
+    /// Optionally specifies the URLs for page links. If set, you must also add logic to receive the
+    /// updated page index from the URL and manually call <see cref="PaginationState.SetCurrentPageIndexAsync" />.
+    /// </summary>
     [Parameter] public Func<int, string>? PageUrl { get; set; }
 
     /// <summary>

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Pagination/Paginator.razor.css
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Pagination/Paginator.razor.css
@@ -17,18 +17,19 @@ nav {
     align-items: center;
 }
 
-    nav button {
+    nav a {
         border: 0;
         background: none center center / 1rem no-repeat;
         width: 2rem;
         height: 2rem;
+        cursor: pointer;
     }
 
-    nav button[disabled] {
+    nav a[disabled] {
         opacity: 0.4;
     }
 
-    nav button:not([disabled]):hover {
+    nav a:not([disabled]):hover {
         background-color: #eee;
     }
 

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
@@ -85,6 +85,8 @@ Microsoft.AspNetCore.Components.QuickGrid.Paginator.State.get -> Microsoft.AspNe
 Microsoft.AspNetCore.Components.QuickGrid.Paginator.State.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.Paginator.SummaryTemplate.get -> Microsoft.AspNetCore.Components.RenderFragment?
 Microsoft.AspNetCore.Components.QuickGrid.Paginator.SummaryTemplate.set -> void
+Microsoft.AspNetCore.Components.QuickGrid.Paginator.PageUrl.get -> System.Func<int, string>?
+Microsoft.AspNetCore.Components.QuickGrid.Paginator.PageUrl.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.PropertyColumn<TGridItem, TProp>
 Microsoft.AspNetCore.Components.QuickGrid.PropertyColumn<TGridItem, TProp>.Format.get -> string?
 Microsoft.AspNetCore.Components.QuickGrid.PropertyColumn<TGridItem, TProp>.Format.set -> void


### PR DESCRIPTION
A simple example of how QuickGrid pagination could support static SSR

### Usage:

```razor
@inject NavigationManager Nav

<Paginator State="@paging" PageUrl="@PageUrl" />

@code {
    [SupplyParameterFromQuery]
    public string? Page { get; set; }

    private PaginationState paging = new();

    protected override async Task OnParametersSetAsync()
    {
        await paging.SetCurrentPageIndexAsync(Page.GetValueOrDefault(0));
    }

    private string PageUrl(int page)
        => Nav.GetUriWithQueryParameter("page", page);
}
```

... plus a `<QuickGrid ... Pagination="@paging">`.