### PR TITLE
Fix disabling anti-forgery check on route groups

### DIFF
--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -159,7 +159,7 @@ public static class RoutingEndpointConventionBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        builder.WithMetadata(AntiforgeryMetadata.ValidationNotRequired);
+        builder.Finally(builder => builder.Metadata.Add(AntiforgeryMetadata.ValidationNotRequired));
         return builder;
     }
 

--- a/src/Http/Routing/test/FunctionalTests/MinimalFormTests.cs
+++ b/src/Http/Routing/test/FunctionalTests/MinimalFormTests.cs
@@ -292,6 +292,53 @@ public class MinimalFormTests
         Assert.Equal(DateTime.Today.AddDays(1), result.DueDate);
     }
 
+    [Fact]
+    public async Task MapPost_WithForm_WithoutAntiforgery_AndRouteGroup_WithoutMiddleware_Works()
+    {
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseEndpoints(b =>
+                        {
+                            var group = b.MapGroup("/todo").DisableAntiforgery();
+                            group.MapPost("", ([FromForm] Todo todo) => todo);
+                        });
+                    })
+                    .UseTestServer();
+            })
+            .ConfigureServices(services =>
+            {
+                services.AddRouting();
+                services.AddAntiforgery();
+            })
+            .Build();
+
+        using var server = host.GetTestServer();
+        await host.StartAsync();
+        var client = server.CreateClient();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "todo");
+        var nameValueCollection = new List<KeyValuePair<string, string>>
+        {
+            new KeyValuePair<string,string>("name", "Test task"),
+            new KeyValuePair<string,string>("isComplete", "false"),
+            new KeyValuePair<string,string>("dueDate", DateTime.Today.AddDays(1).ToString(CultureInfo.InvariantCulture)),
+        };
+        request.Content = new FormUrlEncodedContent(nameValueCollection);
+
+        var response = await client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<Todo>(body, SerializerOptions);
+        Assert.Equal("Test task", result.Name);
+        Assert.False(result.IsCompleted);
+        Assert.Equal(DateTime.Today.AddDays(1), result.DueDate);
+    }
+
     public static IEnumerable<object[]> RequestDelegateData
     {
         get


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/51194.

Anti-forgery metadata is automatically added for form-consuming endpoints in the RequestDelegateFactory. This metadata is populated during the "inference" stage in RDG, which means that it has a higher specificity than metadata populated by conventions.

This PR uses the `Finally` caller to ensure that metadata added by the `DisableAntiforgery` call always has a higher precedence than other metadata, specifically the anti-forgery metadata added by RDF.

An alternative solution here might've been to move where the [automatically anti-forgery metadata](https://source.dot.net/#Microsoft.AspNetCore.Http.Extensions/RequestDelegateFactory.cs,402) was added but that's a more transformative change.