### PR TITLE
Dispose secret instances

### DIFF
--- a/src/DataProtection/DataProtection/src/AuthenticatedEncryption/CngCbcAuthenticatedEncryptorFactory.cs
+++ b/src/DataProtection/DataProtection/src/AuthenticatedEncryption/CngCbcAuthenticatedEncryptorFactory.cs
@@ -55,8 +55,9 @@ public sealed class CngCbcAuthenticatedEncryptorFactory : IAuthenticatedEncrypto
             return null;
         }
 
+        using var secretCopy = new Secret(secret);
         return new CbcAuthenticatedEncryptor(
-            keyDerivationKey: new Secret(secret),
+            keyDerivationKey: secretCopy,
             symmetricAlgorithmHandle: GetSymmetricBlockCipherAlgorithmHandle(configuration),
             symmetricAlgorithmKeySizeInBytes: (uint)(configuration.EncryptionAlgorithmKeySize / 8),
             hmacAlgorithmHandle: GetHmacAlgorithmHandle(configuration));

--- a/src/DataProtection/DataProtection/src/AuthenticatedEncryption/CngCbcAuthenticatedEncryptorFactory.cs
+++ b/src/DataProtection/DataProtection/src/AuthenticatedEncryption/CngCbcAuthenticatedEncryptorFactory.cs
@@ -55,9 +55,9 @@ public sealed class CngCbcAuthenticatedEncryptorFactory : IAuthenticatedEncrypto
             return null;
         }
 
-        using var secretCopy = new Secret(secret);
+        using var key = new Secret(secret);
         return new CbcAuthenticatedEncryptor(
-            keyDerivationKey: secretCopy,
+            keyDerivationKey: key,
             symmetricAlgorithmHandle: GetSymmetricBlockCipherAlgorithmHandle(configuration),
             symmetricAlgorithmKeySizeInBytes: (uint)(configuration.EncryptionAlgorithmKeySize / 8),
             hmacAlgorithmHandle: GetHmacAlgorithmHandle(configuration));

--- a/src/DataProtection/DataProtection/src/AuthenticatedEncryption/CngCbcAuthenticatedEncryptorFactory.cs
+++ b/src/DataProtection/DataProtection/src/AuthenticatedEncryption/CngCbcAuthenticatedEncryptorFactory.cs
@@ -55,9 +55,9 @@ public sealed class CngCbcAuthenticatedEncryptorFactory : IAuthenticatedEncrypto
             return null;
         }
 
-        using var key = new Secret(secret);
+        using var secretCopy = new Secret(secret);
         return new CbcAuthenticatedEncryptor(
-            keyDerivationKey: key,
+            keyDerivationKey: secretCopy,
             symmetricAlgorithmHandle: GetSymmetricBlockCipherAlgorithmHandle(configuration),
             symmetricAlgorithmKeySizeInBytes: (uint)(configuration.EncryptionAlgorithmKeySize / 8),
             hmacAlgorithmHandle: GetHmacAlgorithmHandle(configuration));

--- a/src/DataProtection/DataProtection/src/AuthenticatedEncryption/CngGcmAuthenticatedEncryptorFactory.cs
+++ b/src/DataProtection/DataProtection/src/AuthenticatedEncryption/CngGcmAuthenticatedEncryptorFactory.cs
@@ -57,8 +57,9 @@ public sealed class CngGcmAuthenticatedEncryptorFactory : IAuthenticatedEncrypto
             return null;
         }
 
+        using var key = new Secret(secret);
         return new CngGcmAuthenticatedEncryptor(
-            keyDerivationKey: new Secret(secret),
+            keyDerivationKey: key,
             symmetricAlgorithmHandle: GetSymmetricBlockCipherAlgorithmHandle(configuration),
             symmetricAlgorithmKeySizeInBytes: (uint)(configuration.EncryptionAlgorithmKeySize / 8));
     }

--- a/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/AuthenticatedEncryptorConfiguration.cs
+++ b/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/AuthenticatedEncryptorConfiguration.cs
@@ -44,7 +44,8 @@ public sealed class AuthenticatedEncryptorConfiguration : AlgorithmConfiguration
     {
         var factory = new AuthenticatedEncryptorFactory(NullLoggerFactory.Instance);
         // Run a sample payload through an encrypt -> decrypt operation to make sure data round-trips properly.
-        var encryptor = factory.CreateAuthenticatedEncryptorInstance(Secret.Random(512 / 8), this);
+        using var secret = Secret.Random(512 / 8);
+        var encryptor = factory.CreateAuthenticatedEncryptorInstance(secret, this);
         try
         {
             encryptor.PerformSelfTest();

--- a/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/CngCbcAuthenticatedEncryptorConfiguration.cs
+++ b/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/CngCbcAuthenticatedEncryptorConfiguration.cs
@@ -94,9 +94,8 @@ public sealed class CngCbcAuthenticatedEncryptorConfiguration : AlgorithmConfigu
     {
         var factory = new CngCbcAuthenticatedEncryptorFactory(NullLoggerFactory.Instance);
         // Run a sample payload through an encrypt -> decrypt operation to make sure data round-trips properly.
-        using (var encryptor = factory.CreateAuthenticatedEncryptorInstance(Secret.Random(512 / 8), this))
-        {
-            encryptor.PerformSelfTest();
-        }
+        using var secret = Secret.Random(512 / 8);
+        using var encryptor = factory.CreateAuthenticatedEncryptorInstance(secret, this);
+        encryptor.PerformSelfTest();
     }
 }

--- a/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/CngGcmAuthenticatedEncryptorConfiguration.cs
+++ b/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/CngGcmAuthenticatedEncryptorConfiguration.cs
@@ -70,9 +70,8 @@ public sealed class CngGcmAuthenticatedEncryptorConfiguration : AlgorithmConfigu
     {
         var factory = new CngGcmAuthenticatedEncryptorFactory(NullLoggerFactory.Instance);
         // Run a sample payload through an encrypt -> decrypt operation to make sure data round-trips properly.
-        using (var encryptor = factory.CreateAuthenticatedEncryptorInstance(Secret.Random(512 / 8), this))
-        {
-            encryptor.PerformSelfTest();
-        }
+        using var secret = Secret.Random(512 / 8);
+        using var encryptor = factory.CreateAuthenticatedEncryptorInstance(secret, this);
+        encryptor.PerformSelfTest();
     }
 }

--- a/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/ManagedAuthenticatedEncryptorConfiguration.cs
+++ b/src/DataProtection/DataProtection/src/AuthenticatedEncryption/ConfigurationModel/ManagedAuthenticatedEncryptorConfiguration.cs
@@ -73,10 +73,9 @@ public sealed class ManagedAuthenticatedEncryptorConfiguration : AlgorithmConfig
     {
         var factory = new ManagedAuthenticatedEncryptorFactory(NullLoggerFactory.Instance);
         // Run a sample payload through an encrypt -> decrypt operation to make sure data round-trips properly.
-        using (var encryptor = factory.CreateAuthenticatedEncryptorInstance(Secret.Random(512 / 8), this))
-        {
-            encryptor.PerformSelfTest();
-        }
+        using var secret = Secret.Random(512 / 8);
+        using var encryptor = factory.CreateAuthenticatedEncryptorInstance(secret, this);
+        encryptor.PerformSelfTest();
     }
 
     // Any changes to this method should also be be reflected

--- a/src/DataProtection/DataProtection/src/Cng/DpapiSecretSerializerHelper.cs
+++ b/src/DataProtection/DataProtection/src/Cng/DpapiSecretSerializerHelper.cs
@@ -30,7 +30,8 @@ internal static unsafe class DpapiSecretSerializerHelper
         try
         {
             Guid dummy;
-            ProtectWithDpapi(new Secret((byte*)&dummy, sizeof(Guid)), protectToLocalMachine: false);
+            using var secret = new Secret((byte*)&dummy, sizeof(Guid));
+            ProtectWithDpapi(secret, protectToLocalMachine: false);
             return true;
         }
         catch


### PR DESCRIPTION
We can dispose Secret instances after use to avoid memory leak. Created Secrets used only for copy their content.

