### PR TITLE
Add Overload for AddRateLimiter() Without Options Parameter

### DIFF
--- a/src/Middleware/RateLimiting/src/PublicAPI.Unshipped.txt
+++ b/src/Middleware/RateLimiting/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Microsoft.AspNetCore.Builder.RateLimiterServiceCollectionExtensions.AddRateLimiter(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Middleware/RateLimiting/src/RateLimiterServiceCollectionExtensions.cs
+++ b/src/Middleware/RateLimiting/src/RateLimiterServiceCollectionExtensions.cs
@@ -27,4 +27,18 @@ public static class RateLimiterServiceCollectionExtensions
         services.Configure(configureOptions);
         return services;
     }
+
+    /// <summary>
+    /// Add rate limiting services and configure the related options.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> for adding services.</param>
+    /// <returns></returns>
+    public static IServiceCollection AddRateLimiter(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddMetrics();
+        services.AddSingleton<RateLimitingMetrics>();
+        return services;
+    }
 }

--- a/src/Middleware/RateLimiting/src/RateLimiterServiceCollectionExtensions.cs
+++ b/src/Middleware/RateLimiting/src/RateLimiterServiceCollectionExtensions.cs
@@ -22,8 +22,7 @@ public static class RateLimiterServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configureOptions);
 
-        services.AddMetrics();
-        services.AddSingleton<RateLimitingMetrics>();
+        services.AddRateLimiter();
         services.Configure(configureOptions);
         return services;
     }

--- a/src/Middleware/RateLimiting/test/RateLimitingApplicationBuilderExtensionsTests.cs
+++ b/src/Middleware/RateLimiting/test/RateLimitingApplicationBuilderExtensionsTests.cs
@@ -63,7 +63,7 @@ public class RateLimitingApplicationBuilderExtensionsTests : LoggedTest
     }
 
     [Fact]
-    public void UseRateLimiter_DoNotThrowWithoutOptions()
+    public async Task UseRateLimiter_DoNotThrowWithoutOptions()
     {
         var services = new ServiceCollection();
         services.AddRateLimiter();
@@ -72,9 +72,12 @@ public class RateLimitingApplicationBuilderExtensionsTests : LoggedTest
         var appBuilder = new ApplicationBuilder(serviceProvider);
 
         // Act
-        appBuilder.UseRateLimiter(options);
+        appBuilder.UseRateLimiter();
         var app = appBuilder.Build();
         var context = new DefaultHttpContext();
-        Assert.DoesNotThrow(() => app.Invoke(context));
+        var exception = await Record.ExceptionAsync(() => app.Invoke(context));
+
+        // Assert
+        Assert.Null(exception);
     }
 }

--- a/src/Middleware/RateLimiting/test/RateLimitingApplicationBuilderExtensionsTests.cs
+++ b/src/Middleware/RateLimiting/test/RateLimitingApplicationBuilderExtensionsTests.cs
@@ -61,4 +61,20 @@ public class RateLimitingApplicationBuilderExtensionsTests : LoggedTest
         app.Invoke(context);
         Assert.Equal(429, context.Response.StatusCode);
     }
+
+    [Fact]
+    public void UseRateLimiter_DoNotThrowWithoutOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddRateLimiter();
+        services.AddLogging();
+        var serviceProvider = services.BuildServiceProvider();
+        var appBuilder = new ApplicationBuilder(serviceProvider);
+
+        // Act
+        appBuilder.UseRateLimiter(options);
+        var app = appBuilder.Build();
+        var context = new DefaultHttpContext();
+        Assert.DoesNotThrow(() => app.Invoke(context));
+    }
 }


### PR DESCRIPTION
# Add Overload for AddRateLimiter() Without Options Parameter

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

To simplify usage for scenarios where the `options` parameter isn't necessary, a new overload of the `AddRateLimiter()` method has been added, as discussed in #48531.

Fixes #48531.