### PR TITLE
[Fix-up] Track indicators of excessive stream resets

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -53,6 +53,7 @@ internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHt
     /// if the count ever exceeds 5 * the limit, the connection is aborted.
     /// Note that this means that the limit can kick in before 5 ticks have elapsed.
     /// See <see cref="EnhanceYourCalmTickWindowCount"/>.
+    /// TODO (https://github.com/dotnet/aspnetcore/issues/51308): make this configurable.
     private const string MaximumEnhanceYourCalmCountProperty = "Microsoft.AspNetCore.Server.Kestrel.Http2.MaxEnhanceYourCalmCount";
 
     private static readonly int _enhanceYourCalmMaximumCount = GetMaximumEnhanceYourCalmCount();
@@ -398,10 +399,8 @@ internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHt
                     stream.Abort(new IOException(CoreStrings.Http2StreamAborted, connectionError));
                 }
 
+                // TODO (https://github.com/dotnet/aspnetcore/issues/51307):
                 // For some reason, this loop doesn't terminate when we're trying to abort.
-                // Since we're making a narrow fix for a patch, we'll bypass it in such scenarios.
-                // TODO: This is probably a bug - something in here should probably detect aborted
-                // connections and short-circuit.
                 if (!IsEnhanceYourCalmLimitEnabled || error is not Http2ConnectionErrorException)
                 {
                     // Use the server _serverActiveStreamCount to drain all requests on the server side.

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Connection.cs
@@ -62,10 +62,14 @@ internal sealed partial class Http2Connection : IHttp2StreamLifetimeHandler, IHt
     private static int GetMaximumEnhanceYourCalmCount()
     {
         var data = AppContext.GetData(MaximumEnhanceYourCalmCountProperty);
+
+        // Programmatically-configured values are usually ints
         if (data is int count)
         {
             return count;
         }
+
+        // msbuild-configured values are usually strings
         if (data is string countStr && int.TryParse(countStr, out var parsed))
         {
             return parsed;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
@@ -27,6 +27,7 @@ internal sealed class Http2FrameWriter
     /// That is, the default value is 800, unless <see cref="Http2Limits.MaxStreamsPerConnection"/> is modified.
     /// Choosing a value lower than the maximum number of tracked streams doesn't make sense,
     /// so such values will be adjusted upward.
+    /// TODO (https://github.com/dotnet/aspnetcore/issues/51309): eliminate this limit.
     private const string MaximumFlowControlQueueSizeProperty = "Microsoft.AspNetCore.Server.Kestrel.Http2.MaxConnectionFlowControlQueueSize";
 
     private static readonly int? AppContextMaximumFlowControlQueueSize = GetAppContextMaximumFlowControlQueueSize();

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2FrameWriter.cs
@@ -36,11 +36,13 @@ internal sealed class Http2FrameWriter
     {
         var data = AppContext.GetData(MaximumFlowControlQueueSizeProperty);
 
+        // Programmatically-configured values are usually ints
         if (data is int count)
         {
             return count;
         }
 
+        // msbuild-configured values are usually strings
         if (data is string countStr && int.TryParse(countStr, out var parsed))
         {
             return parsed;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -1654,6 +1654,16 @@ public class Http2ConnectionTests : Http2TestBase
     }
 
     [Fact]
+    public void MinimumMaxTrackedStreams()
+    {
+        _serviceContext.ServerOptions.Limits.Http2.MaxStreamsPerConnection = 1;
+        CreateConnection();
+        // Kestrel always tracks at least 100 streams
+        Assert.Equal(100u, _connection.MaxTrackedStreams);
+        _connection.Abort(new ConnectionAbortedException());
+    }
+
+    [Fact]
     public Task Frame_MultipleStreams_RequestsNotFinished_LowMaxStreamsPerConnection_EnhanceYourCalmAfter100()
     {
         // Kestrel always tracks at least 100 streams
@@ -1666,6 +1676,60 @@ public class Http2ConnectionTests : Http2TestBase
     {
         // Kestrel tracks max streams per connection * 2
         return RequestUntilEnhanceYourCalm(maxStreamsPerConnection: 100, sentStreams: 201);
+    }
+
+    [Fact]
+    public async Task AbortConnectionAfterTooManyEnhanceYourCalms()
+    {
+        _serviceContext.ServerOptions.Limits.Http2.MaxStreamsPerConnection = 999999; // Make sure we don't actually hit this limit
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await InitializeConnectionAsync(_ => Task.FromException(new InvalidOperationException("No requests should be processed")));
+
+        // Reject *every* stream
+        _connection.SendEnhanceYourCalmOnStartStream = true;
+
+        var enhanceYourCalmMaximumCount = Http2Connection.EnhanceYourCalmTickWindowCount * Http2Connection.EnhanceYourCalmMaximumCount;
+        var streamId = 1;
+
+        // There's a burst of activity, but the limit isn't exceeded
+
+        for (var i = 0; i < enhanceYourCalmMaximumCount; i++)
+        {
+            await StartStreamAsync(streamId, _browserRequestHeaders, endStream: false);
+            await WaitForStreamErrorAsync(
+                expectedStreamId: streamId,
+                expectedErrorCode: Http2ErrorCode.ENHANCE_YOUR_CALM,
+                expectedErrorMessage: CoreStrings.Http2TellClientToCalmDown);
+            streamId += 2;
+        }
+
+        // The window expires
+
+        for (var i = 0; i < Http2Connection.EnhanceYourCalmTickWindowCount; i++)
+        {
+            TriggerTick();
+        }
+
+        // We have room for more streams
+
+        for (var i = 0; i < enhanceYourCalmMaximumCount; i++)
+        {
+            await StartStreamAsync(streamId, _browserRequestHeaders, endStream: false);
+            await WaitForStreamErrorAsync(
+                expectedStreamId: streamId,
+                expectedErrorCode: Http2ErrorCode.ENHANCE_YOUR_CALM,
+                expectedErrorMessage: CoreStrings.Http2TellClientToCalmDown);
+            streamId += 2;
+        }
+
+        // The last stream exceeds the limit
+
+        await StartStreamAsync(streamId, _browserRequestHeaders, endStream: false);
+        await WaitForConnectionErrorAsync<Http2ConnectionErrorException>(
+            ignoreNonGoAwayFrames: true,
+            expectedLastStreamId: int.MaxValue,
+            expectedErrorCode: Http2ErrorCode.INTERNAL_ERROR,
+            expectedErrorMessage: CoreStrings.Http2ConnectionFaulted);
     }
 
     private async Task RequestUntilEnhanceYourCalm(int maxStreamsPerConnection, int sentStreams)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -1681,7 +1681,6 @@ public class Http2ConnectionTests : Http2TestBase
     [Fact]
     public async Task AbortConnectionAfterTooManyEnhanceYourCalms()
     {
-        _serviceContext.ServerOptions.Limits.Http2.MaxStreamsPerConnection = 999999; // Make sure we don't actually hit this limit
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         await InitializeConnectionAsync(_ => Task.FromException(new InvalidOperationException("No requests should be processed")));
 


### PR DESCRIPTION
Make improvements to #51304 now that we're in less of a hurry.