### PR TITLE
Add missing steps while building from source in VS

### DIFF
--- a/docs/BuildFromSource.md
+++ b/docs/BuildFromSource.md
@@ -51,6 +51,8 @@ The steps you follow next depend on your preferred development environment:
 
 ## Visual Studio on Windows
 
+1. This repo has JavaScript dependencies, so you need [Node.js](https://nodejs.org/en/). [Yarn](https://yarnpkg.com/) version 1.x will be installed automatically using `npm`, if you have already installed it with a version >= 2.x then you may have to uninstall it as it is not compatible with the aspnetcore build script.
+
 1. Before you open project in Visual Studio, install the required dependencies and set up the repo by running the `restore.cmd` script in the root of the repo:
 
     ```powershell


### PR DESCRIPTION
# Add missing steps while building from source in VS

Hi team,

This is a trivial Markdown document change, so I did not follow the regular procedure (adding tests, creating issues, etc). I hope it will not trouble you.

I found that the [Build From Source](/dotnet/aspnetcore/blob/main/docs/BuildFromSource.md) document is a little bit miss leading. It reads as if node and yarn are not needed when I use Visual Studio on Windows, and they are only needed if I use Visual Studio Code or other editors.

However, it is not the case. I tried to build the project without node or yarn, and Visual Studio complained that node was not found.

Therefore, I add the missing step to suggest installing node and yarn before running `restore.cmd`.