### PR TITLE
Blazor web template cleanup

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/RegisterConfirmation.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/RegisterConfirmation.razor
@@ -36,10 +36,10 @@ else
     private HttpContext HttpContext { get; set; } = default!;
 
     [SupplyParameterFromQuery]
-    public string? Email { get; set; }
+    private string? Email { get; set; }
 
     [SupplyParameterFromQuery]
-    public string? ReturnUrl { get; set; }
+    private string? ReturnUrl { get; set; }
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Shared/AccountLayout.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Shared/AccountLayout.razor
@@ -17,7 +17,7 @@ else
 
 @code {
     [CascadingParameter]
-    public HttpContext? HttpContext { get; set; }
+    private HttpContext? HttpContext { get; set; }
 
     protected override void OnParametersSet()
     {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/App.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/App.razor
@@ -49,7 +49,7 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
-    IComponentRenderMode? RenderModeForPage => HttpContext.Request.Path.StartsWithSegments("/Account")
+    private IComponentRenderMode? RenderModeForPage => HttpContext.Request.Path.StartsWithSegments("/Account")
         ? null
         : InteractiveAuto;
 }
@@ -59,7 +59,7 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
-    IComponentRenderMode? RenderModeForPage => HttpContext.Request.Path.StartsWithSegments("/Account")
+    private IComponentRenderMode? RenderModeForPage => HttpContext.Request.Path.StartsWithSegments("/Account")
         ? null
         : InteractiveServer;
 }
@@ -69,7 +69,7 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
-    IComponentRenderMode? RenderModeForPage => HttpContext.Request.Path.StartsWithSegments("/Account")
+    private IComponentRenderMode? RenderModeForPage => HttpContext.Request.Path.StartsWithSegments("/Account")
         ? null
         : InteractiveWebAssembly;
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/NavMenu.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/NavMenu.razor
@@ -1,4 +1,6 @@
 ﻿@*#if (IndividualLocalAuth)
+@implements IDisposable
+
 @inject NavigationManager NavigationManager
 
 ##endif*@

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Pages/Error.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Pages/Error.razor
@@ -26,10 +26,10 @@
 
 @code{
     [CascadingParameter]
-    public HttpContext? HttpContext { get; set; }
+    private HttpContext? HttpContext { get; set; }
 
-    public string? RequestId { get; set; }
-    public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+    private string? RequestId { get; set; }
+    private bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 
     protected override void OnInitialized() =>
         RequestId = Activity.Current?.Id ?? HttpContext?.TraceIdentifier;


### PR DESCRIPTION
Having a `Dispose()` implementation without `@implements IDisposable` in `NavMenu.razor` when you select the individual auth option is an embarrassing oversight, but I'm not sure it's high impact. Here's what dispose does:

```csharp
    public void Dispose()
    {
        NavigationManager.LocationChanged -= OnLocationChanged;
    }
```

It looks like the `NavigationManager` and the `NavMenu` component generally have the same lifetime since the `NavMenu` is always rendered by the `MainLayout`. However, if the `NavMenu` component were ever to get repeatedly recreated, it would leak memory.

I also took this opportunity to more consistently use `private` for Razor component properties.
