### PR TITLE
Quarantine ResponseTests.HttpsConnectionClosedWhenResponseDoesNotSatisfyMinimumDataRate

### DIFF
--- a/src/Servers/Kestrel/test/FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/ResponseTests.cs
@@ -588,6 +588,7 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/49974")]
     public async Task HttpsConnectionClosedWhenResponseDoesNotSatisfyMinimumDataRate(bool fin)
     {
         const int chunkSize = 1024;


### PR DESCRIPTION
It's already in the retry list, but it's still failing.

See #49974