### PR TITLE
Fix form actions for apps deployed behind reverse proxy

### DIFF
--- a/src/Components/Web/test/HtmlRendering/HtmlRendererTest.cs
+++ b/src/Components/Web/test/HtmlRendering/HtmlRendererTest.cs
@@ -1115,7 +1115,7 @@ And now with HTML encoding: Person with special chars like &#x27; &quot; &lt;/sc
     [InlineData("https://example.com/", "https://example.com/a/b/c?q=1&p=hello%20there", "/a/b/c?q=1&p=hello%20there")]
     [InlineData("https://example.com/subdir/", "https://example.com/subdir", "/subdir")]
     [InlineData("https://example.com/subdir/", "https://example.com/subdir/", "/subdir/")]
-    [InlineData("https://example.com/a/b/", "https://example.com/a/b/c&q=1&p=2", "/a/b/c&q=1&p=2")]
+    [InlineData("https://example.com/a/b/", "https://example.com/a/b/c?q=1&p=2", "/a/b/c?q=1&p=2")]
     [InlineData("http://user:pass@xyz.example.com:1234/a/b/", "http://user:pass@xyz.example.com:1234/a/b/c&q=1&p=2", "/a/b/c&q=1&p=2")]
     public async Task RenderComponentAsync_AddsActionAttributeWithCurrentUrlToFormWithoutAttributes_WhenNoActionSpecified(
         string baseUrl, string currentUrl, string expectedAction)

--- a/src/Components/Web/test/HtmlRendering/HtmlRendererTest.cs
+++ b/src/Components/Web/test/HtmlRendering/HtmlRendererTest.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using System.Text;
+using System.Web;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Forms.Mapping;
 using Microsoft.AspNetCore.Components.Rendering;
@@ -1106,15 +1107,25 @@ And now with HTML encoding: Person with special chars like &#x27; &quot; &lt;/sc
         });
     }
 
-    [Fact]
-    public async Task RenderComponentAsync_AddsActionAttributeWithCurrentUrlToFormWithoutAttributes_WhenNoActionSpecified()
+    [Theory]
+    [InlineData("https://example.com/", "https://example.com", "/")]
+    [InlineData("https://example.com/", "https://example.com/", "/")]
+    [InlineData("https://example.com/", "https://example.com/page", "/page")]
+    [InlineData("https://example.com/", "https://example.com/a/b/c", "/a/b/c")]
+    [InlineData("https://example.com/", "https://example.com/a/b/c?q=1&p=hello%20there", "/a/b/c?q=1&p=hello%20there")]
+    [InlineData("https://example.com/subdir/", "https://example.com/subdir", "/subdir")]
+    [InlineData("https://example.com/subdir/", "https://example.com/subdir/", "/subdir/")]
+    [InlineData("https://example.com/a/b/", "https://example.com/a/b/c&q=1&p=2", "/a/b/c&q=1&p=2")]
+    [InlineData("http://user:pass@xyz.example.com:1234/a/b/", "http://user:pass@xyz.example.com:1234/a/b/c&q=1&p=2", "/a/b/c&q=1&p=2")]
+    public async Task RenderComponentAsync_AddsActionAttributeWithCurrentUrlToFormWithoutAttributes_WhenNoActionSpecified(
+        string baseUrl, string currentUrl, string expectedAction)
     {
         // Arrange
         var serviceProvider = GetServiceProvider(collection => collection.AddSingleton(new RenderFragment(rtb =>
         {
             rtb.OpenElement(0, "form");
             rtb.CloseElement();
-        })).AddScoped<NavigationManager, TestNavigationManager>());
+        })).AddScoped<NavigationManager>(_ => new TestNavigationManager(baseUrl, currentUrl)));
 
         var htmlRenderer = GetHtmlRenderer(serviceProvider);
         await htmlRenderer.Dispatcher.InvokeAsync(async () =>
@@ -1123,7 +1134,7 @@ And now with HTML encoding: Person with special chars like &#x27; &quot; &lt;/sc
             var result = await htmlRenderer.RenderComponentAsync<TestComponent>();
 
             // Assert
-            Assert.Equal("<form action=\"https://www.example.com/page\"></form>", result.ToHtmlString());
+            Assert.Equal($"<form action=\"{HttpUtility.HtmlAttributeEncode(expectedAction)}\"></form>", result.ToHtmlString());
         });
     }
 
@@ -1145,7 +1156,7 @@ And now with HTML encoding: Person with special chars like &#x27; &quot; &lt;/sc
             var result = await htmlRenderer.RenderComponentAsync<TestComponent>();
 
             // Assert
-            Assert.Equal("<form method=\"post\" action=\"https://www.example.com/page\"></form>", result.ToHtmlString());
+            Assert.Equal("<form method=\"post\" action=\"/page\"></form>", result.ToHtmlString());
         });
     }
 
@@ -1382,7 +1393,21 @@ And now with HTML encoding: Person with special chars like &#x27; &quot; &lt;/sc
 
     private class TestNavigationManager : NavigationManager
     {
-        protected override void EnsureInitialized() => Initialize("https://www.example.com/", "https://www.example.com/page");
+        private string _baseUrl;
+        private string _currentUrl;
+
+        public TestNavigationManager()
+            : this("https://www.example.com/", "https://www.example.com/page")
+        {
+        }
+
+        public TestNavigationManager(string baseUrl, string currentUrl)
+        {
+            _baseUrl = baseUrl;
+            _currentUrl = currentUrl;
+        }
+
+        protected override void EnsureInitialized() => Initialize(_baseUrl, _currentUrl);
     }
 
     private IServiceProvider GetServiceProvider(Action<IServiceCollection> configure = null)

--- a/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/FormHandlingTests/FormWithParentBindingContextTest.cs
@@ -306,18 +306,15 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     public void CanBindComplexTypeToDefaultForm(bool suppressEnhancedNavigation)
     {
         var url = "forms/default-form-bound-complextype-parameter";
-        var absoluteUrl = GetActionValue(this, url);
-        var expectedTarget = GetExpectedTarget(this, null, url);
+        var expectedAction = GetExpectedActionValue(this, url);
 
         SuppressEnhancedNavigation(suppressEnhancedNavigation);
         GoTo(url);
 
         Browser.Exists(By.Id("ready"));
         var form = Browser.Exists(By.CssSelector("form"));
-        var formTarget = form.GetAttribute("action");
-        var actionValue = form.GetDomAttribute("action");
-        Assert.Equal(expectedTarget, formTarget);
-        Assert.Equal(absoluteUrl, actionValue);
+        var actionValue = ReadFormActionAttribute(form);
+        Assert.Equal(expectedAction, actionValue);
 
         var name = Browser.Exists(By.CssSelector("""input[name="Model.Name"]"""));
         name.SendKeys("John");
@@ -334,7 +331,7 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
         {
             // Verify the same form element is still in the page
             // We wouldn't be allowed to read the attribute if the element is stale
-            Assert.Equal(expectedTarget, form.GetAttribute("action"));
+            Assert.NotEmpty(form.GetAttribute("action"));
         }
     }
 
@@ -344,18 +341,15 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     public void CanBreakFormIntoMultipleComponents(bool suppressEnhancedNavigation)
     {
         var url = "forms/default-form-bound-complextype-multiple-components";
-        var absoluteUrl = GetActionValue(this, url);
-        var expectedTarget = GetExpectedTarget(this, null, url);
+        var expectedAction = GetExpectedActionValue(this, url);
 
         SuppressEnhancedNavigation(suppressEnhancedNavigation);
         GoTo(url);
 
         Browser.Exists(By.Id("ready"));
         var form = Browser.Exists(By.CssSelector("form"));
-        var formTarget = form.GetAttribute("action");
-        var actionValue = form.GetDomAttribute("action");
-        Assert.Equal(expectedTarget, formTarget);
-        Assert.Equal(absoluteUrl, actionValue);
+        var actionValue = ReadFormActionAttribute(form);
+        Assert.Equal(expectedAction, actionValue);
 
         var name = Browser.Exists(By.CssSelector("""input[name="Model.Name"]"""));
         name.SendKeys("John");
@@ -394,7 +388,7 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
         {
             // Verify the same form element is still in the page
             // We wouldn't be allowed to read the attribute if the element is stale
-            Assert.Equal(expectedTarget, form.GetAttribute("action"));
+            Assert.NotEmpty(form.GetAttribute("action"));
         }
     }
 
@@ -404,18 +398,15 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     public void CanBreakFormIntoMultipleComponentsDisplaysErrorsCorrectly(bool suppressEnhancedNavigation)
     {
         var url = "forms/default-form-bound-complextype-multiple-components";
-        var absoluteUrl = GetActionValue(this, url);
-        var expectedTarget = GetExpectedTarget(this, null, url);
+        var expectedAction = GetExpectedActionValue(this, url);
 
         SuppressEnhancedNavigation(suppressEnhancedNavigation);
         GoTo(url);
 
         Browser.Exists(By.Id("ready"));
         var form = Browser.Exists(By.CssSelector("form"));
-        var formTarget = form.GetAttribute("action");
-        var actionValue = form.GetDomAttribute("action");
-        Assert.Equal(expectedTarget, formTarget);
-        Assert.Equal(absoluteUrl, actionValue);
+        var actionValue = ReadFormActionAttribute(form);
+        Assert.Equal(expectedAction, actionValue);
 
         var name = Browser.Exists(By.CssSelector("""input[name="Model.Name"]"""));
         name.SendKeys("John");
@@ -448,7 +439,7 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
         {
             // Verify the same form element is still in the page
             // We wouldn't be allowed to read the attribute if the element is stale
-            Assert.Equal(expectedTarget, form.GetAttribute("action"));
+            Assert.NotEmpty(form.GetAttribute("action"));
         }
     }
 
@@ -458,18 +449,15 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     public void CanDisplayBindingErrorsComplexTypeToDefaultForm(bool suppressEnhancedNavigation)
     {
         var url = "forms/default-form-bound-complextype-parameter";
-        var absoluteUrl = GetActionValue(this, url);
-        var expectedTarget = GetExpectedTarget(this, null, url);
+        var expectedAction = GetExpectedActionValue(this, url);
 
         SuppressEnhancedNavigation(suppressEnhancedNavigation);
         GoTo(url);
 
         Browser.Exists(By.Id("ready"));
         var form = Browser.Exists(By.CssSelector("form"));
-        var formTarget = form.GetAttribute("action");
-        var actionValue = form.GetDomAttribute("action");
-        Assert.Equal(expectedTarget, formTarget);
-        Assert.Equal(absoluteUrl, actionValue);
+        var actionValue = ReadFormActionAttribute(form);
+        Assert.Equal(expectedAction, actionValue);
 
         var name = Browser.Exists(By.CssSelector("""input[name="Model.Name"]"""));
         name.SendKeys("John");
@@ -489,7 +477,7 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
         {
             // Verify the same form element is still in the page
             // We wouldn't be allowed to read the attribute if the element is stale
-            Assert.Equal(expectedTarget, form.GetAttribute("action"));
+            Assert.NotEmpty(form.GetAttribute("action"));
         }
     }
 
@@ -499,18 +487,15 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     public void CanBindDictionaryToDefaultForm(bool suppressEnhancedNavigation)
     {
         var url = "forms/default-form-bound-dictionary-parameter";
-        var absoluteUrl = GetActionValue(this, url);
-        var expectedTarget = GetExpectedTarget(this, null, url);
+        var expectedAction = GetExpectedActionValue(this, url);
 
         SuppressEnhancedNavigation(suppressEnhancedNavigation);
         GoTo(url);
 
         Browser.Exists(By.Id("ready"));
         var form = Browser.Exists(By.CssSelector("form"));
-        var formTarget = form.GetAttribute("action");
-        var actionValue = form.GetDomAttribute("action");
-        Assert.Equal(expectedTarget, formTarget);
-        Assert.Equal(absoluteUrl, actionValue);
+        var actionValue = ReadFormActionAttribute(form);
+        Assert.Equal(expectedAction, actionValue);
 
         var name = Browser.Exists(By.CssSelector("""input[name="Model[Name]"]"""));
         name.SendKeys("John");
@@ -527,7 +512,7 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
         {
             // Verify the same form element is still in the page
             // We wouldn't be allowed to read the attribute if the element is stale
-            Assert.Equal(expectedTarget, form.GetAttribute("action"));
+            Assert.NotEmpty(form.GetAttribute("action"));
         }
     }
 
@@ -537,18 +522,15 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     public void CanDisplayBindingErrorsDictionaryToDefaultForm(bool suppressEnhancedNavigation)
     {
         var url = "forms/default-form-bound-dictionary-parameter-errors";
-        var absoluteUrl = GetActionValue(this, url);
-        var expectedTarget = GetExpectedTarget(this, null, url);
+        var expectedAction = GetExpectedActionValue(this, url);
 
         SuppressEnhancedNavigation(suppressEnhancedNavigation);
         GoTo(url);
 
         Browser.Exists(By.Id("ready"));
         var form = Browser.Exists(By.CssSelector("form"));
-        var formTarget = form.GetAttribute("action");
-        var actionValue = form.GetDomAttribute("action");
-        Assert.Equal(expectedTarget, formTarget);
-        Assert.Equal(absoluteUrl, actionValue);
+        var actionValue = ReadFormActionAttribute(form);
+        Assert.Equal(expectedAction, actionValue);
 
         var name = Browser.Exists(By.CssSelector("""input[name="Model[Name]"]"""));
         ((IJavaScriptExecutor)Browser).ExecuteScript("arguments[0].setAttribute('value', 'name')", name);
@@ -569,7 +551,7 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
         {
             // Verify the same form element is still in the page
             // We wouldn't be allowed to read the attribute if the element is stale
-            Assert.Equal(expectedTarget, form.GetAttribute("action"));
+            Assert.NotEmpty(form.GetAttribute("action"));
         }
     }
 
@@ -579,18 +561,15 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     public void CanBindCollectionsToDefaultForm(bool suppressEnhancedNavigation)
     {
         var url = "forms/default-form-bound-collection-parameter";
-        var absoluteUrl = GetActionValue(this, url);
-        var expectedTarget = GetExpectedTarget(this, null, url);
+        var expectedAction = GetExpectedActionValue(this, url);
 
         SuppressEnhancedNavigation(suppressEnhancedNavigation);
         GoTo(url);
 
         Browser.Exists(By.Id("ready"));
         var form = Browser.Exists(By.CssSelector("form"));
-        var formTarget = form.GetAttribute("action");
-        var actionValue = form.GetDomAttribute("action");
-        Assert.Equal(expectedTarget, formTarget);
-        Assert.Equal(absoluteUrl, actionValue);
+        var actionValue = ReadFormActionAttribute(form);
+        Assert.Equal(expectedAction, actionValue);
 
         for (var i = 0; i < 2; i++)
         {
@@ -616,7 +595,7 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
         {
             // Verify the same form element is still in the page
             // We wouldn't be allowed to read the attribute if the element is stale
-            Assert.Equal(expectedTarget, form.GetAttribute("action"));
+            Assert.NotEmpty(form.GetAttribute("action"));
         }
     }
 
@@ -626,18 +605,15 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     public void CanDisplayBindingErrorsCollectionsToDefaultForm(bool suppressEnhancedNavigation)
     {
         var url = "forms/default-form-bound-collection-parameter";
-        var absoluteUrl = GetActionValue(this, url);
-        var expectedTarget = GetExpectedTarget(this, null, url);
+        var expectedAction = GetExpectedActionValue(this, url);
 
         SuppressEnhancedNavigation(suppressEnhancedNavigation);
         GoTo(url);
 
         Browser.Exists(By.Id("ready"));
         var form = Browser.Exists(By.CssSelector("form"));
-        var formTarget = form.GetAttribute("action");
-        var actionValue = form.GetDomAttribute("action");
-        Assert.Equal(expectedTarget, formTarget);
-        Assert.Equal(absoluteUrl, actionValue);
+        var actionValue = ReadFormActionAttribute(form);
+        Assert.Equal(expectedAction, actionValue);
 
         for (var i = 0; i < 2; i++)
         {
@@ -668,7 +644,7 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
         {
             // Verify the same form element is still in the page
             // We wouldn't be allowed to read the attribute if the element is stale
-            Assert.Equal(expectedTarget, form.GetAttribute("action"));
+            Assert.NotEmpty(form.GetAttribute("action"));
         }
     }
 
@@ -850,11 +826,11 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     {
         const string url = "forms/streaming-rendering/CanPostFormsWithStreamingRendering";
         GoTo(url);
-        var absoluteUrl = GetActionValue(this, url);
+        var expectedAction = GetExpectedActionValue(this, url);
         Browser.Exists(By.Id("ready"));
         var form = Browser.Exists(By.CssSelector("form"));
-        var actionValue = form.GetDomAttribute("action");
-        Assert.Equal(absoluteUrl, actionValue);
+        var actionValue = ReadFormActionAttribute(form);
+        Assert.Equal(expectedAction, actionValue);
 
         Browser.Click(By.Id("send"));
 
@@ -872,11 +848,11 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     {
         const string url = "forms/modify-http-context/ModifyHttpContext";
         GoTo(url);
-        var absoluteUrl = GetActionValue(this, url);
+        var expectedAction = GetExpectedActionValue(this, url);
         Browser.Exists(By.Id("ready"));
         var form = Browser.Exists(By.CssSelector("form"));
-        var actionValue = form.GetDomAttribute("action");
-        Assert.Equal(absoluteUrl, actionValue);
+        var actionValue = ReadFormActionAttribute(form);
+        Assert.Equal(expectedAction, actionValue);
 
         Browser.Click(By.Id("send"));
 
@@ -1016,11 +992,11 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
     {
         const string url = "forms/non-streaming-async-form-handler/CanHandleFormPostNonStreamingRenderingAsyncHandler";
         GoTo(url);
-        var absoluteUrl = GetActionValue(this, url);
+        var expectedAction = GetExpectedActionValue(this, url);
         Browser.Exists(By.Id("ready"));
         var form = Browser.Exists(By.CssSelector("form"));
-        var actionValue = form.GetDomAttribute("action");
-        Assert.Equal(absoluteUrl, actionValue);
+        var actionValue = ReadFormActionAttribute(form);
+        Assert.Equal(expectedAction, actionValue);
 
         Browser.Click(By.Id("send"));
 
@@ -1361,6 +1337,11 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
         }
     }
 
+    // Can't just use GetAttribute or GetDomAttribute because they both auto-resolve it
+    // to an absolute URL. We want to be able to assert about the attribute's literal value.
+    private string ReadFormActionAttribute(IWebElement form)
+        => (string)((IJavaScriptExecutor)Browser).ExecuteScript("return arguments[0].getAttribute('action')", form);
+
     private void DispatchToFormCore(DispatchToForm dispatch)
     {
         SuppressEnhancedNavigation(dispatch.SuppressEnhancedNavigation);
@@ -1483,11 +1464,8 @@ public class FormWithParentBindingContextTest : ServerTestBase<BasicTestAppServe
         public bool FormIsEnhanced { get; internal set; } = true; // Default to true because that's the case for almost all test cases
     }
 
-    private string GetExpectedTarget(FormWithParentBindingContextTest test, string expectedActionValue, string url)
-        => $"{new Uri(test._serverFixture.RootUri, test.ServerPathBase)}/{expectedActionValue ?? url}";
-
-    private string GetActionValue(FormWithParentBindingContextTest test, string expectedActionValue)
-        => $"{new Uri(test._serverFixture.RootUri, test.ServerPathBase)}/{expectedActionValue}";
+    private string GetExpectedActionValue(FormWithParentBindingContextTest test, string expectedActionValue)
+        => $"{test.ServerPathBase}/{expectedActionValue}";
 
     private void GoTo(string relativePath)
     {


### PR DESCRIPTION
# Fix form actions for apps deployed behind reverse proxy

Makes forms work for apps deployed behind a reverse proxy.

## Description

Apps deployed behind a reverse proxy (e.g., container apps) should not try to emit absolute URLs by default because the scheme/hostname/port may differ from what is reachable from the outside world. The fix is to emit root-relative URLs.

Fixes #51380

## Customer Impact

Without this fix, apps deployed behind a reverse proxy (e.g., in ACA) would not support form posts.

## Regression?

- [ ] Yes
- [x] No

No because this only affects SSR forms, which is a new feature in .NET 8.

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Low because this is only a change to how we generate the URL for a form's `action` attribute. Previously we used an absolute URL, but now we use a root-relative one. There is no other runtime change. Everything else in this PR is extra tests and updating existing tests.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A