### PR TITLE
Fixing Problem #49415 in HtmlHelper.HiddenFor() Functionality for .NET 6

### DIFF
--- a/src/Mvc/Mvc.ViewFeatures/src/DefaultHtmlGenerator.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/DefaultHtmlGenerator.cs
@@ -1246,16 +1246,14 @@ public class DefaultHtmlGenerator : IHtmlGenerator
                     break;
                 }
 
-                var existingValue = tagBuilder.Attributes.GetValueOrDefault("value");
+                var hasValueInHtmlAttributes = tagBuilder.Attributes.ContainsKey("value");
                 var attributeValue = (string)GetModelStateValue(viewContext, fullName, typeof(string));
                 attributeValue ??= useViewData ? EvalString(viewContext, expression, format) : valueParameter;
 
-                if (string.IsNullOrEmpty(attributeValue) && existingValue != null)
+                if (!string.IsNullOrEmpty(attributeValue) || !hasValueInHtmlAttributes)
                 {
-                    break;
+                    tagBuilder.MergeAttribute("value", attributeValue, replaceExisting: isExplicitValue);
                 }
-
-                tagBuilder.MergeAttribute("value", attributeValue, replaceExisting: isExplicitValue);
 
                 break;
         }

--- a/src/Mvc/Mvc.ViewFeatures/src/DefaultHtmlGenerator.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/DefaultHtmlGenerator.cs
@@ -1246,8 +1246,15 @@ public class DefaultHtmlGenerator : IHtmlGenerator
                     break;
                 }
 
+                var existingValue = tagBuilder.Attributes.GetValueOrDefault("value");
                 var attributeValue = (string)GetModelStateValue(viewContext, fullName, typeof(string));
                 attributeValue ??= useViewData ? EvalString(viewContext, expression, format) : valueParameter;
+
+                if (string.IsNullOrEmpty(attributeValue) && existingValue != null)
+                {
+                    break;
+                }
+
                 tagBuilder.MergeAttribute("value", attributeValue, replaceExisting: isExplicitValue);
 
                 break;

--- a/src/Mvc/Mvc.ViewFeatures/test/Rendering/HtmlHelperHiddenTest.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/Rendering/HtmlHelperHiddenTest.cs
@@ -271,10 +271,10 @@ public class HtmlHelperHiddenTest
     }
 
     [Fact]
-    public void HiddenNotInTemplate_DoesNotUseAttributeValue()
+    public void HiddenNotInTemplate_DoesUseAttributeValue()
     {
         // Arrange
-        var expected = @"<input id=""HtmlEncode[[Property1]]"" name=""HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" value="""" />";
+        var expected = @"<input id=""HtmlEncode[[Property1]]"" name=""HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[attribute-value]]"" />";
         var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetViewDataWithNonNullModel());
 
         // Act
@@ -285,11 +285,11 @@ public class HtmlHelperHiddenTest
     }
 
     [Fact]
-    public void HiddenInTemplate_DoesNotUseAttributeValue()
+    public void HiddenInTemplate_DoesUseAttributeValue()
     {
         // Arrange
         var expected = @"<input id=""HtmlEncode[[Prefix_Property1]]"" name=""HtmlEncode[[Prefix.Property1]]"" " +
-            @"type=""HtmlEncode[[hidden]]"" value="""" />";
+            @"type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[attribute-value]]"" />";
         var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetViewDataWithNonNullModel());
         helper.ViewData.TemplateInfo.HtmlFieldPrefix = "Prefix";
 
@@ -657,6 +657,25 @@ public class HtmlHelperHiddenTest
     }
 
     [Fact]
+    public void HiddenFor_IsNotIgnoring_HtmlAttributes_Value()
+    {
+        // Arrange
+        var currentlyExpected = @"<input id=""HtmlEncode[[Property1]]"" name=""HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" value="""" />";
+        var expected = @"<input id=""HtmlEncode[[Property1]]"" name=""HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[bar]]"" />";
+
+        var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetViewDataWithModelStateAndModelAndViewDataValues());
+        helper.ViewData.Model.Property1 = null;
+        helper.ViewData.ModelState.Clear();
+
+        // Act
+        var result = helper.HiddenFor(m => m.Property1, new { value = "bar" });
+
+        // Assert
+        Assert.NotEqual(currentlyExpected, HtmlContentUtilities.HtmlContentToString(result));
+        Assert.Equal(expected, HtmlContentUtilities.HtmlContentToString(result));
+    }
+
+    [Fact]
     public void HiddenForWithAttributesDictionaryAndNullModel_GeneratesExpectedValue()
     {
         // Arrange
@@ -868,10 +887,10 @@ public class HtmlHelperHiddenTest
     }
 
     [Fact]
-    public void HiddenFor_DoesNotUseAttributeValue()
+    public void HiddenFor_DoesUseAttributeValue()
     {
         // Arrange
-        var expected = @"<input id=""HtmlEncode[[Property1]]"" name=""HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" value="""" />";
+        var expected = @"<input id=""HtmlEncode[[Property1]]"" name=""HtmlEncode[[Property1]]"" type=""HtmlEncode[[hidden]]"" value=""HtmlEncode[[AttrValue]]"" />";
         var helper = DefaultTemplatesUtilities.GetHtmlHelper(GetViewDataWithNullModelAndNonNullViewData());
         var attributes = new Dictionary<string, object>
             {


### PR DESCRIPTION
# Fixing Problem #49415 in HtmlHelper.HiddenFor() Functionality for .NET 6

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [✓] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [✓] You've included unit or integration tests for your change, where applicable.
- [✓] You've included inline docs for your change, where applicable.
- [✓] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

This pull request deals with Issue #49415, which is related to how `HtmlHelper.HiddenFor()` works in .NET 6 and up. The issue arises when the `Model`'s property is empty, and a value is given in the `htmlAttributes` parameter. The way it currently behaves is not in line with what is explained in the documentation. In addition, modifications of behavior also have been made to the existing unit tests. Please review, thanks!.

Fixes #49415 (Html.HiddenFor will never use value property from htmlAttributes to assign value)
