### PR TITLE
[release/8.0] Remove network.protocol.name from request duration metric

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingMetrics.cs
@@ -24,12 +24,12 @@ internal sealed class HostingMetrics : IDisposable
         _activeRequestsCounter = _meter.CreateUpDownCounter<long>(
             "http.server.active_requests",
             unit: "{request}",
-            description: "Number of HTTP requests that are currently active on the server.");
+            description: "Number of active HTTP server requests.");
 
         _requestDuration = _meter.CreateHistogram<double>(
             "http.server.request.duration",
             unit: "s",
-            description: "Measures the duration of inbound HTTP requests.");
+            description: "Duration of HTTP server requests.");
     }
 
     // Note: Calling code checks whether counter is enabled.
@@ -54,7 +54,6 @@ internal sealed class HostingMetrics : IDisposable
 
         if (_requestDuration.Enabled)
         {
-            tags.Add("network.protocol.name", "http");
             if (TryGetHttpVersion(protocol, out var httpVersion))
             {
                 tags.Add("network.protocol.version", httpVersion);

--- a/src/Hosting/Hosting/test/HostingMetricsTests.cs
+++ b/src/Hosting/Hosting/test/HostingMetricsTests.cs
@@ -92,7 +92,6 @@ public class HostingMetricsTests
         static void AssertRequestDuration(CollectedMeasurement<double> measurement, string httpVersion, int statusCode, string exceptionName = null, bool? unhandledRequest = null)
         {
             Assert.True(measurement.Value > 0);
-            Assert.Equal("http", (string)measurement.Tags["network.protocol.name"]);
             Assert.Equal(httpVersion, (string)measurement.Tags["network.protocol.version"]);
             Assert.Equal(statusCode, (int)measurement.Tags["http.response.status_code"]);
             if (exceptionName == null)


### PR DESCRIPTION
# Remove network.protocol.name from request duration metric

Some feedback of ASP.NET Core metrics brought up inconsistencies with the spec and other .NET metrics:

* `network.protocol.name` attribute is being added unnecessarily in ASP.NET Core. HttpClient has a similar metric that does the right thing.
* Counter descriptions are different from the OTEL semantic conventions.

These changes should be done now before the metrics are in a GA release. If it is not possible to merge for .NET 8 GA then the changes could happen in 8.0.x servicing. That would minimize the amount of time use metrics before the change.

## Description

* Remove `network.protocol.name` attribute from `http.server.request.duration`.
* Change some counter descriptions.

Fixes https://github.com/dotnet/aspnetcore/issues/51454

## Customer Impact

The HTTP metrics in ASP.NET Core follow the OTEL convention.

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The PR removes an attribute and changes some description strings. Nothing in .NET or ASP.NET Core depends on the name.

## Verification

- [x] Manual (required)
- [x] Automated

Remove `network.protocol.name` tag was manually verified by listening to counter in a sample app:

![image](https://github.com/dotnet/aspnetcore/assets/303201/381ce5d1-ad97-4d33-a68e-da944e1bf2d6)

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props
