### PR TITLE
Use IProblemDetailService in ValidationProblem

### DIFF
--- a/src/Http/Http.Results/test/ProblemResultTests.cs
+++ b/src/Http/Http.Results/test/ProblemResultTests.cs
@@ -44,7 +44,7 @@ public class ProblemResultTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_UsesDefaultsFromProblemDetailsServoce_ForProblemDetails()
+    public async Task ExecuteAsync_UsesDefaultsFromProblemDetailsService_ForProblemDetails()
     {
         // Arrange
         var details = new ProblemDetails();
@@ -232,7 +232,7 @@ public class ProblemResultTests
     [Fact]
     public void ProblemResult_Implements_IValueHttpResultOfT_Correctly()
     {
-        // Arrange 
+        // Arrange
         var value = new ProblemDetails();
 
         // Act & Assert

--- a/src/Http/Http.Results/test/ValidationProblemResultTests.cs
+++ b/src/Http/Http.Results/test/ValidationProblemResultTests.cs
@@ -4,6 +4,7 @@
 using System.Reflection;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
@@ -172,7 +173,6 @@ public class ValidationProblemResultTests
 
     private static void PopulateMetadata<TResult>(MethodInfo method, EndpointBuilder builder)
         where TResult : IEndpointMetadataProvider => TResult.PopulateMetadata(method, builder);
-
 
     private static IServiceCollection CreateServiceCollection()
     {

--- a/src/Http/Http.Results/test/ValidationProblemResultTests.cs
+++ b/src/Http/Http.Results/test/ValidationProblemResultTests.cs
@@ -4,7 +4,6 @@
 using System.Reflection;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
@@ -72,7 +71,7 @@ public class ValidationProblemResultTests
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, httpContext.Response.StatusCode);
         stream.Position = 0;
-        var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, SerializerOptions);
+        var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, new JsonSerializerOptions(JsonSerializerDefaults.Web));
         Assert.Null(responseDetails.Type);
         Assert.Equal("One or more validation errors occurred.", responseDetails.Title);
         Assert.Equal(StatusCodes.Status400BadRequest, responseDetails.Status);

--- a/src/Http/Http.Results/test/ValidationProblemResultTests.cs
+++ b/src/Http/Http.Results/test/ValidationProblemResultTests.cs
@@ -46,6 +46,38 @@ public class ValidationProblemResultTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_UsesDefaultsFromProblemDetailsService_ForProblemDetails()
+    {
+        // Arrange
+        var details = new HttpValidationProblemDetails();
+
+        var result = new ValidationProblem(details);
+        var stream = new MemoryStream();
+        var services = CreateServiceCollection()
+            .AddProblemDetails(options => options.CustomizeProblemDetails = x => x.ProblemDetails.Type = null)
+            .BuildServiceProvider();
+        var httpContext = new DefaultHttpContext()
+        {
+            RequestServices = services,
+            Response =
+                {
+                    Body = stream,
+                },
+        };
+
+        // Act
+        await result.ExecuteAsync(httpContext);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, httpContext.Response.StatusCode);
+        stream.Position = 0;
+        var responseDetails = JsonSerializer.Deserialize<ProblemDetails>(stream, SerializerOptions);
+        Assert.Null(responseDetails.Type);
+        Assert.Equal("One or more validation errors occurred.", responseDetails.Title);
+        Assert.Equal(StatusCodes.Status400BadRequest, responseDetails.Status);
+    }
+
+    [Fact]
     public void ExecuteAsync_ThrowsArgumentNullException_ForNullProblemDetails()
     {
         Assert.Throws<ArgumentNullException>("problemDetails", () => new ValidationProblem(null));
@@ -141,11 +173,18 @@ public class ValidationProblemResultTests
     private static void PopulateMetadata<TResult>(MethodInfo method, EndpointBuilder builder)
         where TResult : IEndpointMetadataProvider => TResult.PopulateMetadata(method, builder);
 
-    private static IServiceProvider CreateServices()
+
+    private static IServiceCollection CreateServiceCollection()
     {
         var services = new ServiceCollection();
         services.AddTransient(typeof(ILogger<>), typeof(NullLogger<>));
         services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        return services;
+    }
+
+    private static IServiceProvider CreateServices()
+    {
+        var services = CreateServiceCollection();
 
         return services.BuildServiceProvider();
     }


### PR DESCRIPTION
# Use IProblemDetailService in ValidationProblem

ValidationProblem should use IProblemDetailService so that project wide customizations can be done

## Description

This is basically a modified version of #47100

Fixes #47631
