### PR TITLE
Update Weather.razor to simplify [StreamRendering] attribute usage.

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Pages/Weather.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Pages/Weather.razor
@@ -1,6 +1,6 @@
 ﻿@page "/weather"
 @*#if (!InteractiveAtRoot) -->
-@attribute [StreamRendering(true)]
+@attribute [StreamRendering]
 ##endif*@
 
 <PageTitle>Weather</PageTitle>


### PR DESCRIPTION
Passing true is no longer required when using the [StreamRendering] attribute as it is now the default.
