### PR TITLE
Update DenyAnonymousAuthorizationRequirement doc comment

### DIFF
--- a/src/Security/Authorization/Core/src/DenyAnonymousAuthorizationRequirement.cs
+++ b/src/Security/Authorization/Core/src/DenyAnonymousAuthorizationRequirement.cs
@@ -9,6 +9,7 @@ namespace Microsoft.AspNetCore.Authorization.Infrastructure;
 /// <summary>
 /// Implements an <see cref="IAuthorizationHandler"/> and <see cref="IAuthorizationRequirement"/>
 /// which requires the current user must be authenticated.
+/// Unlike what the name of the class implies, where you would expect failure if not authenticated, it instead succeeds if you are authenticated. 
 /// </summary>
 public class DenyAnonymousAuthorizationRequirement : AuthorizationHandler<DenyAnonymousAuthorizationRequirement>, IAuthorizationRequirement
 {

--- a/src/Security/Authorization/Core/src/DenyAnonymousAuthorizationRequirement.cs
+++ b/src/Security/Authorization/Core/src/DenyAnonymousAuthorizationRequirement.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Authorization.Infrastructure;
 /// <summary>
 /// Implements an <see cref="IAuthorizationHandler"/> and <see cref="IAuthorizationRequirement"/>
 /// which requires the current user must be authenticated.
-/// Unlike what the name of the class implies, where you would expect failure if not authenticated, it instead succeeds if you are authenticated. 
+/// This calls <see cref="AuthorizationHandlerContext.Succeed"/> for authenticated users. Like all built-in requirements, it never calls <see cref="AuthorizationHandlerContext.Fail"/>. The <see cref="DefaultAuthorizationEvaluator"/> produces a failed <see cref="AuthorizationResult" /> when any requirement has not succeeded even if other requirements have succeeded and no requirement has explicitly failed.
 /// </summary>
 public class DenyAnonymousAuthorizationRequirement : AuthorizationHandler<DenyAnonymousAuthorizationRequirement>, IAuthorizationRequirement
 {

--- a/src/Security/Authorization/Core/src/DenyAnonymousAuthorizationRequirement.cs
+++ b/src/Security/Authorization/Core/src/DenyAnonymousAuthorizationRequirement.cs
@@ -9,7 +9,8 @@ namespace Microsoft.AspNetCore.Authorization.Infrastructure;
 /// <summary>
 /// Implements an <see cref="IAuthorizationHandler"/> and <see cref="IAuthorizationRequirement"/>
 /// which requires the current user must be authenticated.
-/// This calls <see cref="AuthorizationHandlerContext.Succeed"/> for authenticated users. Like all built-in requirements, it never calls <see cref="AuthorizationHandlerContext.Fail"/>. The <see cref="DefaultAuthorizationEvaluator"/> produces a failed <see cref="AuthorizationResult" /> when any requirement has not succeeded even if other requirements have succeeded and no requirement has explicitly failed.
+/// This calls <see cref="AuthorizationHandlerContext.Succeed"/> for authenticated users. Like all built-in requirements, it never calls <see cref="AuthorizationHandlerContext.Fail"/>.
+/// The <see cref="DefaultAuthorizationEvaluator"/> produces a failed <see cref="AuthorizationResult" /> when any requirement has not succeeded even if other requirements have succeeded and no requirement has explicitly failed.
 /// </summary>
 public class DenyAnonymousAuthorizationRequirement : AuthorizationHandler<DenyAnonymousAuthorizationRequirement>, IAuthorizationRequirement
 {

--- a/src/Security/Authorization/Core/src/DenyAnonymousAuthorizationRequirement.cs
+++ b/src/Security/Authorization/Core/src/DenyAnonymousAuthorizationRequirement.cs
@@ -7,10 +7,10 @@ using System.Threading.Tasks;
 namespace Microsoft.AspNetCore.Authorization.Infrastructure;
 
 /// <summary>
-/// Implements an <see cref="IAuthorizationHandler"/> and <see cref="IAuthorizationRequirement"/>
-/// which requires the current user must be authenticated.
-/// This calls <see cref="AuthorizationHandlerContext.Succeed"/> for authenticated users. Like all built-in requirements, it never calls <see cref="AuthorizationHandlerContext.Fail"/>.
-/// The <see cref="DefaultAuthorizationEvaluator"/> produces a failed <see cref="AuthorizationResult" /> when any requirement has not succeeded even if other requirements have succeeded and no requirement has explicitly failed.
+/// Implements an <see cref="IAuthorizationHandler"/> and <see cref="IAuthorizationRequirement"/> which requires the current user must be authenticated.
+/// This calls <see cref="AuthorizationHandlerContext.Succeed(IAuthorizationRequirement)"/> for authenticated users. Like all built-in requirements,
+/// it never calls <see cref="AuthorizationHandlerContext.Fail()"/>. The <see cref="DefaultAuthorizationEvaluator"/> produces a failed <see cref="AuthorizationResult" /> 
+/// when any requirement has not succeeded even if other requirements have succeeded, and no requirement has explicitly failed.
 /// </summary>
 public class DenyAnonymousAuthorizationRequirement : AuthorizationHandler<DenyAnonymousAuthorizationRequirement>, IAuthorizationRequirement
 {


### PR DESCRIPTION
# DenyAnonymousAuthorizationRequirement: Actual behaviour is different than class name

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included inline docs for your change, where applicable.

## Description

Actual behavior of `DenyAnonymousAuthorizationRequirement` is different than class name implies.

Addresses #4656
