### PR TITLE
Remove duplicate .sln from Blazor Web Template WebAssembly and Auto 

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/.template.config/template.json
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/.template.config/template.json
@@ -111,6 +111,12 @@
           ]
         },
         {
+          "condition": "(UseWebAssembly && HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+          "exclude": [
+            "*.sln"
+          ]
+        },
+        {
           "condition": "(!IndividualLocalAuth)",
           "exclude": [
             "BlazorWeb-CSharp/Components/Account/**",

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Pages/Weather.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Pages/Weather.razor
@@ -1,6 +1,6 @@
 ﻿@page "/weather"
 @*#if (!InteractiveAtRoot) -->
-@attribute [StreamRendering(true)]
+@attribute [StreamRendering]
 ##endif*@
 
 <PageTitle>Weather</PageTitle>


### PR DESCRIPTION
# Remove duplicate .sln from Blazor Web Template WebAssembly and Auto 

## Description
When creating a Blazor web template (interactivity WebAssembly or Auto selected) not with cli but in VisualStudio there is duplicate .sln file.

This PR fixes that by removing the duplicate .sln

Fixes https://github.com/dotnet/AspNetCore-ManualTests/issues/2435

## Customer Impact

Customers, who will create Blazor Web project template with WebAssembly or Auto interactivity option selected, will get a duplicate SLN file created.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

The fix is scoped to the logic specific to inclusion of .sln files in the template, and has been manually verified both with VS and CLI.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props
