### PR TITLE
Fix Blazor template bug where a logged in user could appear to be unauthenticated

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Login.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Login.razor
@@ -3,7 +3,6 @@
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Authentication
 @using Microsoft.AspNetCore.Identity
-@using Microsoft.AspNetCore.WebUtilities
 @using BlazorWeb_CSharp.Data
 
 @inject SignInManager<ApplicationUser> SignInManager

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/LoginWithRecoveryCode.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/LoginWithRecoveryCode.razor
@@ -2,7 +2,6 @@
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Identity
-@using Microsoft.AspNetCore.Mvc
 @using BlazorWeb_CSharp.Data
 
 @inject SignInManager<ApplicationUser> SignInManager

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/ExternalLogins.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/ExternalLogins.razor
@@ -2,7 +2,6 @@
 
 @using Microsoft.AspNetCore.Authentication
 @using Microsoft.AspNetCore.Identity
-@using Microsoft.AspNetCore.Mvc.ViewFeatures
 @using BlazorWeb_CSharp.Data
 
 @inject UserManager<ApplicationUser> UserManager

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/Index.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Manage/Index.razor
@@ -1,11 +1,9 @@
 ﻿@page "/Account/Manage"
 
 @using System.ComponentModel.DataAnnotations
-@using System.Security.Claims
 @using Microsoft.AspNetCore.Identity
 @using BlazorWeb_CSharp.Data
 
-@inject AuthenticationStateProvider AuthenticationStateProvider
 @inject UserManager<ApplicationUser> UserManager
 @inject SignInManager<ApplicationUser> SignInManager
 @inject IdentityUserAccessor UserAccessor

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Register.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/Register.razor
@@ -3,7 +3,6 @@
 @using System.ComponentModel.DataAnnotations
 @using System.Text
 @using System.Text.Encodings.Web
-@using Microsoft.AspNetCore.Authentication
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
 @using BlazorWeb_CSharp.Data

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/RegisterConfirmation.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/RegisterConfirmation.razor
@@ -36,10 +36,10 @@ else
     private HttpContext HttpContext { get; set; } = default!;
 
     [SupplyParameterFromQuery]
-    public string? Email { get; set; }
+    private string? Email { get; set; }
 
     [SupplyParameterFromQuery]
-    public string? ReturnUrl { get; set; }
+    private string? ReturnUrl { get; set; }
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/ResendEmailConfirmation.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/ResendEmailConfirmation.razor
@@ -4,7 +4,6 @@
 @using System.Text
 @using System.Text.Encodings.Web
 @using Microsoft.AspNetCore.Identity
-@using Microsoft.AspNetCore.Identity.UI.Services
 @using Microsoft.AspNetCore.WebUtilities
 @using BlazorWeb_CSharp.Data
 

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/ResetPassword.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Pages/ResetPassword.razor
@@ -2,7 +2,6 @@
 
 @using System.ComponentModel.DataAnnotations
 @using System.Text
-@using Microsoft.AspNetCore.Http
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
 @using BlazorWeb_CSharp.Data

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Shared/AccountLayout.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account/Shared/AccountLayout.razor
@@ -17,7 +17,7 @@ else
 
 @code {
     [CascadingParameter]
-    public HttpContext? HttpContext { get; set; }
+    private HttpContext? HttpContext { get; set; }
 
     protected override void OnParametersSet()
     {

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/App.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/App.razor
@@ -49,7 +49,7 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
-    IComponentRenderMode? RenderModeForPage => HttpContext.Request.Path.StartsWithSegments("/Account")
+    private IComponentRenderMode? RenderModeForPage => HttpContext.Request.Path.StartsWithSegments("/Account")
         ? null
         : InteractiveAuto;
 }
@@ -59,7 +59,7 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
-    IComponentRenderMode? RenderModeForPage => HttpContext.Request.Path.StartsWithSegments("/Account")
+    private IComponentRenderMode? RenderModeForPage => HttpContext.Request.Path.StartsWithSegments("/Account")
         ? null
         : InteractiveServer;
 }
@@ -69,7 +69,7 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
-    IComponentRenderMode? RenderModeForPage => HttpContext.Request.Path.StartsWithSegments("/Account")
+    private IComponentRenderMode? RenderModeForPage => HttpContext.Request.Path.StartsWithSegments("/Account")
         ? null
         : InteractiveWebAssembly;
 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/NavMenu.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/NavMenu.razor
@@ -1,4 +1,6 @@
 ﻿@*#if (IndividualLocalAuth)
+@implements IDisposable
+
 @inject NavigationManager NavigationManager
 
 ##endif*@

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Pages/Error.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Pages/Error.razor
@@ -26,10 +26,10 @@
 
 @code{
     [CascadingParameter]
-    public HttpContext? HttpContext { get; set; }
+    private HttpContext? HttpContext { get; set; }
 
-    public string? RequestId { get; set; }
-    public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+    private string? RequestId { get; set; }
+    private bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 
     protected override void OnInitialized() =>
         RequestId = Activity.Current?.Id ?? HttpContext?.TraceIdentifier;


### PR DESCRIPTION
## Description

A customer reported that after enhanced navigation from a WebAssembly-rendered component that does not require authentication state to another WebAssembly-rendered component that does, the client will lose its authentication state. This leads to issues where the server knows the client is authenticated meaning the client can navigate to components that require authentication, but the client thinks the user is unauthenticated for the purposes of rendering something like:

```razor
<AuthorizeView>
    <Authorized>
        <p>You are authorized</p>
        Hello @context.User.Identity?.Name!
    </Authorized>
    <NotAuthorized>
        <p>You are not authorized</p>
    </NotAuthorized>
</AuthorizeView>
```

This was caused by the `PersistentAuthenticationStateProvider` on the client attempting to read the `UserInfo` from `PersistentComponentState` after enhanced navigation. At this point the state from the original page load (`/counter` in the examples below) is cleared, and the state that was persisted during the enhanced navigation to `/auth` is simply ignored and never read by anyone despite calling the `RegisterOnPersisting` callback and rendering the state for each enhanced navigation. The `PersistentComponentState` behavior is by design according to @javiercn, and we can make auth work reliably with the current `PersistentComponentState` behavior by greedily reading the `UserInfo` during initial render before any enhanced navigation which is what this PR does.

Fixes #51368

## Customer Impact

This was thankfully reported by a customer trying out the new Identity Blazor components in RC2. It's possible to get into this state with just the template code if a browser session starts in (or reload on) the template's `/counter` page and then does enhanced navigation to a component that uses an `<AuthorizeView>` like the template's `/auth` page. Without this fix, the user is forced to refresh the `/auth` page or any other page with `<AuthorizeView>` before they can see any rendered content that requires authorization.

https://github.com/dotnet/aspnetcore/assets/54385/742ab1d9-901e-4489-b4d4-183de6423aa5

Notice how the second time I navigate to the "Auth Required" page after refreshing on the "Counter" page, you see "You are authenticated" followed by "You are not authorized" even though any authenticated user should be authorized to see that page. After the fix, you always see "You are authenticated" followed by "You are authorized" and "Hello {email}!" as expected.

https://github.com/dotnet/aspnetcore/assets/54385/f8549468-ec68-4dfa-8e8c-800a29e6e349

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

This is a small change to a single Blazor Identity template component added in RC 2 which slightly simplifies the logic.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
