### PR TITLE
[Component governance] Bump the Azure.Identity dependency

### DIFF
--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -186,6 +186,7 @@ and are generated based on the last package release.
 
   <ItemGroup Label="External dependencies" Condition="'$(DotNetBuildFromSource)' != 'true'">
     <LatestPackageReference Include="AngleSharp" />
+    <LatestPackageReference Include="Azure.Identity" />
     <LatestPackageReference Include="BenchmarkDotNet" />
     <LatestPackageReference Include="CommandLineParser" />
     <LatestPackageReference Include="FSharp.Core" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -284,6 +284,7 @@
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension70x64Version>$(MicrosoftAspNetCoreAzureAppServicesSiteExtension70Version)</MicrosoftAspNetCoreAzureAppServicesSiteExtension70x64Version>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension70x86Version>$(MicrosoftAspNetCoreAzureAppServicesSiteExtension70Version)</MicrosoftAspNetCoreAzureAppServicesSiteExtension70x86Version>
     <!-- 3rd party dependencies -->
+    <AzureIdentityVersion>1.10.2</AzureIdentityVersion>
     <AngleSharpVersion>0.9.9</AngleSharpVersion>
     <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
     <CastleCoreVersion>4.2.1</CastleCoreVersion>

--- a/src/Caching/SqlServer/src/Microsoft.Extensions.Caching.SqlServer.csproj
+++ b/src/Caching/SqlServer/src/Microsoft.Extensions.Caching.SqlServer.csproj
@@ -19,6 +19,7 @@
     <Reference Include="Microsoft.Extensions.Caching.Abstractions" />
     <Reference Include="Microsoft.Extensions.Options" />
     <Reference Include="Microsoft.Data.SqlClient" />
+    <Reference Include="Azure.Identity" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrade Azure.Identity from 1.3.0 (brought in by Microsoft.Data.SqlClient) to 1.10.2