### PR TITLE
Improve path search in Kestrel parsing

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpParser.cs
@@ -105,18 +105,19 @@ public class HttpParser<TRequestHandler> : IHttpParser<TRequestHandler> where TR
         offset++;
 
         // Find end of path and if path is encoded
-        for (; (uint)offset < (uint)requestLine.Length; offset++)
+        var index = requestLine.Slice(offset).IndexOfAny(ByteSpace, ByteQuestionMark, BytePercentage);
+        if (index >= 0)
         {
-            ch = requestLine[offset];
-            if (ch == ByteSpace || ch == ByteQuestionMark)
-            {
-                // End of path
-                break;
-            }
-            else if (ch == BytePercentage)
+            if (requestLine[offset + index] == BytePercentage)
             {
                 pathEncoded = true;
+                offset += index;
+                // Found an encoded character, now just search for end of path
+                index = requestLine.Slice(offset).IndexOfAny(ByteSpace, ByteQuestionMark);
             }
+
+            offset += index;
+            ch = requestLine[offset];
         }
 
         var path = new TargetOffsetPathLength(targetStart, length: offset - targetStart, pathEncoded);


### PR DESCRIPTION
Replaces a manual loop with `IndexOfAny` which is much faster when the paths are longer than ~5 bytes.

The `HttpParserBenchmark` shows large improvements in the larger path cases and some minor regressions in the small paths. Ran twice since there is some noise in the runs.
**Before:**
|                 Method |      Mean |    Error |   StdDev |         Op/s | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------- |----------:|---------:|---------:|-------------:|------:|------:|------:|------:|----------:|
|   PlaintextTechEmpower |  79.16 ns | 0.274 ns | 0.243 ns | 12,633,030.5 |  1.00 |     - |     - |     - |         - |
|        JsonTechEmpower |  77.78 ns | 0.283 ns | 0.251 ns | 12,857,132.1 |  0.98 |     - |     - |     - |         - |
|             LiveAspNet | 140.69 ns | 0.800 ns | 0.710 ns |  7,107,794.5 |  1.78 |     - |     - |     - |         - |
|                Unicode | 248.81 ns | 0.630 ns | 0.589 ns |  4,019,189.1 |  3.14 |     - |     - |     - |         - |
| MultispanUnicodeHeader | 348.31 ns | 1.285 ns | 1.202 ns |  2,871,001.9 |  4.40 |     - |     - |     - |         - |

|                 Method |      Mean |    Error |   StdDev |         Op/s | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------- |----------:|---------:|---------:|-------------:|------:|------:|------:|------:|----------:|
|   PlaintextTechEmpower |  78.22 ns | 0.261 ns | 0.231 ns | 12,785,243.6 |  1.00 |     - |     - |     - |         - |
|        JsonTechEmpower |  75.88 ns | 0.288 ns | 0.270 ns | 13,178,565.6 |  0.97 |     - |     - |     - |         - |
|             LiveAspNet | 141.37 ns | 0.845 ns | 0.705 ns |  7,073,883.6 |  1.81 |     - |     - |     - |         - |
|                Unicode | 244.38 ns | 0.743 ns | 0.695 ns |  4,092,016.3 |  3.12 |     - |     - |     - |         - |
| MultispanUnicodeHeader | 345.19 ns | 1.052 ns | 0.933 ns |  2,896,948.9 |  4.41 |     - |     - |     - |         - |

----------------------------

**After:**
|                 Method |      Mean |    Error |   StdDev |         Op/s | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------- |----------:|---------:|---------:|-------------:|------:|--------:|------:|------:|------:|----------:|
|   PlaintextTechEmpower |  78.01 ns | 0.379 ns | 0.355 ns | 12,818,186.3 |  1.00 |    0.00 |     - |     - |     - |         - |
|        JsonTechEmpower |  77.80 ns | 0.744 ns | 0.696 ns | 12,853,080.1 |  1.00 |    0.01 |     - |     - |     - |         - |
|             LiveAspNet | 143.62 ns | 0.187 ns | 0.156 ns |  6,962,883.2 |  1.84 |    0.01 |     - |     - |     - |         - |
|                Unicode | 192.67 ns | 0.426 ns | 0.332 ns |  5,190,248.7 |  2.47 |    0.01 |     - |     - |     - |         - |
| MultispanUnicodeHeader | 305.62 ns | 2.585 ns | 2.291 ns |  3,272,037.9 |  3.92 |    0.04 |     - |     - |     - |         - |

|                 Method |      Mean |    Error |   StdDev |         Op/s | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------- |----------:|---------:|---------:|-------------:|------:|--------:|------:|------:|------:|----------:|
|   PlaintextTechEmpower |  76.55 ns | 0.554 ns | 0.518 ns | 13,062,710.7 |  1.00 |    0.00 |     - |     - |     - |         - |
|        JsonTechEmpower |  83.28 ns | 0.534 ns | 0.500 ns | 12,007,535.9 |  1.09 |    0.01 |     - |     - |     - |         - |
|             LiveAspNet | 142.14 ns | 1.106 ns | 1.034 ns |  7,035,509.7 |  1.86 |    0.02 |     - |     - |     - |         - |
|                Unicode | 196.96 ns | 0.784 ns | 0.655 ns |  5,077,196.0 |  2.57 |    0.02 |     - |     - |     - |         - |
| MultispanUnicodeHeader | 307.96 ns | 1.276 ns | 1.131 ns |  3,247,125.9 |  4.02 |    0.03 |     - |     - |     - |         - |

Also ran a more micro benchmark to show the difference between just the changed code:
| Method     | Path Length | Mean      | Error     | StdDev    |
|----------- |------ |----------:|----------:|----------:|
| Main | 1     |  1.802 ns | 0.0131 ns | 0.0122 ns |
| PR     | 1     |  4.484 ns | 0.0387 ns | 0.0324 ns |
| Main | 5     |  4.890 ns | 0.0185 ns | 0.0164 ns |
| PR     | 5     |  5.818 ns | 0.0234 ns | 0.0219 ns |
| Main | 10     |  9.653 ns | 0.0382 ns | 0.0319 ns |
| PR     | 10     |  4.477 ns | 0.0213 ns | 0.0199 ns |
| Main | 26     | 24.156 ns | 0.0398 ns | 0.0311 ns |
| PR     | 26     |  4.478 ns | 0.0120 ns | 0.0100 ns |
| Main | 62     | 58.653 ns | 0.4248 ns | 0.3974 ns |
| PR     | 62     |  8.060 ns | 0.0585 ns | 0.0489 ns |