### PR TITLE
Update HubConnection.ts to provide a easier to read order of SignalR params

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/HubConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnection.ts
@@ -994,15 +994,15 @@ export class HubConnection {
         if (nonblocking) {
             if (streamIds.length !== 0) {
                 return {
+                    target: methodName,
                     arguments: args,
                     streamIds,
-                    target: methodName,
                     type: MessageType.Invocation,
                 };
             } else {
                 return {
-                    arguments: args,
                     target: methodName,
+                    arguments: args,
                     type: MessageType.Invocation,
                 };
             }
@@ -1012,17 +1012,17 @@ export class HubConnection {
 
             if (streamIds.length !== 0) {
                 return {
+                    target: methodName,
                     arguments: args,
                     invocationId: invocationId.toString(),
                     streamIds,
-                    target: methodName,
                     type: MessageType.Invocation,
                 };
             } else {
                 return {
+                    target: methodName,
                     arguments: args,
                     invocationId: invocationId.toString(),
-                    target: methodName,
                     type: MessageType.Invocation,
                 };
             }
@@ -1096,17 +1096,17 @@ export class HubConnection {
 
         if (streamIds.length !== 0) {
             return {
+                target: methodName,
                 arguments: args,
                 invocationId: invocationId.toString(),
                 streamIds,
-                target: methodName,
                 type: MessageType.StreamInvocation,
             };
         } else {
             return {
+                target: methodName,
                 arguments: args,
                 invocationId: invocationId.toString(),
-                target: methodName,
                 type: MessageType.StreamInvocation,
             };
         }


### PR DESCRIPTION
# Improved order of the SignalR Message Parameters for Web Clients to improve readability 

This PR changes the order of the SignalR Message to allow being the target field the first in the message.
With changing the order it is not only much more readable during debugging a SignalR Web Client but also follows the
order of the parameters in all messages received by a .Net SignalR server.

Therefore you get consistant requests and response by server and client.


