### PR TITLE
[Component governance] Bump the Azure.Identity dependency

### DIFF
--- a/eng/Dependencies.props
+++ b/eng/Dependencies.props
@@ -176,6 +176,7 @@ and are generated based on the last package release.
 
   <ItemGroup Label="External dependencies" Condition="'$(DotNetBuildFromSource)' != 'true'">
     <LatestPackageReference Include="AngleSharp" />
+    <LatestPackageReference Include="Azure.Identity" />
     <LatestPackageReference Include="BenchmarkDotNet" />
     <LatestPackageReference Include="CommandLineParser" />
     <LatestPackageReference Include="Duende.IdentityServer" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -242,6 +242,7 @@
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension60x64Version>$(MicrosoftAspNetCoreAzureAppServicesSiteExtension60Version)</MicrosoftAspNetCoreAzureAppServicesSiteExtension60x64Version>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension60x86Version>$(MicrosoftAspNetCoreAzureAppServicesSiteExtension60Version)</MicrosoftAspNetCoreAzureAppServicesSiteExtension60x86Version>
     <!-- 3rd party dependencies -->
+    <AzureIdentityVersion>1.10.2</AzureIdentityVersion>
     <AngleSharpVersion>0.9.9</AngleSharpVersion>
     <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
     <CastleCoreVersion>4.2.1</CastleCoreVersion>

--- a/src/Caching/SqlServer/src/Microsoft.Extensions.Caching.SqlServer.csproj
+++ b/src/Caching/SqlServer/src/Microsoft.Extensions.Caching.SqlServer.csproj
@@ -19,6 +19,7 @@
     <Reference Include="Microsoft.Extensions.Caching.Abstractions" />
     <Reference Include="Microsoft.Extensions.Options" />
     <Reference Include="Microsoft.Data.SqlClient" />
+    <Reference Include="Azure.Identity" />
   </ItemGroup>
 
 </Project>

--- a/src/Tools/dotnet-sql-cache/src/dotnet-sql-cache.csproj
+++ b/src/Tools/dotnet-sql-cache/src/dotnet-sql-cache.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.Data.SqlClient" />
+    <Reference Include="Azure.Identity" />
     <Reference Include="System.Private.Uri" />
   </ItemGroup>
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/51498 and https://github.com/dotnet/aspnetcore/pull/51524.

# [Component governance] Bump the Azure.Identity dependency

Bump the version to address a Component Governance warning.

## Description

This is an indirect dependency from Microsoft.Data.SqlClient.  We could wait for [their update](https://github.com/dotnet/SqlClient/pull/2189) to go through and bump that dependency instead.

## Customer Impact

https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-36414

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A