### PR TITLE
[release/8.0] Fix trimming issue affecting Blazor apps with WebAssembly interactivity

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/DefaultWebAssemblyJSRuntime.cs
@@ -105,6 +105,7 @@ internal sealed partial class DefaultWebAssemblyJSRuntime : WebAssemblyJSRuntime
     }
 
     [DynamicDependency(JsonSerialized, typeof(RootComponentOperation))]
+    [DynamicDependency(JsonSerialized, typeof(RootComponentOperationBatch))]
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The correct members will be preserved by the above DynamicDependency")]
     internal static RootComponentOperationBatch DeserializeOperations(string operationsJson)
     {


### PR DESCRIPTION
# [release/8.0] Fix trimming issue affecting Blazor apps with WebAssembly interactivity

Fixes an issue where the Blazor WebAssembly runtime would fail on startup for published Blazor apps utilizing WebAssembly interactivity.

## Description

The problem was caused by the members of `RootComponentOperationBatch` getting trimmed away. This fix explicitly preserves its members to prevent this from happening.

Fixes https://github.com/dotnet/AspNetCore-ManualTests/issues/2420

## Customer Impact

Without this fix, WebAssembly interactivity won't work in any published Blazor Web app.

Today, customers could work around the issue by defining a `<TrimmerRootDescriptor>` in their client project's `.csproj` file. For example:

```csproj
<!-- Client.csproj -->
<ItemGroup>
  <TrimmerRootDescriptor Include="Roots.xml" />
</ItemGroup>
```

```xml
<!-- Roots.xml -->
<linker>
  <assembly fullname="Microsoft.AspNetCore.Components.WebAssembly">
    <type fullname="Microsoft.AspNetCore.Components.RootComponentOperationBatch" preserve="all">
    </type>
  </assembly>
</linker>
```

## Regression?

- [X] Yes
- [ ] No

Regressed from .NET 8 RC2.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The fix does nothing more than mark the members of `RootComponentOperationBatch` to be preserved for JSON serialization.

## Verification

- [X] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A