### PR TITLE
Disable source index build step

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -68,9 +68,10 @@ variables:
     value: true
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-  - name: enableSourceIndex
-    value: true
+# https://github.com/dotnet/aspnetcore/issues/51709
+#- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+- name: enableSourceIndex
+  value: false
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - name: _BuildArgs
     value: /p:TeamName=$(_TeamName)


### PR DESCRIPTION
Current step fails on main builds because of an outdated package version. Tracked by https://github.com/dotnet/aspnetcore/issues/51709