### PR TITLE
[Blazor] Fix warning message for classic initializer being ignored

### DIFF
--- a/src/Components/Web.JS/src/JSInitializers/JSInitializers.ts
+++ b/src/Components/Web.JS/src/JSInitializers/JSInitializers.ts
@@ -92,7 +92,7 @@ export class JSInitializer {
           // Skipping "adjustedPath" initializer.
           jsInitializer.logger?.log(
             LogLevel.Warning,
-            `Initializer '${adjustedPath}' will be ignored because multiple runtimes are available. use 'before(web|webAssembly|server)Start' and 'after(web|webAssembly|server)Started?' instead.)`
+            `Initializer '${adjustedPath}' will be ignored because multiple runtimes are available. Use 'before(Web|WebAssembly|Server)Start' and 'after(Web|WebAssembly|Server)Started' instead.`
           );
         } else if (runLegacyInitializers) {
           return runClassicInitializers(jsInitializer, beforeStart, afterStarted, initializerArguments);


### PR DESCRIPTION
# Fix warning message for classic initializer being ignored

Fixed this message

![before](https://github.com/dotnet/aspnetcore/assets/114938397/c2c63fbf-0272-4324-9cdb-fa4f3fba7d16)

to this:

![after](https://github.com/dotnet/aspnetcore/assets/114938397/4d8119c4-b5b1-4109-b8e4-70d5471f2e5e)


Fixes #51370
