### PR TITLE
Use working directory as relative directory for project file resolution

### DIFF
--- a/src/Tools/dotnet-user-jwts/src/Commands/CreateCommand.cs
+++ b/src/Tools/dotnet-user-jwts/src/Commands/CreateCommand.cs
@@ -109,7 +109,7 @@ internal sealed class CreateCommand
         CommandOption claimsOption)
     {
         var isValid = true;
-        var finder = new MsBuildProjectFinder(projectOption.Value() ?? Directory.GetCurrentDirectory());
+        var finder = new MsBuildProjectFinder(Directory.GetCurrentDirectory());
         var project = finder.FindMsBuildProject(projectOption.Value());
 
         if (project == null)

--- a/src/Tools/dotnet-user-jwts/src/Helpers/DevJwtCliHelpers.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/DevJwtCliHelpers.cs
@@ -27,7 +27,7 @@ internal static class DevJwtCliHelpers
 
     public static bool GetProjectAndSecretsId(string projectPath, IReporter reporter, out string project, out string userSecretsId)
     {
-        var finder = new MsBuildProjectFinder(projectPath ?? Directory.GetCurrentDirectory());
+        var finder = new MsBuildProjectFinder(Directory.GetCurrentDirectory());
         project = finder.FindMsBuildProject(projectPath);
         userSecretsId = null;
         if (project == null)

--- a/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
+++ b/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
@@ -656,6 +656,21 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
         Assert.Contains(Path.Combine(projectPath, project), _console.GetOutput());
     }
 
+    [Fact]
+    public void List_CanHandleRelativePathAsOption()
+    {
+        var projectPath = _fixture.CreateProject();
+        var targetPath = Path.GetRelativePath(Path.GetTempPath(), projectPath);
+        var project = Path.Combine(projectPath, "TestProject.csproj");
+        Directory.SetCurrentDirectory(Path.GetTempPath());
+
+        var app = new Program(_console);
+        app.Run(new[] { "list", "--project", targetPath });
+
+        Assert.DoesNotContain($"The project file '{targetPath}' does not exist.", _console.GetOutput());
+        Assert.Contains(Path.Combine(projectPath, project), _console.GetOutput());
+    }
+
     [ConditionalFact]
     [OSSkipCondition(OperatingSystems.Windows, SkipReason = "UnixFileMode is not supported on Windows.")]
     public void Create_CreatesFileWithUserOnlyUnixFileMode()

--- a/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
+++ b/src/Tools/dotnet-user-jwts/test/UserJwtsTests.cs
@@ -12,23 +12,14 @@ using System.IdentityModel.Tokens.Jwt;
 
 namespace Microsoft.AspNetCore.Authentication.JwtBearer.Tools.Tests;
 
-public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
+public class UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output) : IClassFixture<UserJwtsTestFixture>
 {
-    private readonly TestConsole _console;
-    private readonly UserJwtsTestFixture _fixture;
-    private readonly ITestOutputHelper _testOut;
-
-    public UserJwtsTests(UserJwtsTestFixture fixture, ITestOutputHelper output)
-    {
-        _fixture = fixture;
-        _testOut = output;
-        _console = new TestConsole(output);
-    }
+    private readonly TestConsole _console = new TestConsole(output);
 
     [Fact]
     public void List_NoTokensForNewProject()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "list", "--project", project });
@@ -38,7 +29,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void List_HandlesNoSecretsInProject()
     {
-        var project = Path.Combine(_fixture.CreateProject(false), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(false), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "list", "--project", project });
@@ -49,7 +40,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void Create_CreatesSecretOnNoSecretInproject()
     {
-        var project = Path.Combine(_fixture.CreateProject(false), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(false), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "create", "--project", project });
@@ -62,7 +53,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void Create_WritesGeneratedTokenToDisk()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var appsettings = Path.Combine(Path.GetDirectoryName(project), "appsettings.Development.json");
         var app = new Program(_console);
 
@@ -74,7 +65,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void Create_CanModifyExistingScheme()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var appsettings = Path.Combine(Path.GetDirectoryName(project), "appsettings.Development.json");
         var app = new Program(_console);
 
@@ -93,7 +84,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void Print_ReturnsNothingForMissingToken()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "print", "invalid-id", "--project", project });
@@ -103,7 +94,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void List_ReturnsIdForGeneratedToken()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "create", "--project", project, "--scheme", "MyCustomScheme" });
@@ -117,7 +108,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     public void List_ReturnsIdForGeneratedToken_WithJsonFormat()
     {
         var schemeName = "MyCustomScheme";
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "create", "--project", project, "--scheme", schemeName });
@@ -138,7 +129,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void List_ReturnsEmptyListWhenNoTokens_WithJsonFormat()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "list", "--project", project, "--output", "json" });
@@ -150,7 +141,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void Remove_RemovesGeneratedToken()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var appsettings = Path.Combine(Path.GetDirectoryName(project), "appsettings.Development.json");
         var app = new Program(_console);
 
@@ -168,7 +159,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void Clear_RemovesGeneratedTokens()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var appsettings = Path.Combine(Path.GetDirectoryName(project), "appsettings.Development.json");
         var app = new Program(_console);
 
@@ -186,7 +177,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void Key_CanResetSigningKey()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "create", "--project", project });
@@ -200,9 +191,9 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public async Task Key_CanResetSigningKey_WhenSecretsHasPrepulatedData()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
-        var secretsFilePath = PathHelper.GetSecretsPathFromSecretsId(_fixture.TestSecretsId);
+        var secretsFilePath = PathHelper.GetSecretsPathFromSecretsId(fixture.TestSecretsId);
         await File.WriteAllTextAsync(secretsFilePath,
 @"{
   ""Foo"": {
@@ -228,7 +219,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void Command_ShowsHelpForInvalidCommand()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
 
         var exception = Record.Exception(() => app.Run(new[] { "not-real", "--project", project }));
@@ -240,7 +231,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void CreateCommand_ShowsBasicTokenDetails()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "create", "--project", project });
@@ -254,7 +245,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void CreateCommand_SupportsODateTimeFormats()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "create", "--project", project, "--expires-on", DateTime.Now.AddDays(2).ToString("O") });
@@ -269,7 +260,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void CreateCommand_ShowsCustomizedTokenDetails()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "create", "--project", project, "--scheme", "customScheme" });
@@ -283,7 +274,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void CreateCommand_DisplaysErrorForInvalidExpiresOnCombination()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "create", "--project", project, "--expires-on", DateTime.UtcNow.AddDays(2).ToString("O"), "--valid-for", "2h" });
@@ -296,7 +287,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void PrintCommand_ShowsBasicOptions()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "create", "--project", project });
@@ -315,7 +306,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void PrintCommand_ShowsBasicOptions_WithJsonFormat()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "create", "--project", project });
@@ -335,7 +326,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void PrintCommand_ShowsCustomizedOptions()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "create", "--project", project, "--role", "foobar" });
@@ -356,7 +347,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void PrintComamnd_ShowsAllOptionsWithShowAll()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "create", "--project", project, "--claim", "foo=bar" });
@@ -378,7 +369,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void Create_WithJsonOutput_CanBeSerialized()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "create", "--project", project, "--output", "json" });
@@ -393,7 +384,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void Create_WithTokenOutput_ProducesSingleValue()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "create", "--project", project, "-o", "token" });
@@ -406,7 +397,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void Create_GracefullyHandles_NoLaunchSettings()
     {
-        var projectPath = _fixture.CreateProject();
+        var projectPath = fixture.CreateProject();
         var project = Path.Combine(projectPath, "TestProject.csproj");
         var app = new Program(_console);
         var launchSettingsPath = Path.Combine(projectPath, "Properties", "launchSettings.json");
@@ -422,9 +413,9 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public async Task Create_GracefullyHandles_PrepopulatedSecrets()
     {
-        var projectPath = _fixture.CreateProject();
+        var projectPath = fixture.CreateProject();
         var project = Path.Combine(projectPath, "TestProject.csproj");
-        var secretsFilePath = PathHelper.GetSecretsPathFromSecretsId(_fixture.TestSecretsId);
+        var secretsFilePath = PathHelper.GetSecretsPathFromSecretsId(fixture.TestSecretsId);
         await File.WriteAllTextAsync(secretsFilePath,
 @"{
   ""Foo"": {
@@ -449,7 +440,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void Create_GetsAudiencesFromAllIISAndKestrel()
     {
-        var projectPath = _fixture.CreateProject();
+        var projectPath = fixture.CreateProject();
         var project = Path.Combine(projectPath, "TestProject.csproj");
 
         var app = new Program(_console);
@@ -466,9 +457,9 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public async Task Create_SupportsSettingACustomIssuerAndScheme()
     {
-        var projectPath = _fixture.CreateProject();
+        var projectPath = fixture.CreateProject();
         var project = Path.Combine(projectPath, "TestProject.csproj");
-        var secretsFilePath = PathHelper.GetSecretsPathFromSecretsId(_fixture.TestSecretsId);
+        var secretsFilePath = PathHelper.GetSecretsPathFromSecretsId(fixture.TestSecretsId);
 
         var app = new Program(_console);
         app.Run(new[] { "create", "--project", project, "--issuer", "test-issuer", "--scheme", "test-scheme" });
@@ -487,9 +478,9 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public async Task Create_SupportsSettingMutlipleIssuersAndSingleScheme()
     {
-        var projectPath = _fixture.CreateProject();
+        var projectPath = fixture.CreateProject();
         var project = Path.Combine(projectPath, "TestProject.csproj");
-        var secretsFilePath = PathHelper.GetSecretsPathFromSecretsId(_fixture.TestSecretsId);
+        var secretsFilePath = PathHelper.GetSecretsPathFromSecretsId(fixture.TestSecretsId);
 
         var app = new Program(_console);
         app.Run(new[] { "create", "--project", project, "--issuer", "test-issuer", "--scheme", "test-scheme" });
@@ -509,9 +500,9 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public async Task Create_SupportsSettingSingleIssuerAndMultipleSchemes()
     {
-        var projectPath = _fixture.CreateProject();
+        var projectPath = fixture.CreateProject();
         var project = Path.Combine(projectPath, "TestProject.csproj");
-        var secretsFilePath = PathHelper.GetSecretsPathFromSecretsId(_fixture.TestSecretsId);
+        var secretsFilePath = PathHelper.GetSecretsPathFromSecretsId(fixture.TestSecretsId);
 
         var app = new Program(_console);
         app.Run(new[] { "create", "--project", project, "--issuer", "test-issuer", "--scheme", "test-scheme" });
@@ -534,7 +525,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void Key_CanPrintAndReset_BySchemeAndIssuer()
     {
-        var projectPath = _fixture.CreateProject();
+        var projectPath = fixture.CreateProject();
         var project = Path.Combine(projectPath, "TestProject.csproj");
 
         var app = new Program(_console);
@@ -560,7 +551,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void Key_CanPrintWithBase64()
     {
-        var projectPath = _fixture.CreateProject();
+        var projectPath = fixture.CreateProject();
         var project = Path.Combine(projectPath, "TestProject.csproj");
 
         var app = new Program(_console);
@@ -585,7 +576,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void Create_CanHandleNoProjectOptionProvided()
     {
-        var projectPath = _fixture.CreateProject();
+        var projectPath = fixture.CreateProject();
         Directory.SetCurrentDirectory(projectPath);
 
         var app = new Program(_console);
@@ -647,7 +638,7 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void List_CanHandleProjectOptionAsPath()
     {
-        var projectPath = _fixture.CreateProject();
+        var projectPath = fixture.CreateProject();
         var project = Path.Combine(projectPath, "TestProject.csproj");
 
         var app = new Program(_console);
@@ -659,10 +650,11 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
     [Fact]
     public void List_CanHandleRelativePathAsOption()
     {
-        var projectPath = _fixture.CreateProject();
-        var targetPath = Path.GetRelativePath(Path.GetTempPath(), projectPath);
+        var projectPath = fixture.CreateProject();
+        var tempPath = Path.GetTempPath();
+        var targetPath = Path.GetRelativePath(tempPath, projectPath);
         var project = Path.Combine(projectPath, "TestProject.csproj");
-        Directory.SetCurrentDirectory(Path.GetTempPath());
+        Directory.SetCurrentDirectory(tempPath);
 
         var app = new Program(_console);
         app.Run(new[] { "list", "--project", targetPath });
@@ -671,11 +663,27 @@ public class UserJwtsTests : IClassFixture<UserJwtsTestFixture>
         Assert.Contains(Path.Combine(projectPath, project), _console.GetOutput());
     }
 
+    [Fact]
+    public void Create_CanHandleRelativePathAsOption()
+    {
+        var projectPath = fixture.CreateProject();
+        var tempPath = Path.GetTempPath();
+        var targetPath = Path.GetRelativePath(tempPath, projectPath);
+        var project = Path.Combine(projectPath, "TestProject.csproj");
+        Directory.SetCurrentDirectory(tempPath);
+
+        var app = new Program(_console);
+        app.Run(new[] { "create", "--project", targetPath });
+
+        Assert.DoesNotContain($"The project file '{targetPath}' does not exist.", _console.GetOutput());
+        Assert.Contains("New JWT saved", _console.GetOutput());
+    }
+
     [ConditionalFact]
     [OSSkipCondition(OperatingSystems.Windows, SkipReason = "UnixFileMode is not supported on Windows.")]
     public void Create_CreatesFileWithUserOnlyUnixFileMode()
     {
-        var project = Path.Combine(_fixture.CreateProject(), "TestProject.csproj");
+        var project = Path.Combine(fixture.CreateProject(), "TestProject.csproj");
         var app = new Program(_console);
 
         app.Run(new[] { "create", "--project", project });


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/aspnetcore/issues/46263#issuecomment-1761444762.

Initialize `MsBuildProjectFinder` with current directory to match behavior in `dotnet user-secrets` tool.