### PR TITLE
Backport quarantine of ServerWithOldProtocolVersionClientWithNewProtocolVersionWorksDoesNotAllowStatefulReconnect

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -2834,6 +2834,7 @@ public class HubConnectionTests : FunctionalTestBase
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/51361")]
     public async Task ServerWithOldProtocolVersionClientWithNewProtocolVersionWorksDoesNotAllowStatefulReconnect()
     {
         bool ExpectedErrors(WriteContext writeContext)


### PR DESCRIPTION
Backport the quarantining of ServerWithOldProtocolVersionClientWithNewProtocolVersionWorksDoesNotAllowStatefulReconnect

Originally quarantined in main in https://github.com/dotnet/aspnetcore/pull/51362, but now the same test is failing in `release/8.0` (failing builds: https://dev.azure.com/dnceng-public/public/_build/results?buildId=456729, https://dev.azure.com/dnceng-public/public/_build/results?buildId=438287)