### PR TITLE
Fix duplicate add of items to Compile on Microsoft.Extensions.ApiDescription.Client.targets

### DIFF
--- a/src/Tools/Extensions.ApiDescription.Client/src/build/Microsoft.Extensions.ApiDescription.Client.targets
+++ b/src/Tools/Extensions.ApiDescription.Client/src/build/Microsoft.Extensions.ApiDescription.Client.targets
@@ -118,8 +118,8 @@
           Exclude="@(TypeScriptCompile)"
           Condition="'%(_Files.Extension)' == '.ts' OR '%(_Files.Extension)' == '.tsx'" />
 
-      <Compile Include="@(_Files)"
-          Exclude="@(Compile)"
+      <Compile Include="@(_Files->'%(FullPath)')"
+          Exclude="@(Compile->'%(FullPath)')"
           Condition="'$(DefaultLanguageSourceExtension)' != '.ts' AND '%(_Files.Extension)' == '$(DefaultLanguageSourceExtension)'" />
     </ItemGroup>
 
@@ -138,7 +138,7 @@
       <TypeScriptCompile Include="$(_TypeScriptCompileItemsFromDirectories)" Exclude="@(TypeScriptCompile)" />
 
       <Compile Include="$(_CompileItemsFromDirectories)"
-          Exclude="@(Compile)"
+          Exclude="@(Compile->'%(FullPath)')"
           Condition="'$(DefaultLanguageSourceExtension)' != '.ts'" />
 
       <FileWrites Include="@(_Files);$(_TypeScriptCompileItemsFromDirectories);$(_CompileItemsFromDirectories)"


### PR DESCRIPTION
# Fix duplicate add of items to Compile on [Microsoft.Extensions.ApiDescription.Client.targets](https://github.com/paulomorgado/dotnet-aspnetcore/blob/57de2b412378017c57e38432df313c6180e1993e/src/Tools/Extensions.ApiDescription.Client/src/build/Microsoft.Extensions.ApiDescription.Client.targets)

- [X] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Forces the comparison to be on `FullPath` instead of `Identity`.

## Description

This works for this particular case:

```xml
      <Compile Include="@(_Files)"
          Exclude="@(Compile->'%(FullPath)')"
          Condition="'$(DefaultLanguageSourceExtension)' != '.ts' AND '%(_Files.Extension)' == '$(DefaultLanguageSourceExtension)'" />
```

But, to be on the safe side, I opted for:


```xml
      <Compile Include="@(_Files->'%(FullPath)')"
          Exclude="@(Compile->'%(FullPath)')"
          Condition="'$(DefaultLanguageSourceExtension)' != '.ts' AND '%(_Files.Extension)' == '$(DefaultLanguageSourceExtension)'" />
```

Fixes #51659
