### PR TITLE
SignalR transport has unexpected behaviour about transport when calling withUrl() twice

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnectionBuilder.ts
@@ -138,8 +138,16 @@ export class HubConnectionBuilder {
         } else {
             this.httpConnectionOptions = {
                 ...this.httpConnectionOptions,
-                transport: transportTypeOrOptions,
             };
+
+            if(this.httpConnectionOptions.transport && transportTypeOrOptions) {
+                this.logger?.log(LogLevel.Debug, `Transport option was specified before and will keep its value. If not intended consider explicitly passing optional transportTypeOrOptions`);
+            }
+
+            // If transportTypeOrOptions were specified on first call on withUrl() but not on second time calling it we stick to the old transport options and just change the URL
+            if (transportTypeOrOptions) {
+                this.httpConnectionOptions.transport = transportTypeOrOptions;
+            }
         }
 
         return this;

--- a/src/SignalR/clients/ts/signalr/tests/HubConnectionBuilder.test.ts
+++ b/src/SignalR/clients/ts/signalr/tests/HubConnectionBuilder.test.ts
@@ -425,6 +425,17 @@ describe("HubConnectionBuilder", () => {
 
         expect((connection as any).connection._options._useStatefulReconnect).toBe(true);
     });
+
+    it("Specify withUrl() first with restriction then without should lead to keeping transport option", () => {
+        const connection = createConnectionBuilder()
+            .withUrl("http://example.com", HttpTransportType.LongPolling)
+            .withUrl("http://example.com/2")
+            .withStatefulReconnect()
+            .build();
+
+        expect((connection as any).connection._options._transport).toBe(HttpTransportType.LongPolling);
+        expect((connection as any).connection._options._transport).not.toBe(HttpTransportType.WebSockets);
+    });
 });
 
 class CaptureLogger implements ILogger {


### PR DESCRIPTION
# SignalR transport has unexpected behaviour about transport when calling withUrl() twice

Summary of the changes (Less than 80 chars)

I changed hubConnectionBuilder withUrl transport behaviour to keep its value when withUrl function is called twice

## Description

I propose the following change that prevents unset of transport value when calling withUrl a second time.

In my project I basically do this:
const hubConnectionBuilder = new signalR.HubConnectionBuilder();
const connectionBuilder = hubConnectionBuilder
    .withUrl("http://example.com/1", {transport: HttpTransportType.LongPolling})
    .build();

and at a later point I just want to change the URL so I call:
connectionBuilder.withUrl("http://example.com/2")

For me unexpectedly this changes the transport back to original and tries websockets for http://example.com/2 but websockets are blocked so it fails.

Fixes #{bug number} (in this specific format)

1. withUrl() second parameter ONLY changes transport if specified in the optional parameter
2. a logging of the situation because even in debug logging I did not understand what is going on

I am new here so I don't expect this pullrequest to be flawless or maybe it won't even get accepted because the behaviour is as designed.