### PR TITLE
Fix ambiguous route analyzer false positive with switch

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectAmbiguousRoutes.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectAmbiguousRoutes.cs
@@ -67,24 +67,18 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
 
         while (current != null)
         {
-            if (current.Parent is IBlockOperation blockOperation)
+            if (current.Parent is IBlockOperation or ISwitchCaseOperation)
             {
-                return blockOperation;
+                return current.Parent;
             }
             else if (current.Parent is IConditionalOperation or
                 ICoalesceOperation or
                 IAssignmentOperation or
                 IArgumentOperation or
                 IInvocationOperation or
-                ISwitchCaseOperation)
+                ISwitchExpressionArmOperation)
             {
                 return current;
-            }
-            else if (current.Parent is ISwitchExpressionOperation)
-            {
-                // Switch expression returns builder as a value which could be modified.
-                // Remove from analysis.
-                return null;
             }
 
             current = current.Parent;

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/DetectAmbiguousMappedRoutesTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/DetectAmbiguousMappedRoutesTest.cs
@@ -98,6 +98,51 @@ void Hello() { }
     }
 
     [Fact]
+    public async Task DuplicateRoutes_SwitchStatement_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using System;
+using Microsoft.AspNetCore.Builder;
+var app = WebApplication.Create();
+switch (Random.Shared.Next())
+{
+    case 0:
+        app.MapGet(""/"", () => Hello());
+        return;
+    case 1:
+        app.MapGet(""/"", () => Hello());
+        return;
+}
+void Hello() { }
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task DuplicateRoutes_SwitchExpression_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using System;
+using Microsoft.AspNetCore.Builder;
+var app = WebApplication.Create();
+_ = Random.Shared.Next() switch
+{
+    0 => app.MapGet(""/"", () => Hello()),
+    1 => app.MapGet(""/"", () => Hello()),
+    _ => throw new Exception()
+};
+void Hello() { }
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
     public async Task DuplicateRoutes_NullCoalescing_NoDiagnostics()
     {
         // Arrange


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/51285

The ambiguous route analyzer excludes comparing routes that are in different code paths because there is no way to know which code path is used at runtime.

The current logic doesn't correctly exclude routes in switch statements and expressions. The following will flag the two routes:

```cs
using System;
using Microsoft.AspNetCore.Builder;
var app = WebApplication.Create();
_ = Random.Shared.Next() switch
{
    0 => app.MapGet(""/"", () => Hello()),
    1 => app.MapGet(""/"", () => Hello()),
    _ => throw new Exception()
};
void Hello() { }
```

The fix separates routes in switch statements into different code paths for analysis.