### PR TITLE
Avoid requiring ProblemDetailsService when IExceptionHandler is used

### DIFF
--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddlewareImpl.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddlewareImpl.cs
@@ -188,7 +188,12 @@ internal sealed class ExceptionHandlerMiddlewareImpl
                 }
                 else
                 {
-                    handled = await _problemDetailsService!.TryWriteAsync(new()
+                    if (_problemDetailsService is null)
+                    {
+                        throw new InvalidOperationException(Resources.ExceptionHandlerOptions_NotConfiguredCorrectly);
+                    }
+
+                    handled = await _problemDetailsService.TryWriteAsync(new()
                     {
                         HttpContext = context,
                         AdditionalMetadata = exceptionHandlerFeature.Endpoint?.Metadata,

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddlewareImpl.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddlewareImpl.cs
@@ -48,7 +48,7 @@ internal sealed class ExceptionHandlerMiddlewareImpl
         _metrics = new DiagnosticsMetrics(meterFactory);
         _problemDetailsService = problemDetailsService;
 
-        if (_options.ExceptionHandler == null)
+        if (_options.ExceptionHandler == null && _exceptionHandlers.Length == 0)
         {
             if (_options.ExceptionHandlingPath == null)
             {


### PR DESCRIPTION
Closes https://github.com/dotnet/aspnetcore/issues/51888