### PR TITLE
Allow user to specify antiforgery request token source

### DIFF
--- a/src/Antiforgery/src/AntiforgeryOptions.cs
+++ b/src/Antiforgery/src/AntiforgeryOptions.cs
@@ -81,4 +81,9 @@ public class AntiforgeryOptions
     /// the X-Frame-Options header will not be generated for the response.
     /// </summary>
     public bool SuppressXFrameOptionsHeader { get; set; }
+
+    /// <summary>
+    /// Specifies whether to suppress load of antiforgery token from request body.
+    /// </summary>
+    public bool SuppressReadingTokenFromFormBody { get; set; }
 }

--- a/src/Antiforgery/src/Internal/DefaultAntiforgeryTokenStore.cs
+++ b/src/Antiforgery/src/Internal/DefaultAntiforgeryTokenStore.cs
@@ -48,7 +48,7 @@ internal sealed class DefaultAntiforgeryTokenStore : IAntiforgeryTokenStore
         }
 
         // Fall back to reading form instead
-        if (requestToken.Count == 0 && httpContext.Request.HasFormContentType)
+        if (requestToken.Count == 0 && httpContext.Request.HasFormContentType && !_options.SuppressReadingTokenFromFormBody)
         {
             // Check the content-type before accessing the form collection to make sure
             // we report errors gracefully.

--- a/src/Antiforgery/src/PublicAPI.Unshipped.txt
+++ b/src/Antiforgery/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.AspNetCore.Antiforgery.AntiforgeryOptions.SuppressReadingTokenFromFormBody.get -> bool
+Microsoft.AspNetCore.Antiforgery.AntiforgeryOptions.SuppressReadingTokenFromFormBody.set -> void

--- a/src/Antiforgery/test/DefaultAntiforgeryTokenStoreTest.cs
+++ b/src/Antiforgery/test/DefaultAntiforgeryTokenStoreTest.cs
@@ -123,6 +123,65 @@ public class DefaultAntiforgeryTokenStoreTest
     }
 
     [Fact]
+    public async Task GetRequestTokens_FormTokenDisabled_ReturnsNullToken()
+    {
+        // Arrange
+        var httpContext = GetHttpContext("cookie-name", "cookie-value");
+        httpContext.Request.ContentType = "application/x-www-form-urlencoded";
+        httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>
+            {
+                { "form-field-name", "form-value" },
+            });
+
+        var options = new AntiforgeryOptions
+        {
+            Cookie = { Name = "cookie-name" },
+            FormFieldName = "form-field-name",
+            HeaderName = "header-name",
+            SuppressReadingTokenFromFormBody = true
+        };
+
+        var tokenStore = new DefaultAntiforgeryTokenStore(new TestOptionsManager(options));
+
+        // Act
+        var tokens = await tokenStore.GetRequestTokensAsync(httpContext);
+
+        // Assert
+        Assert.Equal("cookie-value", tokens.CookieToken);
+        Assert.Null(tokens.RequestToken);
+    }
+
+    [Fact]
+    public async Task GetRequestTokens_FormTokenDisabled_ReturnsHeaderToken()
+    {
+        // Arrange
+        var httpContext = GetHttpContext("cookie-name", "cookie-value");
+        httpContext.Request.ContentType = "application/x-www-form-urlencoded";
+        httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>
+            {
+                { "form-field-name", "form-value" },
+            });
+        httpContext.Request.Headers.Add("header-name", "header-value");
+
+        var options = new AntiforgeryOptions
+        {
+            Cookie = { Name = "cookie-name" },
+            FormFieldName = "form-field-name",
+            HeaderName = "header-name",
+            SuppressReadingTokenFromFormBody = true
+        };
+
+        var tokenStore = new DefaultAntiforgeryTokenStore(new TestOptionsManager(options));
+
+        // Act
+        var tokens = await tokenStore.GetRequestTokensAsync(httpContext);
+
+        // Assert
+        Assert.Equal("cookie-value", tokens.CookieToken);
+        Assert.Equal("header-value", tokens.RequestToken);
+    }
+
+    [Fact]
     public async Task GetRequestTokens_NoHeaderToken_FallsBackToFormToken()
     {
         // Arrange


### PR DESCRIPTION
# Allow user to specify antiforgery request token source

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

Currently default antiforgery implementation looks for antiforgery request token in header and when it is not found looks for token in request body (only for form requests).

This PR adds global and endpoint-level option to specify where to look for token. This is especialy useful when you want to prevent default antiforgery from reading request body as it could lead to:
- performance issues on large requests (forms with file uploads)
- request body stream cannot be read twice and will result in failure from custom request parser

Fixes #51912

Note that I've added both global and endpoint-level options. If we decide to keep only one, I will remove second.