### PR TITLE
Override IOQueueCount via env vars

### DIFF
--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketConnectionFactoryOptions.cs
@@ -34,8 +34,9 @@ public class SocketConnectionFactoryOptions
     /// </summary>
     /// <remarks>
     /// Defaults to <see cref="Environment.ProcessorCount" /> rounded down and clamped between 1 and 16.
+    /// Can be overridden via ASPNETCORE_IOQUEUECOUNT environment variable.
     /// </remarks>
-    public int IOQueueCount { get; set; } = Math.Min(Environment.ProcessorCount, 16);
+    public int IOQueueCount { get; set; } = SocketTransportOptions.DefaultIOQueueCount;
 
     /// <summary>
     /// Wait until there is data available to allocate a buffer. Setting this to false can increase throughput at the cost of increased memory usage.

--- a/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
+++ b/src/Servers/Kestrel/Transport.Sockets/src/SocketTransportOptions.cs
@@ -24,13 +24,23 @@ public class SocketTransportOptions
     // Opt-out flag for back compat. Remove in 9.0 (or make public).
     internal bool FinOnError { get; set; } = _finOnError;
 
+    internal static int DefaultIOQueueCount
+    {
+        if (int.TryParse(Environment.GetEnvironmentVariable("ASPNETCORE_IOQUEUECOUNT"), out int count))
+        {
+            return count;
+        }
+        return Math.Min(Environment.ProcessorCount, 16);
+    }
+
     /// <summary>
     /// The number of I/O queues used to process requests. Set to 0 to directly schedule I/O to the ThreadPool.
     /// </summary>
     /// <remarks>
     /// Defaults to <see cref="Environment.ProcessorCount" /> rounded down and clamped between 1 and 16.
+    /// Can be overridden via ASPNETCORE_IOQUEUECOUNT environment variable.
     /// </remarks>
-    public int IOQueueCount { get; set; } = Math.Min(Environment.ProcessorCount, 16);
+    public int IOQueueCount { get; set; } = DefaultIOQueueCount;
 
     /// <summary>
     /// Wait until there is data available to allocate a buffer. Setting this to false can increase throughput at the cost of increased memory usage.


### PR DESCRIPTION
This PR adds ability to change default value for `Socket.IOQueueCount` in Kestrel - this will allow us to easily experiment with the default value on various many-cores system (or with different affinity settings) before we propose a better default here.

E.g. Current RPS on a many-cores arm64 CPU affinitized to 16 cores: 1.2M RPS (Windows)
Same setup with `ASPNETCORE_IOQUEUECOUNT=10`: 1.8M RPS.

cc @sebastienros 