### PR TITLE
[release/8.0] Fix ambiguous route analyzer false positive with switch

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectAmbiguousRoutes.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DetectAmbiguousRoutes.cs
@@ -31,11 +31,11 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
             .Where(u => u.ResolvedOperation != null && !u.MapOperation.RouteUsageModel.UsageContext.HttpMethods.IsDefault)
             .GroupBy(u => new MapOperationGroupKey(u.MapOperation.Builder, u.ResolvedOperation!, u.MapOperation.RouteUsageModel.RoutePattern, u.MapOperation.RouteUsageModel.UsageContext.HttpMethods));
 
-        foreach (var ambigiousGroup in groupedByParent.Where(g => g.Count() >= 2))
+        foreach (var ambiguousGroup in groupedByParent.Where(g => g.Count() >= 2))
         {
-            foreach (var ambigiousMapOperation in ambigiousGroup)
+            foreach (var ambiguousMapOperation in ambiguousGroup)
             {
-                var model = ambigiousMapOperation.MapOperation.RouteUsageModel;
+                var model = ambiguousMapOperation.MapOperation.RouteUsageModel;
 
                 context.ReportDiagnostic(Diagnostic.Create(
                     DiagnosticDescriptors.AmbiguousRouteHandlerRoute,
@@ -67,15 +67,16 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
 
         while (current != null)
         {
-            if (current.Parent is IBlockOperation blockOperation)
+            if (current.Parent is IBlockOperation or ISwitchCaseOperation)
             {
-                return blockOperation;
+                return current.Parent;
             }
             else if (current.Parent is IConditionalOperation or
                 ICoalesceOperation or
                 IAssignmentOperation or
                 IArgumentOperation or
-                IInvocationOperation)
+                IInvocationOperation or
+                ISwitchExpressionArmOperation)
             {
                 return current;
             }

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/DetectAmbiguousMappedRoutesTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/DetectAmbiguousMappedRoutesTest.cs
@@ -98,6 +98,79 @@ void Hello() { }
     }
 
     [Fact]
+    public async Task DuplicateRoutes_SwitchStatement_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using System;
+using Microsoft.AspNetCore.Builder;
+var app = WebApplication.Create();
+switch (Random.Shared.Next())
+{
+    case 0:
+        app.MapGet(""/"", () => Hello());
+        return;
+    case 1:
+        app.MapGet(""/"", () => Hello());
+        return;
+}
+void Hello() { }
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task DuplicateRoutes_InsideSwitchStatement_HasDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using System;
+using Microsoft.AspNetCore.Builder;
+var app = WebApplication.Create();
+switch (Random.Shared.Next())
+{
+    case 0:
+        app.MapGet({|#0:""/""|}, () => Hello());
+        app.MapGet({|#1:""/""|}, () => Hello());
+        return;
+
+}
+void Hello() { }
+";
+
+        var expectedDiagnostics = new[] {
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousRouteHandlerRoute).WithArguments("/").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousRouteHandlerRoute).WithArguments("/").WithLocation(1)
+        };
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source, expectedDiagnostics);
+    }
+
+    [Fact]
+    public async Task DuplicateRoutes_SwitchExpression_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using System;
+using Microsoft.AspNetCore.Builder;
+var app = WebApplication.Create();
+_ = Random.Shared.Next() switch
+{
+    0 => app.MapGet(""/"", () => Hello()),
+    1 => app.MapGet(""/"", () => Hello()),
+    _ => throw new Exception()
+};
+void Hello() { }
+";
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
     public async Task DuplicateRoutes_NullCoalescing_NoDiagnostics()
     {
         // Arrange
@@ -164,6 +237,30 @@ void Hello() { }
 
         // Act & Assert
         await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task DuplicateMapGetRoutes_DuplicatesInsideConditional_NoDiagnostics()
+    {
+        // Arrange
+        var source = @"
+using Microsoft.AspNetCore.Builder;
+var app = WebApplication.Create();
+if (true)
+{
+    app.MapGet({|#0:""/""|}, () => Hello());
+    app.MapGet({|#1:""/""|}, () => Hello());
+}
+void Hello() { }
+";
+
+        var expectedDiagnostics = new[] {
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousRouteHandlerRoute).WithArguments("/").WithLocation(0),
+            new DiagnosticResult(DiagnosticDescriptors.AmbiguousRouteHandlerRoute).WithArguments("/").WithLocation(1)
+        };
+
+        // Act & Assert
+        await VerifyCS.VerifyAnalyzerAsync(source, expectedDiagnostics);
     }
 
     [Fact]


### PR DESCRIPTION
# [release/8.0] Fix ambiguous route analyzer false positive with switch

The ambiguous route analyzer excludes comparing routes that are in different code paths because there is no way to know which code path is used at runtime.

The current logic doesn't correctly exclude routes in switch statements and expressions. The following will flag the two routes:

```cs
using System;
using Microsoft.AspNetCore.Builder;
var app = WebApplication.Create();
_ = Random.Shared.Next() switch
{
    0 => app.MapGet(""/"", () => Hello()),
    1 => app.MapGet(""/"", () => Hello()),
    _ => throw new Exception()
};
void Hello() { }
```

The fix separates routes in switch statements into different code paths for analysis.

Fixes https://github.com/dotnet/aspnetcore/issues/51285

## Customer Impact

Without this fix, ASP.NET Core apps could get false positive warnings about duplicate routes.

Customers can workaround the bad warnings by disabling the analyzer.

## Regression?

- [ ] Yes
- [X] No

## Risk

- [ ] High
- [ ] Medium
- [X] Low

Fix is to an analyzer. No runtime impact.

## Verification

- [X] Manual (required)
- [X] Automated

Before:

![image](https://github.com/dotnet/aspnetcore/assets/303201/d0bcc6f7-f11e-43b8-ba1a-581607502ee6)

After:

![image](https://github.com/dotnet/aspnetcore/assets/303201/75997846-b6e9-4559-818b-34829360f8b8)

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A
