### PR TITLE
[release/8.0] Pass dotnetEfVersion in Helix test runner

### DIFF
--- a/eng/helix/content/runtests.cmd
+++ b/eng/helix/content/runtests.cmd
@@ -9,6 +9,7 @@ set $arch=%4
 set $quarantined=%5
 set $helixTimeout=%6
 set $installPlaywright=%7
+set $dotnetEfVersion=%8
 REM Batch only supports up to 9 arguments using the %# syntax, need to shift to get more
 
 set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
@@ -24,8 +25,8 @@ echo.
 
 set exit_code=0
 
-echo "Running tests: dotnet %HELIX_CORRELATION_PAYLOAD%/HelixTestRunner/HelixTestRunner.dll --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --helixTimeout %$helixTimeout% --playwright %$installPlaywright%"
-dotnet %HELIX_CORRELATION_PAYLOAD%/HelixTestRunner/HelixTestRunner.dll --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --helixTimeout %$helixTimeout% --playwright %$installPlaywright%
+echo "Running tests: dotnet %HELIX_CORRELATION_PAYLOAD%/HelixTestRunner/HelixTestRunner.dll --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --helixTimeout %$helixTimeout% --playwright %$installPlaywright% --dotnetEf %$dotnetEfVersion%"
+dotnet %HELIX_CORRELATION_PAYLOAD%/HelixTestRunner/HelixTestRunner.dll --target %$target% --runtime %$aspRuntimeVersion% --queue %$queue% --arch %$arch% --quarantined %$quarantined% --helixTimeout %$helixTimeout% --playwright %$installPlaywright% --dotnetEf %$dotnetEfVersion%
 if not errorlevel 0 (
     set exit_code=%errorlevel%
 )

--- a/eng/helix/content/runtests.sh
+++ b/eng/helix/content/runtests.sh
@@ -78,8 +78,8 @@ sync
 
 exit_code=0
 
-echo "Running tests: dotnet $HELIX_CORRELATION_PAYLOAD/HelixTestRunner/HelixTestRunner.dll --target $1 --runtime $2 --queue $helixQueue --arch $4 --quarantined $5 --helixTimeout $6 --playwright $installPlaywright"
-dotnet $HELIX_CORRELATION_PAYLOAD/HelixTestRunner/HelixTestRunner.dll --target $1 --runtime $2 --queue $helixQueue --arch $4 --quarantined $5 --helixTimeout $6 --playwright $installPlaywright
+echo "Running tests: dotnet $HELIX_CORRELATION_PAYLOAD/HelixTestRunner/HelixTestRunner.dll --target $1 --runtime $2 --queue $helixQueue --arch $4 --quarantined $5 --helixTimeout $6 --playwright $installPlaywright --dotnetEf $8" 
+dotnet $HELIX_CORRELATION_PAYLOAD/HelixTestRunner/HelixTestRunner.dll --target $1 --runtime $2 --queue $helixQueue --arch $4 --quarantined $5 --helixTimeout $6 --playwright $installPlaywright --dotnetEf $8
 exit_code=$?
 echo "Finished tests...exit_code=$exit_code"
 

--- a/eng/targets/Helix.targets
+++ b/eng/targets/Helix.targets
@@ -221,8 +221,8 @@
           When the targeting pack builds, it has exactly the same version as the shared framework. Passing
           SharedFxVersion because that's needed even when the targeting pack isn't building.
         -->
-        <Command Condition="$(IsWindowsHelixQueue)">call runtests.cmd $(TargetFileName) $(SharedFxVersion) $(_HelixFriendlyNameTargetQueue) $(_TestingArchitecture) $(RunQuarantinedTests) $(HelixTimeout) $(TestDependsOnPlaywright)</Command>
-        <Command Condition="!$(IsWindowsHelixQueue)">./runtests.sh $(TargetFileName) $(SharedFxVersion) $(_HelixFriendlyNameTargetQueue) $(_TestingArchitecture) $(RunQuarantinedTests) $(HelixTimeout) $(TestDependsOnPlaywright)</Command>
+        <Command Condition="$(IsWindowsHelixQueue)">call runtests.cmd $(TargetFileName) $(SharedFxVersion) $(_HelixFriendlyNameTargetQueue) $(_TestingArchitecture) $(RunQuarantinedTests) $(HelixTimeout) $(TestDependsOnPlaywright) $(DotnetEfVersion)</Command>
+        <Command Condition="!$(IsWindowsHelixQueue)">./runtests.sh $(TargetFileName) $(SharedFxVersion) $(_HelixFriendlyNameTargetQueue) $(_TestingArchitecture) $(RunQuarantinedTests) $(HelixTimeout) $(TestDependsOnPlaywright) $(DotnetEfVersion)</Command>
         <Command Condition="'$(HelixCommand)' != ''">$(HelixCommand)</Command>
         <Timeout>$(HelixTimeout)</Timeout>
       </HelixWorkItem>

--- a/eng/tools/HelixTestRunner/HelixTestRunnerOptions.cs
+++ b/eng/tools/HelixTestRunner/HelixTestRunnerOptions.cs
@@ -55,11 +55,17 @@ public class HelixTestRunnerOptions
             new Option(
                 aliases: new string[] { "--source" },
                 description: "The restore sources to use during testing")
-            { Argument = new Argument<string>() { Arity = ArgumentArity.ZeroOrMore }, Required = true }
+            { Argument = new Argument<string>() { Arity = ArgumentArity.ZeroOrMore }, Required = true },
+
+            new Option(
+                aliases: new string[] { "--dotnetEf" },
+                description: "The version of the dotnet-ef tool being installed and used")
+            { Argument = new Argument<string>(), Required = true }
         };
 
         var parseResult = command.Parse(args);
         var sharedFxVersion = parseResult.ValueForOption<string>("--runtime");
+        var dotnetEfVersion = parseResult.ValueForOption<string>("--dotnetEf");
         var options = new HelixTestRunnerOptions
         {
             Architecture = parseResult.ValueForOption<string>("--arch"),
@@ -67,6 +73,7 @@ public class HelixTestRunnerOptions
             InstallPlaywright = parseResult.ValueForOption<bool>("--playwright"),
             Quarantined = parseResult.ValueForOption<bool>("--quarantined"),
             RuntimeVersion = sharedFxVersion,
+            DotnetEfVersion = dotnetEfVersion,
             Target = parseResult.ValueForOption<string>("--target"),
             Timeout = TimeSpan.Parse(parseResult.ValueForOption<string>("--helixTimeout"), CultureInfo.InvariantCulture),
 
@@ -87,6 +94,7 @@ public class HelixTestRunnerOptions
     public bool InstallPlaywright { get; private set; }
     public bool Quarantined { get; private set; }
     public string RuntimeVersion { get; private set; }
+    public string DotnetEfVersion { get; private set; }
     public string Target { get; private set; }
     public TimeSpan Timeout { get; private set; }
 

--- a/eng/tools/HelixTestRunner/TestRunner.cs
+++ b/eng/tools/HelixTestRunner/TestRunner.cs
@@ -140,7 +140,7 @@ public class TestRunner
                 cancellationToken: new CancellationTokenSource(TimeSpan.FromMinutes(2)).Token);
 
             await ProcessUtil.RunAsync($"{Options.DotnetRoot}/dotnet",
-                $"tool install dotnet-ef --tool-path {Options.HELIX_WORKITEM_ROOT} --add-source {correlationPayload}",
+                $"tool install dotnet-ef --tool-path {Options.HELIX_WORKITEM_ROOT} --add-source {correlationPayload} --version {Options.DotnetEfVersion}",
                 environmentVariables: EnvironmentVariables,
                 outputDataReceived: ProcessUtil.PrintMessage,
                 errorDataReceived: ProcessUtil.PrintErrorMessage,


### PR DESCRIPTION
Port of a test fix from 7.0. Without this, the Helix Test Runner downloads the latest stable dotnet-ef from nuget.org, so once 9.0 ships, 8.0 tests using dotnet-ef will fail.