### PR TITLE
Fallback to ArrayPool in Kestrel

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -742,6 +742,8 @@ internal class Http1OutputProducer : IHttpOutputProducer, IDisposable
         }
         else if (sizeHint <= MemoryPool<byte>.Shared.MaxBufferSize)
         {
+            // fallback to ArrayPool instead of the passed in memory pool (default is PinnedBlockMemoryPool)
+            // PinnedBlockMemoryPool currently defaults to a low (4k) max buffer size while ArrayPool is 2G
             var owner = MemoryPool<byte>.Shared.Rent(sizeHint);
             _currentSegment = owner.Memory;
             _currentSegmentOwner = owner;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -740,6 +740,12 @@ internal class Http1OutputProducer : IHttpOutputProducer, IDisposable
             _currentSegment = owner.Memory;
             _currentSegmentOwner = owner;
         }
+        else if (sizeHint <= MemoryPool<byte>.Shared.MaxBufferSize)
+        {
+            var owner = MemoryPool<byte>.Shared.Rent(sizeHint);
+            _currentSegment = owner.Memory;
+            _currentSegmentOwner = owner;
+        }
         else
         {
             _currentSegment = new byte[sizeHint];

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ChunkedResponseTests.cs
@@ -1042,7 +1042,7 @@ public class ChunkedResponseTests : LoggedTest
             Assert.Equal(4096, memory.Length);
 
             memory = response.BodyWriter.GetMemory(1000000);
-            Assert.Equal(1000000, memory.Length);
+            Assert.True(memory.Length >= 1000000);
             await Task.CompletedTask;
         }, testContext))
         {


### PR DESCRIPTION
Shows improvements when writing large Json payloads.
e.g.
Scenario: Modified https://github.com/aspnet/Benchmarks/blob/a10414a273ec5aa5d1482134499f366093c560ba/src/Benchmarks/Middleware/JsonMiddleware.cs#L37 with a 400k json string
RPS: 4.3k -> 10.5k with Kestrel ArrayPool addition
Allocation rate: 5 Billion B/sec -> 568 Million B/sec