### PR TITLE
Unquarantine HttpClientHttp2InteropTests

### DIFF
--- a/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
+++ b/src/Servers/Kestrel/test/Interop.FunctionalTests/HttpClientHttp2InteropTests.cs
@@ -68,7 +68,6 @@ public class HttpClientHttp2InteropTests : LoggedTest
     }
 
     [Theory]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/37943")]
     [MemberData(nameof(SupportedSchemes))]
     public async Task Echo(string scheme)
     {
@@ -99,7 +98,6 @@ public class HttpClientHttp2InteropTests : LoggedTest
 
     // Concurrency testing
     [Theory]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/37943")]
     [MemberData(nameof(SupportedSchemes))]
     public async Task MultiplexGet(string scheme)
     {
@@ -147,7 +145,6 @@ public class HttpClientHttp2InteropTests : LoggedTest
     }
 
     // Concurrency testing
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/38087")]
     [Theory]
     [MemberData(nameof(SupportedSchemes))]
     public async Task MultiplexEcho(string scheme)
@@ -1311,7 +1308,6 @@ public class HttpClientHttp2InteropTests : LoggedTest
 
     [Theory]
     [MemberData(nameof(SupportedSchemes))]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/41363")]
     public async Task Settings_MaxFrameSize_Larger_Server(string scheme)
     {
         var hostBuilder = new HostBuilder()


### PR DESCRIPTION
The H2 impl has been revised since these were quarantined and they're passing now.

Fixes #37943
Fixes #38087
Fixes #41363