### PR TITLE
Stop retrying entire HTTP/3 test classes

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -6,8 +6,6 @@
     {"testName": {"contains": "FlakyTestToEnsureRetryWorks" }},
     {"testName": {"contains": "ConfigureEndpointDevelopmentCertificateGetsLoadedWhenPresent" }},
     {"testName": {"contains": "MaxRequestBufferSizeTests.LargeUpload" }},
-    {"testName": {"contains": "Http3RequestTests"}},
-    {"testName": {"contains": "Http3TlsTests"}},
     {"testName": {"contains": "StreamPool_StreamAbortedOnClientAndServer_NotPooled"}},
     {"testName": {"contains": "TraceIdentifierIsUnique"}},
     {"testName": {"contains": "LocationChangingHandlers_CannotCancelTheNavigationAsynchronously_UntilReturning"}},


### PR DESCRIPTION
Hopefully msquic has stabilized by now.  If not, it would be nice to have retries for individual tests so we know which need work.  (Plus, we shouldn't automatically retry newly added tests.)