### PR TITLE
Don't explicitly retry WebConfigAppendsHostingStartup_OutOfProcess

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -12,7 +12,6 @@
     {"testName": {"contains": "TraceIdentifierIsUnique"}},
     {"testName": {"contains": "LocationChangingHandlers_CannotCancelTheNavigationAsynchronously_UntilReturning"}},
     {"testName": {"contains": "ClientAbortingConnectionImmediatelyIsNotLoggedHigherThanDebug"}},
-    {"testName": {"contains": "WebConfigAppendsHostingStartup_OutOfProcess"}},
     {"testName": {"contains": "HttpsConnectionClosedWhenResponseDoesNotSatisfyMinimumDataRate"}},
     {"testName": {"contains": "BidirectionalStream_ServerReadsDataAndCompletes_GracefullyClosed"}},
     {"testName": {"contains": "POST_ServerAbort_ClientReceivesAbort"}},


### PR DESCRIPTION
It's in Microsoft.AspNetCore.Server.IIS, which is covered by an assembly-level rule below.