### PR TITLE
No longer retry ClientAbortingConnectionImmediatelyIsNotLoggedHigherThanDebug

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -11,7 +11,6 @@
     {"testName": {"contains": "StreamPool_StreamAbortedOnClientAndServer_NotPooled"}},
     {"testName": {"contains": "TraceIdentifierIsUnique"}},
     {"testName": {"contains": "LocationChangingHandlers_CannotCancelTheNavigationAsynchronously_UntilReturning"}},
-    {"testName": {"contains": "ClientAbortingConnectionImmediatelyIsNotLoggedHigherThanDebug"}},
     {"testName": {"contains": "HttpsConnectionClosedWhenResponseDoesNotSatisfyMinimumDataRate"}},
     {"testName": {"contains": "BidirectionalStream_ServerReadsDataAndCompletes_GracefullyClosed"}},
     {"testName": {"contains": "POST_ServerAbort_ClientReceivesAbort"}},


### PR DESCRIPTION
Eighteen months ago, it was failing to close connections cleanly (#41850).  Let's determine whether that's still the case so we can fix it if it is.  The test code looks straightforward (other than checking for the non-existence of a log message), so it could be a product issue.