### PR TITLE
Make custom ApplicationName work for hosting and user secrets

### DIFF
--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -275,14 +275,12 @@ public sealed class WebApplicationBuilder : IHostApplicationBuilder
 
         if (env.IsDevelopment() && env.ApplicationName is { Length: > 0 })
         {
-            try
+            var appAssembly = GetAppAssembly(env.ApplicationName);
+
+            // If the assembly cannot be found, so just skip it.
+            if (appAssembly is not null)
             {
-                var appAssembly = Assembly.GetEntryAssembly() ?? Assembly.Load(new AssemblyName(env.ApplicationName));
                 configuration.AddUserSecrets(appAssembly, optional: true, reloadOnChange: reloadOnChange);
-            }
-            catch (FileNotFoundException)
-            {
-                // The assembly cannot be found, so just skip it.
             }
         }
 
@@ -305,6 +303,18 @@ public sealed class WebApplicationBuilder : IHostApplicationBuilder
                 }
             }
             return result;
+        }
+
+        static Assembly? GetAppAssembly(string applicationName)
+        {
+            try
+            {
+                return Assembly.Load(new AssemblyName(applicationName));
+            }
+            catch
+            {
+                return Assembly.GetEntryAssembly();
+            }
         }
     }
 

--- a/src/DefaultBuilder/src/WebApplicationBuilder.cs
+++ b/src/DefaultBuilder/src/WebApplicationBuilder.cs
@@ -277,7 +277,7 @@ public sealed class WebApplicationBuilder : IHostApplicationBuilder
         {
             try
             {
-                var appAssembly = Assembly.Load(new AssemblyName(env.ApplicationName));
+                var appAssembly = Assembly.GetEntryAssembly() ?? Assembly.Load(new AssemblyName(env.ApplicationName));
                 configuration.AddUserSecrets(appAssembly, optional: true, reloadOnChange: reloadOnChange);
             }
             catch (FileNotFoundException)

--- a/src/Hosting/Hosting/test/WebHostBuilderTests.cs
+++ b/src/Hosting/Hosting/test/WebHostBuilderTests.cs
@@ -803,6 +803,24 @@ public class WebHostBuilderTests
 
     [Theory]
     [MemberData(nameof(DefaultWebHostBuilders))]
+    public void CustomApplicationName(IWebHostBuilder builder)
+    {
+        const string AppName = "MyApp";
+
+        using (var host = builder
+            .UseServer(new TestServer())
+            .UseStartup<Startup>()
+            .UseSetting(WebHostDefaults.ApplicationKey, AppName)
+            .Build())
+        {
+            var hostingEnv = host.Services.GetService<IHostEnvironment>();
+
+            Assert.Equal(AppName, hostingEnv.ApplicationName);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(DefaultWebHostBuilders))]
     public void Configure_SupportsNonStaticMethodDelegate(IWebHostBuilder builder)
     {
         using (var host = builder

--- a/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
+++ b/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Linq;
+using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -76,7 +77,7 @@ public static class MvcCoreServiceCollectionExtensions
         {
             manager = new ApplicationPartManager();
 
-            var entryAssemblyName = environment?.ApplicationName;
+            var entryAssemblyName = GetEntryAssemblyName(environment);
             if (string.IsNullOrEmpty(entryAssemblyName))
             {
                 return manager;
@@ -86,6 +87,24 @@ public static class MvcCoreServiceCollectionExtensions
         }
 
         return manager;
+
+        static string? GetEntryAssemblyName(IWebHostEnvironment? environment)
+        {
+            if (environment is null)
+            {
+                return null;
+            }
+
+            try
+            {
+                _ = Assembly.Load(new AssemblyName(environment.ApplicationName));
+                return environment.ApplicationName;
+            }
+            catch
+            {
+                return Assembly.GetEntryAssembly()?.GetName().Name;
+            }
+        }
     }
 
     private static T? GetServiceFromCollection<T>(IServiceCollection services)

--- a/src/Mvc/test/Mvc.FunctionalTests/SimpleWithWebApplicationBuilderTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/SimpleWithWebApplicationBuilderTests.cs
@@ -147,6 +147,19 @@ public class SimpleWithWebApplicationBuilderTests : IClassFixture<MvcTestFixture
     }
 
     [Fact]
+    public async Task DefaultApplicationName_Is_Name_Of_EntryAssembly()
+    {
+        // Arrange
+        var expected = typeof(SimpleWebSiteWithWebApplicationBuilder.Program).Assembly.GetName().Name;
+
+        // Act
+        var content = await Client.GetStringAsync("http://localhost/appname");
+
+        // Assert
+        Assert.Equal(expected, content);
+    }
+
+    [Fact]
     public async Task Configuration_Can_Be_Overridden()
     {
         // Arrange
@@ -187,6 +200,25 @@ public class SimpleWithWebApplicationBuilderTests : IClassFixture<MvcTestFixture
 
         // Act
         var content = await client.GetStringAsync("http://localhost/environment");
+
+        // Assert
+        Assert.Equal(expected, content);
+    }
+
+    [Fact]
+    public async Task ApplicationName_Can_Be_Overridden()
+    {
+        // Arrange
+        var fixture = _fixture.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting(WebHostDefaults.ApplicationKey, "MyApp");
+        });
+
+        var expected = "MyApp";
+        using var client = fixture.CreateDefaultClient();
+
+        // Act
+        var content = await client.GetStringAsync("http://localhost/appname");
 
         // Assert
         Assert.Equal(expected, content);

--- a/src/Mvc/test/WebSites/SimpleWebSiteWithWebApplicationBuilder/Program.cs
+++ b/src/Mvc/test/WebSites/SimpleWebSiteWithWebApplicationBuilder/Program.cs
@@ -39,6 +39,7 @@ app.MapGet("/many-results", (int id) =>
 
 app.MapGet("/problem", () => Results.Problem("Some problem"));
 
+app.MapGet("/appname", (IHostEnvironment environment) => environment.ApplicationName);
 app.MapGet("/environment", (IHostEnvironment environment) => environment.EnvironmentName);
 app.MapGet("/webroot", (IWebHostEnvironment environment) => environment.WebRootPath);
 


### PR DESCRIPTION
# Make custom ApplicationName work for hosting and user secrets

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Summary of the changes (Less than 80 chars)

Allow configuring a custom ApplicationName w/o crash of the host

## Description

For startup assemblies and user secrets the assembly is loaded by `IHostEnvironment.ApplicationName`. 
If that app name isn't the default one, which is constructed from the entry assembly, then those assemblies may not exist and startup crashes.

This change probes if that assembly actually can be loaded, if so use it, otherwise fallback to the entry assembly.

Fixes #52152

Note: in my local setup I'm unable to build the functional tests, they hang. But I'm quite sure this has to do with my local setup, thus I'll let CI decide if it's good or not.