### PR TITLE
#52325 - Add configurable SpaBuilder regex

### DIFF
--- a/src/Middleware/Spa/SpaServices.Extensions/src/AngularCli/AngularCliMiddlewareExtensions.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/AngularCli/AngularCliMiddlewareExtensions.cs
@@ -23,8 +23,7 @@ public static class AngularCliMiddlewareExtensions
     public static void UseAngularCliServer(
         this ISpaBuilder spaBuilder,
         string npmScript,
-        string finishedRegex = "open your browser on (http\\S+)",
-        int finishedRegexCount = 1)
+        Regex[] finishedRegexes = [new Regex("open your browser on (?<openbrowser>http\\S+)")])
     {
         ArgumentNullException.ThrowIfNull(spaBuilder);
 
@@ -35,6 +34,6 @@ public static class AngularCliMiddlewareExtensions
             throw new InvalidOperationException($"To use {nameof(UseAngularCliServer)}, you must supply a non-empty value for the {nameof(SpaOptions.SourcePath)} property of {nameof(SpaOptions)} when calling {nameof(SpaApplicationBuilderExtensions.UseSpa)}.");
         }
 
-        AngularCliMiddleware.Attach(spaBuilder, npmScript, finishedRegex, finishedRegexCount);
+        AngularCliMiddleware.Attach(spaBuilder, npmScript, finishedRegexes);
     }
 }

--- a/src/Middleware/Spa/SpaServices.Extensions/src/AngularCli/AngularCliMiddlewareExtensions.cs
+++ b/src/Middleware/Spa/SpaServices.Extensions/src/AngularCli/AngularCliMiddlewareExtensions.cs
@@ -22,7 +22,9 @@ public static class AngularCliMiddlewareExtensions
     /// <param name="npmScript">The name of the script in your package.json file that launches the Angular CLI process.</param>
     public static void UseAngularCliServer(
         this ISpaBuilder spaBuilder,
-        string npmScript)
+        string npmScript,
+        string finishedRegex = "open your browser on (http\\S+)",
+        int finishedRegexCount = 1)
     {
         ArgumentNullException.ThrowIfNull(spaBuilder);
 
@@ -33,6 +35,6 @@ public static class AngularCliMiddlewareExtensions
             throw new InvalidOperationException($"To use {nameof(UseAngularCliServer)}, you must supply a non-empty value for the {nameof(SpaOptions.SourcePath)} property of {nameof(SpaOptions)} when calling {nameof(SpaApplicationBuilderExtensions.UseSpa)}.");
         }
 
-        AngularCliMiddleware.Attach(spaBuilder, npmScript);
+        AngularCliMiddleware.Attach(spaBuilder, npmScript, finishedRegex, finishedRegexCount);
     }
 }


### PR DESCRIPTION
# Add configurable SpaBuilder regex

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Some versions of angular produce different output to display the spa-project-url, and indicate when the build is finished. Some versions (16 eg) even display the same text (`Build at:`) twice when Universal is setup.

Most generic way of handling these situations is by an array of regexes. I used a named group for flexibility in custom configuration.

## Linked issue

Fixes #52325 
