### PR TITLE
Add HTTP Gone (410) result

### DIFF
--- a/src/Http/Http.Results/src/Gone.cs
+++ b/src/Http/Http.Results/src/Gone.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Http.HttpResults;
+
+/// <summary>
+/// Represents an <see cref="IResult"/> that when executed will
+/// produce an HTTP response with the Gone (410) status code.
+/// </summary>
+public sealed class Gone : IResult, IEndpointMetadataProvider, IStatusCodeHttpResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Gone"/> class.
+    /// </summary>
+    internal Gone()
+    {
+    }
+
+    /// <summary>
+    /// Gets the HTTP status code: <see cref="StatusCodes.Status410Gone"/>
+    /// </summary>
+    public int StatusCode => StatusCodes.Status410Gone;
+
+    int? IStatusCodeHttpResult.StatusCode => StatusCode;
+
+    /// <inheritdoc/>
+    public Task ExecuteAsync(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        // Creating the logger with a string to preserve the category after the refactoring.
+        var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger("Microsoft.AspNetCore.Http.Result.GoneResult");
+
+        HttpResultsHelper.Log.WritingResultAsStatusCode(logger, StatusCode);
+        httpContext.Response.StatusCode = StatusCode;
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    static void IEndpointMetadataProvider.PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(method);
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(StatusCodes.Status410Gone, typeof(void)));
+    }
+}

--- a/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
+++ b/src/Http/Http.Results/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+Microsoft.AspNetCore.Http.HttpResults.Gone
+Microsoft.AspNetCore.Http.HttpResults.Gone.ExecuteAsync(Microsoft.AspNetCore.Http.HttpContext! httpContext) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Http.HttpResults.Gone.StatusCode.get -> int
+static Microsoft.AspNetCore.Http.Results.Gone() -> Microsoft.AspNetCore.Http.IResult!
+static Microsoft.AspNetCore.Http.TypedResults.Gone() -> Microsoft.AspNetCore.Http.HttpResults.Gone!

--- a/src/Http/Http.Results/src/Results.cs
+++ b/src/Http/Http.Results/src/Results.cs
@@ -59,6 +59,12 @@ public static partial class Results
         => TypedResults.Forbid(properties, authenticationSchemes);
 
     /// <summary>
+    /// Produces a <see cref="StatusCodes.Status410Gone"/> response.
+    /// </summary>
+    /// <returns>The created <see cref="IResult"/> for the response.</returns>
+    public static IResult Gone() => TypedResults.Gone();
+
+    /// <summary>
     /// Creates an <see cref="IResult"/> that on execution invokes <see cref="AuthenticationHttpContextExtensions.SignInAsync(HttpContext, string?, ClaimsPrincipal, AuthenticationProperties?)" />.
     /// </summary>
     /// <param name="principal">The <see cref="ClaimsPrincipal"/> containing the user claims.</param>
@@ -767,7 +773,7 @@ public static partial class Results
 
     /// <summary>
     /// Produces a <see cref="StatusCodes.Status201Created"/> response.
-    /// </summary>   
+    /// </summary>
     /// <returns>The created <see cref="IResult"/> for the response.</returns>
     public static IResult Created()
         => TypedResults.Created();

--- a/src/Http/Http.Results/src/ResultsCache.cs
+++ b/src/Http/Http.Results/src/ResultsCache.cs
@@ -14,4 +14,5 @@ internal static partial class ResultsCache
     public static NoContent NoContent { get; } = new();
     public static Ok Ok { get; } = new();
     public static UnprocessableEntity UnprocessableEntity { get; } = new();
+    public static Gone Gone { get; } = new();
 }

--- a/src/Http/Http.Results/src/TypedResults.cs
+++ b/src/Http/Http.Results/src/TypedResults.cs
@@ -59,6 +59,12 @@ public static class TypedResults
         => new(authenticationSchemes: authenticationSchemes ?? Array.Empty<string>(), properties);
 
     /// <summary>
+    /// Produces a <see cref="StatusCodes.Status410Gone"/> response.
+    /// </summary>
+    /// <returns>The created <see cref="HttpResults.Gone"/> for the response.</returns>
+    public static Gone Gone() => ResultsCache.Gone;
+
+    /// <summary>
     /// Creates a <see cref="SignInHttpResult"/> that on execution invokes <see cref="AuthenticationHttpContextExtensions.SignInAsync(HttpContext, string?, ClaimsPrincipal, AuthenticationProperties?)" />.
     /// </summary>
     /// <param name="principal">The <see cref="ClaimsPrincipal"/> containing the user claims.</param>
@@ -837,7 +843,7 @@ public static class TypedResults
 
     /// <summary>
     /// Produces a <see cref="StatusCodes.Status201Created"/> response.
-    /// </summary>   
+    /// </summary>
     /// <returns>The created <see cref="HttpResults.Created"/> for the response.</returns>
     public static Created Created()
     {

--- a/src/Http/Http.Results/test/GoneResultTests.cs
+++ b/src/Http/Http.Results/test/GoneResultTests.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.AspNetCore.Http.HttpResults;
+
+public class GoneResultTests
+{
+    [Fact]
+    public void GoneResult_SetsStatusCodeAndValue()
+    {
+        // Arrange & Act
+        var result = new Gone();
+
+        // Assert
+        Assert.Equal(StatusCodes.Status410Gone, result.StatusCode);
+    }
+
+    [Fact]
+    public async Task GoneResult_ExecuteAsync_SetsStatusCode()
+    {
+        // Arrange
+        var result = new Gone();
+        var httpContext = new DefaultHttpContext()
+        {
+            RequestServices = CreateServices()
+        };
+
+        // Act
+        await result.ExecuteAsync(httpContext);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status410Gone, httpContext.Response.StatusCode);
+    }
+
+    [Fact]
+    public void PopulateMetadata_AddsResponseTypeMetadata()
+    {
+        // Arrange
+        static Gone MyApi() { throw new NotImplementedException(); }
+        var metadata = new List<object>();
+        var builder = new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0);
+
+        // Act
+        PopulateMetadata<Gone>(((Delegate)MyApi).GetMethodInfo(), builder);
+
+        // Assert
+        var producesResponseTypeMetadata = builder.Metadata.OfType<ProducesResponseTypeMetadata>().Last();
+        Assert.Equal(StatusCodes.Status410Gone, producesResponseTypeMetadata.StatusCode);
+        Assert.Equal(typeof(void), producesResponseTypeMetadata.Type);
+    }
+
+    [Fact]
+    public void ExecuteAsync_ThrowsArgumentNullException_WhenHttpContextIsNull()
+    {
+        // Arrange
+        var result = new Gone();
+        HttpContext httpContext = null;
+
+        // Act & Assert
+        Assert.ThrowsAsync<ArgumentNullException>("httpContext", () => result.ExecuteAsync(httpContext));
+    }
+
+    [Fact]
+    public void PopulateMetadata_ThrowsArgumentNullException_WhenMethodOrBuilderAreNull()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>("method", () => PopulateMetadata<Gone>(null, new RouteEndpointBuilder(requestDelegate: null, RoutePatternFactory.Parse("/"), order: 0)));
+        Assert.Throws<ArgumentNullException>("builder", () => PopulateMetadata<Gone>(((Delegate)PopulateMetadata_ThrowsArgumentNullException_WhenMethodOrBuilderAreNull).GetMethodInfo(), null));
+    }
+
+    [Fact]
+    public void GoneResult_Implements_IStatusCodeHttpResult_Correctly()
+    {
+        // Act & Assert
+        var result = Assert.IsAssignableFrom<IStatusCodeHttpResult>(new Gone());
+        Assert.Equal(StatusCodes.Status410Gone, result.StatusCode);
+    }
+
+    private static void PopulateMetadata<TResult>(MethodInfo method, EndpointBuilder builder)
+        where TResult : IEndpointMetadataProvider => TResult.PopulateMetadata(method, builder);
+
+    private static IServiceProvider CreateServices()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory, NullLoggerFactory>();
+        return services.BuildServiceProvider();
+    }
+}

--- a/src/Http/Http.Results/test/ResultsTests.cs
+++ b/src/Http/Http.Results/test/ResultsTests.cs
@@ -666,7 +666,7 @@ public partial class ResultsTests
         //Arrange
         object value = new { };
 
-        // Act        
+        // Act
         var result = Results.Created(default(string), value) as Created<object>;
 
         //Assert
@@ -680,7 +680,7 @@ public partial class ResultsTests
         //Arrange
         object value = new { };
 
-        // Act        
+        // Act
         var result = Results.Created(string.Empty, value) as Created<object>;
 
         //Assert
@@ -694,7 +694,7 @@ public partial class ResultsTests
         //Arrange
         object value = new { };
 
-        // Act       
+        // Act
         var result = Results.Created(default(Uri), value) as Created<object>;
 
         //Assert
@@ -895,7 +895,7 @@ public partial class ResultsTests
         var options = new JsonSerializerOptions();
         var contentType = "application/custom+json";
         var statusCode = StatusCodes.Status208AlreadyReported;
-            
+
         // Act
         var result = Results.Json(data, options, contentType, statusCode) as JsonHttpResult<object>;
 
@@ -1636,6 +1636,7 @@ public partial class ResultsTests
         (() => Results.File(Path.Join(Path.DirectorySeparatorChar.ToString(), "rooted", "path"), null, null, null, null, false), typeof(PhysicalFileHttpResult)),
         (() => Results.File("path", null, null, null, null, false), typeof(VirtualFileHttpResult)),
         (() => Results.Forbid(null, null), typeof(ForbidHttpResult)),
+        (() => Results.Gone(), typeof(Gone)),
         (() => Results.Json(new(), (JsonSerializerOptions)null, null, null), typeof(JsonHttpResult<object>)),
         (() => Results.NoContent(), typeof(NoContent)),
         (() => Results.NotFound(null), typeof(NotFound)),


### PR DESCRIPTION
# Http.Results Gone(410)

## Description

Adds `Gone` (410) to the `Http.Results` Apis allowing for usage with `TypedResults`.
```csharp
app.MapGet("/", () => TypedResults.Gone());
```

This enables narrower return types, and additionally enables AutoGenerated API documentation (Swagger) to show this as a known response code. 

Fixes #52376
