### PR TITLE
Fix handling of null values in received Json messages

### DIFF
--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonSettings.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/GrpcJsonSettings.cs
@@ -16,6 +16,12 @@ public sealed class GrpcJsonSettings
     public bool IgnoreDefaultValues { get; set; }
 
     /// <summary>
+    /// Gets or sets a value that indicates whether fields received with null value will be set.
+    /// Default value is false.
+    /// </summary>
+    public bool IgnoreNullValues { get; set; }
+
+    /// <summary>
     /// Gets or sets a value that indicates whether <see cref="Enum"/> values are written as integers instead of strings.
     /// Default value is false.
     /// </summary>

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/MessageTypeInfoResolver.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/MessageTypeInfoResolver.cs
@@ -115,7 +115,11 @@ internal sealed class MessageTypeInfoResolver : IJsonTypeInfoResolver
         }
         else
         {
-            propertyInfo.Set = GetSetMethod(field);
+            propertyInfo.Set = (o, v) =>
+            {
+                if (v != null || !_context.Settings.IgnoreNullValues)
+                    GetSetMethod(field).Invoke(o, v);
+            };
         }
 
         return propertyInfo;

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/MessageTypeInfoResolver.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/MessageTypeInfoResolver.cs
@@ -118,7 +118,9 @@ internal sealed class MessageTypeInfoResolver : IJsonTypeInfoResolver
             propertyInfo.Set = (o, v) =>
             {
                 if (v != null || !_context.Settings.IgnoreNullValues)
+                {
                     GetSetMethod(field).Invoke(o, v);
+                }
             };
         }
 

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/PublicAPI.Shipped.txt
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/PublicAPI.Shipped.txt
@@ -3,6 +3,8 @@ Microsoft.AspNetCore.Grpc.JsonTranscoding.GrpcJsonSettings
 Microsoft.AspNetCore.Grpc.JsonTranscoding.GrpcJsonSettings.GrpcJsonSettings() -> void
 Microsoft.AspNetCore.Grpc.JsonTranscoding.GrpcJsonSettings.IgnoreDefaultValues.get -> bool
 Microsoft.AspNetCore.Grpc.JsonTranscoding.GrpcJsonSettings.IgnoreDefaultValues.set -> void
+Microsoft.AspNetCore.Grpc.JsonTranscoding.GrpcJsonSettings.IgnoreNullValues.get -> bool
+Microsoft.AspNetCore.Grpc.JsonTranscoding.GrpcJsonSettings.IgnoreNullValues.set -> void
 Microsoft.AspNetCore.Grpc.JsonTranscoding.GrpcJsonSettings.WriteEnumsAsIntegers.get -> bool
 Microsoft.AspNetCore.Grpc.JsonTranscoding.GrpcJsonSettings.WriteEnumsAsIntegers.set -> void
 Microsoft.AspNetCore.Grpc.JsonTranscoding.GrpcJsonSettings.WriteIndented.get -> bool


### PR DESCRIPTION
# Fix handling of null values in received Json messages

Hello!
Here I've added a small check to see whether a field has `null` value in the JSON message that's being received. I've seen that if we do not set the field on a JSON body, it doesn't get set, so I copied the same behavior to the `if`.
I've also added a new setting on `GrpcJsonSettings` class so that one can have more control over it. This can be removed if needed, but I thought (as said on the suggestion made on the linked issue) that it could be more helpful for a developer.

I haven't seen any unit tests for this part, please do reply if it needs any, but seeing that's a simple `if` I didn't think it needed one.

Fixes #51742
