### PR TITLE
Fix deserializing null properties to Protobuf types

### DIFF
--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonConverterHelper.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonConverterHelper.cs
@@ -78,51 +78,46 @@ internal static class JsonConverterHelper
         }
         else
         {
-            return GetFieldTypeCore(descriptor);
-        }   
+            // Return nullable field types so the serializer can successfully deserialize null value.
+            return GetFieldTypeCore(descriptor, nullableType: true);
+        }
     }
 
-    private static Type GetFieldTypeCore(FieldDescriptor descriptor)
+    private static Type GetFieldTypeCore(FieldDescriptor descriptor, bool nullableType = false)
     {
         switch (descriptor.FieldType)
         {
             case FieldType.Bool:
-                return typeof(bool);
+                return nullableType ? typeof(bool?) : typeof(bool);
             case FieldType.Bytes:
                 return typeof(ByteString);
             case FieldType.String:
                 return typeof(string);
             case FieldType.Double:
-                return typeof(double);
+                return nullableType ? typeof(double?) : typeof(double);
             case FieldType.SInt32:
             case FieldType.Int32:
             case FieldType.SFixed32:
-                return typeof(int);
+                return nullableType ? typeof(int?) : typeof(int);
             case FieldType.Enum:
-                return descriptor.EnumType.ClrType;
+                return nullableType ? typeof(Nullable<>).MakeGenericType(descriptor.EnumType.ClrType) : descriptor.EnumType.ClrType;
             case FieldType.Fixed32:
             case FieldType.UInt32:
-                return typeof(uint);
+                return nullableType ? typeof(uint?) : typeof(uint);
             case FieldType.Fixed64:
             case FieldType.UInt64:
-                return typeof(ulong);
+                return nullableType ? typeof(ulong?) : typeof(ulong);
             case FieldType.SFixed64:
             case FieldType.Int64:
             case FieldType.SInt64:
-                return typeof(long);
+                return nullableType ? typeof(long?) : typeof(long);
             case FieldType.Float:
-                return typeof(float);
+                return nullableType ? typeof(float?) : typeof(float);
             case FieldType.Message:
             case FieldType.Group: // Never expect to get this, but...
                 if (ServiceDescriptorHelpers.IsWrapperType(descriptor.MessageType))
                 {
-                    var t = GetFieldType(descriptor.MessageType.Fields[WrapperValueFieldNumber]);
-                    if (t.IsValueType)
-                    {
-                        return typeof(Nullable<>).MakeGenericType(t);
-                    }
-
-                    return t;
+                    return GetFieldType(descriptor.MessageType.Fields[WrapperValueFieldNumber]);
                 }
 
                 return descriptor.MessageType.ClrType;

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/MessageTypeInfoResolver.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/MessageTypeInfoResolver.cs
@@ -135,14 +135,26 @@ internal sealed class MessageTypeInfoResolver : IJsonTypeInfoResolver
                     throw new InvalidOperationException($"Multiple values specified for oneof {field.RealContainingOneof.Name}.");
                 }
 
-                field.Accessor.SetValue((IMessage)o, v);
+                SetFieldValue(field, (IMessage)o, v);
             };
         }
 
         return (o, v) =>
         {
-            field.Accessor.SetValue((IMessage)o, v);
+            SetFieldValue(field, (IMessage)o, v);
         };
+
+        static void SetFieldValue(FieldDescriptor field, IMessage m, object? v)
+        {
+            if (v != null)
+            {
+                field.Accessor.SetValue(m, v);
+            }
+            else
+            {
+                field.Accessor.Clear(m);
+            }
+        }
     }
 
     private static Dictionary<string, FieldDescriptor> CreateJsonFieldMap(IList<FieldDescriptor> fields)

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
@@ -70,6 +70,42 @@ public class JsonConverterReadTests
     }
 
     [Fact]
+    public void ReadNullStringProperty()
+    {
+        var json = @"{
+  ""name"": null
+}";
+
+        AssertReadJson<HelloRequest>(json);
+    }
+
+    [Fact]
+    public void ReadNullIntProperty()
+    {
+        var json = @"{
+  ""age"": null
+}";
+
+        AssertReadJson<HelloRequest>(json);
+    }
+
+    [Fact]
+    public void ReadNullProperties()
+    {
+        var json = @"{
+  ""age"": null,
+  ""nullValue"": null,
+  ""json_customized_name"": null,
+  ""field_name"": null,
+  ""oneof_name1"": null,
+  ""sub"": null,
+  ""timestamp_value"": null
+}";
+
+        AssertReadJson<HelloRequest>(json);
+    }
+
+    [Fact]
     public void RepeatedStrings()
     {
         var json = @"{
@@ -104,6 +140,34 @@ public class JsonConverterReadTests
   ""singleString"": """",
   ""singleBytes"": """",
   ""singleEnum"": ""NESTED_ENUM_UNSPECIFIED""
+}";
+
+        var serviceDescriptorRegistry = new DescriptorRegistry();
+        serviceDescriptorRegistry.RegisterFileDescriptor(JsonTranscodingGreeter.Descriptor.File);
+
+        AssertReadJson<HelloRequest.Types.DataTypes>(json, descriptorRegistry: serviceDescriptorRegistry);
+    }
+
+    [Fact]
+    public void DataTypes_NullValues()
+    {
+        var json = @"{
+  ""singleInt32"": null,
+  ""singleInt64"": null,
+  ""singleUint32"": null,
+  ""singleUint64"": null,
+  ""singleSint32"": null,
+  ""singleSint64"": null,
+  ""singleFixed32"": null,
+  ""singleFixed64"": null,
+  ""singleSfixed32"": null,
+  ""singleSfixed64"": null,
+  ""singleFloat"": null,
+  ""singleDouble"": null,
+  ""singleBool"": null,
+  ""singleString"": null,
+  ""singleBytes"": null,
+  ""singleEnum"": null
 }";
 
         var serviceDescriptorRegistry = new DescriptorRegistry();


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/51742

gRPC JSON transcoding didn't support deserializing null values. The protobuf JSON spec says that parsing null values is supported and the default value should be set.