### PR TITLE
gRPC JSON transcoding — Fixed parsing string values into enum when provided string is not valid enum value

### DIFF
--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/EnumConverter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/EnumConverter.cs
@@ -31,7 +31,7 @@ internal sealed class EnumConverter<TEnum> : SettingsConverterBase<TEnum> where 
                 var valueDescriptor = enumDescriptor.FindValueByName(value);
                 if (valueDescriptor == null)
                 {
-                    throw new InvalidOperationException($"Invalid enum value: {value} for enum type: {typeToConvert}.");
+                    throw new InvalidOperationException(@$"Error converting value ""{ value }"" to enum type {typeToConvert}.");
                 }
 
                 return ConvertFromInteger(valueDescriptor.Number);

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/EnumConverter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/EnumConverter.cs
@@ -31,7 +31,7 @@ internal sealed class EnumConverter<TEnum> : SettingsConverterBase<TEnum> where 
                 var valueDescriptor = enumDescriptor.FindValueByName(value);
                 if (valueDescriptor == null)
                 {
-                    throw new InvalidOperationException(@$"Error converting value ""{ value }"" to enum type {typeToConvert}.");
+                    throw new InvalidOperationException(@$"Error converting value ""{value}"" to enum type {typeToConvert}.");
                 }
 
                 return ConvertFromInteger(valueDescriptor.Number);

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/EnumConverter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/EnumConverter.cs
@@ -26,7 +26,13 @@ internal sealed class EnumConverter<TEnum> : SettingsConverterBase<TEnum> where 
                 {
                     throw new InvalidOperationException($"Unable to resolve descriptor for {typeToConvert}.");
                 }
-                var valueDescriptor = enumDescriptor.FindValueByName(reader.GetString()!);
+
+                var value = reader.GetString()!;
+                var valueDescriptor = enumDescriptor.FindValueByName(value);
+                if (valueDescriptor == null)
+                {
+                    throw new InvalidOperationException($"Invalid enum value: {value} for enum type: {typeToConvert}.");
+                }
 
                 return ConvertFromInteger(valueDescriptor.Number);
             case JsonTokenType.Number:

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
@@ -145,7 +145,7 @@ public class JsonConverterReadTests
 
         var json = @"{ ""singleEnum"": ""INVALID"" }";
 
-        AssertReadJsonError<HelloRequest.Types.DataTypes>(json, ex => Assert.Equal("Invalid enum value: INVALID for enum type: Transcoding.HelloRequest+Types+DataTypes+Types+NestedEnum.", ex.Message), descriptorRegistry: serviceDescriptorRegistry, serializeOld: false);
+        AssertReadJsonError<HelloRequest.Types.DataTypes>(json, ex => Assert.Equal(@"Error converting value ""INVALID"" to enum type Transcoding.HelloRequest+Types+DataTypes+Types+NestedEnum.", ex.Message), descriptorRegistry: serviceDescriptorRegistry, deserializeOld: false);
     }
 
     [Fact]
@@ -564,7 +564,7 @@ public class JsonConverterReadTests
         return objectNew;
     }
 
-    private void AssertReadJsonError<TValue>(string value, Action<Exception> assertException, GrpcJsonSettings? settings = null, DescriptorRegistry? descriptorRegistry = null, bool serializeOld = true) where TValue : IMessage, new()
+    private void AssertReadJsonError<TValue>(string value, Action<Exception> assertException, GrpcJsonSettings? settings = null, DescriptorRegistry? descriptorRegistry = null, bool deserializeOld = true) where TValue : IMessage, new()
     {
         var typeRegistery = TypeRegistry.FromFiles(
             HelloRequest.Descriptor.File,
@@ -577,7 +577,7 @@ public class JsonConverterReadTests
         var ex = Assert.ThrowsAny<Exception>(() => JsonSerializer.Deserialize<TValue>(value, jsonSerializerOptions));
         assertException(ex);
 
-        if (serializeOld)
+        if (deserializeOld)
         {
             var formatter = new JsonParser(new JsonParser.Settings(
                 recursionLimit: int.MaxValue,


### PR DESCRIPTION
# Fixed parsing string values into enum when provided string is not valid enum value

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

NullReferenceException is thrown when string value cannot be converted to gRPC enum value.

## Description

Right now when we provided JSON string value (for example `INVALID`) into gRPC enum like this (I took it from tests)
```grpc
enum NestedEnum {
  NESTED_ENUM_UNSPECIFIED = 0;
  FOO = 1;
  BAR = 2;
  BAZ = 3;
  NEG = -1;  // Intentionally negative.
}
```
We will get `NullReferenceException` in [this line](https://github.com/dotnet/aspnetcore/blob/main/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/EnumConverter.cs#L31) because `valueDescriptor` won't be found.

Not related issue found
