### PR TITLE
Remove InvariantGlobalization in templates

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/WebApi-CSharp.csproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/WebApi-CSharp.csproj.in
@@ -4,7 +4,6 @@
     <TargetFramework>${DefaultNetCoreTargetFramework}</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <InvariantGlobalization>true</InvariantGlobalization>
     <UserSecretsId Condition="'$(IndividualAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'">aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>

--- a/src/ProjectTemplates/Web.ProjectTemplates/WebApi-FSharp.fsproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/WebApi-FSharp.fsproj.in
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>${DefaultNetCoreTargetFramework}</TargetFramework>
-    <InvariantGlobalization>true</InvariantGlobalization>
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
   </PropertyGroup>

--- a/src/ProjectTemplates/Web.ProjectTemplates/Worker-FSharp.fsproj.in
+++ b/src/ProjectTemplates/Web.ProjectTemplates/Worker-FSharp.fsproj.in
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>${DefaultNetCoreTargetFramework}</TargetFramework>
     <UserSecretsId>dotnet-Company.Application1-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>
-    <InvariantGlobalization>true</InvariantGlobalization>
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.Application1</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
These entries were missed in #48238. InvariantGlobalization should only be set when the template is created for native AOT. That is the way it is for the worker and grpc templates already. These templates don't support AOT.

Fix #52319

We should also fix this in 8.0.