### PR TITLE
Fix reading null struct property value in gRPC JSON transcoding

### DIFF
--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonConverterHelper.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonConverterHelper.cs
@@ -141,7 +141,7 @@ internal static class JsonConverterHelper
         var existingValue = (IDictionary)fieldDescriptor.Accessor.GetValue(message);
         foreach (DictionaryEntry item in newValues)
         {
-            existingValue[item.Key] = item.Value ?? Value.ForNull();
+            existingValue[item.Key] = item.Value;
         }
     }
 

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonConverterHelper.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/JsonConverterHelper.cs
@@ -141,7 +141,7 @@ internal static class JsonConverterHelper
         var existingValue = (IDictionary)fieldDescriptor.Accessor.GetValue(message);
         foreach (DictionaryEntry item in newValues)
         {
-            existingValue[item.Key] = item.Value;
+            existingValue[item.Key] = item.Value ?? Value.ForNull();
         }
     }
 

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/ValueConverter.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/Json/ValueConverter.cs
@@ -10,6 +10,8 @@ namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.Json;
 
 internal sealed class ValueConverter<TMessage> : SettingsConverterBase<TMessage> where TMessage : IMessage, new()
 {
+    public override bool HandleNull => true;
+
     public ValueConverter(JsonContext context) : base(context)
     {
     }

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
@@ -129,6 +129,38 @@ public class JsonConverterReadTests
     }
 
     [Fact]
+    public void Value_Null()
+    {
+        var json = "null";
+
+        AssertReadJson<Value>(json);
+    }
+
+    [Fact]
+    public void Value_Integer()
+    {
+        var json = "1";
+
+        AssertReadJson<Value>(json);
+    }
+
+    [Fact]
+    public void Value_String()
+    {
+        var json = @"""string!""";
+
+        AssertReadJson<Value>(json);
+    }
+
+    [Fact]
+    public void Value_Boolean()
+    {
+        var json = "true";
+
+        AssertReadJson<Value>(json);
+    }
+
+    [Fact]
     public void DataTypes_DefaultValues()
     {
         var json = @"{

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterReadTests.cs
@@ -121,6 +121,14 @@ public class JsonConverterReadTests
     }
 
     [Fact]
+    public void Struct_NullProperty()
+    {
+        var json = @"{ ""prop"": null }";
+
+        AssertReadJson<Struct>(json);
+    }
+
+    [Fact]
     public void DataTypes_DefaultValues()
     {
         var json = @"{

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterWriteTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterWriteTests.cs
@@ -335,6 +335,23 @@ public class JsonConverterWriteTests
     }
 
     [Fact]
+    public void Value_Null()
+    {
+        var helloRequest = new HelloRequest
+        {
+            ValueValue = Value.ForStruct(new Struct
+            {
+                Fields =
+                {
+                    ["prop"] = Value.ForNull()
+                }
+            })
+        };
+
+        AssertWrittenJson(helloRequest);
+    }
+
+    [Fact]
     public void Value_Root()
     {
         var value = Value.ForStruct(new Struct

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterWriteTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/ConverterTests/JsonConverterWriteTests.cs
@@ -335,7 +335,7 @@ public class JsonConverterWriteTests
     }
 
     [Fact]
-    public void Value_Null()
+    public void Struct_NullValue()
     {
         var helloRequest = new HelloRequest
         {
@@ -364,6 +364,14 @@ public class JsonConverterWriteTests
                     Value.ForString("value2"))
             }
         });
+
+        AssertWrittenJson(value);
+    }
+
+    [Fact]
+    public void Value_Null()
+    {
+        var value = Value.ForNull();
 
         AssertWrittenJson(value);
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/51521

Reading null struct property values was erroring because a `Struct` requires null `Value`. Fix by converting null reference to a null `Value` by updating the converter to handle null.