### PR TITLE
Fix auto import of proto files when gRPC JSON transcoding is a transitive reference

### DIFF
--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Microsoft.AspNetCore.Grpc.JsonTranscoding.csproj
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Microsoft.AspNetCore.Grpc.JsonTranscoding.csproj
@@ -34,9 +34,12 @@
       <Pack>true</Pack>
       <PackagePath>content</PackagePath>
     </None>
+    <!-- The build file needs to be in build and buildTransitive. -->
+    <!-- buildTransitive is required so the package reference will work when not directly referenced by the web app. -->
+    <!-- See https://github.com/dotnet/aspnetcore/issues/52006 for more details. -->
     <None Include="build\*.targets">
       <Pack>true</Pack>
-      <PackagePath>build</PackagePath>
+      <PackagePath>build;buildTransitive</PackagePath>
     </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/52006

gRPC JSON transcoding has a _Cool Trick_ to bundle proto files in the package and automatically include them in the proto compilation. This uses msbuild that is shipped with in the nuget package.

The msbuild file is in the package's `/build` directory, which means it doesn't run when Microsoft.AspNetCore.Grpc.JsonTranscoding is transitively referenced by the web app. The fix is to also put it in `/buildTransitive`.

The workaround to this issue is to add a direct reference to Microsoft.AspNetCore.Grpc.JsonTranscoding.