### PR TITLE
Handle rejected promises inside incoming Invocation messages

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/HubConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnection.ts
@@ -614,8 +614,10 @@ export class HubConnection {
 
                 switch (message.type) {
                     case MessageType.Invocation:
-                        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                        this._invokeClientMethod(message);
+                        this._invokeClientMethod(message)
+                            .catch((e) => {
+                                this._logger.log(LogLevel.Error, `Invoke client method threw error: ${getErrorString(e)}`)
+                            });
                         break;
                     case MessageType.StreamItem:
                     case MessageType.Completion: {


### PR DESCRIPTION
# Handle rejected promises inside incoming Invocation messages 

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->
## Description
Incoming messages of Invocation type result in executing a clientMethod promise, but promise rejections are unhandled.  This can result in a unhandled rejected promise, potentially resulting in Node.js process crashing. Note, this was previously detected via eslint and suppressed in code. The user-code callback itself is already [covered by a try-catch block](https://github.com/damirault/aspnetcore/blob/64c3630930f14bbf3b585410a81f0bab739d5ba6/src/SignalR/clients/ts/signalr/src/HubConnection.ts#L787), it's the wrapper invocation function and the sending of the response message that can trigger the promise rejection.

To avoid this, catch promise rejections and log the failure.

One scenario this case can happen is, if during the clientMethod call, the server connection is disconnected, the invokation will still attempt to send a completion message (through _sendWithProtocol). This will then result in a promise rejection, such as the following:

```
Cannot send data if the connection is not in the 'Connected' State.
    at HttpConnection.send (node_modules\@microsoft\signalr\dist\cjs\HttpConnection.js:95:35)
    at HubConnection._sendMessage (node_modules\@microsoft\signalr\dist\cjs\HubConnection.js:266:32)
    at HubConnection._sendWithProtocol (node_modules\@microsoft\signalr\dist\cjs\HubConnection.js:273:21)
    at HubConnection._invokeClientMethod (node_modules\@microsoft\signalr\dist\cjs\HubConnection.js:577:24)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Fixes #52524
