### PR TITLE
HeaderDictionaryTypeExtensions not using Dictionary

### DIFF
--- a/src/Http/Http.Extensions/src/HeaderDictionaryTypeExtensions.cs
+++ b/src/Http/Http.Extensions/src/HeaderDictionaryTypeExtensions.cs
@@ -168,51 +168,53 @@ public static class HeaderDictionaryTypeExtensions
     internal static T? Get<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(this IHeaderDictionary headers, string name)
     {
         ArgumentNullException.ThrowIfNull(headers);
-        var value = headers[name];
+        var headerValue = headers[name];
 
-        if (StringValues.IsNullOrEmpty(value))
+        if (StringValues.IsNullOrEmpty(headerValue))
         {
             return default(T);
         }
+        var value = headerValue.ToString();
 
         // Comparison of typeof(T) is optimized by JIT.
         if (typeof(T) == typeof(CacheControlHeaderValue))
         {
-            return (T?)(object?)ParseCacheControlHeaderValue(value.ToString());
+            return (T?)(object?)ParseCacheControlHeaderValue(value);
         }
         else if (typeof(T) == typeof(ContentDispositionHeaderValue))
         {
-            return (T?)(object?)ParseCacheContentDispositionHeaderValue(value.ToString());
+            return (T?)(object?)ParseCacheContentDispositionHeaderValue(value);
         }
         else if (typeof(T) == typeof(ContentRangeHeaderValue))
         {
-            return (T?)(object?)ParseCacheContentRangeHeaderValue(value.ToString());
+            return (T?)(object?)ParseCacheContentRangeHeaderValue(value);
         }
         else if (typeof(T) == typeof(MediaTypeHeaderValue))
         {
-            return (T?)(object?)ParseCacheMediaTypeHeaderValue(value.ToString());
+            return (T?)(object?)ParseCacheMediaTypeHeaderValue(value);
         }
         else if (typeof(T) == typeof(RangeConditionHeaderValue))
         {
-            return (T?)(object?)ParseCacheRangeConditionHeaderValue(value.ToString());
+            return (T?)(object?)ParseCacheRangeConditionHeaderValue(value);
         }
         else if (typeof(T) == typeof(RangeHeaderValue))
         {
-            return (T?)(object?)ParseCacheRangeHeaderValue(value.ToString());
+            return (T?)(object?)ParseCacheRangeHeaderValue(value);
         }
         else if (typeof(T) == typeof(EntityTagHeaderValue))
         {
-            return (T?)(object?)ParseCacheEntityTagHeaderValue(value.ToString());
+            return (T?)(object?)ParseCacheEntityTagHeaderValue(value);
         }
         else if (typeof(T) == typeof(DateTimeOffset?))
         {
-            return (T?)(object?)ParseCacheDateTimeOffset(value.ToString());
+            return (T?)(object?)ParseCacheDateTimeOffset(value);
         }
         else if (typeof(T) == typeof(long?))
         {
-            return (T?)(object?)ParseCacheInt64(value.ToString());
+            return (T?)(object?)ParseCacheInt64(value);
         }
-        return GetViaReflection<T>(value.ToString());
+
+        return GetViaReflection<T>(value);
     }
 
     internal static IList<T> GetList<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(this IHeaderDictionary headers, string name)
@@ -231,6 +233,7 @@ public static class HeaderDictionaryTypeExtensions
             return Array.Empty<T>();
         }
 
+        // Comparison of typeof(T) is optimized by JIT.
         if (typeof(T) == typeof(MediaTypeHeaderValue))
         {
             return (IList<T>)ParseMediaTypeHeaderValue(values);

--- a/src/Http/Http.Extensions/src/HeaderDictionaryTypeExtensions.cs
+++ b/src/Http/Http.Extensions/src/HeaderDictionaryTypeExtensions.cs
@@ -175,49 +175,41 @@ public static class HeaderDictionaryTypeExtensions
             return default(T);
         }
 
-        object? temp = null;
-#pragma warning disable CS8974 // Converting method group to non-delegate type
         if (typeof(T) == typeof(CacheControlHeaderValue))
         {
-            temp = ParseCacheControlHeaderValue;
+            return (T?)(object?)ParseCacheControlHeaderValue(value.ToString());
         }
         else if (typeof(T) == typeof(ContentDispositionHeaderValue))
         {
-            temp = ParseCacheContentDispositionHeaderValue;
+            return (T?)(object?)ParseCacheContentDispositionHeaderValue(value.ToString());
         }
         else if (typeof(T) == typeof(ContentRangeHeaderValue))
         {
-            temp = ParseCacheContentRangeHeaderValue;
+            return (T?)(object?)ParseCacheContentRangeHeaderValue(value.ToString());
         }
         else if (typeof(T) == typeof(MediaTypeHeaderValue))
         {
-            temp = ParseCacheMediaTypeHeaderValue;
+            return (T?)(object?)ParseCacheMediaTypeHeaderValue(value.ToString());
         }
         else if (typeof(T) == typeof(RangeConditionHeaderValue))
         {
-            temp = ParseCacheRangeConditionHeaderValue;
+            return (T?)(object?)ParseCacheRangeConditionHeaderValue(value.ToString());
         }
         else if (typeof(T) == typeof(RangeHeaderValue))
         {
-            temp = ParseCacheRangeHeaderValue;
+            return (T?)(object?)ParseCacheRangeHeaderValue(value.ToString());
         }
         else if (typeof(T) == typeof(EntityTagHeaderValue))
         {
-            temp = ParseCacheEntityTagHeaderValue;
+            return (T?)(object?)ParseCacheEntityTagHeaderValue(value.ToString());
         }
         else if (typeof(T) == typeof(DateTimeOffset?))
         {
-            temp = ParseCacheDateTimeOffset;
+            return (T?)(object?)ParseCacheDateTimeOffset(value.ToString());
         }
         else if (typeof(T) == typeof(long?))
         {
-            temp = ParseCacheInt64;
-        }
-#pragma warning restore CS8974 // Converting method group to non-delegate type
-
-        if (temp is not null)
-        {
-            return ((Func<string, T>)temp)(value.ToString());
+            return (T?)(object?)ParseCacheInt64(value.ToString());
         }
         return GetViaReflection<T>(value.ToString());
     }
@@ -238,34 +230,25 @@ public static class HeaderDictionaryTypeExtensions
             return Array.Empty<T>();
         }
 
-        object? temp = null;
-#pragma warning disable CS8974 // Converting method group to non-delegate type
         if (typeof(T) == typeof(MediaTypeHeaderValue))
         {
-            temp = ParseMediaTypeHeaderValue;
+            return (IList<T>)ParseMediaTypeHeaderValue(values);
         }
         else if (typeof(T) == typeof(StringWithQualityHeaderValue))
         {
-            temp = ParseStringWithQualityHeaderValue;
+            return (IList<T>)ParseStringWithQualityHeaderValue(values);
         }
         else if (typeof(T) == typeof(CookieHeaderValue))
         {
-            temp = ParseCookieHeaderValue;
+            return (IList<T>)ParseCookieHeaderValue(values);
         }
         else if (typeof(T) == typeof(EntityTagHeaderValue))
         {
-            temp = ParseEntityTagHeaderValue;
+            return (IList<T>)ParseEntityTagHeaderValue(values);
         }
         else if (typeof(T) == typeof(SetCookieHeaderValue))
         {
-            temp = ParseSetCookieHeaderValue;
-        }
-#pragma warning restore CS8974 // Converting method group to non-delegate type
-
-        if (temp is not null)
-        {
-            var func = (Func<IList<string>, IList<T>>)temp;
-            return func(values);
+            return (IList<T>)ParseSetCookieHeaderValue(values);
         }
 
         return GetListViaReflection<T>(values);

--- a/src/Http/Http.Extensions/src/HeaderDictionaryTypeExtensions.cs
+++ b/src/Http/Http.Extensions/src/HeaderDictionaryTypeExtensions.cs
@@ -133,69 +133,93 @@ public static class HeaderDictionaryTypeExtensions
     }
 
     private static CacheControlHeaderValue? ParseCacheControlHeaderValue(string value) => CacheControlHeaderValue.TryParse(value, out var result) ? result : null;
+
     private static ContentDispositionHeaderValue? ParseCacheContentDispositionHeaderValue(string value) => ContentDispositionHeaderValue.TryParse(value, out var result) ? result : null;
+
     private static ContentRangeHeaderValue? ParseCacheContentRangeHeaderValue(string value) => ContentRangeHeaderValue.TryParse(value, out var result) ? result : null;
+
     private static MediaTypeHeaderValue? ParseCacheMediaTypeHeaderValue(string value) => MediaTypeHeaderValue.TryParse(value, out var result) ? result : null;
+
     private static RangeConditionHeaderValue? ParseCacheRangeConditionHeaderValue(string value) => RangeConditionHeaderValue.TryParse(value, out var result) ? result : null;
+
     private static RangeHeaderValue? ParseCacheRangeHeaderValue(string value) => RangeHeaderValue.TryParse(value, out var result) ? result : null;
+
     private static EntityTagHeaderValue? ParseCacheEntityTagHeaderValue(string value) => EntityTagHeaderValue.TryParse(value, out var result) ? result : null;
+
     private static DateTimeOffset? ParseCacheDateTimeOffset(string value) => HeaderUtilities.TryParseDate(value, out var result) ? result : null;
+
     private static long? ParseCacheInt64(string value) => HeaderUtilities.TryParseNonNegativeInt64(value, out var result) ? result : null;
 
-    private static readonly Dictionary<Type, object> KnownListParsers = new()
-    {
-        { typeof(MediaTypeHeaderValue), new Func<IList<string>, IList<MediaTypeHeaderValue>>(value => { return MediaTypeHeaderValue.TryParseList(value, out var result) ? result : Array.Empty<MediaTypeHeaderValue>(); }) },
-        { typeof(StringWithQualityHeaderValue), new Func<IList<string>, IList<StringWithQualityHeaderValue>>(value => { return StringWithQualityHeaderValue.TryParseList(value, out var result) ? result : Array.Empty<StringWithQualityHeaderValue>(); }) },
-        { typeof(CookieHeaderValue), new Func<IList<string>, IList<CookieHeaderValue>>(value => { return CookieHeaderValue.TryParseList(value, out var result) ? result : Array.Empty<CookieHeaderValue>(); }) },
-        { typeof(EntityTagHeaderValue), new Func<IList<string>, IList<EntityTagHeaderValue>>(value => { return EntityTagHeaderValue.TryParseList(value, out var result) ? result : Array.Empty<EntityTagHeaderValue>(); }) },
-        { typeof(SetCookieHeaderValue), new Func<IList<string>, IList<SetCookieHeaderValue>>(value => { return SetCookieHeaderValue.TryParseList(value, out var result) ? result : Array.Empty<SetCookieHeaderValue>(); }) },
-    };
+    private static IList<MediaTypeHeaderValue> ParseMediaTypeHeaderValue(IList<string> value) =>
+        MediaTypeHeaderValue.TryParseList(value, out var result) ? result : Array.Empty<MediaTypeHeaderValue>();
+
+    private static IList<StringWithQualityHeaderValue> ParseStringWithQualityHeaderValue(IList<string> value) =>
+        StringWithQualityHeaderValue.TryParseList(value, out var result) ? result : Array.Empty<StringWithQualityHeaderValue>();
+
+    private static IList<CookieHeaderValue> ParseCookieHeaderValue(IList<string> value) =>
+        CookieHeaderValue.TryParseList(value, out var result) ? result : Array.Empty<CookieHeaderValue>();
+
+    private static IList<EntityTagHeaderValue> ParseEntityTagHeaderValue(IList<string> value) =>
+        EntityTagHeaderValue.TryParseList(value, out var result) ? result : Array.Empty<EntityTagHeaderValue>();
+
+    private static IList<SetCookieHeaderValue> ParseSetCookieHeaderValue(IList<string> value) =>
+        SetCookieHeaderValue.TryParseList(value, out var result) ? result : Array.Empty<SetCookieHeaderValue>();
 
     internal static T? Get<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(this IHeaderDictionary headers, string name)
     {
+        ArgumentNullException.ThrowIfNull(headers);
         var value = headers[name];
-        var tn = typeof(T).Name;
+
+        if (StringValues.IsNullOrEmpty(value))
+        {
+            return default(T);
+        }
 
         object? temp = null;
-        switch (tn[0])
-        {
-            case 'C' when typeof(T) == typeof(CacheControlHeaderValue):
 #pragma warning disable CS8974 // Converting method group to non-delegate type
-                temp = ParseCacheControlHeaderValue;
-                break;
-            case 'C' when typeof(T) == typeof(ContentDispositionHeaderValue):
-                temp = ParseCacheContentDispositionHeaderValue;
-                break;
-            case 'C' when typeof(T) == typeof(ContentRangeHeaderValue):
-                temp = ParseCacheContentRangeHeaderValue;
-                break;
-            case 'M' when typeof(T) == typeof(MediaTypeHeaderValue):
-                temp = ParseCacheMediaTypeHeaderValue;
-                break;
-            case 'R' when typeof(T) == typeof(RangeConditionHeaderValue):
-                temp = ParseCacheRangeConditionHeaderValue;
-                break;
-            case 'R' when typeof(T) == typeof(RangeHeaderValue):
-                temp = ParseCacheRangeHeaderValue;
-                break;
-            case 'E' when typeof(T) == typeof(EntityTagHeaderValue):
-                temp = ParseCacheEntityTagHeaderValue;
-                break;
-            case 'N' when typeof(T) == typeof(DateTimeOffset?):
-                temp = ParseCacheDateTimeOffset;
-                break;
-            case 'N' when typeof(T) == typeof(long?):
-                temp = ParseCacheInt64;
-                break;
-#pragma warning restore CS8974 // Converting method group to non-delegate type
+        if (typeof(T) == typeof(CacheControlHeaderValue))
+        {
+            temp = ParseCacheControlHeaderValue;
         }
+        else if (typeof(T) == typeof(ContentDispositionHeaderValue))
+        {
+            temp = ParseCacheContentDispositionHeaderValue;
+        }
+        else if (typeof(T) == typeof(ContentRangeHeaderValue))
+        {
+            temp = ParseCacheContentRangeHeaderValue;
+        }
+        else if (typeof(T) == typeof(MediaTypeHeaderValue))
+        {
+            temp = ParseCacheMediaTypeHeaderValue;
+        }
+        else if (typeof(T) == typeof(RangeConditionHeaderValue))
+        {
+            temp = ParseCacheRangeConditionHeaderValue;
+        }
+        else if (typeof(T) == typeof(RangeHeaderValue))
+        {
+            temp = ParseCacheRangeHeaderValue;
+        }
+        else if (typeof(T) == typeof(EntityTagHeaderValue))
+        {
+            temp = ParseCacheEntityTagHeaderValue;
+        }
+        else if (typeof(T) == typeof(DateTimeOffset?))
+        {
+            temp = ParseCacheDateTimeOffset;
+        }
+        else if (typeof(T) == typeof(long?))
+        {
+            temp = ParseCacheInt64;
+        }
+#pragma warning restore CS8974 // Converting method group to non-delegate type
+
         if (temp is not null)
         {
             return ((Func<string, T>)temp)(value.ToString());
         }
-
-
-        throw new InvalidOperationException();
+        return GetViaReflection<T>(value.ToString());
     }
 
     internal static IList<T> GetList<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(this IHeaderDictionary headers, string name)
@@ -214,7 +238,31 @@ public static class HeaderDictionaryTypeExtensions
             return Array.Empty<T>();
         }
 
-        if (KnownListParsers.TryGetValue(typeof(T), out var temp))
+        object? temp = null;
+#pragma warning disable CS8974 // Converting method group to non-delegate type
+        if (typeof(T) == typeof(MediaTypeHeaderValue))
+        {
+            temp = ParseMediaTypeHeaderValue;
+        }
+        else if (typeof(T) == typeof(StringWithQualityHeaderValue))
+        {
+            temp = ParseStringWithQualityHeaderValue;
+        }
+        else if (typeof(T) == typeof(CookieHeaderValue))
+        {
+            temp = ParseCookieHeaderValue;
+        }
+        else if (typeof(T) == typeof(EntityTagHeaderValue))
+        {
+            temp = ParseEntityTagHeaderValue;
+        }
+        else if (typeof(T) == typeof(SetCookieHeaderValue))
+        {
+            temp = ParseSetCookieHeaderValue;
+        }
+#pragma warning restore CS8974 // Converting method group to non-delegate type
+
+        if (temp is not null)
         {
             var func = (Func<IList<string>, IList<T>>)temp;
             return func(values);

--- a/src/Http/Http.Extensions/src/HeaderDictionaryTypeExtensions.cs
+++ b/src/Http/Http.Extensions/src/HeaderDictionaryTypeExtensions.cs
@@ -175,6 +175,7 @@ public static class HeaderDictionaryTypeExtensions
             return default(T);
         }
 
+        // Comparison of typeof(T) is optimized by JIT.
         if (typeof(T) == typeof(CacheControlHeaderValue))
         {
             return (T?)(object?)ParseCacheControlHeaderValue(value.ToString());

--- a/src/Http/Http.Extensions/test/HeaderDictionaryTypeExtensionsTest.cs
+++ b/src/Http/Http.Extensions/test/HeaderDictionaryTypeExtensionsTest.cs
@@ -41,6 +41,89 @@ public class HeaderDictionaryTypeExtensionsTest
     }
 
     [Fact]
+    public void GetT_CacheControlHeaderValue_Success()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.CacheControl = "max-age=604800";
+
+        var result = context.Request.GetTypedHeaders().Get<CacheControlHeaderValue>(HeaderNames.CacheControl);
+
+        var expected = new CacheControlHeaderValue() { MaxAge = TimeSpan.FromSeconds(604800) };
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetT_ContentDispositionHeaderValue_Success()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.ContentDisposition = "form-data; name=\"fieldName\"";
+
+        var result = context.Request.GetTypedHeaders().Get<ContentDispositionHeaderValue>(HeaderNames.ContentDisposition);
+
+        var expected = new ContentDispositionHeaderValue("form-data") { Name = "\"fieldName\"" };
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetT_RangeConditionHeaderValue_Success()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.IfRange = "\"etag1\"";
+
+        var result = context.Request.GetTypedHeaders().Get<RangeConditionHeaderValue>(HeaderNames.IfRange);
+
+        var expected = new RangeConditionHeaderValue("\"etag1\"");
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetT_RangeHeaderValue_Success()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Range = "bytes=0-499";
+
+        var result = context.Request.GetTypedHeaders().Get<RangeHeaderValue>(HeaderNames.Range);
+
+        var expected = new RangeHeaderValue(0, 499);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetT_EntityTagHeaderValue_Success()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.ETag = "\"123\"";
+
+        var result = context.Request.GetTypedHeaders().Get<EntityTagHeaderValue>(HeaderNames.ETag);
+
+        var expected = new EntityTagHeaderValue("\"123\"");
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetT_DateTimeOffsetHeaderValue_Success()
+    {
+        var context = new DefaultHttpContext();
+        var expected = new DateTimeOffset(2023, 12, 04, 7, 28, 00, TimeSpan.Zero);
+        context.Request.Headers.ETag = expected.ToString("r");
+
+        var result = context.Request.GetTypedHeaders().Get<DateTimeOffset?>(HeaderNames.ETag);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetT_LongHeaderValue_Success()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.ETag = $"{int.MaxValue + 1L}";
+
+        var result = context.Request.GetTypedHeaders().Get<long?>(HeaderNames.ETag);
+
+        Assert.Equal(int.MaxValue + 1L, result);
+    }
+
+    [Fact]
     public void GetT_UnknownTypeWithTryParseAndValidValue_Success()
     {
         var context = new DefaultHttpContext();
@@ -113,6 +196,54 @@ public class HeaderDictionaryTypeExtensionsTest
         var result = context.Request.GetTypedHeaders().GetList<MediaTypeHeaderValue>(HeaderNames.Accept);
 
         Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GetListT_StringWithQualityHeaderValidValue_Success()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Accept = "text/plain; q=0.5, text/html; q=0.8";
+
+        var result = context.Request.GetTypedHeaders().GetList<StringWithQualityHeaderValue>(HeaderNames.Accept);
+
+        List<StringWithQualityHeaderValue> expected = [new("plain", 0.5), new("html", 0.8)];
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetListT_CookieHeaderValue_Success()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Cookie = "cookie1=a,cookie2=b";
+
+        var result = context.Request.GetTypedHeaders().GetList<CookieHeaderValue>(HeaderNames.Cookie);
+
+        List<CookieHeaderValue> expected = [new("cookie1", "a"), new("cookie2", "b")];
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetListT_EntityTagHeaderValue_Success()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.ETag = "\"123\",\"456\"";
+
+        var result = context.Request.GetTypedHeaders().GetList<EntityTagHeaderValue>(HeaderNames.ETag);
+
+        List<EntityTagHeaderValue> expected = [new("\"123\"", false), new("\"456\"", false)];
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetListT_SetCookieHeaderValue_Success()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.SetCookie = "cookie1=a,cookie2=b";
+
+        var result = context.Request.GetTypedHeaders().GetList<SetCookieHeaderValue>(HeaderNames.SetCookie);
+
+        List<SetCookieHeaderValue> expected = [new("cookie1", "a"), new("cookie2", "b")];
+        Assert.Equal(expected, result);
     }
 
     [Fact]


### PR DESCRIPTION
# HeaderDictionaryTypeExtensions not using Dictionary

Considering using FrozenDictionary in `HeaderDictionaryTypeExtensions` - as the Dictionary for parsers does not change. However, measurements show that using `if-else` results in a better overall performance.

## Description

Based on the discussion and performance measurements in #47569, instead of using a `FrozenDictionary` this PR uses `if-else` branching to match known types and known list types when parsing header values.

This way both the *creation* of the dictionary is faster, as we don't have to create one, as well as the lookup.

