### PR TITLE
Make user in ValidateAsync nullable

### DIFF
--- a/src/Identity/Extensions.Core/src/IPasswordValidator.cs
+++ b/src/Identity/Extensions.Core/src/IPasswordValidator.cs
@@ -18,5 +18,5 @@ public interface IPasswordValidator<TUser> where TUser : class
     /// <param name="user">The user whose password should be validated.</param>
     /// <param name="password">The password supplied for validation</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    Task<IdentityResult> ValidateAsync(UserManager<TUser> manager, TUser user, string? password);
+    Task<IdentityResult> ValidateAsync(UserManager<TUser> manager, TUser? user, string? password);
 }

--- a/src/Identity/Extensions.Core/src/PasswordValidator.cs
+++ b/src/Identity/Extensions.Core/src/PasswordValidator.cs
@@ -37,7 +37,7 @@ public class PasswordValidator<TUser> : IPasswordValidator<TUser> where TUser : 
     /// <param name="user">The user whose password should be validated.</param>
     /// <param name="password">The password supplied for validation</param>
     /// <returns>The task object representing the asynchronous operation.</returns>
-    public virtual Task<IdentityResult> ValidateAsync(UserManager<TUser> manager, TUser user, string? password)
+    public virtual Task<IdentityResult> ValidateAsync(UserManager<TUser> manager, TUser? user, string? password)
     {
         ArgumentNullThrowHelper.ThrowIfNull(password);
         ArgumentNullThrowHelper.ThrowIfNull(manager);


### PR DESCRIPTION
# Make user nullable in IPasswordValidator.ValidateAsync

The user is not used in this method. So It can also be nullable. This case is already handled by the tests. 

Usecase for this is, that you want to validate the inserted password (before a user account was created) to show the user the validation results.


See proposal #52606 