### PR TITLE
redis force-reconnect; fix release failure scenario

### DIFF
--- a/src/Caching/StackExchangeRedis/src/RedisCache.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCache.cs
@@ -650,7 +650,11 @@ public partial class RedisCache : IDistributedCache, IDisposable
 
             // wipe the shared field, but *only* if it is still the cache we were
             // thinking about (once it is null, the next caller will reconnect)
-            ReleaseConnection(Interlocked.CompareExchange(ref _cache, null, cache));
+            var tmp = Interlocked.CompareExchange(ref _cache, null, cache);
+            if (ReferenceEquals(tmp, cache))
+            {
+                ReleaseConnection(tmp);
+            }
         }
     }
 


### PR DESCRIPTION
nit bugfix; redis caching with "force reconnect" enabled (feature flag) resets the connection in some error scenarios; it does this with a `CompareExchange`, but incorrectly it releases the result of this (the old value of `_cache`) irrespective of the outcome; it *should* test whether this was what we expected, and only release the connection if we have actively wiped the connection

problematic scenario (impossible to reproduce on demand):

- `cache` is snapshotted as a non-`null` value
- another thread swaps the connection
- we get to the compare-exchange, which is a no-op because `_cache` isn't still the same reference as we hold in `cache`
- we then release the *active* connection that we have no knowledge of

with the fix, we capture the response of `CompareExchange` and only release the connection if it matches the value we were thinking of, i.e. we have successfully swapped the connection out to `null`