### PR TITLE
Make IDataProtectionKeyContext settable

### DIFF
--- a/src/DataProtection/EntityFrameworkCore/src/IDataProtectionKeyContext.cs
+++ b/src/DataProtection/EntityFrameworkCore/src/IDataProtectionKeyContext.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore;
@@ -13,5 +13,5 @@ public interface IDataProtectionKeyContext
     /// <summary>
     /// A collection of <see cref="DataProtectionKey"/>
     /// </summary>
-    DbSet<DataProtectionKey> DataProtectionKeys { get; }
+    DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
 }

--- a/src/DataProtection/EntityFrameworkCore/src/PublicAPI.Unshipped.txt
+++ b/src/DataProtection/EntityFrameworkCore/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.IDataProtectionKeyContext.DataProtectionKeys.set -> void


### PR DESCRIPTION
Not requiring it is a [footgun](https://github.com/dotnet/aspnetcore/issues/12333#issuecomment-1845881131).

Fixes #52645