### PR TITLE
Fix metrics duration and http.route tag with exception handling

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -150,7 +150,13 @@ internal sealed class HostingApplicationDiagnostics
 
             if (context.MetricsEnabled)
             {
-                var route = httpContext.GetEndpoint()?.Metadata.GetMetadata<IRouteDiagnosticsMetadata>()?.Route;
+                var endpoint = httpContext.GetEndpoint();
+                if (httpContext.Items.TryGetValue(HttpExtensions.ClearedEndpointKey, out var e) && e is Endpoint clearedEndpoint)
+                {
+                    endpoint = clearedEndpoint;
+                }
+
+                var route = endpoint?.Metadata.GetMetadata<IRouteDiagnosticsMetadata>()?.Route;
                 var customTags = context.MetricsTagsFeature?.TagsList;
 
                 _metrics.RequestEnd(

--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -151,7 +151,9 @@ internal sealed class HostingApplicationDiagnostics
             if (context.MetricsEnabled)
             {
                 var endpoint = httpContext.GetEndpoint();
-                if (httpContext.Items.TryGetValue(HttpExtensions.ClearedEndpointKey, out var e) && e is Endpoint clearedEndpoint)
+                // Some middleware re-executing the pipeline. Before they do this, they clear the endpoint.
+                // The original endpoint is stashed with a known key in HttpContext.Items. Use it as a fallback.
+                if (endpoint is null && httpContext.Items.TryGetValue(HttpExtensions.ClearedEndpointKey, out var e) && e is Endpoint clearedEndpoint)
                 {
                     endpoint = clearedEndpoint;
                 }

--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -151,7 +151,7 @@ internal sealed class HostingApplicationDiagnostics
             if (context.MetricsEnabled)
             {
                 var endpoint = httpContext.GetEndpoint();
-                // Some middleware re-executing the pipeline. Before they do this, they clear the endpoint.
+                // Some middleware re-execute the middleware pipeline with the HttpContext. Before they do this, they clear state from context, such as the previously matched endpoint.
                 // The original endpoint is stashed with a known key in HttpContext.Items. Use it as a fallback.
                 if (endpoint is null && httpContext.Items.TryGetValue(HttpExtensions.ClearedEndpointKey, out var e) && e is Endpoint clearedEndpoint)
                 {

--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -150,14 +150,7 @@ internal sealed class HostingApplicationDiagnostics
 
             if (context.MetricsEnabled)
             {
-                var endpoint = httpContext.GetEndpoint();
-                // Some middleware re-execute the middleware pipeline with the HttpContext. Before they do this, they clear state from context, such as the previously matched endpoint.
-                // The original endpoint is stashed with a known key in HttpContext.Items. Use it as a fallback.
-                if (endpoint is null && httpContext.Items.TryGetValue(HttpExtensions.ClearedEndpointKey, out var e) && e is Endpoint clearedEndpoint)
-                {
-                    endpoint = clearedEndpoint;
-                }
-
+                var endpoint = HttpExtensions.GetOriginalEndpoint(httpContext);
                 var route = endpoint?.Metadata.GetMetadata<IRouteDiagnosticsMetadata>()?.Route;
                 var customTags = context.MetricsTagsFeature?.TagsList;
 

--- a/src/Hosting/Hosting/src/Microsoft.AspNetCore.Hosting.csproj
+++ b/src/Hosting/Hosting/src/Microsoft.AspNetCore.Hosting.csproj
@@ -34,6 +34,7 @@
     <Reference Include="Microsoft.Extensions.Options" />
 
     <Compile Include="$(SharedSourceRoot)TypeNameHelper\*.cs" />
+    <Compile Include="$(SharedSourceRoot)HttpExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddlewareImpl.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddlewareImpl.cs
@@ -247,12 +247,7 @@ internal sealed class ExceptionHandlerMiddlewareImpl
 
         // An endpoint may have already been set. Since we're going to re-invoke the middleware pipeline we need to reset
         // the endpoint and route values to ensure things are re-calculated.
-        context.SetEndpoint(endpoint: null);
-        var routeValuesFeature = context.Features.Get<IRouteValuesFeature>();
-        if (routeValuesFeature != null)
-        {
-            routeValuesFeature.RouteValues = null!;
-        }
+        HttpExtensions.ClearEndpoint(context);
     }
 
     private static Task ClearCacheHeaders(object state)

--- a/src/Middleware/Diagnostics/src/Microsoft.AspNetCore.Diagnostics.csproj
+++ b/src/Middleware/Diagnostics/src/Microsoft.AspNetCore.Diagnostics.csproj
@@ -16,6 +16,7 @@
     <Compile Include="$(SharedSourceRoot)StackTrace\**\*.cs" />
     <Compile Include="$(SharedSourceRoot)TypeNameHelper\*.cs" />
     <Compile Include="$(SharedSourceRoot)Reroute.cs" />
+    <Compile Include="$(SharedSourceRoot)HttpExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Middleware/Diagnostics/src/StatusCodePage/StatusCodePagesExtensions.cs
+++ b/src/Middleware/Diagnostics/src/StatusCodePage/StatusCodePagesExtensions.cs
@@ -190,11 +190,7 @@ public static class StatusCodePagesExtensions
 
             // An endpoint may have already been set. Since we're going to re-invoke the middleware pipeline we need to reset
             // the endpoint and route values to ensure things are re-calculated.
-            context.HttpContext.SetEndpoint(endpoint: null);
-            if (routeValuesFeature != null)
-            {
-                routeValuesFeature.RouteValues = null!;
-            }
+            HttpExtensions.ClearEndpoint(context.HttpContext);
 
             context.HttpContext.Request.Path = newPath;
             context.HttpContext.Request.QueryString = newQueryString;

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerMiddlewareTest.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -11,20 +12,18 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.TestHost;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Diagnostics.Metrics;
 using Microsoft.Extensions.Diagnostics.Metrics.Testing;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
-using Microsoft.AspNetCore.Routing.Patterns;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Logging;
-using System.Net;
 
 namespace Microsoft.AspNetCore.Diagnostics;
 

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerMiddlewareTest.cs
@@ -295,11 +295,11 @@ public class ExceptionHandlerMiddlewareTest : LoggedTest
     }
 
     [Fact]
-    public async Task Metrics_ExceptionThrown_Handled_RouteAvailable()
+    public async Task Metrics_ExceptionThrown_Handled_UseOriginalRoute()
     {
         // Arrange
-        var builder = new RouteEndpointBuilder(c => Task.CompletedTask, RoutePatternFactory.Parse("/path"), 0);
-        var endpoint = builder.Build();
+        var originalEndpointBuilder = new RouteEndpointBuilder(c => Task.CompletedTask, RoutePatternFactory.Parse("/path"), 0);
+        var originalEndpoint = originalEndpointBuilder.Build();
 
         var meterFactory = new TestMeterFactory();
         using var requestDurationCollector = new MetricCollector<double>(meterFactory, "Microsoft.AspNetCore.Hosting", "http.server.request.duration");
@@ -323,7 +323,7 @@ public class ExceptionHandlerMiddlewareTest : LoggedTest
                     });
                     app.Run(context =>
                     {
-                        context.SetEndpoint(endpoint);
+                        context.SetEndpoint(originalEndpoint);
                         throw new Exception("Test exception");
                     });
 
@@ -349,6 +349,73 @@ public class ExceptionHandlerMiddlewareTest : LoggedTest
                 Assert.Equal(500, (int)m.Tags["http.response.status_code"]);
                 Assert.Equal("System.Exception", (string)m.Tags["error.type"]);
                 Assert.Equal("/path", (string)m.Tags["http.route"]);
+            });
+        Assert.Collection(requestExceptionCollector.GetMeasurementSnapshot(),
+            m => AssertRequestException(m, "System.Exception", "handled"));
+    }
+
+    [Fact]
+    public async Task Metrics_ExceptionThrown_Handled_UseNewRoute()
+    {
+        // Arrange
+        var originalEndpointBuilder = new RouteEndpointBuilder(c => Task.CompletedTask, RoutePatternFactory.Parse("/path"), 0);
+        var originalEndpoint = originalEndpointBuilder.Build();
+
+        var newEndpointBuilder = new RouteEndpointBuilder(c => Task.CompletedTask, RoutePatternFactory.Parse("/new"), 0);
+        var newEndpoint = newEndpointBuilder.Build();
+
+        var meterFactory = new TestMeterFactory();
+        using var requestDurationCollector = new MetricCollector<double>(meterFactory, "Microsoft.AspNetCore.Hosting", "http.server.request.duration");
+        using var requestExceptionCollector = new MetricCollector<long>(meterFactory, DiagnosticsMetrics.MeterName, "aspnetcore.diagnostics.exceptions");
+
+        using var host = new HostBuilder()
+            .ConfigureServices(s =>
+            {
+                s.AddSingleton<IMeterFactory>(meterFactory);
+                s.AddSingleton(LoggerFactory);
+            })
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                .UseTestServer()
+                .Configure(app =>
+                {
+                    app.UseExceptionHandler(new ExceptionHandlerOptions
+                    {
+                        ExceptionHandler = (c) =>
+                        {
+                            c.SetEndpoint(newEndpoint);
+                            return Task.CompletedTask;
+                        }
+                    });
+                    app.Run(context =>
+                    {
+                        context.SetEndpoint(originalEndpoint);
+                        throw new Exception("Test exception");
+                    });
+
+                });
+            }).Build();
+
+        await host.StartAsync();
+
+        var server = host.GetTestServer();
+
+        // Act
+        var response = await server.CreateClient().GetAsync("/path");
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+
+        await requestDurationCollector.WaitForMeasurementsAsync(minCount: 1).DefaultTimeout();
+
+        // Assert
+        Assert.Collection(
+            requestDurationCollector.GetMeasurementSnapshot(),
+            m =>
+            {
+                Assert.True(m.Value > 0);
+                Assert.Equal(500, (int)m.Tags["http.response.status_code"]);
+                Assert.Equal("System.Exception", (string)m.Tags["error.type"]);
+                Assert.Equal("/new", (string)m.Tags["http.route"]);
             });
         Assert.Collection(requestExceptionCollector.GetMeasurementSnapshot(),
             m => AssertRequestException(m, "System.Exception", "handled"));

--- a/src/Shared/HttpExtensions.cs
+++ b/src/Shared/HttpExtensions.cs
@@ -12,6 +12,7 @@ internal static class HttpExtensions
     internal static bool IsValidHttpMethodForForm(string method) =>
         HttpMethods.IsPost(method) || HttpMethods.IsPut(method) || HttpMethods.IsPatch(method);
 
+    // Key is a string so shared code works across different assemblies (hosting, error handling middleware, etc).
     internal const string OriginalEndpointKey = "__OriginalEndpoint";
 
     internal static bool IsValidContentTypeForForm(string? contentType)

--- a/src/Shared/HttpExtensions.cs
+++ b/src/Shared/HttpExtensions.cs
@@ -1,6 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System.Net.Http;
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/52648

The `http.server.request.duration` counter records information about every HTTP request. One piece of recorded information is the `http.route` which is the matched route pattern. The route pattern is taken from `HttpContext`'s `Endpoint`.

There is a bug that causes `http.route` to not be available when:
* Incoming request to an app that has enabled metrics
* There is an unhandled exception
* App is using `UseExceptionHandler`
* Response hasn't started or aborted
* The exception handler clears the `HttpContext` and re-executes the middleware pipeline **<- problem**
* Value is recorded to `http.server.request.duration` without `http.route`

The exception handler clears the endpoint from the context and re-executes the middleware pipeline. There is no longer an endpoint on the context when `http.server.request.duration` is recorded and the `http.route` value is lost.

The fix is to stash the original endpoint to a known location (a stable key in `HttpContext.Items`) and then falls back to getting the endpoint from that location if the endpoint isn't set. `HttpContext.Items` is used because `IExceptionHandlerPathFeature` (which has an `Endpoint` property with the original endpoint) isn't available at the hosting layer.

A magic string in a dictionary isn't ideal, but we do use this technique in some other places. It would be better to add a new feature - `IOriginalEndpointFeature` perhaps? - but it doesn't seem worth it for this scenario.