### PR TITLE
Add null check for connectionId

### DIFF
--- a/src/SignalR/server/Core/src/Internal/Proxies.cs
+++ b/src/SignalR/server/Core/src/Internal/Proxies.cs
@@ -10,6 +10,8 @@ internal sealed class UserProxy<THub> : IClientProxy where THub : Hub
 
     public UserProxy(HubLifetimeManager<THub> lifetimeManager, string userId)
     {
+        ArgumentNullException.ThrowIfNull(userId);
+
         _lifetimeManager = lifetimeManager;
         _userId = userId;
     }
@@ -44,6 +46,8 @@ internal sealed class GroupProxy<THub> : IClientProxy where THub : Hub
 
     public GroupProxy(HubLifetimeManager<THub> lifetimeManager, string groupName)
     {
+        ArgumentNullException.ThrowIfNull(groupName);
+
         _lifetimeManager = lifetimeManager;
         _groupName = groupName;
     }
@@ -79,6 +83,8 @@ internal sealed class GroupExceptProxy<THub> : IClientProxy where THub : Hub
 
     public GroupExceptProxy(HubLifetimeManager<THub> lifetimeManager, string groupName, IReadOnlyList<string> excludedConnectionIds)
     {
+        ArgumentNullException.ThrowIfNull(groupName);
+
         _lifetimeManager = lifetimeManager;
         _groupName = groupName;
         _excludedConnectionIds = excludedConnectionIds;

--- a/src/SignalR/server/Core/src/Internal/Proxies.cs
+++ b/src/SignalR/server/Core/src/Internal/Proxies.cs
@@ -147,10 +147,7 @@ internal sealed class SingleClientProxy<THub> : ISingleClientProxy where THub : 
     public SingleClientProxy(HubLifetimeManager<THub> lifetimeManager, string connectionId)
     {
         _lifetimeManager = lifetimeManager;
-        if (connectionId == null)
-        {
-            throw new ArgumentNullException(nameof(connectionId));
-        }
+        ArgumentNullException.ThrowIfNull(connectionId, nameof(connectionId));
         _connectionId = connectionId;
     }
 

--- a/src/SignalR/server/Core/src/Internal/Proxies.cs
+++ b/src/SignalR/server/Core/src/Internal/Proxies.cs
@@ -147,6 +147,10 @@ internal sealed class SingleClientProxy<THub> : ISingleClientProxy where THub : 
     public SingleClientProxy(HubLifetimeManager<THub> lifetimeManager, string connectionId)
     {
         _lifetimeManager = lifetimeManager;
+        if (connectionId == null)
+        {
+            throw new ArgumentNullException(nameof(connectionId));
+        }
         _connectionId = connectionId;
     }
 

--- a/src/SignalR/server/Core/src/Internal/Proxies.cs
+++ b/src/SignalR/server/Core/src/Internal/Proxies.cs
@@ -147,7 +147,7 @@ internal sealed class SingleClientProxy<THub> : ISingleClientProxy where THub : 
     public SingleClientProxy(HubLifetimeManager<THub> lifetimeManager, string connectionId)
     {
         _lifetimeManager = lifetimeManager;
-        ArgumentNullException.ThrowIfNull(connectionId, nameof(connectionId));
+        ArgumentNullException.ThrowIfNull(connectionId);
         _connectionId = connectionId;
     }
 


### PR DESCRIPTION
## Description
It makes sence to check connectionId parameter for null. Otherwise an instance of SingleClientProxy will be in invalid state which can't send any message to client side. 
I got this case and getting this exception at the moment when I expect data to be send
```
Value cannot be null. (Parameter 'connectionId')
   at Microsoft.AspNetCore.SignalR.DefaultHubLifetimeManager`1.SendConnectionAsync(String connectionId, String methodName, Object[] args, CancellationToken cancellationToken)
```
