### PR TITLE
Revert "Unskip HelixPlatform_QuicListenerIsSupported on debian 12 (#52235)

### DIFF
--- a/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
+++ b/src/Servers/Kestrel/Transport.Quic/test/WebHostTests.cs
@@ -27,6 +27,7 @@ public class WebHostTests : LoggedTest
     [SkipNonHelix]
     [SkipOnAlpine("https://github.com/dotnet/aspnetcore/issues/46537")]
     [SkipOnMariner("https://github.com/dotnet/aspnetcore/issues/46537")]
+    [SkipOnHelix("https://github.com/dotnet/aspnetcore/issues/46616", Queues = "Debian.12.Arm64.Open;")]
     [OSSkipCondition(OperatingSystems.MacOSX, SkipReason = "HTTP/3 isn't supported on MacOS.")]
     [MinimumOSVersion(OperatingSystems.Windows, WindowsVersions.Win11_21H2)]
     public void HelixPlatform_QuicListenerIsSupported()


### PR DESCRIPTION
This reverts commit 50edfa994d402e34e6e10585cd5b4c25bd36925f.

Unfixes #46616.