### PR TITLE
Reduce allocations in MakeArrayFormatter

### DIFF
--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -1810,13 +1810,13 @@ public static class BindConverter
                 }
 
                 var builder = new StringBuilder("[\"");
-                builder.Append(JsonEncodedText.Encode(elementFormatter(value[0], culture)?.ToString() ?? string.Empty));
+                builder.Append(JsonEncodedText.Encode(elementFormatter(value[0], culture)?.ToString() ?? string.Empty).Value);
                 builder.Append('\"');
 
                 for (var i = 1; i < value.Length; i++)
                 {
                     builder.Append(", \"");
-                    builder.Append(JsonEncodedText.Encode(elementFormatter(value[i], culture)?.ToString() ?? string.Empty));
+                    builder.Append(JsonEncodedText.Encode(elementFormatter(value[i], culture)?.ToString() ?? string.Empty).Value);
                     builder.Append('\"');
                 }
 


### PR DESCRIPTION
JsonEncodedText is a struct. Passing it into StringBuilder.Append will box the value into an object, just to call ToString() on it.

Instead, grab the Value string from the JsonEncodedText and pass the string into StringBuilder.Append, so nothing is boxed.