### PR TITLE
Add s390x support to the runtimearchitecture list

### DIFF
--- a/src/Hosting/Server.IntegrationTesting/src/Common/RuntimeArchitecture.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/RuntimeArchitecture.cs
@@ -8,5 +8,6 @@ public enum RuntimeArchitecture
     arm64,
     x64,
     x86,
-    ppc64le //Power Architecture
+    ppc64le, //Power Architecture
+    s390x
 }

--- a/src/Hosting/Server.IntegrationTesting/src/Common/RuntimeArchitectures.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/Common/RuntimeArchitectures.cs
@@ -17,6 +17,7 @@ public class RuntimeArchitectures
                 Architecture.X64 => RuntimeArchitecture.x64,
                 Architecture.X86 => RuntimeArchitecture.x86,
                 Architecture.Ppc64le => RuntimeArchitecture.ppc64le,
+                Architecture.S390x => RuntimeArchitecture.s390x,
                 _ => throw new NotImplementedException($"Unknown RuntimeInformation.OSArchitecture: {RuntimeInformation.OSArchitecture.ToString()}"),
             };
         }


### PR DESCRIPTION
# {PR title}

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Add "s390x" architecture to the "RuntimeArchitecture" list. This is needed to enable the building and testing of aspnetcore package on s390x.

## Description

In order to enable/provide source build support of aspnetcore package on IBM Z (s390x) system, the architecture need to be added to the "RuntimeArchitecture" list. Raising this PR to enable the support for s390x arch.

Fixes #{bug number} (in this specific format)
