### PR TITLE
Fix app_offline detection for some OSes

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.h
@@ -60,7 +60,6 @@ private:
     HandleWrapper<NullHandleTraits>               m_hChangeNotificationThread;
     HandleWrapper<NullHandleTraits>               _hDirectory;
     HandleWrapper<NullHandleTraits>               m_pDoneCopyEvent;
-    HandleWrapper<NullHandleTraits>               m_pShutdownEvent;
     std::atomic_bool        m_fThreadExit;
     STTIMER                 m_Timer;
     SRWLOCK                 m_copyLock{};


### PR DESCRIPTION
Reverts part of https://github.com/dotnet/aspnetcore/pull/49696. It looks like calling `WaitForMultipleObjects` isn't officially supported on a `HANDLE` from `CreateIoCompletionPort`. See https://stackoverflow.com/questions/39602908/waitforsingleobject-on-a-completion-port for some discussion on this.

On Windows Server 2012 R2 it looks like `ChangeNotificationThread` ends up hanging on `GetQueuedCompletionStatus` because `WaitForMultipleObjects` doesn't work properly with `m_hCompletionPort` and shutdown was triggered which causes `_lStopMonitorCalled` to be set so we don't end up calling `PostQueuedCompletionStatus` which would unblock `GetQueuedCompletionStatus`.

Customer issues https://github.com/dotnet/aspnetcore/issues/52307 and https://github.com/dotnet/aspnetcore/issues/52539, and possibly https://github.com/dotnet/aspnetcore/issues/52525