### PR TITLE
Unquarantine ConnectionClosedWithoutActiveRequestsOrGoAwayFIN

### DIFF
--- a/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
+++ b/src/Servers/Kestrel/test/FunctionalTests/Http2/ShutdownTests.cs
@@ -47,7 +47,6 @@ public class ShutdownTests : TestApplicationErrorLoggerLoggedTest
     }
 
     [ConditionalFact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/51770")]
     public async Task ConnectionClosedWithoutActiveRequestsOrGoAwayFIN()
     {
         var connectionClosed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/51770

Underlying test was fixed in Oct - https://github.com/dotnet/aspnetcore/issues/51770#issuecomment-1787645618. No record of failing tests in the last 30 days.