### PR TITLE
Change how ANCM recycles app

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.cpp
@@ -22,7 +22,8 @@ const PCWSTR HandlerResolver::s_pwzAspnetcoreOutOfProcessRequestHandlerName = L"
 HandlerResolver::HandlerResolver(HMODULE hModule, const IHttpServer &pServer)
     : m_hModule(hModule),
       m_pServer(pServer),
-      m_loadedApplicationHostingModel(HOSTING_UNKNOWN)
+      m_loadedApplicationHostingModel(HOSTING_UNKNOWN),
+      m_shutdownDelay()
 {
     m_disallowRotationOnConfigChange = false;
     InitializeSRWLock(&m_requestHandlerLoadLock);
@@ -171,6 +172,7 @@ HandlerResolver::GetApplicationFactory(const IHttpApplication& pApplication, con
     m_loadedApplicationHostingModel = options.QueryHostingModel();
     m_loadedApplicationId = pApplication.GetApplicationId();
     m_disallowRotationOnConfigChange = options.QueryDisallowRotationOnConfigChange();
+    m_shutdownDelay = options.QueryShutdownDelay();
 
     RETURN_IF_FAILED(LoadRequestHandlerAssembly(pApplication, shadowCopyPath, options, pApplicationFactory, errorContext));
 
@@ -195,6 +197,11 @@ APP_HOSTING_MODEL HandlerResolver::GetHostingModel()
 bool HandlerResolver::GetDisallowRotationOnConfigChange()
 {
     return m_disallowRotationOnConfigChange;
+}
+
+std::chrono::milliseconds HandlerResolver::GetShutdownDelay() const
+{
+    return m_shutdownDelay;
 }
 
 HRESULT

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/HandlerResolver.h
@@ -19,6 +19,7 @@ public:
     void ResetHostingModel();
     APP_HOSTING_MODEL GetHostingModel();
     bool GetDisallowRotationOnConfigChange();
+    std::chrono::milliseconds GetShutdownDelay() const;
 
 private:
     HRESULT LoadRequestHandlerAssembly(const IHttpApplication &pApplication, const std::filesystem::path& shadowCopyPath, const ShimOptions& pConfiguration, std::unique_ptr<ApplicationFactory>& pApplicationFactory, ErrorContext& errorContext);
@@ -40,6 +41,7 @@ private:
     APP_HOSTING_MODEL m_loadedApplicationHostingModel;
     HostFxr m_hHostFxrDll;
     bool m_disallowRotationOnConfigChange;
+    std::chrono::milliseconds m_shutdownDelay;
 
     static const PCWSTR          s_pwzAspnetcoreInProcessRequestHandlerName;
     static const PCWSTR          s_pwzAspnetcoreOutOfProcessRequestHandlerName;

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.cpp
@@ -58,7 +58,7 @@ ShimOptions::ShimOptions(const ConfigurationSource &configurationSource) :
     auto shutdownDelay = find_element(handlerSettings, CS_ASPNETCORE_SHUTDOWN_DELAY).value_or(std::wstring());
     if (shutdownDelay.empty())
     {
-        m_fShutdownDelay = std::chrono::seconds(1);
+        m_fShutdownDelay = std::chrono::seconds(0);
     }
     else
     {

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.cpp
@@ -12,6 +12,7 @@
 #define CS_ASPNETCORE_SHADOW_COPY_DIRECTORY              L"shadowCopyDirectory"
 #define CS_ASPNETCORE_CLEAN_SHADOW_DIRECTORY_CONTENT     L"cleanShadowCopyDirectory"
 #define CS_ASPNETCORE_DISALLOW_ROTATE_CONFIG             L"disallowRotationOnConfigChange"
+#define CS_ASPNETCORE_SHUTDOWN_DELAY                     L"shutdownDelay"
 
 ShimOptions::ShimOptions(const ConfigurationSource &configurationSource) :
         m_hostingModel(HOSTING_UNKNOWN),
@@ -53,6 +54,17 @@ ShimOptions::ShimOptions(const ConfigurationSource &configurationSource) :
 
     auto disallowRotationOnConfigChange = find_element(handlerSettings, CS_ASPNETCORE_DISALLOW_ROTATE_CONFIG).value_or(std::wstring());
     m_fDisallowRotationOnConfigChange = equals_ignore_case(L"true", disallowRotationOnConfigChange);
+
+    auto shutdownDelay = find_element(handlerSettings, CS_ASPNETCORE_SHUTDOWN_DELAY).value_or(std::wstring());
+    if (shutdownDelay.empty())
+    {
+        m_fShutdownDelay = std::chrono::seconds(1);
+    }
+    else
+    {
+        auto str = to_multi_byte_string(shutdownDelay, CP_UTF8);
+        m_fShutdownDelay = std::chrono::milliseconds(std::atoi(str.c_str()));
+    }
                 
     m_strProcessPath = section->GetRequiredString(CS_ASPNETCORE_PROCESS_EXE_PATH);
     m_strArguments = section->GetString(CS_ASPNETCORE_PROCESS_ARGUMENTS).value_or(CS_ASPNETCORE_PROCESS_ARGUMENTS_DEFAULT);

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.cpp
@@ -58,7 +58,7 @@ ShimOptions::ShimOptions(const ConfigurationSource &configurationSource) :
     auto shutdownDelay = find_element(handlerSettings, CS_ASPNETCORE_SHUTDOWN_DELAY).value_or(std::wstring());
     if (shutdownDelay.empty())
     {
-        m_fShutdownDelay = std::chrono::seconds(0);
+        m_fShutdownDelay = std::chrono::seconds(1);
     }
     else
     {

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.h
@@ -111,4 +111,6 @@ private:
     bool                           m_fDisallowRotationOnConfigChange;
     std::wstring                   m_strShadowCopyingDirectory;
     std::chrono::milliseconds      m_fShutdownDelay;
+
+    void SetShutdownDelay(std::wstring& shutdownDelay);
 };

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.h
@@ -90,7 +90,7 @@ public:
     }
 
     std::chrono::milliseconds
-        QueryShutdownDelay() const noexcept
+    QueryShutdownDelay() const noexcept
     {
         return m_fShutdownDelay;
     }
@@ -112,5 +112,5 @@ private:
     std::wstring                   m_strShadowCopyingDirectory;
     std::chrono::milliseconds      m_fShutdownDelay;
 
-    void SetShutdownDelay(std::wstring& shutdownDelay);
+    void SetShutdownDelay(const std::wstring& shutdownDelay);
 };

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/ShimOptions.h
@@ -89,6 +89,12 @@ public:
         return m_fDisallowRotationOnConfigChange;
     }
 
+    std::chrono::milliseconds
+        QueryShutdownDelay() const noexcept
+    {
+        return m_fShutdownDelay;
+    }
+
     ShimOptions(const ConfigurationSource &configurationSource);
 
 private:
@@ -104,4 +110,5 @@ private:
     bool                           m_fCleanShadowCopyDirectory;
     bool                           m_fDisallowRotationOnConfigChange;
     std::wstring                   m_strShadowCopyingDirectory;
+    std::chrono::milliseconds      m_fShutdownDelay;
 };

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp
@@ -200,7 +200,7 @@ APPLICATION_MANAGER::ShutDown()
     g_fInAppOfflineShutdown = true;
     for (auto & [str, applicationInfo] : m_pApplicationInfoHash)
     {
-        applicationInfo->ShutDownApplication(/* fServerInitiated */ false);
+        applicationInfo->ShutDownApplication(/* fServerInitiated */ true);
         applicationInfo = nullptr;
     }
 }

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp
@@ -149,7 +149,7 @@ APPLICATION_MANAGER::RecycleApplicationFromManager(
             {
                 try
                 {
-                    if (GetShutdownDelay() == std::chrono::milliseconds::zero())
+                    if (UseLegacyShutdown())
                     {
                         application->ShutDownApplication(/* fServerInitiated */ false);
                     }
@@ -180,7 +180,7 @@ APPLICATION_MANAGER::RecycleApplicationFromManager(
             }
         }
 
-        if (GetShutdownDelay() == std::chrono::milliseconds::zero())
+        if (UseLegacyShutdown())
         {
             // Remove apps after calling shutdown on each of them
             // This is exclusive to in-process, as the shutdown of an in-process app recycles

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp
@@ -149,9 +149,16 @@ APPLICATION_MANAGER::RecycleApplicationFromManager(
             {
                 try
                 {
-                    // Recycle the process to trigger OnGlobalStopListening
-                    // which will shutdown the server and stop listening for new requests for this app
-                    m_pHttpServer.RecycleProcess(L"AspNetCore InProcess Recycle Process on Demand");
+                    //if (GetShutdownDelay() == std::chrono::milliseconds::zero())
+                    //{
+                    //    application->ShutDownApplication(/* fServerInitiated */ false);
+                    //}
+                    //else
+                    {
+                        // Recycle the process to trigger OnGlobalStopListening
+                        // which will shutdown the server and stop listening for new requests for this app
+                        m_pHttpServer.RecycleProcess(L"AspNetCore InProcess Recycle Process on Demand");
+                    }
                 }
                 catch (...)
                 {

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.cpp
@@ -143,22 +143,19 @@ APPLICATION_MANAGER::RecycleApplicationFromManager(
             }
         }
 
-        // If we receive a request at this point.
-        // OutOfProcess: we will create a new application with new configuration
-        // InProcess: the request would have to be rejected, as we are about to call g_HttpServer->RecycleProcess
-        // on the worker process
-
         if (!applicationsToRecycle.empty())
         {
             for (auto& application : applicationsToRecycle)
             {
                 try
                 {
-                    application->ShutDownApplication(/* fServerInitiated */ false);
+                    // Recycle the process to trigger OnGlobalStopListening
+                    // which will shutdown the server and stop listening for new requests for this app
+                    m_pHttpServer.RecycleProcess(L"AspNetCore InProcess Recycle Process on Demand");
                 }
                 catch (...)
                 {
-                    LOG_ERRORF(L"Failed to stop application '%ls'", application->QueryApplicationInfoKey().c_str());
+                    LOG_ERRORF(L"Failed to recycle application '%ls'", application->QueryApplicationInfoKey().c_str());
                     OBSERVE_CAUGHT_EXCEPTION()
 
                     // Failed to recycle an application. Log an event
@@ -175,29 +172,6 @@ APPLICATION_MANAGER::RecycleApplicationFromManager(
                 }
             }
         }
-
-        // Remove apps after calling shutdown on each of them
-        // This is exclusive to in-process, as the shutdown of an in-process app recycles
-        // the entire worker process.
-        if (m_handlerResolver.GetHostingModel() == APP_HOSTING_MODEL::HOSTING_IN_PROCESS)
-        {
-            SRWExclusiveLock lock(m_srwLock);
-            const std::wstring configurationPath = pszApplicationId;
-
-            auto itr = m_pApplicationInfoHash.begin();
-            while (itr != m_pApplicationInfoHash.end())
-            {
-                if (itr->second != nullptr && itr->second->ConfigurationPathApplies(configurationPath)
-                    && std::find(applicationsToRecycle.begin(), applicationsToRecycle.end(), itr->second) != applicationsToRecycle.end())
-                {
-                    itr = m_pApplicationInfoHash.erase(itr);
-                }
-                else
-                {
-                    ++itr;
-                }
-            }
-        } // Release Exclusive m_srwLock
     }
     CATCH_RETURN()
 
@@ -211,17 +185,22 @@ APPLICATION_MANAGER::RecycleApplicationFromManager(
 VOID
 APPLICATION_MANAGER::ShutDown()
 {
+    // During shutdown we lock until we delete the application
+    SRWExclusiveLock lock(m_srwLock);
+
     // We are guaranteed to only have one outstanding OnGlobalStopListening event at a time
     // However, it is possible to receive multiple OnGlobalStopListening events
     // Protect against this by checking if we already shut down.
+    if (g_fInShutdown)
+    {
+        return;
+    }
+
     g_fInShutdown = TRUE;
     g_fInAppOfflineShutdown = true;
-
-    // During shutdown we lock until we delete the application
-    SRWExclusiveLock lock(m_srwLock);
     for (auto & [str, applicationInfo] : m_pApplicationInfoHash)
     {
-        applicationInfo->ShutDownApplication(/* fServerInitiated */ true);
+        applicationInfo->ShutDownApplication(/* fServerInitiated */ false);
         applicationInfo = nullptr;
     }
 }

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.h
@@ -52,6 +52,11 @@ public:
         return m_handlerResolver.GetShutdownDelay();
     }
 
+    bool UseLegacyShutdown() const
+    {
+        return m_handlerResolver.GetShutdownDelay() == std::chrono::milliseconds::zero();
+    }
+
 private:
 
     std::unordered_map<std::wstring, std::shared_ptr<APPLICATION_INFO>>      m_pApplicationInfoHash;

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.h
@@ -47,6 +47,16 @@ public:
         return !m_handlerResolver.GetDisallowRotationOnConfigChange();
     }
 
+    std::chrono::milliseconds GetShutdownDelay() const
+    {
+        return m_handlerResolver.GetShutdownDelay();
+    }
+
+    bool IsCommandLineLaunch() const
+    {
+        return m_pHttpServer.IsCommandLineLaunch();
+    }
+
 private:
 
     std::unordered_map<std::wstring, std::shared_ptr<APPLICATION_INFO>>      m_pApplicationInfoHash;

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/applicationmanager.h
@@ -52,11 +52,6 @@ public:
         return m_handlerResolver.GetShutdownDelay();
     }
 
-    bool IsCommandLineLaunch() const
-    {
-        return m_pHttpServer.IsCommandLineLaunch();
-    }
-
 private:
 
     std::unordered_map<std::wstring, std::shared_ptr<APPLICATION_INFO>>      m_pApplicationInfoHash;

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/dllmain.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/dllmain.cpp
@@ -126,24 +126,13 @@ HRESULT
                                   RQ_EXECUTE_REQUEST_HANDLER,
                                   0));
 
-    //auto delay = applicationManager->GetShutdownDelay();
     auto pGlobalModule = std::make_unique<ASPNET_CORE_GLOBAL_MODULE>(std::move(applicationManager));
 
-    //if (delay == std::chrono::milliseconds::zero())
-    //{
-    //    RETURN_IF_FAILED(pModuleInfo->SetGlobalNotifications(
-    //        pGlobalModule.release(),
-    //        GL_CONFIGURATION_CHANGE | // Configuration change triggers IIS application stop
-    //        GL_STOP_LISTENING)); // worker process stop
-    //}
-    //else
-    {
-        RETURN_IF_FAILED(pModuleInfo->SetGlobalNotifications(
-            pGlobalModule.release(),
-            GL_CONFIGURATION_CHANGE | // Configuration change triggers IIS application stop
-            GL_STOP_LISTENING | // worker process stop
-            GL_APPLICATION_STOP)); // app pool recycle
-    }
+    RETURN_IF_FAILED(pModuleInfo->SetGlobalNotifications(
+        pGlobalModule.release(),
+        GL_CONFIGURATION_CHANGE | // Configuration change triggers IIS application stop
+        GL_STOP_LISTENING | // worker process will stop listening for http requests
+        GL_APPLICATION_STOP)); // app pool recycle or stop
 
     return S_OK;
 }

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/dllmain.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/dllmain.cpp
@@ -131,7 +131,8 @@ HRESULT
     RETURN_IF_FAILED(pModuleInfo->SetGlobalNotifications(
                                      pGlobalModule.release(),
                                      GL_CONFIGURATION_CHANGE | // Configuration change triggers IIS application stop
-                                     GL_STOP_LISTENING));   // worker process stop or recycle
+                                     GL_STOP_LISTENING | // worker process stop
+                                     GL_APPLICATION_STOP)); // app pool recycle
 
     return S_OK;
 }

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/dllmain.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/dllmain.cpp
@@ -126,17 +126,17 @@ HRESULT
                                   RQ_EXECUTE_REQUEST_HANDLER,
                                   0));
 
-    auto delay = applicationManager->GetShutdownDelay();
+    //auto delay = applicationManager->GetShutdownDelay();
     auto pGlobalModule = std::make_unique<ASPNET_CORE_GLOBAL_MODULE>(std::move(applicationManager));
 
-    if (delay == std::chrono::milliseconds::zero())
-    {
-        RETURN_IF_FAILED(pModuleInfo->SetGlobalNotifications(
-            pGlobalModule.release(),
-            GL_CONFIGURATION_CHANGE | // Configuration change triggers IIS application stop
-            GL_STOP_LISTENING)); // worker process stop
-    }
-    else
+    //if (delay == std::chrono::milliseconds::zero())
+    //{
+    //    RETURN_IF_FAILED(pModuleInfo->SetGlobalNotifications(
+    //        pGlobalModule.release(),
+    //        GL_CONFIGURATION_CHANGE | // Configuration change triggers IIS application stop
+    //        GL_STOP_LISTENING)); // worker process stop
+    //}
+    //else
     {
         RETURN_IF_FAILED(pModuleInfo->SetGlobalNotifications(
             pGlobalModule.release(),

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/dllmain.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/dllmain.cpp
@@ -125,14 +125,25 @@ HRESULT
                                   moduleFactory.release(),
                                   RQ_EXECUTE_REQUEST_HANDLER,
                                   0));
-;
+
+    auto delay = applicationManager->GetShutdownDelay();
     auto pGlobalModule = std::make_unique<ASPNET_CORE_GLOBAL_MODULE>(std::move(applicationManager));
 
-    RETURN_IF_FAILED(pModuleInfo->SetGlobalNotifications(
-                                     pGlobalModule.release(),
-                                     GL_CONFIGURATION_CHANGE | // Configuration change triggers IIS application stop
-                                     GL_STOP_LISTENING | // worker process stop
-                                     GL_APPLICATION_STOP)); // app pool recycle
+    if (delay == std::chrono::milliseconds::zero())
+    {
+        RETURN_IF_FAILED(pModuleInfo->SetGlobalNotifications(
+            pGlobalModule.release(),
+            GL_CONFIGURATION_CHANGE | // Configuration change triggers IIS application stop
+            GL_STOP_LISTENING)); // worker process stop
+    }
+    else
+    {
+        RETURN_IF_FAILED(pModuleInfo->SetGlobalNotifications(
+            pGlobalModule.release(),
+            GL_CONFIGURATION_CHANGE | // Configuration change triggers IIS application stop
+            GL_STOP_LISTENING | // worker process stop
+            GL_APPLICATION_STOP)); // app pool recycle
+    }
 
     return S_OK;
 }

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.cpp
@@ -40,6 +40,11 @@ ASPNET_CORE_GLOBAL_MODULE::OnGlobalApplicationStop(
     IN IHttpApplicationStopProvider* pProvider
 )
 {
+    if (!m_pApplicationManager || m_pApplicationManager->GetShutdownDelay() == std::chrono::milliseconds::zero())
+    {
+        return GL_NOTIFICATION_CONTINUE;
+    }
+
     UNREFERENCED_PARAMETER(pProvider);
     LOG_INFO(L"ASPNET_CORE_GLOBAL_MODULE::OnGlobalApplicationStop");
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.cpp
@@ -40,12 +40,15 @@ ASPNET_CORE_GLOBAL_MODULE::OnGlobalApplicationStop(
     IN IHttpApplicationStopProvider* pProvider
 )
 {
+    UNREFERENCED_PARAMETER(pProvider);
+
+    // If we're already cleaned up just return.
+    // If user has opted out of the new shutdown behavior ignore this call as we never registered for it before
     if (!m_pApplicationManager || m_pApplicationManager->GetShutdownDelay() == std::chrono::milliseconds::zero())
     {
         return GL_NOTIFICATION_CONTINUE;
     }
 
-    UNREFERENCED_PARAMETER(pProvider);
     LOG_INFO(L"ASPNET_CORE_GLOBAL_MODULE::OnGlobalApplicationStop");
 
     if (!g_fInShutdown && !m_shutdown.joinable())

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.cpp
@@ -44,7 +44,7 @@ ASPNET_CORE_GLOBAL_MODULE::OnGlobalApplicationStop(
 
     // If we're already cleaned up just return.
     // If user has opted out of the new shutdown behavior ignore this call as we never registered for it before
-    if (!m_pApplicationManager || m_pApplicationManager->GetShutdownDelay() == std::chrono::milliseconds::zero())
+    if (!m_pApplicationManager || m_pApplicationManager->UseLegacyShutdown())
     {
         return GL_NOTIFICATION_CONTINUE;
     }

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.cpp
@@ -6,7 +6,7 @@
 extern BOOL         g_fInShutdown;
 
 ASPNET_CORE_GLOBAL_MODULE::ASPNET_CORE_GLOBAL_MODULE(std::shared_ptr<APPLICATION_MANAGER> pApplicationManager) noexcept
-    :m_pApplicationManager(std::move(pApplicationManager))
+    : m_pApplicationManager(std::move(pApplicationManager))
 {
 }
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.h
@@ -6,6 +6,8 @@
 #include "applicationmanager.h"
 #include <thread>
 
+extern BOOL         g_fInShutdown;
+
 class ASPNET_CORE_GLOBAL_MODULE : NonCopyable, public CGlobalModule
 {
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.h
@@ -57,18 +57,29 @@ private:
             return;
         }
 
-        // Run shutdown on a background thread. It seems like IIS keeps giving us requests if OnGlobalStopListening is still running
-        // which will result in 503s since we're shutting down.
-        // But if we return ASAP from OnGlobalStopListening (by not shutting down inline),
-        // IIS will actually stop giving us new requests and queue them instead for processing by the new app process.
-        m_shutdown = std::thread([this]()
-            {
-                auto delay = m_pApplicationManager->GetShutdownDelay();
-                LOG_INFOF(L"Shutdown starting in %d ms.", delay.count());
-                // Delay so that any incoming requests while we're returning from OnGlobalStopListening are allowed to be processed
-                std::this_thread::sleep_for(delay);
-                m_pApplicationManager->ShutDown();
-                m_pApplicationManager = nullptr;
-            });
+        // If delay is zero we can go back to the old behavior of calling shutdown inline
+        // this is primarily so that we have a way for users to revert the new behavior if there are issues with it
+        if (m_pApplicationManager->GetShutdownDelay() == std::chrono::milliseconds::zero())
+        {
+            LOG_INFO(L"Shutdown starting.");
+            m_pApplicationManager->ShutDown();
+            m_pApplicationManager = nullptr;
+        }
+        else
+        {
+            // Run shutdown on a background thread. It seems like IIS keeps giving us requests if OnGlobalStopListening is still running
+            // which will result in 503s since we're shutting down.
+            // But if we return ASAP from OnGlobalStopListening (by not shutting down inline),
+            // IIS will actually stop giving us new requests and queue them instead for processing by the new app process.
+            m_shutdown = std::thread([this]()
+                {
+                    auto delay = m_pApplicationManager->GetShutdownDelay();
+                    LOG_INFOF(L"Shutdown starting in %d ms.", delay.count());
+                    // Delay so that any incoming requests while we're returning from OnGlobalStopListening are allowed to be processed
+                    std::this_thread::sleep_for(delay);
+                    m_pApplicationManager->ShutDown();
+                    m_pApplicationManager = nullptr;
+                });
+        }
     }
 };

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.h
@@ -51,8 +51,8 @@ private:
 
     void StartShutdown()
     {
-        // Shutdown has already been started
-        if (m_shutdown.joinable())
+        // Shutdown has already been started/finished
+        if (m_shutdown.joinable() || g_fInShutdown)
         {
             return;
         }

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/globalmodule.h
@@ -59,7 +59,7 @@ private:
 
         // If delay is zero we can go back to the old behavior of calling shutdown inline
         // this is primarily so that we have a way for users to revert the new behavior if there are issues with it
-        if (m_pApplicationManager->GetShutdownDelay() == std::chrono::milliseconds::zero())
+        if (m_pApplicationManager->UseLegacyShutdown())
         {
             LOG_INFO(L"Shutdown starting.");
             m_pApplicationManager->ShutDown();

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/proxymodule.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/proxymodule.cpp
@@ -93,6 +93,7 @@ ASPNET_CORE_PROXY_MODULE::OnExecuteRequestHandler(
     {
         if (g_fInShutdown)
         {
+            LOG_INFO(L"Received request during shutdown. Will return 503.");
             FINISHED(HRESULT_FROM_WIN32(ERROR_SERVER_SHUTDOWN_IN_PROGRESS));
         }
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/proxymodule.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/proxymodule.cpp
@@ -93,7 +93,7 @@ ASPNET_CORE_PROXY_MODULE::OnExecuteRequestHandler(
     {
         if (g_fInShutdown)
         {
-            LOG_INFO(L"Received a request during shutdown. Will return a 503 response.");
+            LOG_WARN(L"Received a request during shutdown. Will return a 503 response.");
             FINISHED(HRESULT_FROM_WIN32(ERROR_SERVER_SHUTDOWN_IN_PROGRESS));
         }
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/proxymodule.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/AspNetCore/proxymodule.cpp
@@ -93,7 +93,7 @@ ASPNET_CORE_PROXY_MODULE::OnExecuteRequestHandler(
     {
         if (g_fInShutdown)
         {
-            LOG_INFO(L"Received request during shutdown. Will return 503.");
+            LOG_INFO(L"Received a request during shutdown. Will return a 503 response.");
             FINISHED(HRESULT_FROM_WIN32(ERROR_SERVER_SHUTDOWN_IN_PROGRESS));
         }
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessApplicationBase.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessApplicationBase.cpp
@@ -17,38 +17,40 @@ InProcessApplicationBase::StopInternal(bool fServerInitiated)
 {
     AppOfflineTrackingApplication::StopInternal(fServerInitiated);
 
+    // Ignore fServerInitiated for IISExpress
+    // Recycle doesn't do anything in IISExpress, we need to explicitly shutdown
+    if (m_pHttpServer.IsCommandLineLaunch())
+    {
+        // Send WM_QUIT to the main window to initiate graceful shutdown
+        EnumWindows([](HWND hwnd, LPARAM) -> BOOL
+            {
+                DWORD processId;
+
+                if (GetWindowThreadProcessId(hwnd, &processId) &&
+                    processId == GetCurrentProcessId() &&
+                    GetConsoleWindow() != hwnd)
+                {
+                    PostMessage(hwnd, WM_QUIT, 0, 0);
+                    return false;
+                }
+
+                return true;
+            }, 0);
+
+        return;
+    }
+
     // Stop was initiated by server no need to do anything, server would stop on it's own
     if (fServerInitiated)
     {
         return;
     }
 
-    if (!m_pHttpServer.IsCommandLineLaunch())
-    {
-        // IIS scenario.
-        // We don't actually handle any shutdown logic here.
-        // Instead, we notify IIS that the process needs to be recycled, which will call
-        // ApplicationManager->Shutdown(). This will call shutdown on the application.
-        LOG_INFO(L"AspNetCore InProcess Recycle Process on Demand");
-        m_pHttpServer.RecycleProcess(L"AspNetCore InProcess Recycle Process on Demand");
-    }
-    else
-    {
-        // Send WM_QUIT to the main window to initiate graceful shutdown
-        EnumWindows([](HWND hwnd, LPARAM) -> BOOL
-        {
-            DWORD processId;
-
-            if (GetWindowThreadProcessId(hwnd, &processId) &&
-                processId == GetCurrentProcessId() &&
-                GetConsoleWindow() != hwnd)
-            {
-                PostMessage(hwnd, WM_QUIT, 0, 0);
-                return false;
-            }
-
-            return true;
-        }, 0);
-    }
+    // IIS scenario.
+    // We don't actually handle any shutdown logic here.
+    // Instead, we notify IIS that the process needs to be recycled, which will call
+    // ApplicationManager->Shutdown(). This will call shutdown on the application.
+    LOG_INFO(L"AspNetCore InProcess Recycle Process on Demand");
+    m_pHttpServer.RecycleProcess(L"AspNetCore InProcess Recycle Process on Demand");
 }
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessApplicationBase.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/InProcessRequestHandler/InProcessApplicationBase.cpp
@@ -40,7 +40,7 @@ InProcessApplicationBase::StopInternal(bool fServerInitiated)
         return;
     }
 
-    // Stop was initiated by server no need to do anything, server would stop on it's own
+    // Stop was initiated by server no need to do anything, server would stop on its own
     if (fServerInitiated)
     {
         return;

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/EventLogHelpers.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/EventLogHelpers.cs
@@ -162,9 +162,16 @@ public class EventLogHelpers
         }
     }
 
-    public static string InProcessShutdown()
+    public static string ShutdownMessage(IISDeploymentResult deploymentResult)
     {
-        return "Application 'MACHINE/WEBROOT/APPHOST/.*?' has shutdown.";
+        if (deploymentResult.DeploymentParameters.HostingModel == HostingModel.InProcess)
+        {
+            return "Application 'MACHINE/WEBROOT/APPHOST/.*?' has shutdown.";
+        }
+        else
+        {
+            return "Application '/LM/W3SVC/1/ROOT' with physical root '.*?' shut down process with Id '.*?' listening on port '.*?'";
+        }
     }
 
     public static string ShutdownFileChange(IISDeploymentResult deploymentResult)

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/EventLogHelpers.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/EventLogHelpers.cs
@@ -79,7 +79,7 @@ public class EventLogHelpers
         return string.Join(",", entries.Select(e => e.Message));
     }
 
-    private static IEnumerable<EventLogEntry> GetEntries(IISDeploymentResult deploymentResult)
+    internal static IEnumerable<EventLogEntry> GetEntries(IISDeploymentResult deploymentResult)
     {
         var eventLog = new EventLog("Application");
 

--- a/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/Helpers.cs
+++ b/src/Servers/IIS/IIS/test/Common.FunctionalTests/Infrastructure/Helpers.cs
@@ -8,6 +8,7 @@ using System.Xml.Linq;
 using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Microsoft.AspNetCore.Server.IntegrationTesting.IIS;
 using Microsoft.Extensions.Logging;
+using Microsoft.Web.Administration;
 using Newtonsoft.Json;
 
 namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
@@ -177,6 +178,15 @@ public static class Helpers
             verificationAction = verificationAction ?? (() => deploymentResult.AssertStarts());
             await verificationAction();
         }
+    }
+
+    // Don't use with IISExpress, recycle isn't a valid operation
+    public static void Recycle(string appPoolName)
+    {
+        using var serverManager = new ServerManager();
+        var appPool = serverManager.ApplicationPools.FirstOrDefault(ap => ap.Name == appPoolName);
+        Assert.NotNull(appPool);
+        appPool.Recycle();
     }
 
     public static IEnumerable<object[]> ToTheoryData<T>(this Dictionary<string, T> dictionary)

--- a/src/Servers/IIS/IIS/test/Common.LongTests/ShutdownTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/ShutdownTests.cs
@@ -262,7 +262,6 @@ public class ShutdownTests : IISFunctionalTestBase
 
     [ConditionalFact]
     [RequiresNewShim]
-    [Repeat(10)] // temp for CI testing
     public async Task RequestsWhileRestartingAppFromConfigChangeAreProcessed()
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
@@ -300,7 +299,6 @@ public class ShutdownTests : IISFunctionalTestBase
 
     [ConditionalFact]
     [RequiresNewShim]
-    [Repeat(10)] // temp for CI testing
     public async Task RequestsWhileRecyclingAppAreProcessed()
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);

--- a/src/Servers/IIS/IIS/test/Common.LongTests/ShutdownTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/ShutdownTests.cs
@@ -257,7 +257,7 @@ public class ShutdownTests : IISFunctionalTestBase
 
         // Shutdown should be graceful here!
         EventLogHelpers.VerifyEventLogEvent(deploymentResult,
-            EventLogHelpers.InProcessShutdown(), Logger);
+            EventLogHelpers.ShutdownMessage(deploymentResult), Logger);
     }
 
     [ConditionalFact]
@@ -295,7 +295,7 @@ public class ShutdownTests : IISFunctionalTestBase
 
         // Shutdown should be graceful here!
         EventLogHelpers.VerifyEventLogEvent(deploymentResult,
-            EventLogHelpers.InProcessShutdown(), Logger);
+            EventLogHelpers.ShutdownMessage(deploymentResult), Logger);
     }
 
     [ConditionalFact]
@@ -333,7 +333,7 @@ public class ShutdownTests : IISFunctionalTestBase
 
         // Shutdown should be graceful here!
         EventLogHelpers.VerifyEventLogEvent(deploymentResult,
-            EventLogHelpers.InProcessShutdown(), Logger);
+            EventLogHelpers.ShutdownMessage(deploymentResult), Logger);
     }
 
     [ConditionalFact]

--- a/src/Servers/IIS/IIS/test/Common.LongTests/ShutdownTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/ShutdownTests.cs
@@ -261,6 +261,82 @@ public class ShutdownTests : IISFunctionalTestBase
     }
 
     [ConditionalFact]
+    [RequiresNewShim]
+    [Repeat(10)] // temp for CI testing
+    public async Task RequestsWhileRestartingAppFromConfigChangeAreProcessed()
+    {
+        var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
+
+        if (deploymentParameters.ServerType == ServerType.IISExpress)
+        {
+            // IISExpress doesn't support recycle
+            return;
+        }
+
+        var deploymentResult = await DeployAsync(deploymentParameters);
+
+        var result = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        result.Dispose();
+
+        // Just "touching" web.config should be enough to restart the process
+        deploymentResult.ModifyWebConfig(element => { });
+
+        // Default shutdown delay is 1 second, we want to send requests while the shutdown is happening
+        // So we send a bunch of requests and one of them hopefully will run during shutdown and be queued for processing by the new app
+        for (var i = 0; i < 2000; i++)
+        {
+            using var res = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
+            await Task.Delay(1);
+            Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+        }
+
+        await deploymentResult.AssertRecycledAsync();
+
+        // Shutdown should be graceful here!
+        EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+            EventLogHelpers.InProcessShutdown(), Logger);
+    }
+
+    [ConditionalFact]
+    [RequiresNewShim]
+    [Repeat(10)] // temp for CI testing
+    public async Task RequestsWhileRecyclingAppAreProcessed()
+    {
+        var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);
+
+        if (deploymentParameters.ServerType == ServerType.IISExpress)
+        {
+            // IISExpress doesn't support recycle
+            return;
+        }
+
+        var deploymentResult = await DeployAsync(deploymentParameters);
+
+        var result = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        result.Dispose();
+
+        // Recycle app pool
+        Helpers.Recycle(deploymentResult.AppPoolName);
+
+        // Default shutdown delay is 1 second, we want to send requests while the shutdown is happening
+        // So we send a bunch of requests and one of them hopefully will run during shutdown and be queued for processing by the new app
+        for (var i = 0; i < 2000; i++)
+        {
+            using var res = await deploymentResult.HttpClient.GetAsync("/HelloWorld");
+            await Task.Delay(1);
+            Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+        }
+
+        await deploymentResult.AssertRecycledAsync();
+
+        // Shutdown should be graceful here!
+        EventLogHelpers.VerifyEventLogEvent(deploymentResult,
+            EventLogHelpers.InProcessShutdown(), Logger);
+    }
+
+    [ConditionalFact]
     public async Task AppOfflineDroppedWhileSiteRunning_SiteShutsDown_InProcess()
     {
         var deploymentResult = await AssertStarts(HostingModel.InProcess);

--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ApplicationInitializationTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ApplicationInitializationTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.ServiceProcess;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.IIS.FunctionalTests.Utilities;
@@ -37,9 +38,11 @@ public class ApplicationInitializationTests : IISFunctionalTestBase
 
     [ConditionalTheory]
     [RequiresIIS(IISCapability.ApplicationInitialization)]
-    [InlineData(HostingModel.InProcess)]
-    [InlineData(HostingModel.OutOfProcess)]
-    public async Task ApplicationPreloadStartsApp(HostingModel hostingModel)
+    [InlineData(HostingModel.InProcess, true)]
+    [InlineData(HostingModel.OutOfProcess, true)]
+    [InlineData(HostingModel.InProcess, false)]
+    [InlineData(HostingModel.OutOfProcess, false)]
+    public async Task ApplicationPreloadStartsApp(HostingModel hostingModel, bool delayShutdown)
     {
         // This test often hits a memory leak in warmup.dll module, it has been reported to IIS team
         using (AppVerifier.Disable(DeployerSelector.ServerType, 0x900))
@@ -49,12 +52,26 @@ public class ApplicationInitializationTests : IISFunctionalTestBase
                 (args, contentRoot) => $"{args} CreateFile \"{Path.Combine(contentRoot, "Started.txt")}\"");
             EnablePreload(baseDeploymentParameters);
 
+            baseDeploymentParameters.HandlerSettings["shutdownDelay"] = delayShutdown ? "1000" : "0";
             var result = await DeployAsync(baseDeploymentParameters);
 
             await Helpers.Retry(async () => await File.ReadAllTextAsync(Path.Combine(result.ContentRoot, "Started.txt")), TimeoutExtensions.DefaultTimeoutValue);
             StopServer();
             EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.Started(result), Logger);
-            EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.ShutdownMessage(result), Logger);
+
+            if (delayShutdown)
+            {
+                EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.ShutdownMessage(result), Logger);
+            }
+            else
+            {
+                Assert.True(result.HostProcess.HasExited);
+
+                var entries = EventLogHelpers.GetEntries(result);
+                var expectedRegex = new Regex(EventLogHelpers.ShutdownMessage(result), RegexOptions.Singleline);
+                var matchedEntries = entries.Where(entry => expectedRegex.IsMatch(entry.Message)).ToArray();
+                Assert.Empty(matchedEntries);
+            }
         }
     }
 

--- a/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ApplicationInitializationTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Shared.FunctionalTests/ApplicationInitializationTests.cs
@@ -54,6 +54,7 @@ public class ApplicationInitializationTests : IISFunctionalTestBase
             await Helpers.Retry(async () => await File.ReadAllTextAsync(Path.Combine(result.ContentRoot, "Started.txt")), TimeoutExtensions.DefaultTimeoutValue);
             StopServer();
             EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.Started(result), Logger);
+            EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.ShutdownMessage(result), Logger);
         }
     }
 
@@ -84,6 +85,7 @@ public class ApplicationInitializationTests : IISFunctionalTestBase
             await Helpers.Retry(async () => await File.ReadAllTextAsync(Path.Combine(result.ContentRoot, "Started.txt")), TimeoutExtensions.DefaultTimeoutValue);
             StopServer();
             EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.Started(result), Logger);
+            EventLogHelpers.VerifyEventLogEvent(result, EventLogHelpers.ShutdownMessage(result), Logger);
         }
     }
 


### PR DESCRIPTION
Fix for https://github.com/dotnet/aspnetcore/issues/41340

#### Issue summary:
When an app is recycling (config change, new deployment, regularly scheduled recycle, resource utilization rule recycle, etc.) IIS will notify our native module and we will initiate a shutdown of the managed application. While we're shutting down we reject any new requests we get with a 503. IIS has a feature (enabled by default) called overlapped recycle, where it will start a new instance of the application while the old one is shutting down, and it will queue then send incoming requests to the new app. In ASP.NET this worked well and 503's would not occur during overlapped recycles. In ASP.NET Core this didn't work and incoming requests weren't being sent to the new app even though it was started.

#### Fix summary:
I discovered that if you blocked the `OnGlobalStopListening` method, which is how IIS tells us it will stop sending us requests, then we will continue to get new requests until we complete the method. And since we were calling shutdown inline in response to that method being called we were blocking until the managed app shutdown and during shutdown we would reject incoming requests with 503. So the fix was to run shutdown on a thread and exit `OnGlobalStopListening` ASAP. This lets IIS stop sending us requests and queue and send them to the new app while we shut down the managed application.

The fix also includes a default delay of 1 second before we call shutdown in order to reduce any races between IIS actually stopping sending us requests after `OnGlobalStopListening` completes and us starting shut down which is when we would start sending 503's. The delay is configurable via `shutdownDelay` in the web config, or `ANCM_shutdownDelay` environment variable (both in milliseconds). I'm sort of leaning towards `delayShutdown` as a name instead, we can bike shed on that 😃 

There is a second fix that was found while trying to fix the original issue. By listening to `GL_APPLICATION_STOP` we can now properly detect "Apps with preload + always running that don't receive a request before recycle/shutdown" and IISExpress app shutdown. Issue https://github.com/dotnet/aspnetcore/issues/28089 and can't find the one about IISExpress 🤷