### PR TITLE
Fix SSR page rendering intermediate state instead of the end state of components

### DIFF
--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -593,7 +593,11 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
     {
         // The pendingTasks collection is only used during prerendering to track quiescence,
         // so will be null at other times.
-        _pendingTasks?.Add(task);
+        if (_pendingTasks is { } tasks)
+        {
+            Dispatcher.AssertAccess();
+            tasks.Add(task);
+        }
     }
 
     internal void AssignEventHandlerId(int renderedByComponentId, ref RenderTreeFrame frame)

--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -107,7 +107,7 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
                     return;
                 }
 
-                await Task.WhenAll(_renderer.AllNonStreamingPendingTasks);
+                await _renderer.WaitForNonStreamingPendingTasks();
             }
             catch (NavigationException ex)
             {

--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -107,7 +107,7 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
                     return;
                 }
 
-                await Task.WhenAll(_renderer.NonStreamingPendingTasks);
+                await Task.WhenAll(_renderer.AllNonStreamingPendingTasks);
             }
             catch (NavigationException ex)
             {

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
@@ -276,25 +276,4 @@ internal partial class EndpointHtmlRenderer
         public Task QuiescenceTask =>
             _htmlToEmitOrNull.HasValue ? _htmlToEmitOrNull.Value.QuiescenceTask : Task.CompletedTask;
     }
-
-    class NonStreamingPendingTasks
-    {
-        private readonly List<Task> _currentTasks = new List<Task>();
-        private readonly List<Task> _allTasks = new List<Task>();
-
-        public int CurrentCount => _currentTasks.Count;
-        public List<Task> CurrentTasks => new List<Task>(_currentTasks);
-        public List<Task> AllTasks => new List<Task>(_allTasks);
-
-        public void AddTask(Task task)
-        {
-            _currentTasks.Add(task);
-            _allTasks.Add(task);
-        }
-
-        public void ClearTasks()
-        {
-            _currentTasks.Clear();
-        }
-    }
 }

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
@@ -161,8 +161,23 @@ internal partial class EndpointHtmlRenderer
         }
         else if (_nonStreamingPendingTasks.Count > 0)
         {
-            // Just wait for quiescence of the non-streaming subtrees
-            await Task.WhenAll(_nonStreamingPendingTasks);
+            await WaitForNonStreamingPendingTasks();
+        }
+    }
+
+    private async Task WaitForNonStreamingPendingTasks()
+    {
+        while (_nonStreamingPendingTasks.Count > 0)
+        {
+            // Create a Task that represents the remaining ongoing work for the rendering process
+            var pendingWork = Task.WhenAll(_nonStreamingPendingTasks);
+
+            // Clear all pending work.
+            _nonStreamingPendingTasks.Clear();
+
+            // new work might be added before we check again as a result of waiting for all
+            // the child components to finish executing SetParametersAsync
+            await pendingWork;
         }
     }
 

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
@@ -165,7 +165,7 @@ internal partial class EndpointHtmlRenderer
         }
     }
 
-    private async Task WaitForNonStreamingPendingTasks()
+    public async Task WaitForNonStreamingPendingTasks()
     {
         while (_nonStreamingPendingTasks.CurrentCount > 0)
         {

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
@@ -46,7 +46,7 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
     // when everything (regardless of streaming SSR) is fully complete. In this subclass we also track
     // the subset of those that are from the non-streaming subtrees, since we want the response to
     // wait for the non-streaming tasks (these ones), then start streaming until full quiescence.
-    private readonly List<Task> _nonStreamingPendingTasks = new();
+    private readonly NonStreamingPendingTasks _nonStreamingPendingTasks = new();
 
     public EndpointHtmlRenderer(IServiceProvider serviceProvider, ILoggerFactory loggerFactory)
         : base(serviceProvider, loggerFactory)
@@ -123,9 +123,7 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
 
         if (!streamRendering)
         {
-            _nonStreamingPendingTasks.Add(task);
-            // For tests only
-            AllNonStreamingPendingTasks.Add(task);
+            _nonStreamingPendingTasks.AddTask(task);
         }
 
         // We still need to determine full quiescence, so always let the base renderer track this task too
@@ -133,7 +131,7 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
     }
 
     // For tests only
-    internal List<Task> AllNonStreamingPendingTasks = new List<Task>();
+    internal List<Task> AllNonStreamingPendingTasks => _nonStreamingPendingTasks.AllTasks;
 
     protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
     {

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
@@ -230,4 +230,25 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
             return _form.GetEnumerator();
         }
     }
+
+    private sealed class NonStreamingPendingTasks
+    {
+        private readonly List<Task> _currentTasks = new List<Task>();
+        private readonly List<Task> _allTasks = new List<Task>();
+
+        public int CurrentCount => _currentTasks.Count;
+        public List<Task> CurrentTasks => new List<Task>(_currentTasks);
+        public List<Task> AllTasks => new List<Task>(_allTasks);
+
+        public void AddTask(Task task)
+        {
+            _currentTasks.Add(task);
+            _allTasks.Add(task);
+        }
+
+        public void ClearTasks()
+        {
+            _currentTasks.Clear();
+        }
+    }
 }

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
@@ -124,6 +124,8 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
         if (!streamRendering)
         {
             _nonStreamingPendingTasks.Add(task);
+            // For tests only
+            AllNonStreamingPendingTasks.Add(task);
         }
 
         // We still need to determine full quiescence, so always let the base renderer track this task too
@@ -131,7 +133,7 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
     }
 
     // For tests only
-    internal List<Task> NonStreamingPendingTasks => _nonStreamingPendingTasks;
+    internal List<Task> AllNonStreamingPendingTasks = new List<Task>();
 
     protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
     {

--- a/src/Components/Endpoints/test/RazorComponentResultTest.cs
+++ b/src/Components/Endpoints/test/RazorComponentResultTest.cs
@@ -336,10 +336,11 @@ public class RazorComponentResultTest
     {
         // Arrange
         var testContext = PrepareVaryStreamingScenariosTests();
-        var initialOutputTask = Task.WhenAll(testContext.Renderer.AllNonStreamingPendingTasks);
+        var initialOutputTask = testContext.Renderer.NonStreamingPendingTasksCompletion;
 
         // Act/Assert: Even if all other blocking tasks complete, we don't produce output until the top-level
         // nonstreaming component completes
+        Assert.NotNull(initialOutputTask);
         testContext.WithinNestedNonstreamingRegionTask.SetResult();
         await Task.Yield(); // Just to show it's still not completed after
         Assert.False(initialOutputTask.IsCompleted);
@@ -368,10 +369,11 @@ public class RazorComponentResultTest
     {
         // Arrange
         var testContext = PrepareVaryStreamingScenariosTests();
-        var initialOutputTask = Task.WhenAll(testContext.Renderer.AllNonStreamingPendingTasks);
+        var initialOutputTask = testContext.Renderer.NonStreamingPendingTasksCompletion;
 
         // Act/Assert: Even if all other nonblocking tasks complete, we don't produce output until
         // the component in the nonstreaming subtree is quiescent
+        Assert.NotNull(initialOutputTask);
         testContext.TopLevelComponentTask.SetResult();
         await Task.Yield(); // Just to show it's still not completed after
         Assert.False(initialOutputTask.IsCompleted);

--- a/src/Components/Endpoints/test/RazorComponentResultTest.cs
+++ b/src/Components/Endpoints/test/RazorComponentResultTest.cs
@@ -336,7 +336,7 @@ public class RazorComponentResultTest
     {
         // Arrange
         var testContext = PrepareVaryStreamingScenariosTests();
-        var initialOutputTask = Task.WhenAll(testContext.Renderer.NonStreamingPendingTasks);
+        var initialOutputTask = Task.WhenAll(testContext.Renderer.AllNonStreamingPendingTasks);
 
         // Act/Assert: Even if all other blocking tasks complete, we don't produce output until the top-level
         // nonstreaming component completes
@@ -368,7 +368,7 @@ public class RazorComponentResultTest
     {
         // Arrange
         var testContext = PrepareVaryStreamingScenariosTests();
-        var initialOutputTask = Task.WhenAll(testContext.Renderer.NonStreamingPendingTasks);
+        var initialOutputTask = Task.WhenAll(testContext.Renderer.AllNonStreamingPendingTasks);
 
         // Act/Assert: Even if all other nonblocking tasks complete, we don't produce output until
         // the component in the nonstreaming subtree is quiescent

--- a/src/Components/test/E2ETest/ServerRenderingTests/RenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/RenderingTest.cs
@@ -57,4 +57,14 @@ public class RenderingTest : ServerTestBase<BasicTestAppServerSiteFixture<RazorC
         Navigate($"{ServerPathBase}/ssr-page-that-delays-loading");
         Browser.Equal("loaded child", () => Browser.Exists(By.Id("child")).Text);
     }
+
+    [Fact]
+    public void PostRequestRendersEndStateOfComponentsOnSSRPage()
+    {
+        Navigate($"{ServerPathBase}/forms/post-form-with-component-that-delays-loading");
+
+        Browser.Exists(By.Id("submit-button")).Click();
+
+        Browser.Equal("loaded child", () => Browser.Exists(By.Id("child")).Text);
+    }
 }

--- a/src/Components/test/E2ETest/ServerRenderingTests/RenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/RenderingTest.cs
@@ -50,4 +50,11 @@ public class RenderingTest : ServerTestBase<BasicTestAppServerSiteFixture<RazorC
         var response = await new HttpClient().GetAsync(Browser.Url);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
+
+    [Fact]
+    public void RendersEndStateOfComponentsOnSSRPage()
+    {
+        Navigate($"{ServerPathBase}/ssr-page-that-delays-loading");
+        Browser.Equal("loaded child", () => Browser.Exists(By.Id("child")).Text);
+    }
 }

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Components/ChildComponentThatDelaysLoading.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Components/ChildComponentThatDelaysLoading.razor
@@ -1,0 +1,13 @@
+﻿<p id="child">@childString</p>
+
+@code {
+    private string childString = "initial child";
+
+    protected override async Task OnInitializedAsync()
+    {
+        await Task.Delay(1000);
+
+        childString = "loaded child";
+    }
+
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Components/ChildComponentThatDelaysLoading.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Components/ChildComponentThatDelaysLoading.razor
@@ -5,7 +5,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        await Task.Delay(1000);
+        await Task.Yield();
 
         childString = "loaded child";
     }

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Components/ParentComponentThatDelaysLoading.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Components/ParentComponentThatDelaysLoading.razor
@@ -14,7 +14,7 @@
 
     private async Task<bool> Load()
     {
-        await Task.Delay(1000);
+        await Task.Yield();
 
         return true;
     }

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Components/ParentComponentThatDelaysLoading.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Components/ParentComponentThatDelaysLoading.razor
@@ -1,0 +1,21 @@
+﻿@if (_loaded)
+{
+    <ChildComponentThatDelaysLoading />
+}
+
+@code {
+    private bool _loaded;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+        _loaded = await Load();
+    }
+
+    private async Task<bool> Load()
+    {
+        await Task.Delay(1000);
+
+        return true;
+    }
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/PostFormWithComponentThatDelaysLoading.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/PostFormWithComponentThatDelaysLoading.razor
@@ -1,0 +1,19 @@
+﻿@page "/forms/post-form-with-component-that-delays-loading"
+@using Microsoft.AspNetCore.Components.Forms
+
+<h3>Post Form With Component That Delays Loading</h3>
+
+@if (_render)
+{
+    <ParentComponentThatDelaysLoading />
+}
+
+<form @onsubmit="@(() => _render = true)" @formname="myform" method="post">
+    <AntiforgeryToken />
+    <button id="submit-button">Submit</button>
+</form>
+
+@code
+{
+    bool _render;
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/SSRPageThatDelaysLoading.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/SSRPageThatDelaysLoading.razor
@@ -1,0 +1,25 @@
+﻿@page "/ssr-page-that-delays-loading"
+<h1>SSR page that delays loading</h1>
+
+@if (_loaded)
+{
+    <ChildComponentThatDelaysLoading />
+}
+
+@code {
+    private bool _loaded;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+        _loaded = await Load();
+    }
+
+    private async Task<bool> Load()
+    {
+        await Task.Delay(1000);
+
+        return true;
+    }
+}
+

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/SSRPageThatDelaysLoading.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/SSRPageThatDelaysLoading.razor
@@ -1,25 +1,5 @@
 ﻿@page "/ssr-page-that-delays-loading"
 <h1>SSR page that delays loading</h1>
 
-@if (_loaded)
-{
-    <ChildComponentThatDelaysLoading />
-}
-
-@code {
-    private bool _loaded;
-
-    protected override async Task OnInitializedAsync()
-    {
-        await base.OnInitializedAsync();
-        _loaded = await Load();
-    }
-
-    private async Task<bool> Load()
-    {
-        await Task.Delay(1000);
-
-        return true;
-    }
-}
+<ParentComponentThatDelaysLoading />
 


### PR DESCRIPTION
# Fix SSR page rendering intermediate state instead of the end state of components

The problem was that not all non streaming pending tasks are awaited.
By the time it reaches this [line](https://github.com/dotnet/aspnetcore/blob/main/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs#L165) not all non streaming pending tasks are in the list. Later other tasks can be added by child components.
I used a similar technique to correctly await all the non streaming pending tasks that is already is used [here](https://github.com/dotnet/aspnetcore/blob/main/src/Components/Components/src/RenderTree/Renderer.cs#L334-L351).

Same problem when post requests awaits non streaming pending tasks. Not all non streaming pending tasks are in the list. Later other tasks can be added by child components.

Fixes #52131
Fixes #52871
