### PR TITLE
Fix shadow copy up to date check on startup

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/Environment.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/Environment.cpp
@@ -231,7 +231,7 @@ bool Environment::CheckUpToDate(const std::wstring& source, const std::filesyste
             auto sourceInnerDirectory = std::filesystem::directory_entry(path);
             if (sourceInnerDirectory.path() != directoryToIgnore)
             {
-                CheckUpToDate(path.path(), destination / path.path().filename(), extension, directoryToIgnore);
+                CheckUpToDate(/* source */ path.path(), /* destination */ destination / path.path().filename(), extension, directoryToIgnore);
             }
         }
     }

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/Environment.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLib/Environment.cpp
@@ -231,7 +231,7 @@ bool Environment::CheckUpToDate(const std::wstring& source, const std::filesyste
             auto sourceInnerDirectory = std::filesystem::directory_entry(path);
             if (sourceInnerDirectory.path() != directoryToIgnore)
             {
-                CheckUpToDate(destination / path.path().filename(), path.path(), extension, directoryToIgnore);
+                CheckUpToDate(path.path(), destination / path.path().filename(), extension, directoryToIgnore);
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/48233

If using shadow copy in ANCM and you shutdown the app (e.g. app_offline.htm) then delete a subfolder (with a dll), starting up the app can cause a crash that can only be resolved by adding back the deleted folder. Or resolved by deleting the shadow copy folder (either manually or with `cleanShadowCopyDirectory` setting turned on).

The issue submitter helpfully pointed out the code that was problematic, we basically swapped which directory is the "main" directory every recursion of the up to date function. The fix is simple, keep the app directory as the main directory.

Test added that repros the scenario.