### PR TITLE
Improve debug views of dictionaries

### DIFF
--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
@@ -20,7 +20,7 @@
     <Compile Include="$(SharedSourceRoot)LinkerFlags.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)QueryStringEnumerable.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
-    <Compile Include="$(SharedSourceRoot)Debugger\IDictionaryDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryDebugView.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <Import Project="Microsoft.AspNetCore.Components.Routing.targets" />

--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
@@ -19,10 +19,12 @@
     <Compile Include="$(ComponentsSharedSourceRoot)src\HotReloadManager.cs" LinkBase="HotReload" />
     <Compile Include="$(SharedSourceRoot)LinkerFlags.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)QueryStringEnumerable.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\IDictionaryDebugView.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <Import Project="Microsoft.AspNetCore.Components.Routing.targets" />
-  
+
   <ItemGroup>
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />

--- a/src/Extensions/Features/src/FeatureCollection.cs
+++ b/src/Extensions/Features/src/FeatureCollection.cs
@@ -161,6 +161,6 @@ public class FeatureCollection : IFeatureCollection
         private readonly FeatureCollection _features = features;
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public KeyValuePair<string, object>[] Items => _features.Select(pair => new KeyValuePair<string, object>(pair.Key.FullName ?? string.Empty, pair.Value)).ToArray();
+        public DictionaryItemDebugView<Type, object>[] Items => _features.Select(pair => new DictionaryItemDebugView<Type, object>(pair)).ToArray();
     }
 }

--- a/src/Extensions/Features/src/Microsoft.Extensions.Features.csproj
+++ b/src/Extensions/Features/src/Microsoft.Extensions.Features.csproj
@@ -19,6 +19,7 @@ Microsoft.AspNetCore.Http.Features.FeatureCollection
     <Compile Include="$(SharedSourceRoot)ThrowHelpers\ArgumentNullThrowHelper.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)ThrowHelpers\ArgumentOutOfRangeThrowHelper.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)CallerArgument\CallerArgumentExpressionAttribute.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
   </ItemGroup>
 
 </Project>

--- a/src/Http/Http.Abstractions/src/HttpContext.cs
+++ b/src/Http/Http.Abstractions/src/HttpContext.cs
@@ -108,6 +108,6 @@ public abstract class HttpContext
         private readonly IFeatureCollection _features = features;
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public KeyValuePair<string, object>[] Items => _features.Select(pair => new KeyValuePair<string, object>(pair.Key.FullName ?? string.Empty, pair.Value)).ToArray();
+        public DictionaryItemDebugView<Type, object>[] Items => _features.Select(pair => new DictionaryItemDebugView<Type, object>(pair)).ToArray();
     }
 }

--- a/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
+++ b/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
@@ -30,7 +30,7 @@ Microsoft.AspNetCore.Http.HttpResponse</Description>
     <Compile Include="$(SharedSourceRoot)Debugger\HttpContextDebugFormatter.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Debugger\DebuggerHelpers.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
-    <Compile Include="$(SharedSourceRoot)Debugger\IDictionaryDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryDebugView.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
+++ b/src/Http/Http.Abstractions/src/Microsoft.AspNetCore.Http.Abstractions.csproj
@@ -29,6 +29,8 @@ Microsoft.AspNetCore.Http.HttpResponse</Description>
     <Compile Include="$(SharedSourceRoot)Reroute.cs" />
     <Compile Include="$(SharedSourceRoot)Debugger\HttpContextDebugFormatter.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Debugger\DebuggerHelpers.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\IDictionaryDebugView.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Http/Http.Abstractions/src/Routing/RouteValueDictionary.cs
+++ b/src/Http/Http.Abstractions/src/Routing/RouteValueDictionary.cs
@@ -4,8 +4,9 @@
 using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Shared;
+
 #if !COMPONENTS
 using System.Collections.Concurrent;
 using System.Reflection.Metadata;
@@ -29,7 +30,7 @@ namespace Microsoft.AspNetCore.Routing;
 /// An <see cref="IDictionary{String, Object}"/> type for route values.
 /// </summary>
 #endif
-[DebuggerTypeProxy(typeof(RouteValueDictionaryDebugView))]
+[DebuggerTypeProxy(typeof(IDictionaryDebugView<string, object?>))]
 [DebuggerDisplay("Count = {Count}")]
 #if !COMPONENTS
 public class RouteValueDictionary : IDictionary<string, object?>, IReadOnlyDictionary<string, object?>
@@ -929,12 +930,4 @@ internal class RouteValueDictionary : IDictionary<string, object?>, IReadOnlyDic
         }
     }
 #endif
-
-    private sealed class RouteValueDictionaryDebugView(RouteValueDictionary dictionary)
-    {
-        private readonly RouteValueDictionary _dictionary = dictionary;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public KeyValuePair<string, object?>[] Items => _dictionary.ToArray();
-    }
 }

--- a/src/Http/Http.Abstractions/src/Routing/RouteValueDictionary.cs
+++ b/src/Http/Http.Abstractions/src/Routing/RouteValueDictionary.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Routing;
 /// An <see cref="IDictionary{String, Object}"/> type for route values.
 /// </summary>
 #endif
-[DebuggerTypeProxy(typeof(IDictionaryDebugView<string, object?>))]
+[DebuggerTypeProxy(typeof(DictionaryDebugView<string, object?>))]
 [DebuggerDisplay("Count = {Count}")]
 #if !COMPONENTS
 public class RouteValueDictionary : IDictionary<string, object?>, IReadOnlyDictionary<string, object?>

--- a/src/Http/Http/src/FormCollection.cs
+++ b/src/Http/Http/src/FormCollection.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
-using Microsoft.AspNetCore.Shared;
 using System.Diagnostics;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Http;

--- a/src/Http/Http/src/FormCollection.cs
+++ b/src/Http/Http/src/FormCollection.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Http;
 /// Contains the parsed HTTP form values.
 /// </summary>
 [DebuggerDisplay("Count = {Count}")]
-[DebuggerTypeProxy(typeof(EnumerableStringValuesDebugView))]
+[DebuggerTypeProxy(typeof(StringValuesDictionaryDebugView))]
 public class FormCollection : IFormCollection
 {
     /// <summary>

--- a/src/Http/Http/src/FormCollection.cs
+++ b/src/Http/Http/src/FormCollection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using Microsoft.AspNetCore.Shared;
+using System.Diagnostics;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Http;
@@ -9,6 +11,8 @@ namespace Microsoft.AspNetCore.Http;
 /// <summary>
 /// Contains the parsed HTTP form values.
 /// </summary>
+[DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(EnumerableStringValuesDebugView))]
 public class FormCollection : IFormCollection
 {
     /// <summary>

--- a/src/Http/Http/src/HeaderDictionary.cs
+++ b/src/Http/Http/src/HeaderDictionary.cs
@@ -4,7 +4,6 @@
 using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Microsoft.AspNetCore.Shared;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
@@ -14,8 +13,8 @@ namespace Microsoft.AspNetCore.Http;
 /// <summary>
 /// Represents a wrapper for RequestHeaders and ResponseHeaders.
 /// </summary>
-[DebuggerTypeProxy(typeof(HeaderDictionaryDebugView))]
 [DebuggerDisplay("{DebuggerToString(),nq}")]
+[DebuggerTypeProxy(typeof(EnumerableStringValuesDebugView))]
 public class HeaderDictionary : IHeaderDictionary
 {
     private static readonly string[] EmptyKeys = Array.Empty<string>();
@@ -455,13 +454,5 @@ public class HeaderDictionary : IHeaderDictionary
                 ((IEnumerator)_dictionaryEnumerator).Reset();
             }
         }
-    }
-
-    private sealed class HeaderDictionaryDebugView(HeaderDictionary dictionary)
-    {
-        private readonly HeaderDictionary _dictionary = dictionary;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public DictionaryItemDebugView<string, string>[] Items => _dictionary.Select(pair => new DictionaryItemDebugView<string, string>(pair.Key, pair.Value.ToString())).ToArray();
     }
 }

--- a/src/Http/Http/src/HeaderDictionary.cs
+++ b/src/Http/Http/src/HeaderDictionary.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 
@@ -461,6 +462,6 @@ public class HeaderDictionary : IHeaderDictionary
         private readonly HeaderDictionary _dictionary = dictionary;
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public KeyValuePair<string, string>[] Items => _dictionary.Select(pair => new KeyValuePair<string, string>(pair.Key, pair.Value.ToString())).ToArray();
+        public DictionaryItemDebugView<string, string>[] Items => _dictionary.Select(pair => new DictionaryItemDebugView<string, string>(pair.Key, pair.Value.ToString())).ToArray();
     }
 }

--- a/src/Http/Http/src/HeaderDictionary.cs
+++ b/src/Http/Http/src/HeaderDictionary.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Http;
 /// Represents a wrapper for RequestHeaders and ResponseHeaders.
 /// </summary>
 [DebuggerDisplay("{DebuggerToString(),nq}")]
-[DebuggerTypeProxy(typeof(EnumerableStringValuesDebugView))]
+[DebuggerTypeProxy(typeof(StringValuesDictionaryDebugView))]
 public class HeaderDictionary : IHeaderDictionary
 {
     private static readonly string[] EmptyKeys = Array.Empty<string>();

--- a/src/Http/Http/src/Internal/ItemsDictionary.cs
+++ b/src/Http/Http/src/Internal/ItemsDictionary.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.AspNetCore.Http;
 
-[DebuggerTypeProxy(typeof(IDictionaryDebugView<object, object>))]
+[DebuggerTypeProxy(typeof(DictionaryDebugView<object, object>))]
 [DebuggerDisplay("Count = {Items.Count}")]
 internal sealed class ItemsDictionary : IDictionary<object, object?>
 {

--- a/src/Http/Http/src/Internal/ItemsDictionary.cs
+++ b/src/Http/Http/src/Internal/ItemsDictionary.cs
@@ -4,11 +4,11 @@
 using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.AspNetCore.Http;
 
-[DebuggerTypeProxy(typeof(ItemsDictionaryDebugView))]
+[DebuggerTypeProxy(typeof(IDictionaryDebugView<object, object>))]
 [DebuggerDisplay("Count = {Items.Count}")]
 internal sealed class ItemsDictionary : IDictionary<object, object?>
 {
@@ -142,7 +142,7 @@ internal sealed class ItemsDictionary : IDictionary<object, object?>
 
     private sealed class EmptyEnumerator : IEnumerator<KeyValuePair<object, object?>>
     {
-        // In own class so only initalized if GetEnumerator is called on an empty ItemsDictionary
+        // In own class so only initialized if GetEnumerator is called on an empty ItemsDictionary
         public static readonly IEnumerator<KeyValuePair<object, object?>> Instance = new EmptyEnumerator();
         public KeyValuePair<object, object?> Current => default;
 
@@ -159,16 +159,8 @@ internal sealed class ItemsDictionary : IDictionary<object, object?>
 
     private static class EmptyDictionary
     {
-        // In own class so only initalized if CopyTo is called on an empty ItemsDictionary
+        // In own class so only initialized if CopyTo is called on an empty ItemsDictionary
         public static readonly IDictionary<object, object?> Dictionary = new Dictionary<object, object?>();
         public static ICollection<KeyValuePair<object, object?>> Collection => Dictionary;
-    }
-
-    private sealed class ItemsDictionaryDebugView(ItemsDictionary dictionary)
-    {
-        private readonly ItemsDictionary _dictionary = dictionary;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public KeyValuePair<object, object?>[] Items => _dictionary.ToArray();
     }
 }

--- a/src/Http/Http/src/Internal/RequestCookieCollection.cs
+++ b/src/Http/Http/src/Internal/RequestCookieCollection.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.AspNetCore.Internal;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 
@@ -231,6 +232,6 @@ internal sealed class RequestCookieCollection : IRequestCookieCollection
         private readonly RequestCookieCollection _collection = collection;
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public KeyValuePair<string, string>[] Items => _collection.ToArray();
+        public DictionaryItemDebugView<string, string>[] Items => _collection.Select(pair => new DictionaryItemDebugView<string, string>(pair)).ToArray();
     }
 }

--- a/src/Http/Http/src/Microsoft.AspNetCore.Http.csproj
+++ b/src/Http/Http/src/Microsoft.AspNetCore.Http.csproj
@@ -22,6 +22,7 @@
     <Compile Include="$(SharedSourceRoot)Debugger\HttpContextDebugFormatter.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Debugger\IDictionaryDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\EnumerableStringValuesDebugView.cs" LinkBase="Shared" />
     <Compile Include="..\..\WebUtilities\src\AspNetCoreTempDirectory.cs" LinkBase="Internal" />
     <Compile Include="..\..\..\Shared\Dictionary\AdaptiveCapacityDictionary.cs" LinkBase="Internal" />
   </ItemGroup>

--- a/src/Http/Http/src/Microsoft.AspNetCore.Http.csproj
+++ b/src/Http/Http/src/Microsoft.AspNetCore.Http.csproj
@@ -21,8 +21,8 @@
     <Compile Include="$(SharedSourceRoot)HttpParseResult.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Debugger\HttpContextDebugFormatter.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
-    <Compile Include="$(SharedSourceRoot)Debugger\IDictionaryDebugView.cs" LinkBase="Shared" />
-    <Compile Include="$(SharedSourceRoot)Debugger\EnumerableStringValuesDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\StringValuesDictionaryDebugView.cs" LinkBase="Shared" />
     <Compile Include="..\..\WebUtilities\src\AspNetCoreTempDirectory.cs" LinkBase="Internal" />
     <Compile Include="..\..\..\Shared\Dictionary\AdaptiveCapacityDictionary.cs" LinkBase="Internal" />
   </ItemGroup>

--- a/src/Http/Http/src/Microsoft.AspNetCore.Http.csproj
+++ b/src/Http/Http/src/Microsoft.AspNetCore.Http.csproj
@@ -20,6 +20,8 @@
     <Compile Include="$(SharedSourceRoot)HttpRuleParser.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)HttpParseResult.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Debugger\HttpContextDebugFormatter.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\IDictionaryDebugView.cs" LinkBase="Shared" />
     <Compile Include="..\..\WebUtilities\src\AspNetCoreTempDirectory.cs" LinkBase="Internal" />
     <Compile Include="..\..\..\Shared\Dictionary\AdaptiveCapacityDictionary.cs" LinkBase="Internal" />
   </ItemGroup>

--- a/src/Http/Http/src/QueryCollection.cs
+++ b/src/Http/Http/src/QueryCollection.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Http;
 /// The HttpRequest query string collection
 /// </summary>
 [DebuggerDisplay("Count = {Count}")]
-[DebuggerTypeProxy(typeof(EnumerableStringValuesDebugView))]
+[DebuggerTypeProxy(typeof(StringValuesDictionaryDebugView))]
 public class QueryCollection : IQueryCollection
 {
     /// <summary>

--- a/src/Http/Http/src/QueryCollection.cs
+++ b/src/Http/Http/src/QueryCollection.cs
@@ -3,7 +3,6 @@
 
 using System.Collections;
 using System.Diagnostics;
-using System.Linq;
 using Microsoft.AspNetCore.Shared;
 using Microsoft.Extensions.Primitives;
 
@@ -13,7 +12,7 @@ namespace Microsoft.AspNetCore.Http;
 /// The HttpRequest query string collection
 /// </summary>
 [DebuggerDisplay("Count = {Count}")]
-[DebuggerTypeProxy(typeof(QueryCollectionDebugView))]
+[DebuggerTypeProxy(typeof(EnumerableStringValuesDebugView))]
 public class QueryCollection : IQueryCollection
 {
     /// <summary>
@@ -250,13 +249,5 @@ public class QueryCollection : IQueryCollection
                 ((IEnumerator)_dictionaryEnumerator).Reset();
             }
         }
-    }
-
-    private sealed class QueryCollectionDebugView(QueryCollectionInternal collection)
-    {
-        private readonly QueryCollectionInternal _collection = collection;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public DictionaryItemDebugView<string, string>[] Items => _collection.Select(pair => new DictionaryItemDebugView<string, string>(pair.Key, pair.Value.ToString())).ToArray();
     }
 }

--- a/src/Http/Http/src/QueryCollection.cs
+++ b/src/Http/Http/src/QueryCollection.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Http;
@@ -256,6 +257,6 @@ public class QueryCollection : IQueryCollection
         private readonly QueryCollectionInternal _collection = collection;
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public KeyValuePair<string, string>[] Items => _collection.Select(pair => new KeyValuePair<string, string>(pair.Key, pair.Value.ToString())).ToArray();
+        public DictionaryItemDebugView<string, string>[] Items => _collection.Select(pair => new DictionaryItemDebugView<string, string>(pair.Key, pair.Value.ToString())).ToArray();
     }
 }

--- a/src/Http/Http/src/QueryCollectionInternal.cs
+++ b/src/Http/Http/src/QueryCollectionInternal.cs
@@ -3,7 +3,6 @@
 
 using System.Collections;
 using System.Diagnostics;
-using System.Linq;
 using Microsoft.AspNetCore.Internal;
 using Microsoft.AspNetCore.Shared;
 using Microsoft.Extensions.Primitives;
@@ -14,7 +13,7 @@ namespace Microsoft.AspNetCore.Http;
 /// The HttpRequest query string collection
 /// </summary>
 [DebuggerDisplay("Count = {Count}")]
-[DebuggerTypeProxy(typeof(QueryCollectionDebugView))]
+[DebuggerTypeProxy(typeof(EnumerableStringValuesDebugView))]
 internal sealed class QueryCollectionInternal : IQueryCollection
 {
     private AdaptiveCapacityDictionary<string, StringValues> Store { get; }
@@ -128,13 +127,5 @@ internal sealed class QueryCollectionInternal : IQueryCollection
                 ((IEnumerator)_dictionaryEnumerator).Reset();
             }
         }
-    }
-
-    private sealed class QueryCollectionDebugView(QueryCollectionInternal collection)
-    {
-        private readonly QueryCollectionInternal _collection = collection;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public DictionaryItemDebugView<string, string>[] Items => _collection.Select(pair => new DictionaryItemDebugView<string, string>(pair.Key, pair.Value.ToString())).ToArray();
     }
 }

--- a/src/Http/Http/src/QueryCollectionInternal.cs
+++ b/src/Http/Http/src/QueryCollectionInternal.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Http;
 /// The HttpRequest query string collection
 /// </summary>
 [DebuggerDisplay("Count = {Count}")]
-[DebuggerTypeProxy(typeof(EnumerableStringValuesDebugView))]
+[DebuggerTypeProxy(typeof(StringValuesDictionaryDebugView))]
 internal sealed class QueryCollectionInternal : IQueryCollection
 {
     private AdaptiveCapacityDictionary<string, StringValues> Store { get; }

--- a/src/Http/Http/src/QueryCollectionInternal.cs
+++ b/src/Http/Http/src/QueryCollectionInternal.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.AspNetCore.Internal;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Http;
@@ -134,6 +135,6 @@ internal sealed class QueryCollectionInternal : IQueryCollection
         private readonly QueryCollectionInternal _collection = collection;
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public KeyValuePair<string, string>[] Items => _collection.Select(pair => new KeyValuePair<string, string>(pair.Key, pair.Value.ToString())).ToArray();
+        public DictionaryItemDebugView<string, string>[] Items => _collection.Select(pair => new DictionaryItemDebugView<string, string>(pair.Key, pair.Value.ToString())).ToArray();
     }
 }

--- a/src/Http/Routing.Abstractions/src/Microsoft.AspNetCore.Routing.Abstractions.csproj
+++ b/src/Http/Routing.Abstractions/src/Microsoft.AspNetCore.Routing.Abstractions.csproj
@@ -16,6 +16,7 @@ Microsoft.AspNetCore.Routing.RouteData</Description>
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)PropertyHelper\*.cs" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Http/Routing.Abstractions/src/RouteData.cs
+++ b/src/Http/Routing.Abstractions/src/RouteData.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.AspNetCore.Routing;
 
@@ -189,7 +190,7 @@ public class RouteData
         private readonly RouteData _routeData = routeData;
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public KeyValuePair<string, object?>[] Items => _routeData.Values.ToArray();
+        public DictionaryItemDebugView<string, object?>[] Items => _routeData.Values.Select(pair => new DictionaryItemDebugView<string, object>(pair)).ToArray();
     }
 
     /// <summary>

--- a/src/Mvc/Mvc.Abstractions/src/Microsoft.AspNetCore.Mvc.Abstractions.csproj
+++ b/src/Mvc/Mvc.Abstractions/src/Microsoft.AspNetCore.Mvc.Abstractions.csproj
@@ -17,7 +17,7 @@ Microsoft.AspNetCore.Mvc.IActionResult</Description>
     <Compile Include="$(SharedSourceRoot)\TypeNameHelper\TypeNameHelper.cs" Link="ModelBinding\TypeNameHelper.cs" />
     <Compile Include="$(SharedSourceRoot)ThrowHelpers\ArgumentNullThrowHelper.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)CallerArgument\CallerArgumentExpressionAttribute.cs" LinkBase="Shared" />
-    <Compile Include="$(SharedSourceRoot)Debugger\IDictionaryDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryDebugView.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
   </ItemGroup>
 

--- a/src/Mvc/Mvc.Abstractions/src/Microsoft.AspNetCore.Mvc.Abstractions.csproj
+++ b/src/Mvc/Mvc.Abstractions/src/Microsoft.AspNetCore.Mvc.Abstractions.csproj
@@ -17,6 +17,8 @@ Microsoft.AspNetCore.Mvc.IActionResult</Description>
     <Compile Include="$(SharedSourceRoot)\TypeNameHelper\TypeNameHelper.cs" Link="ModelBinding\TypeNameHelper.cs" />
     <Compile Include="$(SharedSourceRoot)ThrowHelpers\ArgumentNullThrowHelper.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)CallerArgument\CallerArgumentExpressionAttribute.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\IDictionaryDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelStateDictionary.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/ModelStateDictionary.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -1260,6 +1261,6 @@ public class ModelStateDictionary : IReadOnlyDictionary<string, ModelStateEntry?
         private readonly ModelStateDictionary _dictionary = dictionary;
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public KeyValuePair<string, ModelStateEntry?>[] Items => _dictionary.ToArray();
+        public DictionaryItemDebugView<string, ModelStateEntry?>[] Items => _dictionary.Select(pair => new DictionaryItemDebugView<string, ModelStateEntry?>(pair)).ToArray();
     }
 }

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/Validation/ValidationStateDictionary.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/Validation/ValidationStateDictionary.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 /// Used for tracking validation state to customize validation behavior for a model object.
 /// </summary>
 [DebuggerDisplay("Count = {Count}")]
-[DebuggerTypeProxy(typeof(IDictionaryDebugView<object, ValidationStateEntry>))]
+[DebuggerTypeProxy(typeof(DictionaryDebugView<object, ValidationStateEntry>))]
 public class ValidationStateDictionary :
     IDictionary<object, ValidationStateEntry>,
     IReadOnlyDictionary<object, ValidationStateEntry>

--- a/src/Mvc/Mvc.Abstractions/src/ModelBinding/Validation/ValidationStateDictionary.cs
+++ b/src/Mvc/Mvc.Abstractions/src/ModelBinding/Validation/ValidationStateDictionary.cs
@@ -2,13 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 
 /// <summary>
 /// Used for tracking validation state to customize validation behavior for a model object.
 /// </summary>
+[DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(IDictionaryDebugView<object, ValidationStateEntry>))]
 public class ValidationStateDictionary :
     IDictionary<object, ValidationStateEntry>,
     IReadOnlyDictionary<object, ValidationStateEntry>

--- a/src/Mvc/Mvc.ViewFeatures/src/AttributeDictionary.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/AttributeDictionary.cs
@@ -5,12 +5,15 @@
 
 using System.Collections;
 using System.Diagnostics;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures;
 
 /// <summary>
 /// A dictionary for HTML attributes.
 /// </summary>
+[DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(IDictionaryDebugView<string, string?>))]
 public class AttributeDictionary : IDictionary<string, string?>, IReadOnlyDictionary<string, string?>
 {
     private List<KeyValuePair<string, string?>>? _items;

--- a/src/Mvc/Mvc.ViewFeatures/src/AttributeDictionary.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/AttributeDictionary.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures;
 /// A dictionary for HTML attributes.
 /// </summary>
 [DebuggerDisplay("Count = {Count}")]
-[DebuggerTypeProxy(typeof(IDictionaryDebugView<string, string?>))]
+[DebuggerTypeProxy(typeof(DictionaryDebugView<string, string?>))]
 public class AttributeDictionary : IDictionary<string, string?>, IReadOnlyDictionary<string, string?>
 {
     private List<KeyValuePair<string, string?>>? _items;

--- a/src/Mvc/Mvc.ViewFeatures/src/DynamicViewData.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/DynamicViewData.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Dynamic;
 using System.Linq;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures;
 
@@ -68,6 +69,6 @@ internal sealed class DynamicViewData : DynamicObject
         private readonly ViewDataDictionary _dictionary = dictionary.ViewData;
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public KeyValuePair<string, object>[] Items => _dictionary.ToArray();
+        public DictionaryItemDebugView<string, object>[] Items => _dictionary.Select(pair => new DictionaryItemDebugView<string, object>(pair)).ToArray();
     }
 }

--- a/src/Mvc/Mvc.ViewFeatures/src/TempDataDictionary.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/TempDataDictionary.cs
@@ -6,15 +6,15 @@
 using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures;
 
 /// <inheritdoc />
 [DebuggerDisplay("Count = {Count}")]
-[DebuggerTypeProxy(typeof(TempDataDictionaryDebugView))]
+[DebuggerTypeProxy(typeof(IDictionaryDebugView<string, object?>))]
 public class TempDataDictionary : ITempDataDictionary
 {
     // Perf: Everything here is lazy because the TempDataDictionary is frequently created and passed around
@@ -312,13 +312,5 @@ public class TempDataDictionary : ITempDataDictionary
         {
             _enumerator.Dispose();
         }
-    }
-
-    private sealed class TempDataDictionaryDebugView(TempDataDictionary dictionary)
-    {
-        private readonly TempDataDictionary _dictionary = dictionary;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public KeyValuePair<string, object?>[] Items => _dictionary.ToArray();
     }
 }

--- a/src/Mvc/Mvc.ViewFeatures/src/TempDataDictionary.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/TempDataDictionary.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures;
 
 /// <inheritdoc />
 [DebuggerDisplay("Count = {Count}")]
-[DebuggerTypeProxy(typeof(IDictionaryDebugView<string, object?>))]
+[DebuggerTypeProxy(typeof(DictionaryDebugView<string, object?>))]
 public class TempDataDictionary : ITempDataDictionary
 {
     // Perf: Everything here is lazy because the TempDataDictionary is frequently created and passed around

--- a/src/Mvc/Mvc.ViewFeatures/src/ViewDataDictionary.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/ViewDataDictionary.cs
@@ -6,9 +6,9 @@
 using System.Collections;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Mvc.ViewFeatures;
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures;
 /// A <see cref="IDictionary{TKey, TValue}"/> for view data.
 /// </summary>
 [DebuggerDisplay("Count = {Count}")]
-[DebuggerTypeProxy(typeof(ViewDataDictionaryDebugView))]
+[DebuggerTypeProxy(typeof(IDictionaryDebugView<string, object?>))]
 public class ViewDataDictionary : IDictionary<string, object?>
 {
     private readonly IDictionary<string, object?> _data;
@@ -594,12 +594,4 @@ public class ViewDataDictionary : IDictionary<string, object?>
         return _data.GetEnumerator();
     }
     #endregion
-
-    private sealed class ViewDataDictionaryDebugView(ViewDataDictionary dictionary)
-    {
-        private readonly ViewDataDictionary _dictionary = dictionary;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public KeyValuePair<string, object?>[] Items => _dictionary.ToArray();
-    }
 }

--- a/src/Mvc/Mvc.ViewFeatures/src/ViewDataDictionary.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/ViewDataDictionary.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Mvc.ViewFeatures;
 /// A <see cref="IDictionary{TKey, TValue}"/> for view data.
 /// </summary>
 [DebuggerDisplay("Count = {Count}")]
-[DebuggerTypeProxy(typeof(IDictionaryDebugView<string, object?>))]
+[DebuggerTypeProxy(typeof(DictionaryDebugView<string, object?>))]
 public class ViewDataDictionary : IDictionary<string, object?>
 {
     private readonly IDictionary<string, object?> _data;

--- a/src/Razor/Razor.Runtime/src/Microsoft.AspNetCore.Razor.Runtime.csproj
+++ b/src/Razor/Razor.Runtime/src/Microsoft.AspNetCore.Razor.Runtime.csproj
@@ -11,6 +11,8 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)CopyOnWriteDictionary\**\*.cs" />
+    <Compile Include="$(SharedSourceRoot)Debugger\IDictionaryDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/Razor.Runtime/src/Microsoft.AspNetCore.Razor.Runtime.csproj
+++ b/src/Razor/Razor.Runtime/src/Microsoft.AspNetCore.Razor.Runtime.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)CopyOnWriteDictionary\**\*.cs" />
-    <Compile Include="$(SharedSourceRoot)Debugger\IDictionaryDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryDebugView.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
   </ItemGroup>
 

--- a/src/Servers/Connections.Abstractions/src/ConnectionItems.cs
+++ b/src/Servers/Connections.Abstractions/src/ConnectionItems.cs
@@ -3,12 +3,16 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.AspNetCore.Connections;
 
 /// <summary>
 /// The items associated with a given connection.
 /// </summary>
+[DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(IDictionaryDebugView<object, object?>))]
 public class ConnectionItems : IDictionary<object, object?>
 {
     /// <summary>

--- a/src/Servers/Connections.Abstractions/src/ConnectionItems.cs
+++ b/src/Servers/Connections.Abstractions/src/ConnectionItems.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Connections;
 /// The items associated with a given connection.
 /// </summary>
 [DebuggerDisplay("Count = {Count}")]
-[DebuggerTypeProxy(typeof(IDictionaryDebugView<object, object?>))]
+[DebuggerTypeProxy(typeof(DictionaryDebugView<object, object?>))]
 public class ConnectionItems : IDictionary<object, object?>
 {
     /// <summary>

--- a/src/Servers/Connections.Abstractions/src/Microsoft.AspNetCore.Connections.Abstractions.csproj
+++ b/src/Servers/Connections.Abstractions/src/Microsoft.AspNetCore.Connections.Abstractions.csproj
@@ -19,7 +19,7 @@
     <Compile Include="$(SharedSourceRoot)ActivatorUtilities\*.cs" />
     <Compile Include="$(SharedSourceRoot)ParameterDefaultValue\*.cs" />
     <Compile Include="$(SharedSourceRoot)CodeAnalysis\*.cs" />
-    <Compile Include="$(SharedSourceRoot)Debugger\IDictionaryDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryDebugView.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
   </ItemGroup>
 

--- a/src/Servers/Connections.Abstractions/src/Microsoft.AspNetCore.Connections.Abstractions.csproj
+++ b/src/Servers/Connections.Abstractions/src/Microsoft.AspNetCore.Connections.Abstractions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Core components of ASP.NET Core networking protocol stack.</Description>
@@ -19,6 +19,8 @@
     <Compile Include="$(SharedSourceRoot)ActivatorUtilities\*.cs" />
     <Compile Include="$(SharedSourceRoot)ParameterDefaultValue\*.cs" />
     <Compile Include="$(SharedSourceRoot)CodeAnalysis\*.cs" />
+    <Compile Include="$(SharedSourceRoot)Debugger\IDictionaryDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Servers/HttpSys/src/Microsoft.AspNetCore.Server.HttpSys.csproj
+++ b/src/Servers/HttpSys/src/Microsoft.AspNetCore.Server.HttpSys.csproj
@@ -28,6 +28,7 @@
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\StringUtilities.cs" LinkBase="ServerInfrastructure\StringUtilities.cs" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\HttpCharacters.cs" LinkBase="ServerInfrastructure\HttpCharacters.cs" />
     <Compile Include="$(SharedSourceRoot)TaskToApm.cs" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">

--- a/src/Servers/HttpSys/src/Microsoft.AspNetCore.Server.HttpSys.csproj
+++ b/src/Servers/HttpSys/src/Microsoft.AspNetCore.Server.HttpSys.csproj
@@ -29,6 +29,7 @@
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\HttpCharacters.cs" LinkBase="ServerInfrastructure\HttpCharacters.cs" />
     <Compile Include="$(SharedSourceRoot)TaskToApm.cs" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\EnumerableStringValuesDebugView.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">

--- a/src/Servers/HttpSys/src/Microsoft.AspNetCore.Server.HttpSys.csproj
+++ b/src/Servers/HttpSys/src/Microsoft.AspNetCore.Server.HttpSys.csproj
@@ -29,7 +29,7 @@
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\HttpCharacters.cs" LinkBase="ServerInfrastructure\HttpCharacters.cs" />
     <Compile Include="$(SharedSourceRoot)TaskToApm.cs" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
-    <Compile Include="$(SharedSourceRoot)Debugger\EnumerableStringValuesDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\StringValuesDictionaryDebugView.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">

--- a/src/Servers/IIS/IIS/src/Microsoft.AspNetCore.Server.IIS.csproj
+++ b/src/Servers/IIS/IIS/src/Microsoft.AspNetCore.Server.IIS.csproj
@@ -28,7 +28,7 @@
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\*.cs" LinkBase="Shared\" />
     <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" LinkBase="Shared\" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
-    <Compile Include="$(SharedSourceRoot)Debugger\EnumerableStringValuesDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\StringValuesDictionaryDebugView.cs" LinkBase="Shared" />
     <Compile Remove="SourceBuildStubs.cs" />
   </ItemGroup>
 

--- a/src/Servers/IIS/IIS/src/Microsoft.AspNetCore.Server.IIS.csproj
+++ b/src/Servers/IIS/IIS/src/Microsoft.AspNetCore.Server.IIS.csproj
@@ -27,6 +27,7 @@
     <Compile Include="$(SharedSourceRoot)TaskToApm.cs" Link="Shared\TaskToApm.cs" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\*.cs" LinkBase="Shared\" />
     <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" LinkBase="Shared\" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
     <Compile Remove="SourceBuildStubs.cs" />
   </ItemGroup>
 

--- a/src/Servers/IIS/IIS/src/Microsoft.AspNetCore.Server.IIS.csproj
+++ b/src/Servers/IIS/IIS/src/Microsoft.AspNetCore.Server.IIS.csproj
@@ -28,6 +28,7 @@
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\*.cs" LinkBase="Shared\" />
     <Compile Include="$(SharedSourceRoot)ValueTaskExtensions\**\*.cs" LinkBase="Shared\" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\EnumerableStringValuesDebugView.cs" LinkBase="Shared" />
     <Compile Remove="SourceBuildStubs.cs" />
   </ItemGroup>
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
@@ -16,7 +16,7 @@ using Microsoft.Net.Http.Headers;
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
 [DebuggerDisplay("{DebuggerToString(),nq}")]
-[DebuggerTypeProxy(typeof(HttpHeadersDebugView))]
+[DebuggerTypeProxy(typeof(EnumerableStringValuesDebugView))]
 internal abstract partial class HttpHeaders : IHeaderDictionary
 {
     protected long _bits;
@@ -689,13 +689,5 @@ internal abstract partial class HttpHeaders : IHeaderDictionary
     private static void ThrowInvalidEmptyHeaderName()
     {
         throw new InvalidOperationException(CoreStrings.InvalidEmptyHeaderName);
-    }
-
-    private sealed class HttpHeadersDebugView(HttpHeaders headers)
-    {
-        private readonly HttpHeaders _headers = headers;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public DictionaryItemDebugView<string, string>[] Items => _headers.Select(pair => new DictionaryItemDebugView<string, string>(pair.Key, pair.Value.ToString())).ToArray();
     }
 }

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
@@ -16,7 +16,7 @@ using Microsoft.Net.Http.Headers;
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
 [DebuggerDisplay("{DebuggerToString(),nq}")]
-[DebuggerTypeProxy(typeof(EnumerableStringValuesDebugView))]
+[DebuggerTypeProxy(typeof(StringValuesDictionaryDebugView))]
 internal abstract partial class HttpHeaders : IHeaderDictionary
 {
     protected long _bits;

--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 
@@ -695,6 +696,6 @@ internal abstract partial class HttpHeaders : IHeaderDictionary
         private readonly HttpHeaders _headers = headers;
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public KeyValuePair<string, string>[] Items => _headers.Select(pair => new KeyValuePair<string, string>(pair.Key, pair.Value.ToString())).ToArray();
+        public DictionaryItemDebugView<string, string>[] Items => _headers.Select(pair => new DictionaryItemDebugView<string, string>(pair.Key, pair.Value.ToString())).ToArray();
     }
 }

--- a/src/Servers/Kestrel/Core/src/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
+++ b/src/Servers/Kestrel/Core/src/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
@@ -30,6 +30,7 @@
     <Compile Include="$(SharedSourceRoot)Hpack\**\*.cs" Link="Shared\Hpack\%(Filename)%(Extension)" />
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" />
     <Compile Include="$(SharedSourceRoot)CancellationTokenSourcePool.cs" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
     <Compile Include="$(RepoRoot)src\Shared\TaskToApm.cs" Link="Internal\TaskToApm.cs" />
   </ItemGroup>
 

--- a/src/Servers/Kestrel/Core/src/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
+++ b/src/Servers/Kestrel/Core/src/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
@@ -31,6 +31,7 @@
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" />
     <Compile Include="$(SharedSourceRoot)CancellationTokenSourcePool.cs" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\EnumerableStringValuesDebugView.cs" LinkBase="Shared" />
     <Compile Include="$(RepoRoot)src\Shared\TaskToApm.cs" Link="Internal\TaskToApm.cs" />
   </ItemGroup>
 

--- a/src/Servers/Kestrel/Core/src/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
+++ b/src/Servers/Kestrel/Core/src/Microsoft.AspNetCore.Server.Kestrel.Core.csproj
@@ -31,7 +31,7 @@
     <Compile Include="$(SharedSourceRoot)ServerInfrastructure\**\*.cs" />
     <Compile Include="$(SharedSourceRoot)CancellationTokenSourcePool.cs" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
-    <Compile Include="$(SharedSourceRoot)Debugger\EnumerableStringValuesDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\StringValuesDictionaryDebugView.cs" LinkBase="Shared" />
     <Compile Include="$(RepoRoot)src\Shared\TaskToApm.cs" Link="Internal\TaskToApm.cs" />
   </ItemGroup>
 

--- a/src/Shared/CopyOnWriteDictionary/CopyOnWriteDictionary.cs
+++ b/src/Shared/CopyOnWriteDictionary/CopyOnWriteDictionary.cs
@@ -12,7 +12,7 @@ using Microsoft.AspNetCore.Shared;
 namespace Microsoft.Extensions.Internal;
 
 [DebuggerDisplay("Count = {Count}")]
-[DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
+[DebuggerTypeProxy(typeof(DictionaryDebugView<,>))]
 internal sealed class CopyOnWriteDictionary<TKey, TValue> : IDictionary<TKey, TValue> where TKey : notnull
 {
     private readonly IDictionary<TKey, TValue> _sourceDictionary;

--- a/src/Shared/CopyOnWriteDictionary/CopyOnWriteDictionary.cs
+++ b/src/Shared/CopyOnWriteDictionary/CopyOnWriteDictionary.cs
@@ -5,10 +5,14 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.Extensions.Internal;
 
+[DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
 internal sealed class CopyOnWriteDictionary<TKey, TValue> : IDictionary<TKey, TValue> where TKey : notnull
 {
     private readonly IDictionary<TKey, TValue> _sourceDictionary;

--- a/src/Shared/Debugger/DictionaryDebugView.cs
+++ b/src/Shared/Debugger/DictionaryDebugView.cs
@@ -6,11 +6,11 @@ using System.Diagnostics;
 
 namespace Microsoft.AspNetCore.Shared;
 
-internal sealed class IDictionaryDebugView<TKey, TValue> where TKey : notnull
+internal sealed class DictionaryDebugView<TKey, TValue> where TKey : notnull
 {
     private readonly IDictionary<TKey, TValue> _dict;
 
-    public IDictionaryDebugView(IDictionary<TKey, TValue> dictionary)
+    public DictionaryDebugView(IDictionary<TKey, TValue> dictionary)
     {
         _dict = dictionary;
     }

--- a/src/Shared/Debugger/DictionaryItemDebugView.cs
+++ b/src/Shared/Debugger/DictionaryItemDebugView.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Shared;
+
+/// <summary>
+/// Defines a key/value pair for displaying an item of a dictionary by a debugger.
+/// </summary>
+[DebuggerDisplay("{Value}", Name = "[{Key}]")]
+internal readonly struct DictionaryItemDebugView<TKey, TValue>
+{
+    public DictionaryItemDebugView(TKey key, TValue value)
+    {
+        Key = key;
+        Value = value;
+    }
+
+    public DictionaryItemDebugView(KeyValuePair<TKey, TValue> keyValue)
+    {
+        Key = keyValue.Key;
+        Value = keyValue.Value;
+    }
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
+    public TKey Key { get; }
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
+    public TValue Value { get; }
+}

--- a/src/Shared/Debugger/EnumerableStringValuesDebugView.cs
+++ b/src/Shared/Debugger/EnumerableStringValuesDebugView.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.AspNetCore.Shared;
+
+internal sealed class EnumerableStringValuesDebugView
+{
+    private readonly IEnumerable<KeyValuePair<string, StringValues>> _enumerable;
+
+    public EnumerableStringValuesDebugView(IEnumerable<KeyValuePair<string, StringValues>> enumerable)
+    {
+        _enumerable = enumerable;
+    }
+
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    public DictionaryItemDebugView<string, string>[] Items
+    {
+        get
+        {
+            var keyValuePairs = new List<DictionaryItemDebugView<string, string>>();
+            foreach (var kvp in _enumerable)
+            {
+                keyValuePairs.Add(new DictionaryItemDebugView<string, string>(kvp.Key, kvp.Value.ToString()));
+            }
+            return keyValuePairs.ToArray();
+        }
+    }
+}

--- a/src/Shared/Debugger/IDictionaryDebugView.cs
+++ b/src/Shared/Debugger/IDictionaryDebugView.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Shared;
+
+internal sealed class IDictionaryDebugView<TKey, TValue> where TKey : notnull
+{
+    private readonly IDictionary<TKey, TValue> _dict;
+
+    public IDictionaryDebugView(IDictionary<TKey, TValue> dictionary)
+    {
+        _dict = dictionary;
+    }
+
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    public DictionaryItemDebugView<TKey, TValue>[] Items
+    {
+        get
+        {
+            var keyValuePairs = new KeyValuePair<TKey, TValue>[_dict.Count];
+            _dict.CopyTo(keyValuePairs, 0);
+            var items = new DictionaryItemDebugView<TKey, TValue>[keyValuePairs.Length];
+            for (int i = 0; i < items.Length; i++)
+            {
+                items[i] = new DictionaryItemDebugView<TKey, TValue>(keyValuePairs[i]);
+            }
+            return items;
+        }
+    }
+}

--- a/src/Shared/Debugger/StringValuesDictionaryDebugView.cs
+++ b/src/Shared/Debugger/StringValuesDictionaryDebugView.cs
@@ -6,11 +6,13 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Shared;
 
-internal sealed class EnumerableStringValuesDebugView
+// This type is designed to be a debug proxy for dictionary types.
+// The constructor accepts an enumerable because many of the header collection types implement IHeaderDictionary which doesn't directly implement IDictionary.
+internal sealed class StringValuesDictionaryDebugView
 {
     private readonly IEnumerable<KeyValuePair<string, StringValues>> _enumerable;
 
-    public EnumerableStringValuesDebugView(IEnumerable<KeyValuePair<string, StringValues>> enumerable)
+    public StringValuesDictionaryDebugView(IEnumerable<KeyValuePair<string, StringValues>> enumerable)
     {
         _enumerable = enumerable;
     }

--- a/src/Shared/Dictionary/AdaptiveCapacityDictionary.cs
+++ b/src/Shared/Dictionary/AdaptiveCapacityDictionary.cs
@@ -8,12 +8,15 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.AspNetCore.Internal;
 
 /// <summary>
 /// An <see cref="IDictionary{String, Object}"/> type to hold a small amount of items (10 or less in the common case).
 /// </summary>
+[DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
 internal sealed class AdaptiveCapacityDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue> where TKey : notnull
 {
     // Threshold for size of array to use.

--- a/src/Shared/Dictionary/AdaptiveCapacityDictionary.cs
+++ b/src/Shared/Dictionary/AdaptiveCapacityDictionary.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Internal;
 /// An <see cref="IDictionary{String, Object}"/> type to hold a small amount of items (10 or less in the common case).
 /// </summary>
 [DebuggerDisplay("Count = {Count}")]
-[DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
+[DebuggerTypeProxy(typeof(DictionaryDebugView<,>))]
 internal sealed class AdaptiveCapacityDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue> where TKey : notnull
 {
     // Threshold for size of array to use.

--- a/src/Shared/HttpSys/RequestProcessing/RequestHeaders.cs
+++ b/src/Shared/HttpSys/RequestProcessing/RequestHeaders.cs
@@ -12,7 +12,7 @@ using Microsoft.Net.Http.Headers;
 namespace Microsoft.AspNetCore.HttpSys.Internal;
 
 [DebuggerDisplay("Count = {Count}")]
-[DebuggerTypeProxy(typeof(EnumerableStringValuesDebugView))]
+[DebuggerTypeProxy(typeof(StringValuesDictionaryDebugView))]
 internal sealed partial class RequestHeaders : IHeaderDictionary
 {
     private IDictionary<string, StringValues>? _extra;

--- a/src/Shared/HttpSys/RequestProcessing/RequestHeaders.cs
+++ b/src/Shared/HttpSys/RequestProcessing/RequestHeaders.cs
@@ -12,7 +12,7 @@ using Microsoft.Net.Http.Headers;
 namespace Microsoft.AspNetCore.HttpSys.Internal;
 
 [DebuggerDisplay("Count = {Count}")]
-[DebuggerTypeProxy(typeof(RequestHeadersDebugView))]
+[DebuggerTypeProxy(typeof(EnumerableStringValuesDebugView))]
 internal sealed partial class RequestHeaders : IHeaderDictionary
 {
     private IDictionary<string, StringValues>? _extra;
@@ -301,13 +301,5 @@ internal sealed partial class RequestHeaders : IHeaderDictionary
             }
         }
         return observedHeadersCount;
-    }
-
-    private sealed class RequestHeadersDebugView(RequestHeaders dictionary)
-    {
-        private readonly RequestHeaders _dictionary = dictionary;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public DictionaryItemDebugView<string, string>[] Items => _dictionary.Select(pair => new DictionaryItemDebugView<string, string>(pair.Key, pair.Value.ToString())).ToArray();
     }
 }

--- a/src/Shared/HttpSys/RequestProcessing/RequestHeaders.cs
+++ b/src/Shared/HttpSys/RequestProcessing/RequestHeaders.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Shared;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 
@@ -307,6 +308,6 @@ internal sealed partial class RequestHeaders : IHeaderDictionary
         private readonly RequestHeaders _dictionary = dictionary;
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public KeyValuePair<string, string>[] Items => _dictionary.Select(pair => new KeyValuePair<string, string>(pair.Key, pair.Value.ToString())).ToArray();
+        public DictionaryItemDebugView<string, string>[] Items => _dictionary.Select(pair => new DictionaryItemDebugView<string, string>(pair.Key, pair.Value.ToString())).ToArray();
     }
 }

--- a/src/Shared/test/Shared.Tests/Microsoft.AspNetCore.Shared.Tests.csproj
+++ b/src/Shared/test/Shared.Tests/Microsoft.AspNetCore.Shared.Tests.csproj
@@ -38,6 +38,9 @@
     <Compile Include="$(SharedSourceRoot)TypeNameHelper\*.cs" />
     <Compile Include="$(SharedSourceRoot)TaskToApm.cs" />
     <Compile Include="$(SharedSourceRoot)SegmentWriteStream.cs" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\IDictionaryDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\EnumerableStringValuesDebugView.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Shared/test/Shared.Tests/Microsoft.AspNetCore.Shared.Tests.csproj
+++ b/src/Shared/test/Shared.Tests/Microsoft.AspNetCore.Shared.Tests.csproj
@@ -39,8 +39,8 @@
     <Compile Include="$(SharedSourceRoot)TaskToApm.cs" />
     <Compile Include="$(SharedSourceRoot)SegmentWriteStream.cs" />
     <Compile Include="$(SharedSourceRoot)Debugger\DictionaryItemDebugView.cs" LinkBase="Shared" />
-    <Compile Include="$(SharedSourceRoot)Debugger\IDictionaryDebugView.cs" LinkBase="Shared" />
-    <Compile Include="$(SharedSourceRoot)Debugger\EnumerableStringValuesDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\DictionaryDebugView.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)Debugger\StringValuesDictionaryDebugView.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/51827

Update custom dictionaries in ASP.NET Core to display the key in the name column. There are a lot of dictionaries and I haven't tested all of them, but reusing debugger proxies on most dictionary types means they should just work.

Background: .NET debugging has supported customizing the name for years, but for some reason dictionaries have always displayed a meaningless index in the name column instead of the item key. See https://github.com/dotnet/runtime/issues/88736

---

**Items before:**
![image](https://github.com/dotnet/aspnetcore/assets/303201/a7b97916-0199-4d60-8d56-7c31028625c5)

**Items after:**
![image](https://github.com/dotnet/aspnetcore/assets/303201/850cf2c2-2807-4435-8166-7d0f515aa114)

---

**Cookies before:**
![image](https://github.com/dotnet/aspnetcore/assets/303201/ded798ce-2de3-4ab9-a6bd-b63c670a781a)

**Cookies after:**
![image](https://github.com/dotnet/aspnetcore/assets/303201/9f513fa2-b9c5-4cd9-bc02-e20cef35fe46)

---

**Request headers before:**
![image](https://github.com/dotnet/aspnetcore/assets/303201/fa75e1cf-b434-41f2-a388-f0ceb05e91b3)

**Request headers after:**
![image](https://github.com/dotnet/aspnetcore/assets/303201/f2d3bf0c-2ae1-452f-8c61-ca5b96381c46)

---

**Route values before:**
![image](https://github.com/dotnet/aspnetcore/assets/303201/04d7c5cb-a27e-41cb-9f4f-a5e8cc3bdf81)

**Route values after:**
![image](https://github.com/dotnet/aspnetcore/assets/303201/9dd948cc-dd75-4a7b-be75-1a50159876ae)

---

**Features before:**
![image](https://github.com/dotnet/aspnetcore/assets/303201/1ca68280-cbd3-4cd1-a703-c6332b981878)

**Features after:**
![image](https://github.com/dotnet/aspnetcore/assets/303201/a17661e2-0293-4c33-a969-dc3ccda58f26)
