### PR TITLE
[Test failure] Quarantine Microsoft.AspNetCore.Server.IIS.FunctionalTests.StartupTests.WrongApplicationPath_FailedToRun

### DIFF
--- a/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
+++ b/src/Servers/IIS/IIS/test/Common.LongTests/StartupTests.cs
@@ -378,6 +378,7 @@ public class StartupTests : IISFunctionalTestBase
 
     [ConditionalFact]
     [RequiresNewShim]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/52889")]
     public async Task WrongApplicationPath_FailedToRun()
     {
         var deploymentParameters = Fixture.GetBaseDeploymentParameters(Fixture.InProcessTestSite);


### PR DESCRIPTION
[Microsoft.AspNetCore.Server.IIS.FunctionalTests.StartupTests.WrongApplicationPath_FailedToRun](https://github.com/dotnet/aspnetcore/issues/52889)