### PR TITLE
JSInterop: Enable returning null for a nullable value type

### DIFF
--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/TaskGenericsUtil.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/TaskGenericsUtil.cs
@@ -89,7 +89,9 @@ internal static class TaskGenericsUtil
             // If necessary, attempt a cast
             var typedResult = result is T resultT
                 ? resultT
-                : (T)Convert.ChangeType(result, typeof(T), CultureInfo.InvariantCulture)!;
+                : result == null && default(T) == null
+                    ? default(T)
+                    : (T)Convert.ChangeType(result, typeof(T), CultureInfo.InvariantCulture)!;
 
             typedTcs.SetResult(typedResult!);
         }


### PR DESCRIPTION
# JSInterop: Enable returning null for a nullable value type

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

When a result value is null, and the return type is a nullable value type, Convert.ChangeType throws instead of returning the null value, so in case off null this now uses null directly.

Fixes #30366
