### PR TITLE
Speed up ILEmitTrie jump table using Binary Search Tree

### DIFF
--- a/src/Http/Routing/perf/Microbenchmarks/Matching/JumpTableMultipleEntryBenchmark.cs
+++ b/src/Http/Routing/perf/Microbenchmarks/Matching/JumpTableMultipleEntryBenchmark.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using BenchmarkDotNet.Attributes;

--- a/src/Http/Routing/perf/Microbenchmarks/Matching/JumpTableMultipleEntryBenchmark.cs
+++ b/src/Http/Routing/perf/Microbenchmarks/Matching/JumpTableMultipleEntryBenchmark.cs
@@ -154,11 +154,20 @@ public class JumpTableMultipleEntryBenchmark
 
             // Between 5 and 36 characters
             var text = guid.Substring(0, Math.Max(5, Math.Min(i, 36)));
-            if (char.IsDigit(text[0]))
+
+            // Convert first half of text to letters
+            text = string.Create(text.Length, text, static (buffer, state) =>
             {
-                // Convert first character to a letter.
-                text = ((char)(text[0] + ('G' - '0'))) + text.Substring(1);
-            }
+                for (var c = 0; c < buffer.Length; c++)
+                {
+                    buffer[c] = char.ToUpperInvariant(state[c]);
+
+                    if (char.IsDigit(buffer[c]) && c < buffer.Length / 2)
+                    {
+                        buffer[c] = ((char)(state[c] + ('G' - '0')));
+                    }
+                }
+            });
 
             if (i % 2 == 0)
             {

--- a/src/Http/Routing/src/Matching/ILEmitTrieFactory.cs
+++ b/src/Http/Routing/src/Matching/ILEmitTrieFactory.cs
@@ -405,7 +405,7 @@ internal static class ILEmitTrieFactory
         // p = ref ...
         il.Emit(OpCodes.Stloc, locals.P);
 
-        // if ((uInt16Value & ~0x007FUL) == 0)
+        // if ((uint16Value & ~0x007FUL) == 0)
         // {
         //     goto: NotAscii;
         // }
@@ -423,7 +423,7 @@ internal static class ILEmitTrieFactory
         var groups = entries.GroupBy(e => GetUInt16Key(e.text, index));
         foreach (var group in groups)
         {
-            // if (uInt16Value == 'A' || uint16Value == 'a') { ... }
+            // if (uint16Value == 'A' || uint16Value == 'a') { ... }
             var next = il.DefineLabel();
             var inside = il.DefineLabel();
             il.Emit(OpCodes.Ldloc, locals.UInt16Value);

--- a/src/Http/Routing/src/Matching/ILEmitTrieFactory.cs
+++ b/src/Http/Routing/src/Matching/ILEmitTrieFactory.cs
@@ -286,7 +286,7 @@ internal static class ILEmitTrieFactory
         // uint64UpperIndicator = ...
         il.Emit(OpCodes.Stloc, locals.UInt64UpperIndicator);
 
-        // ulongLowerIndicator ^ ulongUpperIndicator
+        // uint64LowerIndicator ^ uint64UpperIndicator
         il.Emit(OpCodes.Ldloc, locals.UInt64LowerIndicator);
         il.Emit(OpCodes.Ldloc, locals.UInt64UpperIndicator);
         il.Emit(OpCodes.Xor);

--- a/src/Http/Routing/test/UnitTests/Matching/ILEmitTrieJumpTableTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/ILEmitTrieJumpTableTest.cs
@@ -224,8 +224,11 @@ public abstract class ILEmitTreeJumpTableTestBase : MultipleEntryJumpTableTest
     // Tests for correct branching in binary search
     [Theory]
     [InlineData("hello0 world", "hello1 world", "hello2 world", "hello1 world2")]
-    [InlineData("1111", "2222", "3333", "4444", "5555", "6666", "7777", "8888")]
+    [InlineData("1111", "2222", "3333", "4444", "5555", "6666", "7777", "8888")] // vectorized
     [InlineData("1", "7777777", "22", "88888888", "55555", "666666", "333", "4444")]
+    [InlineData("1", "4", "8", "3", "5", "2", "6", "7")] // non-vectorized
+    [InlineData("1", "a", "4", "B", "8", "C", "3", "d", "5", "e", "2", "F", "6", "g", "7")] // mixed letters and numbers
+    [InlineData("@", "1", "a", "4", "B", "8", "C", "3", "d", "5", "e", "2", "F", "6", "g", "7", "`")] // @ and ` are 0x20 apart which means binary search must be disabled
     public void GetDestination_Found_WithBinarySearch(params string[] segments)
     {
         // Arrange

--- a/src/Http/Routing/test/UnitTests/Matching/ILEmitTrieJumpTableTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/ILEmitTrieJumpTableTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Moq;
@@ -51,7 +51,7 @@ public abstract class ILEmitTreeJumpTableTestBase : MultipleEntryJumpTableTest
     [InlineData("\u007F", "he\u007Flo-world", 2, 1)]
     [InlineData("\uFFFF", "he\uFFFFlo-world", 2, 1)]
 
-    // non-ASCII character in first section vectorized comparions
+    // non-ASCII character in first section vectorized comparisons
     [InlineData("hel\u007F", "hel\u007Fo-world", 0, 4)]
     [InlineData("hel\uFFFF", "hel\uFFFFo-world", 0, 4)]
     [InlineData("el\u007Fo", "hel\u007Fo-world", 1, 4)]
@@ -69,7 +69,7 @@ public abstract class ILEmitTreeJumpTableTestBase : MultipleEntryJumpTableTest
     [InlineData("llo-\u007F", "hello-\u007Forld", 2, 5)]
     [InlineData("llo-\uFFFF", "hello-\uFFFFForld", 2, 5)]
 
-    // non-ASCII character in first section vectorized comparions
+    // non-ASCII character in first section vectorized comparisons
     [InlineData("hello-w\u007F", "hello-w\u007Forld", 0, 8)]
     [InlineData("hello-w\uFFFF", "hello-w\uFFFForld", 0, 8)]
     [InlineData("ello-w\u007Fo", "hello-w\u007Forld", 1, 8)]
@@ -97,7 +97,7 @@ public abstract class ILEmitTreeJumpTableTestBase : MultipleEntryJumpTableTest
     }
 
     // Tests for difference in casing with ASCII casing rules. Verifies our case
-    // manipulation algorthm is correct.
+    // manipulation algorithm is correct.
     //
     // We convert from upper case to lower
     // 'A' and 'a' are 32 bits apart at the low end
@@ -112,7 +112,7 @@ public abstract class ILEmitTreeJumpTableTestBase : MultipleEntryJumpTableTest
     [InlineData("A", "healo-world", 2, 1)]
     [InlineData("Z", "hezlo-world", 2, 1)]
 
-    // character in first section vectorized comparions
+    // character in first section vectorized comparisons
     [InlineData("helA", "helao-world", 0, 4)]
     [InlineData("helZ", "helzo-world", 0, 4)]
     [InlineData("elAo", "helao-world", 1, 4)]
@@ -130,7 +130,7 @@ public abstract class ILEmitTreeJumpTableTestBase : MultipleEntryJumpTableTest
     [InlineData("llo-A", "hello-aorld", 2, 5)]
     [InlineData("llo-Z", "hello-zForld", 2, 5)]
 
-    // character in first section vectorized comparions
+    // character in first section vectorized comparisons
     [InlineData("hello-wA", "hello-waorld", 0, 8)]
     [InlineData("hello-wZ", "hello-wzorld", 0, 8)]
     [InlineData("ello-wAo", "hello-waorld", 1, 8)]
@@ -158,7 +158,7 @@ public abstract class ILEmitTreeJumpTableTestBase : MultipleEntryJumpTableTest
     }
 
     // Tests for difference in casing with ASCII casing rules. Verifies our case
-    // manipulation algorthm is correct.
+    // manipulation algorithm is correct.
     //
     // We convert from upper case to lower
     // '@' and '`' are 32 bits apart at the low end
@@ -176,7 +176,7 @@ public abstract class ILEmitTreeJumpTableTestBase : MultipleEntryJumpTableTest
     [InlineData("@", "he`lo-world", 2, 1)]
     [InlineData("[", "he{lo-world", 2, 1)]
 
-    // character in first section vectorized comparions
+    // character in first section vectorized comparisons
     [InlineData("hel@", "hel`o-world", 0, 4)]
     [InlineData("hel[", "hel{o-world", 0, 4)]
     [InlineData("el@o", "hel`o-world", 1, 4)]
@@ -194,7 +194,7 @@ public abstract class ILEmitTreeJumpTableTestBase : MultipleEntryJumpTableTest
     [InlineData("llo-@", "hello-`orld", 2, 5)]
     [InlineData("llo-[", "hello-{Forld", 2, 5)]
 
-    // character in first section vectorized comparions
+    // character in first section vectorized comparisons
     [InlineData("hello-w@", "hello-w`orld", 0, 8)]
     [InlineData("hello-w[", "hello-w{orld", 0, 8)]
     [InlineData("ello-w@o", "hello-w`orld", 1, 8)]
@@ -219,5 +219,28 @@ public abstract class ILEmitTreeJumpTableTestBase : MultipleEntryJumpTableTest
 
         // Assert
         Assert.Equal(0, result);
+    }
+
+    // Tests for correct branching in binary search
+    [Theory]
+    [InlineData("hello0 world", "hello1 world", "hello2 world", "hello1 world2")]
+    [InlineData("1111", "2222", "3333", "4444", "5555", "6666", "7777", "8888")]
+    [InlineData("1", "7777777", "22", "88888888", "55555", "666666", "333", "4444")]
+    public void GetDestination_Found_WithBinarySearch(params string[] segments)
+    {
+        // Arrange
+        var entries = segments.Select((e, i) => (e, i + 1)).ToArray();
+        var table = CreateTable(0, -1, entries);
+
+        foreach (var (segment, destination) in entries)
+        {
+            var pathSegment = new PathSegment(0, segment.Length);
+
+            // Act
+            var result = table.GetDestination(segment, pathSegment);
+
+            // Assert
+            Assert.Equal(destination, result);
+        }
     }
 }


### PR DESCRIPTION
Speed up ILEmitTrie jump table using Binary Search Tree

Fixes #52812

## Description

The main change of this PR is adding Binary Search for `ILEmitTrie` instead of linear search in 3 places however a few additional optimizations were included.

1. Initially when matching the input string based on length. We use binary search to reduce the linear search to a maximum of 3 options (at which point linear search is probably faster). In cases when there are 3 or fewer different lengths, the IL hasn't changed.
2. Similarly to (1) we use binary search on the 4-character vectorized search.
    - Additionally for the vectorized search, we check if all characters we could match are ASCII letters and if so, then we can emit 14 fewer instructions (<-- kind of the same optimization as is done in [StringSearchValues](https://github.com/dotnet/runtime/blob/26722b6879f6b5f4556309e05383ecf7736870b4/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/StringSearchValuesHelper.cs#L113C7-L113C7)) This helps speed up the code even if there are few too branches for binary search, and will probably result in smaller IL code size in a lot of cases.
4. We also add binary search when doing the single character. 2 further notes here as `char.ToLower` seems to be expensive to compute based on previous comments. First we compute the `character | 0x20`.
   - As we emit the comparisons, if we are comparing against a non-letter then we compare against the original character. If we compare against a letter, we compare against the `| 0x20` version.
   - The binary search is done against the `| 0x20` version of the character. This does mean that we must disable the binary search if two characters are the same after `| 0x20` is applied.

This improves the MicroBenchmarks as follows:
- VectorTrie (Count = 25, Count = 50) is now 60% of original duration. Curiously only 80% for Count = 100
- Trie (Count = 100) is now 40% of original duration. Curiously very minor / insignificant impact on other Counts

```
dotnet run -c Release --filter *JumpTableMultiple*Trie*  --launchCount 3
```

## Before

``` ini

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.22621
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=9.0.100-alpha.1.23608.3
  [Host]     : .NET 9.0.0 (9.0.23.61215), X64 RyuJIT
  Job-RMGOVO : .NET 9.0.0 (9.0.23.57707), X64 RyuJIT

Server=True  Toolchain=.NET Core 9.0  LaunchCount=3  
RunStrategy=Throughput  

```
|     Method | Count |       Mean |     Error |    StdDev |          Op/s |
|----------- |------ |-----------:|----------:|----------:|--------------:|
|       **Trie** |     **2** |   **3.284 ns** | **0.0152 ns** | **0.0286 ns** | **304,474,863.5** |
| VectorTrie |     2 |   3.373 ns | 0.0190 ns | 0.0357 ns | 296,466,572.2 |
|       **Trie** |     **5** |   **3.872 ns** | **0.0208 ns** | **0.0386 ns** | **258,288,594.1** |
| VectorTrie |     5 |   4.081 ns | 0.0209 ns | 0.0398 ns | 245,050,802.2 |
|       **Trie** |    **10** |   **4.960 ns** | **0.0501 ns** | **0.0942 ns** | **201,618,909.5** |
| VectorTrie |    10 |   5.069 ns | 0.0594 ns | 0.1129 ns | 197,283,921.0 |
|       **Trie** |    **25** |  **24.888 ns** | **0.2683 ns** | **0.5104 ns** |  **40,180,047.5** |
| VectorTrie |    25 |   8.783 ns | 0.0418 ns | 0.0796 ns | 113,854,026.0 |
|       **Trie** |    **50** |  **41.514 ns** | **0.3654 ns** | **0.6952 ns** |  **24,088,288.4** |
| VectorTrie |    50 |  15.320 ns | 0.1335 ns | 0.2540 ns |  65,273,554.0 |
|       **Trie** |   **100** | **162.799 ns** | **1.0319 ns** | **1.9382 ns** |   **6,142,555.1** |
| VectorTrie |   100 |  38.724 ns | 0.2069 ns | 0.3887 ns |  25,823,634.6 |


## After

``` ini

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.22621
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=9.0.100-alpha.1.23608.3
  [Host]     : .NET 9.0.0 (9.0.23.61215), X64 RyuJIT
  Job-VILVTP : .NET 9.0.0 (9.0.23.57707), X64 RyuJIT

Server=True  Toolchain=.NET Core 9.0  LaunchCount=3  
RunStrategy=Throughput  

```
|     Method | Count |      Mean |     Error |    StdDev |    Median |          Op/s |
|----------- |------ |----------:|----------:|----------:|----------:|--------------:|
|       **Trie** |     **2** |  **3.149 ns** | **0.0169 ns** | **0.0321 ns** |  **3.148 ns** | **317,515,568.2** |
| VectorTrie |     2 |  3.380 ns | 0.0193 ns | 0.0347 ns |  3.371 ns | 295,849,542.1 |
|       **Trie** |     **5** |  **3.791 ns** | **0.0209 ns** | **0.0397 ns** |  **3.806 ns** | **263,756,033.7** |
| VectorTrie |     5 |  4.036 ns | 0.0210 ns | 0.0395 ns |  4.026 ns | 247,769,489.7 |
|       **Trie** |    **10** |  **4.079 ns** | **0.0419 ns** | **0.0766 ns** |  **4.054 ns** | **245,174,104.0** |
| VectorTrie |    10 |  4.197 ns | 0.0210 ns | 0.0400 ns |  4.192 ns | 238,244,013.7 |
|       **Trie** |    **25** | **25.089 ns** | **0.2536 ns** | **0.4826 ns** | **24.883 ns** |  **39,858,055.0** |
| VectorTrie |    25 |  5.478 ns | 0.0306 ns | 0.0582 ns |  5.474 ns | 182,558,428.1 |
|       **Trie** |    **50** | **37.309 ns** | **0.2636 ns** | **0.5015 ns** | **37.299 ns** |  **26,803,430.1** |
| VectorTrie |    50 |  8.761 ns | 0.0302 ns | 0.0575 ns |  8.768 ns | 114,138,948.1 |
|       **Trie** |   **100** | **60.896 ns** | **0.2635 ns** | **0.5013 ns** | **60.724 ns** |  **16,421,417.5** |
| VectorTrie |   100 | 31.195 ns | 0.1460 ns | 0.2742 ns | 31.206 ns |  32,055,996.7 |

cc @JamesNK @rynowak 