### PR TITLE
Revert "Disable source index build step (#51710)"

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -68,10 +68,9 @@ variables:
     value: true
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
-# https://github.com/dotnet/aspnetcore/issues/51709
-#- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-- name: enableSourceIndex
-  value: false
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+  - name: enableSourceIndex
+    value: true
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - name: _BuildArgs
     value: /p:TeamName=$(_TeamName)


### PR DESCRIPTION
Source-index was fixed by https://github.com/dotnet/arcade/pull/14172