### PR TITLE
Add explicit null checks on ObjectPool.Return rather than triggering random failures later on

### DIFF
--- a/src/ObjectPool/src/DefaultObjectPool.cs
+++ b/src/ObjectPool/src/DefaultObjectPool.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.Extensions.ObjectPool;
 
@@ -66,6 +67,7 @@ public class DefaultObjectPool<T> : ObjectPool<T> where T : class
     /// <inheritdoc />
     public override void Return(T obj)
     {
+        ArgumentNullThrowHelper.ThrowIfNull(obj);
         ReturnCore(obj);
     }
 

--- a/src/ObjectPool/src/LeakTrackingObjectPool.cs
+++ b/src/ObjectPool/src/LeakTrackingObjectPool.cs
@@ -46,6 +46,8 @@ public class LeakTrackingObjectPool<T> : ObjectPool<T> where T : class
     /// <inheritdoc/>
     public override void Return(T obj)
     {
+        ArgumentNullThrowHelper.ThrowIfNull(obj);
+
         if (_trackers.TryGetValue(obj, out var tracker))
         {
             _trackers.Remove(obj);

--- a/src/ObjectPool/src/ObjectPool.cs
+++ b/src/ObjectPool/src/ObjectPool.cs
@@ -19,7 +19,7 @@ public abstract class ObjectPool<T> where T : class
     /// Return an object to the pool.
     /// </summary>
     /// <param name="obj">The object to add to the pool.</param>
-    /// <exception cref="System.ArgumentNullException">when <paramref name="obj"/> is null.</exception> 
+    /// <exception cref="System.ArgumentNullException"><paramref name="obj"/> is <see langword="null"/>.</exception> 
     public abstract void Return(T obj);
 }
 

--- a/src/ObjectPool/src/ObjectPool.cs
+++ b/src/ObjectPool/src/ObjectPool.cs
@@ -19,6 +19,7 @@ public abstract class ObjectPool<T> where T : class
     /// Return an object to the pool.
     /// </summary>
     /// <param name="obj">The object to add to the pool.</param>
+    /// <exception cref="System.ArgumentNullException">when <paramref name="obj"/> is null.</exception> 
     public abstract void Return(T obj);
 }
 

--- a/src/ObjectPool/test/DefaultObjectPoolTest.cs
+++ b/src/ObjectPool/test/DefaultObjectPoolTest.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -84,6 +85,13 @@ public class DefaultObjectPoolTest
         p.Return(r);
         Assert.Equal(2, r.ResetCallCount);
         Assert.Same(r, p.Get());
+    }
+
+    [Fact]
+    public void DefaultObjectPool_Throws_WhenNullReturn()
+    {
+        var pool = new DefaultObjectPool<object>(new DefaultPooledObjectPolicy<object>());
+        Assert.Throws<ArgumentNullException>(() => pool.Return(null!));
     }
 
     private sealed class Resettable : IResettable


### PR DESCRIPTION
Without these checks, it's possible to call ObjectPool.Return and pass null, which manifests itself as a later call to ObjectPool.Get returning null. This is surprising to customers and potentially hard to understand/diagnose. The null checks fix this.