### PR TITLE
[release/8.0] Fix SSR page rendering intermediate state instead of the end state of components 

### DIFF
--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -593,7 +593,11 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
     {
         // The pendingTasks collection is only used during prerendering to track quiescence,
         // so will be null at other times.
-        _pendingTasks?.Add(task);
+        if (_pendingTasks is { } tasks)
+        {
+            Dispatcher.AssertAccess();
+            tasks.Add(task);
+        }
     }
 
     internal void AssignEventHandlerId(int renderedByComponentId, ref RenderTreeFrame frame)

--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -107,7 +107,7 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
                     return;
                 }
 
-                await Task.WhenAll(_renderer.NonStreamingPendingTasks);
+                await _renderer.WaitForNonStreamingPendingTasks();
             }
             catch (NavigationException ex)
             {

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
@@ -131,7 +131,7 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
     }
 
     // For tests only
-    internal List<Task> NonStreamingPendingTasks => _nonStreamingPendingTasks;
+    internal Task? NonStreamingPendingTasksCompletion;
 
     protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
     {

--- a/src/Components/Endpoints/test/RazorComponentResultTest.cs
+++ b/src/Components/Endpoints/test/RazorComponentResultTest.cs
@@ -336,10 +336,11 @@ public class RazorComponentResultTest
     {
         // Arrange
         var testContext = PrepareVaryStreamingScenariosTests();
-        var initialOutputTask = Task.WhenAll(testContext.Renderer.NonStreamingPendingTasks);
+        var initialOutputTask = testContext.Renderer.NonStreamingPendingTasksCompletion;
 
         // Act/Assert: Even if all other blocking tasks complete, we don't produce output until the top-level
         // nonstreaming component completes
+        Assert.NotNull(initialOutputTask);
         testContext.WithinNestedNonstreamingRegionTask.SetResult();
         await Task.Yield(); // Just to show it's still not completed after
         Assert.False(initialOutputTask.IsCompleted);
@@ -368,10 +369,11 @@ public class RazorComponentResultTest
     {
         // Arrange
         var testContext = PrepareVaryStreamingScenariosTests();
-        var initialOutputTask = Task.WhenAll(testContext.Renderer.NonStreamingPendingTasks);
+        var initialOutputTask = testContext.Renderer.NonStreamingPendingTasksCompletion;
 
         // Act/Assert: Even if all other nonblocking tasks complete, we don't produce output until
         // the component in the nonstreaming subtree is quiescent
+        Assert.NotNull(initialOutputTask);
         testContext.TopLevelComponentTask.SetResult();
         await Task.Yield(); // Just to show it's still not completed after
         Assert.False(initialOutputTask.IsCompleted);

--- a/src/Components/test/E2ETest/ServerRenderingTests/RenderingTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/RenderingTest.cs
@@ -50,4 +50,21 @@ public class RenderingTest : ServerTestBase<BasicTestAppServerSiteFixture<RazorC
         var response = await new HttpClient().GetAsync(Browser.Url);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
+
+    [Fact]
+    public void RendersEndStateOfComponentsOnSSRPage()
+    {
+        Navigate($"{ServerPathBase}/ssr-page-that-delays-loading");
+        Browser.Equal("loaded child", () => Browser.Exists(By.Id("child")).Text);
+    }
+
+    [Fact]
+    public void PostRequestRendersEndStateOfComponentsOnSSRPage()
+    {
+        Navigate($"{ServerPathBase}/forms/post-form-with-component-that-delays-loading");
+
+        Browser.Exists(By.Id("submit-button")).Click();
+
+        Browser.Equal("loaded child", () => Browser.Exists(By.Id("child")).Text);
+    }
 }

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Components/ChildComponentThatDelaysLoading.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Components/ChildComponentThatDelaysLoading.razor
@@ -1,0 +1,13 @@
+﻿<p id="child">@childString</p>
+
+@code {
+    private string childString = "initial child";
+
+    protected override async Task OnInitializedAsync()
+    {
+        await Task.Yield();
+
+        childString = "loaded child";
+    }
+
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Components/ParentComponentThatDelaysLoading.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Components/ParentComponentThatDelaysLoading.razor
@@ -1,0 +1,21 @@
+﻿@if (_loaded)
+{
+    <ChildComponentThatDelaysLoading />
+}
+
+@code {
+    private bool _loaded;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+        _loaded = await Load();
+    }
+
+    private async Task<bool> Load()
+    {
+        await Task.Yield();
+
+        return true;
+    }
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/PostFormWithComponentThatDelaysLoading.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/PostFormWithComponentThatDelaysLoading.razor
@@ -1,0 +1,19 @@
+﻿@page "/forms/post-form-with-component-that-delays-loading"
+@using Microsoft.AspNetCore.Components.Forms
+
+<h3>Post Form With Component That Delays Loading</h3>
+
+@if (_render)
+{
+    <ParentComponentThatDelaysLoading />
+}
+
+<form @onsubmit="@(() => _render = true)" @formname="myform" method="post">
+    <AntiforgeryToken />
+    <button id="submit-button">Submit</button>
+</form>
+
+@code
+{
+    bool _render;
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/SSRPageThatDelaysLoading.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/SSRPageThatDelaysLoading.razor
@@ -1,0 +1,5 @@
+﻿@page "/ssr-page-that-delays-loading"
+<h1>SSR page that delays loading</h1>
+
+<ParentComponentThatDelaysLoading />
+


### PR DESCRIPTION
# [release/8.0] Fix SSR page rendering intermediate state instead of the end state of components 

Manual backport of [52823](https://github.com/dotnet/aspnetcore/pull/52823)

## Description

This PR fixes SSR page rendering end state of components.
The problem was that non streaming pending tasks were not properly awaiited.

Fixes https://github.com/dotnet/aspnetcore/issues/52131
Fixes https://github.com/dotnet/aspnetcore/issues/52871

## Customer Impact

Without this change customers will have bad experience with SSR pages because in some cases the intermediate state of the components is rendered in the browser. The end state is never rendered. Example:

Add `Child.razor` component to the Blazor Web App project:
```razor
<div>@childString</div>

@code {
   private string childString = "initial child";

   protected override async Task OnInitializedAsync()
   {
        await Task.Delay(1000);

        childString = "loaded child";
   }

}
```
Update Home.razor to:
```razor
@page "/"

<PageTitle>Home</PageTitle>

<h1>Hello, world!</h1>

Welcome to your new app.

@if (someProperty)
{
    <Child />
}

@code {
    private bool someProperty;

    protected override async Task OnInitializedAsync()
    {
        await base.OnInitializedAsync();
        someProperty = await Load();
    }

    private async Task<bool> Load()
    {
        await Task.Delay(1000);

        return true;
    }
}
```

Run the app. The browser displays:
```
Welcome to your new app.
initial child
```

but it should display
```
Welcome to your new app.
loaded child
```
## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

This is a minor change. There are e2e tests for this change as well as manual testing was done.

## Verification

- [x] Manual (required)
- [x] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props

