### PR TITLE
Reenable HTTPs tests

### DIFF
--- a/src/SignalR/clients/ts/FunctionalTests/scripts/run-tests.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/scripts/run-tests.ts
@@ -216,7 +216,7 @@ function runJest(httpsUrl: string, httpUrl: string) {
     return new Promise<number>((resolve, reject) => {
         const logStream = fs.createWriteStream(path.resolve(LOGS_DIR, "node.functionaltests.log"));
         // Use NODE_TLS_REJECT_UNAUTHORIZED to allow our test cert to be used by the Node tests (NEVER use this environment variable outside of testing)
-        const p = exec(`"${process.execPath}" "${jestPath}" --config "${configPath}"`, { env: { SERVER_URL: `${httpsUrl};${httpUrl}`, NODE_TLS_REJECT_UNAUTHORIZED: "false" }, timeout: 200000, maxBuffer: 10 * 1024 * 1024 },
+        const p = exec(`"${process.execPath}" "${jestPath}" --config "${configPath}"`, { env: { SERVER_URL: `${httpsUrl};${httpUrl}`, NODE_TLS_REJECT_UNAUTHORIZED: 0 as any }, timeout: 200000, maxBuffer: 10 * 1024 * 1024 },
             (error: any, stdout, stderr) => {
                 console.log("Finished Node tests.");
                 if (error) {

--- a/src/SignalR/clients/ts/FunctionalTests/ts/Common.ts
+++ b/src/SignalR/clients/ts/FunctionalTests/ts/Common.ts
@@ -135,7 +135,7 @@ export function eachHttpClient(action: (transport: HttpClient) => void): void {
 }
 
 // Run test in Node or Chrome, but not on macOS
-export const shouldRunHttpsTests = false &&
+export const shouldRunHttpsTests =
     // Need to have an HTTPS URL
     !!ENDPOINT_BASE_HTTPS_URL &&
 


### PR DESCRIPTION
* Follow-up from the move to NPM