### PR TITLE
Avoid call to ASCII.GetBytes during HostFilteringMiddleware static initialization

### DIFF
--- a/src/Middleware/HostFiltering/src/HostFilteringMiddleware.cs
+++ b/src/Middleware/HostFiltering/src/HostFilteringMiddleware.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
-using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -16,14 +15,14 @@ namespace Microsoft.AspNetCore.HostFiltering;
 public class HostFilteringMiddleware
 {
     // Matches Http.Sys.
-    private static readonly byte[] DefaultResponse = Encoding.ASCII.GetBytes(
-        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\"\"http://www.w3.org/TR/html4/strict.dtd\">\r\n"
-            + "<HTML><HEAD><TITLE>Bad Request</TITLE>\r\n"
-            + "<META HTTP-EQUIV=\"Content-Type\" Content=\"text/html; charset=us-ascii\"></ HEAD >\r\n"
-            + "<BODY><h2>Bad Request - Invalid Hostname</h2>\r\n"
-            + "<hr><p>HTTP Error 400. The request hostname is invalid.</p>\r\n"
-            + "</BODY></HTML>"
-    );
+    private static readonly byte[] DefaultResponse = (
+        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\"\"http://www.w3.org/TR/html4/strict.dtd\">\r\n"u8
+            + "<HTML><HEAD><TITLE>Bad Request</TITLE>\r\n"u8
+            + "<META HTTP-EQUIV=\"Content-Type\" Content=\"text/html; charset=us-ascii\"></ HEAD >\r\n"u8
+            + "<BODY><h2>Bad Request - Invalid Hostname</h2>\r\n"u8
+            + "<hr><p>HTTP Error 400. The request hostname is invalid.</p>\r\n"u8
+            + "</BODY></HTML>"u8
+        ).ToArray();
 
     private readonly RequestDelegate _next;
     private readonly ILogger<HostFilteringMiddleware> _logger;


### PR DESCRIPTION
Avoid call to ASCII.GetBytes during HostFilteringMiddleware static initialization

## Description

As ASCII and UTF8 are the same if all characters are ASCII characters, it make sense to utilize the `u8` string format to avoid a call to `ASCII.GetBytes(...)`. Unfortunately we still need to allocate using `.ToArray()` as `stream.WriteAsync` doesn't like Spans

## Benchmarks
TLDR ~10ns saved on startup if running on my machine

```C#
using System.Text;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

[MemoryDiagnoser]
public class Utf8Benchmarks
{
    [Benchmark]
    public byte[] AsciiGetBytes() => Encoding.ASCII.GetBytes(
        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\"\"http://www.w3.org/TR/html4/strict.dtd\">\r\n"
            + "<HTML><HEAD><TITLE>Bad Request</TITLE>\r\n"
            + "<META HTTP-EQUIV=\"Content-Type\" Content=\"text/html; charset=us-ascii\"></ HEAD >\r\n"
            + "<BODY><h2>Bad Request - Invalid Hostname</h2>\r\n"
            + "<hr><p>HTTP Error 400. The request hostname is invalid.</p>\r\n"
            + "</BODY></HTML>"
    );

    [Benchmark]
    public byte[] Utf8() => (
        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\"\"http://www.w3.org/TR/html4/strict.dtd\">\r\n"u8
            + "<HTML><HEAD><TITLE>Bad Request</TITLE>\r\n"u8
            + "<META HTTP-EQUIV=\"Content-Type\" Content=\"text/html; charset=us-ascii\"></ HEAD >\r\n"u8
            + "<BODY><h2>Bad Request - Invalid Hostname</h2>\r\n"u8
            + "<hr><p>HTTP Error 400. The request hostname is invalid.</p>\r\n"u8
            + "</BODY></HTML>"u8
        ).ToArray();
}
```

```
// * Summary *

BenchmarkDotNet v0.13.11, Windows 11 (10.0.22621.2861/22H2/2022Update/SunValley2)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK 8.0.100
  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2


| Method        | Mean     | Error    | StdDev   | Gen0   | Allocated |
|-------------- |---------:|---------:|---------:|-------:|----------:|
| AsciiGetBytes | 22.77 ns | 0.282 ns | 0.264 ns | 0.0215 |     360 B |
| Utf8          | 12.23 ns | 0.256 ns | 0.239 ns | 0.0215 |     360 B |
```