### PR TITLE
[release/6.0] [Blazor] Fix duplicated place holder in log message

### DIFF
--- a/src/Components/Components/src/RenderTree/Renderer.Log.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.Log.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Components.RenderTree
             private static readonly LogDefineOptions SkipEnabledCheckLogOptions = new() { SkipEnabledCheck = true };
 
             private static readonly Action<ILogger, int, Type, int, Type, Exception> _initializingChildComponent =
-                LoggerMessage.Define<int, Type, int, Type>(LogLevel.Debug, new EventId(1, "InitializingChildComponent"), "Initializing component {ComponentId} ({ComponentType}) as child of {ParentComponentId} ({ParentComponentId})", SkipEnabledCheckLogOptions);
+                LoggerMessage.Define<int, Type, int, Type>(LogLevel.Debug, new EventId(1, "InitializingChildComponent"), "Initializing component {ComponentId} ({ComponentType}) as child of {ParentComponentId} ({ParentComponentType})", SkipEnabledCheckLogOptions);
 
             private static readonly Action<ILogger, int, Type, Exception> _initializingRootComponent =
                 LoggerMessage.Define<int, Type>(LogLevel.Debug, new EventId(2, "InitializingRootComponent"), "Initializing root component {ComponentId} ({ComponentType})", SkipEnabledCheckLogOptions);


### PR DESCRIPTION
# Fix duplicated place holder in log message

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Fix bug of log message in .NET6 or earlyer.

## Description

[Microsoft.AspNetCore.Components.RenderTree.Renderer+Log.InitializingChildComponent()](https://github.com/dotnet/aspnetcore/blob/36be7ed6d6d56b7da0a2891e3de7ecc2aa48eecd/src/Components/Components/src/RenderTree/Renderer.Log.cs#L19) has duplicated place holder `ParentComponentId`.

However, .NET7 or later are already fixed by #35585

## Customer Impact

This PR can avoid frequent exceptions on some logging frameworks.

- [serilog](https://stackoverflow.com/questions/73775078/blazor-using-serilog-argumentexception-an-item-with-the-same-key-has-already)
- [nlog](https://github.com/NLog/NLog/issues/5048)

## Regression?

- [ ] Yes
- [x] No


## Risk

- [ ] High
- [ ] Medium
- [x] Low

The logic has not been modified, only the message has been modified. 

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

----

## When servicing release/2.1

- [ ] Make necessary changes in eng/PatchConfig.props