### PR TITLE
fix: Added missing AddOptions() to AddLocalization.

### DIFF
--- a/src/Localization/Localization/src/LocalizationServiceCollectionExtensions.cs
+++ b/src/Localization/Localization/src/LocalizationServiceCollectionExtensions.cs
@@ -44,6 +44,8 @@ public static class LocalizationServiceCollectionExtensions
         ArgumentNullThrowHelper.ThrowIfNull(services);
         ArgumentNullThrowHelper.ThrowIfNull(setupAction);
 
+        services.AddOptions();
+        
         AddLocalizationServices(services, setupAction);
 
         return services;


### PR DESCRIPTION
# {PR title}

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

There are two AddLocalization methods that do the same thing, but the second one skips the AddOptions call.
Since this is a trivial fix, some things are missed

## Description

{Detail}

Fixes #{bug number} (in this specific format)
