### PR TITLE
fix: ignore proxy for local address supports comma separated values

### DIFF
--- a/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
+++ b/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
@@ -43,7 +43,7 @@ internal static class DebugProxyLauncher
         var noProxyEnvVar = Environment.GetEnvironmentVariable("NO_PROXY");
         if (noProxyEnvVar is not null)
         {
-            var noProxyEnvVarValues = noProxyEnvVar.Split(",", StringSplitOptions.None);
+            var noProxyEnvVarValues = noProxyEnvVar.Split(",", StringSplitOptions.TrimEntries);
             if (noProxyEnvVarValues.Any(noProxyValue => noProxyValue.Equals("localhost") || noProxyValue.Equals("127.0.0.1")))
             {
                 return "--IgnoreProxyForLocalAddress True";

--- a/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
+++ b/src/Components/WebAssembly/Server/src/DebugProxyLauncher.cs
@@ -43,7 +43,8 @@ internal static class DebugProxyLauncher
         var noProxyEnvVar = Environment.GetEnvironmentVariable("NO_PROXY");
         if (noProxyEnvVar is not null)
         {
-            if (noProxyEnvVar.Equals("localhost") || noProxyEnvVar.Equals("127.0.0.1"))
+            var noProxyEnvVarValues = noProxyEnvVar.Split(",", StringSplitOptions.None);
+            if (noProxyEnvVarValues.Any(noProxyValue => noProxyValue.Equals("localhost") || noProxyValue.Equals("127.0.0.1")))
             {
                 return "--IgnoreProxyForLocalAddress True";
             }


### PR DESCRIPTION
# Make Blazor Debugger noproxy more flexible to allow for more complex scenarios.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars): Allows comma based NO_PROXY values by WebAssembly Debugger

## Description

Splits the NO_PROXY value to support support comma separated lists of NO_PROXY. Continues to work with previously accepted NO_PROXY values.

Fixes #52475