### PR TITLE
[Blazor] Accept an HTML encoder instance from DI if available

### DIFF
--- a/src/Components/Web/src/HtmlRendering/StaticHtmlRenderer.HtmlWriting.cs
+++ b/src/Components/Web/src/HtmlRendering/StaticHtmlRenderer.HtmlWriting.cs
@@ -21,8 +21,8 @@ public partial class StaticHtmlRenderer
         string.Empty,
         typeof(FormMappingContext));
 
-    private static readonly TextEncoder _javaScriptEncoder = JavaScriptEncoder.Default;
-    private TextEncoder _htmlEncoder = HtmlEncoder.Default;
+    private readonly TextEncoder _javaScriptEncoder;
+    private readonly TextEncoder _htmlEncoder;
     private string? _closestSelectValueAsString;
 
     /// <summary>

--- a/src/Components/Web/src/HtmlRendering/StaticHtmlRenderer.HtmlWriting.cs
+++ b/src/Components/Web/src/HtmlRendering/StaticHtmlRenderer.HtmlWriting.cs
@@ -22,7 +22,7 @@ public partial class StaticHtmlRenderer
         typeof(FormMappingContext));
 
     private readonly TextEncoder _javaScriptEncoder;
-    private readonly TextEncoder _htmlEncoder;
+    private TextEncoder _htmlEncoder;
     private string? _closestSelectValueAsString;
 
     /// <summary>

--- a/src/Components/Web/src/HtmlRendering/StaticHtmlRenderer.cs
+++ b/src/Components/Web/src/HtmlRendering/StaticHtmlRenderer.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
+using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.Web.HtmlRendering;
@@ -30,6 +31,8 @@ public partial class StaticHtmlRenderer : Renderer
         : base(serviceProvider, loggerFactory)
     {
         _navigationManager = serviceProvider.GetService<NavigationManager>();
+        _htmlEncoder = serviceProvider.GetService<HtmlEncoder>() ?? HtmlEncoder.Default;
+        _javaScriptEncoder = serviceProvider.GetService<JavaScriptEncoder>() ?? JavaScriptEncoder.Default;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Fixes #47477

Check on the DI container for an encoder implementation and use that if available. Otherwise, fallback to the default.