### PR TITLE
Use macOS-12 in CI

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -188,8 +188,8 @@ jobs:
       - script: df -h
         displayName: Disk size
     - ${{ if eq(parameters.agentOs, 'macOS') }}:
-      - script: sudo xcode-select -s /Applications/Xcode_12.5.1.app/Contents/Developer
-        displayName: Use XCode 12.5.1
+      - script: sudo xcode-select -s /Applications/Xcode_14.2.0.app/Contents/Developer
+        displayName: Use XCode 14.2.0
     - checkout: self
       clean: true
     - ${{ if and(eq(parameters.agentOs, 'Windows'), eq(parameters.isAzDOTestingJob, true)) }}:

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -110,7 +110,7 @@ jobs:
     # See https://github.com/dotnet/arcade/blob/master/Documentation/ChoosingAMachinePool.md
     pool:
       ${{ if eq(parameters.agentOs, 'macOS') }}:
-        vmImage: macOS-latest
+        vmImage: macOS-12
       ${{ if eq(parameters.agentOs, 'Linux') }}:
         ${{ if and(eq(parameters.useHostedUbuntu, true), or(ne(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'Manual', 'PullRequest', 'Schedule'))) }}:
           vmImage: ubuntu-20.04

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -110,7 +110,7 @@ jobs:
     # See https://github.com/dotnet/arcade/blob/master/Documentation/ChoosingAMachinePool.md
     pool:
       ${{ if eq(parameters.agentOs, 'macOS') }}:
-        vmImage: macOS-11
+        vmImage: macOS-latest
       ${{ if eq(parameters.agentOs, 'Linux') }}:
         ${{ if and(eq(parameters.useHostedUbuntu, true), or(ne(variables['System.TeamProject'], 'internal'), in(variables['Build.Reason'], 'Manual', 'PullRequest', 'Schedule'))) }}:
           vmImage: ubuntu-20.04


### PR DESCRIPTION
The macOS-11 images have been unavailable for the past couple days, and it seems like time to update to 12.