### PR TITLE
Use Microsoft.AspNetCore.InternalTesting.csproj for _GetPackageVersionInfo

### DIFF
--- a/eng/Npm.Workspace.nodeproj
+++ b/eng/Npm.Workspace.nodeproj
@@ -53,9 +53,9 @@
     <Message Text="Computed package version info: %(_NodePackageNameAndVersions.PackageName)=%(_NodePackageNameAndVersions.PackageVersion)" Importance="high" />
     -->
     <ItemGroup>
-      <_NodePackageNameAndVersions>
+      <_ResolvedPackageVersionInfo>
         <PackageVersion>$(PackageVersion)</PackageVersion>
-      </_NodePackageNameAndVersions>
+      </_ResolvedPackageVersionInfo>
     </ItemGroup>
   </Target>
 

--- a/eng/Npm.Workspace.nodeproj
+++ b/eng/Npm.Workspace.nodeproj
@@ -53,9 +53,9 @@
     <Message Text="Computed package version info: %(_NodePackageNameAndVersions.PackageName)=%(_NodePackageNameAndVersions.PackageVersion)" Importance="high" />
     -->
     <ItemGroup>
-      <_ResolvedPackageVersionInfo>
+      <_NodePackageNameAndVersions>
         <PackageVersion>$(PackageVersion)</PackageVersion>
-      </_ResolvedPackageVersionInfo>
+      </_NodePackageNameAndVersions>
     </ItemGroup>
   </Target>
 

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -107,7 +107,7 @@
     <MSBuild Projects="$(RepoRoot)src\Testing\src\Microsoft.AspNetCore.InternalTesting.csproj"
         Properties="ExcludeFromBuild=false"
         Targets="_GetPackageVersionInfo">
-      <Output TaskParameter="TargetOutputs" ItemName="_ResolvedPackageVersionInfo" />
+      <Output TaskParameter="TargetOutputs" ItemName="_ResolvedProductVersionInfo" />
     </MSBuild>
 
     <PropertyGroup>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -43,21 +43,16 @@
     DependsOnTargets="_WriteProductVersionFile">
     <!--
       This target is defined in eng/targets/Packaging.targets and Npm.Common.targets and included in every C#, F#,
-      and npm project. We use SignalR.Npm.FunctionalTests.nodeproj because it is non-shipping (we need a non-stable
-      version string to use as our publish location), non-packed (won't be shipped in the future), and it is _not_ a
-      C# or F# project. For now at least, C# and F# projects should not be referenced when using desktop msbuild.
+      and npm project. We use Microsoft.AspNetCore.InternalTesting.csproj because it is non-shipping (we need a non-stable
+      version string to use as our publish location) non-packed (won't be shipped in the future).
     -->
-    <MSBuild Projects="$(RepoRoot)eng\Npm.Workspace.nodeproj"
+    <MSBuild Projects="$(RepoRoot)src\Testing\src\Microsoft.AspNetCore.InternalTesting.csproj"
         Properties="ExcludeFromBuild=false"
         Targets="_GetPackageVersionInfo">
       <Output TaskParameter="TargetOutputs" ItemName="_ResolvedPackageVersionInfo" />
     </MSBuild>
 
     <PropertyGroup>
-      <!-- _GetPackageVersionInfo will return all the versions for all public/shipping packages.
-           They are all the same, so we just take the last one.
-           If this changes in the future, we'll have to update this logic.
-       -->
       <_PackageVersion>@(_ResolvedPackageVersionInfo->'%(PackageVersion)')</_PackageVersion>
     </PropertyGroup>
 

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -100,22 +100,17 @@
     Name="_WriteProductVersionFile"
     Condition=" '$(PublishInstallerBaseVersion)' == 'true'">
     <!--
-      This target is defined in eng/targets/Packaging.targets and Npm.Workspace.nodeproj and included in every C#, F#,
-      and JS project. We use Microsoft.JSInterop.JS.nodeproj because it is shipping (we need a stable
-      version string to use for productVersion.txt), and because it won't break when the SDK requires a newer
-      desktop MSBuild than exists on the build machine.
+      This target is defined in eng/targets/Packaging.targets and Npm.Common.targets and included in every C#, F#,
+      and npm project. We use Microsoft.AspNetCore.InternalTesting.csproj because it is non-shipping (we need a non-stable
+      version string to use as our publish location) non-packed (won't be shipped in the future).
     -->
-    <MSBuild Projects="$(RepoRoot)eng\Npm.Workspace.nodeproj"
+    <MSBuild Projects="$(RepoRoot)src\Testing\src\Microsoft.AspNetCore.InternalTesting.csproj"
         Properties="ExcludeFromBuild=false"
         Targets="_GetPackageVersionInfo">
-      <Output TaskParameter="TargetOutputs" ItemName="_ResolvedProductVersionInfo" />
+      <Output TaskParameter="TargetOutputs" ItemName="_ResolvedPackageVersionInfo" />
     </MSBuild>
 
     <PropertyGroup>
-      <!-- _GetPackageVersionInfo will return all the versions for all public/shipping packages.
-           They are all the same, so we just take the last one.
-           If this changes in the future, we'll have to update this logic.
-       -->
       <_ProductVersion>%(_ResolvedProductVersionInfo.PackageVersion)</_ProductVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
There's no need to use a node project to calculate the nonstable package version of the repo during publishing - use `Microsoft.AspNetCore.InternalTesting.csproj` instead.

Related - https://github.com/dotnet/aspnetcore/issues/53091. @javiercn, is the commented-out portion of the target going to be used anywhere other than in publishing.props? If so we should separate that out into a separate target & name it something else.