### PR TITLE
[release/8.0] Use SHA256 for RPM digest

### DIFF
--- a/src/Installers/Rpm/Directory.Build.targets
+++ b/src/Installers/Rpm/Directory.Build.targets
@@ -76,6 +76,7 @@
       <FpmArgs Include="--depends=&quot;%(RpmDependency.Identity) &gt;= %(RpmDependency.Version)&quot;" Condition=" '%(RpmDependency.Identity)' != '' "  />
       <FpmArgs Include="--rpm-changelog=&quot;$(GeneratedChangeLog)&quot;" />
       <FpmArgs Include="--rpm-summary=&quot;$(PackageSummary)&quot;" />
+      <FpmArgs Include="--rpm-digest=sha256" />
       <FpmArgs Include="--description=&quot;$(PackageDescription)&quot;" />
       <FpmArgs Include="--maintainer=&quot;$(Authors) &lt;$(MaintainerEmail)&gt;&quot;" />
       <FpmArgs Include="--vendor=&quot;$(Company)&quot;" />


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspnetcore/pull/52664

FIPS compliance blocks installation of RPM packages that use MD5 digest algorithm. We use `fpm` tool which defaults to MD5 digests. The fix is to specify SHA256 instead.

The fix was made in `arcade` with https://github.com/dotnet/arcade/pull/14269, `installer` fix is in https://github.com/dotnet/installer/pull/17933

This is the same fix that was made by many other RPM package owners, for instance: https://github.com/influxdata/telegraf
