### PR TITLE
Set all mac job timeouts to 90 minutes

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -357,6 +357,7 @@ stages:
         jobName: MacOs_arm64_build
         jobDisplayName: "Build: macOS arm64"
         agentOs: macOs
+        timeoutInMinutes: 90
         buildArgs:
           --arch arm64
           --pack
@@ -388,6 +389,7 @@ stages:
         jobName: MacOs_x64_build
         jobDisplayName: "Build: macOS x64"
         agentOs: macOs
+        timeoutInMinutes: 90
         buildArgs:
           --pack
           --all
@@ -663,7 +665,7 @@ stages:
           jobName: MacOS_Test
           jobDisplayName: "Test: macOS"
           agentOs: macOS
-          timeoutInMinutes: 240
+          timeoutInMinutes: 90
           isAzDOTestingJob: true
           buildArgs: --all --test --binaryLog "/p:RunTemplateTests=false /p:SkipHelixReadyTests=true" $(_InternalRuntimeDownloadArgs)
           beforeBuild:


### PR DESCRIPTION
We're seeing issues with the Azure mac pools recently, and it's a pain waiting 4 hours for the test job to timeout. Most of these jobs take around 30 minutes, so 90 minutes should be safe.