### PR TITLE
[Blazor] Dispatch inbound activity handlers in Blazor Web apps

### DIFF
--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
 using System.Globalization;
 using System.Linq;
 using System.Security.Claims;

--- a/src/Components/test/E2ETest/ServerRenderingTests/InteractivityTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/InteractivityTest.cs
@@ -1133,6 +1133,14 @@ public class InteractivityTest : ServerTestBase<BasicTestAppServerSiteFixture<Ra
         Browser.Equal("GET", () => Browser.Exists(By.Id("method")).Text);
     }
 
+    [Fact]
+    public void InteractiveServerRootComponent_CanAccessCircuitContext()
+    {
+        Navigate($"{ServerPathBase}/interactivity/circuit-context");
+
+        Browser.Equal("True", () => Browser.FindElement(By.Id("has-circuit-context")).Text);
+    }
+
     private void BlockWebAssemblyResourceLoad()
     {
         ((IJavaScriptExecutor)Browser).ExecuteScript("sessionStorage.setItem('block-load-boot-resource', 'true')");

--- a/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
@@ -8,6 +8,7 @@ using System.Web;
 using Components.TestServer.RazorComponents;
 using Components.TestServer.RazorComponents.Pages.Forms;
 using Components.TestServer.Services;
+using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.Mvc;
 
 namespace TestServer;
@@ -35,6 +36,10 @@ public class RazorComponentEndpointsStartup<TRootComponent>
         services.AddHttpContextAccessor();
         services.AddSingleton<AsyncOperationService>();
         services.AddCascadingAuthenticationState();
+
+        var circuitContextAccessor = new TestCircuitContextAccessor();
+        services.AddSingleton<CircuitHandler>(circuitContextAccessor);
+        services.AddSingleton(circuitContextAccessor);
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Interactivity/CircuitContextPage.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Interactivity/CircuitContextPage.razor
@@ -11,11 +11,14 @@
 @code {
     private bool _hasCircuitContext;
 
-    protected override void OnAfterRender(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
+            await Task.Yield();
+
             _hasCircuitContext = CircuitContextAccessor.HasCircuitContext;
+
             StateHasChanged();
         }
     }

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Interactivity/CircuitContextPage.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Interactivity/CircuitContextPage.razor
@@ -1,0 +1,22 @@
+﻿@page "/interactivity/circuit-context"
+@rendermode RenderMode.InteractiveServer
+@inject TestCircuitContextAccessor CircuitContextAccessor
+
+<h1>Circuit context</h1>
+
+<p>
+    Has circuit context: <span id="has-circuit-context">@_hasCircuitContext</span>
+</p>
+
+@code {
+    private bool _hasCircuitContext;
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _hasCircuitContext = CircuitContextAccessor.HasCircuitContext;
+            StateHasChanged();
+        }
+    }
+}


### PR DESCRIPTION
# Dispatch inbound activity handlers in Blazor Web apps

Fixes an issue where inbound activity handlers do not get invoked in Blazor Web apps

## Description

This PR fixes the issue by:
* Building the inbound activity pipeline in Blazor Web apps just after circuit handlers are retrieved
* Invoking inbound activity handlers in web root component updates

Fixes #51934
