### PR TITLE
Enable gRPC tests on MacOS 12

### DIFF
--- a/eng/targets/Helix.Common.props
+++ b/eng/targets/Helix.Common.props
@@ -49,7 +49,7 @@
         <HelixAvailableTargetQueue Include="$(HelixQueueArmDebian12)" Platform="Linux" />
 
         <!-- Mac -->
-        <HelixAvailableTargetQueue Include="OSX.1100.Amd64.Open" Platform="OSX" />
+        <HelixAvailableTargetQueue Include="OSX.1200.Amd64.Open" Platform="OSX" />
 
         <!-- Windows -->
         <HelixAvailableTargetQueue Include="Windows.Amd64.Server2022.Open" Platform="Windows" />

--- a/src/Grpc/Interop/Directory.Build.props
+++ b/src/Grpc/Interop/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
-
-  <PropertyGroup>
-    <!-- TODO: Remove when Grpc.Tools on MacOS 11 is fixed. See https://github.com/grpc/grpc/issues/32558 -->
-    <ExcludeFromBuild Condition="'$(TargetOsName)' == 'osx'">true</ExcludeFromBuild>
-  </PropertyGroup>
-
-</Project>

--- a/src/Grpc/JsonTranscoding/perf/Directory.Build.props
+++ b/src/Grpc/JsonTranscoding/perf/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
-
-  <PropertyGroup>
-    <!-- TODO: Remove when Grpc.Tools on MacOS 11 is fixed. See https://github.com/grpc/grpc/issues/32558 -->
-    <ExcludeFromBuild Condition="'$(TargetOsName)' == 'osx'">true</ExcludeFromBuild>
-  </PropertyGroup>
-
-</Project>

--- a/src/Grpc/JsonTranscoding/perf/Microsoft.AspNetCore.Grpc.Microbenchmarks/Microsoft.AspNetCore.Grpc.Microbenchmarks.csproj
+++ b/src/Grpc/JsonTranscoding/perf/Microsoft.AspNetCore.Grpc.Microbenchmarks/Microsoft.AspNetCore.Grpc.Microbenchmarks.csproj
@@ -6,8 +6,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TieredCompilation>false</TieredCompilation>
     <DefineConstants>$(DefineConstants);IS_BENCHMARKS</DefineConstants>
-    <!-- TODO: Remove when Grpc.Tools on MacOS 11 is fixed. See https://github.com/grpc/grpc/issues/32558 -->
-    <SkipMicrobenchmarksValidation>true</SkipMicrobenchmarksValidation>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Grpc/JsonTranscoding/test/Directory.Build.props
+++ b/src/Grpc/JsonTranscoding/test/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
-
-  <PropertyGroup>
-    <!-- TODO: Remove when Grpc.Tools on MacOS 11 is fixed. See https://github.com/grpc/grpc/issues/32558 -->
-    <ExcludeFromBuild Condition="'$(TargetOsName)' == 'osx'">true</ExcludeFromBuild>
-  </PropertyGroup>
-
-</Project>

--- a/src/ProjectTemplates/test/Templates.Tests/GrpcTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Tests/GrpcTemplateTest.cs
@@ -34,16 +34,14 @@ public class GrpcTemplateTest : LoggedTest
         }
     }
 
-    // TODO (https://github.com/dotnet/aspnetcore/issues/47336): Don't skip on macos 11
     [ConditionalFact]
-    [SkipOnHelix("Not supported queues", Queues = "OSX.1100.Amd64.Open;windows.11.arm64.open;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
+    [SkipOnHelix("Not supported queues", Queues = "windows.11.arm64.open;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
     [SkipOnAlpine("https://github.com/grpc/grpc/issues/18338")] // protoc doesn't support Alpine. Note that the issue was closed with a workaround which isn't applied to our OS image.
     public async Task GrpcTemplate()
     {
         await GrpcTemplateCore();
     }
 
-    // TODO (https://github.com/dotnet/aspnetcore/issues/47336): Don't skip on macos 11
     [ConditionalFact]
     [SkipOnHelix("Not supported queues", Queues = HelixConstants.NativeAotNotSupportedHelixQueues)]
     [SkipOnAlpine("https://github.com/grpc/grpc/issues/18338")] // protoc doesn't support Alpine. Note that the issue was closed with a workaround which isn't applied to our OS image.
@@ -52,16 +50,14 @@ public class GrpcTemplateTest : LoggedTest
         await GrpcTemplateCore(args: new[] { ArgConstants.PublishNativeAot });
     }
 
-    // TODO (https://github.com/dotnet/aspnetcore/issues/47336): Don't skip on macos 11
     [ConditionalFact]
-    [SkipOnHelix("Not supported queues", Queues = "OSX.1100.Amd64.Open;windows.11.arm64.open;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
+    [SkipOnHelix("Not supported queues", Queues = "windows.11.arm64.open;" + HelixConstants.Windows10Arm64 + HelixConstants.DebianArm64)]
     [SkipOnAlpine("https://github.com/grpc/grpc/issues/18338")] // protoc doesn't support Alpine. Note that the issue was closed with a workaround which isn't applied to our OS image.
     public async Task GrpcTemplateProgramMain()
     {
         await GrpcTemplateCore(args: new[] { ArgConstants.UseProgramMain });
     }
 
-    // TODO (https://github.com/dotnet/aspnetcore/issues/47336): Don't skip on macos 11
     [ConditionalFact]
     [SkipOnHelix("Not supported queues", Queues = HelixConstants.NativeAotNotSupportedHelixQueues)]
     [SkipOnAlpine("https://github.com/grpc/grpc/issues/18338")] // protoc doesn't support Alpine. Note that the issue was closed with a workaround which isn't applied to our OS image.


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/47336

Newer versions of Grpc.Tools didn't support MacOS 11. See https://github.com/dotnet/aspnetcore/issues/47336.

aspnetcore is building on 12 so it's no longer a problem.

@wtgodbe How can I ensure the changes succeed on a full Helix build?