### PR TITLE
Use cached ILogger instances to avoid repeated creation of these instances

### DIFF
--- a/src/Mvc/Mvc.Core/src/Filters/DisableRequestSizeLimitFilter.cs
+++ b/src/Mvc/Mvc.Core/src/Filters/DisableRequestSizeLimitFilter.cs
@@ -19,7 +19,7 @@ internal sealed partial class DisableRequestSizeLimitFilter : IAuthorizationFilt
     /// </summary>
     public DisableRequestSizeLimitFilter(ILoggerFactory loggerFactory)
     {
-        _logger = loggerFactory.CreateLogger<DisableRequestSizeLimitFilter>();
+        _logger = loggerFactory.CreateLogger(typeof(DisableRequestSizeLimitFilter));
     }
 
     /// <summary>

--- a/src/Mvc/Mvc.Core/src/Filters/RequestFormLimitsFilter.cs
+++ b/src/Mvc/Mvc.Core/src/Filters/RequestFormLimitsFilter.cs
@@ -15,7 +15,7 @@ internal sealed partial class RequestFormLimitsFilter : IAuthorizationFilter, IR
 
     public RequestFormLimitsFilter(ILoggerFactory loggerFactory)
     {
-        _logger = loggerFactory.CreateLogger<RequestFormLimitsFilter>();
+        _logger = loggerFactory.CreateLogger(typeof(RequestFormLimitsFilter));
     }
 
     public FormOptions FormOptions { get; set; } = default!;

--- a/src/Mvc/Mvc.Core/src/Filters/RequestSizeLimitFilter.cs
+++ b/src/Mvc/Mvc.Core/src/Filters/RequestSizeLimitFilter.cs
@@ -20,7 +20,7 @@ internal sealed partial class RequestSizeLimitFilter : IAuthorizationFilter, IRe
     /// </summary>
     public RequestSizeLimitFilter(ILoggerFactory loggerFactory)
     {
-        _logger = loggerFactory.CreateLogger<RequestSizeLimitFilter>();
+        _logger = loggerFactory.CreateLogger(typeof(RequestSizeLimitFilter));
     }
 
     public long Bytes { get; set; }

--- a/src/Mvc/Mvc.Core/src/Infrastructure/ControllerActionInvokerProvider.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ControllerActionInvokerProvider.cs
@@ -48,7 +48,7 @@ internal sealed class ControllerActionInvokerProvider : IActionInvokerProvider
         _maxModelValidationErrors = optionsAccessor.Value.MaxModelValidationErrors;
         _maxValidationDepth = optionsAccessor.Value.MaxValidationDepth;
         _maxModelBindingRecursionDepth = optionsAccessor.Value.MaxModelBindingRecursionDepth;
-        _logger = loggerFactory.CreateLogger<ControllerActionInvoker>();
+        _logger = loggerFactory.CreateLogger(typeof(ControllerActionInvoker));
         _diagnosticListener = diagnosticListener;
         _mapper = mapper;
         _actionContextAccessor = actionContextAccessor ?? ActionContextAccessor.Null;

--- a/src/Mvc/Mvc.Core/src/Infrastructure/ModelStateInvalidFilterFactory.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ModelStateInvalidFilterFactory.cs
@@ -21,6 +21,6 @@ internal sealed class ModelStateInvalidFilterFactory : IFilterFactory, IOrderedF
         var options = serviceProvider.GetRequiredService<IOptions<ApiBehaviorOptions>>();
         var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
 
-        return new ModelStateInvalidFilter(options.Value, loggerFactory.CreateLogger<ModelStateInvalidFilter>());
+        return new ModelStateInvalidFilter(options.Value, loggerFactory.CreateLogger(typeof(ModelStateInvalidFilter)));
     }
 }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/BodyModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/BodyModelBinder.cs
@@ -76,7 +76,7 @@ public partial class BodyModelBinder : IModelBinder
         _formatters = formatters;
         _readerFactory = readerFactory.CreateReader;
 
-        _logger = loggerFactory?.CreateLogger<BodyModelBinder>() ?? NullLogger<BodyModelBinder>.Instance;
+        _logger = loggerFactory?.CreateLogger(typeof(BodyModelBinder)) ?? NullLogger<BodyModelBinder>.Instance;
 
         _options = options;
     }

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ByteArrayModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ByteArrayModelBinder.cs
@@ -22,7 +22,7 @@ public class ByteArrayModelBinder : IModelBinder
     {
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
-        _logger = loggerFactory.CreateLogger<ByteArrayModelBinder>();
+        _logger = loggerFactory.CreateLogger(typeof(ByteArrayModelBinder));
     }
 
     /// <inheritdoc />

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexObjectModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexObjectModelBinder.cs
@@ -38,7 +38,7 @@ public sealed partial class ComplexObjectModelBinder : IModelBinder
     internal ComplexObjectModelBinder(
         IDictionary<ModelMetadata, IModelBinder> propertyBinders,
         IReadOnlyList<IModelBinder> parameterBinders,
-        ILogger<ComplexObjectModelBinder> logger)
+        ILogger logger)
     {
         _propertyBinders = propertyBinders;
         _parameterBinders = parameterBinders;

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexObjectModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexObjectModelBinderProvider.cs
@@ -22,7 +22,7 @@ public class ComplexObjectModelBinderProvider : IModelBinderProvider
         if (metadata.IsComplexType && !metadata.IsCollectionType)
         {
             var loggerFactory = context.Services.GetRequiredService<ILoggerFactory>();
-            var logger = loggerFactory.CreateLogger<ComplexObjectModelBinder>();
+            var logger = loggerFactory.CreateLogger(typeof(ComplexObjectModelBinder));
             var parameterBinders = GetParameterBinders(context);
 
             var propertyBinders = new Dictionary<ModelMetadata, IModelBinder>();

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexTypeModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/ComplexTypeModelBinder.cs
@@ -71,7 +71,7 @@ public partial class ComplexTypeModelBinder : IModelBinder
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         _propertyBinders = propertyBinders;
-        _logger = loggerFactory.CreateLogger<ComplexTypeModelBinder>();
+        _logger = loggerFactory.CreateLogger(typeof(ComplexTypeModelBinder));
     }
 
     /// <inheritdoc/>

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateTimeModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DateTimeModelBinder.cs
@@ -26,7 +26,7 @@ public class DateTimeModelBinder : IModelBinder
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         _supportedStyles = supportedStyles;
-        _logger = loggerFactory.CreateLogger<DateTimeModelBinder>();
+        _logger = loggerFactory.CreateLogger(typeof(DateTimeModelBinder));
     }
 
     /// <inheritdoc />

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DecimalModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DecimalModelBinder.cs
@@ -28,7 +28,7 @@ public class DecimalModelBinder : IModelBinder
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         _supportedStyles = supportedStyles;
-        _logger = loggerFactory.CreateLogger<DecimalModelBinder>();
+        _logger = loggerFactory.CreateLogger(typeof(DecimalModelBinder));
     }
 
     /// <inheritdoc />

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DoubleModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/DoubleModelBinder.cs
@@ -28,7 +28,7 @@ public class DoubleModelBinder : IModelBinder
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         _supportedStyles = supportedStyles;
-        _logger = loggerFactory.CreateLogger<DoubleModelBinder>();
+        _logger = loggerFactory.CreateLogger(typeof(DoubleModelBinder));
     }
 
     /// <inheritdoc />

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FloatModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FloatModelBinder.cs
@@ -28,7 +28,7 @@ public class FloatModelBinder : IModelBinder
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         _supportedStyles = supportedStyles;
-        _logger = loggerFactory.CreateLogger<FloatModelBinder>();
+        _logger = loggerFactory.CreateLogger(typeof(FloatModelBinder));
     }
 
     /// <inheritdoc />

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FormCollectionModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FormCollectionModelBinder.cs
@@ -26,7 +26,7 @@ public class FormCollectionModelBinder : IModelBinder
     {
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
-        _logger = loggerFactory.CreateLogger<FormCollectionModelBinder>();
+        _logger = loggerFactory.CreateLogger(typeof(FormCollectionModelBinder));
     }
 
     /// <inheritdoc />

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FormFileModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/FormFileModelBinder.cs
@@ -27,7 +27,7 @@ public partial class FormFileModelBinder : IModelBinder
     {
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
-        _logger = loggerFactory.CreateLogger<FormFileModelBinder>();
+        _logger = loggerFactory.CreateLogger(typeof(FormFileModelBinder));
     }
 
     /// <inheritdoc />

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/HeaderModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/HeaderModelBinder.cs
@@ -24,7 +24,7 @@ public class HeaderModelBinder : IModelBinder
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
     public HeaderModelBinder(ILoggerFactory loggerFactory)
     {
-        _logger = loggerFactory.CreateLogger<HeaderModelBinder>();
+        _logger = loggerFactory.CreateLogger(typeof(HeaderModelBinder));
     }
 
     /// <summary>
@@ -38,7 +38,7 @@ public class HeaderModelBinder : IModelBinder
         ArgumentNullException.ThrowIfNull(loggerFactory);
         ArgumentNullException.ThrowIfNull(innerModelBinder);
 
-        _logger = loggerFactory.CreateLogger<HeaderModelBinder>();
+        _logger = loggerFactory.CreateLogger(typeof(HeaderModelBinder));
         InnerModelBinder = innerModelBinder;
     }
 

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/HeaderModelBinderProvider.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/HeaderModelBinderProvider.cs
@@ -27,7 +27,7 @@ public partial class HeaderModelBinderProvider : IModelBinderProvider
 
         var modelMetadata = context.Metadata;
         var loggerFactory = context.Services.GetRequiredService<ILoggerFactory>();
-        var logger = loggerFactory.CreateLogger<HeaderModelBinderProvider>();
+        var logger = loggerFactory.CreateLogger(typeof(HeaderModelBinderProvider));
 
         if (!IsSimpleType(modelMetadata))
         {

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/KeyValuePairModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/KeyValuePairModelBinder.cs
@@ -32,7 +32,7 @@ public class KeyValuePairModelBinder<TKey, TValue> : IModelBinder
 
         _keyBinder = keyBinder;
         _valueBinder = valueBinder;
-        _logger = loggerFactory.CreateLogger<KeyValuePairModelBinder<TKey, TValue>>();
+        _logger = loggerFactory.CreateLogger(typeof(KeyValuePairModelBinder<TKey, TValue>));
     }
 
     /// <inheritdoc />

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/SimpleTypeModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/SimpleTypeModelBinder.cs
@@ -28,7 +28,7 @@ public class SimpleTypeModelBinder : IModelBinder
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         _typeConverter = TypeDescriptor.GetConverter(type);
-        _logger = loggerFactory.CreateLogger<SimpleTypeModelBinder>();
+        _logger = loggerFactory.CreateLogger(typeof(SimpleTypeModelBinder));
     }
 
     /// <inheritdoc />

--- a/src/Mvc/Mvc.Core/src/ModelBinding/Binders/TryParseModelBinder.cs
+++ b/src/Mvc/Mvc.Core/src/ModelBinding/Binders/TryParseModelBinder.cs
@@ -36,7 +36,7 @@ internal sealed class TryParseModelBinder : IModelBinder
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         _tryParseOperation = CreateTryParseOperation(modelType);
-        _logger = loggerFactory.CreateLogger<TryParseModelBinder>();
+        _logger = loggerFactory.CreateLogger(typeof(TryParseModelBinder));
     }
 
     /// <inheritdoc />

--- a/src/Mvc/Mvc.Core/src/Routing/MvcAttributeRouteHandler.cs
+++ b/src/Mvc/Mvc.Core/src/Routing/MvcAttributeRouteHandler.cs
@@ -26,7 +26,7 @@ internal sealed class MvcAttributeRouteHandler : IRouter
         _actionInvokerFactory = actionInvokerFactory;
         _actionSelector = actionSelector;
         _diagnosticListener = diagnosticListener;
-        _logger = loggerFactory.CreateLogger<MvcAttributeRouteHandler>();
+        _logger = loggerFactory.CreateLogger(typeof(MvcAttributeRouteHandler));
     }
 
     public ActionDescriptor[]? Actions { get; set; }

--- a/src/Mvc/Mvc.NewtonsoftJson/src/DependencyInjection/NewtonsoftJsonMvcOptionsSetup.cs
+++ b/src/Mvc/Mvc.NewtonsoftJson/src/DependencyInjection/NewtonsoftJsonMvcOptionsSetup.cs
@@ -50,7 +50,7 @@ internal sealed class NewtonsoftJsonMvcOptionsSetup : IConfigureOptions<MvcOptio
         // Register JsonPatchInputFormatter before JsonInputFormatter, otherwise
         // JsonInputFormatter would consume "application/json-patch+json" requests
         // before JsonPatchInputFormatter gets to see them.
-        var jsonInputPatchLogger = _loggerFactory.CreateLogger<NewtonsoftJsonPatchInputFormatter>();
+        var jsonInputPatchLogger = _loggerFactory.CreateLogger(typeof(NewtonsoftJsonPatchInputFormatter));
         options.InputFormatters.Add(new NewtonsoftJsonPatchInputFormatter(
             jsonInputPatchLogger,
             _jsonOptions.SerializerSettings,
@@ -59,7 +59,7 @@ internal sealed class NewtonsoftJsonMvcOptionsSetup : IConfigureOptions<MvcOptio
             options,
             _jsonOptions));
 
-        var jsonInputLogger = _loggerFactory.CreateLogger<NewtonsoftJsonInputFormatter>();
+        var jsonInputLogger = _loggerFactory.CreateLogger(typeof(NewtonsoftJsonInputFormatter));
         options.InputFormatters.Add(new NewtonsoftJsonInputFormatter(
             jsonInputLogger,
             _jsonOptions.SerializerSettings,

--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -230,7 +230,7 @@ public partial class HubConnection : IAsyncDisposable
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
 
         _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
-        _logger = _loggerFactory.CreateLogger<HubConnection>();
+        _logger = _loggerFactory.CreateLogger(typeof(HubConnection));
         _state = new ReconnectingConnectionState(_logger);
 
         _logScope = new ConnectionLogScope();

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/HttpConnection.cs
@@ -142,7 +142,7 @@ public partial class HttpConnection : ConnectionContext, IConnectionInherentKeep
 
         _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
 
-        _logger = _loggerFactory.CreateLogger<HttpConnection>();
+        _logger = _loggerFactory.CreateLogger(typeof(HttpConnection));
         _httpConnectionOptions = httpConnectionOptions;
 
         _url = _httpConnectionOptions.Url;

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/LoggingHttpMessageHandler.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/LoggingHttpMessageHandler.cs
@@ -13,13 +13,13 @@ namespace Microsoft.AspNetCore.Http.Connections.Client.Internal;
 
 internal sealed partial class LoggingHttpMessageHandler : DelegatingHandler
 {
-    private readonly ILogger<LoggingHttpMessageHandler> _logger;
+    private readonly ILogger _logger;
 
     public LoggingHttpMessageHandler(HttpMessageHandler inner, ILoggerFactory loggerFactory) : base(inner)
     {
         ArgumentNullThrowHelper.ThrowIfNull(loggerFactory);
 
-        _logger = loggerFactory.CreateLogger<LoggingHttpMessageHandler>();
+        _logger = loggerFactory.CreateLogger(typeof(LoggingHttpMessageHandler));
     }
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/LongPollingTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/LongPollingTransport.cs
@@ -35,7 +35,7 @@ internal sealed partial class LongPollingTransport : ITransport
     public LongPollingTransport(HttpClient httpClient, HttpConnectionOptions? httpConnectionOptions = null, ILoggerFactory? loggerFactory = null)
     {
         _httpClient = httpClient;
-        _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<LongPollingTransport>();
+        _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger(typeof(LongPollingTransport));
         _httpConnectionOptions = httpConnectionOptions ?? new();
     }
 

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/ServerSentEventsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/ServerSentEventsTransport.cs
@@ -40,7 +40,7 @@ internal sealed partial class ServerSentEventsTransport : ITransport
         ArgumentNullThrowHelper.ThrowIfNull(httpClient);
 
         _httpClient = httpClient;
-        _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<ServerSentEventsTransport>();
+        _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger(typeof(ServerSentEventsTransport));
         _httpConnectionOptions = httpConnectionOptions ?? new();
     }
 

--- a/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
+++ b/src/SignalR/clients/csharp/Http.Connections.Client/src/Internal/WebSocketsTransport.cs
@@ -75,7 +75,7 @@ internal sealed partial class WebSocketsTransport : ITransport, IStatefulReconne
         bool useStatefulReconnect = false)
     {
         _useStatefulReconnect = useStatefulReconnect;
-        _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<WebSocketsTransport>();
+        _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger(typeof(WebSocketsTransport));
         _httpConnectionOptions = httpConnectionOptions ?? new HttpConnectionOptions();
 
         _closeTimeout = _httpConnectionOptions.CloseTimeout;

--- a/src/SignalR/server/Core/src/HubConnectionContext.cs
+++ b/src/SignalR/server/Core/src/HubConnectionContext.cs
@@ -72,7 +72,7 @@ public partial class HubConnectionContext
         _statefulReconnectBufferSize = contextOptions.StatefulReconnectBufferSize;
 
         _connectionContext = connectionContext;
-        _logger = loggerFactory.CreateLogger<HubConnectionContext>();
+        _logger = loggerFactory.CreateLogger(typeof(HubConnectionContext));
         ConnectionAborted = _connectionAbortedTokenSource.Token;
         _closedRegistration = connectionContext.ConnectionClosed.Register(static (state) => ((HubConnectionContext)state!).Abort(), this);
 


### PR DESCRIPTION
The basic "problem" is shown by this simple demo:
```c#
using Microsoft.Extensions.Logging;

ILoggerFactory loggerFactory = LoggerFactory.Create(builder => { });

ILogger logger1 = loggerFactory.CreateLogger("foo");
ILogger logger2 = loggerFactory.CreateLogger("foo");
Console.WriteLine(logger1 == logger2);                          // True

logger1 = loggerFactory.CreateLogger<Foo>();
logger2 = loggerFactory.CreateLogger<Foo>();
Console.WriteLine(logger1 == logger2);                          // False

logger1 = loggerFactory.CreateLogger(typeof(Foo));
logger2 = loggerFactory.CreateLogger(typeof(Foo));
Console.WriteLine(logger1 == logger2);                          // True

public class Foo { }
```

So for `loggerFactory.CreateLogger("foo")` and `loggerFactory.CreateLogger(typeof(Foo))` cached instances of `ILogger` are returned.
For `loggerFactory.CreateLogger<Foo>()` always a new instance of `ILogger<Foo>` is created.

This PR basically does
```diff
-loggerFactory.CreateLogger<Foo>();
+loggerFactory.CreateLogger(typeof(Foo));
```
where the `ILogger` 
* isn't already cached in the instance that uses it (e.g. in a field)
* the type that uses the ILogger isn't registered in DI as singleton