### PR TITLE
Added a null check in ResolveHasInvalidAntiforgeryValidationFeature()

### DIFF
--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -21,7 +21,7 @@ public class FormFeature : IFormFeature
     private FormOptions _options;
     private Task<IFormCollection>? _parsedFormTask;
     private IFormCollection? _form;
-	private MediaTypeHeaderValue? _formContentType;
+	private MediaTypeHeaderValue? _formContentType; // null iff _form is null
 
     /// <summary>
     /// Initializes a new instance of <see cref="FormFeature"/>.
@@ -127,7 +127,7 @@ public class FormFeature : IFormFeature
             {
                 _formContentType = null;
             }
-			if (_form is not null && _formContentType is null)
+			else
             {
 				_formContentType ??= new MediaTypeHeaderValue("application/x-www-form-urlencoded");
             }

--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -79,7 +79,7 @@ public class FormFeature : IFormFeature
 				_ = MediaTypeHeaderValue.TryParse(_request.ContentType, out mt);
 			}
 
-			if (Form is not null && mt is null)
+			if (_form is not null && mt is null)
 			{
 				mt = _formContentType;
 			}
@@ -123,6 +123,10 @@ public class FormFeature : IFormFeature
         {
             _parsedFormTask = null;
             _form = value;
+            if (_form is null)
+            {
+                _formContentType = null;
+            }
 			if (_form is not null && _formContentType is null)
             {
 				_formContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");

--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -79,7 +79,10 @@ public class FormFeature : IFormFeature
             }
             else
             {
-                _ = MediaTypeHeaderValue.TryParse(_request.ContentType, out mt);
+                if (_request is not null)
+                {
+                    _ = MediaTypeHeaderValue.TryParse(_request.ContentType, out mt);
+                }
             }
 
             return mt;
@@ -158,6 +161,10 @@ public class FormFeature : IFormFeature
             }
             else
             {
+                if (!HasFormContentType)
+                {
+                    throw new InvalidOperationException("This request does not have a Content-Type header. Forms are available from requests with bodies like POSTs and a form Content-Type of either application/x-www-form-urlencoded or multipart/form-data.");
+                }
                 _parsedFormTask = InnerReadFormAsync(cancellationToken);
             }
         }

--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -129,7 +129,7 @@ public class FormFeature : IFormFeature
             }
 			if (_form is not null && _formContentType is null)
             {
-				_formContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
+				_formContentType ??= new MediaTypeHeaderValue("application/x-www-form-urlencoded");
             }
         }
     }

--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -70,15 +70,18 @@ public class FormFeature : IFormFeature
     {
         get
         {
+            MediaTypeHeaderValue? mt = default;
+
             // Set directly
             if (Form is not null)
             {
-                _ = MediaTypeHeaderValue.TryParse("application/x-www-form-urlencoded", out var mt);
+                mt = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
             }
             else
             {
-                _ = MediaTypeHeaderValue.TryParse(_request.ContentType, out var mt);
+                _ = MediaTypeHeaderValue.TryParse(_request.ContentType, out mt);
             }
+
             return mt;
         }
     }

--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Http.Features;
 /// </summary>
 public class FormFeature : IFormFeature
 {
-    private readonly HttpRequest _request;
+    private readonly HttpRequest? _request;
     private readonly Endpoint? _endpoint;
     private FormOptions _options;
     private Task<IFormCollection>? _parsedFormTask;
@@ -31,7 +31,6 @@ public class FormFeature : IFormFeature
         ArgumentNullException.ThrowIfNull(form);
 
         Form = form;
-        _request = default!;
         _options = FormOptions.Default;
     }
 
@@ -71,7 +70,15 @@ public class FormFeature : IFormFeature
     {
         get
         {
-            _ = MediaTypeHeaderValue.TryParse(_request.ContentType, out var mt);
+            // Set directly
+            if (Form is not null)
+            {
+                _ = MediaTypeHeaderValue.TryParse("application/x-www-form-urlencoded", out var mt);
+            }
+            else
+            {
+                _ = MediaTypeHeaderValue.TryParse(_request.ContentType, out var mt);
+            }
             return mt;
         }
     }
@@ -85,6 +92,11 @@ public class FormFeature : IFormFeature
             if (Form != null)
             {
                 return true;
+            }
+
+            if (_request is null)
+            {
+                return false;
             }
 
             var contentType = ContentType;

--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -326,7 +326,10 @@ public class FormFeature : IFormFeature
 
     private bool ResolveHasInvalidAntiforgeryValidationFeature()
     {
-        if (_request is null) return false;
+        if (_request is null)
+        {
+            return false;
+        }
         var hasInvokedMiddleware = _request.HttpContext.Items.ContainsKey("__AntiforgeryMiddlewareWithEndpointInvoked");
         var hasInvalidToken = _request.HttpContext.Features.Get<IAntiforgeryValidationFeature>() is { IsValid: false };
         return hasInvokedMiddleware && hasInvalidToken;

--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -161,10 +161,6 @@ public class FormFeature : IFormFeature
             }
             else
             {
-                if (!HasFormContentType)
-                {
-                    throw new InvalidOperationException("This request does not have a Content-Type header. Forms are available from requests with bodies like POSTs and a form Content-Type of either application/x-www-form-urlencoded or multipart/form-data.");
-                }
                 _parsedFormTask = InnerReadFormAsync(cancellationToken);
             }
         }
@@ -173,6 +169,11 @@ public class FormFeature : IFormFeature
 
     private async Task<IFormCollection> InnerReadFormAsync(CancellationToken cancellationToken)
     {
+        if (_request is null)
+        {
+            throw new InvalidOperationException("Cannot read form from this request. Request is 'null'.");
+        }
+
         HandleUncheckedAntiforgeryValidationFeature();
         _options = _endpoint is null ? _options : GetFormOptionsFromMetadata(_options, _endpoint);
 

--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -21,6 +21,7 @@ public class FormFeature : IFormFeature
     private FormOptions _options;
     private Task<IFormCollection>? _parsedFormTask;
     private IFormCollection? _form;
+	private MediaTypeHeaderValue? _formContentType;
 
     /// <summary>
     /// Initializes a new instance of <see cref="FormFeature"/>.
@@ -31,6 +32,7 @@ public class FormFeature : IFormFeature
         ArgumentNullException.ThrowIfNull(form);
 
         Form = form;
+		_formContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
         _options = FormOptions.Default;
     }
 
@@ -70,22 +72,19 @@ public class FormFeature : IFormFeature
     {
         get
         {
-            MediaTypeHeaderValue? mt = default;
+			MediaTypeHeaderValue? mt = null;
 
-            // Set directly
-            if (Form is not null)
-            {
-                mt = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
-            }
-            else
-            {
-                if (_request is not null)
-                {
-                    _ = MediaTypeHeaderValue.TryParse(_request.ContentType, out mt);
-                }
-            }
+			if (_request is not null)
+			{
+				_ = MediaTypeHeaderValue.TryParse(_request.ContentType, out mt);
+			}
 
-            return mt;
+			if (Form is not null && mt is null)
+			{
+				mt = _formContentType;
+			}
+
+			return mt;
         }
     }
 
@@ -124,6 +123,10 @@ public class FormFeature : IFormFeature
         {
             _parsedFormTask = null;
             _form = value;
+			if (_form is not null && _formContentType is null)
+            {
+				_formContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
+            }
         }
     }
 

--- a/src/Http/Http/src/Features/FormFeature.cs
+++ b/src/Http/Http/src/Features/FormFeature.cs
@@ -326,6 +326,7 @@ public class FormFeature : IFormFeature
 
     private bool ResolveHasInvalidAntiforgeryValidationFeature()
     {
+        if (_request is null) return false;
         var hasInvokedMiddleware = _request.HttpContext.Items.ContainsKey("__AntiforgeryMiddlewareWithEndpointInvoked");
         var hasInvalidToken = _request.HttpContext.Features.Get<IAntiforgeryValidationFeature>() is { IsValid: false };
         return hasInvokedMiddleware && hasInvalidToken;


### PR DESCRIPTION
# Added a null check in ResolveHasInvalidAntiforgeryValidationFeature()

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Added a null check for the _request field since this will be null when type is constructed with the constructor taking a IFormCollection parameter. 

Fixes #53099 
