### PR TITLE
Improve key service unsupported exception message

### DIFF
--- a/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
+++ b/src/Http/Http.Extensions/gen/StaticRouteHandlerModel/Emitters/EndpointParameterEmitter.cs
@@ -337,7 +337,7 @@ internal static class EndpointParameterEmitter
 
         codeWriter.WriteLine("if (httpContext.RequestServices.GetService<IServiceProviderIsService>() is not IServiceProviderIsKeyedService)");
         codeWriter.StartBlock();
-        codeWriter.WriteLine(@"throw new InvalidOperationException($""Unable to resolve {nameof(FromKeyedServicesAttribute)}. This service provider doesn't support keyed services."");");
+        codeWriter.WriteLine(@"throw new InvalidOperationException($""Unable to resolve service referenced by {nameof(FromKeyedServicesAttribute)}. The service provider doesn't support keyed services."");");
         codeWriter.EndBlock();
 
         var assigningCode = endpointParameter.IsOptional ?

--- a/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
+++ b/src/Http/Http.Extensions/src/RequestDelegateFactory.cs
@@ -790,7 +790,7 @@ public static partial class RequestDelegateFactory
         {
             if (factoryContext.ServiceProviderIsService is not IServiceProviderIsKeyedService)
             {
-                throw new InvalidOperationException($"Unable to resolve {nameof(FromKeyedServicesAttribute)}. This service provider doesn't support keyed services.");
+                throw new InvalidOperationException($"Unable to resolve service referenced by {nameof(FromKeyedServicesAttribute)}. The service provider doesn't support keyed services.");
             }
             var key = keyedServicesAttribute.Key;
             return BindParameterFromKeyedService(parameter, key, factoryContext);

--- a/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.KeyServices.cs
+++ b/src/Http/Http.Extensions/test/RequestDelegateGenerator/RequestDelegateCreationTests.KeyServices.cs
@@ -214,14 +214,14 @@ app.MapGet("/", (HttpContext context, [FromKeyedServices("service1")] TestServic
         if (!IsGeneratorEnabled)
         {
             var runtimeException = Assert.Throws<InvalidOperationException>(() => GetEndpointFromCompilation(compilation, serviceProvider: serviceProvider));
-            Assert.Equal("Unable to resolve FromKeyedServicesAttribute. This service provider doesn't support keyed services.", runtimeException.Message);
+            Assert.Equal("Unable to resolve service referenced by FromKeyedServicesAttribute. The service provider doesn't support keyed services.", runtimeException.Message);
             return;
         }
         var endpoint = GetEndpointFromCompilation(compilation, serviceProvider: serviceProvider);
 
         var httpContext = CreateHttpContext(serviceProvider);
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await endpoint.RequestDelegate(httpContext));
-        Assert.Equal("Unable to resolve FromKeyedServicesAttribute. This service provider doesn't support keyed services.", exception.Message);
+        Assert.Equal("Unable to resolve service referenced by FromKeyedServicesAttribute. The service provider doesn't support keyed services.", exception.Message);
     }
 
     private class MockServiceProvider : IServiceProvider, ISupportRequiredService

--- a/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
+++ b/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
@@ -110,7 +110,7 @@ internal sealed class HubMethodDescriptor
                         }
                         else
                         {
-                            throw new InvalidOperationException($"This service provider doesn't support keyed services.");
+                            throw new InvalidOperationException($"Unable to resolve {nameof(FromKeyedServicesAttribute)}. This service provider doesn't support keyed services.");
                         }
                     }
 

--- a/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
+++ b/src/SignalR/server/Core/src/Internal/HubMethodDescriptor.cs
@@ -110,7 +110,7 @@ internal sealed class HubMethodDescriptor
                         }
                         else
                         {
-                            throw new InvalidOperationException($"Unable to resolve {nameof(FromKeyedServicesAttribute)}. This service provider doesn't support keyed services.");
+                            throw new InvalidOperationException($"Unable to resolve service referenced by {nameof(FromKeyedServicesAttribute)}. The service provider doesn't support keyed services.");
                         }
                     }
 


### PR DESCRIPTION
Make key service unsupported exception message better and consistent between SignalR and Minimal API.