### PR TITLE
Only publish npm assets from Windows

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -23,7 +23,8 @@
     <_InstallersToPublish Remove="@(_InstallersToPublish)" />
     <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.jar" UploadPathSegment="jar" />
     <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.pom" UploadPathSegment="jar" />
-    <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.tgz" UploadPathSegment="npm" />
+    <!-- All builds produce npm assets - only publish them once -->
+    <_InstallersToPublish Include="$(ArtifactsDir)packages\**\*.tgz" UploadPathSegment="npm" Condition="'$(OS)' == 'Windows_NT'" />
     <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.deb" UploadPathSegment="Runtime" />
     <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.exe" UploadPathSegment="Runtime" />
     <_InstallersToPublish Include="$(ArtifactsDir)installers\**\*.msi" UploadPathSegment="Runtime" />


### PR DESCRIPTION
Now that we're building the node components everywhere, we have to make sure we only publish them once to avoid duplicate assets in the build manifest. Fixes errors like https://dev.azure.com/dnceng/internal/_build/results?buildId=2348881&view=logs&j=d17d50ef-afac-5d4b-95a6-3014ce5cf7a4&t=95fe4740-169e-5ca1-2f88-330db40deac4&l=41