### PR TITLE
[FabricBot] Remove usage of 'noActivitySince' operand condition

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -110,68 +110,6 @@
       "subCapability": "IssueCommentResponder",
       "version": "1.0",
       "config": {
-        "conditions": {
-          "operator": "and",
-          "operands": [
-            {
-              "name": "isAction",
-              "parameters": {
-                "action": "created"
-              }
-            },
-            {
-              "operator": "not",
-              "operands": [
-                {
-                  "name": "isOpen",
-                  "parameters": {}
-                }
-              ]
-            },
-            {
-              "name": "activitySenderHasPermissions",
-              "parameters": {
-                "permissions": "none"
-              }
-            },
-            {
-              "name": "noActivitySince",
-              "parameters": {
-                "days": 7
-              }
-            },
-            {
-              "operator": "not",
-              "operands": [
-                {
-                  "name": "isCloseAndComment",
-                  "parameters": {}
-                }
-              ]
-            }
-          ]
-        },
-        "eventType": "issue",
-        "eventNames": [
-          "issue_comment"
-        ],
-        "taskName": "[Closed Issue Management] For issues closed with no activity over 7 days, ask non-contributor to consider opening a new issue instead.",
-        "actions": [
-          {
-            "name": "addReply",
-            "parameters": {
-              "comment": "Hello lovely human, thank you for your comment on this issue. Because this issue has been closed for a period of time, please strongly consider opening a new issue linking to this issue instead to ensure better visibility of your comment. Thank you!\n\nSee [our Issue Management Policies](https://aka.ms/aspnet/issue-policies) for more information."
-            }
-          }
-        ]
-      }
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "IssueCommentResponder",
-      "version": "1.0",
-      "config": {
         "taskName": "[Idle Issue Management] Replace needs author feedback label with needs attention label when the author comments on an issue",
         "conditions": {
           "operator": "and",

--- a/.github/workflows/locker.yml
+++ b/.github/workflows/locker.yml
@@ -1,4 +1,4 @@
-name: Locker - Lock stale issues and PRs
+name: Locker - Lock stale issues
 on:
   schedule:
     - cron: '34 8 * * *' # Once per day, overnight PT, uncommon minute of hour


### PR DESCRIPTION
# [FabricBot] Remove usage of 'noActivitySince' operand condition

This removes the event responder task for automatically replying to semi-stale issue comments.

## Description

With the pending migration away from FabricBot to the Policy Service bot, the `noActivitySince` event condition will no longer be supported. This PR removes the only occurrence of that condition in this repository's configuration. The condition was used to identify comments left on issues that have not had prior activity for 7 days, suggesting that a new issue be filed instead. This task [had never been triggered](https://github.com/dotnet/aspnetcore/issues?q=is%3Aissue+%22hello+lovely+human%22+in%3Acomments) within this repository.

This PR also corrects the name of the Locker workflow. PR #53225 updated the workflow to only apply to issues, but the name of the workflow was not updated.

_Note: The `noActivitySince` search condition will still be supported within scheduled searches as used in this configuration; it's only unsupported in event triggers going forward._