### PR TITLE
[Blazor] each navigation to external logs 2 errors a minute later

### DIFF
--- a/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
@@ -30,6 +30,8 @@ internal partial class RemoteJSRuntime : JSRuntime
 
     public bool IsInitialized => _clientProxy is not null;
 
+    internal bool IsPermanentlyDisconnected => _permanentlyDisconnected;
+
     /// <summary>
     /// Notifies when a runtime exception occurred.
     /// </summary>

--- a/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
+++ b/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
@@ -106,6 +106,12 @@ internal sealed partial class RemoteNavigationManager : NavigationManager, IHost
                 }
 
                 await _jsRuntime.InvokeVoidAsync(Interop.NavigateTo, uri, options);
+                Log.NavigationCompleted(_logger, uri);
+            }
+            catch (TaskCanceledException) when (_jsRuntime is RemoteJSRuntime remoteRuntime && !remoteRuntime.IsInitialized)
+            {
+                Log.NavigationCanceled(_logger, uri);
+                return;
             }
             catch (Exception ex)
             {
@@ -190,5 +196,8 @@ internal sealed partial class RemoteNavigationManager : NavigationManager, IHost
 
         [LoggerMessage(5, LogLevel.Error, "Failed to refresh", EventName = "RefreshFailed")]
         public static partial void RefreshFailed(ILogger logger, Exception exception);
+
+        [LoggerMessage(6, LogLevel.Debug, "Navigation completed when changing the location to {Uri}", EventName = "NavigationCompleted")]
+        public static partial void NavigationCompleted(ILogger logger, string uri);
     }
 }

--- a/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
+++ b/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
@@ -108,17 +108,10 @@ internal sealed partial class RemoteNavigationManager : NavigationManager, IHost
                 await _jsRuntime.InvokeVoidAsync(Interop.NavigateTo, uri, options);
                 Log.NavigationCompleted(_logger, uri);
             }
-<<<<<<< HEAD
             catch (TaskCanceledException)
-            when (_jsRuntime is RemoteJSRuntime remoteRuntime && !remoteRuntime.IsPermanentlyDisconnected)
+            when (_jsRuntime is RemoteJSRuntime remoteRuntime && remoteRuntime.IsPermanentlyDisconnected)
             {
                 Log.NavigationStoppedSessionEnded(_logger, uri);
-=======
-            catch (TaskCanceledException) when (_jsRuntime is RemoteJSRuntime remoteRuntime && !remoteRuntime.IsInitialized)
-            {
-                Log.NavigationCanceled(_logger, uri);
-                return;
->>>>>>> parent of d5cc18e710 (Update NavigationManager.ts to dispatch navigations to external sources asynchronously)
             }
             catch (Exception ex)
             {

--- a/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
+++ b/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
@@ -108,11 +108,6 @@ internal sealed partial class RemoteNavigationManager : NavigationManager, IHost
                 await _jsRuntime.InvokeVoidAsync(Interop.NavigateTo, uri, options);
                 Log.NavigationCompleted(_logger, uri);
             }
-            catch (TaskCanceledException) when (_jsRuntime is RemoteJSRuntime remoteRuntime && !remoteRuntime.IsInitialized)
-            {
-                Log.NavigationCanceled(_logger, uri);
-                return;
-            }
             catch (Exception ex)
             {
                 // We shouldn't ever reach this since exceptions thrown from handlers are handled in HandleLocationChangingHandlerException.

--- a/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
+++ b/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
@@ -108,6 +108,11 @@ internal sealed partial class RemoteNavigationManager : NavigationManager, IHost
                 await _jsRuntime.InvokeVoidAsync(Interop.NavigateTo, uri, options);
                 Log.NavigationCompleted(_logger, uri);
             }
+            catch (TaskCanceledException)
+            when (_jsRuntime is RemoteJSRuntime remoteRuntime && !remoteRuntime.IsPermanentlyDisconnected)
+            {
+                Log.NavigationStoppedSessionEnded(_logger, uri);
+            }
             catch (Exception ex)
             {
                 // We shouldn't ever reach this since exceptions thrown from handlers are handled in HandleLocationChangingHandlerException.
@@ -194,5 +199,8 @@ internal sealed partial class RemoteNavigationManager : NavigationManager, IHost
 
         [LoggerMessage(6, LogLevel.Debug, "Navigation completed when changing the location to {Uri}", EventName = "NavigationCompleted")]
         public static partial void NavigationCompleted(ILogger logger, string uri);
+
+        [LoggerMessage(7, LogLevel.Debug, "Navigation stopped because the session ended when navigating to {Uri}", EventName = "NavigationStoppedSessionEnded")]
+        public static partial void NavigationStoppedSessionEnded(ILogger logger, string uri);
     }
 }

--- a/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
+++ b/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
@@ -108,10 +108,17 @@ internal sealed partial class RemoteNavigationManager : NavigationManager, IHost
                 await _jsRuntime.InvokeVoidAsync(Interop.NavigateTo, uri, options);
                 Log.NavigationCompleted(_logger, uri);
             }
+<<<<<<< HEAD
             catch (TaskCanceledException)
             when (_jsRuntime is RemoteJSRuntime remoteRuntime && !remoteRuntime.IsPermanentlyDisconnected)
             {
                 Log.NavigationStoppedSessionEnded(_logger, uri);
+=======
+            catch (TaskCanceledException) when (_jsRuntime is RemoteJSRuntime remoteRuntime && !remoteRuntime.IsInitialized)
+            {
+                Log.NavigationCanceled(_logger, uri);
+                return;
+>>>>>>> parent of d5cc18e710 (Update NavigationManager.ts to dispatch navigations to external sources asynchronously)
             }
             catch (Exception ex)
             {

--- a/src/Components/Web.JS/src/Services/NavigationManager.ts
+++ b/src/Components/Web.JS/src/Services/NavigationManager.ts
@@ -101,7 +101,7 @@ function isSamePageWithHash(absoluteHref: string): boolean {
   return hashIndex > -1 && location.href.replace(location.hash, '') === absoluteHref.substring(0, hashIndex);
 }
 
-function performScrollToElementOnTheSamePage(absoluteHref: string, replace: boolean, state: string | undefined = undefined): void {
+function performScrollToElementOnTheSamePage(absoluteHref : string, replace: boolean, state: string | undefined = undefined): void {
   saveToBrowserHistory(absoluteHref, replace, state);
 
   const hashIndex = absoluteHref.indexOf('#');
@@ -158,23 +158,19 @@ function navigateToCore(uri: string, options: NavigationOptions, skipLocationCha
 }
 
 function performExternalNavigation(uri: string, replace: boolean) {
-  // If we are navigating to an external URI, defer setting the URL so that we can
-  // complete the current navigation operation if the request comes from .NET.
-  setTimeout(() => {
-    if (location.href === uri) {
-      // If you're already on this URL, you can't append another copy of it to the history stack,
-      // so we can ignore the 'replace' flag. However, reloading the same URL you're already on
-      // requires special handling to avoid triggering browser-specific behavior issues.
-      // For details about what this fixes and why, see https://github.com/dotnet/aspnetcore/pull/10839
-      const temporaryUri = uri + '?';
-      history.replaceState(null, '', temporaryUri);
-      location.replace(uri);
-    } else if (replace) {
-      location.replace(uri);
-    } else {
-      location.href = uri;
-    }
-  }, 0);
+  if (location.href === uri) {
+    // If you're already on this URL, you can't append another copy of it to the history stack,
+    // so we can ignore the 'replace' flag. However, reloading the same URL you're already on
+    // requires special handling to avoid triggering browser-specific behavior issues.
+    // For details about what this fixes and why, see https://github.com/dotnet/aspnetcore/pull/10839
+    const temporaryUri = uri + '?';
+    history.replaceState(null, '', temporaryUri);
+    location.replace(uri);
+  } else if (replace) {
+    location.replace(uri);
+  } else {
+    location.href = uri;
+  }
 }
 
 async function performInternalNavigation(absoluteInternalHref: string, interceptedLink: boolean, replace: boolean, state: string | undefined = undefined, skipLocationChangingCallback = false) {

--- a/src/Components/Web.JS/src/Services/NavigationManager.ts
+++ b/src/Components/Web.JS/src/Services/NavigationManager.ts
@@ -101,7 +101,7 @@ function isSamePageWithHash(absoluteHref: string): boolean {
   return hashIndex > -1 && location.href.replace(location.hash, '') === absoluteHref.substring(0, hashIndex);
 }
 
-function performScrollToElementOnTheSamePage(absoluteHref : string, replace: boolean, state: string | undefined = undefined): void {
+function performScrollToElementOnTheSamePage(absoluteHref: string, replace: boolean, state: string | undefined = undefined): void {
   saveToBrowserHistory(absoluteHref, replace, state);
 
   const hashIndex = absoluteHref.indexOf('#');
@@ -158,19 +158,23 @@ function navigateToCore(uri: string, options: NavigationOptions, skipLocationCha
 }
 
 function performExternalNavigation(uri: string, replace: boolean) {
-  if (location.href === uri) {
-    // If you're already on this URL, you can't append another copy of it to the history stack,
-    // so we can ignore the 'replace' flag. However, reloading the same URL you're already on
-    // requires special handling to avoid triggering browser-specific behavior issues.
-    // For details about what this fixes and why, see https://github.com/dotnet/aspnetcore/pull/10839
-    const temporaryUri = uri + '?';
-    history.replaceState(null, '', temporaryUri);
-    location.replace(uri);
-  } else if (replace) {
-    location.replace(uri);
-  } else {
-    location.href = uri;
-  }
+  // If we are navigating to an external URI, defer setting the URL so that we can
+  // complete the current navigation operation if the request comes from .NET.
+  setTimeout(() => {
+    if (location.href === uri) {
+      // If you're already on this URL, you can't append another copy of it to the history stack,
+      // so we can ignore the 'replace' flag. However, reloading the same URL you're already on
+      // requires special handling to avoid triggering browser-specific behavior issues.
+      // For details about what this fixes and why, see https://github.com/dotnet/aspnetcore/pull/10839
+      const temporaryUri = uri + '?';
+      history.replaceState(null, '', temporaryUri);
+      location.replace(uri);
+    } else if (replace) {
+      location.replace(uri);
+    } else {
+      location.href = uri;
+    }
+  }, 0);
 }
 
 async function performInternalNavigation(absoluteInternalHref: string, interceptedLink: boolean, replace: boolean, state: string | undefined = undefined, skipLocationChangingCallback = false) {


### PR DESCRIPTION
## Scenario
This happens on navigations that are not part of Blazor Server, like a navigation to a Razor Page, or similar, but not to navigations to other origins.

## Explanation
* What happens is that the user clicks the link to the target URL.
* We intercept that link in the JS.
* Call .NET to determine if we need to prevent navigation to the URL.
* We determine we don't need to and call "navigateTo" via JS interop in NavigationManager.ts.
* "navigateTo" determines the URL is external at that point and sets the location to the new URL.
* That automatically triggers the unload event in the browser, which in turn triggers the call to _disconnect.
* The result is that the promise to "navigateTo" never completes (the page gets unloaded before that) and as a result, the associated task in .NET ends up getting cancelled with a timeout.

## Fix
There were two possible fixes:
* Defer the call to `location.url` via setTimeout. This allows the call to "navigateTo" to complete (and we log a message on the server to reflect that).
* Catch `TaskCancelledException` on the server and "swallow" the exception when !JSRuntime.IsInitialized.
  * I chose not to do it this way because it's potentially problematic and I'm not 100% confident on the impact on other scenarios (like the circuit is disconnected but not disposed).