### PR TITLE
[Blazor] Default to iife instead of cjs for blazor.*.js bundles

### DIFF
--- a/src/Components/Shared.JS/rollup.config.mjs
+++ b/src/Components/Shared.JS/rollup.config.mjs
@@ -37,7 +37,7 @@ export default function createBaseConfig({ inputOutputMap, dir, updateConfig }) 
     const baseConfig = {
       output: {
         dir: path.join(dir, '/dist', environment === 'development' ? '/Debug' : '/Release'),
-        format: 'cjs',
+        format: 'iife',
         sourcemap: environment === 'development' ? true : false,
         entryFileNames: '[name].js',
       },


### PR DESCRIPTION
Fixes #53264

`cjs` is not appropriate for the browser and causes name collisions as it pollutes the global scope. Switching to `iife` wraps the bundle into an immediately invoked function expression that creates its own scope.

The issue in this case was that the bundle was defining a `$` in the global scope, which conflicted with jquery's `$`.