### PR TITLE
Fix closing SignalR Websocket connection on server close

### DIFF
--- a/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
+++ b/src/SignalR/common/Http.Connections/src/Internal/HttpConnectionDispatcher.cs
@@ -168,6 +168,14 @@ internal sealed partial class HttpConnectionDispatcher
             {
                 transport = HttpTransportType.WebSockets;
                 connection = await GetOrCreateConnectionAsync(context, options);
+
+                if (connection is not null)
+                {
+                    Log.EstablishedConnection(_logger);
+
+                    // Allow the reads to be canceled
+                    connection.Cancellation ??= new CancellationTokenSource();
+                }
             }
             else
             {

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -2842,6 +2842,35 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
         }
     }
 
+    [Fact]
+    public async Task ServerClosingClosesWebSocketConnection()
+    {
+        using (StartVerifiableLog())
+        {
+            var manager = CreateConnectionManager(LoggerFactory);
+            var connection = manager.CreateConnection();
+
+            var dispatcher = CreateDispatcher(manager, LoggerFactory);
+            var services = new ServiceCollection();
+            services.AddSingleton<TestConnectionHandler>();
+            var context = MakeRequest("/foo", connection, services);
+            SetTransport(context, HttpTransportType.WebSockets);
+
+            var builder = new ConnectionBuilder(services.BuildServiceProvider());
+            builder.UseConnectionHandler<TestConnectionHandler>();
+            var app = builder.Build();
+            var options = new HttpConnectionDispatcherOptions();
+            options.WebSockets.CloseTimeout = TimeSpan.FromSeconds(1);
+
+            _ = dispatcher.ExecuteAsync(context, options, app);
+
+            // "close" server, since we're not using a server in these tests we just simulate what would be called when the server closes
+            await connection.DisposeAsync().DefaultTimeout();
+
+            await connection.ConnectionClosed.WaitForCancellationAsync().DefaultTimeout();
+        }
+    }
+
     public class CustomHttpRequestLifetimeFeature : IHttpRequestLifetimeFeature
     {
         public CancellationToken RequestAborted { get; set; }

--- a/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
+++ b/src/SignalR/common/Http.Connections/test/HttpConnectionDispatcherTests.cs
@@ -2862,12 +2862,14 @@ public class HttpConnectionDispatcherTests : VerifiableLoggedTest
             var options = new HttpConnectionDispatcherOptions();
             options.WebSockets.CloseTimeout = TimeSpan.FromSeconds(1);
 
-            _ = dispatcher.ExecuteAsync(context, options, app);
+            var executeTask = dispatcher.ExecuteAsync(context, options, app);
 
             // "close" server, since we're not using a server in these tests we just simulate what would be called when the server closes
             await connection.DisposeAsync().DefaultTimeout();
 
             await connection.ConnectionClosed.WaitForCancellationAsync().DefaultTimeout();
+
+            await executeTask.DefaultTimeout();
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/53165

Regressed in https://github.com/dotnet/aspnetcore/commit/f56c242d037e7a11626151e78333caa26c3b5d00#diff-1a6e4221ebf9343c0f831c3bddda91e203203f07d212575ad2f413ce3b3e2b34L177
We just never had a "server close" test.