### PR TITLE
Add title to column options. Fixes #52141

### DIFF
--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Columns/ColumnBase.razor
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/Columns/ColumnBase.razor
@@ -19,7 +19,7 @@
         {
             @if (ColumnOptions is not null && (Align != Align.Right && Align != Align.End))
             {
-                <button class="col-options-button" type="button" @onclick="@(() => Grid.ShowColumnOptionsAsync(this))"></button>
+                <button class="col-options-button" type="button" title="Column options" @onclick="@(() => Grid.ShowColumnOptionsAsync(this))"></button>
             }
 
             if (Sortable.HasValue ? Sortable.Value : IsSortableByDefault())
@@ -38,7 +38,7 @@
 
             @if (ColumnOptions is not null && (Align == Align.Right || Align == Align.End))
             {
-                <button class="col-options-button" type="button" @onclick="@(() => Grid.ShowColumnOptionsAsync(this))"></button>
+                <button class="col-options-button" type="button" title="Column options" @onclick="@(() => Grid.ShowColumnOptionsAsync(this))"></button>
             }
         }
     }


### PR DESCRIPTION
# Add title to column options

In QuickGrid, adds a title attribute to the column options button. Required for accessibility.

## Description

Attaches the title "Column options" to the column options button. Fixes the "Buttons must have discernible text" accessibility requirement.

Fixes #52141

## Customer Impact

Previously the button only showed an icon, which is not helpful for screen readers. After this PR you can hover to see the tooltip, and it may be read by assistive technologies.

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

It's literally just adding an HTML attribute that has no other effect.

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A
