### PR TITLE
Update timeout in Templates.Mvc.Tests

### DIFF
--- a/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
+++ b/src/ProjectTemplates/test/Templates.Mvc.Tests/Templates.Mvc.Tests.csproj
@@ -18,7 +18,7 @@
     <TestTemplateCreationFolder>TestTemplates\</TestTemplateCreationFolder>
     <RestoreFolderName>Mvc</RestoreFolderName>
     <TestDependsOnAspNetPackages>true</TestDependsOnAspNetPackages>
-    <HelixTimeout>01:20:00</HelixTimeout>
+    <HelixTimeout>01:50:00</HelixTimeout>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These tests are timing out a lot on windows.11.arm64 helix runs.