### PR TITLE
[release/8.0] [Blazor] Dispatch inbound activity handlers in Blazor Web apps

### DIFF
--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -22,7 +22,7 @@ internal partial class CircuitHost : IAsyncDisposable
     private readonly CircuitOptions _options;
     private readonly RemoteNavigationManager _navigationManager;
     private readonly ILogger _logger;
-    private readonly Func<Func<Task>, Task> _dispatchInboundActivity;
+    private Func<Func<Task>, Task> _dispatchInboundActivity;
     private CircuitHandler[] _circuitHandlers;
     private bool _initialized;
     private bool _isFirstUpdate = true;
@@ -735,11 +735,10 @@ internal partial class CircuitHost : IAsyncDisposable
 
         return Renderer.Dispatcher.InvokeAsync(async () =>
         {
-            var webRootComponentManager = Renderer.GetOrCreateWebRootComponentManager();
             var shouldClearStore = false;
+            var shouldWaitForQuiescence = false;
             var operations = operationBatch.Operations;
             var batchId = operationBatch.BatchId;
-            Task[]? pendingTasks = null;
             try
             {
                 if (Descriptors.Count > 0)
@@ -752,6 +751,7 @@ internal partial class CircuitHost : IAsyncDisposable
                 if (_isFirstUpdate)
                 {
                     _isFirstUpdate = false;
+                    shouldWaitForQuiescence = true;
                     if (store != null)
                     {
                         shouldClearStore = true;
@@ -763,6 +763,7 @@ internal partial class CircuitHost : IAsyncDisposable
 
                     // Retrieve the circuit handlers at this point.
                     _circuitHandlers = [.. _scope.ServiceProvider.GetServices<CircuitHandler>().OrderBy(h => h.Order)];
+                    _dispatchInboundActivity = BuildInboundActivityDispatcher(_circuitHandlers, Circuit);
                     await OnCircuitOpenedAsync(cancellation);
                     await OnConnectionUpAsync(cancellation);
 
@@ -774,44 +775,9 @@ internal partial class CircuitHost : IAsyncDisposable
                             throw new InvalidOperationException($"The first set of update operations must always be of type {nameof(RootComponentOperationType.Add)}");
                         }
                     }
-
-                    pendingTasks = new Task[operations.Length];
                 }
 
-                for (var i = 0; i < operations.Length; i++)
-                {
-                    var operation = operations[i];
-                    switch (operation.Type)
-                    {
-                        case RootComponentOperationType.Add:
-                            var task = webRootComponentManager.AddRootComponentAsync(
-                                operation.SsrComponentId,
-                                operation.Descriptor.ComponentType,
-                                operation.Marker.Value.Key,
-                                operation.Descriptor.Parameters);
-                            if (pendingTasks != null)
-                            {
-                                pendingTasks[i] = task;
-                            }
-                            break;
-                        case RootComponentOperationType.Update:
-                            // We don't need to await component updates as any unhandled exception will be reported and terminate the circuit.
-                            _ = webRootComponentManager.UpdateRootComponentAsync(
-                                operation.SsrComponentId,
-                                operation.Descriptor.ComponentType,
-                                operation.Marker.Value.Key,
-                                operation.Descriptor.Parameters);
-                            break;
-                        case RootComponentOperationType.Remove:
-                            webRootComponentManager.RemoveRootComponent(operation.SsrComponentId);
-                            break;
-                    }
-                }
-
-                if (pendingTasks != null)
-                {
-                    await Task.WhenAll(pendingTasks);
-                }
+                await PerformRootComponentOperations(operations, shouldWaitForQuiescence);
 
                 await Client.SendAsync("JS.EndUpdateRootComponents", batchId);
 
@@ -835,6 +801,58 @@ internal partial class CircuitHost : IAsyncDisposable
                 }
             }
         });
+    }
+
+    private async ValueTask PerformRootComponentOperations(
+        RootComponentOperation[] operations,
+        bool shouldWaitForQuiescence)
+    {
+        var webRootComponentManager = Renderer.GetOrCreateWebRootComponentManager();
+        var pendingTasks = shouldWaitForQuiescence
+            ? new Task[operations.Length]
+            : null;
+
+        // The inbound activity pipeline needs to be awaited because it populates
+        // the pending tasks used to wait for quiescence.
+        await HandleInboundActivityAsync(() =>
+        {
+            for (var i = 0; i < operations.Length; i++)
+            {
+                var operation = operations[i];
+                switch (operation.Type)
+                {
+                    case RootComponentOperationType.Add:
+                        var task = webRootComponentManager.AddRootComponentAsync(
+                            operation.SsrComponentId,
+                            operation.Descriptor.ComponentType,
+                            operation.Marker.Value.Key,
+                            operation.Descriptor.Parameters);
+                        if (pendingTasks != null)
+                        {
+                            pendingTasks[i] = task;
+                        }
+                        break;
+                    case RootComponentOperationType.Update:
+                        // We don't need to await component updates as any unhandled exception will be reported and terminate the circuit.
+                        _ = webRootComponentManager.UpdateRootComponentAsync(
+                            operation.SsrComponentId,
+                            operation.Descriptor.ComponentType,
+                            operation.Marker.Value.Key,
+                            operation.Descriptor.Parameters);
+                        break;
+                    case RootComponentOperationType.Remove:
+                        webRootComponentManager.RemoveRootComponent(operation.SsrComponentId);
+                        break;
+                }
+            }
+
+            return Task.CompletedTask;
+        });
+
+        if (pendingTasks != null)
+        {
+            await Task.WhenAll(pendingTasks);
+        }
     }
 
     private static partial class Log

--- a/src/Components/test/E2ETest/ServerRenderingTests/InteractivityTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/InteractivityTest.cs
@@ -1159,6 +1159,14 @@ public class InteractivityTest : ServerTestBase<BasicTestAppServerSiteFixture<Ra
         Browser.Equal("GET", () => Browser.Exists(By.Id("method")).Text);
     }
 
+    [Fact]
+    public void InteractiveServerRootComponent_CanAccessCircuitContext()
+    {
+        Navigate($"{ServerPathBase}/interactivity/circuit-context");
+
+        Browser.Equal("True", () => Browser.FindElement(By.Id("has-circuit-context")).Text);
+    }
+
     private void BlockWebAssemblyResourceLoad()
     {
         ((IJavaScriptExecutor)Browser).ExecuteScript("sessionStorage.setItem('block-load-boot-resource', 'true')");

--- a/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
@@ -8,6 +8,7 @@ using System.Web;
 using Components.TestServer.RazorComponents;
 using Components.TestServer.RazorComponents.Pages.Forms;
 using Components.TestServer.Services;
+using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.Mvc;
 
 namespace TestServer;
@@ -35,6 +36,10 @@ public class RazorComponentEndpointsStartup<TRootComponent>
         services.AddHttpContextAccessor();
         services.AddSingleton<AsyncOperationService>();
         services.AddCascadingAuthenticationState();
+
+        var circuitContextAccessor = new TestCircuitContextAccessor();
+        services.AddSingleton<CircuitHandler>(circuitContextAccessor);
+        services.AddSingleton(circuitContextAccessor);
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Interactivity/CircuitContextPage.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Interactivity/CircuitContextPage.razor
@@ -1,0 +1,25 @@
+﻿@page "/interactivity/circuit-context"
+@rendermode RenderMode.InteractiveServer
+@inject TestCircuitContextAccessor CircuitContextAccessor
+
+<h1>Circuit context</h1>
+
+<p>
+    Has circuit context: <span id="has-circuit-context">@_hasCircuitContext</span>
+</p>
+
+@code {
+    private bool _hasCircuitContext;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await Task.Yield();
+
+            _hasCircuitContext = CircuitContextAccessor.HasCircuitContext;
+
+            StateHasChanged();
+        }
+    }
+}


### PR DESCRIPTION
# Dispatch inbound activity handlers in Blazor Web apps

Fixes an issue where inbound activity handlers were not getting invoked in Blazor Web apps.

## Description

Inbound activity handlers were a new feature introduced in .NET 8 to allow Blazor Server apps to monitor circuit activity and make services available to Blazor components that wouldn't otherwise be accessible. However, we also introduced a new "Blazor Web" app model that didn't incorporate this new feature correctly.

This PR fixes the issue by:
* Building the inbound activity pipeline in Blazor Web apps just after circuit handlers are retrieved
* Invoking inbound activity handlers in web root component updates

Fixes #51934

## Customer Impact

Multiple customers have indicated being affected by this issue. Since this is a new feature in .NET 8, customers expect it to work in Blazor Web apps, which we recommend for new projects. Without this fix, the functionality only works in traditional Blazor Server apps.

## Regression?

- [ ] Yes
- [X] No

This is a new feature in .NET 8.

## Risk

- [ ] High
- [ ] Medium
- [X] Low

The fix is simple and applies to a well-tested area of the framework, so our E2E tests are likely to catch issues with this change.

## Verification

- [X] Manual (required)
- [X] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [X] N/A