### PR TITLE
Change static readonly properties to const

### DIFF
--- a/src/Identity/Core/src/IdentityConstants.cs
+++ b/src/Identity/Core/src/IdentityConstants.cs
@@ -13,30 +13,30 @@ public class IdentityConstants
     /// <summary>
     /// The scheme used to identify application authentication cookies.
     /// </summary>
-    public static readonly string ApplicationScheme = IdentityPrefix + ".Application";
+    public const string ApplicationScheme = IdentityPrefix + ".Application";
 
     /// <summary>
     /// The scheme used to identify bearer authentication tokens.
     /// </summary>
-    public static readonly string BearerScheme = IdentityPrefix + ".Bearer";
+    public const string BearerScheme = IdentityPrefix + ".Bearer";
 
     /// <summary>
     /// The scheme used to identify combination of <see cref="BearerScheme"/> and <see cref="ApplicationScheme"/>.
     /// </summary>
-    internal const string BearerAndApplicationScheme = IdentityPrefix + ".BearerAndApplication";
+    public const string BearerAndApplicationScheme = IdentityPrefix + ".BearerAndApplication";
 
     /// <summary>
     /// The scheme used to identify external authentication cookies.
     /// </summary>
-    public static readonly string ExternalScheme = IdentityPrefix + ".External";
+    public const string ExternalScheme = IdentityPrefix + ".External";
 
     /// <summary>
     /// The scheme used to identify Two Factor authentication cookies for saving the Remember Me state.
     /// </summary>
-    public static readonly string TwoFactorRememberMeScheme = IdentityPrefix + ".TwoFactorRememberMe";
+    public const string TwoFactorRememberMeScheme = IdentityPrefix + ".TwoFactorRememberMe";
 
     /// <summary>
     /// The scheme used to identify Two Factor authentication cookies for round tripping user identities.
     /// </summary>
-    public static readonly string TwoFactorUserIdScheme = IdentityPrefix + ".TwoFactorUserId";
+    public const string TwoFactorUserIdScheme = IdentityPrefix + ".TwoFactorUserId";
 }

--- a/src/Identity/Core/src/PublicAPI.Shipped.txt
+++ b/src/Identity/Core/src/PublicAPI.Shipped.txt
@@ -187,11 +187,6 @@ static Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensi
 static Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.AddIdentityApiEndpoints<TUser>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Microsoft.AspNetCore.Identity.IdentityOptions!>! configure) -> Microsoft.AspNetCore.Identity.IdentityBuilder!
 static Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.ConfigureApplicationCookie(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.ConfigureExternalCookie(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static readonly Microsoft.AspNetCore.Identity.IdentityConstants.ApplicationScheme -> string!
-static readonly Microsoft.AspNetCore.Identity.IdentityConstants.BearerScheme -> string!
-static readonly Microsoft.AspNetCore.Identity.IdentityConstants.ExternalScheme -> string!
-static readonly Microsoft.AspNetCore.Identity.IdentityConstants.TwoFactorRememberMeScheme -> string!
-static readonly Microsoft.AspNetCore.Identity.IdentityConstants.TwoFactorUserIdScheme -> string!
 virtual Microsoft.AspNetCore.Identity.DataProtectorTokenProvider<TUser>.CanGenerateTwoFactorTokenAsync(Microsoft.AspNetCore.Identity.UserManager<TUser!>! manager, TUser! user) -> System.Threading.Tasks.Task<bool>!
 virtual Microsoft.AspNetCore.Identity.DataProtectorTokenProvider<TUser>.GenerateAsync(string! purpose, Microsoft.AspNetCore.Identity.UserManager<TUser!>! manager, TUser! user) -> System.Threading.Tasks.Task<string!>!
 virtual Microsoft.AspNetCore.Identity.DataProtectorTokenProvider<TUser>.ValidateAsync(string! purpose, string! token, Microsoft.AspNetCore.Identity.UserManager<TUser!>! manager, TUser! user) -> System.Threading.Tasks.Task<bool>!

--- a/src/Identity/Core/src/PublicAPI.Unshipped.txt
+++ b/src/Identity/Core/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+const Microsoft.AspNetCore.Identity.IdentityConstants.ApplicationScheme = "Identity.Application" -> string!
+const Microsoft.AspNetCore.Identity.IdentityConstants.BearerAndApplicationScheme = "Identity.BearerAndApplication" -> string!
+const Microsoft.AspNetCore.Identity.IdentityConstants.BearerScheme = "Identity.Bearer" -> string!
+const Microsoft.AspNetCore.Identity.IdentityConstants.ExternalScheme = "Identity.External" -> string!
+const Microsoft.AspNetCore.Identity.IdentityConstants.TwoFactorRememberMeScheme = "Identity.TwoFactorRememberMe" -> string!
+const Microsoft.AspNetCore.Identity.IdentityConstants.TwoFactorUserIdScheme = "Identity.TwoFactorUserId" -> string!


### PR DESCRIPTION
# Change static readonly properties to const

## Description

This change will allow the use of these properties in places such as an Authorize attribute.
Where as at the moment it causes a compiler error.
