### PR TITLE
[Blazor] Avoid fetching new page content when only the hash changes

### DIFF
--- a/src/Components/Web.JS/src/Services/NavigationEnhancement.ts
+++ b/src/Components/Web.JS/src/Services/NavigationEnhancement.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { synchronizeDomContent } from '../Rendering/DomMerging/DomSync';
-import { attachProgrammaticEnhancedNavigationHandler, handleClickForNavigationInterception, hasInteractiveRouter, notifyEnhancedNavigationListners } from './NavigationUtils';
+import { attachProgrammaticEnhancedNavigationHandler, handleClickForNavigationInterception, hasInteractiveRouter, isSamePageWithHash, notifyEnhancedNavigationListners, performScrollToElementOnTheSamePage } from './NavigationUtils';
 
 /*
 In effect, we have two separate client-side navigation mechanisms:
@@ -89,8 +89,14 @@ function onDocumentClick(event: MouseEvent) {
   }
 
   handleClickForNavigationInterception(event, absoluteInternalHref => {
+    const shouldScrollToHash = isSamePageWithHash(absoluteInternalHref);
     history.pushState(null, /* ignored title */ '', absoluteInternalHref);
-    performEnhancedPageLoad(absoluteInternalHref, /* interceptedLink */ true);
+
+    if (shouldScrollToHash) {
+      performScrollToElementOnTheSamePage(absoluteInternalHref);
+    } else {
+      performEnhancedPageLoad(absoluteInternalHref, /* interceptedLink */ true);
+    }
   });
 }
 
@@ -132,10 +138,10 @@ function onDocumentSubmit(event: SubmitEvent) {
 
     event.preventDefault();
 
-    const url = new URL(event.submitter?.getAttribute('formaction') || formElem.action, document.baseURI); 
-    const fetchOptions: RequestInit = { method: method}; 
+    const url = new URL(event.submitter?.getAttribute('formaction') || formElem.action, document.baseURI);
+    const fetchOptions: RequestInit = { method: method};
     const formData = new FormData(formElem);
-   
+
     const submitterName = event.submitter?.getAttribute('name');
     const submitterValue = event.submitter!.getAttribute('value');
     if (submitterName && submitterValue) {
@@ -153,8 +159,8 @@ function onDocumentSubmit(event: SubmitEvent) {
     } else {
       // Setting request body and content-type header depending on enctype
       const enctype = event.submitter?.getAttribute('formenctype') || formElem.enctype;
-      if (enctype === 'multipart/form-data') { 
-        // Content-Type header will be set to 'multipart/form-data' 
+      if (enctype === 'multipart/form-data') {
+        // Content-Type header will be set to 'multipart/form-data'
         fetchOptions.body = formData;
       } else {
         fetchOptions.body = urlSearchParams;

--- a/src/Components/Web.JS/src/Services/NavigationUtils.ts
+++ b/src/Components/Web.JS/src/Services/NavigationUtils.ts
@@ -49,7 +49,7 @@ export function isWithinBaseUriSpace(href: string) {
 
 export function isSamePageWithHash(absoluteHref: string): boolean {
   const url = new URL(absoluteHref);
-  return location.origin === url.origin && location.pathname === url.pathname && location.search === url.search;
+  return url.hash !== '' && location.origin === url.origin && location.pathname === url.pathname && location.search === url.search;
 }
 
 export function performScrollToElementOnTheSamePage(absoluteHref : string): void {

--- a/src/Components/Web.JS/src/Services/NavigationUtils.ts
+++ b/src/Components/Web.JS/src/Services/NavigationUtils.ts
@@ -47,6 +47,32 @@ export function isWithinBaseUriSpace(href: string) {
   && (nextChar === '' || nextChar === '/' || nextChar === '?' || nextChar === '#');
 }
 
+export function isSamePageWithHash(absoluteHref: string): boolean {
+  const hashIndex = absoluteHref.indexOf('#');
+  return hashIndex > -1 && location.href.replace(location.hash, '') === absoluteHref.substring(0, hashIndex);
+}
+
+export function performScrollToElementOnTheSamePage(absoluteHref : string): void {
+  const hashIndex = absoluteHref.indexOf('#');
+  if (hashIndex === absoluteHref.length - 1) {
+    return;
+  }
+
+  const identifier = absoluteHref.substring(hashIndex + 1);
+  scrollToElement(identifier);
+}
+
+export function scrollToElement(identifier: string): boolean {
+  const element = document.getElementById(identifier);
+
+  if (element) {
+    element.scrollIntoView();
+    return true;
+  }
+
+  return false;
+}
+
 export function attachEnhancedNavigationListener(listener: typeof enhancedNavigationListener) {
   enhancedNavigationListener = listener;
 }
@@ -103,8 +129,8 @@ function findAnchorTarget(event: MouseEvent): HTMLAnchorElement | SVGAElement | 
       if (candidate instanceof HTMLAnchorElement || candidate instanceof SVGAElement) {
         return candidate;
       }
-    } 
-  } 
+    }
+  }
   return null;
 }
 

--- a/src/Components/Web.JS/src/Services/NavigationUtils.ts
+++ b/src/Components/Web.JS/src/Services/NavigationUtils.ts
@@ -62,15 +62,8 @@ export function performScrollToElementOnTheSamePage(absoluteHref : string): void
   scrollToElement(identifier);
 }
 
-export function scrollToElement(identifier: string): boolean {
-  const element = document.getElementById(identifier);
-
-  if (element) {
-    element.scrollIntoView();
-    return true;
-  }
-
-  return false;
+export function scrollToElement(identifier: string): void {
+  document.getElementById(identifier)?.scrollIntoView();
 }
 
 export function attachEnhancedNavigationListener(listener: typeof enhancedNavigationListener) {

--- a/src/Components/Web.JS/src/Services/NavigationUtils.ts
+++ b/src/Components/Web.JS/src/Services/NavigationUtils.ts
@@ -48,8 +48,8 @@ export function isWithinBaseUriSpace(href: string) {
 }
 
 export function isSamePageWithHash(absoluteHref: string): boolean {
-  const hashIndex = absoluteHref.indexOf('#');
-  return hashIndex > -1 && location.href.replace(location.hash, '') === absoluteHref.substring(0, hashIndex);
+  const url = new URL(absoluteHref);
+  return location.origin === url.origin && location.pathname === url.pathname && location.search === url.search;
 }
 
 export function performScrollToElementOnTheSamePage(absoluteHref : string): void {

--- a/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/EnhancedNavigationTest.cs
@@ -597,6 +597,20 @@ public class EnhancedNavigationTest : ServerTestBase<BasicTestAppServerSiteFixtu
         Browser.Equal("0", () => Browser.Exists(By.Id($"location-changing-count-{anotherRuntime}")).Text);
     }
 
+    [Fact]
+    public void CanScrollToHashWithoutPerformingFullNavigation()
+    {
+        Navigate($"{ServerPathBase}/nav/scroll-to-hash");
+        Browser.Equal("Scroll to hash", () => Browser.Exists(By.TagName("h1")).Text);
+
+        Browser.Exists(By.Id("scroll-anchor")).Click();
+        Browser.True(() => Browser.GetScrollY() > 500);
+        Browser.True(() => Browser
+            .Exists(By.Id("uri-on-page-load"))
+            .GetAttribute("data-value")
+            .EndsWith("scroll-to-hash", StringComparison.Ordinal));
+    }
+
     private void AssertEnhancedUpdateCountEquals(long count)
         => Browser.Equal(count, () => ((IJavaScriptExecutor)Browser).ExecuteScript("return window.enhancedPageUpdateCount;"));
 

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/EnhancedNav/PageForScrollingToHash.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/EnhancedNav/PageForScrollingToHash.razor
@@ -1,11 +1,17 @@
 ﻿@page "/nav/scroll-to-hash"
 @attribute [StreamRendering]
+@inject NavigationManager NavigationManager
 
 <PageTitle>Page for scrolling to hash</PageTitle>
 
 <h1>Scroll to hash</h1>
 
 <p>If you scroll down a long way, you'll find more content. We add it asynchronously via streaming rendering.</p>
+
+<p>
+    <a id="scroll-anchor" href="nav/scroll-to-hash#some-content">Scroll via anchor</a>
+    <div id="uri-on-page-load" style="display: none" data-value="@uriOnPageLoad"></div>
+</p>
 
 <div style="height: 2000px; border: 2px dashed red;">spacer</div>
 
@@ -18,9 +24,11 @@
 
 @code {
     bool showContent;
+    string uriOnPageLoad;
 
     protected override async Task OnInitializedAsync()
     {
+        uriOnPageLoad = NavigationManager.Uri;
         await Task.Delay(1000);
         showContent = true;
     }


### PR DESCRIPTION
## Avoid fetching new page content when only the hash changes

Fixes an issue where a page request is made after clicking a link that only updates the hash part of the URL.

The PR fixes the bug by updating the behavior to match what browsers do by default - if the hash is the only part of the URL that changes, scroll to the element with the ID of the new hash.

This was already implemented correctly for interactive routing, so this PR updates enhanced navigation to share the same logic.

Fixes #52583
