### PR TITLE
Better implementation of EventCallback.Equals

### DIFF
--- a/src/Components/Components/src/EventCallback.cs
+++ b/src/Components/Components/src/EventCallback.cs
@@ -80,5 +80,5 @@ public readonly struct EventCallback : IEventCallback
     public override bool Equals(object? obj)
         => obj is EventCallback other
         && ReferenceEquals(Receiver, other.Receiver)
-        && ReferenceEquals(Delegate, other.Delegate);
+        && (Delegate?.Equals(other.Delegate) ?? (other.Delegate == null));
 }

--- a/src/Components/Components/src/EventCallbackOfT.cs
+++ b/src/Components/Components/src/EventCallbackOfT.cs
@@ -80,5 +80,5 @@ public readonly struct EventCallback<TValue> : IEventCallback
     public override bool Equals(object? obj)
         => obj is EventCallback<TValue> other
         && ReferenceEquals(Receiver, other.Receiver)
-        && ReferenceEquals(Delegate, other.Delegate);
+        && (Delegate?.Equals(other.Delegate) ?? (other.Delegate == null));
 }

--- a/src/Components/Components/test/EventCallbackTest.cs
+++ b/src/Components/Components/test/EventCallbackTest.cs
@@ -272,6 +272,24 @@ public class EventCallbackTest
     }
 
     [Fact]
+    public void EventCallbackOf_Equals_WhenANewDelegateIsCreated()
+    {
+        // Arrange
+        var component = new EventCountingComponent();
+
+        var delegate_1 = (EventArgs _) => { };
+        var delegate_2 = (MulticastDelegate)MulticastDelegate.CreateDelegate(typeof(Action<EventArgs>), delegate_1.Target, delegate_1.Method);
+        var eventcallback_1 = new EventCallback(component, delegate_1);
+        var eventcallback_2 = new EventCallback(component, delegate_2);
+
+        // Act
+        var result = eventcallback_1.Equals(eventcallback_2);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
     public async Task EventCallbackOfT_Action_Null()
     {
         // Arrange
@@ -413,6 +431,24 @@ public class EventCallbackTest
         Assert.NotNull(arg);
         Assert.Equal(1, runCount);
         Assert.Equal(1, component.Count);
+    }
+
+    [Fact]
+    public void EventCallbackOfT_Equals_WhenANewDelegateIsCreated()
+    {
+        // Arrange
+        var component = new EventCountingComponent();
+
+        var delegate_1 = (EventArgs _) => { };
+        var delegate_2 = (MulticastDelegate)MulticastDelegate.CreateDelegate(typeof(Action<EventArgs>), delegate_1.Target, delegate_1.Method);
+        var eventcallback_1 = new EventCallback<EventArgs>(component, delegate_1);
+        var eventcallback_2 = new EventCallback<EventArgs>(component, delegate_2);
+
+        // Act
+        var result = eventcallback_1.Equals(eventcallback_2);
+
+        // Assert
+        Assert.True(result);
     }
 
     private class EventCountingComponent : IComponent, IHandleEvent


### PR DESCRIPTION
We noticed after upgrading our blazor application to .net 8.0 that some EventCallback keep being modified. Eventhough the value was the same, the same target component, the same method.

The generated code that renders the component seems to fabricate a new MulticastDelegate, having the same Type, Target and Method. The implementation of EventCallback uses Object.ReferenceEquals, so it concludes it is different every render.

Fixes https://github.com/dotnet/aspnetcore/issues/53361

# NOTE
I recreated this because I have some difficulties changing the pr to go to main (#53362)