### PR TITLE
Add automatic SDK updates

### DIFF
--- a/.github/workflows/update-sdk.yml
+++ b/.github/workflows/update-sdk.yml
@@ -1,0 +1,21 @@
+name: update-dotnet-sdk
+
+on:
+
+  # Scheduled trigger to check for .NET SDK updates at 12 UTC every Monday
+  schedule:
+    - cron:  '00 12 * * MON'
+
+  # Manual trigger to update the .NET SDK on-demand.
+  workflow_dispatch:
+
+jobs:
+  update-dotnet-sdk:
+    name: Update .NET SDK
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: martincostello/update-dotnet-sdk@v3.1.0
+      with:
+        quality: 'daily'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-sdk.yml
+++ b/.github/workflows/update-sdk.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: martincostello/update-dotnet-sdk@v3.1.0
+    - uses: martincostello/update-dotnet-sdk@8765302da88e1a78c845125626f3726190908593
       with:
         quality: 'daily'
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a workflow to automatically update the SDK on Monday. Will update the build-ops docs once this is in.

CC @blowdart we're pinning to the `v3.1.0` tag per your request