### PR TITLE
Fix stale values from [SupplyParameterFromQuery]

### DIFF
--- a/src/Components/Components/src/Routing/QueryParameterValueSupplier.cs
+++ b/src/Components/Components/src/Routing/QueryParameterValueSupplier.cs
@@ -51,10 +51,4 @@ internal sealed class QueryParameterValueSupplier
 
         return default;
     }
-
-    public static bool CanSupplyValueForType(Type targetType)
-    {
-        var elementType = targetType.IsArray ? targetType.GetElementType()! : targetType;
-        return UrlValueConstraint.TryGetByTargetType(elementType, out _);
-    }
 }

--- a/src/Components/Components/src/Routing/SupplyParameterFromQueryValueProvider.cs
+++ b/src/Components/Components/src/Routing/SupplyParameterFromQueryValueProvider.cs
@@ -1,0 +1,134 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Microsoft.AspNetCore.Components.Routing;
+
+internal sealed class SupplyParameterFromQueryValueProvider(NavigationManager navigationManager) : ICascadingValueSupplier, IDisposable
+{
+    private QueryParameterValueSupplier? _queryParameterValueSupplier;
+    private HashSet<ComponentState>? _subscribers;
+    private HashSet<ComponentState>? _pendingSubscribers;
+    private bool _isSubscribedToLocationChanges;
+    private string? _lastUri;
+
+    public bool IsFixed => false;
+
+    public bool CanSupplyValue(in CascadingParameterInfo parameterInfo)
+        => parameterInfo.Attribute is SupplyParameterFromQueryAttribute;
+
+    public object? GetCurrentValue(in CascadingParameterInfo parameterInfo)
+    {
+        TryUpdateQueryParameters();
+
+        var attribute = (SupplyParameterFromQueryAttribute)parameterInfo.Attribute; // Must be a valid cast because we check in CanSupplyValue
+        var queryParameterName = attribute.Name ?? parameterInfo.PropertyName;
+        return _queryParameterValueSupplier.GetQueryParameterValue(parameterInfo.PropertyType, queryParameterName);
+    }
+
+    public void Subscribe(ComponentState subscriber, in CascadingParameterInfo parameterInfo)
+    {
+        if (_pendingSubscribers?.Count > 0 || (TryUpdateQueryParameters() && _isSubscribedToLocationChanges))
+        {
+            // This branch is only taken if there's a pending OnLocationChanged event for the current Uri that we're already subscribed to.
+            // We'll add the _pendingSubscribers to _subscribers and clear _pendingSubscribers during the upcoming call to OnLocationChanged.
+            _pendingSubscribers ??= new();
+            _pendingSubscribers.Add(subscriber);
+            return;
+        }
+
+        _subscribers ??= new();
+        _subscribers.Add(subscriber);
+        SubscribeToLocationChanges();
+    }
+
+    public void Unsubscribe(ComponentState subscriber, in CascadingParameterInfo parameterInfo)
+    {
+        // ICascadingValueSupplier is internal, and Subscribe should always precede Unsubscribe.
+        Debug.Assert(_subscribers is not null);
+        _subscribers.Remove(subscriber);
+        _pendingSubscribers?.Remove(subscriber);
+
+        if (_subscribers.Count == 0 && !(_pendingSubscribers?.Count > 0))
+        {
+            UnsubscribeFromLocationChanges();
+        }
+    }
+
+    [MemberNotNull(nameof(_queryParameterValueSupplier))]
+    private bool TryUpdateQueryParameters()
+    {
+        _queryParameterValueSupplier ??= new();
+
+        // Router.OnLocationChanged calls GetCurrentValue before our own OnLocationChanged handler,
+        // so we have to compare strings rather than rely on a bool set in OnLocationChanged.
+        if (navigationManager.Uri == _lastUri)
+        {
+            return false;
+        }
+
+        var query = GetQueryString(navigationManager.Uri);
+        _queryParameterValueSupplier.ReadParametersFromQuery(query);
+        _lastUri = navigationManager.Uri;
+        return true;
+
+        static ReadOnlyMemory<char> GetQueryString(string url)
+        {
+            var queryStartPos = url.IndexOf('?');
+
+            if (queryStartPos < 0)
+            {
+                return default;
+            }
+
+            var queryEndPos = url.IndexOf('#', queryStartPos);
+            return url.AsMemory(queryStartPos..(queryEndPos < 0 ? url.Length : queryEndPos));
+        }
+    }
+
+    private void SubscribeToLocationChanges()
+    {
+        if (_isSubscribedToLocationChanges)
+        {
+            return;
+        }
+
+        _isSubscribedToLocationChanges = true;
+        navigationManager.LocationChanged += OnLocationChanged;
+    }
+
+    private void UnsubscribeFromLocationChanges()
+    {
+        if (!_isSubscribedToLocationChanges)
+        {
+            return;
+        }
+
+        _isSubscribedToLocationChanges = false;
+        navigationManager.LocationChanged -= OnLocationChanged;
+    }
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs args)
+    {
+        Debug.Assert(_subscribers is not null);
+        foreach (var subscriber in _subscribers)
+        {
+            subscriber.NotifyCascadingValueChanged(ParameterViewLifetime.Unbound);
+        }
+
+        if (_pendingSubscribers is not null)
+        {
+            foreach (var subscriber in _pendingSubscribers)
+            {
+                _subscribers.Add(subscriber);
+            }
+
+            _pendingSubscribers.Clear();
+        }
+    }
+
+    public void Dispose() => UnsubscribeFromLocationChanges();
+}

--- a/src/Components/Components/src/Routing/SupplyParameterFromQueryValueProvider.cs
+++ b/src/Components/Components/src/Routing/SupplyParameterFromQueryValueProvider.cs
@@ -33,8 +33,8 @@ internal sealed class SupplyParameterFromQueryValueProvider(NavigationManager na
     {
         if (_pendingSubscribers?.Count > 0 || (TryUpdateUri() && _isSubscribedToLocationChanges))
         {
-            // This branch is only taken if there's a pending OnLocationChanged event for the current Uri that we're already subscribed to.
-            // We'll add the _pendingSubscribers to _subscribers and clear _pendingSubscribers during the upcoming call to OnLocationChanged.
+            // Renderer.RenderInExistingBatch triggers Unsubscribe via ProcessDisposalQueueInExistingBatch after subscribing with any new components,
+            // so this branch should be taken iff there's a pending OnLocationChanged event for the current Uri that we're already subscribed to.
             _pendingSubscribers ??= new();
             _pendingSubscribers.Add(subscriber);
             return;
@@ -63,8 +63,8 @@ internal sealed class SupplyParameterFromQueryValueProvider(NavigationManager na
     {
         _queryParameterValueSupplier ??= new();
 
-        // Router.OnLocationChanged calls GetCurrentValue before our own OnLocationChanged handler,
-        // so we have to compare strings rather than rely on a bool set in OnLocationChanged.
+        // NavigationManager triggers Router.OnLocationChanged which calls GetCurrentValue before this class's OnLocationHandler
+        // gets a chance to run, so we have to compare strings rather than rely on OnLocationChanged always running before Uri updates.
         if (navigationManager.Uri == _lastUri)
         {
             return false;

--- a/src/Components/Components/src/Routing/SupplyParameterFromQueryValueProvider.cs
+++ b/src/Components/Components/src/Routing/SupplyParameterFromQueryValueProvider.cs
@@ -52,7 +52,7 @@ internal sealed class SupplyParameterFromQueryValueProvider(NavigationManager na
         _subscribers.Remove(subscriber);
         _pendingSubscribers?.Remove(subscriber);
 
-        if (_subscribers.Count == 0 && !(_pendingSubscribers?.Count > 0))
+        if (_subscribers.Count == 0 && _pendingSubscribers is null or { Count: 0 })
         {
             UnsubscribeFromLocationChanges();
         }

--- a/src/Components/Components/src/SupplyParameterFromQueryProviderServiceCollectionExtensions.cs
+++ b/src/Components/Components/src/SupplyParameterFromQueryProviderServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -20,118 +19,7 @@ public static class SupplyParameterFromQueryProviderServiceCollectionExtensions
     /// <returns>The <see cref="IServiceCollection"/>.</returns>
     public static IServiceCollection AddSupplyValueFromQueryProvider(this IServiceCollection services)
     {
-        services.TryAddEnumerable(ServiceDescriptor.Scoped<ICascadingValueSupplier, SupplyValueFromQueryValueProvider>());
+        services.TryAddEnumerable(ServiceDescriptor.Scoped<ICascadingValueSupplier, SupplyParameterFromQueryValueProvider>());
         return services;
-    }
-
-    internal sealed class SupplyValueFromQueryValueProvider : ICascadingValueSupplier, IDisposable
-    {
-        private readonly QueryParameterValueSupplier _queryParameterValueSupplier = new();
-        private readonly NavigationManager _navigationManager;
-        private HashSet<ComponentState>? _subscribers;
-        private bool _isSubscribedToLocationChanges;
-        private bool _queryParametersMightHaveChanged = true;
-
-        public SupplyValueFromQueryValueProvider(NavigationManager navigationManager)
-        {
-            _navigationManager = navigationManager;
-        }
-
-        public bool IsFixed => false;
-
-        public bool CanSupplyValue(in CascadingParameterInfo parameterInfo)
-            => parameterInfo.Attribute is SupplyParameterFromQueryAttribute;
-
-        public object? GetCurrentValue(in CascadingParameterInfo parameterInfo)
-        {
-            if (_queryParametersMightHaveChanged)
-            {
-                _queryParametersMightHaveChanged = false;
-                UpdateQueryParameters();
-            }
-
-            var attribute = (SupplyParameterFromQueryAttribute)parameterInfo.Attribute; // Must be a valid cast because we check in CanSupplyValue
-            var queryParameterName = attribute.Name ?? parameterInfo.PropertyName;
-            return _queryParameterValueSupplier.GetQueryParameterValue(parameterInfo.PropertyType, queryParameterName);
-        }
-
-        public void Subscribe(ComponentState subscriber, in CascadingParameterInfo parameterInfo)
-        {
-            SubscribeToLocationChanges();
-
-            _subscribers ??= new();
-            _subscribers.Add(subscriber);
-        }
-
-        public void Unsubscribe(ComponentState subscriber, in CascadingParameterInfo parameterInfo)
-        {
-            _subscribers!.Remove(subscriber);
-
-            if (_subscribers.Count == 0)
-            {
-                UnsubscribeFromLocationChanges();
-            }
-        }
-
-        private void UpdateQueryParameters()
-        {
-            var query = GetQueryString(_navigationManager.Uri);
-
-            _queryParameterValueSupplier.ReadParametersFromQuery(query);
-
-            static ReadOnlyMemory<char> GetQueryString(string url)
-            {
-                var queryStartPos = url.IndexOf('?');
-
-                if (queryStartPos < 0)
-                {
-                    return default;
-                }
-
-                var queryEndPos = url.IndexOf('#', queryStartPos);
-                return url.AsMemory(queryStartPos..(queryEndPos < 0 ? url.Length : queryEndPos));
-            }
-        }
-
-        private void SubscribeToLocationChanges()
-        {
-            if (_isSubscribedToLocationChanges)
-            {
-                return;
-            }
-
-            _isSubscribedToLocationChanges = true;
-            _queryParametersMightHaveChanged = true;
-            _navigationManager.LocationChanged += OnLocationChanged;
-        }
-
-        private void UnsubscribeFromLocationChanges()
-        {
-            if (!_isSubscribedToLocationChanges)
-            {
-                return;
-            }
-
-            _isSubscribedToLocationChanges = false;
-            _navigationManager.LocationChanged -= OnLocationChanged;
-        }
-
-        private void OnLocationChanged(object? sender, LocationChangedEventArgs args)
-        {
-            _queryParametersMightHaveChanged = true;
-
-            if (_subscribers is not null)
-            {
-                foreach (var subscriber in _subscribers)
-                {
-                    subscriber.NotifyCascadingValueChanged(ParameterViewLifetime.Unbound);
-                }
-            }
-        }
-
-        public void Dispose()
-        {
-            UnsubscribeFromLocationChanges();
-        }
     }
 }

--- a/src/Components/Endpoints/test/RazorComponentsServiceCollectionExtensionsTest.cs
+++ b/src/Components/Endpoints/test/RazorComponentsServiceCollectionExtensionsTest.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms.Mapping;
+using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.FileProviders;
@@ -90,7 +91,7 @@ public class RazorComponentsServiceCollectionExtensionsTest
                 [typeof(ICascadingValueSupplier)] = new[]
                 {
                     typeof(SupplyParameterFromFormValueProvider),
-                    typeof(SupplyParameterFromQueryProviderServiceCollectionExtensions.SupplyValueFromQueryValueProvider),
+                    typeof(SupplyParameterFromQueryValueProvider),
                 }
             };
         }

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/WithQueryGuidParameter.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/WithQueryGuidParameter.razor
@@ -1,0 +1,32 @@
+﻿@page "/WithQueryGuidParameter"
+
+<p>GuidValue: <strong id="value-QueryGuid">@GuidValue</strong></p>
+<p>StringValue: <strong id="value-StringValue">@StringValue</strong></p>
+
+<p>OnParametersSet count: <strong id="param-set-count">@onParametersSetCount</strong></p>
+
+<p>
+    Links:
+    <a href="WithQueryGuidParameter?l=8b7ae9ee-de22-4dd0-8fa1-b31e66abcc79">With GuidValue</a> |
+    <a href="WithQueryParameters/Abc?l=50&l=100&l=-20">Another page with LongValues</a> |
+    <a href="WithQueryParameters/Abc?stringvalue=B">Another page with StringValue</a> |
+</p>
+
+@code
+{
+    private int onParametersSetCount;
+
+    // Use "l" as the query parameter name to test that it doesn't cause problems with
+    // WithQueryParameters.LongValues which is also called "l".
+    // https://github.com/dotnet/aspnetcore/issues/52483
+    [SupplyParameterFromQuery(Name = "l")] public Guid GuidValue { get ; set; }
+
+    [SupplyParameterFromQuery] public string StringValue { get ; set; }
+
+    protected override void OnParametersSet()
+    {
+        onParametersSetCount++;
+        Console.WriteLine($"Count: {onParametersSetCount}");
+        StateHasChanged();
+    }
+}

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/WithQueryGuidParameter.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/WithQueryGuidParameter.razor
@@ -26,7 +26,5 @@
     protected override void OnParametersSet()
     {
         onParametersSetCount++;
-        Console.WriteLine($"Count: {onParametersSetCount}");
-        StateHasChanged();
     }
 }

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/WithQueryParameters.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/WithQueryParameters.razor
@@ -15,6 +15,8 @@
     Links:
     <a href="WithQueryParameters/@FirstName?intvalue=123">With IntValue</a> |
     <a href="WithQueryParameters/@FirstName?l=50&l=100&l=-20&intvalue=123">With IntValue and LongValues</a> |
+    <a href="WithQueryGuidParameter?l=8b7ae9ee-de22-4dd0-8fa1-b31e66abcc79">Another page with GuidValue</a> |
+    <a href="WithQueryGuidParameter?stringvalue=A">Another page with StringValue</a> |
 </p>
 
 @code


### PR DESCRIPTION
`Router.OnLocationChanged` calls `SupplyParameterFromQueryValueProvider.GetCurrentValue` before the `SupplyParameterFromQueryValueProvider.OnLocationChanged` handler which updated the query string values from `QueryParameterValueSupplier`, so we have to compare strings rather than rely on a bool set in `OnLocationChanged`.

~TODO: Add unit test for `SupplyParameterFromQueryValueProvider` in addition to the E2E RoutingTest.cs.~

I think the E2E test is sufficient. I wanted a unit test that directly called into `SupplyParameterFromQueryValueProvider` witha mock `ComponentState`, but `ComponentState` is not very mockable. I could create an internal `ISubscriber` and have `ComponentState` implement it, but I'm trying to reduce the churn since this is going to be backported.

Fixes #52483
