### PR TITLE
Remove suffixes from docker containers

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -528,7 +528,7 @@ stages:
         jobName: Linux_musl_x64_build
         jobDisplayName: "Build: Linux Musl x64"
         agentOs: Linux
-        container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode-20240105204957-5245c86
+        container: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
         buildArgs:
           --arch x64
           --os-name linux-musl
@@ -721,7 +721,7 @@ stages:
       parameters:
         platform:
           name: 'Managed'
-          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8-20240104210103-4893224'
+          container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8'
           buildScript: './eng/build.sh $(_PublishArgs) --no-build-repo-tasks $(_InternalRuntimeDownloadArgs)'
           skipPublishValidation: true
           jobProperties:


### PR DESCRIPTION
Allows us to get the latest updates to these images instead of pinning to a specific version