### PR TITLE
Update update-dotnet-sdk SHA

### DIFF
--- a/.github/workflows/update-sdk.yml
+++ b/.github/workflows/update-sdk.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: martincostello/update-dotnet-sdk@31f3d5a6c2c4a5a0b7eb0e0d5c30501925d6e790
+    - uses: martincostello/update-dotnet-sdk@b3d5ca8064ec275f7a1d0b9640d28a57ab94090b
       with:
         quality: 'daily'
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use the SHA for the [v3.1.1 tag](https://github.com/martincostello/update-dotnet-sdk/tree/v3.1.1) ([diff](https://github.com/martincostello/update-dotnet-sdk/compare/31f3d5a6c2c4a5a0b7eb0e0d5c30501925d6e790...v3.1.1)).

https://github.com/dotnet/aspnetcore/pull/53449#discussion_r1456474898

/cc @wtgodbe
